### PR TITLE
[BUGFIX] Lock files shouldn't be opened twice

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Lock/FlockLockStrategy.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Lock/FlockLockStrategy.php
@@ -97,10 +97,13 @@ class FlockLockStrategy implements LockStrategyInterface
      */
     protected function tryToAquireLock($exclusiveLock)
     {
-        if (($this->filePointer = @fopen($this->lockFileName, 'r')) === false && ($this->filePointer = @fopen($this->lockFileName, 'w')) === false) {
+        $this->filePointer = @fopen($this->lockFileName, 'w');
+        if ($this->filePointer === false) {
             throw new LockNotAcquiredException(sprintf('Lock file "%s" could not be opened', $this->lockFileName), 1386520596);
         }
+
         $this->applyFlock($exclusiveLock);
+
         $fstat = fstat($this->filePointer);
         $stat = stat($this->lockFileName);
         // Make sure that the file did not get unlinked between the fopen and the actual flock


### PR DESCRIPTION
Prevents opening lock files twice, first in read then in
write mode. Only one open should happen if successful.
The change fixes that.