### PR TITLE
[BUGFIX] FlockLockStrategy should clean up lock files

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Lock/FlockLockStrategy.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Lock/FlockLockStrategy.php
@@ -99,6 +99,7 @@ class FlockLockStrategy implements LockStrategyInterface {
 				$success = FALSE;
 			}
 			fclose($this->filePointer);
+			Files::unlink($this->lockFileName);
 		}
 
 		return $success;


### PR DESCRIPTION
The FlockLockStrategy creates files to apply the lock on.
These files reside in the temporary folder but are never cleaned
on releasing the Lock that means the amount of files in this folder
will increase over time unless the folder is cleared manually.
