### PR TITLE
[TASK] Compile CommandController arguments statically

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Cli/CommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Cli/CommandController.php
@@ -13,8 +13,8 @@ namespace TYPO3\Flow\Cli;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Mvc\Controller\Argument;
-use TYPO3\Flow\Mvc\Controller\ControllerInterface;
 use TYPO3\Flow\Mvc\Controller\Arguments;
+use TYPO3\Flow\Mvc\Controller\ControllerInterface;
 use TYPO3\Flow\Mvc\Exception\CommandException;
 use TYPO3\Flow\Mvc\Exception\InvalidArgumentTypeException;
 use TYPO3\Flow\Mvc\Exception\NoSuchCommandException;
@@ -22,7 +22,7 @@ use TYPO3\Flow\Mvc\Exception\StopActionException;
 use TYPO3\Flow\Mvc\Exception\UnsupportedRequestTypeException;
 use TYPO3\Flow\Mvc\RequestInterface;
 use TYPO3\Flow\Mvc\ResponseInterface;
-use TYPO3\Flow\Reflection\ReflectionService;
+use TYPO3\Flow\Object\ObjectManagerInterface;
 
 /**
  * A controller which processes requests from the command line
@@ -58,9 +58,14 @@ class CommandController implements ControllerInterface
     protected $commandMethodName = '';
 
     /**
-     * @var ReflectionService
+     * @var ObjectManagerInterface
      */
-    protected $reflectionService;
+    protected $objectManager;
+
+    /**
+     * @var CommandManager
+     */
+    protected $commandManager;
 
     /**
      * @var ConsoleOutput
@@ -73,19 +78,28 @@ class CommandController implements ControllerInterface
      */
     public function __construct()
     {
-        $this->arguments = new Arguments(array());
+        $this->arguments = new Arguments([]);
         $this->output = new ConsoleOutput();
+    }
+
+    /**
+     * @param CommandManager $commandManager
+     * @return void
+     */
+    public function injectCommandManager(CommandManager $commandManager)
+    {
+        $this->commandManager = $commandManager;
     }
 
     /**
      * Injects the reflection service
      *
-     * @param ReflectionService $reflectionService
+     * @param ObjectManagerInterface $objectManager
      * @return void
      */
-    public function injectReflectionService(ReflectionService $reflectionService)
+    public function injectObjectManager(ObjectManagerInterface $objectManager)
     {
-        $this->reflectionService = $reflectionService;
+        $this->objectManager = $objectManager;
     }
 
     /**
@@ -124,9 +138,10 @@ class CommandController implements ControllerInterface
     protected function resolveCommandMethodName()
     {
         $commandMethodName = $this->request->getControllerCommandName() . 'Command';
-        if (!is_callable(array($this, $commandMethodName))) {
+        if (!is_callable([$this, $commandMethodName])) {
             throw new NoSuchCommandException(sprintf('A command method "%s()" does not exist in controller "%s".', $commandMethodName, get_class($this)), 1300902143);
         }
+
         return $commandMethodName;
     }
 
@@ -140,7 +155,7 @@ class CommandController implements ControllerInterface
     protected function initializeCommandMethodArguments()
     {
         $this->arguments->removeAll();
-        $methodParameters = $this->reflectionService->getMethodParameters(get_class($this), $this->commandMethodName);
+        $methodParameters = $this->commandManager->getCommandMethodParameters(get_class($this), $this->commandMethodName);
 
         foreach ($methodParameters as $parameterName => $parameterInfo) {
             $dataType = null;
@@ -182,7 +197,7 @@ class CommandController implements ControllerInterface
 
             if ($argumentValue === null) {
                 $exception = new CommandException(sprintf('Required argument "%s" is not set.', $argumentName), 1306755520);
-                $this->forward('error', \TYPO3\Flow\Command\HelpCommandController::class, array('exception' => $exception));
+                $this->forward('error', \TYPO3\Flow\Command\HelpCommandController::class, ['exception' => $exception]);
             }
             $argument->setValue($argumentValue);
         }
@@ -200,7 +215,7 @@ class CommandController implements ControllerInterface
      * @return void
      * @throws StopActionException
      */
