### PR TITLE
[TASK] Lazily initialize ResourceManager

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
@@ -517,15 +517,14 @@ class Scripts
     }
 
     /**
-     * Initialize the resource management component, setting up stream wrappers,
-     * publishing the public resources of all found packages, ...
+     * Initialize the stream wrappers.
      *
      * @param Bootstrap $bootstrap
      * @return void
      */
     public static function initializeResources(Bootstrap $bootstrap)
     {
-        $bootstrap->getObjectManager()->get(ResourceManager::class)->initializeStreamWrapper();
+        StreamWrapperAdapter::initializeStreamWrapper($bootstrap->getObjectManager());
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
@@ -17,6 +17,8 @@ use TYPO3\Flow\Monitor\FileMonitor;
 use TYPO3\Flow\Package\Package;
 use TYPO3\Flow\Package\PackageInterface;
 use TYPO3\Flow\Package\PackageManagerInterface;
+use TYPO3\Flow\Resource\ResourceManager;
+use TYPO3\Flow\Resource\Streams\StreamWrapperAdapter;
 
 /**
  * Initialization scripts for modules of the Flow package
@@ -523,8 +525,7 @@ class Scripts
      */
     public static function initializeResources(Bootstrap $bootstrap)
     {
-        $resourceManager = $bootstrap->getObjectManager()->get(\TYPO3\Flow\Resource\ResourceManager::class);
-        $resourceManager->initialize();
+        $bootstrap->getObjectManager()->get(ResourceManager::class)->initializeStreamWrapper();
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/ResourceManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/ResourceManager.php
@@ -555,24 +555,6 @@ class ResourceManager
     }
 
     /**
-     * Registers a Stream Wrapper Adapter for the resource:// scheme.
-     *
-     * @return void
-     */
-    public function initializeStreamWrapper()
-    {
-        $streamWrapperClassNames = static::getStreamWrapperImplementationClassNames($this->objectManager);
-        foreach ($streamWrapperClassNames as $streamWrapperClassName) {
-            $scheme = $streamWrapperClassName::getScheme();
-            if (in_array($scheme, stream_get_wrappers())) {
-                stream_wrapper_unregister($scheme);
-            }
-            stream_wrapper_register($scheme, \TYPO3\Flow\Resource\Streams\StreamWrapperAdapter::class);
-            StreamWrapperAdapter::registerStreamWrapper($scheme, $streamWrapperClassName);
-        }
-    }
-
-    /**
      * Prepare an uploaded file to be imported as resource object. Will check the validity of the file,
      * move it outside of upload folder if open_basedir is enabled and check the filename.
      *
@@ -607,18 +589,6 @@ class ResourceManager
             'filepath' => $temporaryTargetPathAndFilename,
             'filename' => $pathInfo['basename']
         );
-    }
-
-    /**
-     * Returns all class names implementing the StreamWrapperInterface.
-     *
-     * @param ObjectManagerInterface $objectManager
-     * @return array Array of stream wrapper implementations
-     * @Flow\CompileStatic
-     */
-    protected static function getStreamWrapperImplementationClassNames($objectManager)
-    {
-        return $objectManager->get(\TYPO3\Flow\Reflection\ReflectionService::class)->getAllImplementationClassNamesForInterface(\TYPO3\Flow\Resource\Streams\StreamWrapperInterface::class);
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Streams/ResourceStreamWrapper.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Streams/ResourceStreamWrapper.php
@@ -48,7 +48,7 @@ class ResourceStreamWrapper implements StreamWrapperInterface
     protected $packageManager;
 
     /**
-     * @Flow\Inject(lazy = FALSE)
+     * @Flow\Inject
      * @var \TYPO3\Flow\Resource\ResourceManager
      */
     protected $resourceManager;

--- a/TYPO3.Flow/Tests/FunctionalTestCase.php
+++ b/TYPO3.Flow/Tests/FunctionalTestCase.php
@@ -136,8 +136,7 @@ abstract class FunctionalTestCase extends \TYPO3\Flow\Tests\BaseTestCase
         $this->objectManager = self::$bootstrap->getObjectManager();
 
         $this->cleanupPersistentResourcesDirectory();
-        self::$bootstrap->getObjectManager()->get(\TYPO3\Flow\Resource\ResourceManager::class)->initialize();
-
+        self::$bootstrap->getObjectManager()->forgetInstance(\TYPO3\Flow\Resource\ResourceManager::class);
         $session = $this->objectManager->get(\TYPO3\Flow\Session\SessionInterface::class);
         if ($session->isStarted()) {
             $session->destroy(sprintf('assure that session is fresh, in setUp() method of functional test %s.', get_class($this) . '::' . $this->getName()));


### PR DESCRIPTION
The ``ResourceManager`` creates a bunch of objects and iterates over
the whole resource configuration on initialization. In some cases this
initialisation might not even be necessary so with this change we defer
it until the information is really needed.