### PR TITLE
FEATURE: Allow usage of is*/has* accessors in Fluid templates directly

### DIFF
--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Templating.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Templating.rst
@@ -157,8 +157,10 @@ Instead of passing strings to the template, we are passing whole objects around
 now - which is much nicer to use both from the controller and the view side. To
 access certain properties of these objects, you can use Object Accessors. By writing
 ``{blog.title}``, the template engine will call a ``getTitle()`` method on the blog
-object, if it exists. Besides, you can use that syntax to traverse associative arrays
-and public properties.
+object, if it exists. By writing ``{blog.isPublic}`` or ``{blog.hasPosts}``, the
+template engine will call ``isPublic()`` or ``hasPosts()`` respectively, unless
+``getIsPublic()`` or ``getHasPosts()`` methods exist.
+Besides, you can use that syntax to traverse associative arrays and public properties.
 
 .. Tip::
 

--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/Core/Parser/SyntaxTree/ObjectAccessorNode.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/Core/Parser/SyntaxTree/ObjectAccessorNode.php
@@ -88,10 +88,22 @@ class ObjectAccessorNode extends AbstractNode
     {
         $propertyPathSegments = explode('.', $propertyPath);
         foreach ($propertyPathSegments as $pathSegment) {
+            $isHasDirectAccess = false;
             try {
-                $subject = ObjectAccess::getProperty($subject, $pathSegment);
+                if (preg_match('/^(is|has)([A-Z].*)/', $pathSegment, $matches) > 0) {
+                    $subject = ObjectAccess::getProperty($subject, lcfirst($matches[2]));
+                    $isHasDirectAccess = true;
+                }
             } catch (PropertyNotAccessibleException $exception) {
-                $subject = null;
+                // Don't do anything here for backwards compatiblity
+            }
+
+            if (!$isHasDirectAccess) {
+                try {
+                    $subject = ObjectAccess::getProperty($subject, $pathSegment);
+                } catch (PropertyNotAccessibleException $exception) {
+                    $subject = null;
+                }
             }
 
             if ($subject === null) {

--- a/TYPO3.Fluid/Tests/Functional/Core/ParserIntegrationTest.php
+++ b/TYPO3.Fluid/Tests/Functional/Core/ParserIntegrationTest.php
@@ -14,6 +14,7 @@ namespace TYPO3\Fluid\Tests\Functional\Core;
 use org\bovigo\vfs\vfsStreamWrapper;
 use TYPO3\Flow\Http\Request;
 use TYPO3\Flow\Http\Uri;
+use TYPO3\Fluid\Tests\Functional\Form\Fixtures\Domain\Model\Post;
 use TYPO3\Flow\Tests\FunctionalTestCase;
 use TYPO3\Fluid\Tests\Functional\View\Fixtures\View\StandaloneView;
 use TYPO3\Fluid\View\Exception\InvalidTemplateResourceException;
@@ -93,5 +94,28 @@ class ParserIntegrationTest extends FunctionalTestCase
 
         $this->assertSame($uncompiledResult, $compiledResult, 'The rendered compiled template did not match the rendered uncompiled template.');
         $this->assertSame('foo: Content', $standaloneView->render());
+    }
+
+    /**
+     * @test
+     */
+    public function isHasMethodsCanBeAccessedDirectly()
+    {
+        $httpRequest = Request::create(new Uri('http://localhost'));
+        $actionRequest = new \TYPO3\Flow\Mvc\ActionRequest($httpRequest);
+
+        $standaloneView = new StandaloneView($actionRequest, uniqid());
+        $post = new Post();
+        $post->setPrivate(true);
+        $standaloneView->assignMultiple(array('post' => $post));
+        $standaloneView->setTemplateSource('<f:if condition="{post.isPrivate}">Private!</f:if>');
+
+        $actual = $standaloneView->render();
+        $this->assertSame('Private!', $actual);
+
+        $standaloneView->setTemplateSource('<f:if condition="{post.isprivate}">Private!</f:if>');
+
+        $actual = $standaloneView->render();
+        $this->assertSame('', $actual);
     }
 }

--- a/TYPO3.Fluid/Tests/Functional/Form/Fixtures/Domain/Model/Post.php
+++ b/TYPO3.Fluid/Tests/Functional/Form/Fixtures/Domain/Model/Post.php
@@ -105,7 +105,7 @@ class Post
      */
     public function isPrivate()
     {
-        return $this->private;
+        return $this->private ? 'Private!' : 'Public';
     }
 
     /**
@@ -122,6 +122,14 @@ class Post
     public function getCategory()
     {
         return $this->category;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHasCategory()
+    {
+        return !empty($this->category);
     }
 
     /**

--- a/TYPO3.Fluid/Tests/Functional/Form/Fixtures/Domain/Model/Post.php
+++ b/TYPO3.Fluid/Tests/Functional/Form/Fixtures/Domain/Model/Post.php
@@ -101,6 +101,14 @@ class Post
     }
 
     /**
+     * @return boolean
+     */
+    public function isPrivate()
+    {
+        return $this->private;
+    }
+
+    /**
      * @param string $category
      */
     public function setCategory($category)


### PR DESCRIPTION
This changeset adds support for accessor methods is* and has* to be
used directly for property access.
This allows to use such accessors in Fluid templates, which makes
the template code more readable and avoids getIs* and getHas* methods
in domain models.

Example::

    <f:if condition="{someObject.isSomething}"></f:if>

This will call someObject->isSomething() method.