-    protected function forward($commandName, $controllerObjectName = null, array $arguments = array())
+    protected function forward($commandName, $controllerObjectName = null, array $arguments = [])
     {
         $this->request->setDispatched(false);
         $this->request->setControllerCommandName($commandName);
@@ -224,7 +239,7 @@ class CommandController implements ControllerInterface
      */
     protected function callCommandMethod()
     {
-        $preparedArguments = array();
+        $preparedArguments = [];
         /** @var Argument $argument */
         foreach ($this->arguments as $argument) {
             $preparedArguments[] = $argument->getValue();
@@ -235,17 +250,20 @@ class CommandController implements ControllerInterface
             $suggestedCommandMessage = '';
 
             $relatedCommandIdentifiers = $command->getRelatedCommandIdentifiers();
-            if ($relatedCommandIdentifiers !== array()) {
+            if ($relatedCommandIdentifiers !== []) {
                 $suggestedCommandMessage = sprintf(
                     ', use the following command%s instead: %s',
                     count($relatedCommandIdentifiers) > 1 ? 's' : '',
                     implode(', ', $relatedCommandIdentifiers)
                 );
             }
-            $this->outputLine('<b>Warning:</b> This command is <b>DEPRECATED</b>%s%s', array($suggestedCommandMessage, PHP_EOL));
+            $this->outputLine('<b>Warning:</b> This command is <b>DEPRECATED</b>%s%s', [
+                $suggestedCommandMessage,
+                PHP_EOL
+            ]);
         }
 
-        $commandResult = call_user_func_array(array($this, $this->commandMethodName), $preparedArguments);
+        $commandResult = call_user_func_array([$this, $this->commandMethodName], $preparedArguments);
 
         if (is_string($commandResult) && strlen($commandResult) > 0) {
             $this->response->appendContent($commandResult);
@@ -271,6 +289,7 @@ class CommandController implements ControllerInterface
     /**
      * Outputs specified text to the console window
      * You can specify arguments that will be passed to the text via sprintf
+     *
      * @see http://www.php.net/sprintf
      *
      * @param string $text Text to output
@@ -278,7 +297,7 @@ class CommandController implements ControllerInterface
      * @return void
      * @api
      */
-    protected function output($text, array $arguments = array())
+    protected function output($text, array $arguments = [])
     {
         $this->output->output($text, $arguments);
     }
@@ -293,7 +312,7 @@ class CommandController implements ControllerInterface
      * @see outputLines()
      * @api
      */
-    protected function outputLine($text = '', array $arguments = array())
+    protected function outputLine($text = '', array $arguments = [])
     {
         $this->output->outputLine($text, $arguments);
     }
@@ -309,7 +328,7 @@ class CommandController implements ControllerInterface
      * @see outputLine()
      * @api
      */
-    protected function outputFormatted($text = '', array $arguments = array(), $leftPadding = 0)
+    protected function outputFormatted($text = '', array $arguments = [], $leftPadding = 0)
     {
         $this->output->outputFormatted($text, $arguments, $leftPadding);
     }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Cli/CommandManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Cli/CommandManager.php
@@ -12,6 +12,12 @@ namespace TYPO3\Flow\Cli;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Core\Bootstrap;
+use TYPO3\Flow\Mvc\Exception\AmbiguousCommandIdentifierException;
+use TYPO3\Flow\Mvc\Exception\CommandException;
+use TYPO3\Flow\Mvc\Exception\NoSuchCommandException;
+use TYPO3\Flow\Object\ObjectManagerInterface;
+use TYPO3\Flow\Reflection\ReflectionService;
 
 /**
  * A helper for CLI Commands
@@ -31,26 +37,26 @@ class CommandManager
     protected $shortCommandIdentifiers = null;
 
     /**
-     * @var \TYPO3\Flow\Reflection\ReflectionService
-     */
-    protected $reflectionService;
-
-    /**
-     * @var \TYPO3\Flow\Core\Bootstrap
+     * @var Bootstrap
      */
     protected $bootstrap;
 
     /**
-     * @param \TYPO3\Flow\Reflection\ReflectionService $reflectionService
+     * @var ObjectManagerInterface
+     */
+    protected $objectManager;
+
+    /**
+     * @param ObjectManagerInterface $objectManager
      * @return void
      */
-    public function injectReflectionService(\TYPO3\Flow\Reflection\ReflectionService $reflectionService)
+    public function injectObjectManager(ObjectManagerInterface $objectManager)
     {
-        $this->reflectionService = $reflectionService;
+        $this->objectManager = $objectManager;
     }
 
     /**
-     * @param \TYPO3\Flow\Core\Bootstrap $bootstrap
+     * @param Bootstrap $bootstrap
      * @return void
      */
     public function injectBootstrap(\TYPO3\Flow\Core\Bootstrap $bootstrap)
@@ -67,20 +73,15 @@ class CommandManager
     public function getAvailableCommands()
     {
         if ($this->availableCommands === null) {
-            $this->availableCommands = array();
+            $this->availableCommands = [];
 
-            $commandControllerClassNames = $this->reflectionService->getAllSubClassNamesForClass(\TYPO3\Flow\Cli\CommandController::class);
-            foreach ($commandControllerClassNames as $className) {
-                if (!class_exists($className)) {
-                    continue;
-                }
-                foreach (get_class_methods($className) as $methodName) {
-                    if (substr($methodName, -7, 7) === 'Command') {
-                        $this->availableCommands[] = new Command($className, substr($methodName, 0, -7));
-                    }
+            foreach (static::getCommandControllerMethodArguments($this->objectManager) as $className => $methods) {
+                foreach (array_keys($methods) as $methodName) {
+                    $this->availableCommands[] = new Command($className, substr($methodName, 0, -7));
                 }
             }
         }
+
         return $this->availableCommands;
     }
 
@@ -90,9 +91,9 @@ class CommandManager
      * If more than one Command matches an AmbiguousCommandIdentifierException is thrown that contains the matched Commands
      *
      * @param string $commandIdentifier command identifier in the format foo:bar:baz
-     * @return \TYPO3\Flow\Cli\Command
-     * @throws \TYPO3\Flow\Mvc\Exception\NoSuchCommandException if no matching command is available
-     * @throws \TYPO3\Flow\Mvc\Exception\AmbiguousCommandIdentifierException if more than one Command matches the identifier (the exception contains the matched commands)
+     * @return Command
+     * @throws NoSuchCommandException if no matching command is available
+     * @throws AmbiguousCommandIdentifierException if more than one Command matches the identifier (the exception contains the matched commands)
      * @api
      */
     public function getCommandByIdentifier($commandIdentifier)
@@ -107,11 +108,12 @@ class CommandManager
 
         $matchedCommands = $this->getCommandsByIdentifier($commandIdentifier);
         if (count($matchedCommands) === 0) {
-            throw new \TYPO3\Flow\Mvc\Exception\NoSuchCommandException('No command could be found that matches the command identifier "' . $commandIdentifier . '".', 1310556663);
+            throw new NoSuchCommandException('No command could be found that matches the command identifier "' . $commandIdentifier . '".', 1310556663);
         }
         if (count($matchedCommands) > 1) {
-            throw new \TYPO3\Flow\Mvc\Exception\AmbiguousCommandIdentifierException('More than one command matches the command identifier "' . $commandIdentifier . '"', 1310557169, null, $matchedCommands);
+            throw new AmbiguousCommandIdentifierException('More than one command matches the command identifier "' . $commandIdentifier . '"', 1310557169, null, $matchedCommands);
         }
+
         return current($matchedCommands);
     }
 
@@ -126,12 +128,13 @@ class CommandManager
     public function getCommandsByIdentifier($commandIdentifier)
     {
         $availableCommands = $this->getAvailableCommands();
-        $matchedCommands = array();
+        $matchedCommands = [];
         foreach ($availableCommands as $command) {
             if ($this->commandMatchesIdentifier($command, $commandIdentifier)) {
                 $matchedCommands[] = $command;
             }
         }
+
         return $matchedCommands;
     }
 
@@ -151,6 +154,7 @@ class CommandManager
         if (!isset($shortCommandIdentifiers[$command->getCommandIdentifier()])) {
             return $command->getCommandIdentifier();
         }
+
         return $shortCommandIdentifiers[$command->getCommandIdentifier()];
     }
 
@@ -162,14 +166,15 @@ class CommandManager
     protected function getShortCommandIdentifiers()
     {
         if ($this->shortCommandIdentifiers === null) {
-            $commandsByCommandName = array();
+            $commandsByCommandName = [];
+            /** @var Command $availableCommand */
             foreach ($this->getAvailableCommands() as $availableCommand) {
                 list($packageKey, $controllerName, $commandName) = explode(':', $availableCommand->getCommandIdentifier());
                 if (!isset($commandsByCommandName[$commandName])) {
-                    $commandsByCommandName[$commandName] = array();
+                    $commandsByCommandName[$commandName] = [];
                 }
                 if (!isset($commandsByCommandName[$commandName][$controllerName])) {
-                    $commandsByCommandName[$commandName][$controllerName] = array();
+                    $commandsByCommandName[$commandName][$controllerName] = [];
                 }
                 $commandsByCommandName[$commandName][$controllerName][] = $packageKey;
             }
@@ -178,12 +183,12 @@ class CommandManager
                 if (count($commandsByCommandName[$commandName][$controllerName]) > 1 || $this->bootstrap->isCompiletimeCommand($availableCommand->getCommandIdentifier())) {
                     $packageKeyParts = array_reverse(explode('.', $packageKey));
                     for ($i = 1; $i <= count($packageKeyParts); $i++) {
-                        $shortCommandIdentifier = implode('.', array_slice($packageKeyParts, 0, $i)) .  ':' . $controllerName . ':' . $commandName;
+                        $shortCommandIdentifier = implode('.', array_slice($packageKeyParts, 0, $i)) . ':' . $controllerName . ':' . $commandName;
                         try {
                             $this->getCommandByIdentifier($shortCommandIdentifier);
                             $this->shortCommandIdentifiers[$availableCommand->getCommandIdentifier()] = $shortCommandIdentifier;
                             break;
-                        } catch (\TYPO3\Flow\Mvc\Exception\CommandException $exception) {
+                        } catch (CommandException $exception) {
                         }
                     }
                 } else {
@@ -191,6 +196,7 @@ class CommandManager
                 }
             }
         }
+
         return $this->shortCommandIdentifiers;
     }
 
@@ -215,7 +221,8 @@ class CommandManager
         if ($searchedCommandIdentifierPartsCount === 3 || $searchedCommandIdentifierPartsCount === 1) {
             $searchedPackageKey = array_shift($searchedCommandIdentifierParts);
             if ($searchedPackageKey !== $packageKey
-                    && substr($packageKey, - (strlen($searchedPackageKey) + 1)) !== '.' . $searchedPackageKey) {
+                && substr($packageKey, -(strlen($searchedPackageKey) + 1)) !== '.' . $searchedPackageKey
+            ) {
                 return false;
             }
         }
@@ -224,6 +231,48 @@ class CommandManager
         } elseif (count($searchedCommandIdentifierParts) !== 2) {
             return false;
         }
+
         return $searchedCommandIdentifierParts === $commandIdentifierParts;
+    }
+
+    /**
+     * Get the possible parameters for the command specified by CommandController and method name.
+     *
+     * @param string $controllerObjectName
+     * @param string $commandMethodName
+     * @return array
+     */
+    public function getCommandMethodParameters($controllerObjectName, $commandMethodName)
+    {
+        $commandControllerMethodArgumentMap = static::getCommandControllerMethodArguments($this->objectManager);
+
+        return isset($commandControllerMethodArgumentMap[$controllerObjectName][$commandMethodName]) ? $commandControllerMethodArgumentMap[$controllerObjectName][$commandMethodName] : [];
+    }
+
+    /**
+     * @param ObjectManagerInterface $objectManager
+     * @return array Array of method arguments per controller and method.
+     * @Flow\CompileStatic
+     */
+    public static function getCommandControllerMethodArguments($objectManager)
+    {
+        /** @var ReflectionService $reflectionService */
+        $reflectionService = $objectManager->get(ReflectionService::class);
+
+        $commandControllerMethodArgumentMap = [];
+        foreach ($reflectionService->getAllSubClassNamesForClass(CommandController::class) as $className) {
+            if (!class_exists($className)) {
+                continue;
+            }
+            $controllerObjectName = $objectManager->getObjectNameByClassName($className);
+            $commandControllerMethodArgumentMap[$controllerObjectName] = [];
+            foreach (get_class_methods($className) as $methodName) {
+                if (substr($methodName, -7, 7) === 'Command') {
+                    $commandControllerMethodArgumentMap[$className][$methodName] = $reflectionService->getMethodParameters($controllerObjectName, $methodName);
+                }
+            }
+        }
+
+        return $commandControllerMethodArgumentMap;
     }
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Cli/RequestBuilder.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Cli/RequestBuilder.php
@@ -12,7 +12,12 @@ namespace TYPO3\Flow\Cli;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Mvc\Exception\CommandException;
+use TYPO3\Flow\Mvc\Exception\InvalidArgumentMixingException;
 use TYPO3\Flow\Mvc\Exception\InvalidArgumentNameException;
+use TYPO3\Flow\Object\ObjectManagerInterface;
+use TYPO3\Flow\Package\PackageManagerInterface;
+use TYPO3\Flow\Utility\Environment;
 
 /**
  * Builds a CLI request object from the raw command call
@@ -40,24 +45,19 @@ class RequestBuilder
 		/x';
 
     /**
-     * @var \TYPO3\Flow\Utility\Environment
+     * @var Environment
      */
     protected $environment;
 
     /**
-     * @var \TYPO3\Flow\Object\ObjectManagerInterface
+     * @var ObjectManagerInterface
      */
     protected $objectManager;
 
     /**
-     * @var \TYPO3\Flow\Package\PackageManagerInterface
+     * @var PackageManagerInterface
      */
     protected $packageManager;
-
-    /**
-     * @var \TYPO3\Flow\Reflection\ReflectionService
-     */
-    protected $reflectionService;
 
     /**
      * @var CommandManager
@@ -65,39 +65,30 @@ class RequestBuilder
     protected $commandManager;
 
     /**
-     * @param \TYPO3\Flow\Utility\Environment $environment
+     * @param Environment $environment
      * @return void
      */
-    public function injectEnvironment(\TYPO3\Flow\Utility\Environment $environment)
+    public function injectEnvironment(Environment $environment)
     {
         $this->environment = $environment;
     }
 
     /**
-     * @param \TYPO3\Flow\Object\ObjectManagerInterface $objectManager
+     * @param ObjectManagerInterface $objectManager
      * @return void
      */
-    public function injectObjectManager(\TYPO3\Flow\Object\ObjectManagerInterface $objectManager)
+    public function injectObjectManager(ObjectManagerInterface $objectManager)
     {
         $this->objectManager = $objectManager;
     }
 
     /**
-     * @param \TYPO3\Flow\Package\PackageManagerInterface $packageManager
+     * @param PackageManagerInterface $packageManager
      * @return void
      */
-    public function injectPackageManager(\TYPO3\Flow\Package\PackageManagerInterface $packageManager)
+    public function injectPackageManager(PackageManagerInterface $packageManager)
     {
         $this->packageManager = $packageManager;
-    }
-
-    /**
-     * @param \TYPO3\Flow\Reflection\ReflectionService $reflectionService
-     * @return void
-     */
-    public function injectReflectionService(\TYPO3\Flow\Reflection\ReflectionService $reflectionService)
-    {
-        $this->reflectionService = $reflectionService;
     }
 
     /**
@@ -117,8 +108,9 @@ class RequestBuilder
      * name (like in $argv) but start with command right away.
      *
      * @param mixed $commandLine The command line, either as a string or as an array
-     * @return \TYPO3\Flow\Cli\Request The CLI request as an object
-     * @throws \TYPO3\Flow\Mvc\Exception\InvalidArgumentNameException
+     * @return Request The CLI request as an object
+     * @throws InvalidArgumentMixingException
+     * @throws InvalidArgumentNameException
      */
     public function build($commandLine)
     {
@@ -129,10 +121,15 @@ class RequestBuilder
             $rawCommandLineArguments = $commandLine;
         } else {
             preg_match_all(self::ARGUMENT_MATCHING_EXPRESSION, $commandLine, $commandLineMatchings, PREG_SET_ORDER);
-            $rawCommandLineArguments = array();
+            $rawCommandLineArguments = [];
             foreach ($commandLineMatchings as $match) {
                 if (isset($match['NoQuotes'])) {
-                    $rawCommandLineArguments[] = str_replace(array('\ ', '\"', "\\'", '\\\\'), array(' ', '"', "'", '\\'), $match['NoQuotes']);
+                    $rawCommandLineArguments[] = str_replace(['\ ', '\"', "\\'", '\\\\'], [
+                        ' ',
+                        '"',
+                        "'",
+                        '\\'
+                    ], $match['NoQuotes']);
                 } elseif (isset($match['DoubleQuotes'])) {
                     $rawCommandLineArguments[] = str_replace('\\"', '"', $match['DoubleQuotes']);
                 } elseif (isset($match['SingleQuotes'])) {
@@ -144,14 +141,16 @@ class RequestBuilder
         }
         if (count($rawCommandLineArguments) === 0) {
             $request->setControllerCommandName('helpStub');
+
             return $request;
         }
         $commandIdentifier = trim(array_shift($rawCommandLineArguments));
         try {
             $command = $this->commandManager->getCommandByIdentifier($commandIdentifier);
-        } catch (\TYPO3\Flow\Mvc\Exception\CommandException $exception) {
+        } catch (CommandException $exception) {
             $request->setArgument('exception', $exception);
             $request->setControllerCommandName('error');
+
             return $request;
         }
         $controllerObjectName = $this->objectManager->getObjectNameByClassName($command->getControllerClassName());
@@ -174,24 +173,30 @@ class RequestBuilder
      * @param string $controllerObjectName Object name of the designated command controller
      * @param string $controllerCommandName Command name of the recognized command (ie. method name without "Command" suffix)
      * @return array All and exceeding command line arguments
-     * @throws \TYPO3\Flow\Mvc\Exception\InvalidArgumentMixingException
+     * @throws InvalidArgumentMixingException
      */
     protected function parseRawCommandLineArguments(array $rawCommandLineArguments, $controllerObjectName, $controllerCommandName)
     {
-        $commandLineArguments = array();
-        $exceedingArguments = array();
+        $commandLineArguments = [];
+        $exceedingArguments = [];
         $commandMethodName = $controllerCommandName . 'Command';
-        $commandMethodParameters = $this->reflectionService->getMethodParameters($controllerObjectName, $commandMethodName);
+        $commandMethodParameters = $this->commandManager->getCommandMethodParameters($controllerObjectName, $commandMethodName);
 
-        $requiredArguments = array();
-        $optionalArguments = array();
-        $argumentNames = array();
+        $requiredArguments = [];
+        $optionalArguments = [];
+        $argumentNames = [];
         foreach ($commandMethodParameters as $parameterName => $parameterInfo) {
             $argumentNames[] = $parameterName;
             if ($parameterInfo['optional'] === false) {
-                $requiredArguments[strtolower($parameterName)] = array('parameterName' => $parameterName, 'type' => $parameterInfo['type']);
+                $requiredArguments[strtolower($parameterName)] = [
+                    'parameterName' => $parameterName,
+                    'type' => $parameterInfo['type']
+                ];
             } else {
-                $optionalArguments[strtolower($parameterName)] = array('parameterName' => $parameterName, 'type' => $parameterInfo['type']);
+                $optionalArguments[strtolower($parameterName)] = [
+                    'parameterName' => $parameterName,
+                    'type' => $parameterInfo['type']
+                ];
             }
         }
 
@@ -214,7 +219,7 @@ class RequestBuilder
                     $commandLineArguments[$optionalArguments[$argumentName]['parameterName']] = $argumentValue;
                 } elseif (isset($requiredArguments[$argumentName])) {
                     if ($decidedToUseUnnamedArguments) {
-                        throw new \TYPO3\Flow\Mvc\Exception\InvalidArgumentMixingException(sprintf('Unexpected named argument "%s". If you use unnamed arguments, all required arguments must be passed without a name.', $argumentName), 1309971821);
+                        throw new InvalidArgumentMixingException(sprintf('Unexpected named argument "%s". If you use unnamed arguments, all required arguments must be passed without a name.', $argumentName), 1309971821);
                     }
                     $decidedToUseNamedArguments = true;
                     $argumentValue = $this->getValueOfCurrentCommandLineOption($rawArgument, $rawCommandLineArguments, $requiredArguments[$argumentName]['type']);
@@ -224,7 +229,7 @@ class RequestBuilder
             } else {
                 if (count($requiredArguments) > 0) {
                     if ($decidedToUseNamedArguments) {
-                        throw new \TYPO3\Flow\Mvc\Exception\InvalidArgumentMixingException(sprintf('Unexpected unnamed argument "%s". If you use named arguments, all required arguments must be passed named.', $rawArgument), 1309971820);
+                        throw new InvalidArgumentMixingException(sprintf('Unexpected unnamed argument "%s". If you use named arguments, all required arguments must be passed named.', $rawArgument), 1309971820);
                     }
                     $argument = array_shift($requiredArguments);
                     $commandLineArguments[$argument['parameterName']] = $rawArgument;
@@ -233,10 +238,10 @@ class RequestBuilder
                     $exceedingArguments[] = $rawArgument;
                 }
             }
-            $argumentIndex ++;
+            $argumentIndex++;
         }
 
-        return array($commandLineArguments, $exceedingArguments);
+        return [$commandLineArguments, $exceedingArguments];
     }
 
     /**
@@ -248,6 +253,7 @@ class RequestBuilder
     protected function extractArgumentNameFromCommandLinePart($commandLinePart)
     {
         $nameAndValue = explode('=', $commandLinePart, 2);
+
         return strtolower(str_replace('-', '', $nameAndValue[0]));
     }
 
@@ -271,13 +277,14 @@ class RequestBuilder
                 if ($expectedArgumentType !== 'boolean') {
                     return $possibleValue;
                 }
-                if (array_search($possibleValue, array('on', '1', 'y', 'yes', 'true', 'TRUE')) !== false) {
+                if (array_search($possibleValue, ['on', '1', 'y', 'yes', 'true', 'TRUE']) !== false) {
                     return true;
                 }
-                if (array_search($possibleValue, array('off', '0', 'n', 'no', 'false', 'FALSE')) !== false) {
+                if (array_search($possibleValue, ['off', '0', 'n', 'no', 'false', 'FALSE']) !== false) {
                     return false;
                 }
                 array_unshift($rawCommandLineArguments, $possibleValue);
+
                 return true;
             }
             $currentArgument .= $possibleValue;
@@ -290,6 +297,7 @@ class RequestBuilder
         }
 
         $value = (isset($splitArgument[1])) ? $splitArgument[1] : '';
+
         return $value;
     }
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/HelpCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/HelpCommandController.php
@@ -15,7 +15,6 @@ use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Cli\Command;
 use TYPO3\Flow\Cli\CommandArgumentDefinition;
 use TYPO3\Flow\Cli\CommandController;
-use TYPO3\Flow\Cli\CommandManager;
 use TYPO3\Flow\Core\Bootstrap;
 use TYPO3\Flow\Mvc\Exception\AmbiguousCommandIdentifierException;
 use TYPO3\Flow\Mvc\Exception\CommandException;

--- a/TYPO3.Flow/Tests/Unit/Cli/CommandManagerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Cli/CommandManagerTest.php
@@ -12,6 +12,8 @@ namespace TYPO3\Flow\Tests\Unit\Cli;
  */
 
 use TYPO3\Flow\Cli\CommandManager;
+use TYPO3\Flow\Object\ObjectManagerInterface;
+use TYPO3\Flow\Reflection\ReflectionService;
 
 require_once('Fixtures/Command/MockCommandController.php');
 
@@ -50,9 +52,11 @@ class CommandManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
     public function getAvailableCommandsReturnsAllAvailableCommands()
     {
         $commandManager = new CommandManager();
-        $commandManager->injectReflectionService($this->mockReflectionService);
         $mockCommandControllerClassNames = array(\TYPO3\Flow\Tests\Unit\Cli\Fixtures\Command\MockACommandController::class, \TYPO3\Flow\Tests\Unit\Cli\Fixtures\Command\MockBCommandController::class);
         $this->mockReflectionService->expects($this->once())->method('getAllSubClassNamesForClass')->with(\TYPO3\Flow\Cli\CommandController::class)->will($this->returnValue($mockCommandControllerClassNames));
+        $mockObjectManager = $this->getMock(ObjectManagerInterface::class);
+        $mockObjectManager->expects($this->any())->method('get')->with(ReflectionService::class)->willReturn($this->mockReflectionService);
+        $commandManager->injectObjectManager($mockObjectManager);
 
         $commands = $commandManager->getAvailableCommands();
         $this->assertEquals(3, count($commands));

--- a/TYPO3.Flow/Tests/Unit/Cli/RequestBuilderTest.php
+++ b/TYPO3.Flow/Tests/Unit/Cli/RequestBuilderTest.php
@@ -62,7 +62,6 @@ class RequestBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase
 
         $this->requestBuilder = new \TYPO3\Flow\Cli\RequestBuilder();
         $this->requestBuilder->injectObjectManager($this->mockObjectManager);
-        $this->requestBuilder->injectReflectionService($this->mockReflectionService);
         $this->requestBuilder->injectCommandManager($this->mockCommandManager);
     }
 
@@ -73,7 +72,7 @@ class RequestBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function cliAccessWithPackageControllerAndActionNameBuildsCorrectRequest()
     {
-        $this->mockReflectionService->expects($this->once())->method('getMethodParameters')->will($this->returnValue(array()));
+        $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->will($this->returnValue(array()));
 
         $request = $this->requestBuilder->build('acme.test:default:list');
         $this->assertSame('Acme\Test\Command\DefaultCommandController', $request->getControllerObjectName());
@@ -109,7 +108,7 @@ class RequestBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase
             'testArgument' => array('optional' => false, 'type' => 'string'),
             'testArgument2' => array('optional' => false, 'type' => 'string')
         );
-        $this->mockReflectionService->expects($this->once())->method('getMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
+        $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $request = $this->requestBuilder->build('acme.test:default:list --test-argument=value --test-argument2=value2');
         $this->assertTrue($request->hasArgument('testArgument'), 'The given "testArgument" was not found in the built request.');
@@ -131,7 +130,7 @@ class RequestBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase
             'testArgument3' => array('optional' => false, 'type' => 'string'),
             'testArgument4' => array('optional' => false, 'type' => 'string')
         );
-        $this->mockReflectionService->expects($this->once())->method('getMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
+        $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $request = $this->requestBuilder->build('acme.test:default:list --test-argument= value --test-argument2 =value2 --test-argument3 = value3 --test-argument4=value4');
         $this->assertTrue($request->hasArgument('testArgument'), 'The given "testArgument" was not found in the built request.');
@@ -156,7 +155,7 @@ class RequestBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase
             'd' => array('optional' => false, 'type' => 'string'),
             'f' => array('optional' => false, 'type' => 'string'),
         );
-        $this->mockReflectionService->expects($this->once())->method('getMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
+        $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $request = $this->requestBuilder->build('acme.test:default:list -d valued -f=valuef -a = valuea');
         $this->assertTrue($request->hasArgument('d'), 'The given "d" was not found in the built request.');
@@ -191,7 +190,7 @@ class RequestBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase
             'k' => array('optional' => false, 'type' => 'string'),
             'm' => array('optional' => false, 'type' => 'string'),
         );
-        $this->mockReflectionService->expects($this->once())->method('getMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
+        $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $request = $this->requestBuilder->build('acme.test:default:list --test-argument=value --test-argument2= value2 -k --test-argument-3 = value3 --test-argument4=value4 -f valuef -d=valued -a = valuea -c --testArgument7 --test-argument5 = 5 --test-argument6 -j kjk -m');
         $this->assertTrue($request->hasArgument('testArgument'), 'The given "testArgument" was not found in the built request.');
@@ -227,7 +226,7 @@ class RequestBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase
         $methodParameters = array(
             'testArgument' => array('optional' => false, 'type' => 'string')
         );
-        $this->mockReflectionService->expects($this->once())->method('getMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
+        $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $request = $this->requestBuilder->build('acme.test:default:list --test-argument=value');
         $this->assertTrue($request->hasArgument('testArgument'), 'The given "testArgument" was not found in the built request.');
@@ -243,7 +242,7 @@ class RequestBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase
             'testArgument1' => array('optional' => false, 'type' => 'string'),
             'testArgument2' => array('optional' => false, 'type' => 'string'),
         );
-        $this->mockReflectionService->expects($this->exactly(2))->method('getMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
+        $this->mockCommandManager->expects($this->any())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $request = $this->requestBuilder->build('acme.test:default:list --test-argument1 firstArgumentValue --test-argument2 secondArgumentValue');
         $this->assertSame('firstArgumentValue', $request->getArgument('testArgument1'));
@@ -265,7 +264,7 @@ class RequestBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase
             'argument1' => array('optional' => false, 'type' => 'string'),
             'argument2' => array('optional' => false, 'type' => 'string'),
         );
-        $this->mockReflectionService->expects($this->once())->method('getMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
+        $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $request = $this->requestBuilder->build('acme.test:default:list --some -option=value file1 file2');
         $this->assertSame('list', $request->getControllerCommandName());
@@ -283,7 +282,7 @@ class RequestBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase
             'testArgument1' => array('optional' => false, 'type' => 'string'),
             'testArgument2' => array('optional' => false, 'type' => 'string'),
         );
-        $this->mockReflectionService->expects($this->once())->method('getMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
+        $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $expectedArguments = array('testArgument1' => 'firstArgumentValue', 'testArgument2' => 'secondArgumentValue');
 
@@ -302,7 +301,7 @@ class RequestBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase
             'testArgument1' => array('optional' => false, 'type' => 'string'),
             'testArgument2' => array('optional' => false, 'type' => 'string'),
         );
-        $this->mockReflectionService->expects($this->once())->method('getMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
+        $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $this->requestBuilder->build('acme.test:default:list --test-argument1 firstArgumentValue secondArgumentValue');
     }
@@ -317,7 +316,7 @@ class RequestBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase
             'requiredArgument1' => array('optional' => false, 'type' => 'string'),
             'requiredArgument2' => array('optional' => false, 'type' => 'string'),
         );
-        $this->mockReflectionService->expects($this->once())->method('getMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
+        $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $this->requestBuilder->build('acme.test:default:list firstArgumentValue --required-argument2 secondArgumentValue');
     }
@@ -332,7 +331,7 @@ class RequestBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase
             'requiredArgument2' => array('optional' => false, 'type' => 'string'),
             'booleanOption' => array('optional' => true, 'type' => 'boolean'),
         );
