### PR TITLE
[BUGFIX] Support for special characters in ``PositionalArraySorter`` keys

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Utility/PositionalArraySorter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Utility/PositionalArraySorter.php
@@ -220,7 +220,7 @@ class PositionalArraySorter
     {
         $this->beforeKeys = array();
         foreach ($arrayKeysWithPosition as $key => $position) {
-            if (preg_match('/^before ([a-zA-Z0-9]+)(?: ([0-9]+))?$/', $position, $matches) < 1) {
+            if (preg_match('/^before (\S+)(?: ([0-9]+))?$/', $position, $matches) < 1) {
                 continue;
             }
             if (isset($matches[2])) {
@@ -247,7 +247,7 @@ class PositionalArraySorter
     {
         $this->afterKeys = array();
         foreach ($arrayKeysWithPosition as $key => $position) {
-            if (preg_match('/^after ([a-zA-Z0-9]+)(?: ([0-9]+))?$/', $position, $matches) < 1) {
+            if (preg_match('/^after (\S+)(?: ([0-9]+))?$/', $position, $matches) < 1) {
                 continue;
             }
             if (isset($matches[2])) {

--- a/TYPO3.Flow/Tests/Unit/Utility/PositionalArraySorterTest.php
+++ b/TYPO3.Flow/Tests/Unit/Utility/PositionalArraySorterTest.php
@@ -15,6 +15,7 @@ use TYPO3\Flow\Tests\UnitTestCase;
 use TYPO3\Flow\Utility\PositionalArraySorter;
 
 /**
+ * Tests for the PositionalArraySorter utility class
  */
 class PositionalArraySorterTest extends UnitTestCase
 {
@@ -41,7 +42,6 @@ class PositionalArraySorterTest extends UnitTestCase
             array('subject' => array('foo' => array('position' => 'start123'), 'first' => array())),
             array('subject' => array('foo' => array('position' => 'start 12 34'), 'first' => array())),
             array('subject' => array('foo' => array('position' => 'after 12 34 56'), 'first' => array())),
-            array('subject' => array('foo' => array('position' => 'after foo-bar'), 'first' => array())),
         );
     }
 
@@ -55,7 +55,7 @@ class PositionalArraySorterTest extends UnitTestCase
     public function toArrayThrowsExceptionForInvalidPositions(array $subject)
     {
         $positionalArraySorter = new PositionalArraySorter($subject);
-        $sortedArray = $positionalArraySorter->toArray();
+        $positionalArraySorter->toArray();
     }
 
     /**
@@ -141,7 +141,13 @@ class PositionalArraySorterTest extends UnitTestCase
                 'subject' => array('third' => array('__meta' => array('position' => 'after second')), 'second' => array('__meta' => array('position' => 'after first')), 'first' => array()),
                 'positionPropertyPath' => '__meta.position',
                 'expectedArrayKeys' => array('first', 'second', 'third')
-            )
+            ),
+            array(
+                'message' => 'Array keys may contain special characters',
+                'subject' => array('thi:rd' => array('position' => 'end'), 'sec.ond' => array('position' => 'before thi:rd'), 'fir-st' => array('position' => 'before sec.ond')),
+                'positionPropertyPath' => 'position',
+                'expectedArrayKeys' => array('fir-st', 'sec.ond', 'thi:rd')
+            ),
         );
     }
 


### PR DESCRIPTION
When using the ``PositionalArraySorter`` one can position keys
relative to other keys with ``before/after <key>``.
But for the ``<key>`` only ``[a-zA-Z0-9]`` were allowed limiting the
functionality especially when dealing with package keys that contain
a dot.

This change adjusts the regular expression to allow any string to be
referenced.

Fixes: FLOW-422