### PR TITLE
TASK: The ``package:rescan`` command is callable without proxies

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/PackageCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/PackageCommandController.php
@@ -27,7 +27,6 @@ use TYPO3\Flow\Package\PackageManagerInterface;
 class PackageCommandController extends CommandController
 {
     /**
-     * @Flow\Inject
      * @var PackageManagerInterface
      */
     protected $packageManager;
@@ -38,7 +37,6 @@ class PackageCommandController extends CommandController
     protected $settings;
 
     /**
-     * @Flow\Inject
      * @var Bootstrap
      */
     protected $bootstrap;
@@ -50,6 +48,24 @@ class PackageCommandController extends CommandController
     public function injectSettings(array $settings)
     {
         $this->settings = $settings;
+    }
+
+    /**
+     * @param PackageManagerInterface $packageManager
+     * @return void
+     */
+    public function injectPackageManager(PackageManagerInterface $packageManager)
+    {
+        $this->packageManager = $packageManager;
+    }
+
+    /**
+     * @param Bootstrap $bootstrap
+     * @return void
+     */
+    public function injectBootstrap(Bootstrap $bootstrap)
+    {
+        $this->bootstrap = $bootstrap;
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package.php
@@ -45,6 +45,7 @@ class Package extends BasePackage
 
         $bootstrap->registerCompiletimeCommand('typo3.flow:core:*');
         $bootstrap->registerCompiletimeCommand('typo3.flow:cache:flush');
+        $bootstrap->registerCompiletimeCommand('typo3.flow:package:rescan');
 
         $dispatcher = $bootstrap->getSignalSlotDispatcher();
         $dispatcher->connect(\TYPO3\Flow\Mvc\Dispatcher::class, 'afterControllerInvocation', function ($request) use ($bootstrap) {


### PR DESCRIPTION
To mitigate problems with packages not being loaded while creating
proxies the ``package:rescan`` command now becomes a compile time 
command, so it must be called via ``typo3.flow:package:rescan``.