### PR TITLE
[BUGFIX] Make sure expired cache entries get deleted in PdoBackend

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Cache/Backend/PdoBackend.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Cache/Backend/PdoBackend.php
@@ -114,9 +114,7 @@ class PdoBackend extends AbstractBackend implements TaggableBackendInterface
             throw new \TYPO3\Flow\Cache\Exception\InvalidDataException('The specified data is of type "' . gettype($data) . '" but a string is expected.', 1259515601);
         }
 
-        if ($this->has($entryIdentifier)) {
-            $this->remove($entryIdentifier);
-        }
+        $this->remove($entryIdentifier);
 
         $lifetime = ($lifetime === null) ? $this->defaultLifetime : $lifetime;
 


### PR DESCRIPTION
`$this->has($entryIdentifier)` returns false for expired cache entries
which leads to duplicate key violations. Remove existing entries,
including expired ones, before creating new cache entry.

Fixes: FLOW-193
Releases: master, 3.0, 2.3