### PR TITLE
[TASK] Adjust generated proxy code to PHP 7 uniform variable syntax

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Object/DependencyInjection/ProxyClassBuilder.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Object/DependencyInjection/ProxyClassBuilder.php
@@ -221,9 +221,9 @@ class ProxyClassBuilder
 			if(\$entityInformation['entityType'] === 'TYPO3\Flow\Resource\ResourcePointer') continue;
 			\$entity = \$persistenceManager->getObjectByIdentifier(\$entityInformation['identifier'], \$entityInformation['entityType'], TRUE);
 			if (isset(\$entityInformation['entityPath'])) {
-				\$this->\$entityInformation['propertyName'] = \\TYPO3\\Flow\\Utility\\Arrays::setValueByPath(\$this->\$entityInformation['propertyName'], \$entityInformation['entityPath'], \$entity);
+				\$this->{\$entityInformation['propertyName']} = \\TYPO3\\Flow\\Utility\\Arrays::setValueByPath(\$this->{\$entityInformation['propertyName']}, \$entityInformation['entityPath'], \$entity);
 			} else {
-				\$this->\$entityInformation['propertyName'] = \$entity;
+				\$this->{\$entityInformation['propertyName']} = \$entity;
 			}
 		}
 		unset(\$this->Flow_Persistence_RelatedEntities);


### PR DESCRIPTION
This change contains a fix in the "related entities" proxy class code
which makes the generated code PHP 7 compatible.

Related: NEOS-1608