### PR TITLE
[TASK] Improve exception output for subprocesses failing with fatal error

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
@@ -542,6 +542,8 @@ class Scripts
     {
         $command = self::buildSubprocessCommand($commandIdentifier, $settings, $commandArguments);
         $output = array();
+        // Output errors in response
+        $command .= ' 2>&1';
         exec($command, $output, $result);
         if ($result !== 0) {
             if (count($output) > 0) {


### PR DESCRIPTION
Improves the exception output in development context when a command executed
in a subprocess fails with fatal error. Previously the actual error could only
be found by looking in the system log or in some cases by running a CLI command.

Resolves: FLOW-382