### PR TITLE
[TASK] Add DBAL minimum version to make JSON type work

### DIFF
--- a/TYPO3.Flow/composer.json
+++ b/TYPO3.Flow/composer.json
@@ -19,6 +19,7 @@
 
         "doctrine/orm": "~2.4.0",
         "doctrine/migrations": "~1.0.0",
+        "doctrine/dbal": "~2.5.0",
 
         "symfony/yaml": "~2.5.0",
         "symfony/dom-crawler": "~2.5.0",


### PR DESCRIPTION
The Json column type is support in doctrine DBAL only from
version 2.5.0 onwards. The current dependencies allow
installing it but it won't happen automatically, this
change makes sure that dbal is installed in the right
version.