### PR TITLE
[FEATURE] Refactor Files::readDirectoryRecursively

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Configuration/ConfigurationSchemaValidator.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Configuration/ConfigurationSchemaValidator.php
@@ -14,6 +14,7 @@ namespace TYPO3\Flow\Configuration;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Error\Notice;
 use TYPO3\Flow\Error\Result;
+use TYPO3\Flow\Utility\Files;
 
 /**
  * A validator for all configuration entries using Schema
@@ -99,10 +100,9 @@ class ConfigurationSchemaValidator
         $activePackages = $this->packageManager->getActivePackages();
         foreach ($activePackages as $package) {
             $packageKey = $package->getPackageKey();
-            $packageSchemaPath = \TYPO3\Flow\Utility\Files::concatenatePaths(array($package->getResourcesPath(), 'Private/Schema'));
+            $packageSchemaPath = Files::concatenatePaths(array($package->getResourcesPath(), 'Private/Schema'));
             if (is_dir($packageSchemaPath)) {
-                $packageSchemaFiles = \TYPO3\Flow\Utility\Files::readDirectoryRecursively($packageSchemaPath, '.schema.yaml');
-                foreach ($packageSchemaFiles as $schemaFile) {
+                foreach (Files::getRecursiveDirectoryGenerator($packageSchemaPath, '.schema.yaml') as $schemaFile) {
                     $schemaName = substr($schemaFile, strlen($packageSchemaPath) + 1, -strlen('.schema.yaml'));
                     $schemaNameParts = explode('.', str_replace('/', '.', $schemaName), 2);
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Storage/PackageStorage.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Storage/PackageStorage.php
@@ -79,7 +79,7 @@ class PackageStorage extends FileSystemStorage
 
         foreach ($directories as $packageKey => $packageDirectories) {
             foreach ($packageDirectories as $directoryPath) {
-                foreach (Files::readDirectoryRecursively($directoryPath) as $resourcePathAndFilename) {
+                foreach (Files::getRecursiveDirectoryGenerator($directoryPath) as $resourcePathAndFilename) {
                     $pathInfo = UnicodeFunctions::pathinfo($resourcePathAndFilename);
 
                     $object = new Object();

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Files.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Files.php
@@ -81,33 +81,52 @@ class Files
      * @param string $suffix If specified, only filenames with this extension are returned (eg. ".php" or "foo.bar")
      * @param boolean $returnRealPath If turned on, all paths are resolved by calling realpath()
      * @param boolean $returnDotFiles If turned on, also files beginning with a dot will be returned
-     * @param array $filenames Internally used for the recursion - don't specify!
      * @return array Filenames including full path
      * @throws Exception
      * @api
      */
