### PR TITLE
BUGFIX: PackageManager only uses MetaData type if it was set

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
@@ -457,7 +457,9 @@ class PackageManager implements PackageManagerInterface
             return $manifest;
         }
 
-        $manifest['type'] = $packageMetaData->getPackageType();
+        if ($packageMetaData->getPackageType() !== null) {
+            $manifest['type'] = $packageMetaData->getPackageType();
+        }
         $manifest['description'] = $packageMetaData->getDescription() ?: $manifest['description'];
         if ($packageMetaData->getVersion()) {
             $manifest['version'] = $packageMetaData->getVersion();


### PR DESCRIPTION
The deprecated package metadata can contain a type but we should
use it for generating a composer manifest only if the type was
actually set otherwise the given type should be used.