### PR TITLE
BUGFIX: Initialize Bootstrap::requestHandlers with empty array

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Bootstrap.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Bootstrap.php
@@ -51,7 +51,7 @@ class Bootstrap
     /**
      * @var array
      */
-    protected $requestHandlers;
+    protected $requestHandlers = array();
 
     /**
      * @var string


### PR DESCRIPTION
The ``requestHandlers`` property of the Bootstrap is used as an
array but is never initialized. For sake of cleanliness it should be.