### PR TITLE
BUGFIX: Set the subpackage key when setting the package key in forward()

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/Controller/AbstractController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/Controller/AbstractController.php
@@ -196,8 +196,6 @@ abstract class AbstractController implements ControllerInterface
         }
         if ($packageKey !== null) {
             $nextRequest->setControllerPackageKey($packageKey);
-        }
-        if ($subpackageKey !== null) {
             $nextRequest->setControllerSubpackageKey($subpackageKey);
         }
 


### PR DESCRIPTION
There's no logical case where you'd want to forward to a different package but stay within the same subpackage key. That's why the subpackage key should be (re)set whenever the package is changed when forwarding.