### PR TITLE
[BUGFIX] Set correct request port if X-Forwarded-Proto is set

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Request.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Request.php
@@ -95,6 +95,8 @@ class Request extends Message
 
         if ($this->headers->has('X-Forwarded-Port')) {
             $this->uri->setPort($this->headers->get('X-Forwarded-Port'));
+        } elseif ($this->headers->has('X-Forwarded-Proto') && $protocol === 'https') {
+            $this->uri->setPort(443);
         } elseif (isset($server['SERVER_PORT'])) {
             $this->uri->setPort($server['SERVER_PORT']);
         }

--- a/TYPO3.Flow/Tests/Unit/Http/RequestTest.php
+++ b/TYPO3.Flow/Tests/Unit/Http/RequestTest.php
@@ -748,7 +748,7 @@ class RequestTest extends UnitTestCase
                 'forwardedProtocol' => 'https',
                 'forwardedPort' => null,
                 'requestUri' => 'http://acme.com',
-                'expectedUri' => 'https://acme.com:80',
+                'expectedUri' => 'https://acme.com',
             ),
             array(
                 'forwardedProtocol' => 'https',
@@ -760,7 +760,7 @@ class RequestTest extends UnitTestCase
                 'forwardedProtocol' => 'http',
                 'forwardedPort' => null,
                 'requestUri' => 'https://acme.com',
-                'expectedUri' => 'http://acme.com:443',
+                'expectedUri' => 'http://acme.com',
             ),
             array(
                 'forwardedProtocol' => 'http',


### PR DESCRIPTION
This fixes an issue resulting in wrong rendered URLs if Flow is accepting
request from a load balancer or proxy which is accessed via https
externally, sends the X-Forwarded-Proto header to Nginx but does not
specify the X-Forwarded-Port header.

For example, a load balancer (for example Google HTTP/HTTPS load
balancer) is accessible via https and terminates SSL. The load balancer
communicates with Nginx via http on port 80. Google only sends the
X-Forwarded-Proto header ("https") but not the port. URLs, for example
in an action URI of a form, are rendered wrongly.

An expected URL would be https://example.com/foo.html, however, the
rendered URL is https://example.com:80/foo.html

This change changes the behavior in `Request` so that if the
X-Forwarded-Proto header is set, but the X-Forwarded-Port header isn't,
the port is set to the standard port of the given protocol (80 / 443).

Resolves: FLOW-409