### PR TITLE
BUGFIX: StringHelper::startsWith broken with multiple occurance

### DIFF
--- a/TYPO3.Eel/Classes/TYPO3/Eel/Helper/StringHelper.php
+++ b/TYPO3.Eel/Classes/TYPO3/Eel/Helper/StringHelper.php
@@ -281,7 +281,7 @@ class StringHelper implements ProtectedContextAwareInterface
     public function startsWith($string, $search, $position = null)
     {
         $position = $position !== null ? $position : 0;
-        return mb_strrpos($string, $search, null, 'UTF-8') === $position;
+        return mb_strpos($string, $search, null, 'UTF-8') === $position;
     }
 
     /**

--- a/TYPO3.Eel/Tests/Unit/Helper/StringHelperTest.php
+++ b/TYPO3.Eel/Tests/Unit/Helper/StringHelperTest.php
@@ -246,6 +246,7 @@ class StringHelperTest extends \TYPO3\Flow\Tests\UnitTestCase
             'search matched' => array('To be, or not to be, that is the question.', 'To be', null, true),
             'search not matched' => array('To be, or not to be, that is the question.', 'not to be', null, false),
             'search with position' => array('To be, or not to be, that is the question.', 'that is', 21, true),
+            'search with duplicate match' => array('to be, or not to be, that is the question.', 'to be', null, true),
             'unicode content can be searched' => array('Öaßaü', 'Öa', null, true)
         );
     }


### PR DESCRIPTION
In case the search string appeared multiple times in the haystack
startsWith would not correctly report the occurance at the beginning
as it used the same code as endsWith. This is now fixed by using
``mb_strpos`` instead ``mb_strrpos``.

FLOW-423 #close