### PR TITLE
[TASK] Compile StreamWrapper implementations statically

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
@@ -17,6 +17,7 @@ use TYPO3\Flow\Monitor\FileMonitor;
 use TYPO3\Flow\Package\Package;
 use TYPO3\Flow\Package\PackageInterface;
 use TYPO3\Flow\Package\PackageManagerInterface;
+use TYPO3\Flow\Resource\Streams\StreamWrapperAdapter;
 
 /**
  * Initialization scripts for modules of the Flow package
@@ -500,6 +501,7 @@ class Scripts {
 	 * @return void
 	 */
 	static public function initializeResources(Bootstrap $bootstrap) {
+		StreamWrapperAdapter::initializeStreamWrapper($bootstrap->getObjectManager());
 		$resourceManager = $bootstrap->getObjectManager()->get(\TYPO3\Flow\Resource\ResourceManager::class);
 		$resourceManager->initialize();
 	}

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/ResourceManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/ResourceManager.php
@@ -19,7 +19,6 @@ use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Flow\Reflection\ObjectAccess;
 use TYPO3\Flow\Resource\Storage\StorageInterface;
 use TYPO3\Flow\Resource\Storage\WritableStorageInterface;
-use TYPO3\Flow\Resource\Streams\StreamWrapperAdapter;
 use TYPO3\Flow\Resource\Target\TargetInterface;
 use TYPO3\Flow\Utility\Unicode\Functions as UnicodeFunctions;
 
@@ -104,7 +103,6 @@ class ResourceManager {
 	 * @return void
 	 */
 	public function initialize() {
-		$this->initializeStreamWrapper();
 		$this->initializeStorages();
 		$this->initializeTargets();
 		$this->initializeCollections();
@@ -505,23 +503,6 @@ class ResourceManager {
 	}
 
 	/**
-	 * Registers a Stream Wrapper Adapter for the resource:// scheme.
-	 *
-	 * @return void
-	 */
-	protected function initializeStreamWrapper() {
-		$streamWrapperClassNames = static::getStreamWrapperImplementationClassNames($this->objectManager);
-		foreach ($streamWrapperClassNames as $streamWrapperClassName) {
-			$scheme = $streamWrapperClassName::getScheme();
-			if (in_array($scheme, stream_get_wrappers())) {
-				stream_wrapper_unregister($scheme);
-			}
-			stream_wrapper_register($scheme, \TYPO3\Flow\Resource\Streams\StreamWrapperAdapter::class);
-			StreamWrapperAdapter::registerStreamWrapper($scheme, $streamWrapperClassName);
-		}
-	}
-
-	/**
 	 * Prepare an uploaded file to be imported as resource object. Will check the validity of the file,
 	 * move it outside of upload folder if open_basedir is enabled and check the filename.
 	 *
@@ -555,17 +536,6 @@ class ResourceManager {
 			'filepath' => $temporaryTargetPathAndFilename,
 			'filename' => $pathInfo['basename']
 		);
-	}
-
-	/**
-	 * Returns all class names implementing the StreamWrapperInterface.
-	 *
-	 * @param ObjectManagerInterface $objectManager
-	 * @return array Array of stream wrapper implementations
-	 * @Flow\CompileStatic
-	 */
-	static protected function getStreamWrapperImplementationClassNames($objectManager) {
-		return $objectManager->get(\TYPO3\Flow\Reflection\ReflectionService::class)->getAllImplementationClassNamesForInterface(\TYPO3\Flow\Resource\Streams\StreamWrapperInterface::class);
 	}
 
 	/**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Streams/StreamWrapperAdapter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Streams/StreamWrapperAdapter.php
@@ -11,6 +11,9 @@ namespace TYPO3\Flow\Resource\Streams;
  * The TYPO3 project - inspiring people to share!                         *
  *                                                                        */
 
+use TYPO3\Flow\Object\ObjectManagerInterface;
+use TYPO3\Flow\Annotations as Flow;
+
 /**
  * A generic stream wrapper sitting between PHP and stream wrappers implementing
  * \TYPO3\Flow\Resource\Streams\StreamWrapperInterface.
@@ -34,9 +37,28 @@ class StreamWrapperAdapter {
 	public $context;
 
 	/**
-	 * @var \TYPO3\Flow\Resource\Streams\StreamWrapperInterface
+	 * @var StreamWrapperInterface
 	 */
 	protected $streamWrapper;
+
+	/**
+	 * Initialize StreamWrappers with this adapter
+	 *
+	 * @param ObjectManagerInterface $objectManager
+	 * @return void
+	 */
+	public static function initializeStreamWrapper($objectManager) {
+		$streamWrapperClassNames = static::getStreamWrapperImplementationClassNames($objectManager);
+		/** @var StreamWrapperInterface $streamWrapperClassName */
+		foreach ($streamWrapperClassNames as $streamWrapperClassName) {
+			$scheme = $streamWrapperClassName::getScheme();
+			if (in_array($scheme, stream_get_wrappers())) {
+				stream_wrapper_unregister($scheme);
+			}
+			stream_wrapper_register($scheme, 'TYPO3\Flow\Resource\Streams\StreamWrapperAdapter');
+			static::registerStreamWrapper($scheme, $streamWrapperClassName);
+		}
+	}
 
 	/**
 	 * Register a stream wrapper. Later registrations for a scheme will override
@@ -434,4 +456,14 @@ class StreamWrapperAdapter {
 		return $this->streamWrapper->pathStat($path, $flags);
 	}
 
+	/**
+	 * Returns all class names implementing the StreamWrapperInterface.
+	 *
+	 * @param ObjectManagerInterface $objectManager
+	 * @return array Array of stream wrapper implementations
+	 * @Flow\CompileStatic
+	 */
+	static public function getStreamWrapperImplementationClassNames(ObjectManagerInterface $objectManager) {
+		return $objectManager->get('TYPO3\Flow\Reflection\ReflectionService')->getAllImplementationClassNamesForInterface('TYPO3\Flow\Resource\Streams\StreamWrapperInterface');
+	}
 }


### PR DESCRIPTION


Reduce use of ReflectionService by compiling implementations of
``TYPO3\Flow\Resource\Streams\StreamWrapperInterface`` statically into
the StreamWrapperAdapter. This in itself wil not improve performance
because it was done in the ``ResourceManager`` before, but makes the
``ResourceManager`` somewhat cleaner and allows further refactorings
of that.

Change-Id: I98b259ea15a424c426d2831f34df16c98e18a7a8
Releases: master
Relates: NEOS-1294
