### PR TITLE
[BUGFIX] Prevent filenames longer than 255 characters

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Cache/Backend/SimpleFileBackend.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Cache/Backend/SimpleFileBackend.php
@@ -430,6 +430,6 @@ class SimpleFileBackend extends AbstractBackend implements PhpCapableBackendInte
      */
     protected function generateTemporaryPathAndFilename($entryIdentifier)
     {
-        return $this->cacheDirectory . '.' . $entryIdentifier . '.' . microtime(true) . '-' . (getmypid() ?: 0) . '.tmp';
+        return $this->cacheDirectory . '.' . md5($entryIdentifier) . '.' . microtime(true) . '-' . (getmypid() ?: 0) . '.tmp';
     }
 }


### PR DESCRIPTION
The temporary file created in the (Simple)FileBackend should not
exceed 255 characters which happened with the addition of
microtime and process id. Therefore the cache identifier is now
hashed in the temporary file name.

Fixes: #55306