### PR TITLE
BUGFIX: 'Content-Type' (automatic) header fails in virtual browser

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/AbstractMessage.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/AbstractMessage.php
@@ -108,12 +108,19 @@ abstract class AbstractMessage
      * @param array|string|\DateTime $values An array of values or a single value for the specified header field
      * @param boolean $replaceExistingHeader If a header with the same name should be replaced. Default is TRUE.
      * @return self This message, for method chaining
+     * @throws \InvalidArgumentException
      * @api
      */
     public function setHeader($name, $values, $replaceExistingHeader = true)
     {
         switch ($name) {
             case 'Content-Type':
+                if (is_array($values)) {
+                    if (count($values) !== 1) {
+                        throw new \InvalidArgumentException('The "Content-Type" header must be unique and thus only one field value may be specified.', 1454949291);
+                    }
+                    $values = (string) $values[0];
+                }
                 if (stripos($values, 'charset') === false && stripos($values, 'text/') === 0) {
                     $values .= '; charset=' . $this->charset;
                 }

--- a/TYPO3.Flow/Tests/Unit/Http/BrowserTest.php
+++ b/TYPO3.Flow/Tests/Unit/Http/BrowserTest.php
@@ -61,10 +61,12 @@ class BrowserTest extends \TYPO3\Flow\Tests\UnitTestCase
         $this->browser->setRequestEngine($requestEngine);
 
         $this->browser->addAutomaticRequestHeader('X-Test-Header', 'Acme');
+        $this->browser->addAutomaticRequestHeader('Content-Type', 'text/plain');
         $this->browser->request('http://localhost/foo');
 
         $this->assertTrue($this->browser->getLastRequest()->hasHeader('X-Test-Header'));
         $this->assertSame('Acme', $this->browser->getLastRequest()->getHeader('X-Test-Header'));
+        $this->assertContains('text/plain', $this->browser->getLastRequest()->getHeader('Content-Type'));
     }
 
     /**


### PR DESCRIPTION
With adding the `Content-Type` header to the automatic headers of a virtual browser, the request fails every time.

The given value is cast to an array by the `Http\Headers::set()` method. When setting this header in a `Header` (!) instance (`Http\AbstractMessage::setHeader()`) of the request, a string is expected especially for `Content-Type`, but an array is given.

`BrowserTest` extended especially for this header field.

FLOW-305 #close
