### PR TITLE
TASK: Raise doctrine/migrations version to 1.3

### DIFF
--- a/TYPO3.Flow/composer.json
+++ b/TYPO3.Flow/composer.json
@@ -18,7 +18,7 @@
         "typo3/eel": "~3.0.0",
 
         "doctrine/orm": "~2.4.0",
-        "doctrine/migrations": "~1.0.0",
+        "doctrine/migrations": "~1.3.0",
         "doctrine/dbal": "~2.5.0",
 
         "symfony/yaml": "~2.5.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "ext-mbstring": "*",
         "ext-reflection": "*",
         "doctrine/orm": "~2.4.0",
-        "doctrine/migrations": "~1.0.0",
+        "doctrine/migrations": "~1.3.0",
         "doctrine/dbal": "~2.5.0",
         "symfony/yaml": "~2.5.0",
         "symfony/dom-crawler": "~2.5.0",


### PR DESCRIPTION
This may bring a massive speedup and avoids an issue with composer.json
not being included with the 1.0.0 archives.