### PR TITLE
TASK: Split Lock utility off

### DIFF
--- a/Neos.Flow.Lock/Classes/TYPO3/Flow/Utility/Lock/Lock.php
+++ b/Neos.Flow.Lock/Classes/TYPO3/Flow/Utility/Lock/Lock.php
@@ -2,7 +2,7 @@
 namespace TYPO3\Flow\Utility\Lock;
 
 /*
- * This file is part of the TYPO3.Flow package.
+ * This file is part of the Neos.Flow.Lock package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,14 +11,9 @@ namespace TYPO3\Flow\Utility\Lock;
  * source code.
  */
 
-use TYPO3\Flow\Annotations as Flow;
-use TYPO3\Flow\Configuration\ConfigurationManager;
-use TYPO3\Flow\Core\Bootstrap;
-
 /**
  * A general lock class.
  *
- * @Flow\Scope("prototype")
  * @api
  */
 class Lock
@@ -27,6 +22,11 @@ class Lock
      * @var string
      */
     protected static $lockStrategyClassName;
+
+    /**
+     * @var LockManager
+     */
+    protected static $lockManager;
 
     /**
      * @var \TYPO3\Flow\Utility\Lock\LockStrategyInterface
@@ -49,15 +49,10 @@ class Lock
      */
     public function __construct($subject, $exclusiveLock = true)
     {
-        if (self::$lockStrategyClassName === null) {
-            if (Bootstrap::$staticObjectManager === null || !Bootstrap::$staticObjectManager->isRegistered(\TYPO3\Flow\Configuration\ConfigurationManager::class)) {
-                return;
-            }
-            $configurationManager = Bootstrap::$staticObjectManager->get(\TYPO3\Flow\Configuration\ConfigurationManager::class);
-            $settings = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow');
-            self::$lockStrategyClassName = $settings['utility']['lockStrategyClassName'];
+        if (self::$lockManager === null) {
+            return;
         }
-        $this->lockStrategy = new self::$lockStrategyClassName();
+        $this->lockStrategy = self::$lockManager->getLockStrategyInstance();
         $this->lockStrategy->acquire($subject, $exclusiveLock);
     }
 
@@ -67,6 +62,18 @@ class Lock
     public function getLockStrategy()
     {
         return $this->lockStrategy;
+    }
+
+    /**
+     * Set the instance of LockManager to use.
+     *
+     * Must be nullable especially for testing
+     *
+     * @param LockManager $lockManager
+     */
+    public static function setLockManager(LockManager $lockManager = null)
+    {
+        static::$lockManager = $lockManager;
     }
 
     /**

--- a/Neos.Flow.Lock/Classes/TYPO3/Flow/Utility/Lock/LockManager.php
+++ b/Neos.Flow.Lock/Classes/TYPO3/Flow/Utility/Lock/LockManager.php
@@ -1,0 +1,43 @@
+<?php
+namespace TYPO3\Flow\Utility\Lock;
+
+/**
+ * This Lock manager should be used as a singleton and keeps information which LockStrategyInteface to use and the options.
+ */
+class LockManager
+{
+    /**
+     * @var string
+     */
+    protected $lockStrategyClassName;
+
+    /**
+     * @var array
+     */
+    protected $lockStrategyOptions;
+
+    /**
+     * LockManager constructor.
+     *
+     * @param $lockStrategyClassName
+     * @param array $lockStrategyOptions
+     */
+    public function __construct($lockStrategyClassName, array $lockStrategyOptions = [])
+    {
+        if (!class_exists($lockStrategyClassName)) {
+            throw new \InvalidArgumentException('The given class name given as implementation of the LockStrategyInterface does not exist!', 1454694738);
+        }
+
+        $this->lockStrategyClassName = $lockStrategyClassName;
+        $this->lockStrategyOptions = $lockStrategyOptions;
+    }
+
+    /**
+     * @return LockStrategyInterface
+     */
+    public function getLockStrategyInstance()
+    {
+        $lockStrategy = $this->lockStrategyClassName;
+        return new $lockStrategy($this->lockStrategyOptions);
+    }
+}

--- a/Neos.Flow.Lock/Classes/TYPO3/Flow/Utility/Lock/LockNotAcquiredException.php
+++ b/Neos.Flow.Lock/Classes/TYPO3/Flow/Utility/Lock/LockNotAcquiredException.php
@@ -1,8 +1,8 @@
 <?php
-namespace TYPO3\Flow\Utility\Exception;
+namespace TYPO3\Flow\Utility\Lock;
 
 /*
- * This file is part of the TYPO3.Flow package.
+ * This file is part of the Neos.Flow.Lock package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Neos.Flow.Lock/Classes/TYPO3/Flow/Utility/Lock/LockStrategyInterface.php
+++ b/Neos.Flow.Lock/Classes/TYPO3/Flow/Utility/Lock/LockStrategyInterface.php
@@ -2,7 +2,7 @@
 namespace TYPO3\Flow\Utility\Lock;
 
 /*
- * This file is part of the TYPO3.Flow package.
+ * This file is part of the Neos.Flow.Lock package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *

--- a/Neos.Flow.Lock/Readme.rst
+++ b/Neos.Flow.Lock/Readme.rst
@@ -1,0 +1,21 @@
+------------------------
+Flow Lock Implementation
+------------------------
+
+.. note:: This repository is a **read-only subsplit** of a package that is part of the
+Flow framework (learn more on `flow.typo3.org <http://flow.typo3.org/>`_).
+
+If you want to use the Flow framework, please have a look at the `Flow documentation
+<http://flowframework.readthedocs.org/en/stable/>`_
+
+Contribute
+----------
+
+If you want to contribute to the Flow framework, please have a look at
+https://github.com/neos/flow-development-collection - it is the repository
+used for development and all pull requests should go into it.
+
+Dependencies
+------------
+
+This package uses the File Utility of Flow, as soon as that was split to a separete

--- a/Neos.Flow.Lock/composer.json
+++ b/Neos.Flow.Lock/composer.json
@@ -1,0 +1,27 @@
+{
+  "name": "neos/flow-lock",
+  "description" : "Flow Locking Implementation",
+  "license": "MIT",
+  "support": {
+    "email": "hello@neos.io",
+    "slack": "http://slack.neos.io/",
+    "forum": "https://discuss.neos.io/",
+    "issues": "https://jira.neos.io/browse/FLOW",
+    "docs": "http://flowframework.readthedocs.org/",
+    "source": "https://github.com/neos/composer-plugin"
+  },
+  "type": "library",
+  "require": {
+    "typo3/flow": "*"
+  },
+  "autoload": {
+    "psr-0": {
+      "TYPO3\\Flow\\Utility\\Lock\\": "Classes"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "TYPO3\\Flow\\Utility\\Lock\\Tests\\": "Tests"
+    }
+  }
+}

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
@@ -20,6 +20,9 @@ use TYPO3\Flow\Package\PackageInterface;
 use TYPO3\Flow\Package\PackageManagerInterface;
 use TYPO3\Flow\Resource\ResourceManager;
 use TYPO3\Flow\Resource\Streams\StreamWrapperAdapter;
+use TYPO3\Flow\Utility\Files;
+use TYPO3\Flow\Utility\Lock\Lock;
+use TYPO3\Flow\Utility\Lock\LockManager;
 
 /**
  * Initialization scripts for modules of the Flow package
@@ -192,6 +195,12 @@ class Scripts
         } else {
             $environment->setTemporaryDirectoryBase(FLOW_PATH_TEMPORARY_BASE);
         }
+
+        $lockManager = new LockManager($settings['utility']['lockStrategyClassName'], ['lockDirectory' => Files::concatenatePaths([
+            $environment->getPathToTemporaryDirectory(),
+            'Lock'
+        ])]);
+        Lock::setLockManager($lockManager);
 
         $configurationManager->injectEnvironment($environment);
         $packageManager->injectSettings($settings);

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "neos/composer-plugin": "^1.0.1"
     },
     "replace": {
+        "neos/flow-lock": "self.version",
         "typo3/eel": "self.version",
         "typo3/flow": "self.version",
         "typo3/fluid": "self.version",
@@ -36,6 +37,7 @@
     },
     "autoload": {
         "psr-0": {
+            "TYPO3\\Flow\\Utility\\Lock\\": "Neos.Flow.Lock/Classes",
             "TYPO3\\Eel": "TYPO3.Eel/Classes",
             "TYPO3\\Flow": "TYPO3.Flow/Classes",
             "TYPO3\\Fluid": "TYPO3.Fluid/Classes",


### PR DESCRIPTION
This separates the Flow Lock implementation into a separate
package removing almost all dependencies on Flow.
The only dependencies left is on the File utility, so as soon
as that is separated this package can be used without Flow core.

This change is supposed to be non breaking and no fucntionality
has been changed. The Flow bootstrap takes care of initializing
the new ``LockManager``. The only actual change is that the
Exception ``LockNotAcquiredException`` has a different
namespace now.