### PR TITLE
[TASK] Remove composer/installers requirement

### DIFF
--- a/TYPO3.Flow/composer.json
+++ b/TYPO3.Flow/composer.json
@@ -14,6 +14,8 @@
         "ext-mbstring": "*",
         "ext-reflection": "*",
 
+        "neos/composer-plugin": "~1.0.1",
+
         "typo3/fluid": "*",
         "typo3/eel": "*",
 
@@ -22,9 +24,7 @@
 
         "symfony/yaml": "2.5.*",
         "symfony/dom-crawler": "2.5.*",
-        "symfony/console": "2.*",
-
-        "composer/installers": "~1.0.2"
+        "symfony/console": "2.*"
     },
     "suggest": {
         "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",


### PR DESCRIPTION
Removes the leftover composer/installers requirement from
Flow and replaces it with the neos/composer-plugin.

Releases: master, 3.0, 2.3