### PR TITLE
[TASK] Make Condition ViewHelpers fully static compileable

### DIFF
--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/IfViewHelper.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/IfViewHelper.php
@@ -95,7 +95,7 @@ use TYPO3\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IfViewHelper extends AbstractConditionViewHelper
 {
     /**
-     * Renders <f:then> child if $condition is true, otherwise renders <f:else> child.
+     * renders <f:then> child if $condition is true, otherwise renders <f:else> child.
      *
      * @param boolean $condition View helper condition
      * @return string the rendered string
@@ -103,10 +103,6 @@ class IfViewHelper extends AbstractConditionViewHelper
      */
     public function render($condition)
     {
-        if ($condition) {
-            return $this->renderThenChild();
-        } else {
-            return $this->renderElseChild();
-        }
+        return $this->renderInternal();
     }
 }

--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Security/IfAccessViewHelper.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Security/IfAccessViewHelper.php
@@ -12,7 +12,9 @@ namespace TYPO3\Fluid\ViewHelpers\Security;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Object\ObjectManagerInterface;
 use TYPO3\Flow\Security\Authorization\PrivilegeManagerInterface;
+use TYPO3\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 
 /**
@@ -51,12 +53,6 @@ use TYPO3\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IfAccessViewHelper extends AbstractConditionViewHelper
 {
     /**
-     * @Flow\Inject
-     * @var PrivilegeManagerInterface
-     */
-    protected $privilegeManager;
-
-    /**
      * renders <f:then> child if access to the given resource is allowed, otherwise renders <f:else> child.
      *
      * @param string $privilegeTarget The Privilege target identifier
@@ -66,10 +62,24 @@ class IfAccessViewHelper extends AbstractConditionViewHelper
      */
     public function render($privilegeTarget, array $parameters = array())
     {
-        if ($this->privilegeManager->isPrivilegeTargetGranted($privilegeTarget, $parameters)) {
-            return $this->renderThenChild();
-        } else {
-            return $this->renderElseChild();
-        }
+        return $this->renderInternal();
+    }
+
+
+    /**
+     * @param array $arguments
+     * @param RenderingContextInterface $renderingContext
+     * @return boolean
+     */
+    protected static function evaluateCondition($arguments = null, RenderingContextInterface $renderingContext)
+    {
+        $privilegeTarget = $arguments['privilegeTarget'];
+        $parameters = $arguments['parameters'];
+
+        /** @var ObjectManagerInterface $objectManager */
+        $objectManager = $renderingContext->getObjectManager();
+        $privilegeManager = $objectManager->get(PrivilegeManagerInterface::class);
+
+        return $privilegeManager->isPrivilegeTargetGranted($privilegeTarget, $parameters);
     }
 }

--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Security/IfAuthenticatedViewHelper.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Security/IfAuthenticatedViewHelper.php
@@ -11,8 +11,10 @@ namespace TYPO3\Fluid\ViewHelpers\Security;
  * source code.
  */
 
+use TYPO3\Flow\Object\ObjectManagerInterface;
 use TYPO3\Flow\Security\Authentication\TokenInterface;
 use TYPO3\Flow\Security\Context;
+use TYPO3\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 
 /**
@@ -49,36 +51,33 @@ use TYPO3\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 class IfAuthenticatedViewHelper extends AbstractConditionViewHelper
 {
     /**
-     * @var Context
-     */
-    protected $securityContext;
-
-    /**
-     * Injects the Security Context
+     * renders <f:then> child if an account is authenticated, otherwise renders <f:else> child.
      *
-     * @param Context $securityContext
-     * @return void
-     */
-    public function injectSecurityContext(Context $securityContext)
-    {
-        $this->securityContext = $securityContext;
-    }
-
-    /**
-     * Renders <f:then> child if any account is currently authenticated, otherwise renders <f:else> child.
-     *
-     * @return string the rendered string
+     * @return string the rendered then/else child nodes depending on the access
      * @api
      */
     public function render()
     {
-        $activeTokens = $this->securityContext->getAuthenticationTokens();
+        return $this->renderInternal();
+    }
+
+    /**
+     * @param array $arguments
+     * @param RenderingContextInterface $renderingContext
+     * @return boolean
+     */
+    protected static function evaluateCondition($arguments = null, RenderingContextInterface $renderingContext)
+    {
+        /** @var ObjectManagerInterface $objectManager */
+        $objectManager = $renderingContext->getObjectManager();
+        $securityContext = $objectManager->get(Context::class);
+
         /** @var $token TokenInterface */
-        foreach ($activeTokens as $token) {
+        foreach ($securityContext->getAuthenticationTokens() as $token) {
             if ($token->isAuthenticated()) {
-                return $this->renderThenChild();
+                return true;
             }
         }
-        return $this->renderElseChild();
+        return false;
     }
 }

