### PR TITLE
BUGFIX: Prevent overwriting source files

### DIFF
--- a/Neos.Flow/Classes/ResourceManagement/Target/FileSystemTarget.php
+++ b/Neos.Flow/Classes/ResourceManagement/Target/FileSystemTarget.php
@@ -315,7 +315,7 @@ class FileSystemTarget implements TargetInterface
 
         $targetPathAndFilename = $this->path . $relativeTargetPathAndFilename;
         $streamMetaData = stream_get_meta_data($sourceStream);
-        $sourcePathAndFilename = $streamMetaData['uri'];
+        $sourcePathAndFilename = $streamMetaData['uri'] ?? null;
 
         if (@fstat($sourceStream) === false) {
             throw new TargetException(sprintf('Could not publish "%s" into resource publishing target "%s" because the source file is not accessible (file stat failed).', $sourceStream, $this->name), 1375258499);

--- a/Neos.Flow/Classes/ResourceManagement/Target/FileSystemTarget.php
+++ b/Neos.Flow/Classes/ResourceManagement/Target/FileSystemTarget.php
@@ -181,7 +181,7 @@ class FileSystemTarget implements TargetInterface
      * @param StorageInterface $storage
      * @return void
      */
-    public function checkAndRemovePackageSymlinks(StorageInterface $storage)
+    protected function checkAndRemovePackageSymlinks(StorageInterface $storage)
     {
         if (!$storage instanceof PackageStorage) {
             return;

--- a/Neos.Flow/Classes/ResourceManagement/Target/FileSystemTarget.php
+++ b/Neos.Flow/Classes/ResourceManagement/Target/FileSystemTarget.php
@@ -20,6 +20,8 @@ use Neos\Flow\ResourceManagement\Publishing\MessageCollector;
 use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\Flow\ResourceManagement\ResourceMetaDataInterface;
 use Neos\Flow\ResourceManagement\ResourceRepository;
+use Neos\Flow\ResourceManagement\Storage\PackageStorage;
+use Neos\Flow\ResourceManagement\Storage\StorageInterface;
 use Neos\Flow\ResourceManagement\Storage\StorageObject;
 use Neos\Utility\Files;
 use Neos\Utility\Unicode\Functions as UnicodeFunctions;
@@ -173,6 +175,26 @@ class FileSystemTarget implements TargetInterface
     }
 
     /**
+     * Checks if the PackageStorage has been previously initialized with symlinks
+     * and clears them. Otherwise the original sources would be overwritten.
+     *
+     * @param StorageInterface $storage
+     * @return void
+     */
+    public function checkAndRemovePackageSymlinks(StorageInterface $storage)
+    {
+        if (!$storage instanceof PackageStorage) {
+            return;
+        }
+        foreach ($storage->getPublicResourcePaths() as $packageKey => $path) {
+            $targetPathAndFilename = $this->path . $packageKey;
+            if (Files::is_link($targetPathAndFilename)) {
+                Files::unlink($targetPathAndFilename);
+            }
+        }
+    }
+
+    /**
      * Publishes the whole collection to this target
      *
      * @param CollectionInterface $collection The collection to publish
@@ -181,6 +203,8 @@ class FileSystemTarget implements TargetInterface
      */
     public function publishCollection(CollectionInterface $collection, callable $callback = null)
     {
+        $storage = $collection->getStorage();
+        $this->checkAndRemovePackageSymlinks($storage);
         foreach ($collection->getObjects($callback) as $object) {
             /** @var StorageObject $object */
             $sourceStream = $object->getStream();
@@ -290,9 +314,17 @@ class FileSystemTarget implements TargetInterface
         }
 
         $targetPathAndFilename = $this->path . $relativeTargetPathAndFilename;
+        $streamMetaData = stream_get_meta_data($sourceStream);
+        $sourcePathAndFilename = $streamMetaData['uri'];
 
         if (@fstat($sourceStream) === false) {
             throw new TargetException(sprintf('Could not publish "%s" into resource publishing target "%s" because the source file is not accessible (file stat failed).', $sourceStream, $this->name), 1375258499);
+        }
+
+        // If you switch from FileSystemSymlinkTarget than we need to remove the symlink before trying to write the file
+        $targetPathAndFilenameInfo = new \SplFileInfo($targetPathAndFilename);
+        if ($targetPathAndFilenameInfo->isLink() && $targetPathAndFilenameInfo->getRealPath() === $sourcePathAndFilename) {
+            Files::unlink($targetPathAndFilename);
         }
 
         if (!file_exists(dirname($targetPathAndFilename))) {


### PR DESCRIPTION
After switching from `FileSystemSymlinkTarget` to `FileSystemTarget`
the symlinks are still present in the `targetPath` and therefore Flow
tries to copy the stream content in the symlink (original file, same
stream) which results in a 0 byte file.

We handle this issue by removing the symlinks if present.

FLOW-384 #close
