### PR TITLE
[TASK] Add ``applicationPackageKey`` to settings schema

### DIFF
--- a/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.core.schema.yaml
+++ b/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.core.schema.yaml
@@ -2,6 +2,7 @@ type: dictionary
 additionalProperties: FALSE
 properties:
   'context': { type: string, required: TRUE }
+  'applicationPackageKey': { type: string, required: TRUE }
   'phpBinaryPathAndFilename': { type: string, required: TRUE }
   'subRequestEnvironmentVariables':
     type: dictionary


### PR DESCRIPTION
This adds the recently added ``applicationPackageKey`` setting to the YAML
schema for the core settings, to avoid false error reports when using
``configuration:validate``.