### PR TITLE
[BUGFIX] Remove references to „methodTaggedWith“ pointcut designator

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Aop/Pointcut/PointcutExpressionParser.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Aop/Pointcut/PointcutExpressionParser.php
@@ -32,7 +32,7 @@ use TYPO3\Flow\Reflection\ReflectionService;
 class PointcutExpressionParser
 {
     const PATTERN_SPLITBYOPERATOR = '/\s*(\&\&|\|\|)\s*/';
-    const PATTERN_MATCHPOINTCUTDESIGNATOR = '/^\s*(classAnnotatedWith|class|methodAnnotatedWith|methodTaggedWith|method|within|filter|setting|evaluate)/';
+    const PATTERN_MATCHPOINTCUTDESIGNATOR = '/^\s*(classAnnotatedWith|class|methodAnnotatedWith|method|within|filter|setting|evaluate)/';
     const PATTERN_MATCHVISIBILITYMODIFIER = '/^(public|protected) +/';
     const PATTERN_MATCHRUNTIMEEVALUATIONSDEFINITION = '/(?:
 														(?:
@@ -152,7 +152,6 @@ class PointcutExpressionParser
                     case 'classAnnotatedWith':
                     case 'class' :
                     case 'methodAnnotatedWith':
-                    case 'methodTaggedWith' :
                     case 'method' :
                     case 'within' :
                     case 'filter' :

--- a/TYPO3.Flow/Tests/Unit/Aop/Pointcut/PointcutExpressionParserTest.php
+++ b/TYPO3.Flow/Tests/Unit/Aop/Pointcut/PointcutExpressionParserTest.php
@@ -64,7 +64,7 @@ class PointcutExpressionParserTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function parseCallsSpecializedMethodsToParseEachDesignator()
     {
-        $mockMethods = array('parseDesignatorPointcut', 'parseDesignatorClassAnnotatedWith', 'parseDesignatorClass', 'parseDesignatorMethodAnnotatedWith', 'parseDesignatorMethodTaggedWith', 'parseDesignatorMethod', 'parseDesignatorWithin', 'parseDesignatorFilter', 'parseDesignatorSetting', 'parseRuntimeEvaluations');
+        $mockMethods = array('parseDesignatorPointcut', 'parseDesignatorClassAnnotatedWith', 'parseDesignatorClass', 'parseDesignatorMethodAnnotatedWith', 'parseDesignatorMethod', 'parseDesignatorWithin', 'parseDesignatorFilter', 'parseDesignatorSetting', 'parseRuntimeEvaluations');
         $parser = $this->getMock('TYPO3\Flow\Aop\Pointcut\PointcutExpressionParser', $mockMethods, array(), '', false);
 
         $parser->expects($this->once())->method('parseDesignatorPointcut')->with('&&', '\Foo\Bar->baz');
@@ -107,7 +107,7 @@ class PointcutExpressionParserTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function parseSplitsUpTheExpressionIntoDesignatorsAndPassesTheOperatorsToTheDesginatorParseMethod()
     {
-        $mockMethods = array('parseDesignatorPointcut', 'parseDesignatorClass', 'parseDesignatorMethodTaggedWith', 'parseDesignatorMethod', 'parseDesignatorWithin', 'parseDesignatorFilter', 'parseDesignatorSetting');
+        $mockMethods = array('parseDesignatorPointcut', 'parseDesignatorClass', 'parseDesignatorMethod', 'parseDesignatorWithin', 'parseDesignatorFilter', 'parseDesignatorSetting');
         $parser = $this->getMock('TYPO3\Flow\Aop\Pointcut\PointcutExpressionParser', $mockMethods, array(), '', false);
         $parser->injectObjectManager($this->mockObjectManager);
 


### PR DESCRIPTION
The pointcut designator „methodTaggedWith“ has been deprecated for 2.0 already.
This removes some leftover reference to this method.

Fixes: FLOW-417