### PR TITLE
TASK: Deprecate EarlyLogger

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Log/EarlyLogger.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Log/EarlyLogger.php
@@ -15,7 +15,7 @@ namespace TYPO3\Flow\Log;
  * Early logger for logging things that happens earlier in the bootstrap than setup of system logger and dependency
  * injection
  *
- * @api
+ * @deprecated Will be removed in Flow 4.0
  */
 class EarlyLogger implements SystemLoggerInterface
 {
@@ -34,7 +34,6 @@ class EarlyLogger implements SystemLoggerInterface
      *
      * @param \TYPO3\Flow\Log\Backend\BackendInterface $backend A backend implementation
      * @return void
-     * @api
      */
     public function addBackend(\TYPO3\Flow\Log\Backend\BackendInterface $backend)
     {
@@ -47,7 +46,6 @@ class EarlyLogger implements SystemLoggerInterface
      *
      * @param \TYPO3\Flow\Log\Backend\BackendInterface $backend The backend to remove
      * @return void
-     * @api
      */
     public function removeBackend(\TYPO3\Flow\Log\Backend\BackendInterface $backend)
     {
@@ -75,7 +73,6 @@ class EarlyLogger implements SystemLoggerInterface
      * @param string $className Name of the class triggering the log (determined automatically if not specified)
      * @param string $methodName Name of the method triggering the log (determined automatically if not specified)
      * @return void
-     * @api
      */
     public function log($message, $severity = LOG_INFO, $additionalData = null, $packageKey = null, $className = null, $methodName = null)
     {
@@ -88,7 +85,6 @@ class EarlyLogger implements SystemLoggerInterface
      * @param \Exception $exception The exception to log
      * @param array $additionalData Additional data to log
      * @return void
-     * @api
      */
     public function logException(\Exception $exception, array $additionalData = array())
     {
@@ -97,8 +93,6 @@ class EarlyLogger implements SystemLoggerInterface
 
     /**
      * Replays internal logs on provided logger. Use to transfer early logs to real logger when available.
-     *
-     * @see \TYPO3\Flow\Package\PackageManager
      *
      * @param SystemLoggerInterface $logger
      * @param boolean $resetLogs


### PR DESCRIPTION
The ``EarlyLogger`` was explicitly meant for the ``PackageManager``
which is not using it anymore. Therefore the EarlyLogger is deprecated
and bound for removal in the next major Flow version.

To underline the fact that it was never meant for user land code the
``@api`` annotations were removed.