### PR TITLE
BUGFIX: Fix missing refactoring

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
@@ -494,7 +494,7 @@ class PackageManager implements PackageManagerInterface
             if (!$constraint instanceof MetaData\PackageConstraint) {
                 continue;
             }
-            $composerName = isset($this->packageStatesConfiguration['packages'][$constraint->getValue()]['composerName']) ? $this->packageStatesConfiguration['packages'][$constraint->getValue()]['composerName'] : $this->getComposerPackageNameFromPackageKey($constraint->getValue());
+            $composerName = isset($this->packageStatesConfiguration['packages'][$constraint->getValue()]['composerName']) ? $this->packageStatesConfiguration['packages'][$constraint->getValue()]['composerName'] : ComposerUtility::getComposerPackageNameFromPackageKey($constraint->getValue());
             $composerManifestConstraints[$composerName] = '*';
         }
 


### PR DESCRIPTION
Missing refactoring after 30b326a9735c80cd88c0acebcde127c02d6a198b
Method getComposerPackageNameFromPackageKey was moved from PackageManager to ComposerUtility but method call was still pointing to PackageManager.