### PR TITLE
FEATURE: Allow setting validator options for element validators

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Validation/Validator/CollectionValidator.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Validation/Validator/CollectionValidator.php
@@ -25,6 +25,7 @@ class CollectionValidator extends GenericObjectValidator
      */
     protected $supportedOptions = array(
         'elementValidator' => array(null, 'The validator type to use for the collection elements', 'string'),
+        'elementValidatorOptions' => array([], 'The validator options to use for the collection elements', 'array'),
         'elementType' => array(null, 'The type of the elements in the collection', 'string'),
         'validationGroups' => array(null, 'The validation groups to link to', 'string'),
     );
@@ -77,7 +78,7 @@ class CollectionValidator extends GenericObjectValidator
     {
         foreach ($value as $index => $collectionElement) {
             if (isset($this->options['elementValidator'])) {
-                $collectionElementValidator = $this->validatorResolver->createValidator($this->options['elementValidator']);
+                $collectionElementValidator = $this->validatorResolver->createValidator($this->options['elementValidator'], $this->options['elementValidatorOptions']);
             } elseif (isset($this->options['elementType'])) {
                 if (isset($this->options['validationGroups'])) {
                     $collectionElementValidator = $this->validatorResolver->getBaseValidatorConjunction($this->options['elementType'], $this->options['validationGroups']);

--- a/TYPO3.Flow/Tests/Unit/Validation/Validator/CollectionValidatorTest.php
+++ b/TYPO3.Flow/Tests/Unit/Validation/Validator/CollectionValidatorTest.php
@@ -51,7 +51,7 @@ class CollectionValidatorTest extends \TYPO3\Flow\Tests\Unit\Validation\Validato
      */
     public function collectionValidatorValidatesEveryElementOfACollectionWithTheGivenElementValidator()
     {
-        $this->validator->_set('options', array('elementValidator' => 'EmailAddress'));
+        $this->validator->_set('options', array('elementValidator' => 'EmailAddress', 'elementValidatorOptions' => []));
         $this->mockValidatorResolver->expects($this->exactly(4))->method('createValidator')->with('EmailAddress')->will($this->returnValue(new \TYPO3\Flow\Validation\Validator\EmailAddressValidator()));
 
         $arrayOfEmailAddresses = array(
@@ -87,7 +87,7 @@ class CollectionValidatorTest extends \TYPO3\Flow\Tests\Unit\Validation\Validato
 
         // Create validators
         $aValidator = new \TYPO3\Flow\Validation\Validator\GenericObjectValidator(array());
-        $this->validator->_set('options', array('elementValidator' => 'Integer'));
+        $this->validator->_set('options', array('elementValidator' => 'Integer', 'elementValidatorOptions' => []));
         $integerValidator = new \TYPO3\Flow\Validation\Validator\IntegerValidator(array());
 
         // Add validators to properties

--- a/TYPO3.Flow/Tests/Unit/Validation/Validator/CollectionValidatorTest.php
+++ b/TYPO3.Flow/Tests/Unit/Validation/Validator/CollectionValidatorTest.php
@@ -112,4 +112,18 @@ class CollectionValidatorTest extends \TYPO3\Flow\Tests\Unit\Validation\Validato
 
         $this->validator->validate($persistentCollection);
     }
+
+    /**
+     * @test
+     */
+    public function collectionValidatorTransfersElementValidatorOptionsToTheElementValidator()
+    {
+        $elementValidatorOptions = ['minimum' => 5];
+        $this->validator->_set('options', ['elementValidator' => 'NumberRange', 'elementValidatorOptions' => $elementValidatorOptions]);
+        $this->mockValidatorResolver->expects($this->any())->method('createValidator')->with('NumberRange', $elementValidatorOptions)->will($this->returnValue(new \TYPO3\Flow\Validation\Validator\NumberRangeValidator($elementValidatorOptions)));
+
+        $result = $this->validator->validate([5, 6, 1]);
+
+        $this->assertCount(1, $result->getFlattenedErrors());
+    }
 }


### PR DESCRIPTION
The element validators configured for a collection validator couldn't
accept options so far, with this change it is possible to set the
``elementValidatorOptions`` option on the ``CollectionValidator`` to
give options to the element validator.

FLOW-435 #resolve