### PR TITLE
[TASK] Add composer manifest template

### DIFF
--- a/.composer.json
+++ b/.composer.json
@@ -1,0 +1,16 @@
+{
+  "name": "neos/flow-development-collection",
+  "description": "Flow packages in a joined repository for pull requests.",
+  "type": "neos-package-collection",
+  "require": {
+  },
+  "replace": {
+  },
+  "suggest": {
+  },
+  "autoload": {
+  },
+  "extra": {
+    "installer-name": "Framework"
+  }
+}


### PR DESCRIPTION
Adds the template composer.json used to autogenerate
the joined composer.json for this joined repository.

Releases: master, 3.0, 2.3