### PR TITLE
BUGFIX: Inactive packages are handled correctly

### DIFF
--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -254,7 +254,9 @@ TYPO3:
       # Option for the PackageManager::Create to map the packagesPath by package type
       packagesPathByType:
         'typo3-flow-package': 'Application'
+        'neos-package': 'Application'
         'typo3-flow-framework': 'Framework'
+        'neos-framework': 'Framework'
 
     persistence:
 

--- a/TYPO3.Flow/Tests/Unit/Package/PackageManagerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Package/PackageManagerTest.php
@@ -68,12 +68,11 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
             return get_class($object);
         }));
         $mockObjectManager->expects($this->any())->method('get')->with(\TYPO3\Flow\Reflection\ReflectionService::class)->will($this->returnValue($mockReflectionService));
-        $this->packageManager = new PackageManager();
 
         mkdir('vfs://Test/Packages/Application', 0700, true);
         mkdir('vfs://Test/Configuration');
 
-        $mockClassLoader = $this->getMock(\TYPO3\Flow\Core\ClassLoader::class);
+        $this->packageManager = new PackageManager('vfs://Test/Configuration/PackageStates.php');
 
         $composerNameToPackageKeyMap = array(
             'typo3/flow' => 'TYPO3.Flow'
@@ -81,7 +80,6 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
 
         $this->inject($this->packageManager, 'composerNameToPackageKeyMap', $composerNameToPackageKeyMap);
         $this->inject($this->packageManager, 'packagesBasePath', 'vfs://Test/Packages/');
-        $this->inject($this->packageManager, 'packageStatesPathAndFilename', 'vfs://Test/Configuration/PackageStates.php');
 
         $this->mockDispatcher = $this->getMockBuilder(Dispatcher::class)->disableOriginalConstructor()->getMock();
         $this->inject($this->packageManager, 'dispatcher', $this->mockDispatcher);
@@ -248,11 +246,12 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
         );
 
         foreach ($expectedPackageKeys as $packageKey) {
+            $packageName = ComposerUtility::getComposerPackageNameFromPackageKey($packageKey);
             $packagePath = 'vfs://Test/Packages/Application/' . $packageKey . '/';
 
             mkdir($packagePath, 0770, true);
             mkdir($packagePath . 'Classes');
-            file_put_contents($packagePath . 'composer.json', '{"name": "' . $packageKey . '", "type": "flow-test"}');
+            file_put_contents($packagePath . 'composer.json', '{"name": "' . $packageName . '", "type": "flow-test"}');
         }
 
         $packageManager = $this->getAccessibleMock(PackageManager::class, array('emitPackageStatesUpdated'));
@@ -264,7 +263,7 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
 
         $packageManager->_set('packageStatesConfiguration', array(
             'packages' => array(
-                $packageKey => array(
+                $packageName => array(
                     'state' => 'inactive',
                     'frozen' => false,
                     'packagePath' => 'Application/' . $packageKey . '/',
@@ -273,10 +272,8 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
             ),
             'version' => 2
         ));
-        $packageManager->rescanPackages(false);
-
-        $packageStates = require('vfs://Test/Configuration/PackageStates.php');
-        $this->assertEquals('inactive', $packageStates['packages'][$packageKey]['state']);
+        $packageStates = $packageManager->rescanPackages(false);
+        $this->assertEquals('inactive', $packageStates['packages'][$packageName]['state']);
     }
 
 


### PR DESCRIPTION
After the package manager refactoring several inconsistencies with
inactive packages and moving them to a separate directory arose.
The code was adapted to make this more consistent and allow loading
of composer manifests from deactivated packages.