### PR TITLE
BUGFIX: Fix session garbageCollector probability of 0

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Session/Session.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Session/Session.php
@@ -664,9 +664,9 @@ class Session implements SessionInterface
             }
             $this->started = false;
 
-            $decimals = strlen(strrchr($this->garbageCollectionProbability, '.')) - 1;
+            $decimals = (integer)strlen(strrchr($this->garbageCollectionProbability, '.')) - 1;
             $factor = ($decimals > -1) ? $decimals * 10 : 1;
-            if (rand(0, 100 * $factor) <= ($this->garbageCollectionProbability * $factor)) {
+            if (rand(1, 100 * $factor) <= ($this->garbageCollectionProbability * $factor)) {
                 $this->collectGarbage();
             }
         }


### PR DESCRIPTION
I would expect a session garbageCollection.probability of zero would never
trigger garbage collection.

Previously it actually did with a probability 1 / 101 as a it results in the
equation rand(0, 100) <= 0.
