### PR TITLE
BUGFIX: Allow composite keys over foreign entities

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -509,6 +509,9 @@ class FlowAnnotationDriver implements \Doctrine\Common\Persistence\Mapping\Drive
             // Field can only be annotated with one of:
             // @OneToOne, @OneToMany, @ManyToOne, @ManyToMany, @Column (optional)
             if ($oneToOneAnnotation = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\OneToOne')) {
+                if ($this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\Id') !== null) {
+                    $mapping['id'] = true;
+                }
                 if ($oneToOneAnnotation->targetEntity) {
                     $mapping['targetEntity'] = $oneToOneAnnotation->targetEntity;
                 }
@@ -555,6 +558,9 @@ class FlowAnnotationDriver implements \Doctrine\Common\Persistence\Mapping\Drive
 
                 $metadata->mapOneToMany($mapping);
             } elseif ($manyToOneAnnotation = $this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\ManyToOne')) {
+                if ($this->reader->getPropertyAnnotation($property, 'Doctrine\ORM\Mapping\Id') !== null) {
+                    $mapping['id'] = true;
+                }
                 if ($manyToOneAnnotation->targetEntity) {
                     $mapping['targetEntity'] = $manyToOneAnnotation->targetEntity;
                 }

--- a/TYPO3.Flow/Tests/Functional/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriverTest.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriverTest.php
@@ -77,6 +77,19 @@ class FlowAnnotationDriverTest extends \TYPO3\Flow\Tests\FunctionalTestCase
     }
 
     /**
+     * @test
+     */
+    public function compositePrimaryKeyOverEntityRelationIsRegistered()
+    {
+        $classMetadata = new \TYPO3\Flow\Persistence\Doctrine\Mapping\ClassMetadata('TYPO3\Flow\Tests\Functional\Persistence\Fixtures\CompositeKeyTestEntity');
+        $driver = $this->objectManager->get('TYPO3\Flow\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriver');
+        $driver->loadMetadataForClass('TYPO3\Flow\Tests\Functional\Persistence\Fixtures\CompositeKeyTestEntity', $classMetadata);
+        $this->assertTrue($classMetadata->isIdentifierComposite);
+        $this->assertTrue($classMetadata->containsForeignIdentifier);
+        $this->assertEquals($classMetadata->identifier, array('name', 'relatedEntity'));
+    }
+
+    /**
      * Makes sure that
      * - thumbnail and image (same type) do get distinct column names
      * - simple properties get mapped to their name

--- a/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/CompositeKeyTestEntity.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/CompositeKeyTestEntity.php
@@ -1,0 +1,73 @@
+<?php
+namespace TYPO3\Flow\Tests\Functional\Persistence\Fixtures;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use TYPO3\Flow\Annotations as Flow;
+
+/**
+ * A simple entity for persistence tests
+ *
+ * @Flow\Entity
+ * @ORM\Table(name="persistence_compsitekeytestentity")
+ */
+class CompositeKeyTestEntity
+{
+
+    /**
+     * @var string
+     * @ORM\Id
+     * @ORM\Column(length=20)
+     */
+    protected $name = '';
+
+    /**
+     * @var TestEntity
+     * @ORM\Id
+     * @ORM\ManyToOne
+     */
+    protected $relatedEntity;
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return void
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @param TestEntity $relatedEntity
+     * @return void
+     */
+    public function setRelatedEntity(TestEntity $relatedEntity)
+    {
+        $this->relatedEntity = $relatedEntity;
+    }
+
+    /**
+     * @return TestEntity
+     */
+    public function getRelatedEntity()
+    {
+        return $this->relatedEntity;
+    }
+}


### PR DESCRIPTION
Currently, the implementation of the FlowAnnotationDriver prevents
composite primary keys including an foreign entity reference to
work, as in the example of doctrine:
http://docs.doctrine-project.org/en/latest/tutorials/composite-primary-keys.html#identity-through-foreign-entities

This change adds the required mapping informations, which is only
a first step towards full composite key support.

FLOW-259 #close