### PR TITLE
[BUGFIX] Uniform variable syntax for proxy trait

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Object/Proxy/ObjectSerializationTrait.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Object/Proxy/ObjectSerializationTrait.php
@@ -144,7 +144,7 @@ trait ObjectSerializationTrait
                 }
                 $entity = $persistenceManager->getObjectByIdentifier($entityInformation['identifier'], $entityInformation['entityType'], true);
                 if (isset($entityInformation['entityPath'])) {
-                    $this->{$entityInformation['propertyName']} = \TYPO3\Flow\Utility\Arrays::setValueByPath($this->$entityInformation['propertyName'], $entityInformation['entityPath'], $entity);
+                    $this->{$entityInformation['propertyName']} = \TYPO3\Flow\Utility\Arrays::setValueByPath($this->{$entityInformation['propertyName']}, $entityInformation['entityPath'], $entity);
                 } else {
                     $this->{$entityInformation['propertyName']} = $entity;
                 }


### PR DESCRIPTION
Fixes a leftover place which didn't use the uniform variable syntax
and therefore caused notices with PHP7.