### PR TITLE
TASK: Remove typo3.org reference for exception codes

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Error/DebugExceptionHandler.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Error/DebugExceptionHandler.php
@@ -64,14 +64,13 @@ class DebugExceptionHandler extends AbstractExceptionHandler
             $filePathAndName = ($pathPosition !== false) ? substr($exception->getFile(), $pathPosition) : $exception->getFile();
             $exceptionCodeNumber = ($exception->getCode() > 0) ? '#' . $exception->getCode() . ': ' : '';
 
-            $moreInformationLink = ($exceptionCodeNumber != '') ? '<p><a href="http://typo3.org/go/exception/' . $exception->getCode() . '">More information</a></p>' : '';
             $exceptionMessageParts = $this->splitExceptionMessage($exception->getMessage());
 
             $exceptionHeader .= '<h2 class="ExceptionSubject">' . $exceptionCodeNumber . htmlspecialchars($exceptionMessageParts['subject']) . '</h2>';
             if ($exceptionMessageParts['body'] !== '') {
                 $exceptionHeader .= '<p class="ExceptionBody">' . nl2br(htmlspecialchars($exceptionMessageParts['body'])) . '</p>';
             }
-            $exceptionHeader .= $moreInformationLink . '
+            $exceptionHeader .= '
 				<span class="ExceptionProperty">' . get_class($exception) . '</span> thrown in file<br />
 				<span class="ExceptionProperty">' . $filePathAndName . '</span> in line
 				<span class="ExceptionProperty">' . $exception->getLine() . '</span>.<br />';


### PR DESCRIPTION
The ``DebugExceptionHandler`` renders "more information" links
pointing to  wiki.typo3.org. This was never really used to document
exceptions and with the departure from the TYPO3 project this should
be removed. A possible replacement can be readded later.

FLOW-421 #close