### PR TITLE
[BUGFIX] Fix functional test by explicitly naming sequence

### DIFF
--- a/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/AnnotatedIdEntity.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/AnnotatedIdEntity.php
@@ -24,6 +24,7 @@ class AnnotatedIdEntity
     /**
      * @ORM\Id
      * @ORM\GeneratedValue
+     * @ORM\SequenceGenerator(sequenceName="annotatedidentity_seq")
      * @var string
      */
     protected $id;


### PR DESCRIPTION
The auto-generated name of a sequence exceeds the maximum length, is
truncated and thus duplicates an already existing name in the schema.
This is solved by manually giving a name to the sequence.

This bug affects only PostgreSQL and is triggered by a functional test
fixture.