### PR TITLE
[TASK] Behat: ensure that "Given I have the following policies" is executed first

### DIFF
--- a/TYPO3.Flow/Tests/Behavior/Features/Bootstrap/SecurityOperationsTrait.php
+++ b/TYPO3.Flow/Tests/Behavior/Features/Bootstrap/SecurityOperationsTrait.php
@@ -30,10 +30,18 @@ trait SecurityOperationsTrait
     protected static $testingPolicyPathAndFilename;
 
     /**
+     * WARNING: If using this step definition, IT MUST RUN AS ABSOLUTELY FIRST STEP IN A SCENARIO!
+     *
      * @Given /^I have the following policies:$/
      */
     public function iHaveTheFollowingPolicies($string)
     {
+        if ($this->subProcess !== null) {
+            // This check ensures that this statement is ran *before* a subprocess is opened; as the Policy.yaml
+            // which is set here influences the Proxy Building Process.
+            throw new \Exception('Step "I have the following policies:" must run as FIRST step in a scenario, because otherwise the proxy-classes are already built in the wrong manner!');
+        }
+
         self::$testingPolicyPathAndFilename = $this->environment->getPathToTemporaryDirectory() . 'Policy.yaml';
         file_put_contents(self::$testingPolicyPathAndFilename, $string->getRaw());
 


### PR DESCRIPTION

If this is violated, very funny error will appear because proxy
classes have already been built without taking the new Policy.yaml
into account.

This change has been re-targeted for 3.0 from https://github.com/neos/flow-development-collection/pull/27