### PR TITLE
[BUGFIX] Use instanceof instead of relying on typed parameter

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Object/Configuration/Configuration.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Object/Configuration/Configuration.php
@@ -327,6 +327,7 @@ class Configuration
      * method, all (possibly) defined properties are removed from the configuration.
      *
      * @param array $properties Array of \TYPO3\Flow\Object\Configuration\ConfigurationProperty
+     * @throws \TYPO3\Flow\Configuration\Exception\InvalidConfigurationException
      * @return void
      */
     public function setProperties(array $properties)
@@ -335,7 +336,11 @@ class Configuration
             $this->properties = array();
         } else {
             foreach ($properties as $value) {
-                $this->setProperty($value);
+                if ($value instanceof ConfigurationProperty) {
+                    $this->setProperty($value);
+                } else {
+                    throw new \TYPO3\Flow\Configuration\Exception\InvalidConfigurationException(sprintf('Only ConfigurationProperty instances are allowed, "%s" given', is_object($value) ? get_class($value) : gettype($value)), 1449217567);
+                }
             }
         }
     }
@@ -353,10 +358,10 @@ class Configuration
     /**
      * Setter function for a single injection property
      *
-     * @param \TYPO3\Flow\Object\Configuration\ConfigurationProperty $property
+     * @param ConfigurationProperty $property
      * @return void
      */
-    public function setProperty(\TYPO3\Flow\Object\Configuration\ConfigurationProperty $property)
+    public function setProperty(ConfigurationProperty $property)
     {
         $this->properties[$property->getName()] = $property;
     }
@@ -366,6 +371,7 @@ class Configuration
      * method, all (possibly) defined constructor arguments are removed from the configuration.
      *
      * @param array<TYPO3\Flow\Object\Configuration\ConfigurationArgument> $arguments
+     * @throws \TYPO3\Flow\Configuration\Exception\InvalidConfigurationException
      * @return void
      */
     public function setArguments(array $arguments)
@@ -374,8 +380,10 @@ class Configuration
             $this->arguments = array();
         } else {
             foreach ($arguments as $argument) {
-                if ($argument !== null) {
+                if ($argument !== null && $argument instanceof ConfigurationArgument) {
                     $this->setArgument($argument);
+                } else {
+                    throw new \TYPO3\Flow\Configuration\Exception\InvalidConfigurationException(sprintf('Only ConfigurationArgument instances are allowed, "%s" given', is_object($argument) ? get_class($argument) : gettype($argument)), 1449217803);
                 }
             }
         }
@@ -384,10 +392,10 @@ class Configuration
     /**
      * Setter function for a single constructor argument
      *
-     * @param \TYPO3\Flow\Object\Configuration\ConfigurationArgument $argument The argument
+     * @param ConfigurationArgument $argument The argument
      * @return void
      */
-    public function setArgument(\TYPO3\Flow\Object\Configuration\ConfigurationArgument $argument)
+    public function setArgument(ConfigurationArgument $argument)
     {
         $this->arguments[$argument->getIndex()] = $argument;
     }

--- a/TYPO3.Flow/Tests/Unit/Object/Configuration/ConfigurationTest.php
+++ b/TYPO3.Flow/Tests/Unit/Object/Configuration/ConfigurationTest.php
@@ -35,7 +35,7 @@ class ConfigurationTest extends \TYPO3\Flow\Tests\UnitTestCase
      * Checks if setProperties accepts only valid values
      *
      * @test
-     * @expectedException \PHPUnit_Framework_Error
+     * @expectedException TYPO3\Flow\Configuration\Exception\InvalidConfigurationException
      */
     public function setPropertiesOnlyAcceptsValidValues()
     {
@@ -67,7 +67,7 @@ class ConfigurationTest extends \TYPO3\Flow\Tests\UnitTestCase
      * Checks if setArguments accepts only valid values
      *
      * @test
-     * @expectedException \PHPUnit_Framework_Error
+     * @expectedException \TYPO3\Flow\Configuration\Exception\InvalidConfigurationException
      */
     public function setArgumentsOnlyAcceptsValidValues()
     {


### PR DESCRIPTION
The Configuration class relied on type hints to enforce the validity
of user-supplied data. This was explicitly tested, so the assumption is,
this was supposed to be tested properly. An instanceof check is now used
and a proper exception is thrown (instead of a PHP error).

Along the way this fixes some failing unit tests on PHP 7, since the old
assertion in the tests no longer holds.