### PR TITLE
Prevent invalid Cookie pairs from raising errors

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Headers.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Headers.php
@@ -446,6 +446,9 @@ class Headers
     {
         $cookiePairs = explode(';', $rawFieldValue);
         foreach ($cookiePairs as $cookiePair) {
+            if (strpos($cookiePair, '=') === false) {
+                continue;
+            }
             list($name, $value) = explode('=', $cookiePair, 2);
             if (trim($name) !== '') {
                 $this->setCookie(new Cookie(trim($name), urldecode(trim($value, "\t ;\""))));


### PR DESCRIPTION
Formally a Cookie header should consist of semi-colon separated pairs
of ``key=value`` but some clients might sent invalid cookie headers
resulting in a notice raised when there was no equals sign to split a
pair on.