### PR TITLE
[BUGFIX] Make ObjectAccess use TypeHandling (FLOW-397)

### DIFF
--- a/TYPO3.Flow/Tests/Unit/Package/PackageManagerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Package/PackageManagerTest.php
@@ -101,11 +101,19 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
         $package = $this->packageManager->createPackage('Acme.Foobar');
         $dummyObject = $this->createDummyObjectForPackage($package);
 
-        eval('namespace Doctrine\ORM\Proxy; interface Proxy {}');
         mkdir('vfs://Test/Somewhere/For/DoctrineProxies', 0700, true);
         $dummyProxyClassName = 'Proxy_' . str_replace('\\', '_', get_class($dummyObject));
         $dummyProxyClassPath = 'vfs://Test/Somewhere/For/DoctrineProxies/' . $dummyProxyClassName . '.php';
-        file_put_contents($dummyProxyClassPath, '<?php class ' . $dummyProxyClassName . ' extends ' . get_class($dummyObject) . ' implements \Doctrine\ORM\Proxy\Proxy {} ?>');
+        file_put_contents($dummyProxyClassPath, '<?php class ' . $dummyProxyClassName . ' extends ' . get_class($dummyObject) . ' implements \Doctrine\ORM\Proxy\Proxy {
+            public function __setInitialized($initialized) {}
+            public function __setInitializer(Closure $initializer = null) {}
+            public function __getInitializer() {}
+            public function __setCloner(Closure $cloner = null) {}
+            public function __getCloner() {}
+            public function __getLazyProperties() {}
+            public function __load() {}
+            public function __isInitialized() {}
+        } ?>');
         require $dummyProxyClassPath;
         $dummyProxy = new $dummyProxyClassName();
 

--- a/TYPO3.Flow/Tests/Unit/Reflection/Fixture/Model/EntityWithDoctrineProxy.php
+++ b/TYPO3.Flow/Tests/Unit/Reflection/Fixture/Model/EntityWithDoctrineProxy.php
@@ -1,0 +1,122 @@
+<?php
+namespace TYPO3\Flow\Tests\Reflection\Fixture\Model;
+
+/**
+ * A class that is a Doctrine proxy
+ */
+class EntityWithDoctrineProxy extends Entity implements \Doctrine\ORM\Proxy\Proxy
+{
+    /**
+     * @var \Closure the callback responsible for loading properties in the proxy object. This callback is called with
+     *      three parameters, being respectively the proxy object to be initialized, the method that triggered the
+     *      initialization process and an array of ordered parameters that were passed to that method.
+     *
+     * @see \Doctrine\Common\Persistence\Proxy::__setInitializer
+     */
+    public $__initializer__;
+
+    /**
+     * @var \Closure the callback responsible of loading properties that need to be copied in the cloned object
+     *
+     * @see \Doctrine\Common\Persistence\Proxy::__setCloner
+     */
+    public $__cloner__;
+
+    /**
+     * @var boolean flag indicating if this object was already initialized
+     *
+     * @see \Doctrine\Common\Persistence\Proxy::__isInitialized
+     */
+    public $__isInitialized__ = false;
+
+    /**
+     * @var array properties to be lazy loaded, with keys being the property
+     *            names and values being their default values
+     *
+     * @see \Doctrine\Common\Persistence\Proxy::__getLazyProperties
+     */
+    public static $lazyPropertiesDefaults = array();
+
+
+    /**
+     * @param \Closure $initializer
+     * @param \Closure $cloner
+     */
+    public function __construct($initializer = null, $cloner = null)
+    {
+        $this->__initializer__ = $initializer;
+        $this->__cloner__ = $cloner;
+    }
+
+    /**
+     * Forces initialization of the proxy
+     */
+    public function __load()
+    {
+        $this->__initializer__ && $this->__initializer__->__invoke($this, '__load', array());
+    }
+
+    /**
+     * {@inheritDoc}
+     * @internal generated method: use only when explicitly handling proxy specific loading logic
+     */
+    public function __isInitialized()
+    {
+        return $this->__isInitialized__;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @internal generated method: use only when explicitly handling proxy specific loading logic
+     */
+    public function __setInitialized($initialized)
+    {
+        $this->__isInitialized__ = $initialized;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @internal generated method: use only when explicitly handling proxy specific loading logic
+     */
+    public function __setInitializer(\Closure $initializer = null)
+    {
+        $this->__initializer__ = $initializer;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @internal generated method: use only when explicitly handling proxy specific loading logic
+     */
+    public function __getInitializer()
+    {
+        return $this->__initializer__;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @internal generated method: use only when explicitly handling proxy specific loading logic
+     */
+    public function __setCloner(\Closure $cloner = null)
+    {
+        $this->__cloner__ = $cloner;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @internal generated method: use only when explicitly handling proxy specific cloning logic
+     */
+    public function __getCloner()
+    {
+        return $this->__cloner__;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @internal generated method: use only when explicitly handling proxy specific loading logic
+     * @static
+     */
+    public function __getLazyProperties()
+    {
+        return self::$lazyPropertiesDefaults;
+    }
+}

--- a/TYPO3.Flow/Tests/Unit/Reflection/ObjectAccessTest.php
+++ b/TYPO3.Flow/Tests/Unit/Reflection/ObjectAccessTest.php
@@ -15,6 +15,8 @@ use TYPO3\Flow\Reflection\ObjectAccess;
 
 require_once('Fixture/DummyClassWithGettersAndSetters.php');
 require_once('Fixture/ArrayAccessClass.php');
+require_once('Fixture/Model/Entity.php');
+require_once('Fixture/Model/EntityWithDoctrineProxy.php');
 
 /**
  * Testcase for Object Access
@@ -389,6 +391,17 @@ class ObjectAccessTest extends \TYPO3\Flow\Tests\UnitTestCase
             'property2' => null,
             'publicProperty2' => 42);
         $actualProperties = ObjectAccess::getGettableProperties($stdClassObject);
+        $this->assertEquals($expectedProperties, $actualProperties, 'expectedProperties did not return the right values for the properties.');
+    }
+
+    /**
+     * @test
+     */
+    public function getGettablePropertiesHandlesDoctrineProxy()
+    {
+        $proxyObject = new \TYPO3\Flow\Tests\Reflection\Fixture\Model\EntityWithDoctrineProxy();
+        $expectedProperties = array();
+        $actualProperties = ObjectAccess::getGettableProperties($proxyObject);
         $this->assertEquals($expectedProperties, $actualProperties, 'expectedProperties did not return the right values for the properties.');
     }
 


### PR DESCRIPTION
This change adjusts ObjectAccess to use getTypeForValue() instead of
get_class() so Doctrine proxies are handled correctly.