### PR TITLE
BUGFIX: AOP Proxies properly check method existance before upward delegation

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Aop/Builder/ProxyClassBuilder.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Aop/Builder/ProxyClassBuilder.php
@@ -439,7 +439,7 @@ class ProxyClassBuilder
             $proxyClass->addProperty($propertyIntroduction->getPropertyName(), 'NULL', $propertyIntroduction->getPropertyVisibility(), $propertyIntroduction->getPropertyDocComment());
         }
 
-        $proxyClass->getMethod('Flow_Aop_Proxy_buildMethodsAndAdvicesArray')->addPreParentCallCode("\t\tif (method_exists(get_parent_class(\$this), 'Flow_Aop_Proxy_buildMethodsAndAdvicesArray') && is_callable('parent::Flow_Aop_Proxy_buildMethodsAndAdvicesArray')) parent::Flow_Aop_Proxy_buildMethodsAndAdvicesArray();\n");
+        $proxyClass->getMethod('Flow_Aop_Proxy_buildMethodsAndAdvicesArray')->addPreParentCallCode("\t\tif (method_exists(get_parent_class(), 'Flow_Aop_Proxy_buildMethodsAndAdvicesArray') && is_callable('parent::Flow_Aop_Proxy_buildMethodsAndAdvicesArray')) parent::Flow_Aop_Proxy_buildMethodsAndAdvicesArray();\n");
         $proxyClass->getMethod('Flow_Aop_Proxy_buildMethodsAndAdvicesArray')->addPreParentCallCode($this->buildMethodsAndAdvicesArrayCode($interceptedMethods));
         $proxyClass->getMethod('Flow_Aop_Proxy_buildMethodsAndAdvicesArray')->overrideMethodVisibility('protected');
 
@@ -448,7 +448,7 @@ class ProxyClassBuilder
         $proxyClass->getMethod('__wakeup')->addPreParentCallCode($callBuildMethodsAndAdvicesArrayCode);
 
         if (!$this->reflectionService->hasMethod($targetClassName, '__wakeup')) {
-            $proxyClass->getMethod('__wakeup')->addPostParentCallCode("\t\tif (method_exists(get_parent_class(\$this), '__wakeup') && is_callable('parent::__wakeup')) parent::__wakeup();\n");
+            $proxyClass->getMethod('__wakeup')->addPostParentCallCode("\t\tif (method_exists(get_parent_class(), '__wakeup') && is_callable('parent::__wakeup')) parent::__wakeup();\n");
         }
 
         // FIXME this can be removed again once Doctrine is fixed (see fixMethodsAndAdvicesArrayForDoctrineProxiesCode())
@@ -546,7 +546,7 @@ class ProxyClassBuilder
         $code = <<<EOT
 		if (!isset(\$this->Flow_Aop_Proxy_targetMethodsAndGroupedAdvices) || empty(\$this->Flow_Aop_Proxy_targetMethodsAndGroupedAdvices)) {
 			\$this->Flow_Aop_Proxy_buildMethodsAndAdvicesArray();
-			if (is_callable('parent::Flow_Aop_Proxy_fixMethodsAndAdvicesArrayForDoctrineProxies')) parent::Flow_Aop_Proxy_fixMethodsAndAdvicesArrayForDoctrineProxies();
+			if (method_exists(get_parent_class(), 'Flow_Aop_Proxy_fixMethodsAndAdvicesArrayForDoctrineProxies') && is_callable('parent::Flow_Aop_Proxy_fixMethodsAndAdvicesArrayForDoctrineProxies')) parent::Flow_Aop_Proxy_fixMethodsAndAdvicesArrayForDoctrineProxies();
 		}
 EOT;
         return $code;
@@ -568,7 +568,7 @@ EOT;
 			return;
 		}
 		\$this->Flow_Proxy_injectProperties_fixInjectedPropertiesForDoctrineProxies = TRUE;
-		if (is_callable(array(\$this, 'Flow_Proxy_injectProperties'))) {
+		if (method_exists(get_class(), 'Flow_Proxy_injectProperties') && is_callable(array(\$this, 'Flow_Proxy_injectProperties'))) {
 			\$this->Flow_Proxy_injectProperties();
 		}
 EOT;


### PR DESCRIPTION
The usage of method_exists() checks inside the proxy class code was wrong by checking
the existance on the parent class of $this, which might in some circumstances not be
the current proxy class (ie. when checking method was originally called from a doctrine proxy).

This change fixes the method_exists calls by using the get_parent_class() without
parameter. Also, the method_exists check is added to the remaining method checks, that
currently only rely on is_callable, which in turn is always true on hierarchies that implement
__call magic method.