### PR TITLE
FEATURE: Trait introduction via AOP

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Annotations/Introduce.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Annotations/Introduce.php
@@ -33,6 +33,13 @@ final class Introduce
     public $interfaceName;
 
     /**
+     * The trait name to introduce
+     *
+     * @var string
+     */
+    public $traitName;
+
+    /**
      * @param array $values
      * @throws \InvalidArgumentException
      */
@@ -45,6 +52,9 @@ final class Introduce
 
         if (isset($values['interfaceName'])) {
             $this->interfaceName = $values['interfaceName'];
+        }
+        if (isset($values['traitName'])) {
+            $this->traitName = $values['traitName'];
         }
     }
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Aop/AspectContainer.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Aop/AspectContainer.php
@@ -60,6 +60,13 @@ class AspectContainer
     protected $propertyIntroductions = array();
 
     /**
+     * An array of \TYPO3\Flow\Aop\TraitIntroduction objects
+     *
+     * @var array
+     */
+    protected $traitIntroductions = array();
+
+    /**
      * An array of explicitly declared \TYPO3\Flow\Pointcut objects
      * @var array
      */
@@ -121,6 +128,16 @@ class AspectContainer
     }
 
     /**
+     * Returns the trait introductions which were defined in the aspect
+     *
+     * @return array Array of \TYPO3\Flow\Aop\TraitIntroduction objects
+     */
+    public function getTraitIntroductions()
+    {
+        return $this->traitIntroductions;
+    }
+
+    /**
      * Returns the pointcuts which were declared in the aspect. This
      * does not contain the pointcuts which were made out of the pointcut
      * expressions for the advisors!
@@ -135,10 +152,10 @@ class AspectContainer
     /**
      * Adds an advisor to this aspect container
      *
-     * @param \TYPO3\Flow\Aop\Advisor $advisor The advisor to add
+     * @param Advisor $advisor The advisor to add
      * @return void
      */
-    public function addAdvisor(\TYPO3\Flow\Aop\Advisor $advisor)
+    public function addAdvisor(Advisor $advisor)
     {
         $this->advisors[] = $advisor;
     }
@@ -146,10 +163,10 @@ class AspectContainer
     /**
      * Adds an introduction declaration to this aspect container
      *
-     * @param \TYPO3\Flow\Aop\InterfaceIntroduction $introduction
+     * @param InterfaceIntroduction $introduction
      * @return void
      */
-    public function addInterfaceIntroduction(\TYPO3\Flow\Aop\InterfaceIntroduction $introduction)
+    public function addInterfaceIntroduction(InterfaceIntroduction $introduction)
     {
         $this->interfaceIntroductions[] = $introduction;
     }
@@ -157,12 +174,23 @@ class AspectContainer
     /**
      * Adds an introduction declaration to this aspect container
      *
-     * @param \TYPO3\Flow\Aop\PropertyIntroduction $introduction
+     * @param PropertyIntroduction $introduction
      * @return void
      */
-    public function addPropertyIntroduction(\TYPO3\Flow\Aop\PropertyIntroduction $introduction)
+    public function addPropertyIntroduction(PropertyIntroduction $introduction)
     {
         $this->propertyIntroductions[] = $introduction;
+    }
+
+    /**
+     * Adds an introduction declaration to this aspect container
+     *
+     * @param TraitIntroduction $introduction
+     * @return void
+     */
+    public function addTraitIntroduction(TraitIntroduction $introduction)
+    {
+        $this->traitIntroductions[] = $introduction;
     }
 
     /**
@@ -193,6 +221,9 @@ class AspectContainer
         }
         foreach ($this->propertyIntroductions as $propertyIntroduction) {
             $result->applyUnion($propertyIntroduction->getPointcut()->reduceTargetClassNames($classNameIndex));
+        }
+        foreach ($this->traitIntroductions as $traitIntroduction) {
+            $result->applyUnion($traitIntroduction->getPointcut()->reduceTargetClassNames($classNameIndex));
         }
         $this->cachedTargetClassNameCandidates = $result;
         return $result;

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Aop/TraitIntroduction.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Aop/TraitIntroduction.php
@@ -1,0 +1,82 @@
+<?php
+namespace TYPO3\Flow\Aop;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+
+/**
+ * Implementation of the trait introduction declaration.
+ *
+ */
+class TraitIntroduction
+{
+    /**
+     * Name of the aspect declaring this introduction
+     * @var string
+     */
+    protected $declaringAspectClassName;
+
+    /**
+     * Name of the introduced trait
+     * @var string
+     */
+    protected $traitName;
+
+    /**
+     * The pointcut this introduction applies to
+     * @var \TYPO3\Flow\Aop\Pointcut\Pointcut
+     */
+    protected $pointcut;
+
+    /**
+     * Constructor
+     *
+     * @param string $declaringAspectClassName Name of the aspect containing the declaration for this introduction
+     * @param string $traitName Name of the trait to introduce
+     * @param \TYPO3\Flow\Aop\Pointcut\Pointcut $pointcut The pointcut for this introduction
+     */
+    public function __construct($declaringAspectClassName, $traitName, \TYPO3\Flow\Aop\Pointcut\Pointcut $pointcut)
+    {
+        $this->declaringAspectClassName = $declaringAspectClassName;
+        $this->traitName = $traitName;
+        $this->pointcut = $pointcut;
+    }
+
+    /**
+     * Returns the name of the introduced trait
+     *
+     * @return string Name of the introduced trait
+     */
+    public function getTraitName()
+    {
+        return $this->traitName;
+    }
+
+    /**
+     * Returns the pointcut this introduction applies to
+     *
+     * @return \TYPO3\Flow\Aop\Pointcut\Pointcut The pointcut
+     */
+    public function getPointcut()
+    {
+        return $this->pointcut;
+    }
+
+    /**
+     * Returns the object name of the aspect which declared this introduction
+     *
+     * @return string The aspect object name
+     */
+    public function getDeclaringAspectClassName()
+    {
+        return $this->declaringAspectClassName;
+    }
+}

