### PR TITLE
BUGFIX: Allow creation of value objects during property mapping by default

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/PersistentObjectConverter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/PersistentObjectConverter.php
@@ -12,6 +12,7 @@ namespace TYPO3\Flow\Property\TypeConverter;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Annotations\ValueObject;
 use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Flow\Property\Exception\DuplicateObjectException;
 use TYPO3\Flow\Property\Exception\InvalidPropertyMappingConfigurationException;
@@ -226,7 +227,7 @@ class PersistentObjectConverter extends ObjectConverter
     protected function handleArrayData(array $source, $targetType, array &$convertedChildProperties, PropertyMappingConfigurationInterface $configuration = null)
     {
         if (!isset($source['__identity'])) {
-            if ($configuration === null || $configuration->getConfigurationValue('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', self::CONFIGURATION_CREATION_ALLOWED) !== true) {
+            if (($configuration === null && $this->reflectionService->isClassAnnotatedWith($targetType, 'TYPO3\Flow\Annotations\ValueObject') === false) || $configuration->getConfigurationValue('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', self::CONFIGURATION_CREATION_ALLOWED) !== true) {
                 throw new InvalidPropertyMappingConfigurationException('Creation of objects not allowed. To enable this, you need to set the PropertyMappingConfiguration Value "CONFIGURATION_CREATION_ALLOWED" to TRUE');
             }
             $object = $this->buildObject($convertedChildProperties, $targetType);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/PersistentObjectConverter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/PersistentObjectConverter.php
@@ -227,7 +227,7 @@ class PersistentObjectConverter extends ObjectConverter
     protected function handleArrayData(array $source, $targetType, array &$convertedChildProperties, PropertyMappingConfigurationInterface $configuration = null)
     {
         if (!isset($source['__identity'])) {
-            if (($configuration === null && $this->reflectionService->isClassAnnotatedWith($targetType, 'TYPO3\Flow\Annotations\ValueObject') === false) || $configuration->getConfigurationValue('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', self::CONFIGURATION_CREATION_ALLOWED) !== true) {
+            if ($this->reflectionService->isClassAnnotatedWith($targetType, 'TYPO3\Flow\Annotations\ValueObject') === false && ($configuration === null || $configuration->getConfigurationValue('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', self::CONFIGURATION_CREATION_ALLOWED) !== true)) {
                 throw new InvalidPropertyMappingConfigurationException('Creation of objects not allowed. To enable this, you need to set the PropertyMappingConfiguration Value "CONFIGURATION_CREATION_ALLOWED" to TRUE');
             }
             $object = $this->buildObject($convertedChildProperties, $targetType);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/PersistentObjectConverter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/PersistentObjectConverter.php
@@ -227,7 +227,7 @@ class PersistentObjectConverter extends ObjectConverter
     protected function handleArrayData(array $source, $targetType, array &$convertedChildProperties, PropertyMappingConfigurationInterface $configuration = null)
     {
         if (!isset($source['__identity'])) {
-            if ($this->reflectionService->isClassAnnotatedWith($targetType, 'TYPO3\Flow\Annotations\ValueObject') === false && ($configuration === null || $configuration->getConfigurationValue('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', self::CONFIGURATION_CREATION_ALLOWED) !== true)) {
+            if ($this->reflectionService->isClassAnnotatedWith($targetType, 'TYPO3\Flow\Annotations\ValueObject') !== true && ($configuration === null || $configuration->getConfigurationValue('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', self::CONFIGURATION_CREATION_ALLOWED) !== true)) {
                 throw new InvalidPropertyMappingConfigurationException('Creation of objects not allowed. To enable this, you need to set the PropertyMappingConfiguration Value "CONFIGURATION_CREATION_ALLOWED" to TRUE');
             }
             $object = $this->buildObject($convertedChildProperties, $targetType);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/PersistentObjectConverter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/PersistentObjectConverter.php
@@ -227,7 +227,12 @@ class PersistentObjectConverter extends ObjectConverter
     protected function handleArrayData(array $source, $targetType, array &$convertedChildProperties, PropertyMappingConfigurationInterface $configuration = null)
     {
         if (!isset($source['__identity'])) {
-            if ($this->reflectionService->isClassAnnotatedWith($targetType, 'TYPO3\Flow\Annotations\ValueObject') !== true && ($configuration === null || $configuration->getConfigurationValue('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', self::CONFIGURATION_CREATION_ALLOWED) !== true)) {
+            if ($this->reflectionService->isClassAnnotatedWith($targetType, 'TYPO3\Flow\Annotations\ValueObject') === true) {
+                // Allow creation for ValueObjects by default, but prevent if explicitly disallowed
+                if ($configuration !== null && $configuration->getConfigurationValue('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', self::CONFIGURATION_CREATION_ALLOWED) === false) {
+                    throw new InvalidPropertyMappingConfigurationException('Creation of value objects not allowed. To enable this, you need to set the PropertyMappingConfiguration Value "CONFIGURATION_CREATION_ALLOWED" to TRUE');
+                }
+            } elseif ($configuration === null || $configuration->getConfigurationValue('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', self::CONFIGURATION_CREATION_ALLOWED) !== true) {
                 throw new InvalidPropertyMappingConfigurationException('Creation of objects not allowed. To enable this, you need to set the PropertyMappingConfiguration Value "CONFIGURATION_CREATION_ALLOWED" to TRUE');
             }
             $object = $this->buildObject($convertedChildProperties, $targetType);

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/PropertyMapping.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/PropertyMapping.rst
@@ -312,6 +312,14 @@ must be used to explicitly activate the modification or creation of objects. By
 default, the ``PersistentObjectConverter`` does only fetch objects from the persistence,
 but does not create new ones or modifies existing ones.
 
+.. note::
+
+	The only exception to this rule are Value Objects, which may always be created newly by default,
+	as this makes sense as of their nature. If you have a use case where the user may not
+	create new Value Objects, for example because he may only choose from a fixed list, you can
+	however explicitly disallow creation by setting the appropriate property's
+	``CONFIGURATION_CREATION_ALLOWED`` option to ``FALSE``.
+
 
 Default Configuration
 ---------------------


### PR DESCRIPTION
Currently it is impossible to edit value objects without explicitly
allowing creation. This is because value objects are always
created, never loaded from persistence.

This change alters the PersistentObjectConverter to allow creation
of value objects by default.

FLOW-373 #close