### PR TITLE
[BUGFIX] Ignore injected properties for value hash generation

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Aspect/PersistenceMagicAspect.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Aspect/PersistenceMagicAspect.php
@@ -106,11 +106,11 @@ class PersistenceMagicAspect
         $proxyClassName = get_class($proxy);
         $hashSourceParts = array();
 
-        $properties = $this->reflectionService->getClassPropertyNames($proxyClassName);
-        foreach ($properties as $property) {
+        $classSchema = $this->reflectionService->getClassSchema($proxyClassName);
+        foreach ($classSchema->getProperties() as $property => $propertySchema) {
             // Currently, private properties are transient. Should this behaviour change, they need to be included
             // in the value hash generation
-            if ($this->reflectionService->isPropertyAnnotatedWith($proxyClassName, $property, 'TYPO3\\Flow\\Annotations\\Transient')
+            if ($classSchema->isPropertyTransient($property)
                 || $this->reflectionService->isPropertyPrivate($proxyClassName, $property)) {
                 continue;
             }

--- a/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/TestValueObjectWithTransientProperties.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/TestValueObjectWithTransientProperties.php
@@ -34,6 +34,12 @@ class TestValueObjectWithTransientProperties
     protected $value2;
 
     /**
+     * @Flow\Inject
+     * @var \TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntityRepository
+     */
+    protected $dependency;
+
+    /**
      * @var int
      */
     protected $calculatedValue;


### PR DESCRIPTION
When injecting properties into a value object, an exception was thrown that
a closure is tried to be serialized. This was due to the hash generation
in PersistenceMagicAspect only skipping properties that are annotated as
transient.

This change makes the value hash generation resort to the class schema instead
of directly iterating all properties, since the class schema is already focused
on persistence relevant properties and hence contains no injected properties.