### PR TITLE
[TASK] Compile list of properties information into proxy classes

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Object/DependencyInjection/ProxyClassBuilder.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Object/DependencyInjection/ProxyClassBuilder.php
@@ -243,15 +243,23 @@ class ProxyClassBuilder
         $className = $objectConfiguration->getClassName();
         $code = '';
         if ($this->reflectionService->hasMethod($className, '__sleep') === false) {
+            $transientProperties = $this->reflectionService->getPropertyNamesByAnnotation($className, 'TYPO3\Flow\Annotations\Transient');
+            $propertyVarTags = [];
+            foreach ($this->reflectionService->getPropertyNamesByTag($className, 'var') as $propertyName) {
+                $varTagValues = $this->reflectionService->getPropertyTagValues($className, $propertyName, 'var');
+                $propertyVarTags[$propertyName] = isset($varTagValues[0]) ? $varTagValues[0] : null;
+            }
             $code = "\t\t\$this->Flow_Object_PropertiesToSerialize = array();
-	\$reflectionService = \\TYPO3\\Flow\\Core\\Bootstrap::\$staticObjectManager->get(\\TYPO3\\Flow\\Reflection\\ReflectionService::class);
+
+	\$transientProperties = " . var_export($transientProperties, true) . ";
+	\$propertyVarTags = " . var_export($propertyVarTags, true) . ";
 	\$reflectedClass = new \\ReflectionClass('" . $className . "');
 	\$allReflectedProperties = \$reflectedClass->getProperties();
 	foreach (\$allReflectedProperties as \$reflectionProperty) {
 		\$propertyName = \$reflectionProperty->name;
 		if (in_array(\$propertyName, array('Flow_Aop_Proxy_targetMethodsAndGroupedAdvices', 'Flow_Aop_Proxy_groupedAdviceChains', 'Flow_Aop_Proxy_methodIsInAdviceMode'))) continue;
 		if (isset(\$this->Flow_Injected_Properties) && is_array(\$this->Flow_Injected_Properties) && in_array(\$propertyName, \$this->Flow_Injected_Properties)) continue;
-		if (\$reflectionProperty->isStatic() || \$reflectionService->isPropertyAnnotatedWith('" . $className . "', \$propertyName, \\TYPO3\\Flow\\Annotations\\Transient::class)) continue;
+		if (\$reflectionProperty->isStatic() || in_array(\$propertyName, \$transientProperties)) continue;
 		if (is_array(\$this->\$propertyName) || (is_object(\$this->\$propertyName) && (\$this->\$propertyName instanceof \\ArrayObject || \$this->\$propertyName instanceof \\SplObjectStorage ||\$this->\$propertyName instanceof \\Doctrine\\Common\\Collections\\Collection))) {
 			if (count(\$this->\$propertyName) > 0) {
 				foreach (\$this->\$propertyName as \$key => \$value) {
@@ -263,9 +271,8 @@ class ProxyClassBuilder
 			if (\$this->\$propertyName instanceof \\Doctrine\\ORM\\Proxy\\Proxy) {
 				\$className = get_parent_class(\$this->\$propertyName);
 			} else {
-				\$varTagValues = \$reflectionService->getPropertyTagValues('" . $className . "', \$propertyName, 'var');
-				if (count(\$varTagValues) > 0) {
-					\$className = trim(\$varTagValues[0], '\\\\');
+				if (isset(\$propertyVarTags[\$propertyName])) {
+					\$className = trim(\$propertyVarTags[\$propertyName], '\\\\');
 				}
 				if (\\TYPO3\\Flow\\Core\\Bootstrap::\$staticObjectManager->isRegistered(\$className) === FALSE) {
 					\$className = \\TYPO3\\Flow\\Core\\Bootstrap::\$staticObjectManager->getObjectNameByClassName(get_class(\$this->\$propertyName));


### PR DESCRIPTION
Reduce usage of ``ReflectionService`` during Runtime by compiling a list
of transient properties and variable type declarations into proxy classes
to be used during serialisation of objects.

Relates: NEOS-1294