### PR TITLE
TASK: Add support for X-Original-Host HTTP header

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Request.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Request.php
@@ -89,7 +89,11 @@ class Request extends AbstractMessage
         } else {
             $protocol = isset($server['SSL_SESSION_ID']) || (isset($server['HTTPS']) && ($server['HTTPS'] === 'on' || strcmp($server['HTTPS'], '1') === 0)) ? 'https' : 'http';
         }
-        $host = isset($server['HTTP_HOST']) ? $server['HTTP_HOST'] : 'localhost';
+        if ($this->headers->has('X-Original-Host')) {
+            $host = $this->headers->get('X-Original-Host');
+        } else {
+            $host = isset($server['HTTP_HOST']) ? $server['HTTP_HOST'] : 'localhost';
+        }
         $requestUri = isset($server['REQUEST_URI']) ? $server['REQUEST_URI'] : '/';
         if (substr($requestUri, 0, 10) === '/index.php') {
             $requestUri = '/' . ltrim(substr($requestUri, 10), '/');


### PR DESCRIPTION
If Neos is behind a proxy, and the public domain name is not the same as the internal domain name, flow will redirect request from the public domain to the internal domain. This change add support for X-Original-Host HTTP header to get the public domain correctly.