### PR TITLE
[TASK] Fix misleading log message in logException()

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Log/Logger.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Log/Logger.php
@@ -188,7 +188,7 @@ class Logger implements SystemLoggerInterface, SecurityLoggerInterface
         $exceptionCodeNumber = ($exception->getCode() > 0) ? ' #' . $exception->getCode() : '';
         $backTrace = $exception->getTrace();
         $line = isset($backTrace[0]['line']) ? ' in line ' . $backTrace[0]['line'] . ' of ' . $backTrace[0]['file'] : '';
-        return 'Uncaught exception' . $exceptionCodeNumber . $line . ': ' . $exception->getMessage();
+        return 'Exception' . $exceptionCodeNumber . $line . ': ' . $exception->getMessage();
     }
 
     /**


### PR DESCRIPTION
When logException() is used to log an exception that has been caught,
the log will still say "Uncaught exception". This is misleading.