### PR TITLE
[BUGFIX] Fix a syntax error caused by a broken file header

### DIFF
--- a/TYPO3.Flow/Tests/Unit/I18n/LocaleCollectionTest.php
+++ b/TYPO3.Flow/Tests/Unit/I18n/LocaleCollectionTest.php
@@ -7,7 +7,6 @@ namespace TYPO3\Flow\Tests\Unit\I18n;
  * It is free software; you can redistribute it and/or modify it under    *
  * the terms of the MIT license.                                          *
  *                                                                        */
- */
 
 /**
  * Testcase for the LocaleCollection class


### PR DESCRIPTION
The MIT change had introduced a stray block comment end marker.