### PR TITLE
[TASK] Fixing the most obvious references to TYPO3

### DIFF
--- a/TYPO3.Flow/Documentation/index.rst
+++ b/TYPO3.Flow/Documentation/index.rst
@@ -1,4 +1,4 @@
-TYPO3 Flow |version| Documentation
+Flow |version| Documentation
 ==================================
 
 Flow is a free PHP framework licensed under the MIT license, developed to power the enterprise Neos CMS.
@@ -7,13 +7,12 @@ This version of the documentation covering Flow |release| has been rendered at: 
 
 .. note::
 
-	We'd love to get your feedback on this documentation! Please share
-	your thoughts in the `TYPO3 Flow mailing list <http://lists.typo3.org/cgi-bin/mailman/listinfo/flow>`_,
-	`the forum <http://forum.typo3.org/index.php/f/22/>`_ or the `#typo3-flow channel <irc://irc.freenode.net/#typo3-flow>`_
-	on irc.freenode.net.
+	We'd love to get your feedback on this documentation! Please share 
+	your thoughts in our `forum <https://discuss.neos.io>`_, or the #flow-general channel
+	in the `Neos Project's Slack <https://slack.neos.io>`_.
 
 	Help is always greatly appreciated, read :ref:`ch-contributing` to find out how
-	you can improve TYPO3 Flow.
+	you can improve Flow.
 
 
 .. only:: html
@@ -27,7 +26,7 @@ This version of the documentation covering Flow |release| has been rendered at: 
 	The Definitive Guide
 	--------------------
 
-	The Hitchhiker's Guide to TYPO3 Flow and comprehensive almanac:
+	The Hitchhiker's Guide to Flow and comprehensive almanac:
 
 	- :doc:`TheDefinitiveGuide/index`
 
@@ -39,10 +38,10 @@ This version of the documentation covering Flow |release| has been rendered at: 
 	  - :doc:`TheDefinitiveGuide/Contributors`
 
 
-	TYPO3 Publication Style Guide
+	Publication Style Guide
 	-----------------------------
 
-	A style guide giving advice on how to write for the TYPO3 project:
+	A style guide giving advice on how to write for the Neos project:
 
 	- :doc:`StyleGuide/index`
 


### PR DESCRIPTION
This fixes pointers to the forum and chat and some mentions of "TYPO3" in the index.rst of the Flow documentation.