### PR TITLE
!!!TASK: Refactor package management

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/HelpCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/HelpCommandController.php
@@ -63,8 +63,8 @@ class HelpCommandController extends CommandController
     public function helpStubCommand()
     {
         $context = $this->bootstrap->getContext();
-        $composerManifest = $this->packageManager->getPackage($this->applicationPackageKey)->getComposerManifest();
-        $this->outputLine('<b>%s %s ("%s" context)</b>', array($composerManifest->description, $composerManifest->version ?: 'dev', $context));
+        $applicationPackage = $this->packageManager->getPackage($this->applicationPackageKey);
+        $this->outputLine('<b>%s %s ("%s" context)</b>', array($applicationPackage->getComposerManifest('description'), $applicationPackage->getInstalledVersion() ?: 'dev', $context));
         $this->outputLine('<i>usage: %s <command identifier></i>', array($this->getFlowInvocationString()));
         $this->outputLine();
         $this->outputLine('See "%s help" for a list of all available commands.', array($this->getFlowInvocationString()));
@@ -110,8 +110,8 @@ class HelpCommandController extends CommandController
     {
         $context = $this->bootstrap->getContext();
 
-        $composerManifest = $this->packageManager->getPackage($this->applicationPackageKey)->getComposerManifest();
-        $this->outputLine('<b>%s %s ("%s" context)</b>', array($composerManifest->description, $composerManifest->version ?: 'dev', $context));
+        $applicationPackage = $this->packageManager->getPackage($this->applicationPackageKey);
+        $this->outputLine('<b>%s %s ("%s" context)</b>', array($applicationPackage->getComposerManifest('description'), $applicationPackage->getInstalledVersion() ?: 'dev', $context));
         $this->outputLine('<i>usage: %s <command identifier></i>', array($this->getFlowInvocationString()));
         $this->outputLine();
         $this->outputLine('The following commands are currently available:');

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/PackageCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/PackageCommandController.php
@@ -13,6 +13,7 @@ namespace TYPO3\Flow\Command;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Cli\CommandController;
+use TYPO3\Flow\Composer\Utility as ComposerUtility;
 use TYPO3\Flow\Core\Booting\Scripts;
 use TYPO3\Flow\Core\Bootstrap;
 use TYPO3\Flow\Package\PackageInterface;
@@ -63,21 +64,21 @@ class PackageCommandController extends CommandController
      * @return string
      * @see typo3.kickstart:kickstart:package
      */
-    public function createCommand($packageKey, $packageType = 'typo3-flow-package')
+    public function createCommand($packageKey, $packageType = PackageInterface::DEFAULT_COMPOSER_TYPE)
     {
         if (!$this->packageManager->isPackageKeyValid($packageKey)) {
-            $this->outputLine('The package key "%s" is not valid.', array($packageKey));
+            $this->outputLine('The package key "%s" is not valid.', [$packageKey]);
             $this->quit(1);
         }
         if ($this->packageManager->isPackageAvailable($packageKey)) {
-            $this->outputLine('The package "%s" already exists.', array($packageKey));
+            $this->outputLine('The package "%s" already exists.', [$packageKey]);
             $this->quit(1);
         }
-        if (substr($packageType, 0, 11) !== 'typo3-flow-') {
-            $this->outputLine('The package must be a Flow package, but "%s" is not a valid Flow package type.', array($packageKey));
+        if (ComposerUtility::isFlowPackageType($packageType)) {
+            $this->outputLine('The package must be a Flow package, but "%s" is not a valid Flow package type.', [$packageKey]);
             $this->quit(1);
         }
-        $package = $this->packageManager->createPackage($packageKey, null, null, $packageType);
+        $package = $this->packageManager->createPackage($packageKey, null, null, null, ['type' => $packageType]);
         $this->outputLine('Created new package "' . $packageKey . '" at "' . $package->getPackagePath() . '".');
     }
 
@@ -93,11 +94,11 @@ class PackageCommandController extends CommandController
     public function deleteCommand($packageKey)
     {
         if (!$this->packageManager->isPackageAvailable($packageKey)) {
-            $this->outputLine('The package "%s" does not exist.', array($packageKey));
+            $this->outputLine('The package "%s" does not exist.', [$packageKey]);
             $this->quit(1);
         }
         $this->packageManager->deletePackage($packageKey);
-        $this->outputLine('Deleted package "%s".', array($packageKey));
+        $this->outputLine('Deleted package "%s".', [$packageKey]);
         Scripts::executeCommand('typo3.flow:cache:flush', $this->settings, false);
         $this->sendAndExit(0);
     }
@@ -115,17 +116,17 @@ class PackageCommandController extends CommandController
     public function activateCommand($packageKey)
     {
         if (!$this->packageManager->isPackageAvailable($packageKey)) {
-            $this->outputLine('The package "%s" does not exist.', array($packageKey));
+            $this->outputLine('The package "%s" does not exist.', [$packageKey]);
             $this->quit(1);
         }
 
         if ($this->packageManager->isPackageActive($packageKey)) {
-            $this->outputLine('Package "%s" is already active.', array($packageKey));
+            $this->outputLine('Package "%s" is already active.', [$packageKey]);
             $this->quit(1);
         }
 
         $this->packageManager->activatePackage($packageKey);
-        $this->outputLine('Activated package "%s".', array($packageKey));
+        $this->outputLine('Activated package "%s".', [$packageKey]);
         Scripts::executeCommand('typo3.flow:cache:flush', $this->settings, false);
         $this->sendAndExit(0);
     }
@@ -143,17 +144,17 @@ class PackageCommandController extends CommandController
     public function deactivateCommand($packageKey)
     {
         if (!$this->packageManager->isPackageAvailable($packageKey)) {
-            $this->outputLine('The package "%s" does not exist.', array($packageKey));
+            $this->outputLine('The package "%s" does not exist.', [$packageKey]);
             $this->quit(1);
         }
 
         if (!$this->packageManager->isPackageActive($packageKey)) {
-            $this->outputLine('Package "%s" was not active.', array($packageKey));
+            $this->outputLine('Package "%s" was not active.', [$packageKey]);
             $this->quit(1);
         }
 
         $this->packageManager->deactivatePackage($packageKey);
-        $this->outputLine('Deactivated package "%s".', array($packageKey));
+        $this->outputLine('Deactivated package "%s".', [$packageKey]);
         Scripts::executeCommand('typo3.flow:cache:flush', $this->settings, false);
         $this->sendAndExit(0);
     }
@@ -170,9 +171,9 @@ class PackageCommandController extends CommandController
      */
     public function listCommand()
     {
-        $activePackages = array();
-        $inactivePackages = array();
-        $frozenPackages = array();
+        $activePackages = [];
+        $inactivePackages = [];
+        $frozenPackages = [];
         $longestPackageKey = 0;
         $freezeSupported = $this->bootstrap->getContext()->isDevelopment();
 
@@ -196,9 +197,8 @@ class PackageCommandController extends CommandController
         $this->outputLine('ACTIVE PACKAGES:');
         /** @var PackageInterface $package */
         foreach ($activePackages as $package) {
-            $packageMetaData = $package->getPackageMetaData();
             $frozenState = ($freezeSupported && isset($frozenPackages[$package->getPackageKey()]) ? '* ' : '  ');
-            $this->outputLine(' ' . str_pad($package->getPackageKey(), $longestPackageKey + 3) . $frozenState . str_pad($packageMetaData->getVersion(), 15));
+            $this->outputLine(' ' . str_pad($package->getPackageKey(), $longestPackageKey + 3) . $frozenState . str_pad($package->getInstalledVersion(), 15));
         }
 
         if (count($inactivePackages) > 0) {
@@ -206,8 +206,7 @@ class PackageCommandController extends CommandController
             $this->outputLine('INACTIVE PACKAGES:');
             foreach ($inactivePackages as $package) {
                 $frozenState = (isset($frozenPackages[$package->getPackageKey()]) ? '* ' : '  ');
-                $packageMetaData = $package->getPackageMetaData();
-                $this->outputLine(' ' . str_pad($package->getPackageKey(), $longestPackageKey + 3) . $frozenState . str_pad($packageMetaData->getVersion(), 15));
+                $this->outputLine(' ' . str_pad($package->getPackageKey(), $longestPackageKey + 3) . $frozenState . str_pad($package->getInstalledVersion(), 15));
             }
         }
 
@@ -245,7 +244,7 @@ class PackageCommandController extends CommandController
             $this->quit(3);
         }
 
-        $packagesToFreeze = array();
+        $packagesToFreeze = [];
 
         if ($packageKey === 'all') {
             foreach (array_keys($this->packageManager->getActivePackages()) as $packageKey) {
@@ -253,7 +252,7 @@ class PackageCommandController extends CommandController
                     $packagesToFreeze[] = $packageKey;
                 }
             }
-            if ($packagesToFreeze === array()) {
+            if ($packagesToFreeze === []) {
                 $this->outputLine('Nothing to do, all active packages were already frozen.');
                 $this->quit(0);
             }
@@ -263,25 +262,25 @@ class PackageCommandController extends CommandController
         } else {
             if (!$this->packageManager->isPackageActive($packageKey)) {
                 if ($this->packageManager->isPackageAvailable($packageKey)) {
-                    $this->outputLine('Package "%s" is not active and thus cannot be frozen.', array($packageKey));
+                    $this->outputLine('Package "%s" is not active and thus cannot be frozen.', [$packageKey]);
                     $this->quit(1);
                 } else {
-                    $this->outputLine('Package "%s" is not available.', array($packageKey));
+                    $this->outputLine('Package "%s" is not available.', [$packageKey]);
                     $this->quit(2);
                 }
             }
 
             if ($this->packageManager->isPackageFrozen($packageKey)) {
-                $this->outputLine('Package "%s" was already frozen.', array($packageKey));
+                $this->outputLine('Package "%s" was already frozen.', [$packageKey]);
                 $this->quit(0);
             }
 
-            $packagesToFreeze = array($packageKey);
+            $packagesToFreeze = [$packageKey];
         }
 
         foreach ($packagesToFreeze as $packageKey) {
             $this->packageManager->freezePackage($packageKey);
-            $this->outputLine('Froze package "%s".', array($packageKey));
+            $this->outputLine('Froze package "%s".', [$packageKey]);
         }
     }
 
@@ -307,7 +306,7 @@ class PackageCommandController extends CommandController
             $this->quit(3);
         }
 
-        $packagesToUnfreeze = array();
+        $packagesToUnfreeze = [];
 
         if ($packageKey === 'all') {
             foreach (array_keys($this->packageManager->getAvailablePackages()) as $packageKey) {
@@ -315,7 +314,7 @@ class PackageCommandController extends CommandController
                     $packagesToUnfreeze[] = $packageKey;
                 }
             }
-            if ($packagesToUnfreeze === array()) {
+            if ($packagesToUnfreeze === []) {
                 $this->outputLine('Nothing to do, no packages were frozen.');
                 $this->quit(0);
             }
@@ -326,19 +325,19 @@ class PackageCommandController extends CommandController
             }
 
             if (!$this->packageManager->isPackageAvailable($packageKey)) {
-                $this->outputLine('Package "%s" is not available.', array($packageKey));
+                $this->outputLine('Package "%s" is not available.', [$packageKey]);
                 $this->quit(2);
             }
             if (!$this->packageManager->isPackageFrozen($packageKey)) {
-                $this->outputLine('Package "%s" was not frozen.', array($packageKey));
+                $this->outputLine('Package "%s" was not frozen.', [$packageKey]);
                 $this->quit(0);
             }
-            $packagesToUnfreeze = array($packageKey);
+            $packagesToUnfreeze = [$packageKey];
         }
 
         foreach ($packagesToUnfreeze as $packageKey) {
             $this->packageManager->unfreezePackage($packageKey);
-            $this->outputLine('Unfroze package "%s".', array($packageKey));
+            $this->outputLine('Unfroze package "%s".', [$packageKey]);
         }
     }
 
@@ -365,7 +364,7 @@ class PackageCommandController extends CommandController
             $this->quit(3);
         }
 
-        $packagesToRefreeze = array();
+        $packagesToRefreeze = [];
 
         if ($packageKey === 'all') {
             foreach (array_keys($this->packageManager->getAvailablePackages()) as $packageKey) {
@@ -373,7 +372,7 @@ class PackageCommandController extends CommandController
                     $packagesToRefreeze[] = $packageKey;
                 }
             }
-            if ($packagesToRefreeze === array()) {
+            if ($packagesToRefreeze === []) {
                 $this->outputLine('Nothing to do, no packages were frozen.');
                 $this->quit(0);
             }
@@ -384,22 +383,38 @@ class PackageCommandController extends CommandController
             }
 
             if (!$this->packageManager->isPackageAvailable($packageKey)) {
-                $this->outputLine('Package "%s" is not available.', array($packageKey));
+                $this->outputLine('Package "%s" is not available.', [$packageKey]);
                 $this->quit(2);
             }
             if (!$this->packageManager->isPackageFrozen($packageKey)) {
-                $this->outputLine('Package "%s" was not frozen.', array($packageKey));
+                $this->outputLine('Package "%s" was not frozen.', [$packageKey]);
                 $this->quit(0);
             }
-            $packagesToRefreeze = array($packageKey);
+            $packagesToRefreeze = [$packageKey];
         }
 
         foreach ($packagesToRefreeze as $packageKey) {
             $this->packageManager->refreezePackage($packageKey);
-            $this->outputLine('Refroze package "%s".', array($packageKey));
+            $this->outputLine('Refroze package "%s".', [$packageKey]);
         }
 
         Scripts::executeCommand('typo3.flow:cache:flush', $this->settings, false);
         $this->sendAndExit(0);
+    }
+
+    /**
+     * Rescan package availability and recreates the PackageStates configuration.
+     */
+    public function rescanCommand()
+    {
+        $packageStates = $this->packageManager->rescanPackages();
+
+        $this->outputLine('The following packages are registered and will be loaded in this order:');
+        $this->outputLine('');
+        foreach ($packageStates['packages'] as $composerName => $packageState) {
+            $this->outputLine($composerName);
+        }
+        $this->outputLine('');
+        $this->outputLine('Package rescan successful.');
     }
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/PackageCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/PackageCommandController.php
@@ -13,7 +13,7 @@ namespace TYPO3\Flow\Command;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Cli\CommandController;
-use TYPO3\Flow\Composer\Utility as ComposerUtility;
+use TYPO3\Flow\Composer\ComposerUtility;
 use TYPO3\Flow\Core\Booting\Scripts;
 use TYPO3\Flow\Core\Bootstrap;
 use TYPO3\Flow\Package\PackageInterface;

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Composer/ComposerUtility.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Composer/ComposerUtility.php
@@ -17,8 +17,10 @@ use TYPO3\Flow\Utility\Files;
 
 /**
  * Utility to access composer information like composer manifests (composer.json) and the lock file.
+ *
+ *
  */
