### PR TITLE
[BUGFIX] Initialize Router lazily

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/RoutingCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/RoutingCommandController.php
@@ -17,7 +17,7 @@ use TYPO3\Flow\Configuration\ConfigurationManager;
 use TYPO3\Flow\Http\Request;
 use TYPO3\Flow\Mvc\Routing\Exception\InvalidControllerException;
 use TYPO3\Flow\Mvc\Routing\Route;
-use TYPO3\Flow\Mvc\Routing\RouterInterface;
+use TYPO3\Flow\Mvc\Routing\Router;
 use TYPO3\Flow\Object\ObjectManagerInterface;
 
 /**
@@ -35,7 +35,7 @@ class RoutingCommandController extends CommandController
 
     /**
      * @Flow\Inject
-     * @var RouterInterface
+     * @var Router
      */
     protected $router;
 
@@ -54,8 +54,6 @@ class RoutingCommandController extends CommandController
      */
     public function listCommand()
     {
-        $this->initializeRouter();
-
         $this->outputLine('Currently registered routes:');
         /** @var Route $route */
         foreach ($this->router->getRoutes() as $index => $route) {
@@ -74,8 +72,6 @@ class RoutingCommandController extends CommandController
      */
     public function showCommand($index)
     {
-        $this->initializeRouter();
-
         $routes = $this->router->getRoutes();
         if (isset($routes[$index - 1])) {
             /** @var Route $route */
@@ -110,8 +106,6 @@ class RoutingCommandController extends CommandController
      */
     public function getPathCommand($package, $controller = 'Standard', $action = 'index', $format = 'html')
     {
-        $this->initializeRouter();
-
         $packageParts = explode('\\', $package, 2);
         $package = $packageParts[0];
         $subpackage = isset($packageParts[1]) ? $packageParts[1] : null;
@@ -174,8 +168,6 @@ class RoutingCommandController extends CommandController
      */
     public function routePathCommand($path, $method = 'GET')
     {
-        $this->initializeRouter();
-
         $server = array(
             'REQUEST_URI' => $path,
             'REQUEST_METHOD' => $method
@@ -214,17 +206,6 @@ class RoutingCommandController extends CommandController
         }
         $this->outputLine('No matching Route was found');
         $this->quit(1);
-    }
-
-    /**
-     * Initialize the injected router-object
-     *
-     * @return void
-     */
-    protected function initializeRouter()
-    {
-        $routesConfiguration = $this->configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_ROUTES);
-        $this->router->setRoutesConfiguration($routesConfiguration);
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Client/InternalRequestEngine.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Client/InternalRequestEngine.php
@@ -83,16 +83,6 @@ class InternalRequestEngine implements RequestEngineInterface
     }
 
     /**
-     * Initialize this engine
-     *
-     * @return void
-     */
-    public function initializeObject()
-    {
-        $this->router->setRoutesConfiguration($this->configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_ROUTES));
-    }
-
-    /**
      * Sends the given HTTP request
      *
      * @param Http\Request $httpRequest
@@ -117,7 +107,6 @@ class InternalRequestEngine implements RequestEngineInterface
         $objectManager = $this->bootstrap->getObjectManager();
         $baseComponentChain = $objectManager->get('TYPO3\Flow\Http\Component\ComponentChain');
         $componentContext = new ComponentContext($httpRequest, $response);
-        $componentContext->setParameter('TYPO3\Flow\Mvc\Routing\RoutingComponent', 'skipRouterInitialization', true);
 
         try {
             $baseComponentChain->handle($componentContext);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/Routing/RoutingComponent.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/Routing/RoutingComponent.php
@@ -12,11 +12,8 @@ namespace TYPO3\Flow\Mvc\Routing;
  */
 
 use TYPO3\Flow\Annotations as Flow;
-use TYPO3\Flow\Http\Component\Exception as ComponentException;
-use TYPO3\Flow\Configuration\ConfigurationManager;
 use TYPO3\Flow\Http\Component\ComponentContext;
 use TYPO3\Flow\Http\Component\ComponentInterface;
-use TYPO3\Flow\Object\ObjectManagerInterface;
 
 /**
  * A routing HTTP component
@@ -28,12 +25,6 @@ class RoutingComponent implements ComponentInterface
      * @var Router
      */
     protected $router;
-
-    /**
-     * @Flow\Inject
-     * @var ConfigurationManager
-     */
-    protected $configurationManager;
 
     /**
      * @var array
@@ -59,11 +50,6 @@ class RoutingComponent implements ComponentInterface
      */
     public function handle(ComponentContext $componentContext)
     {
-        if ($componentContext->getParameter('TYPO3\Flow\Mvc\Routing\RoutingComponent', 'skipRouterInitialization') !== true) {
-            $routesConfiguration = $this->configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_ROUTES);
-            $this->router->setRoutesConfiguration($routesConfiguration);
-        }
-
         $matchResults = $this->router->route($componentContext->getHttpRequest());
         $componentContext->setParameter('TYPO3\Flow\Mvc\Routing\RoutingComponent', 'matchResults', $matchResults);
     }

--- a/TYPO3.Flow/Tests/Functional/Mvc/RoutingTest.php
+++ b/TYPO3.Flow/Tests/Functional/Mvc/RoutingTest.php
@@ -331,4 +331,52 @@ class RoutingTest extends FunctionalTestCase
         $response = $this->browser->request('http://localhost/http-method-test/', $requestMethod);
         $this->assertEquals($expectedStatus, $response->getStatus());
     }
+
+    /**
+     * @test
+     */
+    public function routerInitializesRoutesIfNotInjectedExplicitly()
+    {
+        $routeValues = array(
+            '@package' => 'TYPO3.Flow',
+            '@subpackage' => 'Tests\Functional\Http\Fixtures',
+            '@controller' => 'Foo',
+            '@action' => 'index',
+            '@format' => 'html'
+        );
+        $actualResult = $this->router->resolve($routeValues);
+
+        $this->assertSame('typo3/flow/test/http/foo', $actualResult);
+    }
+
+    /**
+     * @test
+     */
+    public function explicitlySpecifiedRoutesOverruleConfiguredRoutes()
+    {
+        $routeValues = array(
+            '@package' => 'TYPO3.Flow',
+            '@subpackage' => 'Tests\Functional\Http\Fixtures',
+            '@controller' => 'Foo',
+            '@action' => 'index',
+            '@format' => 'html'
+        );
+        $routesConfiguration = array(
+            array(
+                'uriPattern' => 'custom/uri/pattern',
+                'defaults' => array(
+                    '@package' => 'TYPO3.Flow',
+                    '@subpackage' => 'Tests\Functional\Http\Fixtures',
+                    '@controller' => 'Foo',
+                    '@action' => 'index',
+                    '@format' => 'html'
+                ),
+            )
+        );
+        $this->router->setRoutesConfiguration($routesConfiguration);
+        $this->assertSame('custom/uri/pattern', $this->router->resolve($routeValues));
+
+        // reset router configuration for following tests
+        $this->router->setRoutesConfiguration(null);
+    }
 }

