### PR TITLE
BUGFIX: Evaluate property conditions without security checks

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Authorization/Privilege/Entity/Doctrine/PropertyConditionGenerator.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Authorization/Privilege/Entity/Doctrine/PropertyConditionGenerator.php
@@ -472,7 +472,11 @@ class PropertyConditionGenerator implements SqlGeneratorInterface
             $objectAccess = explode('.', $expression, 3);
             $globalObjectsRegisteredClassName = $this->globalObjects[$objectAccess[1]];
             $globalObject = $this->objectManager->get($globalObjectsRegisteredClassName);
-            return $this->getObjectValueByPath($globalObject, $objectAccess[2]);
+            $this->securityContext->withoutAuthorizationChecks(function () use ($globalObject, $objectAccess, &$globalObjectValue) {
+                $globalObjectValue = $this->getObjectValueByPath($globalObject, $objectAccess[2]);
+            });
+
+            return $globalObjectValue;
         } else {
             return trim($expression, '"\'');
         }


### PR DESCRIPTION
The PropertyConditionGenerator for entity privileges allows the use of
global objects from the configured global context. If those in turn
may be secured, the system runs into an endless loop.

To avoid this, the fetching of the value for the operand is done without
security checks after this change.