### PR TITLE
TASK: Add method to get public URI by path

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/ResourceManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/ResourceManager.php
@@ -36,6 +36,8 @@ class ResourceManager
     const DEFAULT_STATIC_COLLECTION_NAME = 'static';
     const DEFAULT_PERSISTENT_COLLECTION_NAME = 'persistent';
 
+    const PUBLIC_RESSOURCE_REGEXP = '#^resource://(?<packageKey>[^/]+)/Public/(?<relativePathAndFilename>.*)#';
+
     /**
      * @Flow\Inject
      * @var ObjectManagerInterface
@@ -408,6 +410,39 @@ class ResourceManager
         /** @var TargetInterface $target */
         $target = $this->collections[self::DEFAULT_STATIC_COLLECTION_NAME]->getTarget();
         return $target->getPublicStaticResourceUri($packageKey . '/' . $relativePathAndFilename);
+    }
+
+    /**
+     * Returns the public URI for a static resource provided by the public package
+     *
+     * @param string $path The ressource path, like resource://Your.Package/Public/Image/Dummy.png
+     * @return string
+     * @api
+     */
+    public function getPublicPackageResourceUriByPath($path)
+    {
+        $this->initialize();
+        list($packageKey, $relativePathAndFilename) = $this->getPackageAndPathByPublicPath($path);
+        return $this->getPublicPackageResourceUri($packageKey, $relativePathAndFilename);
+    }
+
+    /**
+     * Return the package key and the relative path and filename from the given resource path
+     *
+     * @param string $path The ressource path, like resource://Your.Package/Public/Image/Dummy.png
+     * @return array The array contains two value, first the packageKey followed by the relativePathAndFilename
+     * @throws Exception
+     * @api
+     */
+    public function getPackageAndPathByPublicPath($path)
+    {
+        if (preg_match(self::PUBLIC_RESSOURCE_REGEXP, $path, $matches) !== 1) {
+            throw new Exception(sprintf('The path "%s" which was given must point to a public resource.', $path), 1450358448);
+        }
+        return [
+            0 => $matches['packageKey'],
+            1 => $matches['relativePathAndFilename']
+        ];
     }
 
     /**

--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Uri/ResourceViewHelper.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Uri/ResourceViewHelper.php
@@ -13,6 +13,7 @@ namespace TYPO3\Fluid\ViewHelpers\Uri;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\I18n\Service;
+use TYPO3\Flow\Resource\Exception;
 use TYPO3\Flow\Resource\ResourceManager;
 use TYPO3\Flow\Resource\Resource;
 use TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -97,7 +98,11 @@ class ResourceViewHelper extends AbstractViewHelper
                 $package = $this->controllerContext->getRequest()->getControllerPackageKey();
             }
             if (strpos($path, 'resource://') === 0) {
-                list($package, $path) = $this->resourceManager->getPackageAndPathByPublicPath($path);
+                try {
+                    list($package, $path) = $this->resourceManager->getPackageAndPathByPublicPath($path);
+                } catch (Exception $exception) {
+                    throw new InvalidVariableException(sprintf('The specified path "%s" does not point to a public resource.', $path), 1386458851);
+                }
             }
             if ($localize === true) {
                 $resourcePath = 'resource://' . $package . '/Public/' . $path;

--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Uri/ResourceViewHelper.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Uri/ResourceViewHelper.php
@@ -97,13 +97,7 @@ class ResourceViewHelper extends AbstractViewHelper
                 $package = $this->controllerContext->getRequest()->getControllerPackageKey();
             }
             if (strpos($path, 'resource://') === 0) {
-                $matches = array();
-                if (preg_match('#^resource://([^/]+)/Public/(.*)#', $path, $matches) === 1) {
-                    $package = $matches[1];
-                    $path = $matches[2];
-                } else {
-                    throw new InvalidVariableException(sprintf('The path "%s" which was given to the ResourceViewHelper must point to a public resource.', $path), 1353512639);
-                }
+                list($package, $path) = $this->resourceManager->getPackageAndPathByPublicPath($path);
             }
             if ($localize === true) {
                 $resourcePath = 'resource://' . $package . '/Public/' . $path;

--- a/TYPO3.Fluid/Tests/Unit/ViewHelpers/Uri/ResourceViewHelperTest.php
+++ b/TYPO3.Fluid/Tests/Unit/ViewHelpers/Uri/ResourceViewHelperTest.php
@@ -12,6 +12,7 @@ namespace TYPO3\Fluid\Tests\Unit\ViewHelpers\Uri;
  */
 
 use TYPO3\Flow\I18n\Locale;
+use TYPO3\Flow\Resource\Exception;
 use TYPO3\Flow\Resource\Resource;
 
 require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
@@ -108,7 +109,16 @@ class ResourceViewHelperTest extends \TYPO3\Fluid\ViewHelpers\ViewHelperBaseTest
      */
     public function renderLocalizesResourceGivenAsResourceUri()
     {
-        $this->mockI18nService->expects($this->once())->method('getLocalizedFilename')->with('resource://ThePackageKey/Public/Styles/Main.css')->will($this->returnValue(array('resource://ThePackageKey/Public/Styles/Main.de.css', new Locale('de'))));
+        $this->mockResourceManager
+            ->expects($this->once())
+            ->method('getPackageAndPathByPublicPath')
+            ->with('resource://ThePackageKey/Public/Styles/Main.css')
+            ->will($this->returnValue(['ThePackageKey', 'Styles/Main.css']));
+        $this->mockI18nService
+            ->expects($this->once())
+            ->method('getLocalizedFilename')
+            ->with('resource://ThePackageKey/Public/Styles/Main.css')
+            ->will($this->returnValue(array('resource://ThePackageKey/Public/Styles/Main.de.css', new Locale('de'))));
         $this->mockResourceManager->expects($this->atLeastOnce())->method('getPublicPackageResourceUri')->with('ThePackageKey', 'Styles/Main.de.css')->will($this->returnValue('TheCorrectResourceUri'));
         $resourceUri = $this->viewHelper->render('resource://ThePackageKey/Public/Styles/Main.css');
         $this->assertEquals('TheCorrectResourceUri', $resourceUri);
@@ -147,6 +157,11 @@ class ResourceViewHelperTest extends \TYPO3\Fluid\ViewHelpers\ViewHelperBaseTest
      */
     public function renderThrowsExceptionIfResourceUriNotPointingToPublicWasGivenAsPath()
     {
+        $this->mockResourceManager
+            ->expects($this->once())
+            ->method('getPackageAndPathByPublicPath')
+            ->with('resource://Some.Package/Private/foobar.txt')
+            ->willThrowException(new Exception());
         $this->viewHelper->render('resource://Some.Package/Private/foobar.txt', 'SomePackage');
     }
 }


### PR DESCRIPTION
This change introduces two new methods in the ResourceManager.

The method ``getPackageAndPathByPublicPath`` returns an array with package and
path. This method is useful to avoid duplication of this logic. The second method ``getPublicPackageResourceUriByPath`` is syntactic sugar.

This change also adapts the ``ResourceViewHelper`` to use the new methods.