--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Validation/IfHasErrorsViewHelper.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Validation/IfHasErrorsViewHelper.php
@@ -15,6 +15,7 @@ namespace TYPO3\Fluid\ViewHelpers\Validation;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Error\Result;
 use TYPO3\Flow\Mvc\ActionRequest;
+use TYPO3\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 
 /**
@@ -52,18 +53,29 @@ class IfHasErrorsViewHelper extends AbstractConditionViewHelper
      */
     public function render($for = null)
     {
+        return $this->renderInternal();
+    }
+
+    /**
+     * @param array $arguments
+     * @param RenderingContextInterface $renderingContext
+     * @return boolean
+     */
+    protected static function evaluateCondition($arguments = null, RenderingContextInterface $renderingContext)
+    {
         /** @var $request ActionRequest */
-        $request = $this->controllerContext->getRequest();
+        $request = $renderingContext->getControllerContext()->getRequest();
         /** @var $validationResults Result */
         $validationResults = $request->getInternalArgument('__submittedArgumentValidationResults');
 
         if ($validationResults !== null) {
-            // if $for is not set, ->forProperty will return the initial Result object untouched
-            $validationResults = $validationResults->forProperty($for);
+            // if $for is null, ->forProperty will return the initial Result object untouched
+            $validationResults = $validationResults->forProperty(isset($arguments['for']) ? $arguments['for'] : null);
             if ($validationResults->hasErrors()) {
-                return $this->renderThenChild();
+                return true;
             }
         }
-        return $this->renderElseChild();
+
+        return false;
     }
 }

--- a/TYPO3.Fluid/Tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
+++ b/TYPO3.Fluid/Tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
@@ -11,7 +11,10 @@ namespace TYPO3\Fluid\Tests\Unit\Core\ViewHelper;
  * source code.
  */
 
+use TYPO3\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use TYPO3\Fluid\ViewHelpers\ElseViewHelper;
+use TYPO3\Fluid\ViewHelpers\ThenViewHelper;
 use TYPO3\Fluid\ViewHelpers\ViewHelperBaseTestcase;
 
 require_once(__DIR__ . '/../../ViewHelpers/ViewHelperBaseTestcase.php');
@@ -29,7 +32,7 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
     public function setUp()
     {
         parent::setUp();
-        $this->viewHelper = $this->getAccessibleMock(\TYPO3\Fluid\Core\ViewHelper\AbstractConditionViewHelper::class, array('getRenderingContext', 'renderChildren', 'hasArgument'));
+        $this->viewHelper = $this->getAccessibleMock(AbstractConditionViewHelper::class, array('getRenderingContext', 'renderChildren', 'hasArgument'));
         $this->viewHelper->expects($this->any())->method('getRenderingContext')->will($this->returnValue($this->renderingContext));
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
     }
