### PR TITLE
[TASK] Remove unused method in SimpleFileBackend

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Cache/Backend/SimpleFileBackend.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Cache/Backend/SimpleFileBackend.php
@@ -396,15 +396,4 @@ class SimpleFileBackend extends AbstractBackend implements PhpCapableBackendInte
             $this->cacheFilesIterator->next();
         }
     }
-
-    /**
-     * Generate a temporary file path based on entryIdentifier, microtime and pid if available.
-     *
-     * @param string $entryIdentifier
-     * @return string
-     */
-    protected function generateTemporaryPathAndFilename($entryIdentifier)
-    {
-        return $this->cacheDirectory . '.' . $entryIdentifier . '.' . microtime(true) . '-' . (getmypid() ?: 0) . '.tmp';
-    }
 }


### PR DESCRIPTION
The ``generateTemporaryPathAndFilename`` is no longer in use
since the introduction of locking last year, it can therefore
be removed.