### PR TITLE
[TASK] Add Readme.rst files for individual packages

### DIFF
--- a/TYPO3.Eel/Readme.rst
+++ b/TYPO3.Eel/Readme.rst
@@ -1,0 +1,20 @@
+----------------------------
+Embedded Expression Language
+----------------------------
+
+.. note:: This repository is a **read-only subsplit** of a package that is part of the
+          Flow framework (learn more on `flow.typo3.org <http://flow.typo3.org/>`_).
+
+The Embedded Expression Language (Eel) is a building block for creating Domain
+Specific Languages. Documentation is `available as part of the Neos documentation
+<http://neos.readthedocs.org/en/stable/CreatingASite/TypoScript/EelFlowQuery.html>`_.
+
+If you want to use the Flow framework, please have a look at the `Flow documentation
+<http://flowframework.readthedocs.org/en/stable/>`_
+
+Contribute
+----------
+
+If you want to contribute to the Flow framework, please have a look at
+https://github.com/neos/flow-development-collection - it is the repository
+used for development and all pull requests should go into it.

--- a/TYPO3.Flow/Readme.rst
+++ b/TYPO3.Flow/Readme.rst
@@ -1,0 +1,16 @@
+--------------
+Flow Framework
+--------------
+
+.. note:: This repository is a **read-only subsplit** of a package that is part of the
+          Flow framework (learn more on `flow.typo3.org <http://flow.typo3.org/>`_).
+
+If you want to use the Flow framework, please have a look at the `Flow documentation
+<http://flowframework.readthedocs.org/en/stable/>`_
+
+Contribute
+----------
+
+If you want to contribute to the Flow framework, please have a look at
+https://github.com/neos/flow-development-collection - it is the repository
+used for development and all pull requests should go into it.

--- a/TYPO3.Fluid/Readme.rst
+++ b/TYPO3.Fluid/Readme.rst
@@ -1,0 +1,18 @@
+--------------------------
+Fluid Templating Framework
+--------------------------
+
+.. note:: This repository is a **read-only subsplit** of a package that is part of the
+          Flow framework (learn more on `flow.typo3.org <http://flow.typo3.org/>`_).
+
+Fluid is a next-generation templating framework for Neos and Flow.
+
+If you want to use the Flow framework, please have a look at the `Flow documentation
+<http://flowframework.readthedocs.org/en/stable/>`_
+
+Contribute
+----------
+
+If you want to contribute to the Flow framework, please have a look at
+https://github.com/neos/flow-development-collection - it is the repository
+used for development and all pull requests should go into it.

--- a/TYPO3.Kickstart/Readme.rst
+++ b/TYPO3.Kickstart/Readme.rst
@@ -1,0 +1,18 @@
+----------------
+Flow Kickstarter
+----------------
+
+.. note:: This repository is a **read-only subsplit** of a package that is part of the
+          Flow framework (learn more on `flow.typo3.org <http://flow.typo3.org/>`_).
+
+The Kickstarter is a simple generator for Flow packages, controllers, views and more.
+
+If you want to use the Flow framework, please have a look at the `Flow documentation
+<http://flowframework.readthedocs.org/en/stable/>`_
+
+Contribute
+----------
+
+If you want to contribute to the Flow framework, please have a look at
+https://github.com/neos/flow-development-collection - it is the repository
+used for development and all pull requests should go into it.


### PR DESCRIPTION
This adds a Readme.rst to each package, so that the read-only subplit
repositories have a readme file for GitHub to show and for the users
to read.