### PR TITLE
[!!!][FEATURE] Monitor successful authentication date and failed authentications

### DIFF
--- a/TYPO3.Flow/Migrations/Mysql/Version20151110113650.php
+++ b/TYPO3.Flow/Migrations/Mysql/Version20151110113650.php
@@ -1,0 +1,35 @@
+<?php
+namespace TYPO3\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration,
+    Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Add the two additional fields lastsuccessfulauthenticationdate and failedauthenticationcount to
+ * table typo3_flow_security_account
+ */
+class Version20151110113650 extends AbstractMigration
+{
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql');
+
+        $this->addSql('ALTER TABLE typo3_flow_security_account ADD lastsuccessfulauthenticationdate DATETIME DEFAULT NULL, ADD failedauthenticationcount INT DEFAULT 0');
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql');
+
+        $this->addSql('ALTER TABLE typo3_flow_security_account DROP lastsuccessfulauthenticationdate, DROP failedauthenticationcount');
+    }
+}

--- a/TYPO3.Flow/Migrations/Postgresql/Version20151110113651.php
+++ b/TYPO3.Flow/Migrations/Postgresql/Version20151110113651.php
@@ -1,0 +1,35 @@
+<?php
+namespace TYPO3\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration,
+    Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Add the two additional fields lastsuccessfulauthenticationdate and failedauthenticationcount to
+ * table typo3_flow_security_account
+ */
+class Version20151110113651 extends AbstractMigration
+{
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql');
+
+        $this->addSql('ALTER TABLE typo3_flow_security_account ADD lastsuccessfulauthenticationdate timestamp(0) DEFAULT NULL, ADD failedauthenticationcount INT DEFAULT 0');
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql');
+
+        $this->addSql('ALTER TABLE typo3_flow_security_account DROP lastsuccessfulauthenticationdate, DROP failedauthenticationcount');
+    }
+}

--- a/TYPO3.Flow/Tests/Functional/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
+++ b/TYPO3.Flow/Tests/Functional/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
@@ -1,0 +1,126 @@
+<?php
+namespace TYPO3\Flow\Tests\Functional\Security\Authentication\Provider;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Security\Authentication\Provider\PersistedUsernamePasswordProvider;
+
+/**
+ * Testcase for the persisted username and password provider
+ *
+ */
+class PersistedUsernamePasswordProviderTest extends \TYPO3\Flow\Tests\FunctionalTestCase
+{
+
+    protected $testableSecurityEnabled = true;
+
+    /**
+     * @var PersistedUsernamePasswordProvider
+     */
+    protected $persistedUsernamePasswordProvider;
+
+    /**
+     * @var \TYPO3\Flow\Security\AccountFactory
+     */
+    protected $accountFactory;
+
+    /**
+     * @var \TYPO3\Flow\Security\AccountRepository
+     */
+    protected $accountRepository;
+
+    /**
+     * @var \TYPO3\Flow\Security\Authentication\Token\UsernamePassword
+     */
+    protected $authenticationToken;
+
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->persistedUsernamePasswordProvider = new PersistedUsernamePasswordProvider('myTestProvider');
+        $this->accountFactory = new \TYPO3\Flow\Security\AccountFactory();
+        $this->accountRepository = new \TYPO3\Flow\Security\AccountRepository();
+
+        $authenticationTokenProxyClass = $this->buildAccessibleProxy(\TYPO3\Flow\Security\Authentication\Token\UsernamePassword::class);
+        $this->authenticationToken = new $authenticationTokenProxyClass();
+
+        $account = $this->accountFactory->createAccountWithPassword('username', 'password', array(), 'myTestProvider');
+        $this->accountRepository->add($account);
+        $this->persistenceManager->persistAll();
+    }
+
+    /**
+     * @test
+     */
+    public function successfulAuthentication()
+    {
+        $this->authenticationToken->_set('credentials', ['username' => 'username', 'password' => 'password']);
+
+        $this->persistedUsernamePasswordProvider->authenticate($this->authenticationToken);
+
+        $this->assertTrue($this->authenticationToken->isAuthenticated());
+
+        $account = $this->accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName('username', 'myTestProvider');
+        $this->assertEquals(new \DateTime(), $account->getLastSuccessfulAuthenticationDate());
+        $this->assertEquals(0, $account->getFailedAuthenticationCount());
+    }
+
+    /**
+     * @test
+     */
+    public function authenticationWithWrongPassword()
+    {
+        $this->authenticationToken->_set('credentials', ['username' => 'username', 'password' => 'wrongPW']);
+
+        $this->persistedUsernamePasswordProvider->authenticate($this->authenticationToken);
+
+        $this->assertFalse($this->authenticationToken->isAuthenticated());
+
+        $account = $this->accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName('username', 'myTestProvider');
+        $this->assertEquals(1, $account->getFailedAuthenticationCount());
+    }
+
+
+    /**
+     * @test
+     */
+    public function authenticationWithWrongUserName()
+    {
+        $this->authenticationToken->_set('credentials', ['username' => 'wrongUsername', 'password' => 'password']);
+
+        $this->persistedUsernamePasswordProvider->authenticate($this->authenticationToken);
+
+        $this->assertFalse($this->authenticationToken->isAuthenticated());
+    }
+
+
+    /**
+     * @test
+     */
+    public function authenticationWithCorrectCredentialsResetsFailedAuthenticationCount()
+    {
+        $this->authenticationToken->_set('credentials', ['username' => 'username', 'password' => 'wrongPW']);
+        $this->persistedUsernamePasswordProvider->authenticate($this->authenticationToken);
+
+        $account = $this->accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName('username', 'myTestProvider');
+        $this->assertEquals(1, $account->getFailedAuthenticationCount());
+
+        $this->authenticationToken->_set('credentials', ['username' => 'username', 'password' => 'password']);
+        $this->persistedUsernamePasswordProvider->authenticate($this->authenticationToken);
+
+        $account = $this->accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName('username', 'myTestProvider');
+        $this->assertEquals(new \DateTime(), $account->getLastSuccessfulAuthenticationDate());
+        $this->assertEquals(0, $account->getFailedAuthenticationCount());
+    }
+}

