### PR TITLE
[BUGFIX] Use CollectionInterface in resource management

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Target/FileSystemSymlinkTarget.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Target/FileSystemSymlinkTarget.php
@@ -12,7 +12,7 @@ namespace TYPO3\Flow\Resource\Target;
  */
 
 use TYPO3\Flow\Annotations as Flow;
-use TYPO3\Flow\Resource\Collection;
+use TYPO3\Flow\Resource\CollectionInterface;
 use TYPO3\Flow\Resource\Storage\PackageStorage;
 use TYPO3\Flow\Utility\Files;
 
@@ -24,10 +24,10 @@ class FileSystemSymlinkTarget extends FileSystemTarget
     /**
      * Publishes the whole collection to this target
      *
-     * @param \TYPO3\Flow\Resource\Collection $collection The collection to publish
+     * @param CollectionInterface $collection The collection to publish
      * @return void
      */
-    public function publishCollection(Collection $collection)
+    public function publishCollection(CollectionInterface $collection)
     {
         $storage = $collection->getStorage();
         if ($storage instanceof PackageStorage) {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Target/FileSystemTarget.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Target/FileSystemTarget.php
@@ -13,8 +13,6 @@ namespace TYPO3\Flow\Resource\Target;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Http\HttpRequestHandlerInterface;
-use TYPO3\Flow\Http\Request;
-use TYPO3\Flow\Resource\Collection;
 use TYPO3\Flow\Resource\CollectionInterface;
 use TYPO3\Flow\Resource\Resource;
 use TYPO3\Flow\Resource\ResourceMetaDataInterface;
@@ -153,11 +151,11 @@ class FileSystemTarget implements TargetInterface
     /**
      * Publishes the whole collection to this target
      *
-     * @param \TYPO3\Flow\Resource\Collection $collection The collection to publish
+     * @param \TYPO3\Flow\Resource\CollectionInterface $collection The collection to publish
      * @return void
      * @throws Exception
      */
-    public function publishCollection(Collection $collection)
+    public function publishCollection(CollectionInterface $collection)
     {
         foreach ($collection->getObjects() as $object) {
             /** @var \TYPO3\Flow\Resource\Storage\Object $object */

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Target/TargetInterface.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Target/TargetInterface.php
@@ -14,7 +14,6 @@ namespace TYPO3\Flow\Resource\Target;
 /**
  * Interface for a resource publishing target
  */
-use TYPO3\Flow\Resource\Collection;
 use TYPO3\Flow\Resource\CollectionInterface;
 use TYPO3\Flow\Resource\Resource;
 
@@ -30,10 +29,10 @@ interface TargetInterface
     /**
      * Publishes the whole collection to this target
      *
-     * @param Collection $collection The collection to publish
+     * @param CollectionInterface $collection The collection to publish
      * @return void
      */
-    public function publishCollection(Collection $collection);
+    public function publishCollection(CollectionInterface $collection);
 
     /**
      * Publishes the given persistent resource from the given storage


### PR DESCRIPTION
Currently some methods use the Collection class instead of the
CollectionInterface.