### PR TITLE
Corrected error message in package:create command

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/PackageCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/PackageCommandController.php
@@ -81,7 +81,7 @@ class PackageCommandController extends \TYPO3\Flow\Cli\CommandController {
 			$this->quit(1);
 		}
 		if (substr($packageType, 0, 11) !== 'typo3-flow-') {
-			$this->outputLine('The package must be a Flow package, but "%s" is not a valid Flow package type.', array($packageKey));
+			$this->outputLine('The package must be a Flow package, but "%s" is not a valid Flow package type.', array($packageType));
 			$this->quit(1);
 		}
 		$package = $this->packageManager->createPackage($packageKey, NULL, NULL, $packageType);


### PR DESCRIPTION
`$packageType` is used in the error message if is is not a valid Flow package tpye.