### PR TITLE
[!!!][BUGFIX] Store site lock in Flow temporary base path

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Cache/Backend/SimpleFileBackend.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Cache/Backend/SimpleFileBackend.php
@@ -129,7 +129,7 @@ class SimpleFileBackend extends AbstractBackend implements PhpCapableBackendInte
 		$this->cacheEntryFileExtension = ($cache instanceof PhpFrontend) ? '.php' : '';
 
 		if ((strlen($this->cacheDirectory) + 23) > $this->environment->getMaximumPathLength()) {
-			throw new \TYPO3\Flow\Cache\Exception('The length of the temporary cache path "' . $this->cacheDirectory . '" exceeds the maximum path length of ' . ($this->environment->getMaximumPathLength() - 23) . '. Please consider setting the temporaryDirectoryBase option to a shorter path. ', 1248710426);
+			throw new \TYPO3\Flow\Cache\Exception('The length of the temporary cache path "' . $this->cacheDirectory . '" exceeds the maximum path length of ' . ($this->environment->getMaximumPathLength() - 23) . '. Please consider setting the FLOW_PATH_TEMPORARY_BASE environment variable to a shorter path. ', 1248710426);
 		}
 	}
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/CoreCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/CoreCommandController.php
@@ -347,7 +347,7 @@ class CoreCommandController extends CommandController {
 	 * @throws \RuntimeException
 	 */
 	protected function launchSubProcess() {
-		$systemCommand = 'FLOW_ROOTPATH=' . FLOW_PATH_ROOT . ' FLOW_CONTEXT=' . $this->bootstrap->getContext() . ' ' . PHP_BINDIR . '/php -c ' . php_ini_loaded_file() . ' ' . FLOW_PATH_FLOW . 'Scripts/flow.php --start-slave';
+		$systemCommand = 'FLOW_ROOTPATH=' . FLOW_PATH_ROOT . ' FLOW_PATH_TEMPORARY=' . FLOW_PATH_TEMPORARY . ' FLOW_CONTEXT=' . $this->bootstrap->getContext() . ' ' . PHP_BINDIR . '/php -c ' . php_ini_loaded_file() . ' ' . FLOW_PATH_FLOW . 'Scripts/flow.php --start-slave';
 		$descriptorSpecification = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'a'));
 		$subProcess = proc_open($systemCommand, $descriptorSpecification, $pipes);
 		if (!is_resource($subProcess)) {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
@@ -154,7 +154,6 @@ class Scripts {
 		$settings = $configurationManager->getConfiguration(\TYPO3\Flow\Configuration\ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow');
 
 		$environment = new \TYPO3\Flow\Utility\Environment($context);
-		$environment->setTemporaryDirectoryBase($settings['utility']['environment']['temporaryDirectoryBase']);
 
 		$configurationManager->injectEnvironment($environment);
 		$packageManager->injectSettings($settings);
@@ -573,6 +572,7 @@ class Scripts {
 	public static function buildPhpCommand(array $settings) {
 		$subRequestEnvironmentVariables = array(
 			'FLOW_ROOTPATH' => FLOW_PATH_ROOT,
+			'FLOW_PATH_TEMPORARY' => FLOW_PATH_TEMPORARY,
 			'FLOW_CONTEXT' => $settings['core']['context']
 		);
 		if (isset($settings['core']['subRequestEnvironmentVariables'])) {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/ClassLoader.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/ClassLoader.php
@@ -440,7 +440,7 @@ class ClassLoader {
 	 * @return void
 	 */
 	public function initializeAvailableProxyClasses(ApplicationContext $context) {
-		$proxyClasses = @include(FLOW_PATH_DATA . 'Temporary/' . (string)$context . '/AvailableProxyClasses.php');
+		$proxyClasses = @include(FLOW_PATH_TEMPORARY . '/AvailableProxyClasses.php');
 		if ($proxyClasses !== FALSE) {
 			$this->availableProxyClasses = $proxyClasses;
 		}

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/LockManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/LockManager.php
@@ -62,7 +62,7 @@ class LockManager {
 	 * @return string
 	 */
 	protected function getLockPath() {
-		return rtrim(sys_get_temp_dir(), '/') . '/';
+		return FLOW_PATH_TEMPORARY;
 	}
 
 	/**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Environment.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Environment.php
@@ -33,17 +33,6 @@ class Environment {
 	protected $request;
 
 	/**
-	 * The base path of $temporaryDirectory. This property can (and should) be set from outside.
-	 * @var string
-	 */
-	protected $temporaryDirectoryBase;
-
-	/**
-	 * @var string
-	 */
-	protected $temporaryDirectory = NULL;
-
-	/**
 	 * Initializes the environment instance.
 	 *
 	 * @param \TYPO3\Flow\Core\ApplicationContext $context The Flow context
@@ -57,10 +46,11 @@ class Environment {
 	 *
 	 * @param string $temporaryDirectoryBase Base path of the temporary directory, with trailing slash
 	 * @return void
+	 * @throws Exception
+	 * @deprecated since 3.1 - Set the environment variable FLOW_PATH_TEMPORARY_BASE to change the temporary directory base, see Bootstrap::defineConstants()
 	 */
 	public function setTemporaryDirectoryBase($temporaryDirectoryBase) {
-		$this->temporaryDirectoryBase = $temporaryDirectoryBase;
-		$this->temporaryDirectory = NULL;
+		throw new Exception('Changing the temporary directory path during runtime is no longer supported. Set the environment variable FLOW_PATH_TEMPORARY_BASE to change the temporary directory base', 1441355116);
 	}
 
 	/**
@@ -70,13 +60,7 @@ class Environment {
 	 * @api
 	 */
 	public function getPathToTemporaryDirectory() {
-		if ($this->temporaryDirectory !== NULL) {
-			return $this->temporaryDirectory;
-		}
-
-		$this->temporaryDirectory = $this->createTemporaryDirectory($this->temporaryDirectoryBase);
-
-		return $this->temporaryDirectory;
+		return FLOW_PATH_TEMPORARY;
 	}
 
 	/**
@@ -96,40 +80,6 @@ class Environment {
 	public function isRewriteEnabled() {
 		return (boolean)Bootstrap::getEnvironmentConfigurationSetting('FLOW_REWRITEURLS');
 
-	}
-
-	/**
-	 * Creates Flow's temporary directory - or at least asserts that it exists and is
-	 * writable.
-	 *
-	 * For each Flow Application Context, we create an extra temporary folder,
-	 * and for nested contexts, the folders are prefixed with "SubContext" to
-	 * avoid ambiguity, and look like: Data/Temporary/Production/SubContextLive
-	 *
-	 * @param string $temporaryDirectoryBase Full path to the base for the temporary directory
-	 * @return string The full path to the temporary directory
-	 * @throws \TYPO3\Flow\Utility\Exception if the temporary directory could not be created or is not writable
-	 */
-	protected function createTemporaryDirectory($temporaryDirectoryBase) {
-		$temporaryDirectoryBase = \TYPO3\Flow\Utility\Files::getUnixStylePath($temporaryDirectoryBase);
-		if (substr($temporaryDirectoryBase, -1, 1) !== '/') {
-			$temporaryDirectoryBase .= '/';
-		}
-		$temporaryDirectory = $temporaryDirectoryBase . str_replace('/', '/SubContext', (string)$this->context) . '/';
-
-		if (!is_dir($temporaryDirectory) && !is_link($temporaryDirectory)) {
-			try {
-				\TYPO3\Flow\Utility\Files::createDirectoryRecursively($temporaryDirectory);
-			} catch (\TYPO3\Flow\Error\Exception $exception) {
-				throw new \TYPO3\Flow\Utility\Exception('The temporary directory "' . $temporaryDirectory . '" could not be created. Please make sure permissions are correct for this path or define another temporary directory in your Settings.yaml with the path "TYPO3.Flow.utility.environment.temporaryDirectoryBase".', 1335382361);
-			}
-		}
-
-		if (!is_writable($temporaryDirectory)) {
-			throw new \TYPO3\Flow\Utility\Exception('The temporary directory "' . $temporaryDirectory . '" is not writable. Please make this directory writable or define another temporary directory in your Settings.yaml with the path "TYPO3.Flow.utility.environment.temporaryDirectoryBase".', 1216287176);
-		}
-
-		return $temporaryDirectory;
 	}
 
 	/**

--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -555,14 +555,6 @@ TYPO3:
         domain: NULL
 
     utility:
-      environment:
-
-        # Defines the base directory which Flow may use for storing different kinds
-        # of temporary files.
-        # The directory must be writable and Flow will automatically create a sub
-        # directory (named after the context) which will contain the actual temporary files.
-        temporaryDirectoryBase: '%FLOW_PATH_DATA%Temporary/'
-
       lockStrategyClassName: 'TYPO3\Flow\Utility\Lock\FlockLockStrategy'
 
   # DocTools is a tool used by Flow Developers to help with a variety of documentation tasks.

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/Configuration.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/Configuration.rst
@@ -95,15 +95,16 @@ in the `Reference Manual <http://flowframework.readthedocs.org/en/stable/>`_.
 
 	To avoid errors you should change the cache configuration so it points to a
 	location with a very short absolute file path, for example ``C:\\tmp\\``.
-	Do that by adding the following to the file ``Configuration/Settings.yaml``:
+	Do that by setting the ``FLOW_PATH_TEMPORARY_BASE`` environment variable -
+	For example in the virtual host part of your Apache configuration:
 
-	*Configuration/Settings.yaml*:
+	*httpd.conf*:
 
-	.. code-block:: yaml
+	.. code-block:: none
 
-		utility:
-		  environment:
-		    temporaryDirectoryBase: 'C\\:tmp\\'
+		<VirtualHost ...>
+			SetEnv FLOW_PATH_TEMPORARY_BASE "C\\:tmp\\"
+		</VirtualHost>
 
 .. important::
 	Parsing the YAML configuration files takes a bit of time which remarkably

--- a/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.utility.schema.yaml
+++ b/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.utility.schema.yaml
@@ -1,12 +1,6 @@
 type: dictionary
 additionalProperties: FALSE
 properties:
-  'environment':
-    type: dictionary
-    required: TRUE
-    additionalProperties: FALSE
-    properties:
-      'temporaryDirectoryBase': { type: string, required: TRUE }
   'lockStrategyClassName':
     type: string
     required: TRUE

--- a/TYPO3.Flow/Tests/Behavior/Features/Bootstrap/SubProcess/SubProcess.php
+++ b/TYPO3.Flow/Tests/Behavior/Features/Bootstrap/SubProcess/SubProcess.php
@@ -81,7 +81,7 @@ class SubProcess {
 	 * @throws \RuntimeException
 	 */
 	protected function launchSubProcess() {
-		$systemCommand = 'FLOW_ROOTPATH=' . escapeshellarg(FLOW_PATH_ROOT) . ' FLOW_CONTEXT=' . (string)$this->context . ' ' . PHP_BINDIR . '/php -c ' . escapeshellarg(php_ini_loaded_file()) . ' ' . escapeshellarg(FLOW_PATH_FLOW . 'Scripts/flow.php') . ' --start-slave';
+		$systemCommand = 'FLOW_ROOTPATH=' . escapeshellarg(FLOW_PATH_ROOT) . ' FLOW_PATH_TEMPORARY=' . escapeshellarg(FLOW_PATH_TEMPORARY) . ' ' . ' FLOW_CONTEXT=' . (string)$this->context . ' ' . PHP_BINDIR . '/php -c ' . escapeshellarg(php_ini_loaded_file()) . ' ' . escapeshellarg(FLOW_PATH_FLOW . 'Scripts/flow.php') . ' --start-slave';
 		$descriptorSpecification = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'a'));
 		$this->subProcess = proc_open($systemCommand, $descriptorSpecification, $this->pipes);
 		if (!is_resource($this->subProcess)) {

--- a/TYPO3.Flow/Tests/Behavior/Features/Bootstrap/SubProcess/SubProcess.php
+++ b/TYPO3.Flow/Tests/Behavior/Features/Bootstrap/SubProcess/SubProcess.php
@@ -81,7 +81,7 @@ class SubProcess {
 	 * @throws \RuntimeException
 	 */
 	protected function launchSubProcess() {
-		$systemCommand = 'FLOW_ROOTPATH=' . escapeshellarg(FLOW_PATH_ROOT) . ' FLOW_PATH_TEMPORARY=' . escapeshellarg(FLOW_PATH_TEMPORARY) . ' ' . ' FLOW_CONTEXT=' . (string)$this->context . ' ' . PHP_BINDIR . '/php -c ' . escapeshellarg(php_ini_loaded_file()) . ' ' . escapeshellarg(FLOW_PATH_FLOW . 'Scripts/flow.php') . ' --start-slave';
+		$systemCommand = 'FLOW_ROOTPATH=' . escapeshellarg(FLOW_PATH_ROOT) . ' FLOW_PATH_TEMPORARY=' . escapeshellarg(FLOW_PATH_TEMPORARY) . ' FLOW_CONTEXT=' . (string)$this->context . ' ' . PHP_BINDIR . '/php -c ' . escapeshellarg(php_ini_loaded_file()) . ' ' . escapeshellarg(FLOW_PATH_FLOW . 'Scripts/flow.php') . ' --start-slave';
 		$descriptorSpecification = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'a'));
 		$this->subProcess = proc_open($systemCommand, $descriptorSpecification, $this->pipes);
 		if (!is_resource($this->subProcess)) {

--- a/TYPO3.Flow/Tests/Unit/Utility/EnvironmentTest.php
+++ b/TYPO3.Flow/Tests/Unit/Utility/EnvironmentTest.php
@@ -21,27 +21,6 @@ class EnvironmentTest extends \TYPO3\Flow\Tests\UnitTestCase {
 	/**
 	 * @test
 	 */
-	public function getPathToTemporaryDirectoryReturnsPathWithTrailingSlash() {
-		$environment = new \TYPO3\Flow\Utility\Environment(new ApplicationContext('Testing'));
-		$environment->setTemporaryDirectoryBase(\TYPO3\Flow\Utility\Files::concatenatePaths(array(sys_get_temp_dir(), 'FlowEnvironmentTest')));
-		$path = $environment->getPathToTemporaryDirectory();
-		$this->assertEquals('/', substr($path, -1, 1), 'The temporary path did not end with slash.');
-	}
-
-	/**
-	 * @test
-	 */
-	public function getPathToTemporaryDirectoryReturnsAnExistingPath() {
-		$environment = new \TYPO3\Flow\Utility\Environment(new ApplicationContext('Testing'));
-		$environment->setTemporaryDirectoryBase(\TYPO3\Flow\Utility\Files::concatenatePaths(array(sys_get_temp_dir(), 'FlowEnvironmentTest')));
-
-		$path = $environment->getPathToTemporaryDirectory();
-		$this->assertTrue(file_exists($path), 'The temporary path does not exist.');
-	}
-
-	/**
-	 * @test
-	 */
 	public function getMaximumPathLengthReturnsCorrectValue() {
 		$environment = new \TYPO3\Flow\Utility\Environment(new ApplicationContext('Testing'));
 		$expectedValue = PHP_MAXPATHLEN;


### PR DESCRIPTION
Storing the site lock files in the system temporary directory
could lead to endless locks on some file systems.
This changes the site locks to be stored in the Flow temporary base
path again.

This is a breaking change because it removes the setting
``TYPO3.Flow.utility.environment.temporaryDirectoryBase`` in favor of
a new environment variable ``FLOW_PATH_TEMPORARY_BASE`` that allows for
changing the path if needed.

Background:

FLOW-348 introduced a new locking mechanism that stored lock files
in the systems default temporary folder determined via
``sys_get_temp_dir()``. On some systems files created there by the
PHP process could not be removed afterwards.

Related: FLOW-348
Fixes: FLOW-381
Releases: master, 3.0, 2.3