-    public static function readDirectoryRecursively($path, $suffix = null, $returnRealPath = false, $returnDotFiles = false, &$filenames = array())
+    public static function readDirectoryRecursively($path, $suffix = null, $returnRealPath = false, $returnDotFiles = false)
+    {
+        return iterator_to_array(self::getRecursiveDirectoryGenerator($path, $suffix, $returnRealPath, $returnDotFiles));
+    }
+
+    /**
+     * @param string $path
+     * @param string $suffix
+     * @param boolean $returnRealPath
+     * @param boolean $returnDotFiles
+     * @return \Generator
+     * @throws Exception
+     */
+    public static function getRecursiveDirectoryGenerator($path, $suffix = null, $returnRealPath = false, $returnDotFiles = false)
     {
         if (!is_dir($path)) {
             throw new Exception('"' . $path . '" is no directory.', 1207253462);
         }
 
-        $directoryIterator = new \DirectoryIterator($path);
-        $suffixLength = strlen($suffix);
+        $directories = array(self::getNormalizedPath($path));
+        while ($directories !== array()) {
+            $currentDirectory = array_pop($directories);
+            if ($handle = opendir($currentDirectory)) {
+                while (false !== ($filename = readdir($handle))) {
+                    if ($filename === '.' || $filename === '..') {
+                        continue;
+                    }
 
-        foreach ($directoryIterator as $fileInfo) {
-            $filename = $fileInfo->getFilename();
-            if ($filename === '.' || $filename === '..' || ($returnDotFiles === false && $filename[0] === '.')) {
-                continue;
-            }
-            if ($fileInfo->isFile() && ($suffix === null || substr($filename, -$suffixLength) === $suffix)) {
-                $filenames[] = self::getUnixStylePath(($returnRealPath === true ? realpath($fileInfo->getPathname()) : $fileInfo->getPathname()));
-            }
-            if ($fileInfo->isDir()) {
-                self::readDirectoryRecursively($fileInfo->getPathname(), $suffix, $returnRealPath, $returnDotFiles, $filenames);
+                    if ($filename[0] === '.' && $returnDotFiles === false) {
+                        continue;
+                    }
+
+                    $pathAndFilename = self::concatenatePaths(array($currentDirectory, $filename));
+                    if (is_dir($pathAndFilename)) {
+                        array_push($directories, self::getNormalizedPath($pathAndFilename));
+                    } elseif ($suffix === null || strpos(strrev($filename), strrev($suffix)) === 0) {
+                        yield static::getUnixStylePath(($returnRealPath === true) ? realpath($pathAndFilename) : $pathAndFilename);
+                    }
+                }
+                closedir($handle);
             }
         }
-        return $filenames;
     }
 
     /**
@@ -265,8 +284,7 @@ class Files
             throw new Exception('"' . $targetDirectory . '" is no directory.', 1235428780);
         }
 
-        $sourceFilenames = self::readDirectoryRecursively($sourceDirectory, null, false, $copyDotFiles);
-        foreach ($sourceFilenames as $filename) {
+        foreach (self::getRecursiveDirectoryGenerator($sourceDirectory, null, false, $copyDotFiles) as $filename) {
             $relativeFilename = str_replace($sourceDirectory, '', $filename);
             self::createDirectoryRecursively($targetDirectory . dirname($relativeFilename));
             $targetPathAndFilename = self::concatenatePaths(array($targetDirectory, $relativeFilename));

--- a/TYPO3.Flow/Migrations/Code/Version20140511114700.php
+++ b/TYPO3.Flow/Migrations/Code/Version20140511114700.php
@@ -37,8 +37,7 @@ class Version20140511114700 extends AbstractMigration
     public function up()
     {
         $affectedFiles = array();
-        $allPathsAndFilenames = Files::readDirectoryRecursively($this->targetPackageData['path'], null, true);
-        foreach ($allPathsAndFilenames as $pathAndFilename) {
+        foreach (Files::getRecursiveDirectoryGenerator($this->targetPackageData['path'], null, true) as $pathAndFilename) {
             if (substr($pathAndFilename, -13) !== 'Converter.php') {
                 continue;
             }

--- a/TYPO3.Flow/Scripts/Migrations/AbstractMigration.php
+++ b/TYPO3.Flow/Scripts/Migrations/AbstractMigration.php
@@ -352,8 +352,7 @@ abstract class AbstractMigration
      */
     protected function applySearchAndReplaceOperations()
     {
-        $allPathsAndFilenames = Files::readDirectoryRecursively($this->targetPackageData['path'], null, true);
-        foreach ($allPathsAndFilenames as $pathAndFilename) {
+        foreach (Files::getRecursiveDirectoryGenerator($this->targetPackageData['path'], null, true) as $pathAndFilename) {
             $pathInfo = pathinfo($pathAndFilename);
             if (!isset($pathInfo['filename'])) {
                 continue;
@@ -383,7 +382,6 @@ abstract class AbstractMigration
      */
     protected function applyFileOperations()
     {
-        $allPathsAndFilenames = Files::readDirectoryRecursively($this->targetPackageData['path'], null, true);
         foreach ($this->operations['moveFile'] as $operation) {
             $oldPath = Files::concatenatePaths(array($this->targetPackageData['path'] . '/' . $operation[0]));
             $newPath = Files::concatenatePaths(array($this->targetPackageData['path'] . '/' . $operation[1]));
@@ -399,7 +397,7 @@ abstract class AbstractMigration
                 if (!is_dir($newPath)) {
                     continue;
                 }
-                foreach ($allPathsAndFilenames as $pathAndFilename) {
+                foreach (Files::getRecursiveDirectoryGenerator($this->targetPackageData['path'], null, true) as $pathAndFilename) {
                     if (substr_compare($pathAndFilename, $oldPath, 0, strlen($oldPath)) === 0) {
                         $relativePathAndFilename = substr($pathAndFilename, strlen($oldPath));
                         if (!is_dir(dirname(Files::concatenatePaths(array($newPath, $relativePathAndFilename))))) {

--- a/TYPO3.Flow/Scripts/Migrations/Manager.php
+++ b/TYPO3.Flow/Scripts/Migrations/Manager.php
@@ -397,8 +397,7 @@ class Manager
             return;
         }
 
-        $migrationFilenames = Files::readDirectoryRecursively($migrationsDirectory, '.php');
-        foreach ($migrationFilenames as $filenameAndPath) {
+        foreach (Files::getRecursiveDirectoryGenerator($migrationsDirectory, '.php') as $filenameAndPath) {
             /** @noinspection PhpIncludeInspection */
             require_once($filenameAndPath);
             $baseFilename = basename($filenameAndPath, '.php');


### PR DESCRIPTION


This implements ``Files::readDirectoryRecursively`` in a way
that is using a stack instead of recursive calls. This prevents
``too many files open errors`` as only one directory will be
opened at a time.

Additionally adds a new method ``getRecursiveDirectoryGenerator()``
if you don't need an array of files to manipulate but just want to
iterate the results. This reduces memory consumption.

Usage of ``readDirectoryRecursively`` was changed to
``getRecursiveDirectoryGenerator`` were possible.

Speed should also slightly improve in both cases.

Change-Id: I8b8928e7e5c7449c38d3cff4121fc682e1b4c5a9
Releases: master
