### PR TITLE
TASK: Improve Doctrine CLI tooling

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/DoctrineCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/DoctrineCommandController.php
@@ -409,7 +409,6 @@ class DoctrineCommandController extends CommandController
         $this->outputLine('<info>%s</info>', [$status]);
         $this->outputLine();
         if ($migrationClassPathAndFilename) {
-
             $choices = ['Don\'t Move'];
             $packages = [null];
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/DoctrineCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/DoctrineCommandController.php
@@ -237,18 +237,23 @@ class DoctrineCommandController extends CommandController
      * Displays the migration configuration as well as the number of
      * available, executed and pending migrations.
      *
+     * @param boolean $showMigrations Output a list of all migrations and their status
+     * @param boolean $showDescriptions Show descriptions for the migrations (enables versions display)
      * @return void
      * @see typo3.flow:doctrine:migrate
      * @see typo3.flow:doctrine:migrationexecute
      * @see typo3.flow:doctrine:migrationgenerate
      * @see typo3.flow:doctrine:migrationversion
      */
-    public function migrationStatusCommand()
+    public function migrationStatusCommand($showMigrations = false, $showDescriptions = false)
     {
         // "driver" is used only for Doctrine, thus we (mis-)use it here
         // additionally, when no path is set, skip this step, assuming no DB is needed
         if ($this->settings['backendOptions']['driver'] !== null && $this->settings['backendOptions']['host'] !== null) {
-            $this->outputLine($this->doctrineService->getMigrationStatus());
+            if ($showDescriptions) {
+                $showMigrations = true;
+            }
+            $this->outputLine($this->doctrineService->getMigrationStatus($showMigrations, $showDescriptions));
         } else {
             $this->outputLine('Doctrine migration status not available, the driver and host backend options are not set in /Configuration/Settings.yaml.');
             $this->quit(1);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/DoctrineCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/DoctrineCommandController.php
@@ -13,6 +13,7 @@ namespace TYPO3\Flow\Command;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Util\Debug;
+use Doctrine\DBAL\Migrations\MigrationException;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Cli\CommandController;
 use TYPO3\Flow\Error\Debugger;
@@ -331,7 +332,7 @@ class DoctrineCommandController extends CommandController
     }
 
     /**
-     * Mark/unmark a migration as migrated
+     * Mark/unmark migrations as migrated
      *
      * If <u>all</u> is given as version, all available migrations are marked
      * as requested.
@@ -349,14 +350,14 @@ class DoctrineCommandController extends CommandController
     public function migrationVersionCommand($version, $add = false, $delete = false)
     {
         // "driver" is used only for Doctrine, thus we (mis-)use it here
-        // additionally, when no path is set, skip this step, assuming no DB is needed
+        // additionally, when no host is set, skip this step, assuming no DB is needed
         if ($this->settings['backendOptions']['driver'] !== null && $this->settings['backendOptions']['host'] !== null) {
             if ($add === false && $delete === false) {
                 throw new \InvalidArgumentException('You must specify whether you want to --add or --delete the specified version.');
             }
             try {
                 $this->doctrineService->markAsMigrated($version, $add ?: false);
-            } catch (\Doctrine\DBAL\Migrations\MigrationException $exception) {
+            } catch (MigrationException $exception) {
                 $this->outputLine($exception->getMessage());
                 $this->quit(1);
             }
@@ -384,7 +385,7 @@ class DoctrineCommandController extends CommandController
     public function migrationGenerateCommand($diffAgainstCurrent = true)
     {
         // "driver" is used only for Doctrine, thus we (mis-)use it here
-        // additionally, when no path is set, skip this step, assuming no DB is needed
+        // additionally, when no host is set, skip this step, assuming no DB is needed
         if ($this->settings['backendOptions']['driver'] === null || $this->settings['backendOptions']['host'] === null) {
             $this->outputLine('Doctrine migration generation has been SKIPPED, the driver and host backend options are not set in /Configuration/Settings.yaml.');
             $this->quit(1);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/Service.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/Service.php
@@ -417,7 +417,7 @@ class Service
             }
             return $output;
         } else {
-            return strip_tags(implode(PHP_EOL, $this->output));
+            return implode(PHP_EOL, $this->output);
         }
     }
 
@@ -476,12 +476,12 @@ class Service
 
             if ($markAsMigrated === true) {
                 if ($configuration->hasVersionMigrated($version) === true) {
-                    throw new MigrationException(sprintf('The version "%s" already exists in the version table.', $version));
+                    throw new MigrationException(sprintf('The version "%s" is already marked as executed.', $version));
                 }
                 $version->markMigrated();
             } else {
                 if ($configuration->hasVersionMigrated($version) === false) {
-                    throw new MigrationException(sprintf('The version "%s" does not exist in the version table.', $version));
+                    throw new MigrationException(sprintf('The version "%s" is already marked as not executed.', $version));
                 }
                 $version->markNotMigrated();
             }

--- a/TYPO3.Flow/Resources/Private/Translations/el/Main.xlf
+++ b/TYPO3.Flow/Resources/Private/Translations/el/Main.xlf
@@ -4,7 +4,7 @@
     <body>
       <trans-unit id="authentication.required" xml:space="preserve">
 				<source>Authentication required</source>
-			<target xml:lang="el" state="needs-translation">Authentication required</target></trans-unit>
+			<target xml:lang="el" state="translated">Απαιτείται έλεγχος ταυτότητας</target></trans-unit>
       <trans-unit id="authentication.username" xml:space="preserve">
 				<source>Username</source>
 			<target xml:lang="el" state="needs-translation">Username</target></trans-unit>
@@ -13,19 +13,19 @@
 			<target xml:lang="el" state="needs-translation">Password</target></trans-unit>
       <trans-unit id="authentication.new-password" xml:space="preserve">
 				<source>New password</source>
-			<target xml:lang="el" state="needs-translation">New password</target></trans-unit>
+			<target xml:lang="el" state="translated">Νέος κωδικός πρόσβασης</target></trans-unit>
       <trans-unit id="authentication.login" xml:space="preserve">
 				<source>Login</source>
-			<target xml:lang="el" state="needs-translation">Login</target></trans-unit>
+			<target xml:lang="el" state="translated">Σύνδεση</target></trans-unit>
       <trans-unit id="authentication.logout" xml:space="preserve">
 				<source>Logout</source>
-			<target xml:lang="el" state="needs-translation">Logout</target></trans-unit>
+			<target xml:lang="el" state="translated">Αποσύνδεση</target></trans-unit>
       <trans-unit id="update" xml:space="preserve">
 				<source>Update</source>
-			<target xml:lang="el" state="needs-translation">Update</target></trans-unit>
+			<target xml:lang="el" state="translated">Ενημέρωση</target></trans-unit>
       <trans-unit id="submit" xml:space="preserve">
 				<source>Submit</source>
-			<target xml:lang="el" state="needs-translation">Submit</target></trans-unit>
+			<target xml:lang="el" state="translated">Αποστολή</target></trans-unit>
     </body>
   </file>
 </xliff>

--- a/TYPO3.Flow/Resources/Private/Translations/vi/Main.xlf
+++ b/TYPO3.Flow/Resources/Private/Translations/vi/Main.xlf
@@ -7,25 +7,25 @@
 			<target xml:lang="vi" state="needs-translation">Authentication required</target></trans-unit>
       <trans-unit id="authentication.username" xml:space="preserve">
 				<source>Username</source>
-			<target xml:lang="vi" state="needs-translation">Username</target></trans-unit>
+			<target xml:lang="vi" state="translated">Tên truy cập</target></trans-unit>
       <trans-unit id="authentication.password" xml:space="preserve">
 				<source>Password</source>
-			<target xml:lang="vi" state="needs-translation">Password</target></trans-unit>
+			<target xml:lang="vi" state="translated">Mật khẩu</target></trans-unit>
       <trans-unit id="authentication.new-password" xml:space="preserve">
 				<source>New password</source>
-			<target xml:lang="vi" state="needs-translation">New password</target></trans-unit>
+			<target xml:lang="vi" state="translated">Mật khẩu mới</target></trans-unit>
       <trans-unit id="authentication.login" xml:space="preserve">
 				<source>Login</source>
-			<target xml:lang="vi" state="needs-translation">Login</target></trans-unit>
+			<target xml:lang="vi" state="translated">Đăng nhập</target></trans-unit>
       <trans-unit id="authentication.logout" xml:space="preserve">
 				<source>Logout</source>
-			<target xml:lang="vi" state="needs-translation">Logout</target></trans-unit>
+			<target xml:lang="vi" state="translated">Đăng xuất</target></trans-unit>
       <trans-unit id="update" xml:space="preserve">
 				<source>Update</source>
-			<target xml:lang="vi" state="needs-translation">Update</target></trans-unit>
+			<target xml:lang="vi" state="translated">Cập Nhật</target></trans-unit>
       <trans-unit id="submit" xml:space="preserve">
 				<source>Submit</source>
-			<target xml:lang="vi" state="needs-translation">Submit</target></trans-unit>
+			<target xml:lang="vi" state="translated">Gửi</target></trans-unit>
     </body>
   </file>
 </xliff>

--- a/TYPO3.Flow/Tests/Unit/Cache/Backend/MemcacheBackendTest.php
+++ b/TYPO3.Flow/Tests/Unit/Cache/Backend/MemcacheBackendTest.php
@@ -1,0 +1,23 @@
+<?php
+namespace TYPO3\Flow\Tests\Unit\Cache\Backend;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Core\ApplicationContext;
+
+/**
+ * Testcase for the cache to memcache backend
+ *
+ * @requires extension memcache
+ */
+class MemcacheBackendTest extends MemcachedBackendTest
+{
+}

--- a/TYPO3.Flow/Tests/Unit/Cache/Backend/MemcachedBackendTest.php
+++ b/TYPO3.Flow/Tests/Unit/Cache/Backend/MemcachedBackendTest.php
@@ -16,7 +16,7 @@ use TYPO3\Flow\Core\ApplicationContext;
 /**
  * Testcase for the cache to memcached backend
  *
- * @requires extension memcache
+ * @requires extension memcached
  */
 class MemcachedBackendTest extends \TYPO3\Flow\Tests\UnitTestCase
 {

--- a/TYPO3.Flow/composer.json
+++ b/TYPO3.Flow/composer.json
@@ -30,7 +30,7 @@
         "paragonie/random_compat": "^1.0",
 
         "doctrine/orm": "~2.4.0",
-        "doctrine/migrations": "~1.0.0",
+        "doctrine/migrations": "~1.3.0",
         "doctrine/dbal": "~2.5.0",
 
         "symfony/yaml": "~2.5.0",

--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Form/UploadViewHelper.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Form/UploadViewHelper.php
@@ -105,7 +105,7 @@ class UploadViewHelper extends AbstractFormFieldViewHelper
             if ($this->hasArgument('id')) {
                 $resourceIdentityAttribute = ' id="' . htmlspecialchars($this->arguments['id']) . '-resource-identity"';
             }
-            $output .= '<input type="hidden" name="'. htmlspecialchars($nameAttribute) . '[originallySubmittedResource][__identity]" value="' . $this->persistenceManager->getIdentifierByObject($resource) . '"' . htmlspecialchars($resourceIdentityAttribute) . ' />';
+            $output .= '<input type="hidden" name="'. htmlspecialchars($nameAttribute) . '[originallySubmittedResource][__identity]" value="' . $this->persistenceManager->getIdentifierByObject($resource) . '"' . $resourceIdentityAttribute . ' />';
         }
 
         if ($this->hasArgument('collection') && $this->arguments['collection'] !== false && $this->arguments['collection'] !== '') {

--- a/TYPO3.Fluid/Resources/Private/Translations/el/Main.xlf
+++ b/TYPO3.Fluid/Resources/Private/Translations/el/Main.xlf
@@ -4,10 +4,10 @@
     <body>
       <trans-unit id="widget.paginate.previous" xml:space="preserve">
 				<source>previous</source>
-			<target xml:lang="el" state="needs-translation">previous</target></trans-unit>
+			<target xml:lang="el" state="translated">προηγούμενο</target></trans-unit>
       <trans-unit id="widget.paginate.next" xml:space="preserve">
 				<source>next</source>
-			<target xml:lang="el" state="needs-translation">next</target></trans-unit>
+			<target xml:lang="el" state="translated">επόμενο</target></trans-unit>
     </body>
   </file>
 </xliff>

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ramsey/uuid": "^3.0.0",
         "paragonie/random_compat": "^1.0",
         "doctrine/orm": "~2.4.0",
-        "doctrine/migrations": "~1.0.0",
+        "doctrine/migrations": "~1.3.0",
         "doctrine/dbal": "~2.5.0",
         "symfony/yaml": "~2.5.0",
         "symfony/dom-crawler": "~2.5.0",


### PR DESCRIPTION
This does some code style cleanup in the codebase and makes use of the improvements in Doctrine Migrations 1.3.

The output of `doctrine:migrationstatus` is improved vastly (shows executed but no longer available migrations, shorter default output, can show migration descriptions, color support).

Migration generation has been improved and the error handling and output of `doctrine:migrate` have been improved.

FLOW-292 #close
