### PR TITLE
[BUGFIX] SecurityContext does not inject SessionManagerInterface

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Context.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Context.php
@@ -121,7 +121,7 @@ class Context {
 
 	/**
 	 * @Flow\Inject
-	 * @var \TYPO3\Flow\Session\SessionManager
+	 * @var \TYPO3\Flow\Session\SessionManagerInterface
 	 */
 	protected $sessionManager;
 


### PR DESCRIPTION
In TYPO3/Flow/Security/Context class SessionManagerInterface should be injected
to follow the Objects configuration. This breaks projects where a custom
SessionManager is implemented and switched using Objects configuration.

However in the Unit test for security context SessionManagerInterface is mocked.

PS: This issue is already handled in Flow 3.0 so need a HotFix for 2.3

Fixes: FLOW-380
Releases: 2.3