### PR TITLE
[TASK] Adjust exception handling for compatibility with PHP 7

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Error/AbstractExceptionHandler.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Error/AbstractExceptionHandler.php
@@ -75,10 +75,10 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
     /**
      * Handles the given exception
      *
-     * @param \Exception $exception The exception object
+     * @param object $exception The exception object - can be \Exception, or some type of \Throwable in PHP 7
      * @return void
      */
-    public function handleException(\Exception $exception)
+    public function handleException($exception)
     {
         // Ignore if the error is suppressed by using the shut-up operator @
         if (error_reporting() === 0) {
@@ -88,7 +88,9 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
         $this->renderingOptions = $this->resolveCustomRenderingOptions($exception);
 
         if (is_object($this->systemLogger) && isset($this->renderingOptions['logException']) && $this->renderingOptions['logException']) {
-            $this->systemLogger->logException($exception);
+            if ($exception instanceof \Exception) {
+                $this->systemLogger->logException($exception);
+            }
         }
 
         switch (PHP_SAPI) {
@@ -103,20 +105,20 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
     /**
      * Echoes an exception for the web.
      *
-     * @param \Exception $exception The exception
+     * @param object $exception \Exception or \Throwable
      * @return void
      */
-    abstract protected function echoExceptionWeb(\Exception $exception);
+    abstract protected function echoExceptionWeb($exception);
 
 
     /**
      * Prepares a Fluid view for rendering the custom error page.
      *
-     * @param \Exception $exception
+     * @param object $exception \Exception or \Throwable
      * @param array $renderingOptions Rendering options as defined in the settings
      * @return StandaloneView
      */
-    protected function buildCustomFluidView(\Exception $exception, array $renderingOptions)
+    protected function buildCustomFluidView($exception, array $renderingOptions)
     {
         $statusCode = 500;
         $referenceCode = null;
@@ -154,10 +156,10 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
     /**
      * Checks if custom rendering rules apply to the given $exception and returns those.
      *
-     * @param \Exception $exception
+     * @param object $exception \Exception or \Throwable
      * @return array the custom rendering options, or NULL if no custom rendering is defined for this exception
      */
-    protected function resolveCustomRenderingOptions(\Exception $exception)
+    protected function resolveCustomRenderingOptions($exception)
     {
         $renderingOptions = array();
         if (isset($this->options['defaultRenderingOptions'])) {
@@ -172,10 +174,10 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
     }
 
     /**
-     * @param \Exception $exception
+     * @param object $exception \Exception or \Throwable
      * @return string name of the resolved renderingGroup or NULL if no group could be resolved
      */
-    protected function resolveRenderingGroup(\Exception $exception)
+    protected function resolveRenderingGroup($exception)
     {
         if (!isset($this->options['renderingGroups'])) {
             return null;
@@ -199,10 +201,10 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
     /**
      * Formats and echoes the exception and its previous exceptions (if any) for the command line
      *
-     * @param \Exception $exception The exception object
+     * @param object $exception \Exception or \Throwable
      * @return void
      */
-    protected function echoExceptionCli(\Exception $exception)
+    protected function echoExceptionCli($exception)
     {
         $response = new CliResponse();
 
@@ -220,10 +222,10 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
     /**
      * Renders a single exception including message, code and affected file
      *
-     * @param \Exception $exception
+     * @param object $exception \Exception or \Throwable
      * @return string
      */
-    protected function renderSingleExceptionCli(\Exception $exception)
+    protected function renderSingleExceptionCli($exception)
     {
         $exceptionMessageParts = $this->splitExceptionMessage($exception->getMessage());
         $exceptionMessage = '<error><b>' . $exceptionMessageParts['subject'] . '</b></error>' . PHP_EOL;

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Error/DebugExceptionHandler.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Error/DebugExceptionHandler.php
@@ -27,10 +27,10 @@ class DebugExceptionHandler extends AbstractExceptionHandler
     /**
      * Formats and echoes the exception as XHTML.
      *
-     * @param \Exception $exception The exception object
+     * @param object $exception \Exception or \Throwable
      * @return void
      */
-    protected function echoExceptionWeb(\Exception $exception)
+    protected function echoExceptionWeb($exception)
     {
         $statusCode = 500;
         if ($exception instanceof FlowException) {
@@ -52,10 +52,10 @@ class DebugExceptionHandler extends AbstractExceptionHandler
      * Returns the statically rendered exception message
      *
      * @param integer $statusCode
-     * @param \Exception $exception
+     * @param object $exception \Exception or \Throwable
      * @return void
      */
-    protected function renderStatically($statusCode, \Exception $exception)
+    protected function renderStatically($statusCode, $exception)
     {
         $statusMessage = Response::getStatusMessageByCode($statusCode);
         $exceptionHeader = '';

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Error/ExceptionHandlerInterface.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Error/ExceptionHandlerInterface.php
@@ -13,17 +13,16 @@ namespace TYPO3\Flow\Error;
 
 /**
  * Contract for an exception handler
- *
  */
 interface ExceptionHandlerInterface
 {
     /**
      * Handles the given exception
      *
-     * @param \Exception $exception The exception object
+     * @param object $exception The exception object - can be \Exception, or some type of \Throwable in PHP 7
      * @return void
      */
-    public function handleException(\Exception $exception);
+    public function handleException($exception);
 
     /**
      * Sets options of this exception handler

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Error/ProductionExceptionHandler.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Error/ProductionExceptionHandler.php
@@ -25,10 +25,10 @@ class ProductionExceptionHandler extends AbstractExceptionHandler
     /**
      * Echoes an exception for the web.
      *
-     * @param \Exception $exception The exception
+     * @param object $exception \Exception or \Throwable
      * @return void
      */
-    protected function echoExceptionWeb(\Exception $exception)
+    protected function echoExceptionWeb($exception)
     {
         $statusCode = 500;
         if ($exception instanceof FlowException) {


### PR DESCRIPTION
This change adjusts the non-public API of Flow's exception handling to
fit the new exception types in PHP 7 (`\Throwable`). It does not yet
take advantage of the new possibilites, but rather makes the existing
code compatible with both, PHP 5 and PHP 7.