--- a/TYPO3.Flow/Tests/Unit/Mvc/Routing/RoutingComponentTest.php
+++ b/TYPO3.Flow/Tests/Unit/Mvc/Routing/RoutingComponentTest.php
@@ -57,10 +57,10 @@ class RoutingComponentTest extends UnitTestCase
         $this->routingComponent = new RoutingComponent(array());
 
         $this->mockRouter = $this->getMockBuilder('TYPO3\Flow\Mvc\Routing\Router')->getMock();
-        $this->inject($this->routingComponent, 'router', $this->mockRouter);
-
         $this->mockConfigurationManager = $this->getMockBuilder('TYPO3\Flow\Configuration\ConfigurationManager')->disableOriginalConstructor()->getMock();
-        $this->inject($this->routingComponent, 'configurationManager', $this->mockConfigurationManager);
+        $this->inject($this->mockRouter, 'configurationManager', $this->mockConfigurationManager);
+
+        $this->inject($this->routingComponent, 'router', $this->mockRouter);
 
         $this->mockComponentContext = $this->getMockBuilder('TYPO3\Flow\Http\Component\ComponentContext')->disableOriginalConstructor()->getMock();
 
@@ -71,36 +71,9 @@ class RoutingComponentTest extends UnitTestCase
     /**
      * @test
      */
-    public function handleInitializesRouterByDefault()
-    {
-        $mockRoutesConfiguration = array('someRoutingConfiguration');
-        $this->mockConfigurationManager->expects($this->atLeastOnce())->method('getConfiguration')->with(ConfigurationManager::CONFIGURATION_TYPE_ROUTES)->will($this->returnValue($mockRoutesConfiguration));
-        $this->mockRouter->expects($this->atLeastOnce())->method('setRoutesConfiguration')->with($mockRoutesConfiguration);
-
-        $this->routingComponent->handle($this->mockComponentContext);
-    }
-
-    /**
-     * @test
-     */
-    public function handleDoesNotInitializeRouterIfTheSkipRouterInitializationParameterIsSet()
-    {
-        $this->mockComponentContext->expects($this->atLeastOnce())->method('getParameter')->with('TYPO3\Flow\Mvc\Routing\RoutingComponent', 'skipRouterInitialization')->will($this->returnValue(true));
-
-        $this->mockConfigurationManager->expects($this->never())->method('getConfiguration');
-        $this->mockRouter->expects($this->never())->method('setRoutesConfiguration');
-
-        $this->routingComponent->handle($this->mockComponentContext);
-    }
-
-    /**
-     * @test
-     */
     public function handleStoresRouterMatchResultsInTheComponentContext()
     {
         $mockMatchResults = array('someRouterMatchResults');
-
-        $this->mockConfigurationManager->expects($this->atLeastOnce())->method('getConfiguration')->will($this->returnValue(array()));
 
         $this->mockRouter->expects($this->atLeastOnce())->method('route')->with($this->mockHttpRequest)->will($this->returnValue($mockMatchResults));
         $this->mockComponentContext->expects($this->atLeastOnce())->method('setParameter')->with('TYPO3\Flow\Mvc\Routing\RoutingComponent', 'matchResults', $mockMatchResults);


### PR DESCRIPTION
The Router should be able to initialize configured routes lazily
except when explicitly told not to do so.
This change allows the Router to get the configuration directly
from the ``ConfigurationManager`` if no other routing configuration
exists. If some routing configuration was set, this is used.

Fixes: FLOW-192
Fixes: FLOW-205