### PR TITLE
[BUGFIX] Remove neos composer plugin from reflection

### DIFF
--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -195,14 +195,14 @@ TYPO3:
         'phpunit.*': ['.*']
         'mikey179.vfsStream': ['.*']
         # workaround, should rather be deactivated
-        'Composer.Installers': ['.*']
+        'Neos.ComposerPlugin': ['.*']
 
     package:
 
       # This can be used to make packages inactive, even though they would be
       # activated automatically otherwise.
       inactiveByDefault:
-        - 'Composer.Installers'
+        - 'Neos.ComposerPlugin'
       # Option for the PackageManager::Create to map the packagesPath by package type
       packagesPathByType:
         'typo3-flow-package': 'Application'


### PR DESCRIPTION
As Flow 2.3 still uses a blacklist approach for reflection and proxybuilding the neos composer plugin needs to be excluded instead of the composer installers package.