### PR TITLE
BUGFIX: Make withoutAuthorizationChecks example realistic

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Context.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Context.php
@@ -188,7 +188,7 @@ class Context
      * Lets you switch off authorization checks (CSRF token, policies, content security, ...) for the runtime of $callback
      *
      * Usage:
-     * $this->securityContext->withoutAuthorizationChecks(function ($accountRepository, $username, $providerName, &$account) {
+     * $this->securityContext->withoutAuthorizationChecks(function () use ($accountRepository, $username, $providerName, &$account) {
      *   // this will disable the PersistenceQueryRewritingAspect for this one call
      *   $account = $accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName($username, $providerName)
      * });


### PR DESCRIPTION
The example for usage of ``withoutAuthorizationChecks`` in the docblock
is wrong in as it shows variables used inside the closure as closure
arguments but that is impossible. Instead they must be added to the
closure context via ``use``.