### PR TITLE
BUGFIX: Unlocking site breaks on Windows

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/LockManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/LockManager.php
@@ -94,9 +94,9 @@ class LockManager
     public function unlockSite()
     {
         if (is_resource($this->lockResource)) {
-            unlink($this->lockPathAndFilename);
             flock($this->lockResource, LOCK_UN);
             fclose($this->lockResource);
+            unlink($this->lockPathAndFilename);
         }
     }
 


### PR DESCRIPTION
In the method "unlockSite" the order for unlocking a file is wrong. Under Windows you first have to flock/fclose and then unlink (otherwise the lockfile is locked by OS and can not be removed). Then you get in Context Production the Errormessage "Site is currently locked, exiting.". The above reordering will fix this.