### PR TITLE
[BUGFIX] ResourceTypeConverter should return null for empty source

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/ResourceTypeConverter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/ResourceTypeConverter.php
@@ -137,6 +137,10 @@ class ResourceTypeConverter extends AbstractTypeConverter
      */
     public function convertFrom($source, $targetType, array $convertedChildProperties = array(), PropertyMappingConfigurationInterface $configuration = null)
     {
+        if (empty($source)) {
+            return null;
+        }
+
         if (is_string($source)) {
             $source = array('hash' => $source);
         }


### PR DESCRIPTION
The given source can either be an array or a string and in both cases
an empty value would signify a value that cannot be converted and
probably stems from an empty input. In this case the converter
should return null immediately, otherwise it will go on with processing
the empty value and eventually ends up in returning a conversion error
which would be wrong.