### PR TITLE
[TASK] Refactor the resource management to use PHP Generator

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Collection.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Collection.php
@@ -150,17 +150,18 @@ class Collection implements CollectionInterface
     /**
      * Returns all internal data objects of the storage attached to this collection.
      *
-     * @return array<\TYPO3\Flow\Resource\Storage\Object>
+     * @param callable $callback Function called after each object
+     * @return \Generator<\TYPO3\Flow\Resource\Storage\Object>
      */
-    public function getObjects()
+    public function getObjects(callable $callback = null)
     {
-        $objects = array();
+        $objects = [];
         if ($this->storage instanceof PackageStorage && $this->pathPatterns !== array()) {
             foreach ($this->pathPatterns as $pathPattern) {
-                $objects = array_merge($objects, $this->storage->getObjectsByPathPattern($pathPattern));
+                $objects = array_merge($objects, $this->storage->getObjectsByPathPattern($pathPattern, $callback));
             }
         } else {
-            $objects = $this->storage->getObjectsByCollection($this);
+            $objects = $this->storage->getObjectsByCollection($this, $callback);
         }
 
 #		TODO: Implement filter manipulation here:

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/CollectionInterface.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/CollectionInterface.php
@@ -79,10 +79,9 @@ interface CollectionInterface
     /**
      * Returns all internal data objects of the storage attached to this collection.
      *
-     * @return array<\TYPO3\Flow\Resource\Storage\Object>
+     * @return \Generator<\TYPO3\Flow\Resource\Storage\Object>
      */
     public function getObjects();
-
 
     /**
      * Returns a stream handle of the given persistent resource which allows for opening / copying the resource's

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/ResourceRepository.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/ResourceRepository.php
@@ -11,7 +11,11 @@ namespace TYPO3\Flow\Resource;
  * The TYPO3 project - inspiring people to share!                         *
  *                                                                        */
 
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\Internal\Hydration\IterableResult;
+use Doctrine\ORM\QueryBuilder;
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Flow\Persistence\QueryResultInterface;
 use TYPO3\Flow\Persistence\Repository;
 
@@ -29,7 +33,19 @@ class ResourceRepository extends Repository
     /**
      * @var string
      */
-    const ENTITY_CLASSNAME = 'TYPO3\Flow\Resource\Resource';
+    const ENTITY_CLASSNAME = Resource::class;
+
+    /**
+     * @Flow\Inject
+     * @var ObjectManager
+     */
+    protected $entityManager;
+
+    /**
+     * @Flow\Inject
+     * @var PersistenceManagerInterface
+     */
+    protected $persistenceManager;
 
     /**
      * @var \SplObjectStorage
@@ -103,6 +119,62 @@ class ResourceRepository extends Repository
         }
 
         return $object;
+    }
+
+    /**
+     * Iterator over an IterableResult and return a Generator
+     *
+     * This methos is useful for batch processing huge result set as it clear the object
+     * manager and detach the current object on each iteration.
+     *
+     * @param IterableResult $iterator
+     * @param callable $callback
+     * @return \Generator
+     */
+    public function iterate(IterableResult $iterator, callable $callback = null)
+    {
+        $iteration = 0;
+        foreach ($iterator as $object) {
+            $object = current($object);
+            yield $object;
+            if ($callback !== null) {
+                call_user_func($callback, $iteration, $object);
+            }
+            ++$iteration;
+        }
+    }
+
+    /**
+     * Finds all objects and return an IterableResult
+     *
+     * @return IterableResult
+     */
+    public function findAllIterator()
+    {
+        /** @var QueryBuilder $queryBuilder */
+        $queryBuilder = $this->entityManager->createQueryBuilder();
+        return $queryBuilder
+            ->select('Resource')
+            ->from($this->getEntityClassName(), 'Resource')
+            ->getQuery()->iterate();
+    }
+
+    /**
+     * Finds all objects by collection name and return an IterableResult
+     *
+     * @param string $collectionName
+     * @return IterableResult
+     */
+    public function findByCollectionNameIterator($collectionName)
+    {
+        /** @var QueryBuilder $queryBuilder */
+        $queryBuilder = $this->entityManager->createQueryBuilder();
+        return $queryBuilder
+            ->select('Resource')
+            ->from($this->getEntityClassName(), 'Resource')
+            ->where('Resource.collectionName = :collectionName')
+            ->setParameter(':collectionName', $collectionName)
+            ->getQuery()->iterate();
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Storage/FileSystemStorage.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Storage/FileSystemStorage.php
@@ -128,38 +128,43 @@ class FileSystemStorage implements StorageInterface
     /**
      * Retrieve all Objects stored in this storage.
      *
-     * @return array<\TYPO3\Flow\Resource\Storage\Object>
+     * @param callable $callback Function called after each iteration
+     * @return \Generator<\TYPO3\Flow\Resource\Storage\Object>
      */
-    public function getObjects()
+    public function getObjects(callable $callback = null)
     {
-        $objects = array();
         foreach ($this->resourceManager->getCollectionsByStorage($this) as $collection) {
-            $objects = array_merge($objects, $this->getObjectsByCollection($collection));
+            return $this->getObjectsByCollection($collection, $callback);
         }
-        return $objects;
     }
 
     /**
      * Retrieve all Objects stored in this storage, filtered by the given collection name
      *
+     * @param callable $callback Function called after each iteration
      * @param CollectionInterface $collection
-     * @return array<\TYPO3\Flow\Resource\Storage\Object>
+     * @return \Generator<\TYPO3\Flow\Resource\Storage\Object>
      */
-    public function getObjectsByCollection(CollectionInterface $collection)
+    public function getObjectsByCollection(CollectionInterface $collection, callable $callback = null)
     {
-        $objects = array();
-        $that = $this;
-        foreach ($this->resourceRepository->findByCollectionName($collection->getName()) as $resource) {
+        $iterator = $this->resourceRepository->findByCollectionNameIterator($collection->getName());
+        $iteration = 0;
+        foreach ($this->resourceRepository->iterate($iterator, $callback) as $resource) {
             /** @var \TYPO3\Flow\Resource\Resource $resource */
             $object = new Object();
             $object->setFilename($resource->getFilename());
             $object->setSha1($resource->getSha1());
             $object->setMd5($resource->getMd5());
             $object->setFileSize($resource->getFileSize());
-            $object->setStream(function () use ($that, $resource) { return $that->getStreamByResource($resource); });
-            $objects[] = $object;
+            $object->setStream(function () use ($resource) {
+                return $this->getStreamByResource($resource);
+            });
+            yield $object;
+            if (is_callable($callback)) {
+                call_user_func($callback, $iteration, $object);
+            }
+            ++$iteration;
         }
-        return $objects;
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Storage/PackageStorage.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Storage/PackageStorage.php
@@ -41,9 +41,10 @@ class PackageStorage extends FileSystemStorage
     /**
      * Retrieve all Objects stored in this storage.
      *
-     * @return array<\TYPO3\Flow\Resource\Storage\Object>
+     * @param callable $callback Function called after each iteration
+     * @return \Generator<\TYPO3\Flow\Resource\Storage\Object>
      */
-    public function getObjects()
+    public function getObjects(callable $callback = null)
     {
         return $this->getObjectsByPathPattern('*');
     }
@@ -52,11 +53,11 @@ class PackageStorage extends FileSystemStorage
      * Return all Objects stored in this storage filtered by the given directory / filename pattern
      *
      * @param string $pattern A glob compatible directory / filename pattern
-     * @return array<\TYPO3\Flow\Resource\Storage\Object>
+     * @param callable $callback Function called after each object
+     * @return \Generator<\TYPO3\Flow\Resource\Storage\Object>
      */
-    public function getObjectsByPathPattern($pattern)
+    public function getObjectsByPathPattern($pattern, callable $callback = null)
     {
-        $objects = array();
         $directories = array();
 
         if (strpos($pattern, '/') !== false) {
@@ -77,6 +78,7 @@ class PackageStorage extends FileSystemStorage
             }
         }
 
+        $iteration = 0;
         foreach ($directories as $packageKey => $packageDirectories) {
             foreach ($packageDirectories as $directoryPath) {
                 foreach (Files::readDirectoryRecursively($directoryPath) as $resourcePathAndFilename) {
@@ -91,13 +93,17 @@ class PackageStorage extends FileSystemStorage
                         list(, $path) = explode('/', str_replace($packages[$packageKey]->getResourcesPath(), '', $pathInfo['dirname']), 2);
                         $object->setRelativePublicationPath($packageKey . '/' . $path . '/');
                     }
-                    $object->setStream(function () use ($resourcePathAndFilename) { return fopen($resourcePathAndFilename, 'r'); });
-                    $objects[] = $object;
+                    $object->setStream(function () use ($resourcePathAndFilename) {
+                        return fopen($resourcePathAndFilename, 'r');
+                    });
+                    yield $object;
+                    if (is_callable($callback)) {
+                        call_user_func($callback, $iteration, $object);
+                    }
+                    ++$iteration;
                 }
             }
         }
-
-        return $objects;
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Storage/StorageInterface.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Storage/StorageInterface.php
@@ -52,7 +52,7 @@ interface StorageInterface
     /**
      * Retrieve all Objects stored in this storage.
      *
-     * @return array<\TYPO3\Flow\Resource\Storage\Object>
+     * @return \Generator<\TYPO3\Flow\Resource\Storage\Object>
      * @api
      */
     public function getObjects();
@@ -61,7 +61,7 @@ interface StorageInterface
      * Retrieve all Objects stored in this storage, filtered by the given collection name
      *
      * @param CollectionInterface $collection
-     * @return array<\TYPO3\Flow\Resource\Storage\Object>
+     * @return \Generator<\TYPO3\Flow\Resource\Storage\Object>
      * @api
      */
     public function getObjectsByCollection(CollectionInterface $collection);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Target/FileSystemSymlinkTarget.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Target/FileSystemSymlinkTarget.php
@@ -13,6 +13,7 @@ namespace TYPO3\Flow\Resource\Target;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Resource\Collection;
+use TYPO3\Flow\Resource\CollectionInterface;
 use TYPO3\Flow\Resource\Storage\PackageStorage;
 use TYPO3\Flow\Utility\Files;
 
@@ -24,10 +25,11 @@ class FileSystemSymlinkTarget extends FileSystemTarget
     /**
      * Publishes the whole collection to this target
      *
-     * @param \TYPO3\Flow\Resource\Collection $collection The collection to publish
+     * @param CollectionInterface $collection The collection to publish
+     * @param callable $callback Function called after each resource publishing
      * @return void
      */
-    public function publishCollection(Collection $collection)
+    public function publishCollection(CollectionInterface $collection, callable $callback = null)
     {
         $storage = $collection->getStorage();
         if ($storage instanceof PackageStorage) {
@@ -35,7 +37,7 @@ class FileSystemSymlinkTarget extends FileSystemTarget
                 $this->publishDirectory($path, $packageKey);
             }
         } else {
-            parent::publishCollection($collection);
+            parent::publishCollection($collection, $callback);
         }
     }
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Target/FileSystemTarget.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Target/FileSystemTarget.php
@@ -153,13 +153,14 @@ class FileSystemTarget implements TargetInterface
     /**
      * Publishes the whole collection to this target
      *
-     * @param \TYPO3\Flow\Resource\Collection $collection The collection to publish
+     * @param CollectionInterface $collection The collection to publish
+     * @param callable $callback Function called after each resource publishing
      * @return void
      * @throws Exception
      */
-    public function publishCollection(Collection $collection)
+    public function publishCollection(CollectionInterface $collection, callable $callback = null)
     {
-        foreach ($collection->getObjects() as $object) {
+        foreach ($collection->getObjects($callback) as $object) {
             /** @var \TYPO3\Flow\Resource\Storage\Object $object */
             $sourceStream = $object->getStream();
             if ($sourceStream === false) {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Target/TargetInterface.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Target/TargetInterface.php
@@ -14,7 +14,6 @@ namespace TYPO3\Flow\Resource\Target;
 /**
  * Interface for a resource publishing target
  */
-use TYPO3\Flow\Resource\Collection;
 use TYPO3\Flow\Resource\CollectionInterface;
 use TYPO3\Flow\Resource\Resource;
 
@@ -30,10 +29,10 @@ interface TargetInterface
     /**
      * Publishes the whole collection to this target
      *
-     * @param Collection $collection The collection to publish
+     * @param CollectionInterface $collection The collection to publish
      * @return void
      */
-    public function publishCollection(Collection $collection);
+    public function publishCollection(CollectionInterface $collection);
 
     /**
      * Publishes the given persistent resource from the given storage


### PR DESCRIPTION
Currently the Resource Management does not scale with a lots of
resources. This change introduce some API refactoring to use PHP
Generator to iterate during resource cleanup and publishing.

Some method can now receive a callback function, the function will
receive the current iteration, as integer, and the currently
processed object, as TYPO3\Flow\Resource\Storage\Object. The callback
is executed after each object processing.

All interfaces (``CollectionInterface``, ``StorageInterface`` and
``TargetInterface``) are not changed to stay BC.

Resolves: FLOW-294