--- a/TYPO3.Flow/Tests/Unit/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
+++ b/TYPO3.Flow/Tests/Unit/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
@@ -33,6 +33,11 @@ class PersistedUsernamePasswordProviderTest extends \TYPO3\Flow\Tests\UnitTestCa
     protected $mockAccountRepository;
 
     /**
+     * @var \TYPO3\Flow\Persistence\PersistenceManagerInterface
+     */
+    protected $mockPersistenceManager;
+
+    /**
      * @var \TYPO3\Flow\Security\Authentication\Token\UsernamePassword
      */
     protected $mockToken;
@@ -53,9 +58,10 @@ class PersistedUsernamePasswordProviderTest extends \TYPO3\Flow\Tests\UnitTestCa
         $this->mockHashService = $this->getMock(\TYPO3\Flow\Security\Cryptography\HashService::class);
         $this->mockAccount = $this->getMock(\TYPO3\Flow\Security\Account::class, array(), array(), '', false);
         $this->mockAccountRepository = $this->getMock(\TYPO3\Flow\Security\AccountRepository::class, array(), array(), '', false);
+        $this->mockPersistenceManager = $this->getMock(\TYPO3\Flow\Persistence\PersistenceManagerInterface::class, array(), array(), '', false);
         $this->mockToken = $this->getMock(\TYPO3\Flow\Security\Authentication\Token\UsernamePassword::class, array(), array(), '', false);
-
         $this->mockSecurityContext = $this->getMock(\TYPO3\Flow\Security\Context::class);
+
         $this->mockSecurityContext->expects($this->any())->method('withoutAuthorizationChecks')->will($this->returnCallback(function ($callback) {
             return $callback->__invoke();
         }));
@@ -63,6 +69,7 @@ class PersistedUsernamePasswordProviderTest extends \TYPO3\Flow\Tests\UnitTestCa
         $this->persistedUsernamePasswordProvider = $this->getAccessibleMock(\TYPO3\Flow\Security\Authentication\Provider\PersistedUsernamePasswordProvider::class, array('dummy'), array('myProvider', array()));
         $this->persistedUsernamePasswordProvider->_set('hashService', $this->mockHashService);
         $this->persistedUsernamePasswordProvider->_set('accountRepository', $this->mockAccountRepository);
+        $this->persistedUsernamePasswordProvider->_set('persistenceManager', $this->mockPersistenceManager);
         $this->persistedUsernamePasswordProvider->_set('securityContext', $this->mockSecurityContext);
     }
 


### PR DESCRIPTION
To improve security, it is helpful to show the last successful authentication
and the failed authentication count since last successful authentication to the
user.