### PR TITLE
[BUGFIX] Roles are refreshed after setting authentication status

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Authentication/AuthenticationProviderManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Authentication/AuthenticationProviderManager.php
@@ -182,6 +182,7 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
                 }
                 if ($this->securityContext->getAuthenticationStrategy() === Context::AUTHENTICATE_ONE_TOKEN) {
                     $this->isAuthenticated = true;
+                    $this->securityContext->refreshRoles();
                     return;
                 }
                 $anyTokenAuthenticated = true;
@@ -197,6 +198,7 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
         }
 
         $this->isAuthenticated = $anyTokenAuthenticated;
+        $this->securityContext->refreshRoles();
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Context.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Context.php
@@ -748,6 +748,18 @@ class Context
     }
 
     /**
+     * Refreshes the currently effective roles. In fact the roles first level cache
+     * is reset and the effective roles get recalculated by calling getRoles().
+     *
+     * @return void
+     */
+    public function refreshRoles()
+    {
+        $this->roles = null;
+        $this->getRoles();
+    }
+
+    /**
      * Shut the object down
      *
      * @return void


### PR DESCRIPTION
Otherwise getRoles() might act on the wrong value of the overall
authentication status stored in the authentication manager.