--- a/TYPO3.Flow/Tests/Functional/Aop/Fixtures/Introduced01Trait.php
+++ b/TYPO3.Flow/Tests/Functional/Aop/Fixtures/Introduced01Trait.php
@@ -1,0 +1,34 @@
+<?php
+namespace TYPO3\Flow\Tests\Functional\Aop\Fixtures;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A trait which is introduced into TargetClass01
+ */
+trait Introduced01Trait
+{
+    /**
+     * @return string
+     */
+    public function sayHello()
+    {
+        return 'Hello from trait';
+    }
+
+    /**
+     * @return string
+     */
+    public function introducedTraitMethod()
+    {
+        return 'I\'m the traitor';
+    }
+}

--- a/TYPO3.Flow/Tests/Functional/Aop/Fixtures/TraitIntroductionTestingAspect.php
+++ b/TYPO3.Flow/Tests/Functional/Aop/Fixtures/TraitIntroductionTestingAspect.php
@@ -1,0 +1,24 @@
+<?php
+namespace TYPO3\Flow\Tests\Functional\Aop\Fixtures;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+
+/**
+ * An aspect for testing trait introduction
+ *
+ * @Flow\Introduce("class(TYPO3\Flow\Tests\Functional\Aop\Fixtures\TargetClass01)", traitName="TYPO3\Flow\Tests\Functional\Aop\Fixtures\Introduced01Trait")
+ * @Flow\Aspect
+ */
+class TraitIntroductionTestingAspect
+{
+}

--- a/TYPO3.Flow/Tests/Functional/Aop/FrameworkTest.php
+++ b/TYPO3.Flow/Tests/Functional/Aop/FrameworkTest.php
@@ -191,6 +191,27 @@ class FrameworkTest extends \TYPO3\Flow\Tests\FunctionalTestCase
     }
 
     /**
+     * @test
+     */
+    public function traitWithNewMethodCanBeIntroduced()
+    {
+        $targetClass = new Fixtures\TargetClass01();
+
+        $this->assertEquals('I\'m the traitor', call_user_func(array($targetClass, 'introducedTraitMethod')));
+    }
+
+    /**
+     * @test
+     */
+    public function introducedTraitMethodWontOverrideExistingMethods()
+    {
+        $targetClass = new Fixtures\TargetClass01();
+
+        $this->assertNotEquals('Hello from trait', $targetClass->sayHello());
+        $this->assertEquals('Hello World', $targetClass->sayHello());
+    }
+
+    /**
      * Public and protected properties can be introduced.
      *
      * @test


### PR DESCRIPTION
This allows to introduce traits in generated proxy classes
via AOP. You can use the ``Introduce`` annotation with the
argument ``traitName`` to introdue the given trait into
generated proxy classes matching the pointcut.

For example::

  @Flow\Introduce(
    traitName="Vendor\Package\Service\Traits\ExampleTrait"
    pointcutExpression="class(TYPO3\Flow\Mvc\Controller\ActionController)"
  )

Would introduce the trait ``\Vendor\Package\Service\Traits\ExampleTrait``
into all proxies that either are the class or extend the class
``TYPO3\Flow\Mvc\Controller\ActionController``.

Resolves: FLOW-123