### PR TITLE
[TASK] Include Exception class in ExceptionHandler with full path

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Error/AbstractExceptionHandler.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Error/AbstractExceptionHandler.php
@@ -18,7 +18,7 @@ use TYPO3\Flow\Log\SystemLoggerInterface;
 use TYPO3\Flow\Utility\Arrays;
 use TYPO3\Fluid\View\StandaloneView;
 
-require_once('Exception.php');
+require_once(FLOW_PATH_FLOW . 'Classes/TYPO3/Flow/Error/Exception.php');
 
 /**
  * An abstract exception handler


### PR DESCRIPTION


The ExceptionHandler includes the Flow Exception class directly by using
the relative path. This might not work out if at some point we decide to
combine autoloaded classes as this class is autoloaded and the relative
path will be wrong then. Using the FLOW_PATH_FLOW constant we can easily
construct a full path to the file.

Change-Id: I1154677458afc1633994158479fe8b3f18763d90
Releases: master
