### PR TITLE
[TASK] Add permissions check for setfilepermissions.sh

### DIFF
--- a/TYPO3.Flow/Scripts/flow.php
+++ b/TYPO3.Flow/Scripts/flow.php
@@ -20,6 +20,11 @@ if (PHP_SAPI !== 'cli') {
 }
 
 if (isset($argv[1]) && ($argv[1] === 'typo3.flow:core:setfilepermissions' || $argv[1] === 'flow:core:setfilepermissions' || $argv[1] === 'core:setfilepermissions')) {
+       $filePermissions = decoct(fileperms(__DIR__ . '/setfilepermissions.sh') & 0777);
+    if ($filePermissions !== '700'){
+        chmod(__DIR__ . '/setfilepermissions.sh', 0700);
+    }
+    
     if (DIRECTORY_SEPARATOR !== '/') {
         exit('The core:setfilepermissions command is only available on UNIX platforms.' . PHP_EOL);
     }


### PR DESCRIPTION
Using the setfilepermissions.sh script fails due to wrong file permissions left by the composer installation (missing executable bit). Added the checking of the file's permissions, and correcting the file's permissions if needed. Mode 0700 is set as the setfilepermissions.sh script sets it's own permissions to that mode.