### PR TITLE
[BUGFIX] Class loader includes some files twice

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/ClassLoader.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/ClassLoader.php
@@ -218,7 +218,7 @@ class ClassLoader {
 			$pathConstructor = 'buildClassPathWith' . $possiblePathData['mappingType'];
 			$possibleFilePath = $this->$pathConstructor($namespaceParts, $possiblePathData['path'], $packageNamespacePartCount);
 			if (is_file($possibleFilePath)) {
-				$result = include($possibleFilePath);
+				$result = include_once($possibleFilePath);
 				if ($result !== FALSE) {
 					return TRUE;
 				}


### PR DESCRIPTION
For some reason, the FLOW class loader includes some files twice.
This especially occurs when a Composer dependency declares an autoload file that contains function definitions (one example for a package like that being `guzzlehttp/promises`).

This commit fixes this issue by replacing `include` with `include_once`.

Fixes: FLOW-362
Releases: master, 2.3, 3.0