### PR TITLE
BUGFIX: Respect constructor arguments that are no properties during property mapping

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/PersistentObjectConverter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/PersistentObjectConverter.php
@@ -129,7 +129,11 @@ class PersistentObjectConverter extends ObjectConverter
 
         $schema = $this->reflectionService->getClassSchema($targetType);
         $setterMethodName = ObjectAccess::buildSetterMethodName($propertyName);
-        if ($schema->hasProperty($propertyName)) {
+        $constructorParameters = $this->reflectionService->getMethodParameters($targetType, '__construct');
+
+        if (isset($constructorParameters[$propertyName]) && isset($constructorParameters[$propertyName]['type'])) {
+            return $constructorParameters[$propertyName]['type'];
+        } elseif ($schema->hasProperty($propertyName)) {
             $propertyInformation = $schema->getProperty($propertyName);
             return $propertyInformation['type'] . ($propertyInformation['elementType'] !== null ? '<' . $propertyInformation['elementType'] . '>' : '');
         } elseif ($this->reflectionService->hasMethod($targetType, $setterMethodName)) {

--- a/TYPO3.Flow/Tests/Unit/Fixtures/ClassWithSettersAndConstructor.php
+++ b/TYPO3.Flow/Tests/Unit/Fixtures/ClassWithSettersAndConstructor.php
@@ -27,9 +27,20 @@ class ClassWithSettersAndConstructor
      */
     protected $property2;
 
-    public function __construct($property1)
+
+    /**
+     * @var string
+     */
+    protected $property3;
+
+    /**
+     * @param mixed $property1
+     * @param string $anotherProperty
+     */
+    public function __construct($property1, $anotherProperty = '')
     {
         $this->property1 = $property1;
+        $this->property3 = $anotherProperty;
     }
 
     public function getProperty1()

--- a/TYPO3.Flow/Tests/Unit/Property/TypeConverter/PersistentObjectConverterTest.php
+++ b/TYPO3.Flow/Tests/Unit/Property/TypeConverter/PersistentObjectConverterTest.php
@@ -166,7 +166,7 @@ class PersistentObjectConverterTest extends UnitTestCase
             array('TheTargetType', 'setVirtualPropertyName', array(array('type' => 'TheTypeOfSubObject')))
         )));
 
-        $this->mockReflectionService->expects($this->any())->method('hasMethod')->with('TheTargetType', 'setVirtualPropertyName')->will($this->returnValue(TRUE));
+        $this->mockReflectionService->expects($this->any())->method('hasMethod')->with('TheTargetType', 'setVirtualPropertyName')->will($this->returnValue(true));
         $this->mockReflectionService
             ->expects($this->exactly(2))
             ->method('getMethodParameters')
@@ -180,10 +180,12 @@ class PersistentObjectConverterTest extends UnitTestCase
         $configuration = $this->buildConfiguration(array());
         $this->assertEquals('TheTypeOfSubObject', $this->converter->getTypeOfChildProperty('TheTargetType', 'virtualPropertyName', $configuration));
     }
+
     /**
      * @test
      */
-    public function getTypeOfChildPropertyShouldConsiderConstructors() {
+    public function getTypeOfChildPropertyShouldConsiderConstructors()
+    {
         $mockSchema = $this->getMockBuilder(\TYPO3\Flow\Reflection\ClassSchema::class)->disableOriginalConstructor()->getMock();
         $this->mockReflectionService->expects($this->any())->method('getClassSchema')->with('TheTargetType')->will($this->returnValue($mockSchema));
         $this->mockReflectionService

--- a/TYPO3.Flow/Tests/Unit/Property/TypeConverter/PersistentObjectConverterTest.php
+++ b/TYPO3.Flow/Tests/Unit/Property/TypeConverter/PersistentObjectConverterTest.php
@@ -165,9 +165,38 @@ class PersistentObjectConverterTest extends UnitTestCase
             array('type' => 'TheTypeOfSubObject')
         )));
 
+        $this->mockReflectionService->expects($this->any())->method('hasMethod')->with('TheTargetType', 'setVirtualPropertyName')->will($this->returnValue(TRUE));
+        $this->mockReflectionService
+            ->expects($this->exactly(2))
+            ->method('getMethodParameters')
+            ->withConsecutive(
+                array($this->equalTo('TheTargetType'), $this->equalTo('__construct')),
+                array($this->equalTo('TheTargetType'), $this->equalTo('setVirtualPropertyName'))
+            )
+            ->will($this->returnValue(array(
+                array('type' => 'TheTypeOfSubObject')
+        )));
         $configuration = $this->buildConfiguration(array());
         $this->assertEquals('TheTypeOfSubObject', $this->converter->getTypeOfChildProperty('TheTargetType', 'virtualPropertyName', $configuration));
     }
+    /**
+     * @test
+     */
+    public function getTypeOfChildPropertyShouldConsiderConstructors() {
+        $mockSchema = $this->getMockBuilder(\TYPO3\Flow\Reflection\ClassSchema::class)->disableOriginalConstructor()->getMock();
+        $this->mockReflectionService->expects($this->any())->method('getClassSchema')->with('TheTargetType')->will($this->returnValue($mockSchema));
+        $this->mockReflectionService
+            ->expects($this->exactly(1))
+            ->method('getMethodParameters')
+            ->with('TheTargetType', '__construct')
+            ->will($this->returnValue(array(
+                'anotherProperty' => array('type' => 'string')
+        )));
+
+        $configuration = $this->buildConfiguration(array());
+        $this->assertEquals('string', $this->converter->getTypeOfChildProperty('TheTargetType', 'anotherProperty', $configuration));
+    }
+
 
     /**
      * @test

--- a/TYPO3.Flow/Tests/Unit/Property/TypeConverter/PersistentObjectConverterTest.php
+++ b/TYPO3.Flow/Tests/Unit/Property/TypeConverter/PersistentObjectConverterTest.php
@@ -161,8 +161,9 @@ class PersistentObjectConverterTest extends UnitTestCase
         $mockSchema->expects($this->any())->method('hasProperty')->with('virtualPropertyName')->will($this->returnValue(false));
 
         $this->mockReflectionService->expects($this->any())->method('hasMethod')->with('TheTargetType', 'setVirtualPropertyName')->will($this->returnValue(true));
-        $this->mockReflectionService->expects($this->any())->method('getMethodParameters')->with('TheTargetType', 'setVirtualPropertyName')->will($this->returnValue(array(
-            array('type' => 'TheTypeOfSubObject')
+        $this->mockReflectionService->expects($this->any())->method('getMethodParameters')->will($this->returnValueMap(array(
+            array('TheTargetType', '__construct', array()),
+            array('TheTargetType', 'setVirtualPropertyName', array(array('type' => 'TheTypeOfSubObject')))
         )));
 
         $this->mockReflectionService->expects($this->any())->method('hasMethod')->with('TheTargetType', 'setVirtualPropertyName')->will($this->returnValue(TRUE));


### PR DESCRIPTION
The PersistentObjectConverter does not evaluate constructor arguments
when determining the type of its children.

This patch adds the check and now constructor arguments that are not
also a property are mapped again.

FLOW-371 #close