### PR TITLE
[BUGFIX] Fix two small formatting issues in docs

### DIFF
--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartI/EssentialDesignPatterns.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartI/EssentialDesignPatterns.rst
@@ -34,7 +34,7 @@ boundaries of classes and even packages. One example for such a cross-cutting
 concern is security: Although the main purpose of a Forum package is to display
 and manage posts of a forum, it has to implement some kind of security to assert
 that only moderators can approve or delete posts. And many more packages need a
-similar functionality for protect the creation, deletion and update of records. .
+similar functionality for protect the creation, deletion and update of records. 
 AOP enables you to move the security (or any other) aspect into its own package
 and leave the other objects with clear responsibilities, probably not
 implementing any security themselves.

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/Introduction.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/Introduction.rst
@@ -30,7 +30,7 @@ to produce clean code in no time.
 .. note::
 	If you're stuck at some point or stumble over some weirdnesses during the
 	tutorial, please let us know! We appreciate any feedback in our `forum <https://discuss.neos.io/>`_, as
-	a ticket in our `issue tracker <https://jira.neos.io/browse/FLOW>`_ or via `Slack <http://slack.neos.io/>`.
+	a ticket in our `issue tracker <https://jira.neos.io/browse/FLOW>`_ or via `Slack <http://slack.neos.io/>`_.
 
 .. tip::
 	This tutorial goes best with a Caffè Latte or, if it's afternoon or late night


### PR DESCRIPTION
The dot was one to much, and the link didn't render because of formatting issue.

Beside that, `EssentialDesignPatterns.rst` was not posix conform as the last line was missing new line character.