### PR TITLE
[TASK] Break after 10000 lock attempts

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Lock/FlockLockStrategy.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Lock/FlockLockStrategy.php
@@ -56,6 +56,7 @@ class FlockLockStrategy implements LockStrategyInterface
      * @param string $subject
      * @param boolean $exclusiveLock TRUE to, acquire an exclusive (write) lock, FALSE for a shared (read) lock.
      * @return void
+     * @throws LockNotAcquiredException
      */
     public function acquire($subject, $exclusiveLock)
     {
@@ -65,8 +66,13 @@ class FlockLockStrategy implements LockStrategyInterface
 
         $this->lockFileName = Files::concatenatePaths(array(self::$temporaryDirectory, md5($subject)));
         $aquiredLock = false;
+        $i = 0;
         while ($aquiredLock === false) {
             $aquiredLock = $this->tryToAquireLock($exclusiveLock);
+            $i++;
+            if ($i > 10000) {
+                throw new LockNotAcquiredException(sprintf('After 10000 attempts a lock could not be aquired for subject "%s".', $subject), 1449829188);
+            }
         }
     }
 


### PR DESCRIPTION
The ``FlockLockStrategy`` should at some point always be able
to aquire a lock even if it takes a while. But to prevent really
long running processes that interlock each other a natural
boundary to the amount of lock attempts is introduced.
The strategy will throw an exception after 10000 tries to aquire
the lock file. Depending on the results of random the maximum time
to reach this upper boundary is about 2 seconds.