### PR TITLE
TASK: Exclude classes pulled in by doctrine/migrations 1.3

### DIFF
--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -194,6 +194,8 @@ TYPO3:
         'symfony.*': ['.*']
         'phpunit.*': ['.*']
         'mikey179.vfsStream': ['.*']
+        'zendframework.*': ['.*']
+        'ocramius.proxymanager': ['.*']
         # workaround, should rather be deactivated
         'neos.composerplugin': ['.*']
         'Composer.Installers': ['.*']

--- a/TYPO3.Flow/composer.json
+++ b/TYPO3.Flow/composer.json
@@ -18,7 +18,7 @@
         "typo3/eel": "~2.3.0",
 
         "doctrine/orm": "2.4.*",
-        "doctrine/migrations": "1.0.0-alpha3",
+        "doctrine/migrations": "~1.3.0",
 
         "symfony/yaml": "2.5.*",
         "symfony/dom-crawler": "2.5.*",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "ext-session": "*",
         "typo3/party": "2.3.*",
         "doctrine/orm": "2.4.*",
-        "doctrine/migrations": "1.0.0-alpha3",
+        "doctrine/migrations": "~1.3.0",
         "symfony/yaml": "2.5.*",
         "symfony/dom-crawler": "2.5.*",
         "symfony/console": "2.*",


### PR DESCRIPTION
Pulling in doctrine/migrations 1.3 works fine, but it comes with some
new dependencies that need to be excluded from reflection.