### PR TITLE
[FEATURE] Setting for application name

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/HelpCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/HelpCommandController.php
@@ -41,6 +41,12 @@ class HelpCommandController extends CommandController
     protected $bootstrap;
 
     /**
+     * @Flow\InjectConfiguration(path = "core.applicationPackageKey")
+     * @var string
+     */
+    protected $applicationPackageKey;
+
+    /**
      * @Flow\Inject
      * @var CommandManager
      */
@@ -58,8 +64,8 @@ class HelpCommandController extends CommandController
     public function helpStubCommand()
     {
         $context = $this->bootstrap->getContext();
-
-        $this->outputLine('<b>TYPO3 Flow %s ("%s" context)</b>', array($this->packageManager->getPackage('TYPO3.Flow')->getPackageMetaData()->getVersion() ?: FLOW_VERSION_BRANCH, $context));
+        $composerManifest = $this->packageManager->getPackage($this->applicationPackageKey)->getComposerManifest();
+        $this->outputLine('<b>%s %s ("%s" context)</b>', array($composerManifest->description, $composerManifest->version ?: 'dev', $context));
         $this->outputLine('<i>usage: %s <command identifier></i>', array($this->getFlowInvocationString()));
         $this->outputLine();
         $this->outputLine('See "%s help" for a list of all available commands.', array($this->getFlowInvocationString()));
@@ -105,7 +111,8 @@ class HelpCommandController extends CommandController
     {
         $context = $this->bootstrap->getContext();
 
-        $this->outputLine('<b>TYPO3 Flow %s ("%s" context)</b>', array($this->packageManager->getPackage('TYPO3.Flow')->getPackageMetaData()->getVersion() ?: FLOW_VERSION_BRANCH, $context));
+        $composerManifest = $this->packageManager->getPackage($this->applicationPackageKey)->getComposerManifest();
+        $this->outputLine('<b>%s %s ("%s" context)</b>', array($composerManifest->description, $composerManifest->version ?: 'dev', $context));
         $this->outputLine('<i>usage: %s <command identifier></i>', array($this->getFlowInvocationString()));
         $this->outputLine();
         $this->outputLine('The following commands are currently available:');

--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -35,6 +35,10 @@ TYPO3:
       # This setting is automatically set by the configuration manager and can't be set manually.
       context: ''
 
+      # Key of the "main" package of the application. This package's meta data is used for displaying the application
+      # name, version etc. in the ./flow command line help and where else needed.
+      applicationPackageKey: 'TYPO3.Flow'
+
       # Path and filename of the PHP binary
       # The constant PHP_BINDIR usually contains the path, but on Windows this doesn't work reliably
       phpBinaryPathAndFilename: '%PHP_BINDIR%/php'

--- a/TYPO3.Flow/composer.json
+++ b/TYPO3.Flow/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "typo3/flow",
     "type": "typo3-flow-framework",
-    "description": "Flow Application Framework",
+    "description": "Flow",
     "homepage": "http://flow.typo3.org",
     "license": ["MIT"],
 


### PR DESCRIPTION
This change introduces a new setting which allows developers to display
a custom application name and version in the ./flow help commands and
potentially elsewhere. For example, ./flow will display "Neos" and the
version number of the Neos package, when the command is run in a Neos
distribution.

The setting does not refer to the application name directly, but to a
package key. The specified package's meta data (Composer manifest) is
used to determine the application name and version. Since it is best
practice to use the "description" property of the Composer manifest for
specifying the application name, that field is used as the application
name in ./flow too (see also comments by Jordi at
https://github.com/composer/composer/issues/1140).