### PR TITLE
BUGFIX: Don't leak version as "X-Flow-Powered" Header

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Response.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Response.php
@@ -111,7 +111,7 @@ class Response extends AbstractMessage implements ResponseInterface
     public function __construct(Response $parentResponse = null)
     {
         $this->headers = new Headers();
-        $this->headers->set('X-Flow-Powered', 'Flow/' . FLOW_VERSION_BRANCH);
+        $this->headers->set('X-Flow-Powered', 'Flow');
         $this->headers->set('Content-Type', 'text/html; charset=' . $this->charset);
         $this->parentResponse = $parentResponse;
     }

--- a/TYPO3.Flow/Tests/Unit/Http/ResponseTest.php
+++ b/TYPO3.Flow/Tests/Unit/Http/ResponseTest.php
@@ -217,7 +217,7 @@ class ResponseTest extends \TYPO3\Flow\Tests\UnitTestCase
 
         $expectedHeaders = array(
             'HTTP/1.1 123 Custom Status',
-            'X-Flow-Powered: Flow/' . FLOW_VERSION_BRANCH,
+            'X-Flow-Powered: Flow',
             'Content-Type: text/html; charset=UTF-8',
             'MyHeader: MyValue',
             'OtherHeader: OtherValue',


### PR DESCRIPTION
The Version shouldn't be leaked as a Header value.
This is kind of a security hole. Maybe we should make it optional, but I don't understand the advantage of leaking the version anyway.