### PR TITLE
[BUGFIX] Skip commonObjectIsPersistedAndIsReconstituted() on PgSQL

### DIFF
--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
@@ -1006,6 +1006,15 @@ possibly inconsistent query results.
 	reading queries. However, this might lead to higher load on the master database and should be
 	well observed.
 
+Known issues
+------------
+
+* When using PostgreSQL the use of the ``object``, and ``array`` mapping types is not possible, this is
+  caused by Doctrine using ``serialize()`` to prepare data that is stored in text column (contained
+  zero bytes truncate the string and lead to error during hydration). [#]_
+
+  The Flow mapping types ``flow_json_array`` and ``objectarray`` provide solutions for this.
+
 Generic Persistence
 ===================
 
@@ -1189,3 +1198,4 @@ the array of objects being returned.
 .. [#] See https://github.com/doctrine/doctrine2/pull/265 for one approach in the making.
 .. [#] https://doctrine-orm.readthedocs.org/en/latest/reference/events.html
 .. [#] https://doctrine-orm.readthedocs.org/en/latest/reference/filters.html#filters
+.. [#] http://www.doctrine-project.org/jira/browse/DDC-3241

--- a/TYPO3.Flow/Tests/Functional/Persistence/PersistenceTest.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/PersistenceTest.php
@@ -421,6 +421,10 @@ class PersistenceTest extends \TYPO3\Flow\Tests\FunctionalTestCase
      */
     public function commonObjectIsPersistedAndIsReconstituted()
     {
+        if ($this->objectManager->get(\TYPO3\Flow\Configuration\ConfigurationManager::class)->getConfiguration(\TYPO3\Flow\Configuration\ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow.persistence.backendOptions.driver') === 'pdo_pgsql') {
+            $this->markTestSkipped('Doctrine ORM on PostgreSQL cannot store serialized data, thus storing objects with Type::OBJECT would fail. See http://www.doctrine-project.org/jira/browse/DDC-3241');
+        }
+
         $commonObject = new CommonObject();
         $commonObject->setFoo('foo');
 


### PR DESCRIPTION
The object we assign in the test is `Persistence\Fixtures\CommonObject`,
containing a protected property. Doctrine stores `object` as
`serialize()`d PHP data in a text column. Which doesn't work on
PostgreSQL, since the string is truncated at the first `null` byte,
used in the serialised data to mark the protected property.

The official fix is to use a custom datatype if you need it, for the
test I decided to skip it if on PostgreSQL.

Related: FLOW-396