@@ -50,8 +53,8 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
      */
     public function renderThenChildReturnsThenViewHelperChildIfConditionIsTrueAndThenViewHelperChildExists()
     {
-        $mockThenViewHelperNode = $this->getMock(\TYPO3\Fluid\Core\Parser\SyntaxTree\ViewHelperNode::class, array('getViewHelperClassName', 'evaluate'), array(), '', false);
-        $mockThenViewHelperNode->expects($this->at(0))->method('getViewHelperClassName')->will($this->returnValue(\TYPO3\Fluid\ViewHelpers\ThenViewHelper::class));
+        $mockThenViewHelperNode = $this->getMock(ViewHelperNode::class, array('getViewHelperClassName', 'evaluate'), array(), '', false);
+        $mockThenViewHelperNode->expects($this->at(0))->method('getViewHelperClassName')->will($this->returnValue(ThenViewHelper::class));
         $mockThenViewHelperNode->expects($this->at(1))->method('evaluate')->with($this->renderingContext)->will($this->returnValue('ThenViewHelperResults'));
 
         $this->viewHelper->setChildNodes(array($mockThenViewHelperNode));
@@ -64,7 +67,7 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
      */
     public function renderThenChildReturnsValueOfThenArgumentIfItIsSpecified()
     {
-        $this->viewHelper->expects($this->atLeastOnce())->method('hasArgument')->with('then')->will($this->returnValue(true));
+        $this->viewHelper->expects($this->any())->method('hasArgument')->with('then')->will($this->returnValue(true));
         $this->arguments['then'] = 'ThenArgument';
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
 
@@ -77,8 +80,8 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
      */
     public function renderThenChildReturnsEmptyStringIfChildNodesOnlyContainElseViewHelper()
     {
-        $mockElseViewHelperNode = $this->getMock(\TYPO3\Fluid\Core\Parser\SyntaxTree\ViewHelperNode::class, array('getViewHelperClassName', 'evaluate'), array(), '', false);
-        $mockElseViewHelperNode->expects($this->any())->method('getViewHelperClassName')->will($this->returnValue(\TYPO3\Fluid\ViewHelpers\ElseViewHelper::class));
+        $mockElseViewHelperNode = $this->getMock(ViewHelperNode::class, array('getViewHelperClassName', 'evaluate'), array(), '', false);
+        $mockElseViewHelperNode->expects($this->any())->method('getViewHelperClassName')->will($this->returnValue(ElseViewHelper::class));
         $this->viewHelper->setChildNodes(array($mockElseViewHelperNode));
         $this->viewHelper->expects($this->never())->method('renderChildren')->will($this->returnValue('Child nodes'));
 
@@ -100,8 +103,8 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
      */
     public function renderElseChildRendersElseViewHelperChildIfConditionIsFalseAndNoThenViewHelperChildExists()
     {
-        $mockElseViewHelperNode = $this->getMock(\TYPO3\Fluid\Core\Parser\SyntaxTree\ViewHelperNode::class, array('getViewHelperClassName', 'evaluate', 'setRenderingContext'), array(), '', false);
-        $mockElseViewHelperNode->expects($this->at(0))->method('getViewHelperClassName')->will($this->returnValue(\TYPO3\Fluid\ViewHelpers\ElseViewHelper::class));
+        $mockElseViewHelperNode = $this->getMock(ViewHelperNode::class, array('getViewHelperClassName', 'evaluate', 'setRenderingContext'), array(), '', false);
+        $mockElseViewHelperNode->expects($this->at(0))->method('getViewHelperClassName')->will($this->returnValue(ElseViewHelper::class));
         $mockElseViewHelperNode->expects($this->at(1))->method('evaluate')->with($this->renderingContext)->will($this->returnValue('ElseViewHelperResults'));
 
         $this->viewHelper->setChildNodes(array($mockElseViewHelperNode));
@@ -114,12 +117,12 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
      */
     public function thenArgumentHasPriorityOverChildNodesIfConditionIsTrue()
     {
-        $mockThenViewHelperNode = $this->getMock(\TYPO3\Fluid\Core\Parser\SyntaxTree\ViewHelperNode::class, array('getViewHelperClassName', 'evaluate', 'setRenderingContext'), array(), '', false);
+        $mockThenViewHelperNode = $this->getMock(ViewHelperNode::class, array('getViewHelperClassName', 'evaluate', 'setRenderingContext'), array(), '', false);
         $mockThenViewHelperNode->expects($this->never())->method('evaluate');
 
         $this->viewHelper->setChildNodes(array($mockThenViewHelperNode));
 
-        $this->viewHelper->expects($this->atLeastOnce())->method('hasArgument')->with('then')->will($this->returnValue(true));
+        $this->viewHelper->expects($this->any())->method('hasArgument')->with('then')->will($this->returnValue(true));
         $this->arguments['then'] = 'ThenArgument';
 
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
@@ -133,7 +136,7 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
      */
     public function renderReturnsValueOfElseArgumentIfConditionIsFalse()
     {
-        $this->viewHelper->expects($this->atLeastOnce())->method('hasArgument')->with('else')->will($this->returnValue(true));
+        $this->viewHelper->expects($this->any())->method('hasArgument')->with('else')->will($this->returnValue(true));
         $this->arguments['else'] = 'ElseArgument';
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
 
@@ -146,13 +149,13 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
      */
     public function elseArgumentHasPriorityOverChildNodesIfConditionIsFalse()
     {
-        $mockElseViewHelperNode = $this->getMock(\TYPO3\Fluid\Core\Parser\SyntaxTree\ViewHelperNode::class, array('getViewHelperClassName', 'evaluate', 'setRenderingContext'), array(), '', false);
-        $mockElseViewHelperNode->expects($this->any())->method('getViewHelperClassName')->will($this->returnValue(\TYPO3\Fluid\ViewHelpers\ElseViewHelper::class));
+        $mockElseViewHelperNode = $this->getMock(ViewHelperNode::class, array('getViewHelperClassName', 'evaluate', 'setRenderingContext'), array(), '', false);
+        $mockElseViewHelperNode->expects($this->any())->method('getViewHelperClassName')->will($this->returnValue(ElseViewHelper::class));
         $mockElseViewHelperNode->expects($this->never())->method('evaluate');
 
         $this->viewHelper->setChildNodes(array($mockElseViewHelperNode));
 
-        $this->viewHelper->expects($this->atLeastOnce())->method('hasArgument')->with('else')->will($this->returnValue(true));
+        $this->viewHelper->expects($this->any())->method('hasArgument')->with('else')->will($this->returnValue(true));
         $this->arguments['else'] = 'ElseArgument';
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
 

--- a/TYPO3.Fluid/Tests/Unit/ViewHelpers/IfViewHelperTest.php
+++ b/TYPO3.Fluid/Tests/Unit/ViewHelpers/IfViewHelperTest.php
@@ -37,7 +37,7 @@ class IfViewHelperTest extends \TYPO3\Fluid\ViewHelpers\ViewHelperBaseTestcase
     public function viewHelperRendersThenChildIfConditionIsTrue()
     {
         $this->viewHelper->expects($this->at(0))->method('renderThenChild')->will($this->returnValue('foo'));
-
+        $this->viewHelper->_set('arguments', ['condition' => true]);
         $actualResult = $this->viewHelper->render(true);
         $this->assertEquals('foo', $actualResult);
     }

--- a/TYPO3.Fluid/Tests/Unit/ViewHelpers/Security/IfAccessViewHelperTest.php
+++ b/TYPO3.Fluid/Tests/Unit/ViewHelpers/Security/IfAccessViewHelperTest.php
@@ -11,7 +11,9 @@ namespace TYPO3\Fluid\Tests\Unit\ViewHelpers\Security;
  * source code.
  */
 
+use TYPO3\Flow\Object\ObjectManagerInterface;
 use TYPO3\Flow\Security\Authorization\PrivilegeManagerInterface;
+use TYPO3\Fluid\Core\Rendering\RenderingContext;
 use TYPO3\Fluid\ViewHelpers\Security\IfAccessViewHelper;
 use TYPO3\Fluid\ViewHelpers\ViewHelperBaseTestcase;
 
@@ -33,12 +35,22 @@ class IfAccessViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $mockPrivilegeManager;
 
+    /**
+     * @var RenderingContext
+     */
+    protected $renderingContextMock;
+
     public function setUp()
     {
         $this->mockPrivilegeManager = $this->getMockBuilder(\TYPO3\Flow\Security\Authorization\PrivilegeManagerInterface::class)->getMock();
+        $objectManagerMock = $this->getMock(ObjectManagerInterface::class);
+        $objectManagerMock->expects(self::any())->method('get')->with(PrivilegeManagerInterface::class)->willReturn($this->mockPrivilegeManager);
+
+        $this->renderingContextMock = $this->getMock(RenderingContext::class);
+        $this->renderingContextMock->expects(self::any())->method('getObjectManager')->willReturn($objectManagerMock);
 
         $this->ifAccessViewHelper = $this->getAccessibleMock(\TYPO3\Fluid\ViewHelpers\Security\IfAccessViewHelper::class, array('renderThenChild', 'renderElseChild'));
-        $this->inject($this->ifAccessViewHelper, 'privilegeManager', $this->mockPrivilegeManager);
+        $this->ifAccessViewHelper->setRenderingContext($this->renderingContextMock);
     }
 
     /**
@@ -47,7 +59,9 @@ class IfAccessViewHelperTest extends ViewHelperBaseTestcase
     public function viewHelperRendersThenIfHasAccessToPrivilegeTargetReturnsTrue()
     {
         $this->mockPrivilegeManager->expects($this->once())->method('isPrivilegeTargetGranted')->with('somePrivilegeTarget')->will($this->returnValue(true));
-        $this->ifAccessViewHelper->expects($this->once())->method('renderThenChild')->will($this->returnValue('foo'));
+        $this->ifAccessViewHelper->expects($this->once())->method('renderThenChild')->willReturn('foo');
+
+        $this->ifAccessViewHelper->_set('arguments', ['privilegeTarget' => 'somePrivilegeTarget', 'parameters' => []]);
 
         $actualResult = $this->ifAccessViewHelper->render('somePrivilegeTarget');
         $this->assertEquals('foo', $actualResult);
@@ -60,6 +74,8 @@ class IfAccessViewHelperTest extends ViewHelperBaseTestcase
     {
         $this->mockPrivilegeManager->expects($this->once())->method('isPrivilegeTargetGranted')->with('somePrivilegeTarget')->will($this->returnValue(false));
         $this->ifAccessViewHelper->expects($this->once())->method('renderElseChild')->will($this->returnValue('ElseViewHelperResults'));
+
+        $this->ifAccessViewHelper->_set('arguments', ['privilegeTarget' => 'somePrivilegeTarget', 'parameters' => []]);
 
         $actualResult = $this->ifAccessViewHelper->render('somePrivilegeTarget');
         $this->assertEquals('ElseViewHelperResults', $actualResult);

--- a/TYPO3.Fluid/Tests/Unit/ViewHelpers/Validation/IfHasErrorsViewHelperTest.php
+++ b/TYPO3.Fluid/Tests/Unit/ViewHelpers/Validation/IfHasErrorsViewHelperTest.php
@@ -13,6 +13,7 @@ namespace TYPO3\Fluid\Tests\Unit\ViewHelpers\Security;
 
 use TYPO3\Flow\Error\Error;
 use TYPO3\Flow\Error\Result;
+use TYPO3\Fluid\Core\Rendering\RenderingContext;
 use TYPO3\Fluid\ViewHelpers\Validation\IfHasErrorsViewHelper;
 use TYPO3\Fluid\ViewHelpers\ViewHelperBaseTestcase;
 
@@ -33,8 +34,12 @@ class IfHasErrorsViewHelperTest extends ViewHelperBaseTestcase
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(\TYPO3\Fluid\ViewHelpers\Validation\IfHasErrorsViewHelper::class, array('renderThenChild', 'renderElseChild'));
+
+        $renderingContextMock = $this->getMock(RenderingContext::class);
+        $renderingContextMock->expects(self::any())->method('getControllerContext')->willReturn($this->controllerContext);
+        $this->viewHelper->setRenderingContext($renderingContextMock);
+
         $this->inject($this->viewHelper, 'controllerContext', $this->controllerContext);
-        //$this->inject($this->ifAccessViewHelper, 'accessDecisionManager', $this->mockAccessDecisionManager);
     }
 
     /**
@@ -73,6 +78,7 @@ class IfHasErrorsViewHelperTest extends ViewHelperBaseTestcase
         /** @var $requestMock \PHPUnit_Framework_MockObject_MockObject */
         $requestMock = $this->request;
         $requestMock->expects($this->once())->method('getInternalArgument')->with('__submittedArgumentValidationResults')->will($this->returnValue($resultMock));
+        $this->viewHelper->_set('arguments', ['for' => 'foo.bar.baz']);
 
         $this->viewHelper->render('foo.bar.baz');
     }


### PR DESCRIPTION
All Condition view helpers are now fully compileable and
the default implementation allows for easily implementing
custom conditions while still keeping it compileable.