### PR TITLE
[BUGFIX] Refresh first level roles cache on authentication

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Cache/Backend/SimpleFileBackend.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Cache/Backend/SimpleFileBackend.php
@@ -131,7 +131,7 @@ class SimpleFileBackend extends AbstractBackend implements PhpCapableBackendInte
         $this->cacheEntryFileExtension = ($cache instanceof PhpFrontend) ? '.php' : '';
 
         if ((strlen($this->cacheDirectory) + 23) > $this->environment->getMaximumPathLength()) {
-            throw new \TYPO3\Flow\Cache\Exception('The length of the temporary cache path "' . $this->cacheDirectory . '" exceeds the maximum path length of ' . ($this->environment->getMaximumPathLength() - 23) . '. Please consider setting the temporaryDirectoryBase option to a shorter path. ', 1248710426);
+            throw new \TYPO3\Flow\Cache\Exception('The length of the temporary cache path "' . $this->cacheDirectory . '" exceeds the maximum path length of ' . ($this->environment->getMaximumPathLength() - 23) . '. Please consider setting the FLOW_PATH_TEMPORARY_BASE environment variable to a shorter path. ', 1248710426);
         }
     }
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/CoreCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/CoreCommandController.php
@@ -362,7 +362,7 @@ class CoreCommandController extends CommandController
      */
     protected function launchSubProcess()
     {
-        $systemCommand = 'FLOW_ROOTPATH=' . FLOW_PATH_ROOT . ' ' . 'FLOW_CONTEXT=' . $this->bootstrap->getContext() . ' ' . PHP_BINDIR . '/php -c ' . php_ini_loaded_file() . ' ' . FLOW_PATH_FLOW . 'Scripts/flow.php' . ' --start-slave';
+        $systemCommand = 'FLOW_ROOTPATH=' . FLOW_PATH_ROOT . ' FLOW_PATH_TEMPORARY_BASE=' . FLOW_PATH_TEMPORARY_BASE . ' ' . 'FLOW_CONTEXT=' . $this->bootstrap->getContext() . ' ' . PHP_BINDIR . '/php -c ' . php_ini_loaded_file() . ' ' . FLOW_PATH_FLOW . 'Scripts/flow.php' . ' --start-slave';
         $descriptorSpecification = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'a'));
         $subProcess = proc_open($systemCommand, $descriptorSpecification, $pipes);
         if (!is_resource($subProcess)) {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
@@ -148,6 +148,7 @@ class Scripts
      *
      * @param Bootstrap $bootstrap
      * @return void
+     * @throws \TYPO3\Flow\Exception
      */
     public static function initializeConfiguration(Bootstrap $bootstrap)
     {
@@ -162,7 +163,15 @@ class Scripts
         $settings = $configurationManager->getConfiguration(\TYPO3\Flow\Configuration\ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow');
 
         $environment = new \TYPO3\Flow\Utility\Environment($context);
-        $environment->setTemporaryDirectoryBase($settings['utility']['environment']['temporaryDirectoryBase']);
+        if (isset($settings['utility']['environment']['temporaryDirectoryBase'])) {
+            $defaultTemporaryDirectoryBase = FLOW_PATH_DATA . '/Temporary';
+            if (FLOW_PATH_TEMPORARY_BASE !== $defaultTemporaryDirectoryBase) {
+                throw new \TYPO3\Flow\Exception(sprintf('It seems like the PHP default temporary base path has been changed from "%s" to "%s" via the FLOW_PATH_TEMPORARY_BASE environment variable. If that variable is present, the TYPO3.Flow.utility.environment.temporaryDirectoryBase setting must not be specified!', $defaultTemporaryDirectoryBase, FLOW_PATH_TEMPORARY_BASE), 1447707261);
+            }
+            $environment->setTemporaryDirectoryBase($settings['utility']['environment']['temporaryDirectoryBase']);
+        } else {
+            $environment->setTemporaryDirectoryBase(FLOW_PATH_TEMPORARY_BASE);
+        }
 
         $configurationManager->injectEnvironment($environment);
         $packageManager->injectSettings($settings);
@@ -601,6 +610,7 @@ class Scripts
     {
         $subRequestEnvironmentVariables = array(
             'FLOW_ROOTPATH' => FLOW_PATH_ROOT,
+            'FLOW_PATH_TEMPORARY_BASE' => FLOW_PATH_TEMPORARY_BASE,
             'FLOW_CONTEXT' => $settings['core']['context']
         );
         if (isset($settings['core']['subRequestEnvironmentVariables'])) {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Bootstrap.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Bootstrap.php
@@ -90,11 +90,11 @@ class Bootstrap
      */
     public function __construct($context)
     {
-        $this->defineConstants();
-        $this->ensureRequiredEnvironment();
-
         $this->context = new ApplicationContext($context);
         $this->earlyInstances[__CLASS__] = $this;
+
+        $this->defineConstants();
+        $this->ensureRequiredEnvironment();
     }
 
     /**
@@ -533,6 +533,12 @@ class Bootstrap
         define('FLOW_PATH_DATA', FLOW_PATH_ROOT . 'Data/');
         define('FLOW_PATH_PACKAGES', FLOW_PATH_ROOT . 'Packages/');
 
+        if (!defined('FLOW_PATH_TEMPORARY_BASE')) {
+            define('FLOW_PATH_TEMPORARY_BASE', self::getEnvironmentConfigurationSetting('FLOW_PATH_TEMPORARY_BASE') ?: FLOW_PATH_DATA . '/Temporary');
+            $temporaryDirectoryPath = Files::concatenatePaths(array(FLOW_PATH_TEMPORARY_BASE, str_replace('/', '/SubContext', (string)$this->context))) . '/';
+            define('FLOW_PATH_TEMPORARY', $temporaryDirectoryPath);
+        }
+
         define('FLOW_VERSION_BRANCH', '3.0');
     }
 
@@ -583,6 +589,15 @@ class Bootstrap
                 echo('Flow could not create the directory "' . FLOW_PATH_DATA . 'Persistent". Please check the file permissions manually or run "sudo ./flow flow:core:setfilepermissions" to fix the problem. (Error #1347526553)');
                 exit(1);
             }
+        }
+        if (!is_dir(FLOW_PATH_TEMPORARY) && !is_link(FLOW_PATH_TEMPORARY)) {
+            // We can't use Files::createDirectoryRecursively() because mkdir() without shutup operator will lead to a PHP warning
+            $oldMask = umask(000);
+            if (!@mkdir(FLOW_PATH_TEMPORARY, 0777, true)) {
+                echo('Flow could not create the directory "' . FLOW_PATH_TEMPORARY . '". Please check the file permissions manually or run "sudo ./flow flow:core:setfilepermissions" to fix the problem. (Error #1441354578)');
+                exit(1);
+            }
+            umask($oldMask);
         }
     }
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/ClassLoader.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/ClassLoader.php
@@ -440,7 +440,10 @@ class ClassLoader
         }
 
         if ($context !== null) {
-            $this->initializeAvailableProxyClasses($context);
+            $proxyClasses = @include(FLOW_PATH_TEMPORARY . 'AvailableProxyClasses.php');
+            if ($proxyClasses !== false) {
+                $this->availableProxyClasses = $proxyClasses;
+            }
         }
     }
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/LockManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/LockManager.php
@@ -64,7 +64,7 @@ class LockManager
      */
     protected function getLockPath()
     {
-        return rtrim(sys_get_temp_dir(), '/') . '/';
+        return FLOW_PATH_TEMPORARY;
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Authentication/AuthenticationProviderManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Authentication/AuthenticationProviderManager.php
@@ -191,6 +191,7 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
                 }
                 if ($this->securityContext->getAuthenticationStrategy() === Context::AUTHENTICATE_ONE_TOKEN) {
                     $this->isAuthenticated = true;
+                    $this->securityContext->refreshRoles();
                     return;
                 }
                 $anyTokenAuthenticated = true;
@@ -206,6 +207,7 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
         }
 
         $this->isAuthenticated = $anyTokenAuthenticated;
+        $this->securityContext->refreshRoles();
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Context.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Context.php
@@ -789,6 +789,7 @@ class Context
     public function refreshRoles()
     {
         $this->roles = null;
+        $this->contextHash = null;
         $this->getRoles();
     }
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Context.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Context.php
@@ -781,6 +781,18 @@ class Context
     }
 
     /**
+     * Refreshes the currently effective roles. In fact the roles first level cache
+     * is reset and the effective roles get recalculated by calling getRoles().
+     *
+     * @return void
+     */
+    public function refreshRoles()
+    {
+        $this->roles = null;
+        $this->getRoles();
+    }
+
+    /**
      * Shut the object down
      *
      * @return void

--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -575,14 +575,6 @@ TYPO3:
         domain: NULL
 
     utility:
-      environment:
-
-        # Defines the base directory which Flow may use for storing different kinds
-        # of temporary files.
-        # The directory must be writable and Flow will automatically create a sub
-        # directory (named after the context) which will contain the actual temporary files.
-        temporaryDirectoryBase: '%FLOW_PATH_DATA%Temporary/'
-
       lockStrategyClassName: 'TYPO3\Flow\Utility\Lock\FlockLockStrategy'
 
   # DocTools is a tool used by Flow Developers to help with a variety of documentation tasks.

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/Configuration.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/Configuration.rst
@@ -95,15 +95,16 @@ in the `Reference Manual <http://flowframework.readthedocs.org/en/stable/>`_.
 
 	To avoid errors you should change the cache configuration so it points to a
 	location with a very short absolute file path, for example ``C:\\tmp\\``.
-	Do that by adding the following to the file ``Configuration/Settings.yaml``:
+	Do that by setting the ``FLOW_PATH_TEMPORARY_BASE`` environment variable -
+	For example in the virtual host part of your Apache configuration:
 
-	*Configuration/Settings.yaml*:
+	*httpd.conf*:
 
-	.. code-block:: yaml
+	.. code-block:: none
 
-		utility:
-		  environment:
-		    temporaryDirectoryBase: 'C\\:tmp\\'
+		<VirtualHost ...>
+			SetEnv FLOW_PATH_TEMPORARY_BASE "C\\:tmp\\"
+		</VirtualHost>
 
 .. important::
 	Parsing the YAML configuration files takes a bit of time which remarkably

--- a/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.utility.schema.yaml
+++ b/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.utility.schema.yaml
@@ -1,12 +1,6 @@
 type: dictionary
 additionalProperties: FALSE
 properties:
-  'environment':
-    type: dictionary
-    required: TRUE
-    additionalProperties: FALSE
-    properties:
-      'temporaryDirectoryBase': { type: string, required: TRUE }
   'lockStrategyClassName':
     type: string
     required: TRUE

--- a/TYPO3.Flow/Tests/Behavior/Features/Bootstrap/SubProcess/SubProcess.php
+++ b/TYPO3.Flow/Tests/Behavior/Features/Bootstrap/SubProcess/SubProcess.php
@@ -86,7 +86,7 @@ class SubProcess
      */
     protected function launchSubProcess()
     {
-        $systemCommand = 'FLOW_ROOTPATH=' . escapeshellarg(FLOW_PATH_ROOT) . ' FLOW_CONTEXT=' . (string)$this->context . ' ' . PHP_BINDIR . '/php -c ' . escapeshellarg(php_ini_loaded_file()) . ' ' . escapeshellarg(FLOW_PATH_FLOW . 'Scripts/flow.php') . ' --start-slave';
+        $systemCommand = 'FLOW_ROOTPATH=' . FLOW_PATH_ROOT . ' FLOW_PATH_TEMPORARY_BASE=' . escapeshellarg(FLOW_PATH_TEMPORARY_BASE) . ' FLOW_CONTEXT=' . (string)$this->context . ' ' . PHP_BINDIR . '/php -c ' . php_ini_loaded_file() . ' ' . FLOW_PATH_FLOW . 'Scripts/flow.php' . ' --start-slave';
         $descriptorSpecification = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'a'));
         $this->subProcess = proc_open($systemCommand, $descriptorSpecification, $this->pipes);
         if (!is_resource($this->subProcess)) {

--- a/TYPO3.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderManagerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderManagerTest.php
@@ -88,7 +88,7 @@ class AuthenticationProviderManagerTest extends UnitTestCase
         $account = new Account();
         $account->setAccountIdentifier('admin');
 
-        $securityContext = $this->getMock('TYPO3\Flow\Security\Context', array('getAuthenticationStrategy', 'getAuthenticationTokens', 'refreshTokens'), array(), '', false);
+        $securityContext = $this->getMock('TYPO3\Flow\Security\Context', array('getAuthenticationStrategy', 'getAuthenticationTokens', 'refreshTokens', 'refreshRoles'), array(), '', false);
 
         $token = $this->getMock('TYPO3\Flow\Security\Authentication\TokenInterface');
         $token->expects($this->any())->method('getAccount')->will($this->returnValue($account));


### PR DESCRIPTION
As soon as an authentication process completes, roles might
have changed. Therefore we have to reinitialize the roles
first level cache in the security context.

Fixes: FLOW-415