### PR TITLE
[BUGFIX] Use correct log signature in AbstractViewHelper

### DIFF
--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/Core/ViewHelper/AbstractViewHelper.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/Core/ViewHelper/AbstractViewHelper.php
@@ -304,7 +304,7 @@ abstract class AbstractViewHelper {
 			if (!$this->objectManager->getContext()->isProduction()) {
 				throw $exception;
 			} else {
-				$this->systemLogger->log('An Exception was captured: ' . $exception->getMessage() . '(' . $exception->getCode() . ')', LOG_ERR, 'TYPO3.Fluid', get_class($this));
+				$this->systemLogger->log(sprintf('An Exception was captured: %s (%d)', $exception->getMessage(), $exception->getCode()), LOG_ERR, NULL, 'TYPO3.Fluid', get_class($this));
 				return '';
 			}
 		}


### PR DESCRIPTION


Within the ``AbstractViewHelper::callRenderMethod()`` method a log
entry will be created if an exception is thrown in production context.
But the method signature of the systemLogger
(``\TYPO3\Flow\Log\LoggerInterface``) looks slightly different to the
method call.

``LoggerInterface::log()`` defines that the third parameter is
``$additionalData`, but within ``AbstractViewHelper::callRenderMethod()``
this parameter is missing.

Change-Id: I8a54a3130988ee12712f77dee3f55e7a735dbb89
Fixes: #51239
Releases: master, 2.2, 2.1
