### PR TITLE
BUGFIX: Adjust index names to match Doctrine DBAL 2.5

### DIFF
--- a/TYPO3.Flow/Migrations/Mysql/Version20160212111357.php
+++ b/TYPO3.Flow/Migrations/Mysql/Version20160212111357.php
@@ -1,0 +1,62 @@
+<?php
+namespace TYPO3\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Adjust some (old) index names to current Doctrine DBAL behavior (see https://jira.neos.io/browse/FLOW-427)
+ */
+class Version20160212111357 extends AbstractMigration
+{
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+
+        $this->addSql("ALTER TABLE typo3_flow_resource_resource DROP FOREIGN KEY FK_B4D45B32A4A851AF");
+        $this->addSql("ALTER TABLE typo3_flow_resource_resource DROP FOREIGN KEY typo3_flow_resource_resource_ibfk_1");
+        $this->addSql("DROP INDEX idx_b4d45b323cb65d1 ON typo3_flow_resource_resource");
+        $this->addSql("CREATE INDEX IDX_35DC14F03CB65D1 ON typo3_flow_resource_resource (resourcepointer)");
+        $this->addSql("DROP INDEX idx_b4d45b32a4a851af ON typo3_flow_resource_resource");
+        $this->addSql("CREATE INDEX IDX_35DC14F0A4A851AF ON typo3_flow_resource_resource (publishingconfiguration)");
+        $this->addSql("ALTER TABLE typo3_flow_resource_resource ADD CONSTRAINT FK_B4D45B32A4A851AF FOREIGN KEY (publishingconfiguration) REFERENCES typo3_flow_resource_publishing_abstractpublishingconfiguration (persistence_object_identifier)");
+        $this->addSql("ALTER TABLE typo3_flow_resource_resource ADD CONSTRAINT typo3_flow_resource_resource_ibfk_1 FOREIGN KEY (resourcepointer) REFERENCES typo3_flow_resource_resourcepointer (hash)");
+
+        $this->addSql("ALTER TABLE typo3_flow_security_account DROP FOREIGN KEY typo3_flow_security_account_ibfk_1");
+        $this->addSql("DROP INDEX idx_65efb31c89954ee0 ON typo3_flow_security_account");
+        $this->addSql("CREATE INDEX IDX_D3B6BCC889954EE0 ON typo3_flow_security_account (party)");
+        $this->addSql("DROP INDEX flow3_identity_typo3_flow3_security_account ON typo3_flow_security_account");
+        $this->addSql("CREATE UNIQUE INDEX flow_identity_typo3_flow_security_account ON typo3_flow_security_account (accountidentifier, authenticationprovidername)");
+        $this->addSql("ALTER TABLE typo3_flow_security_account ADD CONSTRAINT typo3_flow_security_account_ibfk_1 FOREIGN KEY (party) REFERENCES typo3_party_domain_model_abstractparty (persistence_object_identifier)");
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+
+        $this->addSql("ALTER TABLE typo3_flow_resource_resource DROP FOREIGN KEY typo3_flow_resource_resource_ibfk_1");
+        $this->addSql("ALTER TABLE typo3_flow_resource_resource DROP FOREIGN KEY FK_B4D45B32A4A851AF");
+        $this->addSql("DROP INDEX idx_35dc14f03cb65d1 ON typo3_flow_resource_resource");
+        $this->addSql("CREATE INDEX IDX_B4D45B323CB65D1 ON typo3_flow_resource_resource (resourcepointer)");
+        $this->addSql("DROP INDEX idx_35dc14f0a4a851af ON typo3_flow_resource_resource");
+        $this->addSql("CREATE INDEX IDX_B4D45B32A4A851AF ON typo3_flow_resource_resource (publishingconfiguration)");
+        $this->addSql("ALTER TABLE typo3_flow_resource_resource ADD CONSTRAINT typo3_flow_resource_resource_ibfk_1 FOREIGN KEY (resourcepointer) REFERENCES typo3_flow_resource_resourcepointer (hash)");
+        $this->addSql("ALTER TABLE typo3_flow_resource_resource ADD CONSTRAINT FK_B4D45B32A4A851AF FOREIGN KEY (publishingconfiguration) REFERENCES typo3_flow_resource_publishing_abstractpublishingconfiguration (persistence_object_identifier)");
+
+        $this->addSql("ALTER TABLE typo3_flow_security_account DROP FOREIGN KEY typo3_flow_security_account_ibfk_1");
+        $this->addSql("DROP INDEX flow_identity_typo3_flow_security_account ON typo3_flow_security_account");
+        $this->addSql("CREATE UNIQUE INDEX flow3_identity_typo3_flow3_security_account ON typo3_flow_security_account (accountidentifier, authenticationprovidername)");
+        $this->addSql("DROP INDEX idx_d3b6bcc889954ee0 ON typo3_flow_security_account");
+        $this->addSql("CREATE INDEX IDX_65EFB31C89954EE0 ON typo3_flow_security_account (party)");
+        $this->addSql("ALTER TABLE typo3_flow_security_account ADD CONSTRAINT typo3_flow_security_account_ibfk_1 FOREIGN KEY (party) REFERENCES typo3_party_domain_model_abstractparty (persistence_object_identifier)");
+    }
+}

--- a/TYPO3.Flow/Migrations/Postgresql/Version20160212112848.php
+++ b/TYPO3.Flow/Migrations/Postgresql/Version20160212112848.php
@@ -1,0 +1,46 @@
+<?php
+namespace TYPO3\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Adjust some (old) index names to current Doctrine DBAL behavior (see https://jira.neos.io/browse/FLOW-427)
+ */
+class Version20160212112848 extends AbstractMigration
+{
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
+
+        // typo3_flow_resource_resource
+        $this->addSql("ALTER INDEX idx_b4d45b323cb65d1 RENAME TO IDX_35DC14F03CB65D1");
+        $this->addSql("ALTER INDEX idx_b4d45b32a4a851af RENAME TO IDX_35DC14F0A4A851AF");
+
+        // typo3_flow_security_account
+        $this->addSql("ALTER INDEX idx_65efb31c89954ee0 RENAME TO IDX_D3B6BCC889954EE0");
+        $this->addSql("ALTER INDEX flow3_identity_typo3_flow3_security_account RENAME TO flow_identity_typo3_flow_security_account");
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
+
+        // typo3_flow_security_account
+        $this->addSql("ALTER INDEX flow_identity_typo3_flow_security_account RENAME TO flow3_identity_typo3_flow3_security_account");
+        $this->addSql("ALTER INDEX idx_d3b6bcc889954ee0 RENAME TO idx_65efb31c89954ee0");
+
+        // typo3_flow_resource_resource
+        $this->addSql("ALTER INDEX idx_35dc14f03cb65d1 RENAME TO idx_b4d45b323cb65d1");
+        $this->addSql("ALTER INDEX idx_35dc14f0a4a851af RENAME TO idx_b4d45b32a4a851af");
+    }
+}


### PR DESCRIPTION
The use of Doctrine 2.5 (instead of 2.4) exposes the fact that some
(old) index names in the Flow database schema do not match the names
that are generated currently.

This adjusts those index names, something that is a one-time adjustment.

FLOW-427 #close Adjusts indexes as needed
FLOW-222 #close Adjusts indexes as needed