### PR TITLE
[BUGFIX] transmitting value objects by identifier

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/PersistentObjectConverter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/PersistentObjectConverter.php
@@ -159,9 +159,12 @@ class PersistentObjectConverter extends ObjectConverter
     {
         if (is_array($source)) {
             if ($this->reflectionService->isClassAnnotatedWith($targetType, \TYPO3\Flow\Annotations\ValueObject::class)) {
-                // Unset identity for value objects to use constructor mapping, since the identity is determined from
-                // property values after construction
-                unset($source['__identity']);
+                if (isset($source['__identity']) && (count($source) > 1)) {
+                    // @TODO fix that in the URI building and transfer VOs as values instead as with their identities
+                    // Unset identity for value objects to use constructor mapping, since the identity is determined from
+                    // property values after construction
+                    unset($source['__identity']);
+                }
             }
             $object = $this->handleArrayData($source, $targetType, $convertedChildProperties, $configuration);
             if ($object instanceof TargetNotFoundError) {


### PR DESCRIPTION
given:

```
/**
	 * @param Article\Keyword $keyword
	 */
	public function showKeywordAction(Article\Keyword $keyword) {
….
```

```
<f:link.action action="showKeyword" arguments="{keyword:keyword}" class="btn btn-default btn-sm“>

...
```

```
/**
 * @Flow\ValueObject
 */
class Keyword
{
    /**
     * @var string
     */
    protected $keyword;

    public function __construct($keyword) {
        $this->keyword = $keyword;
    }
...
```

url looks like: `/article/showkeyword?keyword%5B__identity%5D=761842cbf8e2c16abac74a60aaeada1b6203f4a9`

and the exceptions are:

#1297759968: Exception while property mapping for target type "SBS\Materialdatenbank\Domain\Model\Article\Keyword", at property path "": Missing constructor argument "keyword" for object of type "SBS\Materialdatenbank\Domain\Model\Article\Keyword“.

#1268734872: Missing constructor argument "keyword" for object of type "SBS\Materialdatenbank\Domain\Model\Article\Keyword".

I do use FLOW 3.0.0 in that project