### PR TITLE
[TASK] Use more sophisticated UUID generator

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Algorithms.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Algorithms.php
@@ -10,6 +10,7 @@ namespace TYPO3\Flow\Utility;
 
 require_once(FLOW_PATH_FLOW . 'Resources/PHP/iSecurity/Security_Randomizer.php');
 
+use Ramsey\Uuid\Uuid;
 use TYPO3\Flow\Annotations as Flow;
 
 /**
@@ -23,12 +24,18 @@ class Algorithms
      * Generates a universally unique identifier (UUID) according to RFC 4122.
      * The algorithm used here, might not be completely random.
      *
+     * If php-uuid was installed it will be used instead to speed up the process.
+     *
      * @return string The universally unique id
-     * @todo check for randomness, optionally generate type 1 and type 5 UUIDs, use php5-uuid extension if available
+     * @todo Optionally generate type 1 and type 5 UUIDs.
      */
     public static function generateUUID()
     {
-        return strtolower(\Security_Randomizer::getRandomGUID());
+        if (is_callable('uuid_create')) {
+            return strtolower(uuid_create(UUID_TYPE_RANDOM));
+        }
+
+        return (string)Uuid::uuid4();
     }
 
     /**

--- a/TYPO3.Flow/composer.json
+++ b/TYPO3.Flow/composer.json
@@ -17,6 +17,8 @@
         "typo3/fluid": "*",
         "typo3/eel": "*",
 
+        "ramsey/uuid": "^3.0.0",
+
         "doctrine/orm": "2.4.*",
         "doctrine/migrations": "1.0.*",
 
@@ -29,7 +31,8 @@
     "suggest": {
         "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
         "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
-        "typo3/party": "To make use of basic user handling"
+        "typo3/party": "To make use of basic user handling",
+        "php-uuid": "For fast generation of UUIDs used in the persistence."
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,9 @@
 {
     "name": "neos/flow-development-collection",
     "description": "Flow packages in a joined repository for pull requests.",
-    "license": ["MIT"],
+    "license": [
+        "MIT"
+    ],
     "type": "neos-package-collection",
     "require": {
         "php": ">=5.5.0",
@@ -10,6 +12,7 @@
         "ext-json": ">=1.2.0",
         "ext-mbstring": "*",
         "ext-reflection": "*",
+        "ramsey/uuid": "^3.0.0",
         "doctrine/orm": "2.4.*",
         "doctrine/migrations": "1.0.*",
         "symfony/yaml": "2.5.*",
@@ -26,7 +29,8 @@
     "suggest": {
         "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",
         "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",
-        "typo3/party": "To make use of basic user handling"
+        "typo3/party": "To make use of basic user handling",
+        "php-uuid": "For fast generation of UUIDs used in the persistence."
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION


Uses php-uuid extension if available and otherwise the
``https://github.com/ramsey/uuid`` library which is a complete
solution for generating and working with UUIDs.

Change-Id: Ide03010ffb3ded05c9d8d646e80c544a411b6e40
Releases: master
