### PR TITLE
[BUGFIX] FastCGI compatible resources ``.htaccess`` file

### DIFF
--- a/TYPO3.Flow/Resources/Private/Installer/Distribution/Defaults/Web/_Resources/.htaccess
+++ b/TYPO3.Flow/Resources/Private/Installer/Distribution/Defaults/Web/_Resources/.htaccess
@@ -1,2 +1,16 @@
+# Disable unwanted options
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Prevent execution of script files
 SetHandler default-handler
-php_flag engine off
+<Files *>
+  # Override again if executed later in the evaluation list
+  SetHandler default-handler
+</Files>
+
+<IfModule mod_php5.c>
+  php_flag engine off
+</IfModule>
+<IfModule mod_php7.c>
+  php_flag engine off
+</IfModule>


### PR DESCRIPTION
The ``.htaccess`` file in ``Web/_Resources`` contained php_flag,
which requires the ``mod_php`` module to be installed. Since FastCGI
setups don't have this module, an invalid command error is thrown.

In this change the flag is wrapped in ``IfModule`` tags to avoid that error,
and the ``SetHandler`` statement is added a second time in a ``Files`` tag
to avoid it being overwritten in certain cases.