### PR TITLE
BUGFIX: Properly escape sub process variables on windows

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
@@ -576,7 +576,8 @@ class Scripts
             if (DIRECTORY_SEPARATOR === '/') {
                 $command .= sprintf('%s=%s ', $argumentKey, escapeshellarg($argumentValue));
             } else {
-                $command .= sprintf('SET %s=%s&', $argumentKey, escapeshellarg($argumentValue));
+                // SET does not parse out quotes, hence we need escapeshellcmd here instead
+                $command .= sprintf('SET %s=%s&', $argumentKey, escapeshellcmd($argumentValue));
             }
         }
         if (DIRECTORY_SEPARATOR === '/') {


### PR DESCRIPTION
Windows SET command does not parse out quotes of the variable value but rather treats them as part of the value,
which currently results in an error on windows since the fix for FLOW-381:

  Flow could not create the directory
  ""C:/workspace/Flow/Data/Temporary"/Development/".

Note the extra quotes around the temporary base path.

This change fixes that by properly escaping the SET command arguments on windows by using escapeshellcmd instead
of escapeshellarg.

FLOW-425 #comment Fix for 2.3.x