### PR TITLE
[TASK] Object shutdown should be run without security checks

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Object/CompileTimeObjectManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Object/CompileTimeObjectManager.php
@@ -458,4 +458,15 @@ class CompileTimeObjectManager extends ObjectManager
         array_pop($this->objectNameBuildStack);
         return $object;
     }
+
+    /**
+     * Shuts down this Object Container by calling the shutdown methods of all
+     * object instances which were configured to be shut down.
+     *
+     * @return void
+     */
+    public function shutdown()
+    {
+        $this->shutdownLifecycleObjects();
+    }
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Object/ObjectManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Object/ObjectManager.php
@@ -17,6 +17,7 @@ use TYPO3\Flow\Core\ApplicationContext;
 use Doctrine\ORM\Mapping as ORM;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Object\DependencyInjection\DependencyProxy;
+use TYPO3\Flow\Security\Context;
 
 /**
  * Object Manager
@@ -423,6 +424,19 @@ class ObjectManager implements ObjectManagerInterface
      * @return void
      */
     public function shutdown()
+    {
+        $this->get(Context::class)->withoutAuthorizationChecks(function () {
+           $this->shutdownLifecycleObjects();
+        });
+    }
+
+    /**
+     * Executes the shutdown of object instances which were configured to be
+     * shut down by this object container.
+     *
+     * @return void
+     */
+    protected function shutdownLifecycleObjects()
     {
         foreach ($this->shutdownObjects as $object) {
             $methodName = $this->shutdownObjects[$object];


### PR DESCRIPTION
The ``ObjectManager`` will shutdown configured objects when
shutdown is called on it. As the session is shutdown as one
of those configured objects reliance on it and therefore on the
Security\Context is not possible. To prevent any errors stemming
from the fact that the security couldn't be initalized while in
shutdown we execute the whole shutdown without security.

Due to the special nature of the ``CompileTimeObjectManager``
we need to call the shutdown as before, but security will not
be used during compile time.