### PR TITLE
BUGFIX: Fix two small formatting issues in docs

### DIFF
--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartI/EssentialDesignPatterns.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartI/EssentialDesignPatterns.rst
@@ -34,7 +34,7 @@ boundaries of classes and even packages. One example for such a cross-cutting
 concern is security: Although the main purpose of a Forum package is to display
 and manage posts of a forum, it has to implement some kind of security to assert
 that only moderators can approve or delete posts. And many more packages need a
-similar functionality for protect the creation, deletion and update of records. .
+similar functionality for protect the creation, deletion and update of records.
 AOP enables you to move the security (or any other) aspect into its own package
 and leave the other objects with clear responsibilities, probably not
 implementing any security themselves.

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/Introduction.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/Introduction.rst
@@ -2,17 +2,17 @@
 Introduction
 ============
 
-.. sectionauthor:: Robert Lemke <robert@typo3.org>
+.. sectionauthor:: Robert Lemke <robert@neos.io>
 
-What's TYPO3 Flow
-=================
+What's Flow
+===========
 
-TYPO3 Flow is a PHP-based application framework. It is especially well-suited for
+Flow is a PHP-based application framework. It is especially well-suited for
 enterprise-grade applications and explicitly supports Domain-Driven Design, a
 powerful software design philosophy. Convention over configuration, Test-Driven
 Development, Continuous Integration and an easy-to-read source code are other
-important principles we follow for the development of TYPO3 Flow. Needless to say,
-TYPO3 Flow provides you with a full-stack MVC framework for building
+important principles we follow for the development of Flow. Needless to say,
+Flow provides you with a full-stack MVC framework for building
 state-of-the-art web applications. More exciting though are the first class
 Dependency Injection support and the Aspect-Oriented Programming capabilities
 which can be used without a single line of configuration.
@@ -21,7 +21,7 @@ What's in this tutorial?
 ========================
 
 This tutorial explains all the steps to get you started with your very own
-first TYPO3 Flow project.
+first Flow project.
 
 Please bring your own computer, a reasonable knowledge of PHP and HTML and at
 least some initial experience with object-oriented programming. In return
@@ -30,14 +30,10 @@ to produce clean code in no time.
 
 .. note::
 	If you're stuck at some point or stumble over some weirdnesses during the
-	tutorial, please let us know! We appreciate any feedback in our mailing
-	lists, as a ticket in our issue tracker or via private email. [#]_
+	tutorial, please let us know! We appreciate any feedback in our `forum <https://discuss.neos.io/>`_,
+	as a ticket in our `issue tracker <https://jira.neos.io/browse/FLOW>`_ or via `Slack
+	<http://slack.neos.io/>`_.
 
 .. tip::
 	This tutorial goes best with a Caffè Latte or, if it's afternoon or late night
 	already, with a few shots of Espresso ...
-
-------
-
-.. [#] I'll read any feedback you send me to robert@typo3.org but I don't always manage to answer quickly.
-


### PR DESCRIPTION
The dot was one to much, and the link didn't render because of formatting
issue.

Beside that, `EssentialDesignPatterns.rst` was not posix conform as the last
line was missing new line character. Some leftover "TYPO Flow" uses have
been removed as well.