### PR TITLE
BUGFIX: Value objects can be property mapped when submitted by identifier only

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/PersistentObjectConverter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/PersistentObjectConverter.php
@@ -151,9 +151,12 @@ class PersistentObjectConverter extends ObjectConverter
     {
         if (is_array($source)) {
             if ($this->reflectionService->isClassAnnotatedWith($targetType, 'TYPO3\Flow\Annotations\ValueObject')) {
-                // Unset identity for valueobject to use constructor mapping, since the identity is determined from
-                // constructor arguments
-                unset($source['__identity']);
+                if (isset($source['__identity']) && (count($source) > 1)) {
+                    // @TODO fix that in the URI building and transfer VOs as values instead as with their identities
+                    // Unset identity for valueobject to use constructor mapping, since the identity is determined from
+                    // constructor arguments
+                    unset($source['__identity']);
+                }
             }
             $object = $this->handleArrayData($source, $targetType, $convertedChildProperties, $configuration);
         } elseif (is_string($source)) {


### PR DESCRIPTION
The identifier is unset from the submitted properties for Value Objects, because
they should use constructor arguments to be reconstituted. However, in forms
value objects are currently submitted by identifier, which will make property
mapping fail with an error.

This change fixes that by only unsetting the identifier if there are other
properties submitted.