### PR TITLE
TASK: Add permissions check for setfilepermissions.sh

### DIFF
--- a/TYPO3.Flow/Scripts/flow.php
+++ b/TYPO3.Flow/Scripts/flow.php
@@ -23,6 +23,12 @@ if (isset($argv[1]) && ($argv[1] === 'typo3.flow:core:setfilepermissions' || $ar
     if (DIRECTORY_SEPARATOR !== '/') {
         exit('The core:setfilepermissions command is only available on UNIX platforms.' . PHP_EOL);
     }
+    
+    $filePermissions = decoct(fileperms(__DIR__ . '/setfilepermissions.sh') & 0777);
+    if ($filePermissions !== '700'){
+        chmod(__DIR__ . '/setfilepermissions.sh', 0700);
+    }
+    
     array_shift($argv);
     array_shift($argv);
     $returnValue = 0;

--- a/TYPO3.Flow/Scripts/flow.php
+++ b/TYPO3.Flow/Scripts/flow.php
@@ -25,7 +25,7 @@ if (isset($argv[1]) && ($argv[1] === 'typo3.flow:core:setfilepermissions' || $ar
     }
     
     $filePermissions = decoct(fileperms(__DIR__ . '/setfilepermissions.sh') & 0777);
-    if ($filePermissions !== '700'){
+    if ($filePermissions !== '700') {
         chmod(__DIR__ . '/setfilepermissions.sh', 0700);
     }
     


### PR DESCRIPTION
Using the ``setfilepermissions.sh`` script fails due to wrong file permissions left by the composer installation (missing executable bit). Added the checking of the file's permissions, and correcting the file's permissions if needed. Mode 0700 is set as the ``setfilepermissions.sh`` script sets it's own permissions to that mode.

FLOW-400 #close
