### PR TITLE
TASK: Use ReflectionObject in the Debugger to dump dynamic properties

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Error/Debugger.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Error/Debugger.php
@@ -259,8 +259,8 @@ class Debugger
                     $dump .= self::renderObjectDump($value, 0, false, $plaintext, $ansiColors);
                 }
             } else {
-                $classReflection = new \ReflectionClass($className);
-                $properties = $classReflection->getProperties();
+                $objectReflection = new \ReflectionObject($object);
+                $properties = $objectReflection->getProperties();
                 foreach ($properties as $property) {
                     if (preg_match(self::$blacklistedPropertyNames, $property->getName())) {
                         continue;


### PR DESCRIPTION
This change replaces the usage of ReflectionClass in the Debugger
class by ReflectionObject. This allows for debugging properties which
are set on the object during runtime but are not defined as property
on the class. Without this change those properties are ignored in the
var_dump command.