### PR TITLE
TASK: When reconnecting to DB, log preceding exception

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/PersistenceManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/PersistenceManager.php
@@ -153,6 +153,7 @@ class PersistenceManager extends \TYPO3\Flow\Persistence\AbstractPersistenceMana
         try {
             $this->entityManager->flush();
         } catch (Exception $exception) {
+            $this->systemLogger->logException($exception);
             /** @var Connection $connection */
             $connection = $this->entityManager->getConnection();
             $connection->close();


### PR DESCRIPTION
When flushing fails with Doctrine, we try to reconnect and flush again,
to work around dropped connections.

If the disconnection was caused by a "real" error, the cause was lost.
This change logs the exception that caused the reconnection to ease
debugging.