### PR TITLE
[TASK] Make Http\Request easier to use for outbound Requests

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/AbstractMessage.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/AbstractMessage.php
@@ -38,7 +38,7 @@ abstract class AbstractMessage
      *
      * @var string
      */
-    protected $content;
+    protected $content = '';
 
     /**
      * @var string

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Request.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Request.php
@@ -170,7 +170,9 @@ class Request extends AbstractMessage
      */
     public static function createFromEnvironment()
     {
-        return new static($_GET, $_POST, $_FILES, $_SERVER);
+        $request = new static($_GET, $_POST, $_FILES, $_SERVER);
+        $request->setContent(null);
+        return $request;
     }
 
     /**

--- a/TYPO3.Flow/Tests/Unit/Http/RequestTest.php
+++ b/TYPO3.Flow/Tests/Unit/Http/RequestTest.php
@@ -311,6 +311,7 @@ class RequestTest extends UnitTestCase
         file_put_contents('vfs://Foo/content.txt', $expectedContent);
 
         $request = Request::create(new Uri('http://flow.typo3.org'));
+        $request->setContent(null);
         $this->inject($request, 'inputStreamUri', 'vfs://Foo/content.txt');
 
         $actualContent = $request->getContent();
@@ -328,6 +329,7 @@ class RequestTest extends UnitTestCase
         file_put_contents('vfs://Foo/content.txt', $expectedContent);
 
         $request = Request::create(new Uri('http://flow.typo3.org'));
+        $request->setContent(null);
         $this->inject($request, 'inputStreamUri', 'vfs://Foo/content.txt');
 
         $resource = $request->getContent(true);


### PR DESCRIPTION


Currently the ``Http\Request`` defaults to php://input for
content. This is good for a request coming in to Flow, but rather
error prone for outbound requests as it can lead to different behavior
depending if the Request is created during a GET, POST or even CLI
call. So sometimes outbound requests might work and other times they
won't work. This change adjusts the defaul to have the Request an
empty ``Content`` (body) and sets it to NULL (which will trigger the
fallback to php://input) just if the Request is created by using
``Request::createFromEnvironment()``

Change-Id: I091033527fcd47f3bbaf4fbbd0ac9405195dd8d3
Releases: master
Resolves: FLOW-235