### PR TITLE
[TASK] Remove use of deprecated apigen options

### DIFF
--- a/apigen.yml
+++ b/apigen.yml
@@ -7,7 +7,7 @@ title: 'Flow Framework 2.3'
 docs-repository: 'neos/api-docs'
 exclude: 'TYPO3.*/Tests/*,TYPO3.*/Resources/*,TYPO3.*/Migrations/*'
 template-theme: 'bootstrap'
-annotation-groups: 'api'
+annotation-groups: 'api,deprecated,todo'
 
 # privates are useful to know for developers
 access-levels: public,protected,private
@@ -15,7 +15,3 @@ access-levels: public,protected,private
 internal: yes
 # the php lib is already documented on php.net
 php: false
-# the doc should contain deprecated to not differ from source
-deprecated: true
-# useful for developers AND users to know
-todo: true


### PR DESCRIPTION
The todo and deprecated options have been deprecated in favour of the
annotation-groups feature. This adjusts apigen.yml to comply.