### PR TITLE
[TASK] Some tweaks to unit tests

### DIFF
--- a/TYPO3.Flow/Tests/Unit/Http/RequestTest.php
+++ b/TYPO3.Flow/Tests/Unit/Http/RequestTest.php
@@ -18,14 +18,23 @@ use TYPO3\Flow\Tests\UnitTestCase;
 
 /**
  * Test case for the Http Request class
+ *
+ * In some tests backupGlobals is disabled, this is to avoid risky test warnings caused by changed globals
+ * that are needed to be changed in those tests.
+ *
+ * Additionally those tests backup/restore the SCRIPT_NAME in the $_SERVER superglobal to avoid a warning
+ * with PHPUnit when it tries to access that in phpunit/phpunit/src/Util/Filter.php on line 29
  */
 class RequestTest extends UnitTestCase
 {
     /**
      * @test
+     * @backupGlobals disabled
      */
     public function createFromEnvironmentCreatesAReasonableRequestObjectFromTheSuperGlobals()
     {
+        $scriptName = $_SERVER['SCRIPT_NAME'];
+
         $_GET = array('getKey1' => 'getValue1', 'getKey2' => 'getValue2');
         $_POST = array();
         $_COOKIE = array();
@@ -69,13 +78,18 @@ class RequestTest extends UnitTestCase
 
         $this->assertEquals('GET', $request->getMethod());
         $this->assertEquals('http://dev.blog.rob/posts/2011/11/28/laboriosam-soluta-est-minus-molestiae?getKey1=getValue1&getKey2=getValue2', (string)$request->getUri());
+
+        $_SERVER['SCRIPT_NAME'] = $scriptName;
     }
 
     /**
      * @test
+     * @backupGlobals disabled
      */
     public function createFromEnvironmentWithEmptyServerVariableWorks()
     {
+        $scriptName = $_SERVER['SCRIPT_NAME'];
+
         $_GET = array();
         $_POST = array();
         $_COOKIE = array();
@@ -85,6 +99,8 @@ class RequestTest extends UnitTestCase
         $request = Request::createFromEnvironment();
 
         $this->assertEquals('http://localhost/', (string)$request->getUri());
+
+        $_SERVER['SCRIPT_NAME'] = $scriptName;
     }
 
     /**
@@ -669,9 +685,12 @@ class RequestTest extends UnitTestCase
     /**
      * RFC 2616 / 14.23 (Host)
      * @test
+     * @backupGlobals disabled
      */
     public function portInProxyHeaderIsAcknowledged()
     {
+        $scriptName = $_SERVER['SCRIPT_NAME'];
+
         $_SERVER = array(
             'HTTP_HOST' => 'dev.blog.rob',
             'HTTP_X_FORWARDED_PORT' => 2727,
@@ -685,6 +704,8 @@ class RequestTest extends UnitTestCase
 
         $request = Request::create(new Uri('https://dev.blog.rob/foo/bar?baz=quux&coffee=due'), array(), array(), array(), $_SERVER);
         $this->assertSame(2727, $request->getPort());
+
+        $_SERVER['SCRIPT_NAME'] = $scriptName;
     }
 
     /**
@@ -1241,5 +1262,8 @@ class RequestTest extends UnitTestCase
             'HTTP_HTTPS' => '1',
         );
         new Request(array(), array(), array(), $server);
+
+        // dummy assertion to avoid PHPUnit warning
+        $this->assertTrue(true);
     }
 }

--- a/TYPO3.Flow/Tests/Unit/Persistence/Generic/DataMapperTest.php
+++ b/TYPO3.Flow/Tests/Unit/Persistence/Generic/DataMapperTest.php
@@ -229,14 +229,11 @@ class DataMapperTest extends \TYPO3\Flow\Tests\UnitTestCase
     /**
      * @test
      * @see http://forge.typo3.org/issues/9684
-     * @todo check for correct order again, somehow...
      */
     public function thawPropertiesFollowsOrderOfGivenObjectData()
     {
-        $this->markTestSkipped('The test needs to check for the correct order again, somehow....');
-
         $className = 'Class' . md5(uniqid(mt_rand(), true));
-        eval('class ' . $className . ' { public $firstProperty; public $secondProperty; public $thirdProperty; }');
+        eval('class ' . $className . ' { protected $properties = []; public function __set($name, $value) { $this->properties[] = [$name => $value]; } }');
         $object = new $className();
 
         $objectData = array(
@@ -271,12 +268,11 @@ class DataMapperTest extends \TYPO3\Flow\Tests\UnitTestCase
 
         $dataMapper = $this->getAccessibleMock(\TYPO3\Flow\Persistence\Generic\DataMapper::class, array('dummy'));
         $dataMapper->injectReflectionService($mockReflectionService);
-        $dataMapper->_call('thawProperties', $object, 1234, $objectData);
+        $dataMapper->_call('thawProperties', $object, '1234', $objectData);
 
         // the order of setting those is important, but cannot be tested for now (static setProperty)
-        $this->assertAttributeEquals('secondValue', 'secondProperty', $object);
-        $this->assertAttributeEquals('firstValue', 'firstProperty', $object);
-        $this->assertAttributeEquals('thirdValue', 'thirdProperty', $object);
+        $expected = [['secondProperty' => 'secondValue'],['firstProperty' => 'firstValue'],['thirdProperty' => 'thirdValue'],['Persistence_Object_Identifier' => '1234']];
+        $this->assertAttributeSame($expected, 'properties', $object);
     }
 
     /**

--- a/TYPO3.Flow/Tests/Unit/Persistence/Generic/PersistenceManagerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Persistence/Generic/PersistenceManagerTest.php
@@ -230,7 +230,13 @@ class PersistenceManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function updateSchedulesAnObjectForPersistence()
     {
-        $this->markTestIncomplete('Needs to be tested and coded');
+        $object = new \ArrayObject(array('val' => '1'));
+        $persistenceManager = $this->getMock(\TYPO3\Flow\Persistence\Generic\PersistenceManager::class, array('isNewObject'));
+        $persistenceManager->expects($this->any())->method('isNewObject')->willReturn(false);
+
+        $this->assertAttributeNotContains($object, 'changedObjects', $persistenceManager);
+        $persistenceManager->update($object);
+        $this->assertAttributeContains($object, 'changedObjects', $persistenceManager);
     }
 
     /**


### PR DESCRIPTION
This fixes some notices about undefined array indexes with PHPUnit,
removes some (wrong) risky test warnings and brings one skipped and one
incomplete test back to life.