### PR TITLE
[BUGFIX] Check if migrations exist before trying to register them

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/Service.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/Service.php
@@ -197,13 +197,14 @@ class Service
 
         $databasePlatformName = $this->getDatabasePlatformName();
         foreach ($this->packageManager->getActivePackages() as $package) {
-            $configuration->registerMigrationsFromDirectory(
-                \TYPO3\Flow\Utility\Files::concatenatePaths(array(
+            $path = \TYPO3\Flow\Utility\Files::concatenatePaths(array(
                     $package->getPackagePath(),
                     'Migrations',
                     $databasePlatformName
-                ))
-            );
+                ));
+            if (is_dir($path)) {
+                $configuration->registerMigrationsFromDirectory($path);
+            }
         }
 
         return $configuration;


### PR DESCRIPTION
Backport from 9823ae980e803 (Author: Laurent Cherpit @lcherpit )

Currently the check for the existence of migration files is delegated
to the doctrine/migration third party library.

The behavior has changed and an exception is thrown if the folder doesn't
exist. To not let the third party library handle that and to prevent this,
the check is done upstream in Flow.
