### PR TITLE
BUGFIX: package:create allows flow package typep

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/PackageCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/PackageCommandController.php
@@ -90,7 +90,8 @@ class PackageCommandController extends CommandController
             $this->outputLine('The package "%s" already exists.', [$packageKey]);
             $this->quit(1);
         }
-        if (ComposerUtility::isFlowPackageType($packageType)) {
+
+        if (!ComposerUtility::isFlowPackageType($packageType)) {
             $this->outputLine('The package must be a Flow package, but "%s" is not a valid Flow package type.', [$packageKey]);
             $this->quit(1);
         }


### PR DESCRIPTION
The condition to check for a valid Flow package type in
the ``package:create`` command was not negated correctly and
so didn't allow creation of any flow package type.

This is now fixed and creation of packages works again.