### PR TITLE
[BUGFIX] Ignore race condition on cached Configuration include

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Configuration/ConfigurationManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Configuration/ConfigurationManager.php
@@ -602,8 +602,8 @@ class ConfigurationManager
         $includeCachedConfigurationsCode = <<< "EOD"
 <?php
 if (FLOW_PATH_ROOT !== '$flowRootPath' || !file_exists('$cachePathAndFilename')) {
-	unlink(__FILE__);
-	return array();
+	@unlink(__FILE__);
+	return [];
 }
 return require '$cachePathAndFilename';
 EOD;

--- a/TYPO3.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -675,8 +675,8 @@ EOD;
         $expectedInclusionCode = <<< "EOD"
 <?php
 if (FLOW_PATH_ROOT !== 'XXX' || !file_exists('vfs://Flow/TemporaryDirectory/Configuration/FooContextConfigurations.php')) {
-	unlink(__FILE__);
-	return array();
+	@unlink(__FILE__);
+	return [];
 }
 return require 'vfs://Flow/TemporaryDirectory/Configuration/FooContextConfigurations.php';
 EOD;


### PR DESCRIPTION
It can happen that the cache include file was already removed
by a subrequest before getting to the unlink. The warning that
would follow can safely be ignored.