### PR TITLE
BUGFIX: Security context not available in shutdown lifecycle objects

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Object/CompileTimeObjectManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Object/CompileTimeObjectManager.php
@@ -458,4 +458,16 @@ class CompileTimeObjectManager extends ObjectManager
         array_pop($this->objectNameBuildStack);
         return $object;
     }
+
+    /**
+     * Shuts down this Object Container by calling the shutdown methods of all
+     * object instances which were configured to be shut down.
+     *
+     * @return void
+     */
+    public function shutdown()
+    {
+        $this->callShutdownMethods($this->shutdownObjects);
+        $this->callShutdownMethods($this->internalShutdownObjects);
+    }
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Object/ObjectManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Object/ObjectManager.php
@@ -547,5 +547,4 @@ class ObjectManager implements ObjectManagerInterface
             $object->$methodName();
         }
     }
-
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Object/ObjectManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Object/ObjectManager.php
@@ -92,6 +92,7 @@ class ObjectManager implements ObjectManagerInterface
     {
         $this->context = $context;
         $this->shutdownObjects = new \SplObjectStorage;
+        $this->internalShutdownObjects = new \SplObjectStorage;
     }
 
     /**
@@ -159,7 +160,7 @@ class ObjectManager implements ObjectManagerInterface
      */
     public function registerShutdownObject($object, $shutdownLifecycleMethodName)
     {
-        if (substr(get_class($object), 0, 1) === 'TYPO3\Flow\\') {
+        if (strpos(get_class($object), 'TYPO3\Flow\\') === 0) {
             $this->internalShutdownObjects[$object] = $shutdownLifecycleMethodName;
         } else {
             $this->shutdownObjects[$object] = $shutdownLifecycleMethodName;


### PR DESCRIPTION
Because the order of shutdown methods being executed by the Object
Manager is undetermined, it may happen that `shutdownObject()` methods
relying on an initialized security context will fail because that
context is not available anymore. Additionally, Flow's own shutdown
object methods might fail because security checks are still active
even though the security framework is not available anymore.

This change makes sure that

1. shutdown methods of any other than the Flow package are executed first
2. Flow's own shutdown methods are called last, and without security checks

Due to the special nature of the CompileTimeObjectManager
we need to call the shutdown as before, but security will not
be used during compile time.