### PR TITLE
[TASK] Improve variable access in compiled templates

### DIFF
--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/Core/ViewHelper/TemplateVariableContainer.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/Core/ViewHelper/TemplateVariableContainer.php
@@ -210,4 +210,19 @@ class TemplateVariableContainer implements \ArrayAccess
     {
         return $this->get($identifier);
     }
+
+    /**
+     * Gets a variable or NULL if it does not exist
+     *
+     * @param string $variableName name of the variable
+     * @return mixed the stored variable or NULL
+     */
+    public function getOrNull($variableName)
+    {
+        if ($variableName === '_all') {
+            return $this->variables;
+        }
+
+        return isset($this->variables[$variableName]) ? $this->variables[$variableName] : null;
+    }
 }


### PR DESCRIPTION
This is a slight improvement for variable access in Fluid
that reduces recursions of ``getPropertyPath`` by one level
by pre evaluating the property path and fetching the first level
directly from the variable container in compiled templates.