### PR TITLE
[TASK] Defer initialization of PersistenceManager

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
@@ -492,18 +492,6 @@ class Scripts
     }
 
     /**
-     * Initializes the persistence framework
-     *
-     * @param Bootstrap $bootstrap
-     * @return void
-     */
-    public static function initializePersistence(Bootstrap $bootstrap)
-    {
-        $persistenceManager = $bootstrap->getObjectManager()->get(\TYPO3\Flow\Persistence\PersistenceManagerInterface::class);
-        $persistenceManager->initialize();
-    }
-
-    /**
      * Initializes the session framework
      *
      * @param Bootstrap $bootstrap

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package.php
@@ -48,10 +48,12 @@ class Package extends BasePackage
 
         $dispatcher = $bootstrap->getSignalSlotDispatcher();
         $dispatcher->connect(\TYPO3\Flow\Mvc\Dispatcher::class, 'afterControllerInvocation', function ($request) use ($bootstrap) {
-            if (!$request instanceof Mvc\ActionRequest || $request->getHttpRequest()->isMethodSafe() !== true) {
-                $bootstrap->getObjectManager()->get(\TYPO3\Flow\Persistence\PersistenceManagerInterface::class)->persistAll();
-            } elseif ($request->getHttpRequest()->isMethodSafe()) {
-                $bootstrap->getObjectManager()->get(\TYPO3\Flow\Persistence\PersistenceManagerInterface::class)->persistAll(true);
+            if ($bootstrap->getObjectManager()->hasInstance('TYPO3\Flow\Persistence\PersistenceManagerInterface')) {
+                if (!$request instanceof Mvc\ActionRequest || $request->getHttpRequest()->isMethodSafe() !== true) {
+                    $bootstrap->getObjectManager()->get(\TYPO3\Flow\Persistence\PersistenceManagerInterface::class)->persistAll();
+                } elseif ($request->getHttpRequest()->isMethodSafe()) {
+                    $bootstrap->getObjectManager()->get(\TYPO3\Flow\Persistence\PersistenceManagerInterface::class)->persistAll(true);
+                }
             }
         });
         $dispatcher->connect(\TYPO3\Flow\Cli\SlaveRequestHandler::class, 'dispatchedCommandLineSlaveRequest', \TYPO3\Flow\Persistence\PersistenceManagerInterface::class, 'persistAll');

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/PersistenceManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/PersistenceManager.php
@@ -54,9 +54,9 @@ class PersistenceManager extends \TYPO3\Flow\Persistence\AbstractPersistenceMana
      *
      * @return void
      */
-    public function initialize()
+    public function initializeObject()
     {
-        $this->entityManager->getEventManager()->addEventListener(array(\Doctrine\ORM\Events::onFlush), $this);
+        $this->entityManager->getEventManager()->addEventListener([\Doctrine\ORM\Events::onFlush], $this);
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/PersistenceManagerInterface.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/PersistenceManagerInterface.php
@@ -27,13 +27,12 @@ interface PersistenceManagerInterface
      */
     public function injectSettings(array $settings);
 
-    /**
-     * Initializes the persistence manager, called by Flow.
-     *
-     * @return void
-     * @api
+    /*
+     * The "initialize" method has been deprecated and was already removed from the interface.
+     * It is still called until the next major Flow version, but you should replace it by
+     * using "initializeObject" instead.
+     * TODO: Remove for next major Flow version.
      */
-    public function initialize();
 
     /**
      * Commits new objects and changes to objects in the current persistence session into the backend.

--- a/TYPO3.Flow/Configuration/Objects.yaml
+++ b/TYPO3.Flow/Configuration/Objects.yaml
@@ -226,6 +226,8 @@ Doctrine\Common\Persistence\ObjectManager:
 
 TYPO3\Flow\Persistence\PersistenceManagerInterface:
   className: TYPO3\Flow\Persistence\Doctrine\PersistenceManager
+  factoryObjectName: TYPO3\Flow\Core\Bootstrap
+  factoryMethodName: initializePersistenceManager
 
 TYPO3\Flow\Persistence\Doctrine\Logging\SqlLogger:
   properties:


### PR DESCRIPTION
Removes initialization of the PersistenceManager from the bootstrap as
that can be done lazily. For backwards compatibility the
``PersistenceManagerInterface::initialize`` method was removed but is
still called when available. All existing code should work as expected
but it is advisable to switch to using ``initializeObject`` instead. As
the ``initialize`` method will no longer be called starting from the next
major Flow version.
A separate breaking change will remove the backwards compatibility layer.

Before ``persistAll`` is called after a runtime run finished it is first
checked if there is a ``PersistenceManagerInterface`` instance registered
because otherwise  an unnecessary initialization of the PersistenceManager
would be triggered.