### PR TITLE
[BUGFIX] Now extends DateTime for backwards compatibility

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Now.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Now.php
@@ -23,7 +23,8 @@ use TYPO3\Flow\Annotations as Flow;
  *
  * @Flow\Scope("singleton")
  * @api
+ * TODO: Change to \DateTimeImmutable for next major version after 3.0
  */
-class Now extends \DateTimeImmutable
+class Now extends \DateTime
 {
 }


### PR DESCRIPTION
This partially reverts ``6b1448d2c540d79e882f527449e05660bc5095e3``
which changed ``\TYPO3\Flow\Utility\Now`` to extend the
``DateTimeImmutable`` class introduced with PHP 5.5.
As this is potentially breaking this part of the change is reverted
and will be reintroduced as breaking change in the next major
version.