### PR TITLE
[TASK] Use DateTimeInterface in Flow

### DIFF
--- a/TYPO3.Eel/Classes/TYPO3/Eel/Helper/DateHelper.php
+++ b/TYPO3.Eel/Classes/TYPO3/Eel/Helper/DateHelper.php
@@ -44,7 +44,7 @@ class DateHelper implements ProtectedContextAwareInterface
      */
     public function format($date, $format)
     {
-        if ($date instanceof \DateTime) {
+        if ($date instanceof \DateTimeInterface) {
             return $date->format($format);
         } elseif ($date instanceof \DateInterval) {
             return $date->format($format);
@@ -127,10 +127,10 @@ class DateHelper implements ProtectedContextAwareInterface
     /**
      * Get the day of month of a date
      *
-     * @param \DateTime $dateTime
+     * @param \DateTimeInterface $dateTime
      * @return integer The day of month of the given date
      */
-    public function dayOfMonth(\DateTime $dateTime)
+    public function dayOfMonth(\DateTimeInterface $dateTime)
     {
         return (integer)$dateTime->format('d');
     }
@@ -138,10 +138,10 @@ class DateHelper implements ProtectedContextAwareInterface
     /**
      * Get the month of a date
      *
-     * @param \DateTime $dateTime
+     * @param \DateTimeInterface $dateTime
      * @return integer The month of the given date
      */
-    public function month(\DateTime $dateTime)
+    public function month(\DateTimeInterface $dateTime)
     {
         return (integer)$dateTime->format('m');
     }
@@ -149,10 +149,10 @@ class DateHelper implements ProtectedContextAwareInterface
     /**
      * Get the year of a date
      *
-     * @param \DateTime $dateTime
+     * @param \DateTimeInterface $dateTime
      * @return integer The year of the given date
      */
-    public function year(\DateTime $dateTime)
+    public function year(\DateTimeInterface $dateTime)
     {
         return (integer)$dateTime->format('Y');
     }
@@ -160,10 +160,10 @@ class DateHelper implements ProtectedContextAwareInterface
     /**
      * Get the hour of a date (24 hour format)
      *
-     * @param \DateTime $dateTime
+     * @param \DateTimeInterface $dateTime
      * @return integer The hour of the given date
      */
-    public function hour(\DateTime $dateTime)
+    public function hour(\DateTimeInterface $dateTime)
     {
         return (integer)$dateTime->format('H');
     }
@@ -171,10 +171,10 @@ class DateHelper implements ProtectedContextAwareInterface
     /**
      * Get the minute of a date
      *
-     * @param \DateTime $dateTime
+     * @param \DateTimeInterface $dateTime
      * @return integer The minute of the given date
      */
-    public function minute(\DateTime $dateTime)
+    public function minute(\DateTimeInterface $dateTime)
     {
         return (integer)$dateTime->format('i');
     }
@@ -182,10 +182,10 @@ class DateHelper implements ProtectedContextAwareInterface
     /**
      * Get the second of a date
      *
-     * @param \DateTime $dateTime
+     * @param \DateTimeInterface $dateTime
      * @return integer The second of the given date
      */
-    public function second(\DateTime $dateTime)
+    public function second(\DateTimeInterface $dateTime)
     {
         return (integer)$dateTime->format('s');
     }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Headers.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Headers.php
@@ -106,7 +106,7 @@ class Headers
             throw new \InvalidArgumentException('The "Set-Cookie" headers must be set via setCookie().', 1345128153);
         }
 
-        if ($values instanceof \DateTime) {
+        if ($values instanceof \DateTimeInterface) {
             $date = clone $values;
             $date->setTimezone(new \DateTimeZone('GMT'));
             $values = array($date->format('D, d M Y H:i:s') . ' GMT');

--- a/TYPO3.Flow/Classes/TYPO3/Flow/I18n/Formatter/DatetimeFormatter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/I18n/Formatter/DatetimeFormatter.php
@@ -84,14 +84,14 @@ class DatetimeFormatter implements \TYPO3\Flow\I18n\Formatter\FormatterInterface
      * Format is remembered in this classes cache and won't be parsed again for
      * some time.
      *
-     * @param \DateTime $dateTime PHP object representing particular point in time
+     * @param \DateTimeInterface $dateTime PHP object representing particular point in time
      * @param string $format Format string
      * @param \TYPO3\Flow\I18n\Locale $locale A locale used for finding literals array
      * @return string Formatted date / time. Unimplemented subformats in format string will be silently ignored
      * @api
      * @see \TYPO3\Flow\I18n\Cldr\Reader\DatesReader
      */
-    public function formatDateTimeWithCustomPattern(\DateTime $dateTime, $format, \TYPO3\Flow\I18n\Locale $locale)
+    public function formatDateTimeWithCustomPattern(\DateTimeInterface $dateTime, $format, \TYPO3\Flow\I18n\Locale $locale)
     {
         return $this->doFormattingWithParsedFormat($dateTime, $this->datesReader->parseCustomFormat($format), $this->datesReader->getLocalizedLiteralsForLocale($locale));
     }
@@ -100,13 +100,13 @@ class DatetimeFormatter implements \TYPO3\Flow\I18n\Formatter\FormatterInterface
      * Formats date with format string for date defined in CLDR for particular
      * locale.
      *
-     * @param \DateTime $date PHP object representing particular point in time
+     * @param \DateTimeInterface $date PHP object representing particular point in time
      * @param \TYPO3\Flow\I18n\Locale $locale
      * @param string $formatLength One of DatesReader FORMAT_LENGTH constants
      * @return string Formatted date
      * @api
      */
-    public function formatDate(\DateTime $date, \TYPO3\Flow\I18n\Locale $locale, $formatLength = \TYPO3\Flow\I18n\Cldr\Reader\DatesReader::FORMAT_LENGTH_DEFAULT)
+    public function formatDate(\DateTimeInterface $date, \TYPO3\Flow\I18n\Locale $locale, $formatLength = \TYPO3\Flow\I18n\Cldr\Reader\DatesReader::FORMAT_LENGTH_DEFAULT)
     {
         \TYPO3\Flow\I18n\Cldr\Reader\DatesReader::validateFormatLength($formatLength);
         return $this->doFormattingWithParsedFormat($date, $this->datesReader->parseFormatFromCldr($locale, \TYPO3\Flow\I18n\Cldr\Reader\DatesReader::FORMAT_TYPE_DATE, $formatLength), $this->datesReader->getLocalizedLiteralsForLocale($locale));
@@ -116,13 +116,13 @@ class DatetimeFormatter implements \TYPO3\Flow\I18n\Formatter\FormatterInterface
      * Formats time with format string for time defined in CLDR for particular
      * locale.
      *
-     * @param \DateTime $time PHP object representing particular point in time
+     * @param \DateTimeInterface $time PHP object representing particular point in time
      * @param \TYPO3\Flow\I18n\Locale $locale
      * @param string $formatLength One of DatesReader FORMAT_LENGTH constants
      * @return string Formatted time
      * @api
      */
-    public function formatTime(\DateTime $time, \TYPO3\Flow\I18n\Locale $locale, $formatLength = \TYPO3\Flow\I18n\Cldr\Reader\DatesReader::FORMAT_LENGTH_DEFAULT)
+    public function formatTime(\DateTimeInterface $time, \TYPO3\Flow\I18n\Locale $locale, $formatLength = \TYPO3\Flow\I18n\Cldr\Reader\DatesReader::FORMAT_LENGTH_DEFAULT)
     {
         \TYPO3\Flow\I18n\Cldr\Reader\DatesReader::validateFormatLength($formatLength);
         return $this->doFormattingWithParsedFormat($time, $this->datesReader->parseFormatFromCldr($locale, \TYPO3\Flow\I18n\Cldr\Reader\DatesReader::FORMAT_TYPE_TIME, $formatLength), $this->datesReader->getLocalizedLiteralsForLocale($locale));
@@ -135,13 +135,13 @@ class DatetimeFormatter implements \TYPO3\Flow\I18n\Formatter\FormatterInterface
      * First date and time are formatted separately, and then dateTime format
      * from CLDR is used to place date and time in correct order.
      *
-     * @param \DateTime $dateTime PHP object representing particular point in time
+     * @param \DateTimeInterface $dateTime PHP object representing particular point in time
      * @param \TYPO3\Flow\I18n\Locale $locale
      * @param string $formatLength One of DatesReader FORMAT_LENGTH constants
      * @return string Formatted date and time
      * @api
      */
-    public function formatDateTime(\DateTime $dateTime, \TYPO3\Flow\I18n\Locale $locale, $formatLength = \TYPO3\Flow\I18n\Cldr\Reader\DatesReader::FORMAT_LENGTH_DEFAULT)
+    public function formatDateTime(\DateTimeInterface $dateTime, \TYPO3\Flow\I18n\Locale $locale, $formatLength = \TYPO3\Flow\I18n\Cldr\Reader\DatesReader::FORMAT_LENGTH_DEFAULT)
     {
         \TYPO3\Flow\I18n\Cldr\Reader\DatesReader::validateFormatLength($formatLength);
         return $this->doFormattingWithParsedFormat($dateTime, $this->datesReader->parseFormatFromCldr($locale, \TYPO3\Flow\I18n\Cldr\Reader\DatesReader::FORMAT_TYPE_DATETIME, $formatLength), $this->datesReader->getLocalizedLiteralsForLocale($locale));
@@ -153,12 +153,12 @@ class DatetimeFormatter implements \TYPO3\Flow\I18n\Formatter\FormatterInterface
      * Format rules defined in $parsedFormat array are used. Localizable literals
      * are replaced with elements from $localizedLiterals array.
      *
-     * @param \DateTime $dateTime PHP object representing particular point in time
+     * @param \DateTimeInterface $dateTime PHP object representing particular point in time
      * @param array $parsedFormat An array describing format (as in $parsedFormats property)
      * @param array $localizedLiterals An array with literals to use (as in $localizedLiterals property)
      * @return string Formatted date / time
      */
-    protected function doFormattingWithParsedFormat(\DateTime $dateTime, array $parsedFormat, array $localizedLiterals)
+    protected function doFormattingWithParsedFormat(\DateTimeInterface $dateTime, array $parsedFormat, array $localizedLiterals)
     {
         $formattedDateTime = '';
 
@@ -186,14 +186,14 @@ class DatetimeFormatter implements \TYPO3\Flow\I18n\Formatter\FormatterInterface
      * Cases in the code are ordered in such way that probably mostly used are
      * on the top (but they are also grouped by similarity).
      *
-     * @param \DateTime $dateTime PHP object representing particular point in time
+     * @param \DateTimeInterface $dateTime PHP object representing particular point in time
      * @param string $subformat One element of format string (e.g., 'yyyy', 'mm', etc)
      * @param array $localizedLiterals Array of date / time literals from CLDR
      * @return string Formatted part of date / time
      * @throws \TYPO3\Flow\I18n\Exception\InvalidArgumentException When $subformat use symbol that is not recognized
      * @see \TYPO3\Flow\I18n\Cldr\Reader\DatesReader
      */
-    protected function doFormattingForSubpattern(\DateTime $dateTime, $subformat, array $localizedLiterals)
+    protected function doFormattingForSubpattern(\DateTimeInterface $dateTime, $subformat, array $localizedLiterals)
     {
         $formatLengthOfSubformat = strlen($subformat);
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/Routing/IdentityRoutePart.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/Routing/IdentityRoutePart.php
@@ -273,7 +273,7 @@ class IdentityRoutePart extends DynamicRoutePart
                 $propertyPath = $dynamicPathSegmentParts[0];
                 $dynamicPathSegment = ObjectAccess::getPropertyPath($object, $propertyPath);
                 if (is_object($dynamicPathSegment)) {
-                    if ($dynamicPathSegment instanceof \DateTime) {
+                    if ($dynamicPathSegment instanceof \DateTimeInterface) {
                         $dateFormat = isset($dynamicPathSegmentParts[1]) ? trim($dynamicPathSegmentParts[1]) : 'Y-m-d';
                         $pathSegment .= $this->rewriteForUri($dynamicPathSegment->format($dateFormat));
                     } else {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/View/JsonView.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/View/JsonView.php
@@ -269,7 +269,7 @@ class JsonView extends \TYPO3\Flow\Mvc\View\AbstractView
      */
     protected function transformObject($object, array $configuration)
     {
-        if ($object instanceof \DateTime) {
+        if ($object instanceof \DateTimeInterface) {
             return $object->format(\DateTime::ISO8601);
         } else {
             $propertyNames = \TYPO3\Flow\Reflection\ObjectAccess::getGettablePropertyNames($object);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/DataTypes/JsonArrayType.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/DataTypes/JsonArrayType.php
@@ -169,7 +169,7 @@ class JsonArrayType extends DoctrineJsonArrayType
 
             $propertyClassName = TypeHandling::getTypeForValue($value);
 
-            if ($value instanceof \DateTime) {
+            if ($value instanceof \DateTimeInterface) {
                 $value = array(
                     'date' => $value->format('Y-m-d H:i:s.u'),
                     'timezone' => $value->format('e'),

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Generic/Backend/AbstractBackend.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Generic/Backend/AbstractBackend.php
@@ -582,7 +582,7 @@ abstract class AbstractBackend implements \TYPO3\Flow\Persistence\Generic\Backen
 
         $values = array();
         foreach ($array as $key => $value) {
-            if ($value instanceof \DateTime) {
+            if ($value instanceof \DateTimeInterface) {
                 $values[] = array(
                     'type' => 'DateTime',
                     'index' => $key,
@@ -717,7 +717,7 @@ abstract class AbstractBackend implements \TYPO3\Flow\Persistence\Generic\Backen
 
         $values = array();
         foreach ($splObjectStorage as $object) {
-            if ($object instanceof \DateTime) {
+            if ($object instanceof \DateTimeInterface) {
                 $values[] = array(
                     'type' => 'DateTime',
                     'index' => null,
@@ -775,9 +775,9 @@ abstract class AbstractBackend implements \TYPO3\Flow\Persistence\Generic\Backen
      * @param \DateTime $dateTime
      * @return integer
      */
-    protected function processDateTime(\DateTime $dateTime = null)
+    protected function processDateTime(\DateTimeInterface $dateTime = null)
     {
-        if ($dateTime instanceof \DateTime) {
+        if ($dateTime instanceof \DateTimeInterface) {
             return $dateTime->getTimestamp();
         } else {
             return null;

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Generic/Query.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Generic/Query.php
@@ -513,7 +513,7 @@ class Query implements \TYPO3\Flow\Persistence\QueryInterface
         if ($this->classSchema->isMultiValuedProperty($propertyName)) {
             throw new \TYPO3\Flow\Persistence\Exception\InvalidQueryException('Property "' . $propertyName . '" must not be multi-valued', 1276784963);
         }
-        if (!($operand instanceof \DateTime) && !\TYPO3\Flow\Utility\TypeHandling::isLiteral(gettype($operand))) {
+        if (!($operand instanceof \DateTimeInterface) && !\TYPO3\Flow\Utility\TypeHandling::isLiteral(gettype($operand))) {
             throw new \TYPO3\Flow\Persistence\Exception\InvalidQueryException('Operand must be a literal or DateTime, was ' . gettype($operand), 1276784964);
         }
 
@@ -538,7 +538,7 @@ class Query implements \TYPO3\Flow\Persistence\QueryInterface
         if ($this->classSchema->isMultiValuedProperty($propertyName)) {
             throw new \TYPO3\Flow\Persistence\Exception\InvalidQueryException('Property "' . $propertyName . '" must not be multi-valued', 1276784943);
         }
-        if (!($operand instanceof \DateTime) && !\TYPO3\Flow\Utility\TypeHandling::isLiteral(gettype($operand))) {
+        if (!($operand instanceof \DateTimeInterface) && !\TYPO3\Flow\Utility\TypeHandling::isLiteral(gettype($operand))) {
             throw new \TYPO3\Flow\Persistence\Exception\InvalidQueryException('Operand must be a literal or DateTime, was ' . gettype($operand), 1276784944);
         }
 
@@ -563,7 +563,7 @@ class Query implements \TYPO3\Flow\Persistence\QueryInterface
         if ($this->classSchema->isMultiValuedProperty($propertyName)) {
             throw new \TYPO3\Flow\Persistence\Exception\InvalidQueryException('Property "' . $propertyName . '" must not be multi-valued', 1276774885);
         }
-        if (!($operand instanceof \DateTime) && !\TYPO3\Flow\Utility\TypeHandling::isLiteral(gettype($operand))) {
+        if (!($operand instanceof \DateTimeInterface) && !\TYPO3\Flow\Utility\TypeHandling::isLiteral(gettype($operand))) {
             throw new \TYPO3\Flow\Persistence\Exception\InvalidQueryException('Operand must be a literal or DateTime, was ' . gettype($operand), 1276774886);
         }
 
@@ -588,7 +588,7 @@ class Query implements \TYPO3\Flow\Persistence\QueryInterface
         if ($this->classSchema->isMultiValuedProperty($propertyName)) {
             throw new \TYPO3\Flow\Persistence\Exception\InvalidQueryException('Property "' . $propertyName . '" must not be multi-valued', 1276774883);
         }
-        if (!($operand instanceof \DateTime) && !\TYPO3\Flow\Utility\TypeHandling::isLiteral(gettype($operand))) {
+        if (!($operand instanceof \DateTimeInterface) && !\TYPO3\Flow\Utility\TypeHandling::isLiteral(gettype($operand))) {
             throw new \TYPO3\Flow\Persistence\Exception\InvalidQueryException('Operand must be a literal or DateTime, was ' . gettype($operand), 1276774884);
         }
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Generic/Session.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Generic/Session.php
@@ -245,7 +245,7 @@ class Session
                 }
             break;
             case 'DateTime':
-                if ($currentValue instanceof \DateTime && $currentValue->getTimestamp() === (int) $previousValue) {
+                if ($currentValue instanceof \DateTimeInterface && $currentValue->getTimestamp() === (int) $previousValue) {
                     return false;
                 }
             break;

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/IntegerConverter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/IntegerConverter.php
@@ -53,7 +53,7 @@ class IntegerConverter extends AbstractTypeConverter
      */
     public function convertFrom($source, $targetType, array $convertedChildProperties = array(), \TYPO3\Flow\Property\PropertyMappingConfigurationInterface $configuration = null)
     {
-        if ($source instanceof \DateTime) {
+        if ($source instanceof \DateTimeInterface) {
             return $source->format('U');
         }
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/StringConverter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/StringConverter.php
@@ -99,7 +99,7 @@ class StringConverter extends AbstractTypeConverter
      */
     public function convertFrom($source, $targetType, array $convertedChildProperties = array(), \TYPO3\Flow\Property\PropertyMappingConfigurationInterface $configuration = null)
     {
-        if ($source instanceof \DateTime) {
+        if ($source instanceof \DateTimeInterface) {
             $dateFormat = $this->getDateFormat($configuration);
 
             return $source->format($dateFormat);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Now.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Now.php
@@ -24,6 +24,6 @@ use TYPO3\Flow\Annotations as Flow;
  * @Flow\Scope("singleton")
  * @api
  */
-class Now extends \DateTime
+class Now extends \DateTimeImmutable
 {
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Validation/Validator/DateTimeRangeValidator.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Validation/Validator/DateTimeRangeValidator.php
@@ -70,7 +70,7 @@ class DateTimeRangeValidator extends AbstractValidator
      */
     protected function isValid($dateTime)
     {
-        if (!$dateTime instanceof \DateTime) {
+        if (!$dateTime instanceof \DateTimeInterface) {
             $this->addError('The given value was not a valid date', 1324314378);
             return;
         }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Validation/Validator/DateTimeValidator.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Validation/Validator/DateTimeValidator.php
@@ -51,7 +51,7 @@ class DateTimeValidator extends AbstractValidator
      */
     protected function isValid($value)
     {
-        if ($value instanceof \DateTime) {
+        if ($value instanceof \DateTimeInterface) {
             return;
         }
         if (!isset($this->options['locale'])) {

--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Format/DateViewHelper.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Format/DateViewHelper.php
@@ -121,7 +121,7 @@ class DateViewHelper extends AbstractLocaleAwareViewHelper
                 return '';
             }
         }
-        if (!$date instanceof \DateTime) {
+        if (!$date instanceof \DateTimeInterface) {
             try {
                 $date = new \DateTime($date);
             } catch (\Exception $exception) {

--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/GroupedForViewHelper.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/GroupedForViewHelper.php
@@ -139,7 +139,7 @@ class GroupedForViewHelper extends AbstractViewHelper
                 throw new ViewHelper\Exception('GroupedForViewHelper only supports multi-dimensional arrays and objects', 1253120365);
             }
             $currentGroupKeyValue = $currentGroupIndex;
-            if ($currentGroupIndex instanceof \DateTime) {
+            if ($currentGroupIndex instanceof \DateTimeInterface) {
                 $currentGroupIndex = $currentGroupIndex->format(\DateTime::RFC850);
             } elseif (is_object($currentGroupIndex)) {
                 $currentGroupIndex = spl_object_hash($currentGroupIndex);


### PR DESCRIPTION
Since Flow requires PHP 5.5 it should use and support the ``\DateTimeInterface``.
With support for it the ``Now`` class can extend from ``DateTimeImmutable`` to
prevent changes to the singleton throughout a request.