-class Utility
+class ComposerUtility
 {
     /**
      * Runtime cache for composer.json data

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Composer/ComposerUtility.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Composer/ComposerUtility.php
@@ -18,7 +18,7 @@ use TYPO3\Flow\Utility\Files;
 /**
  * Utility to access composer information like composer manifests (composer.json) and the lock file.
  *
- *
+ * Meant to be used only inside the Flow package management code.
  */
 class ComposerUtility
 {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Composer/Exception/MissingPackageManifestException.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Composer/Exception/MissingPackageManifestException.php
@@ -1,5 +1,5 @@
 <?php
-namespace TYPO3\Flow\Package\Exception;
+namespace TYPO3\Flow\Composer\Exception;
 
 /*
  * This file is part of the TYPO3.Flow package.

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Composer/InstallerScripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Composer/InstallerScripts.php
@@ -15,6 +15,7 @@ use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\Script\CommandEvent;
 use Composer\Script\PackageEvent;
+use TYPO3\Flow\Package\PackageManager;
 use TYPO3\Flow\Utility\Files;
 
 /**
@@ -36,6 +37,8 @@ class InstallerScripts
 
         Files::copyDirectoryRecursively('Packages/Framework/TYPO3.Flow/Resources/Private/Installer/Distribution/Essentials', './', false, true);
         Files::copyDirectoryRecursively('Packages/Framework/TYPO3.Flow/Resources/Private/Installer/Distribution/Defaults', './', true, true);
+        $packageManager = new PackageManager();
+        $packageManager->rescanPackages();
 
         chmod('flow', 0755);
     }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Composer/Utility.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Composer/Utility.php
@@ -1,0 +1,175 @@
+<?php
+namespace TYPO3\Flow\Composer;
+
+/*                                                                        *
+ * This script belongs to the TYPO3 Flow framework.                       *
+ *                                                                        *
+ * It is free software; you can redistribute it and/or modify it under    *
+ * the terms of the GNU Lesser General Public License, either version 3   *
+ * of the License, or (at your option) any later version.                 *
+ *                                                                        *
+ * The TYPO3 project - inspiring people to share!                         *
+ *                                                                        */
+
+use TYPO3\Flow\Package\PackageInterface;
+use TYPO3\Flow\Reflection\ObjectAccess;
+use TYPO3\Flow\Utility\Files;
+
+/**
+ * Utility to access composer information like composer manifests (composer.json) and the lock file.
+ */
+class Utility
+{
+    /**
+     * Runtime cache for composer.json data
+     *
+     * @var array
+     */
+    protected static $composerManifestCache;
+
+    /**
+     * Runtime cache for composer.lock data
+     *
+     * @var array
+     */
+    protected static $composerLockCache;
+
+    /**
+     * Returns contents of Composer manifest - or part there of.
+     *
+     * @param string $manifestPath
+     * @param string $configurationPath Optional. Only return the part of the manifest indexed by configurationPath
+     * @return array|mixed
+     */
+    public static function getComposerManifest($manifestPath, $configurationPath = null)
+    {
+        $composerManifest = static::readComposerManifest($manifestPath);
+        if ($composerManifest === null) {
+            return null;
+        }
+
+        if ($configurationPath !== null) {
+            return ObjectAccess::getPropertyPath($composerManifest, $configurationPath);
+        } else {
+            return $composerManifest;
+        }
+    }
+
+    /**
+     * Read the content of the composer.lock
+     *
+     * @return array
+     */
+    public static function readComposerLock()
+    {
+        if (self::$composerLockCache !== null) {
+            return self::$composerLockCache;
+        }
+
+        if (!file_exists(FLOW_PATH_ROOT . 'composer.lock')) {
+            return [];
+        }
+
+        $json = file_get_contents(FLOW_PATH_ROOT . 'composer.lock');
+        $composerLock = json_decode($json, true);
+        $composerPackageVersions = isset($composerLock['packages']) ? $composerLock['packages'] : [];
+        $composerPackageDevVersions = isset($composerLock['packages-dev']) ? $composerLock['packages-dev'] : [];
+        self::$composerLockCache = array_merge($composerPackageVersions, $composerPackageDevVersions);
+
+        return self::$composerLockCache;
+    }
+
+    /**
+     * Read the content of composer.json in the given path
+     *
+     * @param string $manifestPath
+     * @return array
+     * @throws Exception\MissingPackageManifestException
+     */
+    protected static function readComposerManifest($manifestPath)
+    {
+        $manifestPathAndFilename = $manifestPath . 'composer.json';
+        if (isset(self::$composerManifestCache[$manifestPathAndFilename])) {
+            return self::$composerManifestCache[$manifestPathAndFilename];
+        }
+
+        if (!is_file($manifestPathAndFilename)) {
+            throw new Exception\MissingPackageManifestException(sprintf('No composer manifest file found at "%s".', $manifestPathAndFilename), 1349868540);
+        }
+        $json = file_get_contents($manifestPathAndFilename);
+        $composerManifest = json_decode($json, true);
+
+        self::$composerManifestCache[$manifestPathAndFilename] = $composerManifest;
+        return $composerManifest;
+    }
+
+    /**
+     * Checks if the given (composer) package type is a type native to the neos project.
+     *
+     * @param string $packageType
+     * @return boolean
+     */
+    public static function isFlowPackageType($packageType)
+    {
+        foreach (['typo3-flow-', 'neos-'] as $allowedPackageTypePrefix) {
+            if (strpos($packageType, $allowedPackageTypePrefix) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determines the composer package name ("vendor/foo-bar") from the Flow package key ("Vendor.Foo.Bar")
+     *
+     * @param string $packageKey
+     * @return string
+     */
+    public static function getComposerPackageNameFromPackageKey($packageKey)
+    {
+        $nameParts = explode('.', $packageKey);
+        $vendor = array_shift($nameParts);
+        return strtolower($vendor . '/' . implode('-', $nameParts));
+    }
+
+    /**
+     * Write a composer manifest for the package.
+     *
+     * @param string $manifestPath
+     * @param string $packageKey
+     * @param array $composerManifestData
+     * @return array the manifest data written
+     */
+    public static function writeComposerManifest($manifestPath, $packageKey, array $composerManifestData = [])
+    {
+        $manifest = [
+            'description' => ''
+        ];
+
+        if ($composerManifestData !== null) {
+            $manifest = array_merge($manifest, $composerManifestData);
+        }
+        if (!isset($manifest['name']) || empty($manifest['name'])) {
+            $manifest['name'] = static::getComposerPackageNameFromPackageKey($packageKey);
+        }
+
+        if (!isset($manifest['require']) || empty($manifest['require'])) {
+            $manifest['require'] = array('typo3/flow' => '*');
+        }
+
+        if (!isset($manifest['autoload'])) {
+            $manifest['autoload'] = array('psr-0' => array(str_replace('.', '\\', $packageKey) => PackageInterface::DIRECTORY_CLASSES));
+        }
+
+        $manifest['extra']['neos']['package-key'] = $packageKey;
+
+        if (defined('JSON_PRETTY_PRINT')) {
+            file_put_contents(Files::concatenatePaths(array($manifestPath, 'composer.json')), json_encode($manifest, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        } else {
+            file_put_contents(Files::concatenatePaths(array($manifestPath, 'composer.json')), json_encode($manifest));
+        }
+
+        return $manifest;
+    }
+}

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/ClassLoader.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/ClassLoader.php
@@ -13,6 +13,7 @@ namespace TYPO3\Flow\Core;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Package;
+use TYPO3\Flow\Utility\Files;
 
 /**
  * Class Loader implementation which loads .php files found in the classes
@@ -26,12 +27,22 @@ class ClassLoader
     /**
      * @var string
      */
-    const MAPPING_TYPE_PSR0 = 'Psr0';
+    const MAPPING_TYPE_PSR0 = 'psr-0';
 
     /**
      * @var string
      */
-    const MAPPING_TYPE_PSR4 = 'Psr4';
+    const MAPPING_TYPE_PSR4 = 'psr-4';
+
+    /**
+     * @var string
+     */
+    const MAPPING_TYPE_CLASSMAP = 'classmap';
+
+    /**
+     * @var string
+     */
+    const MAPPING_TYPE_FILES = 'files';
 
     /**
      * @var \TYPO3\Flow\Cache\Frontend\PhpFrontend
@@ -108,12 +119,18 @@ class ClassLoader
 
     /**
      * @param ApplicationContext $context
+     * @param array $defaultPackageEntries Adds default entries for packages that should be available for very early loading
      */
-    public function __construct(ApplicationContext $context = null)
+    public function __construct(ApplicationContext $context = null, $defaultPackageEntries = [])
     {
         $distributionComposerManifest = json_decode(file_get_contents(FLOW_PATH_ROOT . 'composer.json'));
         $this->defaultVendorDirectory = $distributionComposerManifest->config->{'vendor-dir'};
         $composerPath = FLOW_PATH_ROOT . $this->defaultVendorDirectory . '/composer/';
+
+        foreach ($defaultPackageEntries as $entry) {
+            $this->createNamespaceMapEntry($entry['namespace'], $entry['classPath'], $entry['mappingType']);
+        }
+
         $this->initializeAutoloadInformation($composerPath, $context);
     }
 
@@ -155,7 +172,6 @@ class ClassLoader
 
         if (isset($this->classMap[$className])) {
             include($this->classMap[$className]);
-
             return true;
         }
 
@@ -163,16 +179,6 @@ class ClassLoader
         $classNameParts = explode('_', $classNamePart);
         $namespaceParts = array_merge($namespaceParts, $classNameParts);
         $namespacePartCount = count($namespaceParts);
-
-        // Load classes from the Flow package at a very early stage where no packages have been registered yet:
-        if ($this->packageNamespaces === array()) {
-            if ($namespaceParts[0] === 'TYPO3' && $namespaceParts[1] === 'Flow') {
-                require(FLOW_PATH_FLOW . 'Classes/TYPO3/Flow/' . implode('/', array_slice($namespaceParts, 2)) . '.php');
-                return true;
-            } else {
-                return false;
-            }
-        }
 
         $currentPackageArray = $this->packageNamespaces;
         $packagenamespacePartCount = 0;
@@ -218,8 +224,14 @@ class ClassLoader
     protected function loadClassFromPossiblePaths(array $possiblePaths, array $namespaceParts, $packageNamespacePartCount)
     {
         foreach ($possiblePaths as $possiblePathData) {
-            $pathConstructor = 'buildClassPathWith' . $possiblePathData['mappingType'];
-            $possibleFilePath = $this->$pathConstructor($namespaceParts, $possiblePathData['path'], $packageNamespacePartCount);
+            $possibleFilePath = '';
+            if ($possiblePathData['mappingType'] === self::MAPPING_TYPE_PSR0) {
+                $possibleFilePath = $this->buildClassPathWithPsr0($namespaceParts, $possiblePathData['path'], $packageNamespacePartCount);
+            }
+            if ($possiblePathData['mappingType'] === self::MAPPING_TYPE_PSR4) {
+                $possibleFilePath = $this->buildClassPathWithPsr4($namespaceParts, $possiblePathData['path'], $packageNamespacePartCount);
+            }
+
             if (is_file($possibleFilePath)) {
                 $result = include_once($possibleFilePath);
                 if ($result !== false) {
@@ -234,33 +246,19 @@ class ClassLoader
     /**
      * Sets the available packages
      *
-     * @param array $allPackages An array of \TYPO3\Flow\Package\Package objects
      * @param array $activePackages An array of \TYPO3\Flow\Package\Package objects
      * @return void
      */
-    public function setPackages(array $allPackages, array $activePackages)
+    public function setPackages(array $activePackages)
     {
         /** @var Package $package */
-        foreach ($allPackages as $packageKey => $package) {
-            if (isset($activePackages[$packageKey])) {
-                if ($package->getAutoloadType() === Package::AUTOLOADER_TYPE_PSR4) {
-                    $this->createNamespaceMapEntry($package->getNamespace(), $package->getClassesPath(), self::MAPPING_TYPE_PSR4);
-                } else {
-                    $this->createNamespaceMapEntry($package->getNamespace(), $package->getClassesPath());
-                }
-                if ($this->considerTestsNamespace) {
-                    $this->createNamespaceMapEntry($package->getNamespace(), $package->getPackagePath(), self::MAPPING_TYPE_PSR4);
-                }
-            } else {
-                // Remove entries coming from composer for inactive packages.
-                if ($package->getAutoloadType() === Package::AUTOLOADER_TYPE_PSR4) {
-                    $this->removeNamespaceMapEntry($package->getNamespace(), $package->getClassesPath(), self::MAPPING_TYPE_PSR4);
-                } else {
-                    $this->removeNamespaceMapEntry($package->getNamespace(), $package->getClassesPath());
-                }
-                if ($this->considerTestsNamespace) {
-                    $this->removeNamespaceMapEntry($package->getNamespace(), $package->getPackagePath(), self::MAPPING_TYPE_PSR4);
-                }
+        foreach ($activePackages as $packageKey => $package) {
+            foreach ($package->getFlattenedAutoloadConfiguration() as $configuration) {
+                $this->createNamespaceMapEntry($configuration['namespace'], $configuration['classPath'], $configuration['mappingType']);
+            }
+            // TODO: Replace with "autoload-dev" usage
+            if ($this->considerTestsNamespace) {
+                $this->createNamespaceMapEntry($package->getNamespace(), $package->getPackagePath(), self::MAPPING_TYPE_PSR4);
             }
         }
     }
@@ -275,7 +273,8 @@ class ClassLoader
      */
     protected function createNamespaceMapEntry($namespace, $classPath, $mappingType = self::MAPPING_TYPE_PSR0)
     {
-        $unifiedClassPath = ((substr($classPath, -1, 1) === '/') ? $classPath : $classPath . '/');
+        $unifiedClassPath = Files::getNormalizedPath($classPath);
+        $entryIdentifier = md5($unifiedClassPath . '-' . $mappingType);
 
         $currentArray = & $this->packageNamespaces;
         foreach (explode('\\', rtrim($namespace, '\\')) as $namespacePart) {
@@ -288,7 +287,7 @@ class ClassLoader
             $currentArray['_pathData'] = array();
         }
 
-        $currentArray['_pathData'][md5($unifiedClassPath . '-' . $mappingType)] = array(
+        $currentArray['_pathData'][$entryIdentifier] = array(
             'mappingType' => $mappingType,
             'path' => $unifiedClassPath
         );
@@ -321,7 +320,8 @@ class ClassLoader
      */
     protected function removeNamespaceMapEntry($namespace, $classPath, $mappingType = self::MAPPING_TYPE_PSR0)
     {
-        $unifiedClassPath = ((substr($classPath, -1, 1) === '/') ? $classPath : $classPath . '/');
+        $unifiedClassPath = Files::getNormalizedPath($classPath);
+        $entryIdentifier = md5($unifiedClassPath . '-' . $mappingType);
 
         $currentArray = & $this->packageNamespaces;
         foreach (explode('\\', rtrim($namespace, '\\')) as $namespacePart) {
@@ -334,8 +334,8 @@ class ClassLoader
             return;
         }
 
-        if (isset($currentArray['_pathData'][md5($unifiedClassPath . '-' . $mappingType)])) {
-            unset($currentArray['_pathData'][md5($unifiedClassPath . '-' . $mappingType)]);
+        if (isset($currentArray['_pathData'][$entryIdentifier])) {
+            unset($currentArray['_pathData'][$entryIdentifier]);
             if (empty($currentArray['_pathData'])) {
                 unset($currentArray['_pathData']);
             }
@@ -390,7 +390,7 @@ class ClassLoader
             if ($namespaceMap !== false) {
                 foreach ($namespaceMap as $namespace => $paths) {
                     if (!is_array($paths)) {
-                        $paths = array($paths);
+                        $paths = [$paths];
                     }
                     foreach ($paths as $path) {
                         if ($namespace === '') {
@@ -408,7 +408,7 @@ class ClassLoader
             if ($psr4Map !== false) {
                 foreach ($psr4Map as $namespace => $possibleClassPaths) {
                     if (!is_array($possibleClassPaths)) {
-                        $possibleClassPaths = array($possibleClassPaths);
+                        $possibleClassPaths = [$possibleClassPaths];
                     }
                     foreach ($possibleClassPaths as $possibleClassPath) {
                         if ($namespace === '') {
@@ -425,7 +425,7 @@ class ClassLoader
             $includePaths = include($composerPath . 'include_paths.php');
             if ($includePaths !== false) {
                 array_push($includePaths, get_include_path());
-                set_include_path(join(PATH_SEPARATOR, $includePaths));
+                set_include_path(implode(PATH_SEPARATOR, $includePaths));
             }
         }
 
@@ -470,5 +470,16 @@ class ClassLoader
     public function setConsiderTestsNamespace($flag)
     {
         $this->considerTestsNamespace = $flag;
+    }
+
+    /**
+     * Is the given mapping type predictable in terms of path to class name
+     *
+     * @param string $mappingType
+     * @return boolean
+     */
+    public static function isAutoloadTypeWithPredictableClassPath($mappingType)
+    {
+        return ($mappingType === static::MAPPING_TYPE_PSR0 || $mappingType === static::MAPPING_TYPE_PSR4);
     }
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/ClassLoader.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/ClassLoader.php
@@ -214,7 +214,9 @@ class ClassLoader
     }
 
     /**
-     * Tries to load a class from a list of possible paths
+     * Tries to load a class from a list of possible paths. This is needed because packages are not prefix-free; i.e.
+     * there may exist a package "Neos" and a package "Neos.NodeTypes" -- so a class Neos\NodeTypes\Foo must be first
+     * loaded (if it exists) from Neos.NodeTypes, falling back to Neos afterwards.
      *
      * @param array $possiblePaths
      * @param array $namespaceParts

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Object/CompileTimeObjectManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Object/CompileTimeObjectManager.php
@@ -11,7 +11,7 @@ namespace TYPO3\Flow\Object;
  * source code.
  */
 
-use TYPO3\Flow\Composer\Utility as ComposerUtility;
+use TYPO3\Flow\Composer\ComposerUtility as ComposerUtility;
 use TYPO3\Flow\Object\Configuration\Configuration;
 use TYPO3\Flow\Object\Configuration\ConfigurationProperty as Property;
 use Doctrine\ORM\Mapping as ORM;

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Object/CompileTimeObjectManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Object/CompileTimeObjectManager.php
@@ -11,6 +11,7 @@ namespace TYPO3\Flow\Object;
  * source code.
  */
 
+use TYPO3\Flow\Composer\Utility as ComposerUtility;
 use TYPO3\Flow\Object\Configuration\Configuration;
 use TYPO3\Flow\Object\Configuration\ConfigurationProperty as Property;
 use Doctrine\ORM\Mapping as ORM;
@@ -206,17 +207,20 @@ class CompileTimeObjectManager extends ObjectManager
         $availableClassNames = array('' => array('DateTime'));
         /** @var \TYPO3\Flow\Package\Package $package */
         foreach ($packages as $packageKey => $package) {
-            if ($package->isObjectManagementEnabled() && (strpos($package->getComposerManifest('type'), 'typo3-flow') === 0 || isset($includeClassesConfiguration[$packageKey]))) {
-                $classFiles = $package->getClassFiles();
-                if (count($classFiles) > 0) {
-                    if (isset($this->allSettings['TYPO3']['Flow']['object']['registerFunctionalTestClasses']) && $this->allSettings['TYPO3']['Flow']['object']['registerFunctionalTestClasses'] === true) {
-                        $classFiles = array_merge($classFiles, $package->getFunctionalTestsClassFiles());
+            if ($package->isObjectManagementEnabled() && (ComposerUtility::isFlowPackageType($package->getComposerManifest('type')) || isset($includeClassesConfiguration[$packageKey]))) {
+                foreach ($package->getClassFiles() as $fullClassName => $path) {
+                    if (substr($fullClassName, -9, 9) !== 'Exception') {
+                        $availableClassNames[$packageKey][] = $fullClassName;
                     }
-                    foreach (array_keys($classFiles) as $fullClassName) {
+                }
+                if (isset($this->allSettings['TYPO3']['Flow']['object']['registerFunctionalTestClasses']) && $this->allSettings['TYPO3']['Flow']['object']['registerFunctionalTestClasses'] === true) {
+                    foreach ($package->getFunctionalTestsClassFiles() as $fullClassName => $path) {
                         if (substr($fullClassName, -9, 9) !== 'Exception') {
                             $availableClassNames[$packageKey][] = $fullClassName;
                         }
                     }
+                }
+                if (isset($availableClassNames[$packageKey]) && is_array($availableClassNames[$packageKey])) {
                     $availableClassNames[$packageKey] = array_unique($availableClassNames[$packageKey]);
                 }
             }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/Package.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/Package.php
@@ -11,7 +11,9 @@ namespace TYPO3\Flow\Package;
  * source code.
  */
 
+use TYPO3\Flow\Composer\Utility;
 use TYPO3\Flow\Core\Bootstrap;
+use TYPO3\Flow\Core\ClassLoader;
 use TYPO3\Flow\Utility\Files;
 
 /**
@@ -22,77 +24,60 @@ use TYPO3\Flow\Utility\Files;
 class Package implements PackageInterface
 {
     /**
-     * @var string
-     */
-    const AUTOLOADER_TYPE_PSR0 = 'psr-0';
-
-    /**
-     * @var string
-     */
-    const AUTOLOADER_TYPE_PSR4 = 'psr-4';
-
-    /**
-     * @var string
-     */
-    const AUTOLOADER_TYPE_CLASSMAP = 'classmap';
-
-    /**
-     * @var string
-     */
-    const AUTOLOADER_TYPE_FILES = 'files';
-
-    /**
      * Unique key of this package. Example for the Flow package: "TYPO3.Flow"
+     *
      * @var string
      */
     protected $packageKey;
 
     /**
+     * composer name for this package
+     *
      * @var string
      */
-    protected $manifestPath;
+    protected $composerName;
 
     /**
      * Full path to this package's main directory
+     *
      * @var string
      */
     protected $packagePath;
 
     /**
-     * Full path to this package's PSR-0 class loader entry point
-     * @var string
-     */
-    protected $classesPath;
-
-    /**
      * If this package is protected and therefore cannot be deactivated or deleted
+     *
      * @var boolean
      * @api
      */
     protected $protected = false;
 
     /**
-     * @var \stdClass
-     */
-    protected $composerManifest;
-
-    /**
      * Meta information about this package
+     *
      * @var \TYPO3\Flow\Package\MetaData
+     * TODO: Remove after deprecation period (Flow 4.0)
      */
     protected $packageMetaData;
 
     /**
-     * Names and relative paths (to this package directory) of files containing classes
-     * @var array
-     */
-    protected $classFiles;
-
-    /**
      * The namespace of the classes contained in this package
+     *
      * @var string
      */
     protected $namespace;
+
+    /**
+     * Array of all declared autoload namespaces contained in this package
+     *
+     * @var string[]
+     */
+    protected $namespaces;
+
+    /**
+     * @var string[]
+     */
+    protected $autoloadTypes;
 
     /**
      * If enabled, the files in the Classes directory are registered and Reflection, Dependency Injection, AOP etc. are supported.
@@ -104,55 +89,30 @@ class Package implements PackageInterface
     protected $objectManagementEnabled = true;
 
     /**
-     * @var \TYPO3\Flow\Package\PackageManager
+     * @var array
      */
-    protected $packageManager;
+    protected $autoloadConfiguration;
+
+    /**
+     * @var array
+     */
+    protected $flattenedAutoloadConfiguration;
 
     /**
      * Constructor
      *
-     * @param \TYPO3\Flow\Package\PackageManager $packageManager the package manager which knows this package
      * @param string $packageKey Key of this package
+     * @param string $composerName
      * @param string $packagePath Absolute path to the location of the package's composer manifest
-     * @param string $classesPath Path the classes of the package are in, relative to $packagePath. Optional, PSR-0/PSR-4 mappings of the composer manifest overrule this argument, if present
-     * @param string $manifestPath Path the composer manifest of the package, relative to $packagePath. Optional, defaults to ''
-     * @throws \TYPO3\Flow\Package\Exception\InvalidPackageKeyException if an invalid package key was passed
-     * @throws \TYPO3\Flow\Package\Exception\InvalidPackagePathException if an invalid package path was passed
-     * @throws \TYPO3\Flow\Package\Exception\InvalidPackageManifestException if no composer manifest file could be found
+     * @param array $autoloadConfiguration
+     * @throws Exception\InvalidPackageKeyException
      */
-    public function __construct(PackageManager $packageManager, $packageKey, $packagePath, $classesPath = null, $manifestPath = '')
+    public function __construct($packageKey, $composerName, $packagePath, array $autoloadConfiguration = [])
     {
-        if (preg_match(self::PATTERN_MATCH_PACKAGEKEY, $packageKey) !== 1) {
-            throw new Exception\InvalidPackageKeyException('"' . $packageKey . '" is not a valid package key.', 1217959510);
-        }
-        if (!(is_dir($packagePath) || (Files::is_link($packagePath) && is_dir(Files::getNormalizedPath($packagePath))))) {
-            throw new Exception\InvalidPackagePathException(sprintf('Tried to instantiate a package object for package "%s" with a non-existing package path "%s". Either the package does not exist anymore, or the code creating this object contains an error.', $packageKey, $packagePath), 1166631889);
-        }
-        if (substr($packagePath, -1, 1) !== '/') {
-            throw new Exception\InvalidPackagePathException(sprintf('The package path "%s" provided for package "%s" has no trailing forward slash.', $packagePath, $packageKey), 1166633720);
-        }
-        if (substr($classesPath, 0, 1) === '/') {
-            throw new Exception\InvalidPackagePathException(sprintf('The package classes path provided for package "%s" has a leading forward slash.', $packageKey), 1334841320);
-        }
-        if (!file_exists($packagePath . $manifestPath . 'composer.json')) {
-            throw new Exception\InvalidPackageManifestException(sprintf('No composer manifest file found for package "%s". Please create one at "%scomposer.json".', $packageKey, $packagePath . $manifestPath), 1349776393);
-        }
-
-        $this->packageManager = $packageManager;
-        $this->manifestPath = $manifestPath;
-        $this->packageKey = $packageKey;
+        $this->autoloadConfiguration = $autoloadConfiguration;
         $this->packagePath = Files::getNormalizedPath($packagePath);
-        $autoloadType = $this->getAutoloadType();
-
-        if ($autoloadType === self::AUTOLOADER_TYPE_PSR0 || $autoloadType === self::AUTOLOADER_TYPE_PSR4) {
-            $autoloadPath = $this->getComposerManifest('autoload')->{$autoloadType}->{$this->getNamespace()};
-            if (is_array($autoloadPath)) {
-                $autoloadPath = $autoloadPath[0];
-            }
-            $this->classesPath = Files::getNormalizedPath($this->packagePath . $autoloadPath);
-        } else {
-            $this->classesPath = Files::getNormalizedPath($this->packagePath . $classesPath);
-        }
+        $this->packageKey = $packageKey;
+        $this->composerName = $composerName;
     }
 
     /**
@@ -167,8 +127,11 @@ class Package implements PackageInterface
 
     /**
      * Returns the package meta data object of this package.
+     * Note that since Flow 3.1 the MetaData won't contain any constraints,
+     * please use the composer manifest directly if you need this information.
      *
      * @return \TYPO3\Flow\Package\MetaData
+     * @deprecated To be removed in Flow 4.0
      */
     public function getPackageMetaData()
     {
@@ -177,48 +140,27 @@ class Package implements PackageInterface
             $this->packageMetaData->setDescription($this->getComposerManifest('description'));
             $this->packageMetaData->setVersion($this->getComposerManifest('version'));
             $this->packageMetaData->setPackageType($this->getComposerManifest('type'));
-            $requirements = $this->getComposerManifest('require');
-            if ($requirements !== null) {
-                foreach ($requirements as $requirement => $version) {
-                    if ($this->packageRequirementIsComposerPackage($requirement) === false) {
-                        // Skip non-package requirements
-                        continue;
-                    }
-                    try {
-                        $packageKey = $this->packageManager->getPackageKeyFromComposerName($requirement);
-                    } catch (Exception\InvalidPackageStateException $exception) {
-                        continue;
-                    }
-                    $constraint = new MetaData\PackageConstraint(MetaDataInterface::CONSTRAINT_TYPE_DEPENDS, $packageKey);
-                    $this->packageMetaData->addConstraint($constraint);
-                }
-            }
         }
-        return $this->packageMetaData;
-    }
 
-    /**
-     * Check whether the given package requirement (like "typo3/flow" or "php") is a composer package or not
-     *
-     * @param string $requirement the composer requirement string
-     * @return boolean TRUE if $requirement is a composer package (contains a slash), FALSE otherwise
-     */
-    protected function packageRequirementIsComposerPackage($requirement)
-    {
-        return (strpos($requirement, '/') !== false);
+        return $this->packageMetaData;
     }
 
     /**
      * Returns the array of filenames of the class files
      *
-     * @return array An array of class names (key) and their filename, including the relative path to the package's directory
+     * @return \Generator A Generator for class names (key) and their filename, including the absolute path.
      */
     public function getClassFiles()
     {
-        if (!is_array($this->classFiles)) {
-            $this->classFiles = $this->buildArrayOfClassFiles($this->classesPath);
+        foreach ($this->getFlattenedAutoloadConfiguration() as $configuration) {
+            $normalizedAutoloadPath = $this->normalizeAutoloadPath($configuration['mappingType'], $configuration['namespace'], $configuration['classPath']);
+            if (!is_dir($normalizedAutoloadPath)) {
+                continue;
+            }
+            foreach ($this->getClassesInNormalizedAutoloadPath($normalizedAutoloadPath, $configuration['namespace']) as $className => $classPath) {
+                yield $className => $classPath;
+            }
         }
-        return $this->classFiles;
     }
 
     /**
@@ -228,8 +170,16 @@ class Package implements PackageInterface
      */
     public function getFunctionalTestsClassFiles()
     {
-        $namespacePrefix = str_replace('/', '\\', Files::concatenatePaths((array((($this->getAutoloadType() === self::AUTOLOADER_TYPE_PSR0) ? $this->getNamespace() : ''), '\\Tests\\Functional\\'))));
-        return $this->buildArrayOfClassFiles($this->packagePath . self::DIRECTORY_TESTS_FUNCTIONAL, $namespacePrefix);
+        if (is_dir($this->packagePath . self::DIRECTORY_TESTS_FUNCTIONAL)) {
+            // TODO REFACTOR replace with usage of "autoload-dev"
+            $namespacePrefix = str_replace('/', '\\', Files::concatenatePaths([
+                $this->getNamespace(),
+                '\\Tests\\Functional\\'
+            ]));
+            foreach ($this->getClassesInNormalizedAutoloadPath($this->packagePath . self::DIRECTORY_TESTS_FUNCTIONAL, $namespacePrefix) as $className => $classPath) {
+                yield $className => $classPath;
+            }
+        }
     }
 
     /**
@@ -244,51 +194,74 @@ class Package implements PackageInterface
     }
 
     /**
+     * Returns the packages composer name
+     *
+     * @return string
+     * TODO: Should be added to the interface in the next major Flow version (4.0)
+     */
+    public function getComposerName()
+    {
+        return $this->composerName;
+    }
+
+    /**
+     * Returns array of all declared autoload namespaces contained in this package
+     *
+     * @return array
+     * @api
+     * TODO: Should be added to the interface in the next major Flow version (4.0)
+     */
+    public function getNamespaces()
+    {
+        if ($this->namespaces === null) {
+            $this->explodeAutoloadConfiguration();
+        }
+
+        return $this->namespaces;
+    }
+
+    /**
      * Returns the PHP namespace of classes in this package.
      *
      * @return string
-     * @throws \TYPO3\Flow\Package\Exception\InvalidPackageStateException
      * @api
+     * @deprecated see getNamespaces()
      */
     public function getNamespace()
     {
-        if (!$this->namespace) {
-            $autoloadConfiguration = $this->getComposerManifest('autoload');
-            $autoloadType = $this->getAutoloadType();
-            if ($autoloadType === self::AUTOLOADER_TYPE_PSR0 || $autoloadType === self::AUTOLOADER_TYPE_PSR4) {
-                $namespaces = (array)$autoloadConfiguration->{$autoloadType};
-                $namespace = key($namespaces);
-            } else {
-                $namespace = str_replace('.', '\\', $this->getPackageKey());
-            }
-            $this->namespace = $namespace;
+        $allNamespaces = $this->getNamespaces();
+
+        return reset($allNamespaces);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAutoloadTypes()
+    {
+        if ($this->autoloadTypes === null) {
+            $this->explodeAutoloadConfiguration();
         }
-        return $this->namespace;
+
+        return $this->autoloadTypes;
     }
 
     /**
      * PSR autoloading type
      *
      * @return string see self::AUTOLOADER_TYPE_* - NULL in case it is not defined or unknown
-     * @api
+     * @deprecated see getAutoloadTypes()
      */
     public function getAutoloadType()
     {
-        $autoloadConfiguration = $this->getComposerManifest('autoload');
-        if (isset($autoloadConfiguration->{self::AUTOLOADER_TYPE_PSR0})) {
-            return self::AUTOLOADER_TYPE_PSR0;
-        }
-        if (isset($autoloadConfiguration->{self::AUTOLOADER_TYPE_PSR4})) {
-            return self::AUTOLOADER_TYPE_PSR4;
-        }
-        if (isset($autoloadConfiguration->{self::AUTOLOADER_TYPE_CLASSMAP})) {
-            return self::AUTOLOADER_TYPE_CLASSMAP;
-        }
-        if (isset($autoloadConfiguration->{self::AUTOLOADER_TYPE_FILES})) {
-            return self::AUTOLOADER_TYPE_FILES;
+        $autoloadConfigurations = $this->getFlattenedAutoloadConfiguration();
+        $firstAutoload = reset($autoloadConfigurations);
+
+        if ($firstAutoload === false) {
+            return null;
         }
 
-        return null;
+        return $firstAutoload['mappingType'];
     }
 
     /**
@@ -336,37 +309,55 @@ class Package implements PackageInterface
     }
 
     /**
-     * Returns the full path to the packages Composer manifest
-     *
-     * @return string
-     */
-    public function getManifestPath()
-    {
-        return $this->packagePath . $this->manifestPath;
-    }
-
-    /**
      * Returns the full path to this package's Classes directory
      *
      * @return string Path to this package's Classes directory
      * @api
+     * @deprecated
      */
     public function getClassesPath()
     {
-        return $this->classesPath;
+        $autoloadConfigurations = $this->getFlattenedAutoloadConfiguration();
+        $firstAutoload = reset($autoloadConfigurations);
+
+        if ($firstAutoload === false) {
+            return null;
+        }
+
+        return $firstAutoload['classPath'];
+    }
+
+    /**
+     * @return array
+     */
+    public function getAutoloadPaths()
+    {
+        return array_map(function ($configuration) {
+            return $configuration['classPath'];
+        }, $this->getFlattenedAutoloadConfiguration());
     }
 
     /**
      * Returns the full path to the package's classes namespace entry path,
      * e.g. "My.Package/ClassesPath/My/Package/"
      *
-     * @return string Path to this package's Classes directory
+     * @return string Path to this package's autoload directory
      * @api
+     * @deprecated
      */
     public function getClassesNamespaceEntryPath()
     {
-        $pathifiedNamespace = str_replace('\\', '/', $this->getNamespace());
-        return Files::getNormalizedPath($this->classesPath . trim($pathifiedNamespace, '/'));
+        $autoloadConfigurations = $this->getFlattenedAutoloadConfiguration();
+        $firstAutoload = reset($autoloadConfigurations);
+
+        $basePath = $firstAutoload['classPath'];
+
+        $pathifiedNamespace = '';
+        if ($firstAutoload['mappingType'] === ClassLoader::MAPPING_TYPE_PSR0) {
+            $pathifiedNamespace = str_replace('\\', '/', $firstAutoload['namespace']);
+        }
+
+        return Files::concatenatePaths($basePath . $pathifiedNamespace);
     }
 
     /**
@@ -374,6 +365,7 @@ class Package implements PackageInterface
      *
      * @return string Path to this package's functional tests directory
      * @api
+     * TODO: Should be replaced by using autoload-dev
      */
     public function getFunctionalTestsPath()
     {
@@ -406,7 +398,7 @@ class Package implements PackageInterface
      * Returns the full path to the package's meta data directory
      *
      * @return string Full path to the package's meta data directory
-     * @api
+     * @deprecated To be removed in Flow 4.0
      */
     public function getMetaPath()
     {
@@ -417,7 +409,7 @@ class Package implements PackageInterface
      * Returns the full path to the package's documentation directory
      *
      * @return string Full path to the package's documentation directory
-     * @api
+     * @deprecated To be removed in Flow 4.0
      */
     public function getDocumentationPath()
     {
@@ -425,14 +417,143 @@ class Package implements PackageInterface
     }
 
     /**
+     * Get the autoload configuration for this package. Any valid composer "autoload" configuration.
+     *
+     * @return array
+     */
+    public function getAutoloadConfiguration()
+    {
+        return $this->autoloadConfiguration;
+    }
+
+    /**
+     * Get a flattened array of autoload configurations that have a predictable pattern (PSR-0, PSR-4)
+     *
+     * @return array Keys: "namespace", "classPath", "mappingType"
+     */
+    public function getFlattenedAutoloadConfiguration()
+    {
+        if ($this->flattenedAutoloadConfiguration === null) {
+            $this->explodeAutoloadConfiguration();
+        }
+
+        return $this->flattenedAutoloadConfiguration;
+    }
+
+    /**
+     * Returns contents of Composer manifest - or part there of.
+     *
+     * @param string $key Optional. Only return the part of the manifest indexed by 'key'
+     * @return array|mixed
+     * @api
+     * TODO: Should be added to the interface in the next major Flow version (4.0)
+     */
+    public function getComposerManifest($key = null)
+    {
+        return Utility::getComposerManifest($this->packagePath, $key);
+    }
+
+    /**
+     * Get the installed package version (from composer)
+     *
+     * @return string
+     * @api
+     * TODO: Should be added to the interface in the next major Flow version (4.0)
+     */
+    public function getInstalledVersion()
+    {
+        return PackageManager::getPackageVersion($this->composerName);
+    }
+
+    /**
+     * @param string $autoloadType
+     * @param string $autoloadNamespace
+     * @param string $autoloadPath
+     * @return string
+     */
+    protected function normalizeAutoloadPath($autoloadType, $autoloadNamespace, $autoloadPath)
+    {
+        $normalizedAutoloadPath = $autoloadPath;
+        if ($autoloadType === ClassLoader::MAPPING_TYPE_PSR0) {
+            $normalizedAutoloadPath = Files::concatenatePaths([
+                    $autoloadPath,
+                    str_replace('\\', '/', $autoloadNamespace)
+                ]) . '/';
+        }
+
+        return $normalizedAutoloadPath;
+    }
+
+    /**
+     * @param string $baseAutoloadPath
+     * @param string $autoloadNamespace
+     * @return \Generator
+     */
+    protected function getClassesInNormalizedAutoloadPath($baseAutoloadPath, $autoloadNamespace)
+    {
+        $autoloadNamespace = trim($autoloadNamespace, '\\') . '\\';
+        $directories = [''];
+        while ($directories !== []) {
+            $currentRelativeDirectory = array_pop($directories);
+            $currentAbsoluteDirectory = $baseAutoloadPath . $currentRelativeDirectory;
+            if ($handle = opendir($currentAbsoluteDirectory)) {
+                while (false !== ($filename = readdir($handle))) {
+                    if ($filename[0] === '.') {
+                        continue;
+                    }
+                    $pathAndFilename = $currentAbsoluteDirectory . $filename;
+                    if (is_dir($pathAndFilename)) {
+                        $directories[] = $currentRelativeDirectory . $filename . '/';
+                        continue;
+                    }
+                    if (strpos(strrev($filename), 'php.') === 0) {
+                        $potentialClassNamespace = $autoloadNamespace . str_replace('/', '\\', $currentRelativeDirectory) . basename($filename, '.php');
+                        yield $potentialClassNamespace => $pathAndFilename;
+                    }
+                }
+                closedir($handle);
+            }
+        }
+    }
+
+    /**
+     * Brings the composer autoload configuration into an easy to use format for various parts of Flow.
+     *
+     * @return void
+     */
+    protected function explodeAutoloadConfiguration()
+    {
+        $this->namespaces = [];
+        $this->autoloadTypes = [];
+        $this->flattenedAutoloadConfiguration = [];
+        $allAutoloadConfiguration = $this->autoloadConfiguration;
+        foreach ($allAutoloadConfiguration as $autoloadType => $autoloadConfiguration) {
+            $this->autoloadTypes[] = $autoloadType;
+            if (ClassLoader::isAutoloadTypeWithPredictableClassPath($autoloadType)) {
+                $this->namespaces = array_merge($this->namespaces, array_keys($autoloadConfiguration));
+                foreach ($autoloadConfiguration as $namespace => $paths) {
+                    $paths = (array)$paths;
+                    foreach ($paths as $path) {
+                        $this->flattenedAutoloadConfiguration[] = [
+                            'namespace' => $namespace,
+                            'classPath' => $this->packagePath . $path,
+                            'mappingType' => $autoloadType
+                        ];
+                    }
+                }
+            }
+        }
+    }
+
+    /**
      * Returns the available documentations for this package
      *
      * @return array Array of \TYPO3\Flow\Package\Documentation
-     * @api
+     * @deprecated To be removed in Flow 4.0
      */
     public function getPackageDocumentations()
     {
-        $documentations = array();
+        $documentations = [];
         $documentationPath = $this->getDocumentationPath();
         if (is_dir($documentationPath)) {
             $documentationsDirectoryIterator = new \DirectoryIterator($documentationPath);
@@ -444,78 +565,11 @@ class Package implements PackageInterface
                     $documentation = new Documentation($this, $filename, $documentationPath . $filename . '/');
                     $documentations[$filename] = $documentation;
                 }
+
                 $documentationsDirectoryIterator->next();
             }
         }
+
         return $documentations;
-    }
-
-    /**
-     * Returns contents of Composer manifest - or part there of.
-     *
-     * @param string $key Optional. Only return the part of the manifest indexed by 'key'
-     * @return mixed|NULL
-     * @see json_decode for return values
-     */
-    public function getComposerManifest($key = null)
-    {
-        if (!isset($this->composerManifest)) {
-            $this->composerManifest = PackageManager::getComposerManifest($this->getManifestPath());
-        }
-
-        return PackageManager::getComposerManifest($this->getManifestPath(), $key, $this->composerManifest);
-    }
-
-    /**
-     * Builds and returns an array of class names => file names of all
-     * *.php files in the package's Classes directory and its sub-
-     * directories.
-     *
-     * @param string $classesPath Base path acting as the parent directory for potential class files
-     * @param string $extraNamespaceSegment A PHP class namespace segment which should be inserted like so: \TYPO3\PackageKey\{namespacePrefix\}PathSegment\PathSegment\Filename
-     * @param string $subDirectory Used internally
-     * @param integer $recursionLevel Used internally
-     * @return array
-     * @throws \TYPO3\Flow\Package\Exception if recursion into directories was too deep or another error occurred
-     */
-    protected function buildArrayOfClassFiles($classesPath, $extraNamespaceSegment = '', $subDirectory = '', $recursionLevel = 0)
-    {
-        $classFiles = array();
-        $currentPath = $classesPath . $subDirectory;
-        $currentRelativePath = substr($currentPath, strlen($this->packagePath));
-        $namespacePrefix = '';
-
-        if ($this->getAutoloadType() === self::AUTOLOADER_TYPE_PSR4) {
-            $namespacePrefix = $this->getNamespace();
-        }
-
-        if (!is_dir($currentPath)) {
-            return array();
-        }
-        if ($recursionLevel > 100) {
-            throw new Exception('Recursion too deep while collecting class files.', 1166635495);
-        }
-
-        try {
-            $classesDirectoryIterator = new \DirectoryIterator($currentPath);
-            while ($classesDirectoryIterator->valid()) {
-                $filename = $classesDirectoryIterator->getFilename();
-                if ($filename[0] != '.') {
-                    if (is_dir($currentPath . $filename)) {
-                        $classFiles = array_merge($classFiles, $this->buildArrayOfClassFiles($classesPath, $extraNamespaceSegment, $subDirectory . $filename . '/', ($recursionLevel + 1)));
-                    } else {
-                        if (substr($filename, -4, 4) === '.php') {
-                            $className = Files::concatenatePaths(array($namespacePrefix, $extraNamespaceSegment, substr($currentPath, strlen($classesPath)), substr($filename, 0, -4)));
-                            $className = str_replace('/', '\\', $className);
-                            $classFiles[$className] = $currentRelativePath . $filename;
-                        }
-                    }
-                }
-                $classesDirectoryIterator->next();
-            }
-        } catch (\Exception $exception) {
-            throw new Exception($exception->getMessage(), 1166633720);
-        }
-        return $classFiles;
     }
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/Package.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/Package.php
@@ -398,6 +398,7 @@ class Package implements PackageInterface
      * Returns the full path to the package's meta data directory
      *
      * @return string Full path to the package's meta data directory
+     * @api
      * @deprecated To be removed in Flow 4.0
      */
     public function getMetaPath()
@@ -409,6 +410,7 @@ class Package implements PackageInterface
      * Returns the full path to the package's documentation directory
      *
      * @return string Full path to the package's documentation directory
+     * @api
      * @deprecated To be removed in Flow 4.0
      */
     public function getDocumentationPath()
@@ -549,6 +551,7 @@ class Package implements PackageInterface
      * Returns the available documentations for this package
      *
      * @return array Array of \TYPO3\Flow\Package\Documentation
+     * @api
      * @deprecated To be removed in Flow 4.0
      */
     public function getPackageDocumentations()

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/Package.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/Package.php
@@ -11,7 +11,7 @@ namespace TYPO3\Flow\Package;
  * source code.
  */
 
-use TYPO3\Flow\Composer\Utility;
+use TYPO3\Flow\Composer\ComposerUtility;
 use TYPO3\Flow\Core\Bootstrap;
 use TYPO3\Flow\Core\ClassLoader;
 use TYPO3\Flow\Utility\Files;
@@ -450,7 +450,7 @@ class Package implements PackageInterface
      */
     public function getComposerManifest($key = null)
     {
-        return Utility::getComposerManifest($this->packagePath, $key);
+        return ComposerUtility::getComposerManifest($this->packagePath, $key);
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageFactory.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageFactory.php
@@ -11,7 +11,8 @@ namespace TYPO3\Flow\Package;
  * source code.
  */
 
-use TYPO3\Flow\Package\Exception\MissingPackageManifestException;
+use TYPO3\Flow\Core\ClassLoader;
+use TYPO3\Flow\Package\Exception\InvalidPackagePathException;
 use TYPO3\Flow\Utility\Files;
 use TYPO3\Flow\Utility\PhpAnalyzer;
 
@@ -21,101 +22,71 @@ use TYPO3\Flow\Utility\PhpAnalyzer;
 class PackageFactory
 {
     /**
-     * @var PackageManagerInterface
-     */
-    protected $packageManager;
-
-    /**
-     * @param \TYPO3\Flow\Package\PackageManagerInterface $packageManager
-     */
-    public function __construct(PackageManagerInterface $packageManager)
-    {
-        $this->packageManager = $packageManager;
-    }
-
-    /**
      * Returns a package instance.
      *
      * @param string $packagesBasePath the base install path of packages,
      * @param string $packagePath path to package, relative to base path
      * @param string $packageKey key / name of the package
-     * @param string $classesPath path to the classes directory, relative to the package path
-     * @param string $manifestPath path to the package's Composer manifest, relative to package path, defaults to same path
-     * @return \TYPO3\Flow\Package\PackageInterface
+     * @param string $composerName
+     * @param array $autoloadConfiguration Autoload configuration as defined in composer.json
+     * @param array $packageClassInformation
+     * @return PackageInterface
      * @throws Exception\CorruptPackageException
      */
-    public function create($packagesBasePath, $packagePath, $packageKey, $classesPath = null, $manifestPath = null)
+    public function create($packagesBasePath, $packagePath, $packageKey, $composerName, array $autoloadConfiguration = [], array $packageClassInformation = null)
     {
         $absolutePackagePath = Files::concatenatePaths(array($packagesBasePath, $packagePath)) . '/';
-        $absoluteManifestPath = $manifestPath === null ? $absolutePackagePath : Files::concatenatePaths(array($absolutePackagePath, $manifestPath)) . '/';
-        $autoLoadDirectives = array();
-        try {
-            $autoLoadDirectives = (array)PackageManager::getComposerManifest($absoluteManifestPath, 'autoload');
-        } catch (MissingPackageManifestException $exception) {
+
+        if ($packageClassInformation === null) {
+            $packageClassInformation = $this->detectFlowPackageFilePath($packageKey, $absolutePackagePath, $autoloadConfiguration);
         }
-        if (isset($autoLoadDirectives[Package::AUTOLOADER_TYPE_PSR4])) {
-            $packageClassPathAndFilename = Files::concatenatePaths(array($absolutePackagePath, 'Classes', 'Package.php'));
-        } else {
-            $packageClassPathAndFilename = Files::concatenatePaths(array($absolutePackagePath, 'Classes', str_replace('.', '/', $packageKey), 'Package.php'));
+
+        $packageClassName = Package::class;
+        if (!empty($packageClassInformation)) {
+            $packageClassName = $packageClassInformation['className'];
+            $packageClassPath = Files::concatenatePaths(array($absolutePackagePath, $packageClassInformation['pathAndFilename']));
+            require_once($packageClassPath);
         }
-        $package = null;
-        if (file_exists($packageClassPathAndFilename)) {
-            require_once($packageClassPathAndFilename);
-            $packageClassContents = file_get_contents($packageClassPathAndFilename);
-            $packageClassName = (new PhpAnalyzer($packageClassContents))->extractFullyQualifiedClassName();
-            if ($packageClassName === null) {
-                throw new Exception\CorruptPackageException(sprintf('The package "%s" does not contain a valid package class. Check if the file "%s" really contains a class.', $packageKey, $packageClassPathAndFilename), 1327587091);
-            }
-            $package = new $packageClassName($this->packageManager, $packageKey, $absolutePackagePath, $classesPath, $manifestPath);
-            if (!$package instanceof PackageInterface) {
-                throw new Exception\CorruptPackageException(sprintf('The package class of package "%s" does not implement \TYPO3\Flow\Package\PackageInterface. Check the file "%s".', $packageKey, $packageClassPathAndFilename), 1427193370);
-            }
-            return $package;
+
+        $package = new $packageClassName($packageKey, $composerName, $absolutePackagePath, $autoloadConfiguration);
+        if (!$package instanceof PackageInterface) {
+            throw new Exception\CorruptPackageException(sprintf('The package class of package "%s" does not implement \TYPO3\Flow\Package\PackageInterface. Check the file "%s".', $packageKey, $packageClassInformation['pathAndFilename']), 1427193370);
         }
-        return new Package($this->packageManager, $packageKey, $absolutePackagePath, $classesPath, $manifestPath);
+
+        return $package;
     }
 
     /**
-     * Resolves package key from Composer manifest
+     * Detects if the package contains a package file and returns the path and classname.
      *
-     * If it is a Flow package the name of the containing directory will be used.
-     *
-     * Else if the composer name of the package matches the first part of the lowercased namespace of the package, the mixed
-     * case version of the composer name / namespace will be used, with backslashes replaced by dots.
-     *
-     * Else the composer name will be used with the slash replaced by a dot
-     *
-     * @param object $manifest
-     * @param string $packagePath
-     * @param string $packagesBasePath
-     * @return string
-     * @throws \TYPO3\Flow\Package\Exception\InvalidPackageManifestException
+     * @param string $packageKey The package key
+     * @param string $absolutePackagePath Absolute path to the package
+     * @param array $autoloadDirectives
+     * @return array The path to the package file and classname for this package or an empty array if none was found.
+     * @throws Exception\CorruptPackageException
+     * @throws InvalidPackagePathException
      */
-    public static function getPackageKeyFromManifest($manifest, $packagePath, $packagesBasePath)
+    public function detectFlowPackageFilePath($packageKey, $absolutePackagePath, array $autoloadDirectives = [])
     {
-        if (!is_object($manifest)) {
-            throw new  \TYPO3\Flow\Package\Exception\InvalidPackageManifestException('Invalid composer manifest.', 1348146450);
+        if (!is_dir($absolutePackagePath)) {
+            throw new InvalidPackagePathException(sprintf('The given package path "%s" is not a readable directory.', $absolutePackagePath), 1445904440);
         }
-        if (isset($manifest->type) && substr($manifest->type, 0, 11) === 'typo3-flow-') {
-            $relativePackagePath = substr($packagePath, strlen($packagesBasePath));
-            $packageKey = substr($relativePackagePath, strpos($relativePackagePath, '/') + 1, -1);
-            /**
-             * @todo check that manifest name and directory follows convention
-             */
+        if (isset($autoloadDirectives[ClassLoader::MAPPING_TYPE_PSR4])) {
+            $packageClassPathAndFilename = Files::concatenatePaths(array('Classes', 'Package.php'));
         } else {
-            $packageKey = str_replace('/', '.', $manifest->name);
-            if (isset($manifest->autoload) && isset($manifest->autoload->{'psr-0'})) {
-                $namespaces = array_keys(get_object_vars($manifest->autoload->{'psr-0'}));
-                foreach ($namespaces as $namespace) {
-                    $namespaceLead = substr($namespace, 0, strlen($manifest->name));
-                    $dottedNamespaceLead = str_replace('\\', '.', $namespaceLead);
-                    if (strtolower($dottedNamespaceLead) === $packageKey) {
-                        $packageKey = $dottedNamespaceLead;
-                    }
-                }
-            }
+            $packageClassPathAndFilename = Files::concatenatePaths(array('Classes', str_replace('.', '/', $packageKey), 'Package.php'));
         }
-        $packageKey = preg_replace('/[^A-Za-z0-9.]/', '', $packageKey);
-        return $packageKey;
+        $absolutePackageClassPath = Files::concatenatePaths(array($absolutePackagePath, $packageClassPathAndFilename));
+        if (!is_file($absolutePackageClassPath)) {
+            return [];
+        }
+
+        $packageClassContents = file_get_contents($absolutePackageClassPath);
+        $packageClassName = (new PhpAnalyzer($packageClassContents))->extractFullyQualifiedClassName();
+        if ($packageClassName === null) {
+            throw new Exception\CorruptPackageException(sprintf('The package "%s" does not contain a valid package class. Check if the file "%s" really contains a class.', $packageKey, $packageClassPathAndFilename), 1327587091);
+        }
+
+        return array('className' => $packageClassName, 'pathAndFilename' => $packageClassPathAndFilename);
     }
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageInterface.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageInterface.php
@@ -65,6 +65,7 @@ interface PackageInterface
      * Returns the PHP namespace of classes in this package.
      *
      * @return string
+     * @api
      * @deprecated Use getNamespaces() - To be removed in Flow 4.0
      */
     public function getNamespace();
@@ -105,6 +106,7 @@ interface PackageInterface
      * Returns the full path to this package's Classes directory
      *
      * @return string Path to this package's Classes directory
+     * @api
      * @deprecated To be removed in Flow 4.0
      */
     public function getClassesPath();
@@ -114,6 +116,7 @@ interface PackageInterface
      * e.g. "My.Package/ClassesPath/My/Package/"
      *
      * @return string Path to this package's Classes directory
+     * @api
      * @deprecated To be removed in Flow 4.0
      */
     public function getClassesNamespaceEntryPath();
@@ -138,6 +141,7 @@ interface PackageInterface
      * Returns the full path to this package's Package.xml file
      *
      * @return string Path to this package's Package.xml file
+     * @api
      * @deprecated To be removed in Flow 4.0
      */
     public function getMetaPath();
@@ -146,6 +150,7 @@ interface PackageInterface
      * Returns the full path to the package's documentation directory
      *
      * @return string Full path to the package's documentation directory
+     * @api
      * @deprecated To be removed in Flow 4.0
      */
     public function getDocumentationPath();
@@ -154,6 +159,7 @@ interface PackageInterface
      * Returns the available documentations for this package
      *
      * @return array Array of \TYPO3\Flow\Package\Documentation
+     * @api
      * @deprecated To be removed in Flow 4.0
      */
     public function getPackageDocumentations();

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageInterface.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageInterface.php
@@ -28,6 +28,8 @@ interface PackageInterface
     const DIRECTORY_TESTS_UNIT = 'Tests/Unit/';
     const DIRECTORY_RESOURCES = 'Resources/';
 
+    const DEFAULT_COMPOSER_TYPE = 'neos-package';
+
     /**
      * Invokes custom PHP code directly after the package manager has been initialized.
      *
@@ -63,7 +65,7 @@ interface PackageInterface
      * Returns the PHP namespace of classes in this package.
      *
      * @return string
-     * @api
+     * @deprecated Use getNamespaces() - To be removed in Flow 4.0
      */
     public function getNamespace();
 
@@ -103,7 +105,7 @@ interface PackageInterface
      * Returns the full path to this package's Classes directory
      *
      * @return string Path to this package's Classes directory
-     * @api
+     * @deprecated To be removed in Flow 4.0
      */
     public function getClassesPath();
 
@@ -112,7 +114,7 @@ interface PackageInterface
      * e.g. "My.Package/ClassesPath/My/Package/"
      *
      * @return string Path to this package's Classes directory
-     * @api
+     * @deprecated To be removed in Flow 4.0
      */
     public function getClassesNamespaceEntryPath();
 
@@ -136,7 +138,7 @@ interface PackageInterface
      * Returns the full path to this package's Package.xml file
      *
      * @return string Path to this package's Package.xml file
-     * @api
+     * @deprecated To be removed in Flow 4.0
      */
     public function getMetaPath();
 
@@ -144,7 +146,7 @@ interface PackageInterface
      * Returns the full path to the package's documentation directory
      *
      * @return string Full path to the package's documentation directory
-     * @api
+     * @deprecated To be removed in Flow 4.0
      */
     public function getDocumentationPath();
 
@@ -152,7 +154,7 @@ interface PackageInterface
      * Returns the available documentations for this package
      *
      * @return array Array of \TYPO3\Flow\Package\Documentation
-     * @api
+     * @deprecated To be removed in Flow 4.0
      */
     public function getPackageDocumentations();
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
@@ -11,10 +11,15 @@ namespace TYPO3\Flow\Package;
  * source code.
  */
 
-use TYPO3\Flow\Package\Exception\MissingPackageManifestException;
-use TYPO3\Flow\SignalSlot\Dispatcher;
-use TYPO3\Flow\Utility\Files;
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Composer\Exception\InvalidConfigurationException;
+use TYPO3\Flow\Composer\Exception\MissingPackageManifestException;
+use TYPO3\Flow\Composer\Utility as ComposerUtility;
+use TYPO3\Flow\Core\Bootstrap;
+use TYPO3\Flow\Core\ClassLoader;
+use TYPO3\Flow\SignalSlot\Dispatcher;
+use TYPO3\Flow\Utility\Exception as UtilityException;
+use TYPO3\Flow\Utility\Files;
 use TYPO3\Flow\Utility\OpcodeCacheHelper;
 use TYPO3\Flow\Utility\TypeHandling;
 
@@ -24,15 +29,20 @@ use TYPO3\Flow\Utility\TypeHandling;
  * @api
  * @Flow\Scope("singleton")
  */
-class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
+class PackageManager implements PackageManagerInterface
 {
     /**
-     * @var \TYPO3\Flow\Core\ClassLoader
+     * The current format version for PackageStates.php files
      */
-    protected $classLoader;
+    const PACKAGESTATE_FORMAT_VERSION = 6;
 
     /**
-     * @var \TYPO3\Flow\Core\Bootstrap
+     * The folder name for inactive packages.
+     */
+    const INACTIVE_PACKAGES_FOLDER = 'Inactive';
+
+    /**
+     * @var Bootstrap
      */
     protected $bootstrap;
 
@@ -47,36 +57,36 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
     protected $dispatcher;
 
     /**
-     * @var array
-     */
-    protected static $composerLockCache = null;
-
-    /**
      * Array of available packages, indexed by package key (case sensitive)
+     *
      * @var array
      */
-    protected $packages = array();
+    protected $packages = [];
 
     /**
      * A translation table between lower cased and upper camel cased package keys
+     *
      * @var array
      */
-    protected $packageKeys = array();
+    protected $packageKeys = [];
 
     /**
      * A map between ComposerName and PackageKey, only available when scanAvailablePackages is run
+     *
      * @var array
      */
-    protected $composerNameToPackageKeyMap = array();
+    protected $composerNameToPackageKeyMap = [];
 
     /**
      * List of active packages as package key => package object
+     *
      * @var array
      */
-    protected $activePackages = array();
+    protected $activePackages = [];
 
     /**
      * Absolute path leading to the various package directories
+     *
      * @var string
      */
     protected $packagesBasePath = FLOW_PATH_PACKAGES;
@@ -88,33 +98,15 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
 
     /**
      * Package states configuration as stored in the PackageStates.php file
+     *
      * @var array
      */
-    protected $packageStatesConfiguration = array();
+    protected $packageStatesConfiguration = [];
 
     /**
      * @var array
      */
     protected $settings;
-
-    /**
-     * @var \TYPO3\Flow\Log\SystemLoggerInterface
-     */
-    protected $systemLogger;
-
-    /**
-     * Cached composer manifest data for this request
-     */
-    protected static $composerManifestData = array();
-
-    /**
-     * @param \TYPO3\Flow\Core\ClassLoader $classLoader
-     * @return void
-     */
-    public function injectClassLoader(\TYPO3\Flow\Core\ClassLoader $classLoader)
-    {
-        $this->classLoader = $classLoader;
-    }
 
     /**
      * @param array $settings
@@ -126,42 +118,21 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
     }
 
     /**
-     * @param \TYPO3\Flow\Log\SystemLoggerInterface $systemLogger
-     * @return void
-     */
-    public function injectSystemLogger(\TYPO3\Flow\Log\SystemLoggerInterface $systemLogger)
-    {
-        if ($this->systemLogger instanceof \TYPO3\Flow\Log\EarlyLogger) {
-            $this->systemLogger->replayLogsOn($systemLogger);
-            unset($this->systemLogger);
-        }
-        $this->systemLogger = $systemLogger;
-    }
-
-    /**
      * Initializes the package manager
      *
-     * @param \TYPO3\Flow\Core\Bootstrap $bootstrap The current bootstrap
+     * @param Bootstrap $bootstrap The current bootstrap
      * @return void
      */
-    public function initialize(\TYPO3\Flow\Core\Bootstrap $bootstrap)
+    public function initialize(Bootstrap $bootstrap)
     {
-        $this->systemLogger = new \TYPO3\Flow\Log\EarlyLogger();
-
         $this->bootstrap = $bootstrap;
         $this->packageStatesPathAndFilename = $this->packageStatesPathAndFilename ?: FLOW_PATH_CONFIGURATION . 'PackageStates.php';
-        $this->packageFactory = new PackageFactory($this);
+        $this->packageFactory = new PackageFactory();
 
-        $this->loadPackageStates();
-
-        $this->activePackages = array();
-        foreach ($this->packages as $packageKey => $package) {
-            if ($package->isProtected() || (isset($this->packageStatesConfiguration['packages'][$packageKey]['state']) && $this->packageStatesConfiguration['packages'][$packageKey]['state'] === 'active')) {
-                $this->activePackages[$packageKey] = $package;
-            }
-        }
-
-        $this->classLoader->setPackages($this->packages, $this->activePackages);
+        $this->packageStatesConfiguration = $this->getCurrentPackageStates();
+        $this->activePackages = [];
+        $this->registerPackagesFromConfiguration($this->packageStatesConfiguration);
+        /** @var PackageInterface $package */
 
         foreach ($this->activePackages as $package) {
             $package->boot($bootstrap);
@@ -178,8 +149,7 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
      */
     public function isPackageAvailable($packageKey)
     {
-        $packageKey = $this->getCaseSensitivePackageKey($packageKey);
-        return (isset($this->packages[$packageKey]));
+        return ($this->getCaseSensitivePackageKey($packageKey) !== false);
     }
 
     /**
@@ -206,18 +176,18 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
 
     /**
      * Returns a PackageInterface object for the specified package.
-     * A package is available, if the package directory contains valid MetaData information.
      *
      * @param string $packageKey
      * @return \TYPO3\Flow\Package\PackageInterface The requested package object
-     * @throws \TYPO3\Flow\Package\Exception\UnknownPackageException if the specified package is not known
+     * @throws Exception\UnknownPackageException if the specified package is not known
      * @api
      */
     public function getPackage($packageKey)
     {
         if (!$this->isPackageAvailable($packageKey)) {
-            throw new \TYPO3\Flow\Package\Exception\UnknownPackageException('Package "' . $packageKey . '" is not available. Please check if the package exists and that the package key is correct (package keys are case sensitive).', 1166546734);
+            throw new Exception\UnknownPackageException('Package "' . $packageKey . '" is not available. Please check if the package exists and that the package key is correct (package keys are case sensitive).', 1166546734);
         }
+
         return $this->packages[$packageKey];
     }
 
@@ -230,6 +200,7 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
      *
      * @param object $object The object to find the possessing package of
      * @return PackageInterface The package the given object belongs to or NULL if it could not be found
+     * @deprecated
      */
     public function getPackageOfObject($object)
     {
@@ -241,6 +212,7 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
      *
      * @param string $className The fully qualified class name to find the possessing package of
      * @return PackageInterface The package the given object belongs to or NULL if it could not be found
+     * @deprecated
      */
     public function getPackageByClassName($className)
     {
@@ -255,6 +227,7 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
                 return $package;
             }
         }
+
         return null;
     }
 
@@ -292,15 +265,18 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
      */
     public function getFrozenPackages()
     {
-        $frozenPackages = array();
+        $frozenPackages = [];
         if ($this->bootstrap->getContext()->isDevelopment()) {
+            /** @var PackageInterface $package */
             foreach ($this->packages as $packageKey => $package) {
-                if (isset($this->packageStatesConfiguration['packages'][$packageKey]['frozen']) &&
-                        $this->packageStatesConfiguration['packages'][$packageKey]['frozen'] === true) {
+                if (isset($this->packageStatesConfiguration['packages'][$package->getComposerName()]['frozen']) &&
+                    $this->packageStatesConfiguration['packages'][$package->getComposerName()]['frozen'] === true
+                ) {
                     $frozenPackages[$packageKey] = $package;
                 }
             }
         }
+
         return $frozenPackages;
     }
 
@@ -318,19 +294,18 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
      */
     public function getFilteredPackages($packageState = 'available', $packagePath = null, $packageType = null)
     {
-        $packages = array();
         switch (strtolower($packageState)) {
             case 'available':
                 $packages = $this->getAvailablePackages();
-            break;
+                break;
             case 'active':
                 $packages = $this->getActivePackages();
-            break;
+                break;
             case 'frozen':
                 $packages = $this->getFrozenPackages();
-            break;
+                break;
             default:
-                throw new \TYPO3\Flow\Package\Exception\InvalidPackageStateException('The package state "' . $packageState . '" is invalid', 1372458274);
+                throw new Exception\InvalidPackageStateException('The package state "' . $packageState . '" is invalid', 1372458274);
         }
 
         if ($packagePath !== null) {
@@ -353,7 +328,7 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
      */
     protected function filterPackagesByPath(&$packages, $filterPath)
     {
-        $filteredPackages = array();
+        $filteredPackages = [];
         /** @var $package Package */
         foreach ($packages as $package) {
             $packagePath = substr($package->getPackagePath(), strlen(FLOW_PATH_PACKAGES));
@@ -362,6 +337,7 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
                 $filteredPackages[$package->getPackageKey()] = $package;
             }
         }
+
         return $filteredPackages;
     }
 
@@ -375,61 +351,15 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
      */
     protected function filterPackagesByType(&$packages, $packageType)
     {
-        $filteredPackages = array();
+        $filteredPackages = [];
         /** @var $package Package */
         foreach ($packages as $package) {
             if ($package->getComposerManifest('type') === $packageType) {
                 $filteredPackages[$package->getPackageKey()] = $package;
             }
         }
+
         return $filteredPackages;
-    }
-
-    /**
-     * Returns the upper camel cased version of the given package key or FALSE
-     * if no such package is available.
-     *
-     * @param string $unknownCasedPackageKey The package key to convert
-     * @return mixed The upper camel cased package key or FALSE if no such package exists
-     * @api
-     */
-    public function getCaseSensitivePackageKey($unknownCasedPackageKey)
-    {
-        $lowerCasedPackageKey = strtolower($unknownCasedPackageKey);
-        return (isset($this->packageKeys[$lowerCasedPackageKey])) ? $this->packageKeys[$lowerCasedPackageKey] : false;
-    }
-
-    /**
-     * Resolves a Flow package key from a composer package name.
-     *
-     * @param string $composerName
-     * @return string
-     * @throws Exception\InvalidPackageStateException
-     */
-    public function getPackageKeyFromComposerName($composerName)
-    {
-        if (count($this->composerNameToPackageKeyMap) === 0) {
-            foreach ($this->packageStatesConfiguration['packages'] as $packageKey => $packageStateConfiguration) {
-                $this->composerNameToPackageKeyMap[strtolower($packageStateConfiguration['composerName'])] = $packageKey;
-            }
-        }
-        $lowercasedComposerName = strtolower($composerName);
-        if (!isset($this->composerNameToPackageKeyMap[$lowercasedComposerName])) {
-            throw new \TYPO3\Flow\Package\Exception\InvalidPackageStateException('Could not find package with composer name "' . $composerName . '" in PackageStates configuration.', 1352320649);
-        }
-        return $this->composerNameToPackageKeyMap[$lowercasedComposerName];
-    }
-
-    /**
-     * Check the conformance of the given package key
-     *
-     * @param string $packageKey The package key to validate
-     * @return boolean If the package key is valid, returns TRUE otherwise FALSE
-     * @api
-     */
-    public function isPackageKeyValid($packageKey)
-    {
-        return preg_match(PackageInterface::PATTERN_MATCH_PACKAGEKEY, $packageKey) === 1;
     }
 
     /**
@@ -438,115 +368,109 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
      * @param string $packageKey The package key of the new package
      * @param \TYPO3\Flow\Package\MetaData $packageMetaData If specified, this package meta object is used for writing the Package.xml file, otherwise a rudimentary Package.xml file is created
      * @param string $packagesPath If specified, the package will be created in this path, otherwise the default "Application" directory is used
-     * @param string $packageType If specified, the package type will be set, otherwise it will default to "typo3-flow-package"
+     * @param string $packageType
+     * @param array $manifest A composer manifest as associative array. This is a preparation for the signature change in Flow 4.0. If you use this argument, then $packageMetaData and $packageType will be ignored.
      * @return PackageInterface The newly created package
-     * @throws \TYPO3\Flow\Package\Exception
-     * @throws \TYPO3\Flow\Package\Exception\PackageKeyAlreadyExistsException
-     * @throws \TYPO3\Flow\Package\Exception\InvalidPackageKeyException
+     *
+     * @throws Exception\InvalidPackageKeyException
+     * @throws Exception\PackageKeyAlreadyExistsException
      * @api
+     * @deprecated The method signature of this method will change with Flow 4.0, the method itself will stay.
+     * @see \TYPO3\Flow\Package\PackageManagerInterface::createPackage
      */
-    public function createPackage($packageKey, \TYPO3\Flow\Package\MetaData $packageMetaData = null, $packagesPath = null, $packageType = 'typo3-flow-package')
+    public function createPackage($packageKey, \TYPO3\Flow\Package\MetaData $packageMetaData = null, $packagesPath = null, $packageType = 'neos-package', array $manifest = null)
     {
         if (!$this->isPackageKeyValid($packageKey)) {
-            throw new \TYPO3\Flow\Package\Exception\InvalidPackageKeyException('The package key "' . $packageKey . '" is invalid', 1220722210);
+            throw new Exception\InvalidPackageKeyException('The package key "' . $packageKey . '" is invalid', 1220722210);
         }
         if ($this->isPackageAvailable($packageKey)) {
-            throw new \TYPO3\Flow\Package\Exception\PackageKeyAlreadyExistsException('The package key "' . $packageKey . '" already exists', 1220722873);
+            throw new Exception\PackageKeyAlreadyExistsException('The package key "' . $packageKey . '" already exists', 1220722873);
+        }
+
+        // TODO: This if and the method used can be removed for Flow 4.0 together with the MetaData classes.
+        if ($manifest === null) {
+            $manifest = $this->generateManifestFromMetaDataAndType($packageType, $packageMetaData);
         }
 
         if ($packagesPath === null) {
+            $packagesPath = 'Application';
+            $packageType = isset($manifest['type']) ? $manifest['type'] : PackageInterface::DEFAULT_COMPOSER_TYPE;
             if (is_array($this->settings['package']['packagesPathByType']) && isset($this->settings['package']['packagesPathByType'][$packageType])) {
                 $packagesPath = $this->settings['package']['packagesPathByType'][$packageType];
-            } else {
-                $packagesPath = 'Application';
             }
-            $packagesPath = Files::getUnixStylePath(Files::concatenatePaths(array($this->packagesBasePath, $packagesPath)));
+
+            $packagesPath = Files::getUnixStylePath(Files::concatenatePaths([$this->packagesBasePath, $packagesPath]));
         }
 
-        if ($packageMetaData === null) {
-            $packageMetaData = new MetaData($packageKey);
-        }
-        if ($packageMetaData->getPackageType() === null) {
-            $packageMetaData->setPackageType($packageType);
-        }
-
-        $packagePath = Files::concatenatePaths(array($packagesPath, $packageKey)) . '/';
+        $packagePath = Files::concatenatePaths([$packagesPath, $packageKey]) . '/';
         Files::createDirectoryRecursively($packagePath);
 
         foreach (
-            array(
-                PackageInterface::DIRECTORY_METADATA,
+            [
                 PackageInterface::DIRECTORY_CLASSES,
                 PackageInterface::DIRECTORY_CONFIGURATION,
                 PackageInterface::DIRECTORY_DOCUMENTATION,
                 PackageInterface::DIRECTORY_RESOURCES,
                 PackageInterface::DIRECTORY_TESTS_UNIT,
                 PackageInterface::DIRECTORY_TESTS_FUNCTIONAL,
-            ) as $path) {
-            Files::createDirectoryRecursively(Files::concatenatePaths(array($packagePath, $path)));
+            ] as $path) {
+            Files::createDirectoryRecursively(Files::concatenatePaths([$packagePath, $path]));
         }
 
-        $this->writeComposerManifest($packagePath, $packageKey, $packageMetaData);
+        $manifest = ComposerUtility::writeComposerManifest($packagePath, $packageKey, $manifest);
 
         $packagePath = str_replace($this->packagesBasePath, '', $packagePath);
-        $package = $this->packageFactory->create($this->packagesBasePath, $packagePath, $packageKey, PackageInterface::DIRECTORY_CLASSES);
+        $package = $this->packageFactory->create($this->packagesBasePath, $packagePath, $packageKey, $manifest['name'], (isset($manifest['autoload']) ? $manifest['autoload'] : []), null);
+
+        $refreshedPackageStatesConfiguration = $this->scanAvailablePackages($this->packageStatesConfiguration);
+        $this->savePackageStates($refreshedPackageStatesConfiguration);
 
         $this->packages[$packageKey] = $package;
-        foreach (array_keys($this->packages) as $upperCamelCasedPackageKey) {
-            $this->packageKeys[strtolower($upperCamelCasedPackageKey)] = $upperCamelCasedPackageKey;
-        }
-
-        $this->activatePackage($packageKey);
+        $this->activePackages[$packageKey] = $package;
+        $this->packageKeys[strtolower($packageKey)] = $packageKey;
 
         return $package;
     }
 
     /**
-     * Write a composer manifest for the package.
+     * Generates composer manifest data out of a MetaData object.
      *
-     * @param string $manifestPath
-     * @param string $packageKey
-     * @param MetaData $packageMetaData
-     * @return void
+     * @param string $packageType
+     * @param MetaData|null $packageMetaData
+     * @return array manifest data generated from the MetaData object
+     * @deprecated This method will be removed with Flow 4.0 together with the MetaData model
      */
-    protected function writeComposerManifest($manifestPath, $packageKey, \TYPO3\Flow\Package\MetaData $packageMetaData = null)
+    protected function generateManifestFromMetaDataAndType($packageType, \TYPO3\Flow\Package\MetaData $packageMetaData = null)
     {
-        $manifest = array(
-            'name' => $this->getComposerPackageNameFromPackageKey($packageKey)
-        );
+        $manifest = [
+            'type' => $packageType,
+            'description' => 'Add description here',
+            'require' => ['typo3/flow' => '*']
+        ];
 
-        if ($packageMetaData !== null) {
-            $manifest['type'] = $packageMetaData->getPackageType();
-            $manifest['description'] = $packageMetaData->getDescription() ?: 'Add description here';
-            if ($packageMetaData->getVersion()) {
-                $manifest['version'] = $packageMetaData->getVersion();
-            }
-            $dependsConstraints = $this->getComposerManifestConstraints(MetaDataInterface::CONSTRAINT_TYPE_DEPENDS, $packageMetaData);
-            if ($dependsConstraints !== array()) {
-                $manifest['require'] = $dependsConstraints;
-            }
-            $suggestsConstraints = $this->getComposerManifestConstraints(MetaDataInterface::CONSTRAINT_TYPE_SUGGESTS, $packageMetaData);
-            if ($suggestsConstraints !== array()) {
-                $manifest['suggest'] = $suggestsConstraints;
-            }
-            $conflictsConstraints = $this->getComposerManifestConstraints(MetaDataInterface::CONSTRAINT_TYPE_CONFLICTS, $packageMetaData);
-            if ($conflictsConstraints !== array()) {
-                $manifest['conflict'] = $conflictsConstraints;
-            }
-        } else {
-            $manifest['type'] = 'typo3-flow-package';
-            $manifest['description'] = '';
+        if ($packageMetaData === null) {
+            return $manifest;
         }
-        if (!isset($manifest['require']) || empty($manifest['require'])) {
-            $manifest['require'] = array('typo3/flow' => '*');
-        }
-        $manifest['autoload'] = array('psr-0' => array(str_replace('.', '\\', $packageKey) => 'Classes'));
 
-        if (defined('JSON_PRETTY_PRINT')) {
-            file_put_contents(Files::concatenatePaths(array($manifestPath, 'composer.json')), json_encode($manifest, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
-        } else {
-            file_put_contents(Files::concatenatePaths(array($manifestPath, 'composer.json')), json_encode($manifest));
+        $manifest['type'] = $packageMetaData->getPackageType();
+        $manifest['description'] = $packageMetaData->getDescription() ?: $manifest['description'];
+        if ($packageMetaData->getVersion()) {
+            $manifest['version'] = $packageMetaData->getVersion();
         }
+        $dependsConstraints = $this->getComposerManifestConstraints(MetaDataInterface::CONSTRAINT_TYPE_DEPENDS, $packageMetaData);
+        if ($dependsConstraints !== []) {
+            $manifest['require'] = $dependsConstraints;
+        }
+        $suggestsConstraints = $this->getComposerManifestConstraints(MetaDataInterface::CONSTRAINT_TYPE_SUGGESTS, $packageMetaData);
+        if ($suggestsConstraints !== []) {
+            $manifest['suggest'] = $suggestsConstraints;
+        }
+        $conflictsConstraints = $this->getComposerManifestConstraints(MetaDataInterface::CONSTRAINT_TYPE_CONFLICTS, $packageMetaData);
+        if ($conflictsConstraints !== []) {
+            $manifest['conflict'] = $conflictsConstraints;
+        }
+
+        return $manifest;
     }
 
     /**
@@ -555,10 +479,11 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
      * @param string $constraintType one of the MetaDataInterface::CONSTRAINT_TYPE_* constants
      * @param MetaData $packageMetaData
      * @return array in the format array('<ComposerPackageName>' => '*', ...)
+     * @deprecated This will be removed with Flow 4.0 together with the MetaData model
      */
     protected function getComposerManifestConstraints($constraintType, MetaData $packageMetaData)
     {
-        $composerManifestConstraints = array();
+        $composerManifestConstraints = [];
         $constraints = $packageMetaData->getConstraintsByType($constraintType);
         foreach ($constraints as $constraint) {
             if (!$constraint instanceof MetaData\PackageConstraint) {
@@ -567,20 +492,8 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
             $composerName = isset($this->packageStatesConfiguration['packages'][$constraint->getValue()]['composerName']) ? $this->packageStatesConfiguration['packages'][$constraint->getValue()]['composerName'] : $this->getComposerPackageNameFromPackageKey($constraint->getValue());
             $composerManifestConstraints[$composerName] = '*';
         }
-        return $composerManifestConstraints;
-    }
 
-    /**
-     * Determines the composer package name ("vendor/foo-bar") from the Flow package key ("Vendor.Foo.Bar")
-     *
-     * @param string $packageKey
-     * @return string
-     */
-    protected function getComposerPackageNameFromPackageKey($packageKey)
-    {
-        $nameParts = explode('.', $packageKey);
-        $vendor = array_shift($nameParts);
-        return strtolower($vendor . '/' . implode('-', $nameParts));
+        return $composerManifestConstraints;
     }
 
     /**
@@ -588,7 +501,7 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
      *
      * @param string $packageKey The package to deactivate
      * @return void
-     * @throws \TYPO3\Flow\Package\Exception\ProtectedPackageKeyException if a package is protected and cannot be deactivated
+     * @throws Exception\ProtectedPackageKeyException if a package is protected and cannot be deactivated
      * @api
      */
     public function deactivatePackage($packageKey)
@@ -599,12 +512,13 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
 
         $package = $this->getPackage($packageKey);
         if ($package->isProtected()) {
-            throw new \TYPO3\Flow\Package\Exception\ProtectedPackageKeyException('The package "' . $packageKey . '" is protected and cannot be deactivated.', 1308662891);
+            throw new Exception\ProtectedPackageKeyException('The package "' . $packageKey . '" is protected and cannot be deactivated.', 1308662891);
         }
 
         unset($this->activePackages[$packageKey]);
-        $this->packageStatesConfiguration['packages'][$packageKey]['state'] = 'inactive';
-        $this->sortAndSavePackageStates();
+        $this->packageStatesConfiguration['packages'][$package->getComposerName()]['state'] = self::PACKAGE_STATE_INACTIVE;
+        $this->movePackageToDeactivatedPackages($package->getPackagePath());
+        $this->savePackageStates($this->packageStatesConfiguration);
     }
 
     /**
@@ -622,14 +536,34 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
 
         $package = $this->getPackage($packageKey);
         $this->activePackages[$packageKey] = $package;
-        $this->packageStatesConfiguration['packages'][$packageKey]['state'] = 'active';
-        if (!isset($this->packageStatesConfiguration['packages'][$packageKey]['packagePath'])) {
-            $this->packageStatesConfiguration['packages'][$packageKey]['packagePath'] = str_replace($this->packagesBasePath, '', $package->getPackagePath());
-        }
-        if (!isset($this->packageStatesConfiguration['packages'][$packageKey]['classesPath'])) {
-            $this->packageStatesConfiguration['packages'][$packageKey]['classesPath'] = Package::DIRECTORY_CLASSES;
-        }
-        $this->sortAndSavePackageStates();
+        $this->packageStatesConfiguration['packages'][$package->getComposerName()]['state'] = self::PACKAGE_STATE_ACTIVE;
+        $inactivePackagePath = $this->buildInactivePackagePath($package->getPackagePath());
+        Files::copyDirectoryRecursively($inactivePackagePath, $package->getPackagePath(), false, true);
+        Files::removeDirectoryRecursively($inactivePackagePath);
+        $this->savePackageStates($this->packageStatesConfiguration);
+    }
+
+    /**
+     * Build the absolute path to store a deactivated package based on the package.
+     *
+     * @param string $packagePath absolute path to the package
+     * @return string
+     */
+    protected function buildInactivePackagePath($packagePath)
+    {
+        return FLOW_PATH_PACKAGES . self::INACTIVE_PACKAGES_FOLDER . '/' . substr($packagePath, strlen(FLOW_PATH_PACKAGES));
+    }
+
+    /**
+     * Moves a package from the regular package path to the inactive packages directory.
+     *
+     * @param string $packagePath absolute path to the package
+     * @return void
+     */
+    protected function movePackageToDeactivatedPackages($packagePath)
+    {
+        Files::copyDirectoryRecursively($packagePath, $this->buildInactivePackagePath($packagePath), false, true);
+        Files::removeDirectoryRecursively($packagePath);
     }
 
     /**
@@ -638,7 +572,7 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
      * @param string $packageKey The package to freeze
      * @return void
      * @throws \LogicException
-     * @throws \TYPO3\Flow\Package\Exception\UnknownPackageException
+     * @throws Exception\UnknownPackageException
      */
     public function freezePackage($packageKey)
     {
@@ -647,16 +581,17 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
         }
 
         if (!$this->isPackageActive($packageKey)) {
-            throw new \TYPO3\Flow\Package\Exception\UnknownPackageException('Package "' . $packageKey . '" is not available or active.', 1331715956);
+            throw new Exception\UnknownPackageException('Package "' . $packageKey . '" is not available or active.', 1331715956);
         }
         if ($this->isPackageFrozen($packageKey)) {
             return;
         }
 
+        $package = $this->packages[$packageKey];
         $this->bootstrap->getObjectManager()->get(\TYPO3\Flow\Reflection\ReflectionService::class)->freezePackageReflection($packageKey);
 
-        $this->packageStatesConfiguration['packages'][$packageKey]['frozen'] = true;
-        $this->sortAndSavePackageStates();
+        $this->packageStatesConfiguration['packages'][$package->getComposerName()]['frozen'] = true;
+        $this->savePackageStates($this->packageStatesConfiguration);
     }
 
     /**
@@ -667,10 +602,15 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
      */
     public function isPackageFrozen($packageKey)
     {
+        if (!isset($this->packages[$packageKey])) {
+            return false;
+        }
+        $composerName = $this->packages[$packageKey]->getComposerName();
+
         return (
             $this->bootstrap->getContext()->isDevelopment()
-            && isset($this->packageStatesConfiguration['packages'][$packageKey]['frozen'])
-            && $this->packageStatesConfiguration['packages'][$packageKey]['frozen'] === true
+            && isset($this->packageStatesConfiguration['packages'][$composerName]['frozen'])
+            && $this->packageStatesConfiguration['packages'][$composerName]['frozen'] === true
         );
     }
 
@@ -685,11 +625,15 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
         if (!$this->isPackageFrozen($packageKey)) {
             return;
         }
+        if (!isset($this->packages[$packageKey])) {
+            return;
+        }
+        $composerName = $this->packages[$packageKey]->getComposerName();
 
         $this->bootstrap->getObjectManager()->get(\TYPO3\Flow\Reflection\ReflectionService::class)->unfreezePackageReflection($packageKey);
 
-        unset($this->packageStatesConfiguration['packages'][$packageKey]['frozen']);
-        $this->sortAndSavePackageStates();
+        unset($this->packageStatesConfiguration['packages'][$composerName]['frozen']);
+        $this->savePackageStates($this->packageStatesConfiguration);
     }
 
     /**
@@ -708,30 +652,38 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
     }
 
     /**
-     * Register a native Flow package
+     * Removes a package from registry and deletes it from filesystem
      *
-     * @param PackageInterface $package The Package to be registered
-     * @param boolean $sortAndSave allows for not saving packagestates when used in loops etc.
-     * @return PackageInterface
-     * @throws Exception\InvalidPackageStateException
+     * @param string $packageKey package to remove
+     * @return void
+     * @throws Exception\UnknownPackageException if the specified package is not known
+     * @throws Exception\ProtectedPackageKeyException if a package is protected and cannot be deleted
+     * @throws Exception
+     * @api
      */
-    public function registerPackage(PackageInterface $package, $sortAndSave = true)
+    public function deletePackage($packageKey)
     {
-        $packageKey = $package->getPackageKey();
-        $caseSensitivePackageKey = $this->getCaseSensitivePackageKey($packageKey);
-        if ($this->isPackageAvailable($caseSensitivePackageKey)) {
-            throw new Exception\InvalidPackageStateException('Package "' . $packageKey . '" is already registered as "' . $caseSensitivePackageKey . '".', 1338996122);
+        if (!$this->isPackageAvailable($packageKey)) {
+            throw new Exception\UnknownPackageException('Package "' . $packageKey . '" is not available and cannot be removed.', 1166543253);
         }
 
-        $this->packages[$packageKey] = $package;
-        $this->packageStatesConfiguration['packages'][$packageKey]['packagePath'] = str_replace($this->packagesBasePath, '', $package->getPackagePath());
-        $this->packageStatesConfiguration['packages'][$packageKey]['classesPath'] = str_replace($package->getPackagePath(), '', $package->getClassesPath());
-
-        if ($sortAndSave === true) {
-            $this->sortAndSavePackageStates();
+        $package = $this->getPackage($packageKey);
+        if ($package->isProtected()) {
+            throw new Exception\ProtectedPackageKeyException('The package "' . $packageKey . '" is protected and cannot be removed.', 1220722120);
         }
 
-        return $package;
+        if ($this->isPackageActive($packageKey)) {
+            $this->deactivatePackage($packageKey);
+        }
+
+        $this->unregisterPackage($package);
+
+        $packagePath = $this->buildInactivePackagePath($package->getPackagePath());
+        try {
+            Files::removeDirectoryRecursively($packagePath);
+        } catch (UtilityException $exception) {
+            throw new Exception('Please check file permissions. The directory "' . $packagePath . '" for package "' . $packageKey . '" could not be removed.', 1301491089, $exception);
+        }
     }
 
     /**
@@ -741,296 +693,206 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
      * @return void
      * @throws Exception\InvalidPackageStateException
      */
-    public function unregisterPackage(PackageInterface $package)
+    protected function unregisterPackage(PackageInterface $package)
     {
         $packageKey = $package->getPackageKey();
         if (!$this->isPackageAvailable($packageKey)) {
             throw new Exception\InvalidPackageStateException('Package "' . $packageKey . '" is not registered.', 1338996142);
         }
-        $this->unregisterPackageByPackageKey($packageKey);
+
+        if (!isset($this->packages[$packageKey])) {
+            return;
+        }
+        $composerName = $package->getComposerName();
+
+        unset($this->packages[$packageKey], $this->packageKeys[strtolower($packageKey)], $this->packageStatesConfiguration['packages'][$composerName]);
+        $this->sortAndSavePackageStates($this->packageStatesConfiguration);
     }
 
     /**
-     * Unregisters a package from the list of available packages
+     * Rescans available packages, order and write a new PackageStates file.
      *
-     * @param string $packageKey Package Key of the package to be unregistered
-     * @return void
-     */
-    protected function unregisterPackageByPackageKey($packageKey)
-    {
-        unset($this->packages[$packageKey]);
-        unset($this->packageKeys[strtolower($packageKey)]);
-        unset($this->packageStatesConfiguration['packages'][$packageKey]);
-        $this->sortAndSavePackageStates();
-    }
-
-    /**
-     * Removes a package from registry and deletes it from filesystem
-     *
-     * @param string $packageKey package to remove
-     * @return void
-     * @throws \TYPO3\Flow\Package\Exception\UnknownPackageException if the specified package is not known
-     * @throws \TYPO3\Flow\Package\Exception\ProtectedPackageKeyException if a package is protected and cannot be deleted
-     * @throws \TYPO3\Flow\Package\Exception
+     * @param boolean $reloadPackageStates Should the package states be loaded before scanning or use the current configuration
+     * @return array The found and sorted package states.
      * @api
+     * TODO: Add to Interface with Flow 4.0
      */
-    public function deletePackage($packageKey)
+    public function rescanPackages($reloadPackageStates = true)
     {
-        if (!$this->isPackageAvailable($packageKey)) {
-            throw new \TYPO3\Flow\Package\Exception\UnknownPackageException('Package "' . $packageKey . '" is not available and cannot be removed.', 1166543253);
+        $loadedPackageStates = $this->packageStatesConfiguration;
+        if ($reloadPackageStates) {
+            $loadedPackageStates = $this->loadPackageStates();
         }
+        $loadedPackageStates = $this->scanAvailablePackages($loadedPackageStates);
+        $loadedPackageStates = $this->sortAndSavePackageStates($loadedPackageStates);
 
-        $package = $this->getPackage($packageKey);
-        if ($package->isProtected()) {
-            throw new \TYPO3\Flow\Package\Exception\ProtectedPackageKeyException('The package "' . $packageKey . '" is protected and cannot be removed.', 1220722120);
-        }
-
-        if ($this->isPackageActive($packageKey)) {
-            $this->deactivatePackage($packageKey);
-        }
-
-        $packagePath = $package->getPackagePath();
-        try {
-            Files::removeDirectoryRecursively($packagePath);
-        } catch (\TYPO3\Flow\Utility\Exception $exception) {
-            throw new \TYPO3\Flow\Package\Exception('Please check file permissions. The directory "' . $packagePath . '" for package "' . $packageKey . '" could not be removed.', 1301491089, $exception);
-        }
-
-        $this->unregisterPackage($package);
+        return $loadedPackageStates;
     }
 
     /**
-     * Loads the states of available packages from the PackageStates.php file.
-     * The result is stored in $this->packageStatesConfiguration.
+     * Loads the states of available packages from the PackageStates.php file and
+     * initialises a package scan if the file was not found or the configuration format
+     * was not current.
      *
-     * @return void
+     * @return array
+     */
+    protected function getCurrentPackageStates()
+    {
+        $savePackageStates = false;
+        $loadedPackageStates = $this->loadPackageStates();
+        if (
+            empty($loadedPackageStates)
+            || !isset($loadedPackageStates['version'])
+            || $loadedPackageStates['version'] < self::PACKAGESTATE_FORMAT_VERSION
+        ) {
+            $loadedPackageStates = $this->scanAvailablePackages($loadedPackageStates);
+            $savePackageStates = true;
+        }
+
+        if ($savePackageStates) {
+            $loadedPackageStates = $this->sortAndSavePackageStates($loadedPackageStates);
+        }
+
+        return $loadedPackageStates;
+    }
+
+    /**
+     * Load the current package states
+     *
+     * @return array
      */
     protected function loadPackageStates()
     {
-        $this->packageStatesConfiguration = file_exists($this->packageStatesPathAndFilename) ? include($this->packageStatesPathAndFilename) : array();
-        if (!isset($this->packageStatesConfiguration['version']) || $this->packageStatesConfiguration['version'] < 5) {
-            $this->packageStatesConfiguration = array();
-        }
-        if ($this->packageStatesConfiguration === array() || !$this->bootstrap->getContext()->isProduction()) {
-            $this->scanAvailablePackages();
-        } else {
-            $this->registerPackagesFromConfiguration();
-        }
+        return (is_file($this->packageStatesPathAndFilename) ? include($this->packageStatesPathAndFilename) : []);
     }
 
     /**
      * Scans all directories in the packages directories for available packages.
      * For each package a Package object is created and stored in $this->packages.
      *
-     * @return void
-     * @throws \TYPO3\Flow\Package\Exception\DuplicatePackageException
+     * @param array $previousPackageStatesConfiguration Existing package state configuration
+     * @return array
+     * @throws InvalidConfigurationException
      */
-    protected function scanAvailablePackages()
+    protected function scanAvailablePackages($previousPackageStatesConfiguration)
     {
-        $previousPackageStatesConfiguration = $this->packageStatesConfiguration;
+        $recoveredStateByPackage = $this->recoverStateFromConfiguration($previousPackageStatesConfiguration);
+        $newPackageStatesConfiguration = ['packages' => []];
 
-        if (isset($this->packageStatesConfiguration['packages'])) {
-            foreach ($this->packageStatesConfiguration['packages'] as $packageKey => $configuration) {
-                if (!file_exists($this->packagesBasePath . $configuration['packagePath'])) {
-                    unset($this->packageStatesConfiguration['packages'][$packageKey]);
+        $inactivePackages = [];
+        try {
+            $globalComposerManifest = ComposerUtility::getComposerManifest(FLOW_PATH_ROOT);
+            $inactivePackages = (isset($globalComposerManifest['extra']['neos']['default-disabled-packages']) && is_array($globalComposerManifest['extra']['neos']['default-disabled-packages'])) ? $globalComposerManifest['extra']['neos']['default-disabled-packages'] : [];
+        } catch (MissingPackageManifestException $exception) {
+            // TODO: We should probably throw an exception here and warn about the missing composer.json, but on production machines it might be missing...
+        }
+
+        foreach ($this->findComposerPackagesInPath($this->packagesBasePath) as $packagePath) {
+            $composerManifest = ComposerUtility::getComposerManifest($packagePath);
+            if (!isset($composerManifest['name'])) {
+                throw new InvalidConfigurationException(sprintf('A package composer.json was found at "%s" that contained no "name".', $packagePath), 1445933572);
+            }
+
+            $packageKey = $this->getPackageKeyFromManifest($composerManifest, $packagePath);
+            $this->composerNameToPackageKeyMap[strtolower($composerManifest['name'])] = $packageKey;
+
+            $state = in_array($composerManifest['name'], $inactivePackages, true) ? self::PACKAGE_STATE_INACTIVE : self::PACKAGE_STATE_ACTIVE;
+
+            if (isset($recoveredStateByPackage[$composerManifest['name']])) {
+                $state = $recoveredStateByPackage[$composerManifest['name']];
+            }
+
+            $packageConfiguration = $this->preparePackageStateConfiguration($packageKey, $packagePath, $composerManifest, $state);
+            $newPackageStatesConfiguration['packages'][$composerManifest['name']] = $packageConfiguration;
+
+            if ($state === self::PACKAGE_STATE_INACTIVE && is_dir($packagePath)) {
+                $this->movePackageToDeactivatedPackages($packagePath);
+            }
+        }
+
+        return $newPackageStatesConfiguration;
+    }
+
+    /**
+     * Recursively traverses directories from the given starting points and returns all folder paths that contain a composer.json and
+     * which does NOT have the key "extra.neos.is-merged-repository" set, as that indicates a composer package that joins several "real" packages together.
+     * In case a "is-merged-repository" is found the traversal continues inside.
+     *
+     * @param string $startingDirectory
+     * @return \Generator
+     */
+    protected function findComposerPackagesInPath($startingDirectory)
+    {
+        $directories = [$startingDirectory];
+        while ($directories !== []) {
+            $currentDirectory = array_pop($directories);
+            if ($handle = opendir($currentDirectory)) {
+                while (false !== ($filename = readdir($handle))) {
+                    if ($filename[0] === '.') {
+                        continue;
+                    }
+                    $pathAndFilename = $currentDirectory . $filename;
+                    // Never scan inactive packages folder.
+                    if ($pathAndFilename === FLOW_PATH_PACKAGES . self::INACTIVE_PACKAGES_FOLDER) {
+                        continue;
+                    }
+                    if (is_dir($pathAndFilename)) {
+                        $potentialPackageDirectory = $pathAndFilename . '/';
+                        if (is_file($potentialPackageDirectory . 'composer.json')) {
+                            $composerManifest = ComposerUtility::getComposerManifest($potentialPackageDirectory);
+                            // TODO: Maybe get rid of magic string "neos-package-collection" by fetching collection package types from outside.
+                            if (isset($composerManifest['type']) && $composerManifest['type'] === 'neos-package-collection') {
+                                $directories[] = $potentialPackageDirectory;
+                                continue;
+                            }
+                            yield $potentialPackageDirectory;
+                        } else {
+                            $directories[] = $potentialPackageDirectory;
+                        }
+                    }
                 }
+                closedir($handle);
             }
-        } else {
-            $this->packageStatesConfiguration['packages'] = array();
-        }
-
-        $packagePaths = array();
-        foreach (new \DirectoryIterator($this->packagesBasePath) as $parentFileInfo) {
-            $parentFilename = $parentFileInfo->getFilename();
-            if ($parentFilename[0] !== '.' && $parentFileInfo->isDir()) {
-                $packagePaths = array_merge($packagePaths, $this->scanPackagesInPath($parentFileInfo->getPathName()));
-            }
-        }
-
-        /**
-         * @todo similar functionality in registerPackage - should be refactored
-         */
-        foreach ($packagePaths as $packagePath => $composerManifestPath) {
-            try {
-                $composerManifest = self::getComposerManifest($composerManifestPath);
-                $packageKey = PackageFactory::getPackageKeyFromManifest($composerManifest, $packagePath, $this->packagesBasePath);
-                $this->composerNameToPackageKeyMap[strtolower($composerManifest->name)] = $packageKey;
-                $this->packageStatesConfiguration['packages'][$packageKey]['manifestPath'] = substr($composerManifestPath, strlen($packagePath)) ?: '';
-                $this->packageStatesConfiguration['packages'][$packageKey]['composerName'] = $composerManifest->name;
-            } catch (MissingPackageManifestException $exception) {
-                $relativePackagePath = substr($packagePath, strlen($this->packagesBasePath));
-                $packageKey = substr($relativePackagePath, strpos($relativePackagePath, '/') + 1, -1);
-            }
-            if (!isset($this->packageStatesConfiguration['packages'][$packageKey]['state'])) {
-                /**
-                 * @todo doesn't work, settings not available at this time
-                 */
-                if (is_array($this->settings['package']['inactiveByDefault']) && in_array($packageKey, $this->settings['package']['inactiveByDefault'], true)) {
-                    $this->packageStatesConfiguration['packages'][$packageKey]['state'] = 'inactive';
-                } else {
-                    $this->packageStatesConfiguration['packages'][$packageKey]['state'] = 'active';
-                }
-            }
-
-            $this->packageStatesConfiguration['packages'][$packageKey]['packagePath'] = str_replace($this->packagesBasePath, '', $packagePath);
-
-            // Change this to read the target from Composer or any other source
-            $this->packageStatesConfiguration['packages'][$packageKey]['classesPath'] = Package::DIRECTORY_CLASSES;
-        }
-
-        $this->registerPackagesFromConfiguration();
-        if ($this->packageStatesConfiguration != $previousPackageStatesConfiguration) {
-            $this->sortAndSavePackageStates();
         }
     }
 
     /**
-     * Looks for composer.json in the given path and returns a path or NULL.
-     *
+     * @param string $packageKey
      * @param string $packagePath
+     * @param array $composerManifest
+     * @param string $state
      * @return array
      */
-    protected function findComposerManifestPaths($packagePath)
+    protected function preparePackageStateConfiguration($packageKey, $packagePath, $composerManifest, $state = self::PACKAGE_STATE_ACTIVE)
     {
-        $manifestPaths = array();
-        if (file_exists($packagePath . '/composer.json')) {
-            $manifestPaths[] = $packagePath . '/';
-        } else {
-            $jsonPathsAndFilenames = Files::readDirectoryRecursively($packagePath, '.json');
-            asort($jsonPathsAndFilenames);
-            while (list($unusedKey, $jsonPathAndFilename) = each($jsonPathsAndFilenames)) {
-                if (basename($jsonPathAndFilename) === 'composer.json') {
-                    $manifestPath = dirname($jsonPathAndFilename) . '/';
-                    $manifestPaths[] = $manifestPath;
-                    $isNotSubPathOfManifestPath = function ($otherPath) use ($manifestPath) {
-                        return strpos($otherPath, $manifestPath) !== 0;
-                    };
-                    $jsonPathsAndFilenames = array_filter($jsonPathsAndFilenames, $isNotSubPathOfManifestPath);
-                }
-            }
-        }
+        $autoload = isset($composerManifest['autoload']) ? $composerManifest['autoload'] : [];
 
-        return $manifestPaths;
-    }
-
-    /**
-     * Scans all sub directories of the specified directory and collects the package keys of packages it finds.
-     *
-     * The return of the array is to make this method usable in array_merge.
-     *
-     * @param string $startPath
-     * @param array $collectedPackagePaths
-     * @return array
-     */
-    protected function scanPackagesInPath($startPath, array &$collectedPackagePaths = array())
-    {
-        foreach (new \DirectoryIterator($startPath) as $fileInfo) {
-            if (!$fileInfo->isDir()) {
-                continue;
-            }
-            $filename = $fileInfo->getFilename();
-            if ($filename[0] !== '.') {
-                $currentPath = Files::getUnixStylePath($fileInfo->getPathName());
-                $composerManifestPaths = $this->findComposerManifestPaths($currentPath);
-                foreach ($composerManifestPaths as $composerManifestPath) {
-                    $targetDirectory = rtrim(self::getComposerManifest($composerManifestPath, 'target-dir'), '/');
-                    $packagePath = $targetDirectory ? substr(rtrim($composerManifestPath, '/'), 0, -strlen((string)$targetDirectory)) : $composerManifestPath;
-                    $collectedPackagePaths[$packagePath] = $composerManifestPath;
-                }
-            }
-        }
-        return $collectedPackagePaths;
-    }
-
-    /**
-     * Returns contents of Composer manifest - or part there of.
-     *
-     * @param string $manifestPath
-     * @param string $key Optional. Only return the part of the manifest indexed by 'key'
-     * @param object $composerManifest Optional. Manifest to use instead of reading it from file
-     * @return mixed
-     * @throws MissingPackageManifestException
-     * @see json_decode for return values
-     */
-    public static function getComposerManifest($manifestPath, $key = null, $composerManifest = null)
-    {
-        if ($composerManifest === null) {
-            $composerManifest = self::readComposerManifest($manifestPath);
-        }
-
-        if ($key !== null) {
-            if (isset($composerManifest->{$key})) {
-                $value = $composerManifest->{$key};
-            } else {
-                $value = null;
-            }
-        } else {
-            $value = $composerManifest;
-        }
-        return $value;
-    }
-
-    /**
-     * Read the content of the composer.lock
-     *
-     * @return array
-     */
-    public static function readComposerLock()
-    {
-        if (self::$composerLockCache === null) {
-            if (!file_exists(FLOW_PATH_ROOT . 'composer.lock')) {
-                return array();
-            }
-            $json = file_get_contents(FLOW_PATH_ROOT . 'composer.lock');
-            $composerLock = json_decode($json, true);
-            $composerPackageVersions = isset($composerLock['packages']) ? $composerLock['packages'] : array();
-            $composerPackageDevVersions = isset($composerLock['packages-dev']) ? $composerLock['packages-dev'] : array();
-            self::$composerLockCache = array_merge($composerPackageVersions, $composerPackageDevVersions);
-        }
-
-        return self::$composerLockCache;
-    }
-
-    /**
-     * Read the content of composer.json in the given path
-     *
-     * @param string $manifestPath
-     * @return \stdClass
-     * @throws MissingPackageManifestException
-     */
-    protected static function readComposerManifest($manifestPath)
-    {
-        if (isset(self::$composerManifestData[$manifestPath])) {
-            return self::$composerManifestData[$manifestPath];
-        }
-
-        if (!file_exists($manifestPath . 'composer.json')) {
-            throw new MissingPackageManifestException(sprintf('No composer manifest file found at "%s/composer.json".', $manifestPath), 1349868540);
-        }
-        $json = file_get_contents($manifestPath . 'composer.json');
-        $composerManifest = json_decode($json);
-        $composerManifest->version = self::getPackageVersion($composerManifest->name);
-
-        self::$composerManifestData[$manifestPath] = $composerManifest;
-        return $composerManifest;
+        return [
+            'state' => $state,
+            'packageKey' => $packageKey,
+            'packagePath' => str_replace($this->packagesBasePath, '', $packagePath),
+            'composerName' => $composerManifest['name'],
+            'autoloadConfiguration' => $autoload,
+            'packageClassInformation' => $this->packageFactory->detectFlowPackageFilePath($packageKey, $packagePath, $autoload)
+        ];
     }
 
     /**
      * Get the package version of the given package
      * Return normalized package version.
      *
-     * @param string $packageName
+     * @param string $composerName
      * @return string
      * @see https://getcomposer.org/doc/04-schema.md#version
      */
-    protected static function getPackageVersion($packageName)
+    public static function getPackageVersion($composerName)
     {
-        foreach (self::readComposerLock() as $packageState) {
-            if (!isset($packageState['name'])) {
+        foreach (ComposerUtility::readComposerLock() as $composerLockData) {
+            if (!isset($composerLockData['name'])) {
                 continue;
             }
-            if ($packageState['name'] === $packageName) {
-                return preg_replace('/^v([0-9])/', '$1', $packageState['version'], 1);
+            if ($composerLockData['name'] === $composerName) {
+                return preg_replace('/^v([0-9])/', '$1', $composerLockData['version'], 1);
             }
         }
 
@@ -1040,59 +902,57 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
     /**
      * Requires and registers all packages which were defined in packageStatesConfiguration
      *
-     * @return void
-     * @throws \TYPO3\Flow\Package\Exception\CorruptPackageException
+     * @param array $packageStatesConfiguration
      */
-    protected function registerPackagesFromConfiguration()
+    protected function registerPackagesFromConfiguration($packageStatesConfiguration)
     {
-        foreach ($this->packageStatesConfiguration['packages'] as $packageKey => $stateConfiguration) {
-            $packagePath = isset($stateConfiguration['packagePath']) ? $stateConfiguration['packagePath'] : null;
-            $classesPath = isset($stateConfiguration['classesPath']) ? $stateConfiguration['classesPath'] : null;
-            $manifestPath = isset($stateConfiguration['manifestPath']) ? $stateConfiguration['manifestPath'] : null;
-
-            try {
-                $package = $this->packageFactory->create($this->packagesBasePath, $packagePath, $packageKey, $classesPath, $manifestPath);
-            } catch (\TYPO3\Flow\Package\Exception\InvalidPackagePathException $exception) {
-                $this->unregisterPackageByPackageKey($packageKey);
-                $this->systemLogger->log('Package ' . $packageKey . ' could not be loaded, it has been unregistered. Error description: "' . $exception->getMessage() . '" (' . $exception->getCode() . ')', LOG_WARNING);
-                continue;
-            }
-
-            $this->registerPackage($package, false);
-
-            if (!$this->packages[$packageKey] instanceof PackageInterface) {
-                throw new \TYPO3\Flow\Package\Exception\CorruptPackageException(sprintf('The package class in package "%s" does not implement PackageInterface.', $packageKey), 1300782487);
-            }
-
-            $this->packageKeys[strtolower($packageKey)] = $packageKey;
-            if ($stateConfiguration['state'] === 'active') {
-                $this->activePackages[$packageKey] = $this->packages[$packageKey];
+        foreach ($packageStatesConfiguration['packages'] as $composerName => $packageStateConfiguration) {
+            $packagePath = isset($packageStateConfiguration['packagePath']) ? $packageStateConfiguration['packagePath'] : null;
+            $packageClassInformation = isset($packageStateConfiguration['packageClassInformation']) ? $packageStateConfiguration['packageClassInformation'] : null;
+            $package = $this->packageFactory->create($this->packagesBasePath, $packagePath, $packageStateConfiguration['packageKey'], $composerName, $packageStateConfiguration['autoloadConfiguration'], $packageClassInformation);
+            $this->packageKeys[strtolower($package->getPackageKey())] = $package->getPackageKey();
+            $this->packages[$package->getPackageKey()] = $package;
+            if ((isset($packageStateConfiguration['state']) && $packageStateConfiguration['state'] === self::PACKAGE_STATE_ACTIVE) || $package->isProtected()) {
+                $this->activePackages[$package->getPackageKey()] = $package;
             }
         }
     }
 
     /**
-     * Saves the current content of $this->packageStatesConfiguration to the
-     * PackageStates.php file.
+     * Takes the given packageStatesConfiguration, sorts it by dependencies, saves it and returns
+     * the ordered list
      *
-     * @return void
+     * @param array $packageStates
+     * @return array
+     */
+    protected function sortAndSavePackageStates(array $packageStates)
+    {
+        $orderedPackageStates = $this->sortAvailablePackagesByDependencies($packageStates);
+        $this->savePackageStates($orderedPackageStates);
+
+        return $orderedPackageStates;
+    }
+
+    /**
+     * Save the given (ordered) array of package states data
+     *
+     * @param array $orderedPackageStates
      * @throws Exception\PackageStatesFileNotWritableException
      */
-    protected function sortAndSavePackageStates()
+    protected function savePackageStates(array $orderedPackageStates)
     {
-        $this->sortAvailablePackagesByDependencies();
-
-        $this->packageStatesConfiguration['version'] = 5;
+        $orderedPackageStates['version'] = static::PACKAGESTATE_FORMAT_VERSION;
 
         $fileDescription = "# PackageStates.php\n\n";
-        $fileDescription .= "# This file is maintained by Flow's package management. Although you can edit it\n";
+        $fileDescription .= "# This file is maintained by Flow's package management. You shouldn't edit it manually\n";
         $fileDescription .= "# manually, you should rather use the command line commands for maintaining packages.\n";
         $fileDescription .= "# You'll find detailed information about the typo3.flow:package:* commands in their\n";
         $fileDescription .= "# respective help screens.\n\n";
         $fileDescription .= "# This file will be regenerated automatically if it doesn't exist. Deleting this file\n";
         $fileDescription .= "# should, however, never become necessary if you use the package commands.\n";
 
-        $packageStatesCode = "<?php\n" . $fileDescription . "\nreturn " . var_export($this->packageStatesConfiguration, true) . ';';
+        $packageStatesCode = "<?php\n" . $fileDescription . "\nreturn " . var_export($orderedPackageStates, true) . ';';
+
         $result = @file_put_contents($this->packageStatesPathAndFilename, $packageStatesCode);
         if ($result === false) {
             throw new Exception\PackageStatesFileNotWritableException(sprintf('Flow could not update the list of installed packages because the file %s is not writable. Please, check the file system permissions and make sure that the web server can write to it.', $this->packageStatesPathAndFilename), 1382449759);
@@ -1107,53 +967,177 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
      * and package configurations arrays holds all packages in the correct
      * initialization order.
      *
-     * @return void
+     * @param array $packageStates The unordered package states
+     * @return array ordered package states.
      */
-    protected function sortAvailablePackagesByDependencies()
+    protected function sortAvailablePackagesByDependencies(array $packageStates)
     {
-        $sortedPackages = array();
-        $unsortedPackages = array_fill_keys(array_keys($this->packages), 0);
+        $packageOrderResolver = new PackageOrderResolver($packageStates['packages'], $this->collectPackageManifestData($packageStates));
+        $packageStates['packages'] = $packageOrderResolver->sort();
 
-        while (!empty($unsortedPackages)) {
-            reset($unsortedPackages);
-            $this->sortPackagesByDependencies(key($unsortedPackages), $sortedPackages, $unsortedPackages);
-        }
-
-        $this->packages = $sortedPackages;
-
-        $packageStatesConfiguration = array();
-        foreach ($sortedPackages as $packageKey => $package) {
-            $packageStatesConfiguration[$packageKey] = $this->packageStatesConfiguration['packages'][$packageKey];
-        }
-        $this->packageStatesConfiguration['packages'] = $packageStatesConfiguration;
+        return $packageStates;
     }
 
     /**
-     * Recursively sort dependencies of a package. This is a depth-first approach that recursively
-     * adds all dependent packages to the sorted list before adding the given package. Visited
-     * packages are flagged to break up cyclic dependencies.
+     * Collects the manifest data for all packages in the given package states array
      *
-     * @param string $packageKey Package key to process
-     * @param array $sortedPackages Array to sort packages into
-     * @param array $unsortedPackages Array with state information of still unsorted packages
+     * @param array $packageStates
+     * @return array
      */
-    protected function sortPackagesByDependencies($packageKey, array &$sortedPackages, array &$unsortedPackages)
+    protected function collectPackageManifestData(array $packageStates)
     {
-        if ($unsortedPackages[$packageKey] === 0) {
-            $package = $this->packages[$packageKey];
-            $unsortedPackages[$packageKey] = 1;
-            $dependentPackageConstraints = $package->getPackageMetaData()->getConstraintsByType(MetaDataInterface::CONSTRAINT_TYPE_DEPENDS);
-            foreach ($dependentPackageConstraints as $constraint) {
-                if ($constraint instanceof MetaData\PackageConstraint) {
-                    $dependentPackageKey = $constraint->getValue();
-                    if (isset($unsortedPackages[$dependentPackageKey])) {
-                        $this->sortPackagesByDependencies($dependentPackageKey, $sortedPackages, $unsortedPackages);
+        return array_map(function ($packageState) {
+            return ComposerUtility::getComposerManifest(Files::getNormalizedPath(Files::concatenatePaths([$this->packagesBasePath, $packageState['packagePath']])));
+        }, $packageStates['packages']);
+    }
+
+    /**
+     * Recover previous package state from given packageStatesConfiguration to be used
+     * after rescanning packages.
+     *
+     * @param array $packageStatesConfiguration
+     * @return array
+     */
+    protected function recoverStateFromConfiguration($packageStatesConfiguration)
+    {
+        $packageStateByComposerName = [];
+        if (isset($packageStatesConfiguration['packages']) && is_array($packageStatesConfiguration['packages'])) {
+            foreach ($packageStatesConfiguration['packages'] as $key => $package) {
+                if (isset($package['state'])) {
+                    if (isset($package['packageKey']) && $this->isPackageKeyValid($package['packageKey']) && isset($package['composerName'])) {
+                        $packageStateByComposerName[$package['composerName']] = $package['state'];
+                    } else {
+                        $packageStateByComposerName[$key] = $package['state'];
                     }
                 }
             }
-            unset($unsortedPackages[$packageKey]);
-            $sortedPackages[$packageKey] = $package;
         }
+
+        return $packageStateByComposerName;
+    }
+
+    /**
+     * Returns the correctly cased version of the given package key or FALSE
+     * if no such package is available.
+     *
+     * @param string $unknownCasedPackageKey The package key to convert
+     * @return mixed The upper camel cased package key or FALSE if no such package exists
+     * @api
+     */
+    public function getCaseSensitivePackageKey($unknownCasedPackageKey)
+    {
+        $lowerCasedPackageKey = strtolower($unknownCasedPackageKey);
+
+        return (isset($this->packageKeys[$lowerCasedPackageKey])) ? $this->packageKeys[$lowerCasedPackageKey] : false;
+    }
+
+    /**
+     * Resolves a Flow package key from a composer package name.
+     *
+     * @param string $composerName
+     * @return string
+     * @throws Exception\InvalidPackageStateException
+     */
+    public function getPackageKeyFromComposerName($composerName)
+    {
+        if ($this->composerNameToPackageKeyMap === []) {
+            foreach ($this->packageStatesConfiguration['packages'] as $packageStateConfiguration) {
+                $this->composerNameToPackageKeyMap[$packageStateConfiguration['composerName']] = $packageStateConfiguration['packageKey'];
+            }
+        }
+
+        $lowercasedComposerName = strtolower($composerName);
+        if (!isset($this->composerNameToPackageKeyMap[$lowercasedComposerName])) {
+            throw new Exception\InvalidPackageStateException('Could not find package with composer name "' . $lowercasedComposerName . '" in PackageStates configuration.', 1352320649);
+        }
+
+        return $this->composerNameToPackageKeyMap[$lowercasedComposerName];
+    }
+
+    /**
+     * Check the conformance of the given package key
+     *
+     * @param string $packageKey The package key to validate
+     * @return boolean If the package key is valid, returns TRUE otherwise FALSE
+     * @api
+     */
+    public function isPackageKeyValid($packageKey)
+    {
+        return preg_match(PackageInterface::PATTERN_MATCH_PACKAGEKEY, $packageKey) === 1;
+    }
+
+    /**
+     * Resolves package key from Composer manifest
+     *
+     * If it is a Flow package the name of the containing directory will be used.
+     *
+     * Else if the composer name of the package matches the first part of the lowercased namespace of the package, the mixed
+     * case version of the composer name / namespace will be used, with backslashes replaced by dots.
+     *
+     * Else the composer name will be used with the slash replaced by a dot
+     *
+     * @param array $manifest
+     * @param string $packagePath
+     * @return string
+     */
+    protected function getPackageKeyFromManifest(array $manifest, $packagePath)
+    {
+        if (isset($manifest['extra']['neos']['package-key']) && $this->isPackageKeyValid($manifest['extra']['neos']['package-key'])) {
+            return $manifest['extra']['neos']['package-key'];
+        }
+
+        $composerName = $manifest['name'];
+        $autoloadNamespace = null;
+        $type = null;
+        if (isset($manifest['autoload']['psr-0']) && is_array($manifest['autoload']['psr-0'])) {
+            $namespaces = array_keys($manifest['autoload']['psr-0']);
+            $autoloadNamespace = reset($namespaces);
+        }
+
+        if (isset($manifest['type'])) {
+            $type = $manifest['type'];
+        }
+
+        return $this->derivePackageKey($composerName, $type, $packagePath, $autoloadNamespace);
+    }
+
+    /**
+     * Derive a flow package key from the given information.
+     * The order of importance is:
+     *
+     * - package install path
+     * - first found autoload namespace
+     * - composer name
+     *
+     * @param string $composerName
+     * @param string $packageType
+     * @param string $packagePath
+     * @param string $autoloadNamespace
+     * @return string
+     */
+    protected function derivePackageKey($composerName, $packageType = null, $packagePath = null, $autoloadNamespace = null)
+    {
+        $packageKey = '';
+
+        if ($packageType !== null && ComposerUtility::isFlowPackageType($packageType)) {
+            $lastSegmentOfPackagePath = substr(trim($packagePath, '/'), strrpos(trim($packagePath, '/'), '/') + 1);
+            if (strpos($lastSegmentOfPackagePath, '.') !== false) {
+                $packageKey = $lastSegmentOfPackagePath;
+            }
+        }
+
+        if ($autoloadNamespace !== null && ($packageKey === null || $this->isPackageKeyValid($packageKey) === false)) {
+            $packageKey = str_replace('\\', '.', $autoloadNamespace);
+        }
+
+        if (($packageKey === null || $this->isPackageKeyValid($packageKey) === false)) {
+            $packageKey = str_replace('/', '.', $composerName);
+        }
+
+        $packageKey = trim($packageKey, '.');
+        $packageKey = preg_replace('/[^A-Za-z0-9.]/', '', $packageKey);
+
+        return $packageKey;
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
@@ -14,7 +14,7 @@ namespace TYPO3\Flow\Package;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Composer\Exception\InvalidConfigurationException;
 use TYPO3\Flow\Composer\Exception\MissingPackageManifestException;
-use TYPO3\Flow\Composer\Utility as ComposerUtility;
+use TYPO3\Flow\Composer\ComposerUtility as ComposerUtility;
 use TYPO3\Flow\Core\Bootstrap;
 use TYPO3\Flow\Core\ClassLoader;
 use TYPO3\Flow\SignalSlot\Dispatcher;

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
@@ -16,7 +16,6 @@ use TYPO3\Flow\Composer\Exception\InvalidConfigurationException;
 use TYPO3\Flow\Composer\Exception\MissingPackageManifestException;
 use TYPO3\Flow\Composer\ComposerUtility as ComposerUtility;
 use TYPO3\Flow\Core\Bootstrap;
-use TYPO3\Flow\Core\ClassLoader;
 use TYPO3\Flow\SignalSlot\Dispatcher;
 use TYPO3\Flow\Utility\Exception as UtilityException;
 use TYPO3\Flow\Utility\Files;

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManagerInterface.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManagerInterface.php
@@ -18,6 +18,10 @@ namespace TYPO3\Flow\Package;
  */
 interface PackageManagerInterface
 {
+    const PACKAGE_STATE_INACTIVE = 'inactive';
+
+    const PACKAGE_STATE_ACTIVE = 'active';
+
     /**
      * Initializes the package manager
      *
@@ -132,6 +136,9 @@ interface PackageManagerInterface
      * @param string $packageType If specified, the package type will be set
      * @return \TYPO3\Flow\Package\Package The newly created package
      * @api
+     * @deprecated This methods signature is deprecated and will change with Flow 4.0
+     *
+     * TODO: Change signature for Flow 4.0 to ($packageKey, $manifest, $packagesPath)
      */
     public function createPackage($packageKey, \TYPO3\Flow\Package\MetaData $packageMetaData = null, $packagesPath = null, $packageType = null);
 
@@ -184,24 +191,6 @@ interface PackageManagerInterface
      * @return void
      */
     public function refreezePackage($packageKey);
-
-    /**
-     * Register a native Flow package
-     *
-     * @param PackageInterface $package The Package to be registered
-     * @param boolean $sortAndSave allows for not saving packagestates when used in loops etc.
-     * @return PackageInterface
-     * @throws Exception\CorruptPackageException
-     */
-    public function registerPackage(PackageInterface $package, $sortAndSave = true);
-
-    /**
-     * Unregisters a package from the list of available packages
-     *
-     * @param PackageInterface $package The package to be unregistered
-     * @throws Exception\InvalidPackageStateException
-     */
-    public function unregisterPackage(PackageInterface $package);
 
     /**
      * Removes a package from registry and deletes it from filesystem

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageOrderResolver.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageOrderResolver.php
@@ -121,7 +121,6 @@ class PackageOrderResolver
             unset($unsortedPackages[$packageKey]);
             $sortedPackages[$packageKey] = $packageState;
             return true;
-
         } elseif ($unsortedPackages[$packageKey] > 20) {
             // SECOND case: ERROR case. This happens with MANY cyclic dependencies, in this case we just degrade by arbitarily sorting the package; and continue. Alternative would be throwing an Exception.
             unset($unsortedPackages[$packageKey]);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageOrderResolver.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageOrderResolver.php
@@ -1,0 +1,136 @@
+<?php
+namespace TYPO3\Flow\Package;
+
+use TYPO3\Flow\Composer\Utility;
+
+/**
+ * A simple package dependency order solver. Just sorts by simple dependencies, does no checking or versions.
+ */
+class PackageOrderResolver
+{
+    /**
+     * @var array
+     */
+    protected $manifestData;
+
+    /**
+     * @var array
+     */
+    protected $packageStates;
+
+    /**
+     * @var array
+     */
+    protected $sortedPackages;
+
+    /**
+     * @param array $packages The array of package states to order by dependencies
+     * @param array $manifestData The manifests of all given packages for reading dependencies
+     */
+    public function __construct(array $packages, array $manifestData)
+    {
+        $this->manifestData = $manifestData;
+        $this->packageStates = $packages;
+    }
+
+    /**
+     * Sorts the packages and returns the sorted packages array
+     *
+     * @return array
+     */
+    public function sort()
+    {
+        if ($this->sortedPackages === null) {
+            $unsortedPackageKeys = array_fill_keys(array_keys($this->packageStates), 0);
+            $sortedPackages = array();
+
+            while (!empty($unsortedPackageKeys)) {
+                $resolved = $this->sortPackagesByDependencies(key($unsortedPackageKeys), $sortedPackages, $unsortedPackageKeys);
+                if ($resolved) {
+                    reset($unsortedPackageKeys);
+                } else {
+                    next($unsortedPackageKeys);
+                }
+            }
+
+            $this->sortedPackages = $sortedPackages;
+        }
+
+
+        return $this->sortedPackages;
+    }
+
+    /**
+     * Recursively sort dependencies of a package. This is a depth-first approach that recursively
+     * adds all dependent packages to the sorted list before adding the given package. Visited
+     * packages are flagged to break up cyclic dependencies.
+     *
+     * @param string $packageKey Package key to process
+     * @param array $sortedPackages Array to sort packages into
+     * @param array $unsortedPackages Array with state information of still unsorted packages
+     * @return boolean
+     */
+    protected function sortPackagesByDependencies($packageKey, array &$sortedPackages, array &$unsortedPackages)
+    {
+        if (!isset($this->packageStates[$packageKey])) {
+            return true;
+        }
+
+        /** @var array $packageState */
+        $packageState = $this->packageStates[$packageKey];
+
+        // $iteationForPackage will be -1 if the package is already worked on in a stack, in that case we will return instantly.
+        $iterationForPackage = $unsortedPackages[$packageKey];
+
+        if ($iterationForPackage === -1) {
+            return false;
+        }
+
+        if (!isset($unsortedPackages[$packageKey])) {
+            return true;
+        }
+
+        $unsortedPackages[$packageKey] = -1;
+        $packageComposerManifest = $this->manifestData[$packageKey];
+        $packageRequirements = isset($packageComposerManifest['require']) ? array_keys($packageComposerManifest['require']) : [];
+        $unresolvedDependencies = 0;
+
+        foreach ($packageRequirements as $requiredComposerName) {
+            if (!$this->packageRequirementIsComposerPackage($requiredComposerName)) {
+                continue;
+            }
+
+            if (isset($sortedPackages[$packageKey])) {
+                continue;
+            }
+
+            if (isset($unsortedPackages[$requiredComposerName])) {
+                $resolved = $this->sortPackagesByDependencies($requiredComposerName, $sortedPackages, $unsortedPackages);
+                if (!$resolved) {
+                    $unresolvedDependencies++;
+                }
+            }
+        }
+
+        $unsortedPackages[$packageKey] = $iterationForPackage + 1;
+
+        if ($unresolvedDependencies === 0 || $unsortedPackages[$packageKey] > 20) {
+            unset($unsortedPackages[$packageKey]);
+            $sortedPackages[$packageKey] = $packageState;
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check whether the given package requirement (like "typo3/flow" or "php") is a composer package or not
+     *
+     * @param string $requirement the composer requirement string
+     * @return boolean TRUE if $requirement is a composer package (contains a slash), FALSE otherwise
+     */
+    protected function packageRequirementIsComposerPackage($requirement)
+    {
+        return (strpos($requirement, '/') !== false);
+    }
+}

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageOrderResolver.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageOrderResolver.php
@@ -1,8 +1,6 @@
 <?php
 namespace TYPO3\Flow\Package;
 
-use TYPO3\Flow\Composer\ComposerUtility;
-
 /**
  * A simple package dependency order solver. Just sorts by simple dependencies, does no checking or versions.
  */
@@ -118,8 +116,19 @@ class PackageOrderResolver
 
         $unsortedPackages[$packageKey] = $iterationForPackage + 1;
 
-        if ($unresolvedDependencies === 0 || $unsortedPackages[$packageKey] > 20) {
+        if ($unresolvedDependencies === 0) {
+            // we are validly able to sort the package to this position.
             unset($unsortedPackages[$packageKey]);
+            $sortedPackages[$packageKey] = $packageState;
+            return true;
+
+        } elseif ($unsortedPackages[$packageKey] > 20) {
+            // SECOND case: ERROR case. This happens with MANY cyclic dependencies, in this case we just degrade by arbitarily sorting the package; and continue. Alternative would be throwing an Exception.
+            unset($unsortedPackages[$packageKey]);
+
+            // In order to be able to debug this kind of error (if we hit it), we at least try to write to PackageStates.php
+            // so if people send it to us, we have some chance of finding the error.
+            $packageState['error-sorting-limit-reached'] = true;
             $sortedPackages[$packageKey] = $packageState;
             return true;
         }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageOrderResolver.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageOrderResolver.php
@@ -1,7 +1,7 @@
 <?php
 namespace TYPO3\Flow\Package;
 
-use TYPO3\Flow\Composer\Utility;
+use TYPO3\Flow\Composer\ComposerUtility;
 
 /**
  * A simple package dependency order solver. Just sorts by simple dependencies, does no checking or versions.

--- a/TYPO3.Flow/Tests/Unit/Object/CompileTimeObjectManagerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Object/CompileTimeObjectManagerTest.php
@@ -59,10 +59,10 @@ class CompileTimeObjectManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
     {
         $packagePath = 'vfs://Packages/Vendor.TestPackage/';
         mkdir($packagePath . 'Classes/', 0777, true);
-        file_put_contents($packagePath . 'composer.json', '{"name": "vendor/testpackage", "type": "typo3-flow"}');
+        file_put_contents($packagePath . 'composer.json', '{"name": "vendor/testpackage", "type": "typo3-flow-package"}');
         file_put_contents($packagePath . 'Classes/Test.php', '<?php ?>');
 
-        $testPackage = new \TYPO3\Flow\Package\Package($this->mockPackageManager, 'Vendor.TestPackage', $packagePath, 'Classes');
+        $testPackage = new \TYPO3\Flow\Package\Package('Vendor.TestPackage', 'vendor/testpackage', $packagePath, ['psr-4' => ['Vendor\\TestPackage' => 'Classes/']]);
 
         $objectManagementEnabledClasses = $this->compileTimeObjectManager->_call('registerClassFiles', array('Vendor.TestPackage' => $testPackage));
         // Count is at least 1 as '' => 'DateTime' is hardcoded
@@ -80,7 +80,7 @@ class CompileTimeObjectManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
         file_put_contents($packagePath . 'composer.json', '{"name": "vendor/testpackage", "type": "some-non-flow-package-type"}');
         file_put_contents($packagePath . 'Classes/Test.php', '<?php ?>');
 
-        $testPackage = new \TYPO3\Flow\Package\Package($this->mockPackageManager, 'NonFlow.TestPackage', $packagePath, 'Classes');
+        $testPackage = new \TYPO3\Flow\Package\Package('NonFlow.TestPackage', 'vendor/testpackage', $packagePath, ['psr-0' => ['NonFlow\\TestPackage' => 'Classes/']]);
 
         $objectManagementEnabledClasses = $this->compileTimeObjectManager->_call('registerClassFiles', array('NonFlow.TestPackage' => $testPackage));
         // Count is at least 1 as '' => 'DateTime' is hardcoded
@@ -97,7 +97,7 @@ class CompileTimeObjectManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
         file_put_contents($packagePath . 'composer.json', '{"name": "nonflow/includeallclasses", "type": "some-non-flow-package-type"}');
         file_put_contents($packagePath . 'Classes/Test.php', '<?php ?>');
 
-        $testPackage = new \TYPO3\Flow\Package\Package($this->mockPackageManager, 'NonFlow.IncludeAllClasses', $packagePath, 'Classes');
+        $testPackage = new \TYPO3\Flow\Package\Package('NonFlow.IncludeAllClasses', 'nonflow/includeallclasses', $packagePath, ['psr-4' => ['NonFlow\\IncludeAllClasses' => 'Classes/']]);
 
         $objectManagementEnabledClasses = $this->compileTimeObjectManager->_call('registerClassFiles', array('NonFlow.IncludeAllClasses' => $testPackage));
         // Count is at least 1 as '' => 'DateTime' is hardcoded
@@ -115,7 +115,7 @@ class CompileTimeObjectManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
         file_put_contents($packagePath . 'composer.json', '{"name": "nonflow/includeandexclude", "type": "some-non-flow-package-type"}');
         file_put_contents($packagePath . 'Classes/Test.php', '<?php ?>');
 
-        $testPackage = new \TYPO3\Flow\Package\Package($this->mockPackageManager, 'NonFlow.IncludeAndExclude', $packagePath, 'Classes');
+        $testPackage = new \TYPO3\Flow\Package\Package('NonFlow.IncludeAndExclude', 'nonflow/includeandexclude', $packagePath, ['psr-0' => ['NonFlow\\IncludeAndExclude' => 'Classes/']]);
 
         $objectManagementEnabledClasses = $this->compileTimeObjectManager->_call('registerClassFiles', array('NonFlow.IncludeAndExclude' => $testPackage));
         // Count is at least 1 as '' => 'DateTime' is hardcoded
@@ -132,7 +132,7 @@ class CompileTimeObjectManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
         file_put_contents($packagePath . 'composer.json', '{"name": "vendor/anotherpackage", "type": "typo3-flow"}');
         file_put_contents($packagePath . 'Classes/Test.php', '<?php ?>');
 
-        $testPackage = new \TYPO3\Flow\Package\Package($this->mockPackageManager, 'Vendor.AnotherPackage', $packagePath, 'Classes');
+        $testPackage = new \TYPO3\Flow\Package\Package('Vendor.AnotherPackage', 'vendor/anotherpackage', $packagePath, ['psr-0' => ['Vendor\\AnotherPackage' => 'Classes/']]);
 
         $objectManagementEnabledClasses = $this->compileTimeObjectManager->_call('registerClassFiles', array('Vendor.AnotherPackage' => $testPackage));
         // Count is at least 1 as '' => 'DateTime' is hardcoded

--- a/TYPO3.Flow/Tests/Unit/Package/PackageFactoryTest.php
+++ b/TYPO3.Flow/Tests/Unit/Package/PackageFactoryTest.php
@@ -49,27 +49,7 @@ class PackageFactoryTest extends UnitTestCase
      */
     public function createThrowsExceptionWhenSpecifyingANonExistingPackagePath()
     {
-        $this->packageFactory->create('vfs://Packages/', 'Some/Non/Existing/Path/Some.Package/', 'Some.Package');
-    }
-
-    /**
-     * @test
-     * @expectedException \TYPO3\Flow\Package\Exception\InvalidPackageKeyException
-     */
-    public function createThrowsExceptionWhenSpecifyingAnInvalidPackageKey()
-    {
-        $this->packageFactory->create('vfs://Packages/', 'Some/Path/InvalidPackageKey/', 'InvalidPackageKey');
-    }
-
-    /**
-     * @test
-     * @expectedException \TYPO3\Flow\Package\Exception\InvalidPackageManifestException
-     */
-    public function createThrowsExceptionWhenSpecifyingAPathWithMissingComposerManifest()
-    {
-        $packagePath = 'vfs://Packages/Some/Path/Some.Package/';
-        mkdir($packagePath, 0777, true);
-        $this->packageFactory->create('vfs://Packages/', 'Some/Path/Some.Package/', 'Some.Package');
+        $this->packageFactory->create('vfs://Packages/', 'Some/Non/Existing/Path/Some.Package/', 'Some.Package', 'some/package');
     }
 
     /**
@@ -84,7 +64,7 @@ class PackageFactoryTest extends UnitTestCase
         file_put_contents($packagePath . 'composer.json', '{"name": "some/package", "type": "flow-test", "autoload": { "psr-0": { "Foo": "bar" }}}');
         file_put_contents($packageFilePath, '<?php // no class');
 
-        $this->packageFactory->create('vfs://Packages/', 'Some/Path/Some.Package/', 'Some.Package');
+        $this->packageFactory->create('vfs://Packages/', 'Some/Path/Some.Package/', 'Some.Package', 'some/package');
     }
 
     /**
@@ -101,7 +81,7 @@ class PackageFactoryTest extends UnitTestCase
 
         require($packageFilePath);
 
-        $this->packageFactory->create('vfs://Packages/', 'Some/Path/Some.Package/', 'Some.Package');
+        $this->packageFactory->create('vfs://Packages/', 'Some/Path/Some.Package/', 'Some.Package', 'some/package');
     }
 
     /**
@@ -117,7 +97,7 @@ class PackageFactoryTest extends UnitTestCase
 
         require($packageFilePath);
 
-        $package = $this->packageFactory->create('vfs://Packages/', 'Some/Path/Some.Package/', 'Some.Package');
+        $package = $this->packageFactory->create('vfs://Packages/', 'Some/Path/Some.Package/', 'Some.Package', 'some/package');
         $this->assertSame('TYPO3\Flow\Fixtures\CustomPackage2', get_class($package));
     }
 
@@ -126,15 +106,17 @@ class PackageFactoryTest extends UnitTestCase
      */
     public function createTakesAutoloaderTypeIntoAccountWhenLoadingCustomPackage()
     {
-        $packagePath = 'vfs://Packages/Some/Path/Some.CustomPackage/';
+        $packagePath = 'vfs://Packages/Some/Path/Some.Package/';
         $packageFilePath = $packagePath . 'Classes/Package.php';
         mkdir(dirname($packageFilePath), 0777, true);
-        file_put_contents($packagePath . 'composer.json', '{"name": "some/custom-package", "type": "flow-test", "autoload": { "psr-4": { "Foo": "bar" }}}');
+        $rawComposerManifest = '{"name": "some/package", "type": "flow-test", "autoload": { "psr-4": { "Foo": "bar" }}}';
+        $composerManifest = json_decode($rawComposerManifest, true);
+        file_put_contents($packagePath . 'composer.json', $rawComposerManifest);
         file_put_contents($packageFilePath, '<?php namespace TYPO3\\Flow\\Fixtures { class CustomPackage3 extends \\TYPO3\\Flow\\Package\\Package {}}');
 
         require($packageFilePath);
 
-        $package = $this->packageFactory->create('vfs://Packages/', 'Some/Path/Some.CustomPackage/', 'Some.CustomPackage');
+        $package = $this->packageFactory->create('vfs://Packages/', 'Some/Path/Some.Package/', 'Some.Package', 'some/package', $composerManifest['autoload']);
         $this->assertSame('TYPO3\Flow\Fixtures\CustomPackage3', get_class($package));
     }
 
@@ -147,7 +129,7 @@ class PackageFactoryTest extends UnitTestCase
         mkdir($packagePath, 0777, true);
         file_put_contents($packagePath . 'composer.json', '{"name": "some/package", "type": "flow-test"}');
 
-        $package = $this->packageFactory->create('vfs://Packages/', 'Some/Path/Some.Package/', 'Some.Package');
+        $package = $this->packageFactory->create('vfs://Packages/', 'Some/Path/Some.Package/', 'Some.Package', 'some/package');
         $this->assertSame(\TYPO3\Flow\Package\Package::class, get_class($package));
     }
 }

--- a/TYPO3.Flow/Tests/Unit/Package/PackageManagerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Package/PackageManagerTest.php
@@ -11,10 +11,13 @@ namespace TYPO3\Flow\Tests\Unit\Package;
  * source code.
  */
 
+use TYPO3\Flow\Composer\Utility;
 use TYPO3\Flow\Core\ApplicationContext;
 use TYPO3\Flow\Core\Bootstrap;
 use TYPO3\Flow\Package\PackageInterface;
 use org\bovigo\vfs\vfsStream;
+use TYPO3\Flow\Package\PackageManager;
+use TYPO3\Flow\Package\PackageOrderResolver;
 use TYPO3\Flow\SignalSlot\Dispatcher;
 
 /**
@@ -77,7 +80,6 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
             'typo3/flow' => 'TYPO3.Flow'
         );
 
-        $this->packageManager->injectClassLoader($mockClassLoader);
         $this->inject($this->packageManager, 'composerNameToPackageKeyMap', $composerNameToPackageKeyMap);
         $this->inject($this->packageManager, 'packagesBasePath', 'vfs://Test/Packages/');
         $this->inject($this->packageManager, 'packageStatesPathAndFilename', 'vfs://Test/Configuration/PackageStates.php');
@@ -227,7 +229,7 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
         $this->inject($packageManager, 'packageFactory', $packageFactory);
 
         $packageManager->_set('packages', array());
-        $packageManager->_call('scanAvailablePackages');
+        $packageManager->rescanPackages();
 
         $packageStates = require('vfs://Test/Configuration/PackageStates.php');
         $actualPackageKeys = array_keys($packageStates['packages']);
@@ -272,8 +274,7 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
             ),
             'version' => 2
         ));
-        $packageManager->_call('scanAvailablePackages');
-        $packageManager->_call('sortAndsavePackageStates');
+        $packageManager->rescanPackages(false);
 
         $packageStates = require('vfs://Test/Configuration/PackageStates.php');
         $this->assertEquals('inactive', $packageStates['packages'][$packageKey]['state']);
@@ -296,7 +297,7 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
 
             mkdir($packagePath, 0770, true);
             mkdir($packagePath . 'Classes');
-            file_put_contents($packagePath . 'composer.json', '{"name": "' . $packageKey . '", "type": "flow-test"}');
+            Utility::writeComposerManifest($packagePath, $packageKey, ['type' => 'flow-test', 'autoload' => []]);
         }
 
         $packageManager = $this->getAccessibleMock(\TYPO3\Flow\Package\PackageManager::class, array('updateShortcuts', 'emitPackageStatesUpdated'), array(), '', false);
@@ -307,20 +308,21 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
         $this->inject($packageManager, 'packageFactory', $packageFactory);
 
         $packageManager->_set('packages', array());
-        $packageManager->_call('scanAvailablePackages');
+        $actualPackageStatesConfiguration = $packageManager->rescanPackages();
 
         $expectedPackageStatesConfiguration = array();
         foreach ($packageKeys as $packageKey) {
-            $expectedPackageStatesConfiguration[$packageKey] = array(
+            $composerName = Utility::getComposerPackageNameFromPackageKey($packageKey);
+            $expectedPackageStatesConfiguration[$composerName] = array(
                 'state' => 'active',
                 'packagePath' => 'Application/' . $packageKey . '/',
-                'classesPath' => 'Classes/',
-                'manifestPath' => '',
-                'composerName' => $packageKey
+                'composerName' => $composerName,
+                'packageClassInformation' => array(),
+                'packageKey' => $packageKey,
+                'autoloadConfiguration' => []
             );
         }
 
-        $actualPackageStatesConfiguration = $packageManager->_get('packageStatesConfiguration');
         $this->assertEquals($expectedPackageStatesConfiguration, $actualPackageStatesConfiguration['packages']);
     }
 
@@ -357,10 +359,16 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function createPackageWritesAComposerManifestUsingTheGivenMetaObject()
     {
-        $metaData = new \TYPO3\Flow\Package\MetaData('Acme.YetAnotherTestPackage');
-        $metaData->setDescription('Yet Another Test Package');
-
-        $package = $this->packageManager->createPackage('Acme.YetAnotherTestPackage', $metaData);
+        $package = $this->packageManager->createPackage('Acme.YetAnotherTestPackage', null, null, null, [
+            'name' => 'acme/yetanothertestpackage',
+            'type' => 'typo3-flow-package',
+            'description' => 'Yet Another Test Package',
+            'autoload' => [
+                'psr-0' => [
+                    'Acme\\YetAnotherTestPackage' => 'Classes/'
+                ]
+            ]
+        ]);
 
         $json = file_get_contents($package->getPackagePath() . '/composer.json');
         $composerManifest = json_decode($json);
@@ -374,11 +382,18 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function createPackageCanChangePackageTypeInComposerManifest()
     {
-        $metaData = new \TYPO3\Flow\Package\MetaData('Acme.YetAnotherTestPackage2');
-        $metaData->setDescription('Yet Another Test Package');
-        $metaData->setPackageType('flow-custom-package');
+        $metaData = [
+            'name' => 'acme/yetanothertestpackage2',
+            'type' => 'flow-custom-package',
+            'description' => 'Yet Another Test Package',
+            'autoload' => [
+                'psr-0' => [
+                    'Acme\\YetAnotherTestPackage2' => 'Classes/'
+                ]
+            ]
+        ];
 
-        $package = $this->packageManager->createPackage('Acme.YetAnotherTestPackage2', $metaData);
+        $package = $this->packageManager->createPackage('Acme.YetAnotherTestPackage2', null, null, null, $metaData);
 
         $json = file_get_contents($package->getPackagePath() . '/composer.json');
         $composerManifest = json_decode($json);
@@ -402,7 +417,6 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
         $this->assertTrue(is_dir($packagePath . PackageInterface::DIRECTORY_RESOURCES), 'Resources directory was not created');
         $this->assertTrue(is_dir($packagePath . PackageInterface::DIRECTORY_TESTS_UNIT), 'Tests/Unit directory was not created');
         $this->assertTrue(is_dir($packagePath . PackageInterface::DIRECTORY_TESTS_FUNCTIONAL), 'Tests/Functional directory was not created');
-        $this->assertTrue(is_dir($packagePath . PackageInterface::DIRECTORY_METADATA), 'Metadata directory was not created');
     }
 
     /**
@@ -495,349 +509,15 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
         $package = $this->packageManager->createPackage('Acme.YetAnotherTestPackage');
         $packagePath = $package->getPackagePath();
 
-        $this->assertTrue(is_dir($packagePath . PackageInterface::DIRECTORY_METADATA));
-        $this->assertTrue($this->packageManager->isPackageActive('Acme.YetAnotherTestPackage'));
-        $this->assertTrue($this->packageManager->isPackageAvailable('Acme.YetAnotherTestPackage'));
+        $this->assertTrue(is_dir($packagePath . PackageInterface::DIRECTORY_CONFIGURATION), 'The package configuration directory does not exist.');
+        $this->assertTrue($this->packageManager->isPackageActive('Acme.YetAnotherTestPackage'), 'The package is not active.');
+        $this->assertTrue($this->packageManager->isPackageAvailable('Acme.YetAnotherTestPackage'), 'The package is not available.');
 
         $this->packageManager->deletePackage('Acme.YetAnotherTestPackage');
 
-        $this->assertFalse(is_dir($packagePath . PackageInterface::DIRECTORY_METADATA));
-        $this->assertFalse($this->packageManager->isPackageActive('Acme.YetAnotherTestPackage'));
-        $this->assertFalse($this->packageManager->isPackageAvailable('Acme.YetAnotherTestPackage'));
-    }
-
-    /**
-     * @test
-     * @dataProvider packagesAndDependenciesOrder
-     * @param array $packages
-     * @param array $expectedPackageOrder
-     */
-    public function availablePackagesAreSortedAfterTheirDependencies($packages, $expectedPackageOrder)
-    {
-        $unsortedPackages = array();
-        foreach ($packages as $packageKey => $package) {
-            $mockPackageConstraints = array();
-            foreach ($package['dependencies'] as $dependency) {
-                $mockPackageConstraints[] = new \TYPO3\Flow\Package\MetaData\PackageConstraint('depends', $dependency);
-            }
-            $mockMetaData = $this->getMock(\TYPO3\Flow\Package\MetaDataInterface::class);
-            $mockMetaData->expects($this->any())->method('getConstraintsByType')->will($this->returnValue($mockPackageConstraints));
-            $mockPackage = $this->getMock(\TYPO3\Flow\Package\PackageInterface::class);
-            $mockPackage->expects($this->any())->method('getPackageKey')->will($this->returnValue($packageKey));
-            $mockPackage->expects($this->any())->method('getPackageMetaData')->will($this->returnValue($mockMetaData));
-            $unsortedPackages[$packageKey] = $mockPackage;
-        }
-
-        $packageManager = $this->getAccessibleMock(\TYPO3\Flow\Package\PackageManager::class, array('emitPackageStatesUpdated'));
-        $packageManager->_set('packages', $unsortedPackages);
-        $packageManager->_set('packageStatesConfiguration', array('packages' => $packages));
-        $packageManager->_call('sortAvailablePackagesByDependencies');
-
-        /*
-        // There are many "correct" orders of packages. A order is correct if all dependent
-        // packages are ordered before a given package (except for cyclic dependencies).
-        // The following can be used to check that order (but due to cyclic dependencies between
-        // e.g. Flow and Fluid this can not be asserted by default).
-        $newPackageOrder = array_keys($packageManager->_get('packages'));
-        foreach ($packages as $packageKey => $package) {
-            $packagePosition = array_search($packageKey, $newPackageOrder);
-            foreach ($package['dependencies'] as $dependency) {
-                $dependencyPosition = array_search($dependency, $newPackageOrder);
-                if ($dependencyPosition > $packagePosition) {
-                    echo "$packageKey->$dependency";
-                }
-            }
-        }
-        */
-
-        $actualPackages = $packageManager->_get('packages');
-        $actualPackageStatesConfiguration = $packageManager->_get('packageStatesConfiguration');
-
-        $this->assertEquals($expectedPackageOrder, array_keys($actualPackages), 'The packages have not been ordered according to their dependencies!');
-        $this->assertEquals($expectedPackageOrder, array_keys($actualPackageStatesConfiguration['packages']), 'The package states configurations have not been ordered according to their dependencies!');
-    }
-
-    public function packagesAndDependenciesOrder()
-    {
-        return array(
-            array(
-                array(
-                    'Doctrine.ORM' => array(
-                        'dependencies' => array('Doctrine.DBAL'),
-                    ),
-                    'Symfony.Component.Yaml' => array(
-                        'dependencies' => array(),
-                    ),
-                    'TYPO3.Flow' => array(
-                        'dependencies' => array('Symfony.Component.Yaml', 'Doctrine.ORM'),
-                    ),
-                    'Doctrine.Common' => array(
-                        'dependencies' => array(),
-                    ),
-                    'Doctrine.DBAL' => array(
-                        'dependencies' => array('Doctrine.Common'),
-                    ),
-                ),
-                array(
-                    'Doctrine.Common',
-                    'Doctrine.DBAL',
-                    'Doctrine.ORM',
-                    'Symfony.Component.Yaml',
-                    'TYPO3.Flow'
-                ),
-            ),
-            array(
-                array(
-                    'TYPO3.NeosDemoTypo3Org' => array(
-                        'dependencies' => array(
-                            'TYPO3.Neos',
-                        ),
-                    ),
-                    'Flowpack.Behat' => array(
-                        'dependencies' => array(
-                            'TYPO3.Flow',
-                        ),
-                    ),
-                    'TYPO3.Imagine' => array(
-                        'dependencies' => array(
-                            'imagine.imagine',
-                            'TYPO3.Flow',
-                        ),
-                    ),
-                    'TYPO3.TYPO3CR' => array(
-                        'dependencies' => array(
-                            'TYPO3.Flow',
-                        ),
-                    ),
-                    'TYPO3.Neos' => array(
-                        'dependencies' => array(
-                            'TYPO3.TYPO3CR',
-                            'TYPO3.Twitter.Bootstrap',
-                            'TYPO3.Setup',
-                            'TYPO3.TypoScript',
-                            'TYPO3.Neos.NodeTypes',
-                            'TYPO3.Media',
-                            'TYPO3.ExtJS',
-                            'TYPO3.Flow',
-                        ),
-                    ),
-                    'TYPO3.Setup' => array(
-                        'dependencies' => array(
-                            'TYPO3.Twitter.Bootstrap',
-                            'TYPO3.Form',
-                            'TYPO3.Flow',
-                        ),
-                    ),
-                    'TYPO3.Media' => array(
-                        'dependencies' => array(
-                            'imagine.imagine',
-                            'TYPO3.Flow',
-                        ),
-                    ),
-                    'TYPO3.ExtJS' => array(
-                        'dependencies' => array(
-                            'TYPO3.Flow',
-                        ),
-                    ),
-                    'TYPO3.Neos.NodeTypes' => array(
-                        'dependencies' => array(
-                            'TYPO3.TypoScript',
-                            'TYPO3.Flow',
-                        ),
-                    ),
-                    'TYPO3.TypoScript' => array(
-                        'dependencies' => array(
-                            'TYPO3.Eel',
-                            'TYPO3.Flow',
-                        ),
-                    ),
-                    'TYPO3.Form' => array(
-                        'dependencies' => array(
-                            'TYPO3.Flow',
-                        ),
-                    ),
-                    'TYPO3.Twitter.Bootstrap' => array(
-                        'dependencies' => array(
-                            'TYPO3.Flow',
-                        ),
-                    ),
-                    'TYPO3.SiteKickstarter' => array(
-                        'dependencies' => array(
-                            'TYPO3.Kickstart',
-                            'TYPO3.Flow',
-                        ),
-                    ),
-                    'imagine.imagine' => array(
-                        'dependencies' => array(),
-                    ),
-                    'mikey179.vfsStream' => array(
-                        'dependencies' => array(),
-                    ),
-                    'Composer.Installers' => array(
-                        'dependencies' => array(),
-                    ),
-                    'symfony.console' => array(
-                        'dependencies' => array(),
-                    ),
-                    'symfony.domcrawler' => array(
-                        'dependencies' => array(),
-                    ),
-                    'symfony.yaml' => array(
-                        'dependencies' => array(),
-                    ),
-                    'doctrine.annotations' => array(
-                        'dependencies' => array(
-                            0 => 'doctrine.lexer',
-                        ),
-                    ),
-                    'doctrine.cache' => array(
-                        'dependencies' => array(),
-                    ),
-                    'doctrine.collections' => array(
-                        'dependencies' => array(),
-                    ),
-                    'Doctrine.Common' => array(
-                        'dependencies' => array(
-                            'doctrine.annotations',
-                            'doctrine.lexer',
-                            'doctrine.collections',
-                            'doctrine.cache',
-                            'doctrine.inflector',
-                        ),
-                    ),
-                    'Doctrine.DBAL' => array(
-                        'dependencies' => array(
-                            'Doctrine.Common',
-                        ),
-                    ),
-                    'doctrine.inflector' => array(
-                        'dependencies' => array(),
-                    ),
-                    'doctrine.lexer' => array(
-                        'dependencies' => array(),
-                    ),
-                    'doctrine.migrations' => array(
-                        'dependencies' => array(
-                            'Doctrine.DBAL',
-                        ),
-                    ),
-                    'Doctrine.ORM' => array(
-                        'dependencies' => array(
-                            'symfony.console',
-                            'Doctrine.DBAL',
-                        ),
-                    ),
-                    'phpunit.phpcodecoverage' => array(
-                        'dependencies' => array(
-                            'phpunit.phptexttemplate',
-                            'phpunit.phptokenstream',
-                            'phpunit.phpfileiterator',
-                        ),
-                    ),
-                    'phpunit.phpfileiterator' => array(
-                        'dependencies' => array(),
-                    ),
-                    'phpunit.phptexttemplate' => array(
-                        'dependencies' => array(),
-                    ),
-                    'phpunit.phptimer' => array(
-                        'dependencies' => array(),
-                    ),
-                    'phpunit.phptokenstream' => array(
-                        'dependencies' => array(),
-                    ),
-                    'phpunit.phpunitmockobjects' => array(
-                        'dependencies' => array(
-                            'phpunit.phptexttemplate',
-                        ),
-                    ),
-                    'phpunit.phpunit' => array(
-                        'dependencies' => array(
-                            'symfony.yaml',
-                            'phpunit.phpunitmockobjects',
-                            'phpunit.phptimer',
-                            'phpunit.phpcodecoverage',
-                            'phpunit.phptexttemplate',
-                            'phpunit.phpfileiterator',
-                        ),
-                    ),
-                    'TYPO3.Party' => array(
-                        'dependencies' => array(
-                            'TYPO3.Flow',
-                        ),
-                    ),
-                    'TYPO3.Flow' => array(
-                        'dependencies' => array(
-                            'Composer.Installers',
-                            'symfony.domcrawler',
-                            'symfony.yaml',
-                            'doctrine.migrations',
-                            'Doctrine.ORM',
-                            'TYPO3.Eel',
-                            'TYPO3.Party',
-                            'TYPO3.Fluid',
-                        ),
-                    ),
-                    'TYPO3.Eel' => array(
-                        'dependencies' => array(
-                            'TYPO3.Flow',
-                        ),
-                    ),
-                    'TYPO3.Kickstart' => array(
-                        'dependencies' => array(
-                            'TYPO3.Flow',
-                        ),
-                    ),
-                    'TYPO3.Fluid' => array(
-                        'dependencies' => array(
-                            'TYPO3.Flow',
-                        ),
-                    ),
-                ),
-                array(
-                    'Composer.Installers',
-                    'symfony.domcrawler',
-                    'symfony.yaml',
-                    'doctrine.lexer',
-                    'doctrine.annotations',
-                    'doctrine.collections',
-                    'doctrine.cache',
-                    'doctrine.inflector',
-                    'Doctrine.Common',
-                    'Doctrine.DBAL',
-                    'doctrine.migrations',
-                    'symfony.console',
-                    'Doctrine.ORM',
-                    'TYPO3.Eel',
-                    'TYPO3.Party',
-                    'TYPO3.Fluid',
-                    'TYPO3.Flow',
-                    'TYPO3.TYPO3CR',
-                    'TYPO3.Twitter.Bootstrap',
-                    'TYPO3.Form',
-                    'TYPO3.Setup',
-                    'TYPO3.TypoScript',
-                    'TYPO3.Neos.NodeTypes',
-                    'imagine.imagine',
-                    'TYPO3.Media',
-                    'TYPO3.ExtJS',
-                    'TYPO3.Neos',
-                    'TYPO3.NeosDemoTypo3Org',
-                    'Flowpack.Behat',
-                    'TYPO3.Imagine',
-                    'TYPO3.Kickstart',
-                    'TYPO3.SiteKickstarter',
-                    'mikey179.vfsStream',
-                    'phpunit.phptexttemplate',
-                    'phpunit.phptokenstream',
-                    'phpunit.phpfileiterator',
-                    'phpunit.phpcodecoverage',
-                    'phpunit.phptimer',
-                    'phpunit.phpunitmockobjects',
-                    'phpunit.phpunit',
-                ),
-            ),
-        );
+        $this->assertFalse(is_dir($packagePath . PackageInterface::DIRECTORY_CONFIGURATION), 'The package configuration directory does still exist.');
+        $this->assertFalse($this->packageManager->isPackageActive('Acme.YetAnotherTestPackage'), 'The package is still active.');
+        $this->assertFalse($this->packageManager->isPackageAvailable('Acme.YetAnotherTestPackage'), 'The package is still available.');
     }
 
     /**
@@ -859,16 +539,18 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function getPackageKeyFromComposerNameIgnoresCaseDifferences($composerName, $packageKey)
     {
-        $packageStatesConfiguration = array('packages' =>
-            array(
-                'TYPO3.Flow' => array(
+        $packageStatesConfiguration = [
+            'packages' => [
+                'typo3/flow' => [
+                    'packageKey' => 'TYPO3.Flow',
                     'composerName' => 'typo3/flow'
-                ),
-                'imagine.Imagine' => array(
-                    'composerName' => 'imagine/Imagine'
-                )
-            )
-        );
+                ],
+                'imagine/imagine' => [
+                    'packageKey' => 'imagine.Imagine',
+                    'composerName' => 'imagine/imagine'
+                ]
+            ]
+        ];
 
         $packageManager = $this->getAccessibleMock(\TYPO3\Flow\Package\PackageManager::class, array('resolvePackageDependencies'));
         $packageManager->_set('packageStatesConfiguration', $packageStatesConfiguration);
@@ -926,7 +608,9 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
     {
         $this->mockApplicationContext->expects($this->atLeastOnce())->method('isDevelopment')->will($this->returnValue(true));
 
-        $this->packageManager->createPackage('Some.Package');
+        $this->packageManager->createPackage('Some.Package', null, null, null, [
+            'name' => 'some/package'
+        ]);
 
         $this->mockDispatcher->expects($this->once())->method('dispatch')->with(\TYPO3\Flow\Package\PackageManager::class, 'packageStatesUpdated');
         $this->packageManager->freezePackage('Some.Package');
@@ -939,7 +623,10 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
     {
         $this->mockApplicationContext->expects($this->atLeastOnce())->method('isDevelopment')->will($this->returnValue(true));
 
-        $this->packageManager->createPackage('Some.Package');
+        $this->packageManager->createPackage('Some.Package', null, null, null, [
+            'name' => 'some/package',
+            'type' => 'typo3-flow-package'
+        ]);
         $this->packageManager->freezePackage('Some.Package');
 
         $this->mockDispatcher->expects($this->once())->method('dispatch')->with(\TYPO3\Flow\Package\PackageManager::class, 'packageStatesUpdated');

--- a/TYPO3.Flow/Tests/Unit/Package/PackageManagerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Package/PackageManagerTest.php
@@ -17,7 +17,6 @@ use TYPO3\Flow\Core\Bootstrap;
 use TYPO3\Flow\Package\PackageInterface;
 use org\bovigo\vfs\vfsStream;
 use TYPO3\Flow\Package\PackageManager;
-use TYPO3\Flow\Package\PackageOrderResolver;
 use TYPO3\Flow\SignalSlot\Dispatcher;
 
 /**
@@ -27,7 +26,7 @@ use TYPO3\Flow\SignalSlot\Dispatcher;
 class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
 {
     /**
-     * @var \TYPO3\Flow\Package\PackageManager
+     * @var PackageManager
      */
     protected $packageManager;
 
@@ -69,7 +68,7 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
             return get_class($object);
         }));
         $mockObjectManager->expects($this->any())->method('get')->with(\TYPO3\Flow\Reflection\ReflectionService::class)->will($this->returnValue($mockReflectionService));
-        $this->packageManager = new \TYPO3\Flow\Package\PackageManager();
+        $this->packageManager = new PackageManager();
 
         mkdir('vfs://Test/Packages/Application', 0700, true);
         mkdir('vfs://Test/Configuration');
@@ -196,7 +195,7 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function getCaseSensitivePackageKeyReturnsTheUpperCamelCaseVersionOfAGivenPackageKeyIfThePackageIsRegistered()
     {
-        $packageManager = $this->getAccessibleMock(\TYPO3\Flow\Package\PackageManager::class, array('dummy'));
+        $packageManager = $this->getAccessibleMock(PackageManager::class, array('dummy'));
         $packageManager->_set('packageKeys', array('acme.testpackage' => 'Acme.TestPackage'));
         $this->assertEquals('Acme.TestPackage', $packageManager->getCaseSensitivePackageKey('acme.testpackage'));
     }
@@ -221,7 +220,7 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
             file_put_contents($packagePath . 'composer.json', '{"name": "' . $packageKey . '", "type": "flow-test"}');
         }
 
-        $packageManager = $this->getAccessibleMock(\TYPO3\Flow\Package\PackageManager::class, array('emitPackageStatesUpdated'));
+        $packageManager = $this->getAccessibleMock(PackageManager::class, array('emitPackageStatesUpdated'));
         $packageManager->_set('packagesBasePath', 'vfs://Test/Packages/');
         $packageManager->_set('packageStatesPathAndFilename', 'vfs://Test/Configuration/PackageStates.php');
 
@@ -256,7 +255,7 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
             file_put_contents($packagePath . 'composer.json', '{"name": "' . $packageKey . '", "type": "flow-test"}');
         }
 
-        $packageManager = $this->getAccessibleMock(\TYPO3\Flow\Package\PackageManager::class, array('emitPackageStatesUpdated'));
+        $packageManager = $this->getAccessibleMock(PackageManager::class, array('emitPackageStatesUpdated'));
         $packageManager->_set('packagesBasePath', 'vfs://Test/Packages/');
         $packageManager->_set('packageStatesPathAndFilename', 'vfs://Test/Configuration/PackageStates.php');
 
@@ -300,7 +299,7 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
             ComposerUtility::writeComposerManifest($packagePath, $packageKey, ['type' => 'flow-test', 'autoload' => []]);
         }
 
-        $packageManager = $this->getAccessibleMock(\TYPO3\Flow\Package\PackageManager::class, array('updateShortcuts', 'emitPackageStatesUpdated'), array(), '', false);
+        $packageManager = $this->getAccessibleMock(PackageManager::class, array('updateShortcuts', 'emitPackageStatesUpdated'), array(), '', false);
         $packageManager->_set('packagesBasePath', 'vfs://Test/Packages/');
         $packageManager->_set('packageStatesPathAndFilename', 'vfs://Test/Configuration/PackageStates.php');
 
@@ -552,7 +551,7 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
             ]
         ];
 
-        $packageManager = $this->getAccessibleMock(\TYPO3\Flow\Package\PackageManager::class, array('resolvePackageDependencies'));
+        $packageManager = $this->getAccessibleMock(PackageManager::class, array('resolvePackageDependencies'));
         $packageManager->_set('packageStatesConfiguration', $packageStatesConfiguration);
 
         $this->assertEquals($packageKey, $packageManager->_call('getPackageKeyFromComposerName', $composerName));
@@ -573,7 +572,7 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function createPackageEmitsPackageStatesUpdatedSignal()
     {
-        $this->mockDispatcher->expects($this->once())->method('dispatch')->with(\TYPO3\Flow\Package\PackageManager::class, 'packageStatesUpdated');
+        $this->mockDispatcher->expects($this->once())->method('dispatch')->with(PackageManager::class, 'packageStatesUpdated');
         $this->packageManager->createPackage('Some.Package');
     }
 
@@ -585,7 +584,7 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
         $this->packageManager->createPackage('Some.Package');
         $this->packageManager->deactivatePackage('Some.Package');
 
-        $this->mockDispatcher->expects($this->once())->method('dispatch')->with(\TYPO3\Flow\Package\PackageManager::class, 'packageStatesUpdated');
+        $this->mockDispatcher->expects($this->once())->method('dispatch')->with(PackageManager::class, 'packageStatesUpdated');
         $this->packageManager->activatePackage('Some.Package');
     }
 
@@ -596,7 +595,7 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
     {
         $this->packageManager->createPackage('Some.Package');
 
-        $this->mockDispatcher->expects($this->once())->method('dispatch')->with(\TYPO3\Flow\Package\PackageManager::class, 'packageStatesUpdated');
+        $this->mockDispatcher->expects($this->once())->method('dispatch')->with(PackageManager::class, 'packageStatesUpdated');
         $this->packageManager->deactivatePackage('Some.Package');
     }
 
@@ -612,7 +611,7 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
             'name' => 'some/package'
         ]);
 
-        $this->mockDispatcher->expects($this->once())->method('dispatch')->with(\TYPO3\Flow\Package\PackageManager::class, 'packageStatesUpdated');
+        $this->mockDispatcher->expects($this->once())->method('dispatch')->with(PackageManager::class, 'packageStatesUpdated');
         $this->packageManager->freezePackage('Some.Package');
     }
 
@@ -629,7 +628,7 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
         ]);
         $this->packageManager->freezePackage('Some.Package');
 
-        $this->mockDispatcher->expects($this->once())->method('dispatch')->with(\TYPO3\Flow\Package\PackageManager::class, 'packageStatesUpdated');
+        $this->mockDispatcher->expects($this->once())->method('dispatch')->with(PackageManager::class, 'packageStatesUpdated');
         $this->packageManager->unfreezePackage('Some.Package');
     }
 }

--- a/TYPO3.Flow/Tests/Unit/Package/PackageManagerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Package/PackageManagerTest.php
@@ -11,7 +11,7 @@ namespace TYPO3\Flow\Tests\Unit\Package;
  * source code.
  */
 
-use TYPO3\Flow\Composer\Utility;
+use TYPO3\Flow\Composer\ComposerUtility;
 use TYPO3\Flow\Core\ApplicationContext;
 use TYPO3\Flow\Core\Bootstrap;
 use TYPO3\Flow\Package\PackageInterface;
@@ -297,7 +297,7 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
 
             mkdir($packagePath, 0770, true);
             mkdir($packagePath . 'Classes');
-            Utility::writeComposerManifest($packagePath, $packageKey, ['type' => 'flow-test', 'autoload' => []]);
+            ComposerUtility::writeComposerManifest($packagePath, $packageKey, ['type' => 'flow-test', 'autoload' => []]);
         }
 
         $packageManager = $this->getAccessibleMock(\TYPO3\Flow\Package\PackageManager::class, array('updateShortcuts', 'emitPackageStatesUpdated'), array(), '', false);
@@ -312,7 +312,7 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
 
         $expectedPackageStatesConfiguration = array();
         foreach ($packageKeys as $packageKey) {
-            $composerName = Utility::getComposerPackageNameFromPackageKey($packageKey);
+            $composerName = ComposerUtility::getComposerPackageNameFromPackageKey($packageKey);
             $expectedPackageStatesConfiguration[$composerName] = array(
                 'state' => 'active',
                 'packagePath' => 'Application/' . $packageKey . '/',

--- a/TYPO3.Flow/Tests/Unit/Package/PackageOrderResolverTest.php
+++ b/TYPO3.Flow/Tests/Unit/Package/PackageOrderResolverTest.php
@@ -1,0 +1,365 @@
+<?php
+namespace TYPO3\Flow\Tests\Unit\Package;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+use TYPO3\Flow\Package\PackageOrderResolver;
+
+/**
+ * Test the PackageOrderResolver
+ */
+class PackageOrderResolverTest extends \TYPO3\Flow\Tests\UnitTestCase
+{
+    /**
+     * Data provider for testing if a list of unordered packages gets ordered correctly.
+     *
+     * @return array
+     */
+    public function packagesAndDependenciesOrder()
+    {
+        return [
+            [
+                [
+                    'doctrine/orm' => [
+                        'name' => 'doctrine/orm',
+                        'require' => ['doctrine/dbal' => 'dev-master'],
+                    ],
+                    'symfony/component-yaml' => [
+                        'name' => 'symfony/component-yaml',
+                        'require' => [],
+                    ],
+                    'typo3/flow' => [
+                        'name' => 'typo3/flow',
+                        'require' => ['symfony/component-yaml' => 'dev-master', 'doctrine/orm' => 'dev-master'],
+                    ],
+                    'doctrine/common' => [
+                        'name' => 'doctrine/common',
+                        'require' => [],
+                    ],
+                    'doctrine/dbal' => [
+                        'name' => 'doctrine/dbal',
+                        'require' => ['doctrine/common' => 'dev-master'],
+                    ],
+                ],
+                [
+                    'doctrine/common',
+                    'doctrine/dbal',
+                    'doctrine/orm',
+                    'symfony/component-yaml',
+                    'typo3/flow'
+                ],
+            ],
+            [
+                [
+                    'typo3/neosdemotypo3org' => [
+                        'name' => 'typo3/neosdemotypo3org',
+                        'require' => [
+                            'typo3/neos' => 'dev-master',
+                        ],
+                    ],
+                    'flowpack/behat' => [
+                        'name' => 'flowpack/behat',
+                        'require' => [
+                            'typo3/flow' => 'dev-master',
+                        ],
+                    ],
+                    'typo3/imagine' => [
+                        'name' => 'typo3/imagine',
+                        'require' => [
+                            'imagine/imagine' => 'dev-master',
+                            'typo3/flow' => 'dev-master',
+                        ],
+                    ],
+                    'typo3/typo3cr' => [
+                        'name' => 'typo3/typo3cr',
+                        'require' => [
+                            'typo3/flow' => 'dev-master',
+                        ],
+                    ],
+                    'typo3/neos' => [
+                        'name' => 'typo3/neos',
+                        'require' => [
+                            'typo3/typo3cr' => 'dev-master',
+                            'typo3/twitter-bootstrap' => 'dev-master',
+                            'typo3/setup' => 'dev-master',
+                            'typo3/typoscript' => 'dev-master',
+                            'typo3/neos-nodetypes' => 'dev-master',
+                            'typo3/media' => 'dev-master',
+                            'typo3/extjs' => 'dev-master',
+                            'typo3/flow' => 'dev-master',
+                        ],
+                    ],
+                    'typo3/setup' => [
+                        'name' => 'typo3/setup',
+                        'require' => [
+                            'typo3/twitter-bootstrap' => 'dev-master',
+                            'typo3/form' => 'dev-master',
+                            'typo3/flow' => 'dev-master',
+                        ],
+                    ],
+                    'typo3/media' => [
+                        'name' => 'typo3/media',
+                        'require' => [
+                            'typo3/imagine' => 'dev-master',
+                            'typo3/flow' => 'dev-master',
+                        ],
+                    ],
+                    'typo3/extjs' => [
+                        'name' => 'typo3/extjs',
+                        'require' => [
+                            'typo3/flow' => 'dev-master',
+                        ],
+                    ],
+                    'typo3/neos-nodetypes' => [
+                        'name' => 'typo3/neos-nodetypes',
+                        'require' => [
+                            'typo3/typoscript' => 'dev-master',
+                            'typo3/flow' => 'dev-master',
+                        ],
+                    ],
+                    'typo3/typoscript' => [
+                        'name' => 'typo3/typoscript',
+                        'require' => [
+                            'typo3/eel' => 'dev-master',
+                            'typo3/flow' => 'dev-master',
+                        ],
+                    ],
+                    'typo3/form' => [
+                        'name' => 'typo3/form',
+                        'require' => [
+                            'typo3/flow' => 'dev-master',
+                        ],
+                    ],
+                    'typo3/twitter-bootstrap' => [
+                        'name' => 'typo3/twitter-bootstrap',
+                        'require' => [
+                            'typo3/flow' => 'dev-master',
+                        ],
+                    ],
+                    'typo3/sitekickstarter' => [
+                        'name' => 'typo3/sitekickstarter',
+                        'require' => [
+                            'typo3/kickstart' => 'dev-master',
+                            'typo3/flow' => 'dev-master',
+                        ],
+                    ],
+                    'imagine/imagine' => [
+                        'name' => 'imagine/imagine',
+                        'require' => [],
+                    ],
+                    'mikey179/vfsstream' => [
+                        'name' => 'mikey179/vfsstream',
+                        'require' => [],
+                    ],
+                    'composer/installers' => [
+                        'name' => 'composer/installers',
+                        'require' => [],
+                    ],
+                    'symfony/console' => [
+                        'name' => 'symfony/console',
+                        'require' => [],
+                    ],
+                    'symfony/domcrawler' => [
+                        'name' => 'symfony/domcrawler',
+                        'require' => [],
+                    ],
+                    'symfony/yaml' => [
+                        'name' => 'symfony/yaml',
+                        'require' => [],
+                    ],
+                    'doctrine/annotations' => [
+                        'name' => 'doctrine/annotations',
+                        'require' => [
+                            'doctrine/lexer' => 'dev-master',
+                        ],
+                    ],
+                    'doctrine/cache' => [
+                        'name' => 'doctrine/cache',
+                        'require' => [],
+                    ],
+                    'doctrine/collections' => [
+                        'name' => 'doctrine/collections',
+                        'require' => [],
+                    ],
+                    'doctrine/common' => [
+                        'name' => 'doctrine/common',
+                        'require' => [
+                            'doctrine/annotations' => 'dev-master',
+                            'doctrine/lexer' => 'dev-master',
+                            'doctrine/collections' => 'dev-master',
+                            'doctrine/cache' => 'dev-master',
+                            'doctrine/inflector' => 'dev-master',
+                        ],
+                    ],
+                    'doctrine/dbal' => [
+                        'name' => 'doctrine/dbal',
+                        'require' => [
+                            'doctrine/common' => 'dev-master',
+                        ],
+                    ],
+                    'doctrine/inflector' => [
+                        'name' => 'doctrine/inflector',
+                        'require' => [],
+                    ],
+                    'doctrine/lexer' => [
+                        'name' => 'doctrine/lexer',
+                        'require' => [],
+                    ],
+                    'doctrine/migrations' => [
+                        'name' => 'doctrine/migrations',
+                        'require' => [
+                            'doctrine/dbal' => 'dev-master',
+                        ],
+                    ],
+                    'doctrine/orm' => [
+                        'name' => 'doctrine/orm',
+                        'require' => [
+                            'symfony/console' => 'dev-master',
+                            'doctrine/dbal' => 'dev-master',
+                        ],
+                    ],
+                    'phpunit/phpcodecoverage' => [
+                        'name' => 'phpunit/phpcodecoverage',
+                        'require' => [
+                            'phpunit/phptexttemplate' => 'dev-master',
+                            'phpunit/phptokenstream' => 'dev-master',
+                            'phpunit/phpfileiterator' => 'dev-master',
+                        ],
+                    ],
+                    'phpunit/phpfileiterator' => [
+                        'name' => 'phpunit/phpfileiterator',
+                        'require' => [],
+                    ],
+                    'phpunit/phptexttemplate' => [
+                        'name' => 'phpunit/phptexttemplate',
+                        'require' => [],
+                    ],
+                    'phpunit/phptimer' => [
+                        'name' => 'phpunit/phptimer',
+                        'require' => [],
+                    ],
+                    'phpunit/phptokenstream' => [
+                        'name' => 'phpunit/phptokenstream',
+                        'require' => [],
+                    ],
+                    'phpunit/phpunitmockobjects' => [
+                        'name' => 'phpunit/phpunitmockobjects',
+                        'require' => [
+                            'phpunit/phptexttemplate' => 'dev-master',
+                        ],
+                    ],
+                    'phpunit/phpunit' => [
+                        'name' => 'phpunit/phpunit',
+                        'require' => [
+                            'symfony/yaml' => 'dev-master',
+                            'phpunit/phpunitmockobjects' => 'dev-master',
+                            'phpunit/phptimer' => 'dev-master',
+                            'phpunit/phpcodecoverage' => 'dev-master',
+                            'phpunit/phptexttemplate' => 'dev-master',
+                            'phpunit/phpfileiterator' => 'dev-master',
+                        ],
+                    ],
+                    'typo3/party' => [
+                        'name' => 'typo3/party',
+                        'require' => [
+                            'typo3/flow' => 'dev-master',
+                        ],
+                    ],
+                    'typo3/flow' => [
+                        'name' => 'typo3/flow',
+                        'require' => [
+                            'composer/installers' => 'dev-master',
+                            'symfony/domcrawler' => 'dev-master',
+                            'symfony/yaml' => 'dev-master',
+                            'doctrine/migrations' => 'dev-master',
+                            'doctrine/orm' => 'dev-master',
+                            'typo3/eel' => 'dev-master',
+                            'typo3/party' => 'dev-master',
+                            'typo3/fluid' => 'dev-master',
+                        ],
+                    ],
+                    'typo3/eel' => [
+                        'name' => 'typo3/eel',
+                        'require' => [
+                            'typo3/flow' => 'dev-master',
+                        ],
+                    ],
+                    'typo3/kickstart' => [
+                        'name' => 'typo3/kickstart',
+                        'require' => [
+                            'typo3/flow' => 'dev-master',
+                        ],
+                    ],
+                    'typo3/fluid' => [
+                        'name' => 'typo3/fluid',
+                        'require' => [
+                            'typo3/flow' => 'dev-master',
+                        ],
+                    ],
+                ],
+                [
+                    'composer/installers',
+                    'symfony/domcrawler',
+                    'symfony/yaml',
+                    'doctrine/lexer',
+                    'doctrine/annotations',
+                    'doctrine/collections',
+                    'doctrine/cache',
+                    'doctrine/inflector',
+                    'doctrine/common',
+                    'doctrine/dbal',
+                    'doctrine/migrations',
+                    'symfony/console',
+                    'doctrine/orm',
+                    'imagine/imagine',
+                    'typo3/eel',
+                    'typo3/party',
+                    'typo3/fluid',
+                    'typo3/flow',
+                    'typo3/form',
+                    'typo3/typoscript',
+                    'typo3/neos-nodetypes',
+                    'typo3/imagine',
+                    'typo3/media',
+                    'typo3/extjs',
+                    'typo3/twitter-bootstrap',
+                    'typo3/setup',
+                    'typo3/typo3cr',
+                    'typo3/neos',
+                    'typo3/neosdemotypo3org',
+                    'flowpack/behat',
+                    'typo3/kickstart',
+                    'typo3/sitekickstarter',
+                    'mikey179/vfsstream',
+                    'phpunit/phptexttemplate',
+                    'phpunit/phptokenstream',
+                    'phpunit/phpfileiterator',
+                    'phpunit/phpcodecoverage',
+                    'phpunit/phptimer',
+                    'phpunit/phpunitmockobjects',
+                    'phpunit/phpunit',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider packagesAndDependenciesOrder
+     * @param array $packages
+     * @param array $expectedPackageOrder
+     */
+    public function availablePackagesAreSortedAfterTheirDependencies($packages, $expectedPackageOrder)
+    {
+        $orderResolver = new PackageOrderResolver($packages, $packages);
+        $sortedPackages = $orderResolver->sort();
+        $this->assertEquals($expectedPackageOrder, array_keys($sortedPackages), 'The packages have not been ordered according to their require!');
+    }
+}

--- a/TYPO3.Flow/Tests/Unit/Package/PackageTest.php
+++ b/TYPO3.Flow/Tests/Unit/Package/PackageTest.php
@@ -11,9 +11,6 @@ namespace TYPO3\Flow\Tests\Unit\Package;
  * source code.
  */
 
-use TYPO3\Flow\Package\Exception\InvalidPackageStateException;
-use TYPO3\Flow\Package\MetaData\PackageConstraint;
-use TYPO3\Flow\Package\MetaDataInterface;
 use TYPO3\Flow\Package\Package;
 use org\bovigo\vfs\vfsStream;
 use TYPO3\Flow\Package\PackageManager;
@@ -42,81 +39,17 @@ class PackageTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \TYPO3\Flow\Package\Exception\InvalidPackageKeyException
-     */
-    public function constructorThrowsInvalidPackageKeyExceptionIfTheSpecifiedPackageKeyIsNotValid()
-    {
-        $packagePath = 'vfs://Packages/Vendor.TestPackage';
-        mkdir($packagePath, 0777, true);
-        new Package($this->mockPackageManager, 'InvalidPackageKey', $packagePath);
-    }
-
-    /**
-     * @test
-     * @expectedException \TYPO3\Flow\Package\Exception\InvalidPackagePathException
-     */
-    public function constructorThrowsInvalidPackagePathExceptionIfTheSpecifiedPackagePathDoesNotExist()
-    {
-        new Package($this->mockPackageManager, 'Vendor.TestPackage', './ThisPackageSurelyDoesNotExist');
-    }
-
-    /**
-     * @test
-     * @expectedException \TYPO3\Flow\Package\Exception\InvalidPackagePathException
-     */
-    public function constructorThrowsInvalidPackagePathExceptionIfTheSpecifiedPackagePathDoesHaveATrailingSlash()
-    {
-        $packagePath = 'vfs://Packages/Vendor.TestPackage';
-        mkdir($packagePath, 0777, true);
-        new Package($this->mockPackageManager, 'Vendor.TestPackage', $packagePath);
-    }
-
-    /**
-     * @test
-     * @expectedException \TYPO3\Flow\Package\Exception\InvalidPackagePathException
-     */
-    public function constructorThrowsInvalidPackagePathExceptionIfTheSpecifiedClassesPathHasALeadingSlash()
-    {
-        $packagePath = 'vfs://Packages/Vendor.TestPackage/';
-        mkdir($packagePath, 0777, true);
-        new Package($this->mockPackageManager, 'Vendor.TestPackage', $packagePath, '/tmp');
-    }
-
-    /**
-     * @test
-     * @expectedException \TYPO3\Flow\Package\Exception\InvalidPackageManifestException
-     */
-    public function constructorThrowsInvalidPackageManifestExceptionIfNoComposerManifestWasFound()
-    {
-        $packagePath = 'vfs://Packages/Vendor.TestPackage/';
-        mkdir($packagePath, 0777, true);
-        new Package($this->mockPackageManager, 'Vendor.TestPackage', $packagePath);
-    }
-
-    /**
-     * @test
-     */
-    public function constructorSetsTheClassesPathAsSpecifiedIfNoPsrMappingExists()
-    {
-        $packagePath = 'vfs://Packages/Vendor.TestPackage/';
-        mkdir($packagePath, 0777, true);
-        file_put_contents($packagePath . 'composer.json', '{"name": "vendor/testpackage", "type": "flow-test"}');
-
-        $package = new Package($this->mockPackageManager, 'Vendor.TestPackage', $packagePath, 'Some/Classes/Path');
-        $this->assertSame('vfs://Packages/Vendor.TestPackage/Some/Classes/Path/', $package->getClassesPath());
-    }
-
-    /**
-     * @test
      */
     public function constructorSetsTheClassesPathAccordingToThePsr0MappingIfItExists()
     {
-        $packagePath = 'vfs://Packages/Vendor.TestPsr0Package/';
+        $packagePath = 'vfs://Packages/Vendor.TestPackage/';
         mkdir($packagePath, 0777, true);
-        file_put_contents($packagePath . 'composer.json', '{"name": "vendor/testpackage", "type": "flow-test", "autoload": { "psr-0": { "Psr0Namespace": "Psr0/Path" }, "psr-4": { "Psr4Namespace": "Psr4/Path" } }}');
+        $rawComposerManifest = '{"name": "vendor/testpackage", "type": "flow-test", "autoload": { "psr-0": { "Psr0Namespace": "Psr0/Path" }, "psr-4": { "Psr4Namespace": "Psr4/Path" } }}';
+        $composerManifest = json_decode($rawComposerManifest, true);
+        file_put_contents($packagePath . 'composer.json', $rawComposerManifest);
 
-        $package = new Package($this->mockPackageManager, 'Vendor.TestPsr0Package', $packagePath, 'Some/Classes/Path');
-        $this->assertSame('vfs://Packages/Vendor.TestPsr0Package/Psr0/Path/', $package->getClassesPath());
+        $package = new Package('Vendor.TestPackage', 'vendor/testpackage', $packagePath, $composerManifest['autoload']);
+        $this->assertSame('vfs://Packages/Vendor.TestPackage/Psr0/Path', $package->getClassesPath());
     }
 
     /**
@@ -124,12 +57,14 @@ class PackageTest extends UnitTestCase
      */
     public function constructorSetsTheClassesPathAccordingToThePsr4MappingIfItExists()
     {
-        $packagePath = 'vfs://Packages/Vendor.TestPsr4Package/';
+        $packagePath = 'vfs://Packages/Vendor.TestPackage/';
         mkdir($packagePath, 0777, true);
-        file_put_contents($packagePath . 'composer.json', '{"name": "vendor/testpackage", "type": "flow-test", "autoload": { "psr-4": { "Psr4Namespace": "Psr4/Path" } }}');
+        $rawComposerManifest = '{"name": "vendor/testpackage", "type": "flow-test", "autoload": { "psr-4": { "Psr4Namespace": "Psr4/Path" } }}';
+        $composerManifest = json_decode($rawComposerManifest, true);
+        file_put_contents($packagePath . 'composer.json', $rawComposerManifest);
 
-        $package = new Package($this->mockPackageManager, 'Vendor.TestPsr4Package', $packagePath, 'Some/Classes/Path');
-        $this->assertSame('vfs://Packages/Vendor.TestPsr4Package/Psr4/Path/', $package->getClassesPath());
+        $package = new Package('Vendor.TestPackage', 'vendor/testpackage', $packagePath, $composerManifest['autoload']);
+        $this->assertSame('vfs://Packages/Vendor.TestPackage/Psr4/Path', $package->getClassesPath());
     }
 
     /**
@@ -137,62 +72,14 @@ class PackageTest extends UnitTestCase
      */
     public function constructorSetsTheClassesPathToFirstConfiguredPsr0Mapping()
     {
-        $packagePath = 'vfs://Packages/Vendor.TestMappedPsr0Package/';
+        $packagePath = 'vfs://Packages/Vendor.TestPackage/';
         mkdir($packagePath, 0777, true);
-        file_put_contents($packagePath . 'composer.json', '{"name": "vendor/testpackage", "type": "flow-test", "autoload": { "psr-0": { "Psr0Namespace": ["Psr0/Path", "Psr0/Foo"] } }}');
+        $rawComposerManifest = '{"name": "vendor/testpackage", "type": "flow-test", "autoload": { "psr-0": { "Psr0Namespace": ["Psr0/Path", "Psr0/Foo"] } }}';
+        $composerManifest = json_decode($rawComposerManifest, true);
+        file_put_contents($packagePath . 'composer.json', $rawComposerManifest);
 
-        $package = new Package($this->mockPackageManager, 'Vendor.TestMappedPsr0Package', $packagePath, 'Some/Classes/Path');
-        $this->assertSame('vfs://Packages/Vendor.TestMappedPsr0Package/Psr0/Path/', $package->getClassesPath());
-    }
-
-    /**
-     */
-    public function validPackageKeys()
-    {
-        return array(
-            array('Doctrine.DBAL'),
-            array('TYPO3.Flow'),
-            array('RobertLemke.Flow.Twitter'),
-            array('Sumphonos.Stem'),
-            array('Schalke04.Soccer.MagicTrainer')
-        );
-    }
-
-    /**
-     * @test
-     * @dataProvider validPackageKeys
-     */
-    public function constructAcceptsValidPackageKeys($packageKey)
-    {
-        $packagePath = 'vfs://Packages/' . str_replace('\\', '/', $packageKey) . '/';
-        mkdir($packagePath, 0777, true);
-        file_put_contents($packagePath . 'composer.json', '{"name": "' . $packageKey . '", "type": "flow-test"}');
-
-        $package = new Package($this->mockPackageManager, $packageKey, $packagePath);
-        $this->assertEquals($packageKey, $package->getPackageKey());
-    }
-
-    /**
-     */
-    public function invalidPackageKeys()
-    {
-        return array(
-            array('TYPO3..Flow'),
-            array('RobertLemke.Flow. Twitter'),
-            array('Schalke*4')
-        );
-    }
-
-    /**
-     * @test
-     * @dataProvider invalidPackageKeys
-     * @expectedException \TYPO3\Flow\Package\Exception\InvalidPackageKeyException
-     */
-    public function constructRejectsInvalidPackageKeys($packageKey)
-    {
-        $packagePath = 'vfs://Packages/' . str_replace('\\', '/', $packageKey) . '/';
-        mkdir($packagePath, 0777, true);
-        new Package($this->mockPackageManager, $packageKey, $packagePath);
+        $package = new Package('Vendor.TestPackage', 'vendor/testpackage', $packagePath, $composerManifest['autoload']);
+        $this->assertSame('vfs://Packages/Vendor.TestPackage/Psr0/Path', $package->getClassesPath());
     }
 
     /**
@@ -200,10 +87,13 @@ class PackageTest extends UnitTestCase
      */
     public function getNamespaceReturnsThePsr0NamespaceIfAPsr0MappingIsDefined()
     {
-        $packagePath = 'vfs://Packages/Application/Acme.MyPsr0Package/';
+        $packagePath = 'vfs://Packages/Application/Acme.MyPackage/';
         mkdir($packagePath, 0777, true);
-        file_put_contents($packagePath . 'composer.json', '{"name": "acme/mypackage", "type": "flow-test", "autoload": { "psr-0": { "Namespace1": "path1" }, "psr-4": { "Namespace2": "path2" } }}');
-        $package = new Package($this->mockPackageManager, 'Acme.MyPsr0Package', $packagePath);
+        $rawComposerManifest = '{"name": "acme/mypackage", "type": "flow-test", "autoload": { "psr-0": { "Namespace1": "path1" }, "psr-4": { "Namespace2": "path2" } }}';
+        $composerManifest = json_decode($rawComposerManifest, true);
+        file_put_contents($packagePath . 'composer.json', $rawComposerManifest);
+
+        $package = new Package('Acme.MyPackage', 'acme/mypackage', $packagePath, $composerManifest['autoload']);
         $this->assertEquals('Namespace1', $package->getNamespace());
     }
 
@@ -212,10 +102,12 @@ class PackageTest extends UnitTestCase
      */
     public function getNamespaceReturnsTheFirstPsr0NamespaceIfMultiplePsr0MappingsAreDefined()
     {
-        $packagePath = 'vfs://Packages/Application/Acme.MyMultiplePsr0Package/';
+        $packagePath = 'vfs://Packages/Application/Acme.MyPackage4123/';
         mkdir($packagePath, 0777, true);
-        file_put_contents($packagePath . 'composer.json', '{"name": "acme/mypackage", "type": "flow-test", "autoload": { "psr-0": { "Namespace1": "path2", "Namespace2": "path2" } }}');
-        $package = new Package($this->mockPackageManager, 'Acme.MyMultiplePsr0Package', $packagePath);
+        $rawComposerManifest = '{"name": "acme/mypackage4123", "type": "flow-test", "autoload": { "psr-0": { "Namespace1": "path2", "Namespace2": "path2" } }}';
+        $composerManifest = json_decode($rawComposerManifest, true);
+        file_put_contents($packagePath . 'composer.json', $rawComposerManifest);
+        $package = new Package('Acme.MyPackage4123', 'acme/mypackage4123', $packagePath, $composerManifest['autoload']);
         $this->assertEquals('Namespace1', $package->getNamespace());
     }
 
@@ -224,10 +116,12 @@ class PackageTest extends UnitTestCase
      */
     public function getNamespaceReturnsPsr4NamespaceIfNoPsr0MappingIsDefined()
     {
-        $packagePath = 'vfs://Packages/Application/Acme.MyPsr4Package/';
+        $packagePath = 'vfs://Packages/Application/Acme.MyPackage3412/';
         mkdir($packagePath, 0777, true);
-        file_put_contents($packagePath . 'composer.json', '{"name": "acme/mypackage", "type": "flow-test", "autoload": { "psr-4": { "Namespace2": "path2" } }}');
-        $package = new Package($this->mockPackageManager, 'Acme.MyPsr4Package', $packagePath);
+        $rawComposerManifest = '{"name": "acme/mypackage3412", "type": "flow-test", "autoload": { "psr-4": { "Namespace2": "path2" } }}';
+        $composerManifest = json_decode($rawComposerManifest, true);
+        file_put_contents($packagePath . 'composer.json', $rawComposerManifest);
+        $package = new Package('Acme.MyPackage3412', 'acme/mypackage3412', $packagePath, $composerManifest['autoload']);
         $this->assertEquals('Namespace2', $package->getNamespace());
     }
 
@@ -236,23 +130,13 @@ class PackageTest extends UnitTestCase
      */
     public function getNamespaceReturnsTheFirstPsr4NamespaceIfMultiplePsr4MappingsAreDefined()
     {
-        $packagePath = 'vfs://Packages/Application/Acme.MyMultiplePsr4Package/';
+        $packagePath = 'vfs://Packages/Application/Acme.MyPackage2341/';
         mkdir($packagePath, 0777, true);
-        file_put_contents($packagePath . 'composer.json', '{"name": "acme/mypackage", "type": "flow-test", "autoload": { "psr-4": { "Namespace2": "path2", "Namespace3": "path3" } }}');
-        $package = new Package($this->mockPackageManager, 'Acme.MyMultiplePsr4Package', $packagePath);
+        $rawComposerManifest = '{"name": "acme/mypackage2341", "type": "flow-test", "autoload": { "psr-4": { "Namespace2": "path2", "Namespace3": "path3" } }}';
+        $composerManifest = json_decode($rawComposerManifest, true);
+        file_put_contents($packagePath . 'composer.json', $rawComposerManifest);
+        $package = new Package('Acme.MyPackage2341', 'acme/mypackage2341', $packagePath, $composerManifest['autoload']);
         $this->assertEquals('Namespace2', $package->getNamespace());
-    }
-
-    /**
-     * @test
-     */
-    public function getNamespaceReturnsThePhpNamespaceCorrespondingToThePackageKeyIfNoPsrMappingIsDefined()
-    {
-        $packagePath = 'vfs://Packages/Application/Acme.MyPackage/';
-        mkdir($packagePath, 0777, true);
-        file_put_contents($packagePath . 'composer.json', '{"name": "acme/mypackage", "type": "flow-test"}');
-        $package = new Package($this->mockPackageManager, 'Acme.MyPackage', $packagePath);
-        $this->assertEquals('Acme\\MyPackage', $package->getNamespace());
     }
 
     /**
@@ -281,7 +165,7 @@ class PackageTest extends UnitTestCase
      */
     public function getClassesPathReturnsPathToClasses()
     {
-        $package = new Package($this->mockPackageManager, 'TYPO3.Flow', FLOW_PATH_FLOW, Package::DIRECTORY_CLASSES);
+        $package = new Package('TYPO3.Flow', 'typo3/flow', FLOW_PATH_FLOW, ['psr-0' => ['TYPO3\\Flow' => 'Classes/']]);
         $packageClassesPath = $package->getClassesPath();
         $expected = $package->getPackagePath() . Package::DIRECTORY_CLASSES;
         $this->assertEquals($expected, $packageClassesPath);
@@ -294,9 +178,11 @@ class PackageTest extends UnitTestCase
     {
         $packagePath = 'vfs://Packages/Application/Acme/MyPackage/';
         mkdir($packagePath, 0777, true);
-        file_put_contents($packagePath . 'composer.json', '{"name": "acme/mypackage", "type": "flow-test"}');
+        $rawComposerManifest = '{"name": "acme/mypackage", "type": "flow-test", "autoload": {"psr-0": {"Acme\\\\MyPackage": "no/trailing/slash/"}}}';
+        $composerManifest = json_decode($rawComposerManifest, true);
+        file_put_contents($packagePath . 'composer.json', $rawComposerManifest);
 
-        $package = new Package($this->mockPackageManager, 'Acme.MyPackage', $packagePath, 'no/trailing/slash');
+        $package = new Package('Acme.MyPackage', 'acme/mypackage', $packagePath, $composerManifest['autoload']);
 
         $packageClassesPath = $package->getClassesPath();
         $expected = $package->getPackagePath() . 'no/trailing/slash/';
@@ -314,7 +200,7 @@ class PackageTest extends UnitTestCase
         $packagePath = vfsStream::url('testDirectory') . '/';
         file_put_contents($packagePath . 'composer.json', '{"name": "typo3/flow", "type": "flow-test"}');
 
-        $package = new Package($this->mockPackageManager, 'TYPO3.Flow', $packagePath);
+        $package = new Package('TYPO3.Flow', 'typo3/flow', $packagePath);
         $documentations = $package->getPackageDocumentations();
 
         $this->assertEquals(array(), $documentations);
@@ -328,7 +214,7 @@ class PackageTest extends UnitTestCase
         $packagePath = 'vfs://Packages/Application/Vendor/Dummy/';
         mkdir($packagePath, 0700, true);
         file_put_contents($packagePath . 'composer.json', '{"name": "vendor/dummy", "type": "flow-test"}');
-        $package = new Package($this->mockPackageManager, 'Vendor.Dummy', $packagePath);
+        $package = new Package('Vendor.Dummy', 'vendor/dummy', $packagePath);
 
         $this->assertFalse($package->isProtected());
         $package->setProtected(true);
@@ -343,7 +229,7 @@ class PackageTest extends UnitTestCase
         $packagePath = 'vfs://Packages/Application/Vendor/Dummy/';
         mkdir($packagePath, 0700, true);
         file_put_contents($packagePath . 'composer.json', '{"name": "vendor/dummy", "type": "typo3-flow-test"}');
-        $package = new Package($this->mockPackageManager, 'Vendor.Dummy', $packagePath);
+        $package = new Package('Vendor.Dummy', 'vendor/dummy', $packagePath);
 
         $this->assertTrue($package->isObjectManagementEnabled());
     }
@@ -355,7 +241,9 @@ class PackageTest extends UnitTestCase
     {
         $packagePath = 'vfs://Packages/Application/Acme.MyPackage/';
         mkdir($packagePath, 0777, true);
-        file_put_contents($packagePath . 'composer.json', '{"name": "acme/mypackage", "type": "flow-test"}');
+        $rawComposerManifest = '{"name": "acme/mypackage", "type": "flow-test", "autoload": {"psr-0": {"Acme\\\\MyPackage": "Classes/"}}}';
+        $composerManifest = json_decode($rawComposerManifest, true);
+        file_put_contents($packagePath . 'composer.json', $rawComposerManifest);
 
         mkdir($packagePath . 'Classes/Acme/MyPackage/Controller', 0770, true);
         mkdir($packagePath . 'Classes/Acme/MyPackage/Domain/Model', 0770, true);
@@ -365,15 +253,16 @@ class PackageTest extends UnitTestCase
         file_put_contents($packagePath . 'Classes/Acme/MyPackage/Domain/Model/Bar.php', '');
 
         $expectedClassFilesArray = array(
-            'Acme\MyPackage\Controller\FooController' => 'Classes/Acme/MyPackage/Controller/FooController.php',
-            'Acme\MyPackage\Domain\Model\Foo' => 'Classes/Acme/MyPackage/Domain/Model/Foo.php',
-            'Acme\MyPackage\Domain\Model\Bar' => 'Classes/Acme/MyPackage/Domain/Model/Bar.php',
+            'Acme\MyPackage\Controller\FooController' => $packagePath .'Classes/Acme/MyPackage/Controller/FooController.php',
+            'Acme\MyPackage\Domain\Model\Foo' => $packagePath .'Classes/Acme/MyPackage/Domain/Model/Foo.php',
+            'Acme\MyPackage\Domain\Model\Bar' => $packagePath . 'Classes/Acme/MyPackage/Domain/Model/Bar.php',
         );
 
-        $package = new Package($this->mockPackageManager, 'Acme.MyPackage', $packagePath, 'Classes');
-        $actualClassFilesArray = $package->getClassFiles();
-
-        $this->assertEquals($expectedClassFilesArray, $actualClassFilesArray);
+        $package = new Package('Acme.MyPackage', 'acme/mypackage', $packagePath, $composerManifest['autoload']);
+        foreach ($package->getClassFiles() as $className => $classPath) {
+            $this->assertArrayHasKey($className, $expectedClassFilesArray);
+            $this->assertEquals($expectedClassFilesArray[$className], $classPath);
+        }
     }
 
     /**
@@ -385,7 +274,7 @@ class PackageTest extends UnitTestCase
         mkdir($packagePath, 0777, true);
         file_put_contents($packagePath . 'composer.json', '{"name": "acme/mypackage", "type": "flow-test"}');
 
-        $package = new Package($this->getMock(\TYPO3\Flow\Package\PackageManager::class), 'Acme.MyPackage', $packagePath, 'Classes');
+        $package = new Package('Acme.MyPackage', 'acme/mypackage', $packagePath, ['psr-0' => ['acme\\MyPackage' => 'Classes/']]);
 
         $metaData = $package->getPackageMetaData();
         $this->assertEquals('flow-test', $metaData->getPackageType());
@@ -393,42 +282,13 @@ class PackageTest extends UnitTestCase
 
     /**
      * @test
+     * @expectedException \TYPO3\Flow\Composer\Exception\MissingPackageManifestException
      */
-    public function getPackageMetaDataAddsRequiredPackagesAsConstraint()
+    public function throwExceptionWhenSpecifyingAPathWithMissingComposerManifest()
     {
-        $packagePath = 'vfs://Packages/Application/Acme.MyMetaDataTestPackage/';
+        $packagePath = 'vfs://Packages/Some/Path/Some.Package/';
         mkdir($packagePath, 0777, true);
-        file_put_contents($packagePath . 'composer.json', '{"name": "acme/mypackage", "type": "flow-test", "require": { "some/other/package": "*" }}');
-
-        $mockPackageManager = $this->getMockBuilder(PackageManager::class)->disableOriginalConstructor()->getMock();
-        $mockPackageManager->expects($this->once())->method('getPackageKeyFromComposerName')->with('some/other/package')->will($this->returnValue('Some.Other.Package'));
-
-        $package = new Package($mockPackageManager, 'Acme.MyMetaDataTestPackage', $packagePath, 'Classes');
-        $metaData = $package->getPackageMetaData();
-        $packageConstraints = $metaData->getConstraintsByType(MetaDataInterface::CONSTRAINT_TYPE_DEPENDS);
-
-        $this->assertCount(1, $packageConstraints);
-
-        $expectedConstraint = new PackageConstraint(MetaDataInterface::CONSTRAINT_TYPE_DEPENDS, 'Some.Other.Package');
-        $this->assertEquals($expectedConstraint, $packageConstraints[0]);
-    }
-
-    /**
-     * @test
-     */
-    public function getPackageMetaDataIgnoresUnresolvableConstraints()
-    {
-        $packagePath = 'vfs://Packages/Application/Acme.MyUnresolvableConstraintsTestPackage/';
-        mkdir($packagePath, 0777, true);
-        file_put_contents($packagePath . 'composer.json', '{"name": "acme/mypackage", "type": "flow-test", "require": { "non/existing/package": "*" }}');
-
-        $mockPackageManager = $this->getMockBuilder(PackageManager::class)->disableOriginalConstructor()->getMock();
-        $mockPackageManager->expects($this->once())->method('getPackageKeyFromComposerName')->with('non/existing/package')->will($this->throwException(new InvalidPackageStateException()));
-
-        $package = new Package($mockPackageManager, 'Acme.MyUnresolvableConstraintsTestPackage', $packagePath, 'Classes');
-        $metaData = $package->getPackageMetaData();
-        $packageConstraints = $metaData->getConstraintsByType(MetaDataInterface::CONSTRAINT_TYPE_DEPENDS);
-
-        $this->assertCount(0, $packageConstraints);
+        $package = new Package('Some.Package', 'some/package', 'vfs://Packages/Some/Path/Some.Package/', []);
+        $package->getComposerManifest();
     }
 }


### PR DESCRIPTION
This is a major refactoring of the package management.
With this change the structure of the ``PackageStates`` file
is overhauled now using the composer key for consistency to
avoid problems if namespace or autoload information changes
as that would change the (Flow) package key.

Additionally makes the resolution mechanism for Flow package
keys more robust and stores additional metadata in the
``PackageStates.php`` to avoid loading all composer manifests
at runtime.
Furthermore the package loading order generation was improved by
using a more sophisticated algorithm to get the order right.

All the changes together lead to a noticeable speed improvement
in runtime situations.

Deactivating packages now results in the package being moved out
of regular package paths into an ``Inactive`` directory.

This change is marked breaking due to the following:

New packages are only automatically picked up if they were
installed via composer or created through the Flow package
management. In all other cases you need to run the:
``package:rescan`` command to pick new package up.

Some @api classes and methods were deprecated and will be removed
or changed in the next major Flow version.

Some newly added methods of PackageManager and Package are used
in the Flow core now, so if someone would reimplement both
according to interface it would not work with Flow, but that
is already the case without this change, so it shouldn't be an issue.

The whole MetaData part of the package management is no longer
used and will be removed in the next major version.