### PR TITLE
[BUGFIX] Use jsonb in JsonArrayType on PostgreSQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: php
+addons:
+  postgresql: "9.4"
+services:
+  - postgresql
 matrix:
   fast_finish: true
   include:
@@ -8,8 +12,10 @@ matrix:
       env: DB=mysql
     - php: 5.6
       env: DB=mysql BEHAT=true
-#    - php: 5.6
-#      env: DB=pgsql
+    - php: 5.6
+      env: DB=pgsql
+    - php: 5.6
+      env: DB=pgsql BEHAT=true
     - php: 5.5
       env: DB=sqlite
 cache:

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/DataTypes/JsonArrayType.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/DataTypes/JsonArrayType.php
@@ -54,6 +54,23 @@ class JsonArrayType extends DoctrineJsonArrayType
     }
 
     /**
+     * Use jsonb for PostgreSQL, this means we require PostgreSQL 9.4
+     *
+     * @param array $fieldDeclaration The field declaration
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform The currently used database platform
+     * @return string
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        switch ($platform->getName()) {
+            case 'postgresql':
+                return 'jsonb';
+            default:
+                return $platform->getJsonTypeDeclarationSQL($fieldDeclaration);
+        }
+    }
+
+    /**
      * We map jsonb fields to our datatype by default. Doctrine doesn't use jsonb at all.
      *
      * @param AbstractPlatform $platform

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
@@ -1020,6 +1020,13 @@ Known issues
 
   The Flow mapping types ``flow_json_array`` and ``objectarray`` provide solutions for this.
 
+* When using PostgreSQL the use of the ``json_array`` mapping type can lead to issues when queries
+  need comparisons on such columns (e.g. when grouping or doing distinct queries), because the ``json``
+  type used by Doctrine doesn't support comparisons.
+
+  The Flow mapping type ``flow_json_array`` uses the ``jsonb`` type available as of PostgreSQL 9.4,
+  circumventing this restriction.
+
 Generic Persistence
 ===================
 


### PR DESCRIPTION
The `JsonArrayType` in Flow inherits from the same type in Doctrine DBAL.

That type uses the `json` format, which is not comparable in PostgreSQL,
something that leads to issues if you want to use `DISTINCT` in a query.
Starting with PostgreSQL 9.4 the `jsonb` type is available, and the DB
knows how to compare it, making distinct queries possible.

Neos uses that, so the easiest way to fix this is to always use `jsonb`
for our custom type. The downside: the minimum supported version is
raised to 9.4.

Related: FLOW-396
Related: NEOS-1627