### PR TITLE
BUGFIX: Default constructor arguments only autowired if needed

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Object/Configuration/ConfigurationBuilder.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Object/Configuration/ConfigurationBuilder.php
@@ -367,35 +367,39 @@ class ConfigurationBuilder
             }
 
             $className = $objectConfiguration->getClassName();
+            if (!$this->reflectionService->hasMethod($className, '__construct')) {
+                continue;
+            }
+
+            $autowiringAnnotation = $this->reflectionService->getMethodAnnotation($className, '__construct', \TYPO3\Flow\Annotations\Autowiring::class);
             $arguments = $objectConfiguration->getArguments();
-
-            if ($this->reflectionService->hasMethod($className, '__construct')) {
-                foreach ($this->reflectionService->getMethodParameters($className, '__construct') as $parameterName => $parameterInformation) {
-                    $debuggingHint = '';
-                    $index = $parameterInformation['position'] + 1;
-                    if (!isset($arguments[$index])) {
-                        if ($parameterInformation['optional'] === true) {
-                            $defaultValue = (isset($parameterInformation['defaultValue'])) ? $parameterInformation['defaultValue'] : null;
-                            $arguments[$index] = new ConfigurationArgument($index, $defaultValue, ConfigurationArgument::ARGUMENT_TYPES_STRAIGHTVALUE);
-                        } elseif ($parameterInformation['class'] !== null && isset($objectConfigurations[$parameterInformation['class']])) {
-                            $arguments[$index] = new ConfigurationArgument($index, $parameterInformation['class'], ConfigurationArgument::ARGUMENT_TYPES_OBJECT);
-                        } elseif ($parameterInformation['allowsNull'] === true) {
-                            $arguments[$index] = new ConfigurationArgument($index, null, ConfigurationArgument::ARGUMENT_TYPES_STRAIGHTVALUE);
-                        } elseif (interface_exists($parameterInformation['class'])) {
-                            $debuggingHint = sprintf('No default implementation for the required interface %s was configured, therefore no specific class name could be used for this dependency. ', $parameterInformation['class']);
-                        }
-
-                        $autowiringAnnotation = $this->reflectionService->getMethodAnnotation($className, '__construct', \TYPO3\Flow\Annotations\Autowiring::class);
-                        if (isset($arguments[$index]) && ($objectConfiguration->getAutowiring() === Configuration::AUTOWIRING_MODE_OFF
-                                || $autowiringAnnotation !== null && $autowiringAnnotation->enabled === false)) {
-                            $arguments[$index]->setAutowiring(Configuration::AUTOWIRING_MODE_OFF);
-                            $arguments[$index]->set($index, null);
-                        }
-
-                        if (!isset($arguments[$index]) && $objectConfiguration->getScope() === Configuration::SCOPE_SINGLETON) {
-                            throw new \TYPO3\Flow\Object\Exception\UnresolvedDependenciesException(sprintf('Could not autowire required constructor argument $%s for singleton class %s. %sCheck the type hint of that argument and your Objects.yaml configuration.', $parameterName, $className, $debuggingHint), 1298629392);
-                        }
+            foreach ($this->reflectionService->getMethodParameters($className, '__construct') as $parameterName => $parameterInformation) {
+                $debuggingHint = '';
+                $index = $parameterInformation['position'] + 1;
+                if (!isset($arguments[$index])) {
+                    if ($parameterInformation['optional'] === true) {
+                        $defaultValue = (isset($parameterInformation['defaultValue'])) ? $parameterInformation['defaultValue'] : null;
+                        $arguments[$index] = new ConfigurationArgument($index, $defaultValue, ConfigurationArgument::ARGUMENT_TYPES_STRAIGHTVALUE);
+                        $arguments[$index]->setAutowiring(Configuration::AUTOWIRING_MODE_OFF);
+                    } elseif ($parameterInformation['class'] !== null && isset($objectConfigurations[$parameterInformation['class']])) {
+                        $arguments[$index] = new ConfigurationArgument($index, $parameterInformation['class'], ConfigurationArgument::ARGUMENT_TYPES_OBJECT);
+                    } elseif ($parameterInformation['allowsNull'] === true) {
+                        $arguments[$index] = new ConfigurationArgument($index, null, ConfigurationArgument::ARGUMENT_TYPES_STRAIGHTVALUE);
+                        $arguments[$index]->setAutowiring(Configuration::AUTOWIRING_MODE_OFF);
+                    } elseif (interface_exists($parameterInformation['class'])) {
+                        $debuggingHint = sprintf('No default implementation for the required interface %s was configured, therefore no specific class name could be used for this dependency. ', $parameterInformation['class']);
                     }
+
+                    if (isset($arguments[$index]) && ($objectConfiguration->getAutowiring() === Configuration::AUTOWIRING_MODE_OFF
+                            || $autowiringAnnotation !== null && $autowiringAnnotation->enabled === false)
+                    ) {
+                        $arguments[$index]->setAutowiring(Configuration::AUTOWIRING_MODE_OFF);
+                        $arguments[$index]->set($index, null);
+                    }
+                }
+
+                if (!isset($arguments[$index]) && $objectConfiguration->getScope() === Configuration::SCOPE_SINGLETON) {
+                    throw new \TYPO3\Flow\Object\Exception\UnresolvedDependenciesException(sprintf('Could not autowire required constructor argument $%s for singleton class %s. %sCheck the type hint of that argument and your Objects.yaml configuration.', $parameterName, $className, $debuggingHint), 1298629392);
                 }
             }
             $objectConfiguration->setArguments($arguments);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Object/DependencyInjection/ProxyClassBuilder.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Object/DependencyInjection/ProxyClassBuilder.php
@@ -243,35 +243,43 @@ class ProxyClassBuilder
     {
         $assignments = array();
 
-        $argumentConfigurations = $objectConfiguration->getArguments();
+        $configurationArguments = $objectConfiguration->getArguments();
         $constructorParameterInfo = $this->reflectionService->getMethodParameters($objectConfiguration->getClassName(), '__construct');
         $argumentNumberToOptionalInfo = array();
         foreach ($constructorParameterInfo as $parameterInfo) {
             $argumentNumberToOptionalInfo[($parameterInfo['position'] + 1)] = $parameterInfo['optional'];
         }
 
-        foreach ($argumentConfigurations as $argumentNumber => $argumentConfiguration) {
-            if ($argumentConfiguration === null) {
+        $highestArgumentPositionWithAutowiringEnabled = -1;
+
+        /**  @var ConfigurationArgument $configurationArgument */
+        foreach ($configurationArguments as $argumentNumber => $configurationArgument) {
+            if ($configurationArgument === null) {
                 continue;
             }
-            $argumentValue = $argumentConfiguration->getValue();
-            $assignmentPrologue = 'if (!array_key_exists(' . ($argumentNumber - 1) . ', $arguments)) $arguments[' . ($argumentNumber - 1) . '] = ';
+            $argumentPosition = $argumentNumber - 1;
+            if ($configurationArgument->getAutowiring() === Configuration::AUTOWIRING_MODE_ON) {
+                $highestArgumentPositionWithAutowiringEnabled = $argumentPosition;
+            }
+
+            $argumentValue = $configurationArgument->getValue();
+            $assignmentPrologue = 'if (!array_key_exists(' . $argumentPosition . ', $arguments)) $arguments[' . ($argumentNumber - 1) . '] = ';
             if ($argumentValue === null && isset($argumentNumberToOptionalInfo[$argumentNumber]) && $argumentNumberToOptionalInfo[$argumentNumber] === true) {
-                $assignments[] = $assignmentPrologue . 'NULL';
+                $assignments[$argumentPosition] = $assignmentPrologue . 'NULL';
             } else {
-                switch ($argumentConfiguration->getType()) {
+                switch ($configurationArgument->getType()) {
                     case ConfigurationArgument::ARGUMENT_TYPES_OBJECT:
                         if ($argumentValue instanceof Configuration) {
                             $argumentValueObjectName = $argumentValue->getObjectName();
                             $argumentValueClassName = $argumentValue->getClassName();
                             if ($argumentValueClassName === null) {
                                 $preparedArgument = $this->buildCustomFactoryCall($argumentValue->getFactoryObjectName(), $argumentValue->getFactoryMethodName(), $argumentValue->getArguments());
-                                $assignments[] = $assignmentPrologue . $preparedArgument;
+                                $assignments[$argumentPosition] = $assignmentPrologue . $preparedArgument;
                             } else {
                                 if ($this->objectConfigurations[$argumentValueObjectName]->getScope() === Configuration::SCOPE_PROTOTYPE) {
-                                    $assignments[] = $assignmentPrologue . 'new \\' . $argumentValueObjectName . '(' . $this->buildMethodParametersCode($argumentValue->getArguments()) . ')';
+                                    $assignments[$argumentPosition] = $assignmentPrologue . 'new \\' . $argumentValueObjectName . '(' . $this->buildMethodParametersCode($argumentValue->getArguments()) . ')';
                                 } else {
-                                    $assignments[] = $assignmentPrologue . '\TYPO3\Flow\Core\Bootstrap::$staticObjectManager->get(\'' . $argumentValueObjectName . '\')';
+                                    $assignments[$argumentPosition] = $assignmentPrologue . '\TYPO3\Flow\Core\Bootstrap::$staticObjectManager->get(\'' . $argumentValueObjectName . '\')';
                                 }
                             }
                         } else {
@@ -283,21 +291,26 @@ class ProxyClassBuilder
                             if (!isset($this->objectConfigurations[$argumentValue])) {
                                 throw new \TYPO3\Flow\Object\Exception\UnknownObjectException('The object "' . $argumentValue . '" which was specified as an argument in the object configuration of object "' . $objectConfiguration->getObjectName() . '" does not exist.', 1264669967);
                             }
-                            $assignments[] = $assignmentPrologue . '\TYPO3\Flow\Core\Bootstrap::$staticObjectManager->get(\'' . $argumentValue . '\')';
+                            $assignments[$argumentPosition] = $assignmentPrologue . '\TYPO3\Flow\Core\Bootstrap::$staticObjectManager->get(\'' . $argumentValue . '\')';
                         }
                     break;
 
                     case ConfigurationArgument::ARGUMENT_TYPES_STRAIGHTVALUE:
-                        $assignments[] = $assignmentPrologue . var_export($argumentValue, true);
+                        $assignments[$argumentPosition] = $assignmentPrologue . var_export($argumentValue, true);
                     break;
 
                     case ConfigurationArgument::ARGUMENT_TYPES_SETTING:
-                        $assignments[] = $assignmentPrologue . '\TYPO3\Flow\Core\Bootstrap::$staticObjectManager->getSettingsByPath(explode(\'.\', \'' . $argumentValue . '\'))';
+                        $assignments[$argumentPosition] = $assignmentPrologue . '\TYPO3\Flow\Core\Bootstrap::$staticObjectManager->getSettingsByPath(explode(\'.\', \'' . $argumentValue . '\'))';
                     break;
                 }
             }
         }
-        $code = count($assignments) > 0 ? "\n        " . implode(";\n        ", $assignments) . ";\n" : '';
+
+        for ($argumentCounter = count($assignments) - 1; $argumentCounter > $highestArgumentPositionWithAutowiringEnabled; $argumentCounter--) {
+            unset($assignments[$argumentCounter]);
+        }
+
+        $code = $argumentCounter >= 0 ? "\n        " . implode(";\n        ", $assignments) . ";\n" : '';
 
         $index = 0;
         foreach ($constructorParameterInfo as $parameterName => $parameterInfo) {


### PR DESCRIPTION
So far all constructor arguments were treated as autowired unless
configured otherwise. This can result in problems and one example
is seen with the constructor of ``ArrayObject`` starting from PHP 7.0.2.

Unfortunately PHP does not allow Reflection of build-in functions
arguments. This includes methods of build-in classes like ``ArrayObject``.
This results in our ReflectionService to report ``null`` as default for
those arguments which will then be autowired. Since PHP 7.0.2 all three
arguments of the ``ArrayObject`` constructor are reported correctly by
Reflection but due to our autowiring the third argument will be given
as ``null`` in the proxy class which results in a fatal error.

The solution is to mark configured arguments that use the default or null
to be not autowired and do not give them to the original constructor if
they are not followed by an autowired argument.

FLOW-431 #close Fixes the issue by changing the way we apply default values