### PR TITLE
BUGFIX: setHeader fails if 'Content-Type' value is not string

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/AbstractMessage.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/AbstractMessage.php
@@ -114,8 +114,15 @@ abstract class AbstractMessage
     {
         switch ($name) {
             case 'Content-Type':
+                $typeOfValues = gettype($values);
+                if ($typeOfValues == 'array') {
+                    $values = implode(" ", $values);
+                }
                 if (stripos($values, 'charset') === false && stripos($values, 'text/') === 0) {
                     $values .= '; charset=' . $this->charset;
+                }
+                if ($typeOfValues == 'array') {
+                    $values = (array) $values;
                 }
             break;
         }

--- a/TYPO3.Flow/Tests/Unit/Http/BrowserTest.php
+++ b/TYPO3.Flow/Tests/Unit/Http/BrowserTest.php
@@ -61,10 +61,12 @@ class BrowserTest extends \TYPO3\Flow\Tests\UnitTestCase
         $this->browser->setRequestEngine($requestEngine);
 
         $this->browser->addAutomaticRequestHeader('X-Test-Header', 'Acme');
+        $this->browser->addAutomaticRequestHeader('Content-Type', 'text/plain');
         $this->browser->request('http://localhost/foo');
 
         $this->assertTrue($this->browser->getLastRequest()->hasHeader('X-Test-Header'));
         $this->assertSame('Acme', $this->browser->getLastRequest()->getHeader('X-Test-Header'));
+        $this->assertContains('text/plain', $this->browser->getLastRequest()->getHeader('Content-Type'));
     }
 
     /**


### PR DESCRIPTION
If you add 'Content-Type' to the automatic request headers of a virtual browser, it fails every time. The given value will be casted to an array automatically. But 'Http\AbstractMessage::setHeader()' expects a string value for 'Content-Type'.
UnitTest extended especially for this header field.
See: https://jira.neos.io/browse/FLOW-305