-        $this->mockReflectionService->expects($this->once())->method('getMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
+        $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $expectedArguments = array('requiredArgument1' => 'firstArgumentValue', 'requiredArgument2' => 'secondArgumentValue', 'booleanOption' => true);
 
@@ -350,7 +349,7 @@ class RequestBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase
             'requiredArgument2' => array('optional' => false, 'type' => 'string'),
             'booleanOption' => array('optional' => true, 'type' => 'boolean'),
         );
-        $this->mockReflectionService->expects($this->once())->method('getMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
+        $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $expectedArguments = array('requiredArgument1' => 'firstArgumentValue', 'requiredArgument2' => 'secondArgumentValue');
 
@@ -368,7 +367,7 @@ class RequestBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase
             'requiredArgument2' => array('optional' => false, 'type' => 'string'),
             'booleanOption' => array('optional' => true, 'type' => 'boolean'),
         );
-        $this->mockReflectionService->expects($this->once())->method('getMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
+        $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $expectedExceedingArguments = array('true');
 
@@ -389,7 +388,7 @@ class RequestBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase
             'b5' => array('optional' => true, 'type' => 'boolean'),
             'b6' => array('optional' => true, 'type' => 'boolean'),
         );
-        $this->mockReflectionService->expects($this->once())->method('getMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
+        $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $expectedArguments = array('b1' => true, 'b2' => true, 'b3' => true, 'b4' => false, 'b5' => false, 'b6' => false);
 
@@ -428,7 +427,7 @@ class RequestBuilderTest extends \TYPO3\Flow\Tests\UnitTestCase
             'requiredArgument1' => array('optional' => false, 'type' => 'string'),
             'requiredArgument2' => array('optional' => false, 'type' => 'string'),
         );
