### PR TITLE
[BUGFIX] Bind expression storing closer to privilege data

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Aop/Pointcut/RuntimeExpressionEvaluator.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Aop/Pointcut/RuntimeExpressionEvaluator.php
@@ -72,7 +72,7 @@ class RuntimeExpressionEvaluator
      *
      * @return void
      */
-    public function shutdownObject()
+    public function saveRuntimeExpressions()
     {
         if ($this->newExpressions === array()) {
             return;

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package.php
@@ -95,6 +95,7 @@ class Package extends BasePackage
         $dispatcher->connect('TYPO3\Flow\Core\Bootstrap', 'bootstrapShuttingDown', 'TYPO3\Flow\Reflection\ReflectionService', 'saveToCache');
 
         $dispatcher->connect('TYPO3\Flow\Command\CoreCommandController', 'finishedCompilationRun', 'TYPO3\Flow\Security\Authorization\Privilege\Method\MethodPrivilegePointcutFilter', 'savePolicyCache');
+        $dispatcher->connect('TYPO3\Flow\Command\CoreCommandController', 'finishedCompilationRun', 'TYPO3\Flow\Aop\Pointcut\RuntimeExpressionEvaluator', 'saveRuntimeExpressions');
 
         $dispatcher->connect('TYPO3\Flow\Security\Authentication\AuthenticationProviderManager', 'authenticatedToken', function () use ($bootstrap) {
             $session = $bootstrap->getObjectManager()->get('TYPO3\Flow\Session\SessionInterface');


### PR DESCRIPTION
As the runtime expressions are generated while evaluating the
method privileges in the ``MethodPrivilegePointcutFilter`` both
should be saved at the same point in time, so instead of saving
the expressions via lifecycle methods they are now saved on the
same signal as the method permission cache entry.
This can prevent race conditions that might happen between
writing the permission cache and the expression cache.