### PR TITLE
FEATURE: .env file can configure application environment variables

### DIFF
--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/Installation.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/Installation.rst
@@ -217,6 +217,15 @@ machine. Add the following line to your */etc/hosts* file
 	# You can specify a default context by activating this option:
 	SetEnv FLOW_CONTEXT Production
 
+Or if you are not using Apache as webserver, you can simply add a ``.env`` file
+to the root directory of your Flow application with the following content:
+
+*.env*:
+
+.. code-block:: none
+
+	FLOW_CONTEXT=Production
+
 Welcome to Flow
 ---------------
 

--- a/TYPO3.Flow/Resources/Private/Installer/Distribution/Defaults/.gitignore
+++ b/TYPO3.Flow/Resources/Private/Installer/Distribution/Defaults/.gitignore
@@ -8,3 +8,4 @@
 /Upgrading.rst
 /flow
 /flow.bat
+/.env

--- a/TYPO3.Flow/Resources/Private/Installer/Distribution/Defaults/Web/index.php
+++ b/TYPO3.Flow/Resources/Private/Installer/Distribution/Defaults/Web/index.php
@@ -20,6 +20,14 @@ if ($rootPath === false) {
     $rootPath .= '/';
 }
 
+if (file_exists($rootPath . '.env')) {
+    require($rootPath . 'Packages/Libraries/vlucas/phpdotenv/src/Dotenv.php');
+    require($rootPath . 'Packages/Libraries/vlucas/phpdotenv/src/Loader.php');
+    require($rootPath . 'Packages/Libraries/vlucas/phpdotenv/src/Validator.php');
+    $dotenv = new \Dotenv\Dotenv($rootPath);
+    $dotenv->overload();
+}
+
 require($rootPath . 'Packages/Framework/TYPO3.Flow/Classes/TYPO3/Flow/Core/Bootstrap.php');
 
 $context = \TYPO3\Flow\Core\Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT') ?: 'Development';

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "symfony/yaml": "2.5.*",
         "symfony/dom-crawler": "2.5.*",
         "symfony/console": "2.*",
-        "neos/composer-plugin": "^1.0.1"
+        "neos/composer-plugin": "^1.0.1",
+        "vlucas/phpdotenv": "^2.0"
     },
     "replace": {
         "typo3/eel": "self.version",


### PR DESCRIPTION
You can put a .env file (INI-format) into the root directory of your
Flow application to configure global variables like FLOW_CONTEXT.

FLOW-389 #close