-        $this->mockReflectionService->expects($this->once())->method('getMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
+        $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $expectedArguments = array('requiredArgument1' => 'firstArgumentValue', 'requiredArgument2' => $expectedResult);
 

--- a/TYPO3.Flow/Tests/Unit/Mvc/Controller/CommandControllerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Mvc/Controller/CommandControllerTest.php
@@ -12,8 +12,8 @@ namespace TYPO3\Flow\Tests\Unit\Mvc\Controller;
  */
 
 use TYPO3\Flow\Cli\CommandController;
+use TYPO3\Flow\Cli\CommandManager;
 use TYPO3\Flow\Mvc\Controller\Arguments;
-use TYPO3\Flow\Reflection\ReflectionService;
 use TYPO3\Flow\Tests\UnitTestCase;
 
 /**
@@ -27,9 +27,9 @@ class CommandControllerTest extends UnitTestCase
     protected $commandController;
 
     /**
-     * @var ReflectionService|\PHPUnit_Framework_MockObject_MockObject
+     * @var CommandManager|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $mockReflectionService;
+    protected $mockCommandManager;
 
     /**
      * @var \TYPO3\Flow\Cli\ConsoleOutput|\PHPUnit_Framework_MockObject_MockObject
@@ -40,9 +40,9 @@ class CommandControllerTest extends UnitTestCase
     {
         $this->commandController = $this->getAccessibleMock(\TYPO3\Flow\Cli\CommandController::class, array('resolveCommandMethodName', 'callCommandMethod'));
 
-        $this->mockReflectionService = $this->getMockBuilder(\TYPO3\Flow\Reflection\ReflectionService::class)->disableOriginalConstructor()->getMock();
-        $this->mockReflectionService->expects($this->any())->method('getMethodParameters')->will($this->returnValue(array()));
-        $this->inject($this->commandController, 'reflectionService', $this->mockReflectionService);
+        $this->mockCommandManager = $this->getMockBuilder(CommandManager::class)->disableOriginalConstructor()->getMock();
+        $this->mockCommandManager->expects($this->any())->method('getCommandMethodParameters')->will($this->returnValue(array()));
+        $this->inject($this->commandController, 'commandManager', $this->mockCommandManager);
 
         $this->mockConsoleOutput = $this->getMockBuilder(\TYPO3\Flow\Cli\ConsoleOutput::class)->disableOriginalConstructor()->getMock();
         $this->inject($this->commandController, 'output', $this->mockConsoleOutput);


### PR DESCRIPTION
Instead of using the ReflectionService at runtime to determine
arguments for commands they will be compiled statically and just
read from the array. Additionally this was centralized into the
``CommandManager`` as ``CommandController``, ``RequestBuilder`` and
``CommandManager`` all fetched similar information from the
``ReflectionService``.

Related: NEOS-1294
