### PR TITLE
BUGFIX: InstallerScripts can run ``rescanPackages``

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Composer/InstallerScripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Composer/InstallerScripts.php
@@ -32,6 +32,18 @@ class InstallerScripts
      */
     public static function postUpdateAndInstall(CommandEvent $event)
     {
+        if (!defined('FLOW_PATH_ROOT')) {
+            define('FLOW_PATH_ROOT', getcwd() . '/');
+        }
+
+        if (!defined('FLOW_PATH_PACKAGES')) {
+            define('FLOW_PATH_PACKAGES', getcwd() . '/Packages/');
+        }
+
+        if (!defined('FLOW_PATH_CONFIGURATION')) {
+            define('FLOW_PATH_CONFIGURATION', getcwd() . '/Configuration/');
+        }
+
         Files::createDirectoryRecursively('Configuration');
         Files::createDirectoryRecursively('Data');
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
@@ -117,6 +117,15 @@ class PackageManager implements PackageManagerInterface
     }
 
     /**
+     * @param string $packageStatesPathAndFilename
+     */
+    public function __construct($packageStatesPathAndFilename = '')
+    {
+        $this->packageFactory = new PackageFactory();
+        $this->packageStatesPathAndFilename = $packageStatesPathAndFilename ?: FLOW_PATH_CONFIGURATION . 'PackageStates.php';
+    }
+
+    /**
      * Initializes the package manager
      *
      * @param Bootstrap $bootstrap The current bootstrap
@@ -125,9 +134,6 @@ class PackageManager implements PackageManagerInterface
     public function initialize(Bootstrap $bootstrap)
     {
         $this->bootstrap = $bootstrap;
-        $this->packageStatesPathAndFilename = $this->packageStatesPathAndFilename ?: FLOW_PATH_CONFIGURATION . 'PackageStates.php';
-        $this->packageFactory = new PackageFactory();
-
         $this->packageStatesConfiguration = $this->getCurrentPackageStates();
         $this->activePackages = [];
         $this->registerPackagesFromConfiguration($this->packageStatesConfiguration);
@@ -1149,6 +1155,10 @@ class PackageManager implements PackageManagerInterface
      */
     protected function emitPackageStatesUpdated()
     {
+        if ($this->bootstrap === null) {
+            return;
+        }
+
         if ($this->dispatcher === null) {
             $this->dispatcher = $this->bootstrap->getEarlyInstance(Dispatcher::class);
         }


### PR DESCRIPTION
In order to update package states when composer changes packages
the PackageManager must work with minimal dependencies.
To make that possible all neccessary initialisations are moved to
the constructor and ``InstallerScripts`` define necessary
constants.