### PR TITLE
[BUGFIX] Fix lookup path for ``AvailableProxyClasses.php``

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/ClassLoader.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/ClassLoader.php
@@ -440,7 +440,9 @@ class ClassLoader {
 	 * @return void
 	 */
 	public function initializeAvailableProxyClasses(ApplicationContext $context) {
-		$proxyClasses = @include(FLOW_PATH_DATA . 'Temporary/' . (string)$context . '/AvailableProxyClasses.php');
+		// see Environment::createTemporaryDirectory()
+		$temporaryDirectory = FLOW_PATH_DATA . 'Temporary/' . str_replace('/', '/SubContext', (string)$context) . '/';
+		$proxyClasses = @include($temporaryDirectory . '/AvailableProxyClasses.php');
 		if ($proxyClasses !== FALSE) {
 			$this->availableProxyClasses = $proxyClasses;
 		}


### PR DESCRIPTION
Since 2787b2a3216deb188c4cd1c9b2b823e6e3a10da3 Flow creates a
map for available proxy classes stored in ````AvailableProxyClasses.php``
within the temporary directory.

The ``ClassLoader`` failed to include that file though when run in
a nested Application Context. That is fixed with this change.

Releases: master, 3.0, 2.3, 2.2