### PR TITLE
BUGFIX: Rendering docs produced errors and warnings

### DIFF
--- a/TYPO3.Flow/Documentation/Quickstart/index.rst
+++ b/TYPO3.Flow/Documentation/Quickstart/index.rst
@@ -30,8 +30,8 @@ a lot of universal development techniques you can learn.
 
 .. tip::
 
-	This tutorial goes best with a Caffè Latte or, if it's afternoon or late night
-	already, with a few shots of Espresso ...
+    This tutorial goes best with a Caffè Latte or, if it's afternoon or late night
+    already, with a few shots of Espresso ...
 
 Installing TYPO3 Flow
 ---------------------
@@ -49,14 +49,14 @@ which boils down to this in the simplest case::
  curl -s https://getcomposer.org/installer | php
 
 .. note::
-	Feel free to install the composer command to a global location, by moving
-	the phar archive to e.g. */usr/local/bin/composer* and making it executable.
-	The following documentation assumes ``composer`` is installed globally.
+    Feel free to install the composer command to a global location, by moving
+    the phar archive to e.g. */usr/local/bin/composer* and making it executable.
+    The following documentation assumes ``composer`` is installed globally.
 
 .. tip::
-	Running ``composer selfupdate`` from time to time keeps it up to date
-	and can prevent errors caused by composer not understanding e.g. new
-	syntax in manifest files.
+    Running ``composer selfupdate`` from time to time keeps it up to date
+    and can prevent errors caused by composer not understanding e.g. new
+    syntax in manifest files.
 
 Then use Composer in a directory which will be accessible by your web server to download
 and install all packages of the TYPO3 Flow Base Distribution. The following command will
@@ -94,7 +94,7 @@ accordingly. But don't worry, this is simply done by changing to the TYPO3 Flow 
 
 *command line*::
 
-	./flow core:setfilepermissions john www-data www-data
+    ./flow core:setfilepermissions john www-data www-data
 
 Please replace *john* by your own username. The second argument is supposed to be the
 username of your web server and the last one specifies the web server's group. For most
@@ -106,22 +106,22 @@ group. On a Linux machine this can be done by typing:
 
 *command line*::
 
-	sudo usermod -a -G _www john
+    sudo usermod -a -G _www john
 
 On a Mac you can add a user to the web group with the following command:
 
 *command line*::
 
-	sudo dscl . -append /Groups/_www GroupMembership johndoe
+    sudo dscl . -append /Groups/_www GroupMembership johndoe
 
 You will have to exit your shell / terminal window and open it again for the
 new group membership to take effect.
 
 .. note::
 
-	Setting file permissions is not necessary and not possible on Windows machines.
-	For Apache to be able to create symlinks, you need to use Windows Vista (or
-	newer) and Apache needs to be started with Administrator privileges.
+    Setting file permissions is not necessary and not possible on Windows machines.
+    For Apache to be able to create symlinks, you need to use Windows Vista (or
+    newer) and Apache needs to be started with Administrator privileges.
 
 Setting up a virtual host
 -------------------------
@@ -142,24 +142,24 @@ Testing the Installation
 ------------------------
 
 .. figure:: Images/Welcome.png
-	:alt: The TYPO3 Flow Welcome Screen
-	:class: screenshot-fullsize
+    :alt: The TYPO3 Flow Welcome Screen
+    :class: screenshot-fullsize
 
-	The TYPO3 Flow Welcome Screen
+    The TYPO3 Flow Welcome Screen
 
 If your system is configured correctly you should now be able to access the Welcome
 screen:
 
 .. code-block:: text
 
-	http://quickstart/
+    http://quickstart/
 
 If you did not follow our advice to create a virtual host, point your browser to the
 ``Web`` directory of your TYPO3 Flow installation throughout this tutorial, for example:
 
 .. code-block:: text
 
-	http://localhost/Quickstart/Web/
+    http://localhost/Quickstart/Web/
 
 The result should look similar to the screen you see in the screenshot. If something went
 wrong, it usually can be blamed on a misconfigured web server or insufficient file
@@ -167,19 +167,19 @@ permissions.
 
 .. note::
 
-	If all you get is a 404, you might need to edit the ``.htaccess`` file in the
-	``Web`` folder to adjust the ``RewriteBase`` directive as needed.
+    If all you get is a 404, you might need to edit the ``.htaccess`` file in the
+    ``Web`` folder to adjust the ``RewriteBase`` directive as needed.
 
 .. note::
 
-	Depending on your environment (especially on Windows systems) you might need to set the
-	path to the PHP binary in ``Configuration/Settings.yaml``. If you copied the provided
-	example Settings you only need to uncomment the corresponding lines and adjust the path.
+    Depending on your environment (especially on Windows systems) you might need to set the
+    path to the PHP binary in ``Configuration/Settings.yaml``. If you copied the provided
+    example Settings you only need to uncomment the corresponding lines and adjust the path.
 
 .. tip::
 
-	There are some friendly ghosts in our `IRC channel`_ and in the `users mailing list`_
-	– they will gladly help you out if you describe your problem as precisely as possible.
+    There are some friendly ghosts in our `IRC channel`_ and in the `users mailing list`_
+    – they will gladly help you out if you describe your problem as precisely as possible.
 
 .. rubric:: Some Note About Speed
 
@@ -202,44 +202,44 @@ Let's create a *Demo* package for our fictive company *Acme*:
 
 .. code-block:: none
 
-	$ ./flow kickstart:package Acme.Demo
-	Created .../Acme.Demo/Classes/Acme/Demo/Controller/StandardController.php
-	Created .../Acme.Demo/Resources/Private/Layouts/Default.html
-	Created .../Acme.Demo/Resources/Private/Templates/Standard/Index.html
+    $ ./flow kickstart:package Acme.Demo
+    Created .../Acme.Demo/Classes/Acme/Demo/Controller/StandardController.php
+    Created .../Acme.Demo/Resources/Private/Layouts/Default.html
+    Created .../Acme.Demo/Resources/Private/Templates/Standard/Index.html
 
 The Kickstarter will create a new package directory in *Packages/Application/* resulting
 in the following structure:
 
 .. code-block:: text
 
-	Packages/
-	  Application/
-	    Acme.Demo/
-	      Classes/Acme/Demo/
-	      Configuration/
-	      Documentation/
-	      Meta/
-	      Resources/
-	      Tests/
+    Packages/
+      Application/
+        Acme.Demo/
+          Classes/Acme/Demo/
+          Configuration/
+          Documentation/
+          Meta/
+          Resources/
+          Tests/
 
 The :command:`kickstart:package` command also generates a sample controller which displays
 some content. You should be able to access it through the following URL:
 
 .. code-block:: text
 
-	http://quickstart/Acme.Demo
+    http://quickstart/Acme.Demo
 
 .. tip::
 
-	In case your web server lacks mod_rewrite, it could be that you need to call this to access
-	the controller:
+    In case your web server lacks mod_rewrite, it could be that you need to call this to access
+    the controller:
 
-	.. code-block:: text
+    .. code-block:: text
 
-		http://quickstart/index.php/Acme.Demo
+        http://quickstart/index.php/Acme.Demo
 
-	If this the case, keep in mind to add ``index.php`` to the following URLs in this
-	Quickstart tutorial.
+    If this the case, keep in mind to add ``index.php`` to the following URLs in this
+    Quickstart tutorial.
 
 Hello World
 -----------
@@ -249,45 +249,45 @@ class file in *Packages/Application/Acme.Demo/Classes/Acme/Demo/Controller/* you
 method *indexAction()* which is responsible for the output you've just seen in your web
 browser::
 
-	/**
-	 * @return void
-	 */
-	public function indexAction() {
-		$this->view->assign('foos', array(
-			'bar', 'baz'
-		));
-	}
+    /**
+     * @return void
+     */
+    public function indexAction() {
+        $this->view->assign('foos', array(
+            'bar', 'baz'
+        ));
+    }
 
 Accepting some kind of user input is essential for most applications and TYPO3 Flow does a
 great deal of processing and sanitizing any incoming data. Try it out – create a new
 action method like this one::
 
-	/**
-	 * This action outputs a custom greeting
-	 *
-	 * @param string $name your name
-	 * @return string custom greeting
-	 */
-	public function helloAction($name) {
-		return 'Hello ' . $name . '!';
-	}
+    /**
+     * This action outputs a custom greeting
+     *
+     * @param string $name your name
+     * @return string custom greeting
+     */
+    public function helloAction($name) {
+        return 'Hello ' . $name . '!';
+    }
 
 .. important::
 
-	For the sake of simplicity the above example does not contain any input/output sanitation.
-	If your controller action directly returns something, make sure to filter the data!
+    For the sake of simplicity the above example does not contain any input/output sanitation.
+    If your controller action directly returns something, make sure to filter the data!
 
 .. tip::
 
-	You should always properly document all your functions and class properties. This
-	will not only help other developers to understand your code, but is also essential for
-	TYPO3 Flow to work properly.
+    You should always properly document all your functions and class properties. This
+    will not only help other developers to understand your code, but is also essential for
+    TYPO3 Flow to work properly.
 
 Now test the new action by passing it a name like in the following URL:
 
 .. code-block:: text
 
-	http://quickstart/Acme.Demo/Standard/hello?name=Robert
+    http://quickstart/Acme.Demo/Standard/hello?name=Robert
 
 The path segments of this URL tell TYPO3 Flow to which controller and action the web request
 should be dispatched to. In our example the parts are:
@@ -319,38 +319,38 @@ setup, it would look similar to this:
 
 .. code-block:: yaml
 
-	TYPO3:
-	  Flow:
-	    persistence:
-	      backendOptions:
-	        driver: 'pdo_mysql'
-	        dbname: 'quickstart' # adjust to your database name
-	        user: 'root'         # adjust to your database user
-	        password: 'password' # adjust to your database password
-	        host: '127.0.0.1'    # adjust to your database host
+    TYPO3:
+      Flow:
+        persistence:
+          backendOptions:
+            driver: 'pdo_mysql'
+            dbname: 'quickstart' # adjust to your database name
+            user: 'root'         # adjust to your database user
+            password: 'password' # adjust to your database password
+            host: '127.0.0.1'    # adjust to your database host
 
 .. note::
 
-	If you are not familiar with the `YAML` format yet, there are two things you should
-	know at least:
+    If you are not familiar with the `YAML` format yet, there are two things you should
+    know at least:
 
-	* Indentation has a meaning: by different levels of indentation, a structure is
-	  defined.
-	* Spaces, not tabs: you must indent with exactly 2 spaces per level, don't use tabs.
+    * Indentation has a meaning: by different levels of indentation, a structure is
+      defined.
+    * Spaces, not tabs: you must indent with exactly 2 spaces per level, don't use tabs.
 
 If you configured everything correctly, the following command will create the initial
 table structure needed by TYPO3 Flow:
 
 .. code-block:: bash
 
-	$ ./flow doctrine:migrate
-	Migrating up to 2011xxxxx00 from 0
+    $ ./flow doctrine:migrate
+    Migrating up to 2011xxxxx00 from 0
 
-	++ migrating 2011xxxxx00
-		-> CREATE TABLE flow_resource_resourcepointer (hash VARCHAR(255) NOT NULL, PRIMARY
-		-> CREATE TABLE flow_resource_resource (persistence_object_identifier VARCHAR(40)
-	...
-	++ finished in 0.76
+    ++ migrating 2011xxxxx00
+        -> CREATE TABLE flow_resource_resourcepointer (hash VARCHAR(255) NOT NULL, PRIMARY
+        -> CREATE TABLE flow_resource_resource (persistence_object_identifier VARCHAR(40)
+    ...
+    ++ finished in 0.76
 
 
 Storing Objects
@@ -361,17 +361,17 @@ just generate some example with the kickstarter:
 
 .. code-block:: bash
 
-	$ ./flow kickstart:actioncontroller --generate-actions --generate-related Acme.Demo CoffeeBean
-	Created .../Acme.Demo/Classes/Acme/Demo/Domain/Model/CoffeeBean.php
-	Created .../Acme.Demo/Tests/Unit/Domain/Model/CoffeeBeanTest.php
-	Created .../Acme.Demo/Classes/Acme/Demo/Domain/Repository/CoffeeBeanRepository.php
-	Created .../Acme.Demo/Classes/Acme/Demo/Controller/CoffeeBeanController.php
-	Omitted .../Acme.Demo/Resources/Private/Layouts/Default.html
-	Created .../Acme.Demo/Resources/Private/Templates/CoffeeBean/Index.html
-	Created .../Acme.Demo/Resources/Private/Templates/CoffeeBean/New.html
-	Created .../Acme.Demo/Resources/Private/Templates/CoffeeBean/Edit.html
-	Created .../Acme.Demo/Resources/Private/Templates/CoffeeBean/Show.html
-	As new models were generated, don't forget to update the database schema with the respective doctrine:* commands.
+    $ ./flow kickstart:actioncontroller --generate-actions --generate-related Acme.Demo CoffeeBean
+    Created .../Acme.Demo/Classes/Acme/Demo/Domain/Model/CoffeeBean.php
+    Created .../Acme.Demo/Tests/Unit/Domain/Model/CoffeeBeanTest.php
+    Created .../Acme.Demo/Classes/Acme/Demo/Domain/Repository/CoffeeBeanRepository.php
+    Created .../Acme.Demo/Classes/Acme/Demo/Controller/CoffeeBeanController.php
+    Omitted .../Acme.Demo/Resources/Private/Layouts/Default.html
+    Created .../Acme.Demo/Resources/Private/Templates/CoffeeBean/Index.html
+    Created .../Acme.Demo/Resources/Private/Templates/CoffeeBean/New.html
+    Created .../Acme.Demo/Resources/Private/Templates/CoffeeBean/Edit.html
+    Created .../Acme.Demo/Resources/Private/Templates/CoffeeBean/Show.html
+    As new models were generated, do not forget to update the database schema with the respective doctrine:* commands.
 
 Whenever a model is created or modified, the database structure needs to be adjusted to
 fit the new PHP code. This is something you should do consciously because existing data
@@ -382,14 +382,14 @@ structure to the database, just run the :command:`doctrine:update` command:
 
 .. code-block:: bash
 
-	$ ./flow doctrine:update
-	Executed a database schema update.
+    $ ./flow doctrine:update
+    Executed a database schema update.
 
 .. tip::
 
-	In a real project you should avoid the :command:`doctrine:update` command and instead
-	work with migrations. See the "Persistence" section of the
-	:doc:`The Definitive Guide <../TheDefinitiveGuide/index>` for more details
+    In a real project you should avoid the :command:`doctrine:update` command and instead
+    work with migrations. See the "Persistence" section of the
+    :doc:`The Definitive Guide <../TheDefinitiveGuide/index>` for more details
 
 A quick glance at the table structure (using your preferred database management tool) will
 reveal that a new table for coffee beans has been created.
@@ -399,16 +399,16 @@ creating, editing and deleting coffee beans. Try it out by accessing this URL:
 
 .. code-block:: text
 
-	http://quickstart/Acme.Demo/CoffeeBean
+    http://quickstart/Acme.Demo/CoffeeBean
 
 Create a few coffee beans, edit and delete them and take a look at the database tables
 if you can't resist ...
 
 .. figure:: Images/CoffeeBeanController.png
-	:alt: List and create coffee beans
-	:class: screenshot-fullsize
+    :alt: List and create coffee beans
+    :class: screenshot-fullsize
 
-	List and create coffee beans
+    List and create coffee beans
 
 A Closer Look at the Example
 ----------------------------
@@ -423,74 +423,74 @@ With this background, the following complete code listing powering the previous 
 may seem a bit odd, if not magical to you. Take a close look at each of the methods –
 can you imagine what they do? ::
 
-	class CoffeeBeanController extends ActionController {
+    class CoffeeBeanController extends ActionController {
 
-		/**
-		 * @Flow\Inject
-		 * @var \Acme\Demo\Domain\Repository\CoffeeBeanRepository
-		 */
-		protected $coffeeBeanRepository;
+        /**
+         * @Flow\Inject
+         * @var \Acme\Demo\Domain\Repository\CoffeeBeanRepository
+         */
+        protected $coffeeBeanRepository;
 
-		/**
-		 * @return void
-		 */
-		public function indexAction() {
-			$this->view->assign('coffeeBeans', $this->coffeeBeanRepository->findAll());
-		}
+        /**
+         * @return void
+         */
+        public function indexAction() {
+            $this->view->assign('coffeeBeans', $this->coffeeBeanRepository->findAll());
+        }
 
-		/**
-		 * @param \Acme\Demo\Domain\Model\CoffeeBean $coffeeBean
-		 * @return void
-		 */
-		public function showAction(CoffeeBean $coffeeBean) {
-			$this->view->assign('coffeeBean', $coffeeBean);
-		}
+        /**
+         * @param \Acme\Demo\Domain\Model\CoffeeBean $coffeeBean
+         * @return void
+         */
+        public function showAction(CoffeeBean $coffeeBean) {
+            $this->view->assign('coffeeBean', $coffeeBean);
+        }
 
-		/**
-		 * @return void
-		 */
-		public function newAction() {
-		}
+        /**
+         * @return void
+         */
+        public function newAction() {
+        }
 
-		/**
-		 * @param \Acme\Demo\Domain\Model\CoffeeBean $newCoffeeBean
-		 * @return void
-		 */
-		public function createAction(CoffeeBean $newCoffeeBean) {
-			$this->coffeeBeanRepository->add($newCoffeeBean);
-			$this->addFlashMessage('Created a new coffee bean.');
-			$this->redirect('index');
-		}
+        /**
+         * @param \Acme\Demo\Domain\Model\CoffeeBean $newCoffeeBean
+         * @return void
+         */
+        public function createAction(CoffeeBean $newCoffeeBean) {
+            $this->coffeeBeanRepository->add($newCoffeeBean);
+            $this->addFlashMessage('Created a new coffee bean.');
+            $this->redirect('index');
+        }
 
-		/**
-		 * @param \Acme\Demo\Domain\Model\CoffeeBean $coffeeBean
-		 * @return void
-		 */
-		public function editAction(CoffeeBean $coffeeBean) {
-			$this->view->assign('coffeeBean', $coffeeBean);
-		}
+        /**
+         * @param \Acme\Demo\Domain\Model\CoffeeBean $coffeeBean
+         * @return void
+         */
+        public function editAction(CoffeeBean $coffeeBean) {
+            $this->view->assign('coffeeBean', $coffeeBean);
+        }
 
-		/**
-		 * @param \Acme\Demo\Domain\Model\CoffeeBean $coffeeBean
-		 * @return void
-		 */
-		public function updateAction(CoffeeBean $coffeeBean) {
-			$this->coffeeBeanRepository->update($coffeeBean);
-			$this->addFlashMessage('Updated the coffee bean.');
-			$this->redirect('index');
-		}
+        /**
+         * @param \Acme\Demo\Domain\Model\CoffeeBean $coffeeBean
+         * @return void
+         */
+        public function updateAction(CoffeeBean $coffeeBean) {
+            $this->coffeeBeanRepository->update($coffeeBean);
+            $this->addFlashMessage('Updated the coffee bean.');
+            $this->redirect('index');
+        }
 
-		/**
-		 * @param \Acme\Demo\Domain\Model\CoffeeBean $coffeeBean
-		 * @return void
-		 */
-		public function deleteAction(CoffeeBean $coffeeBean) {
-			$this->coffeeBeanRepository->remove($coffeeBean);
-			$this->addFlashMessage('Deleted a coffee bean.');
-			$this->redirect('index');
-		}
+        /**
+         * @param \Acme\Demo\Domain\Model\CoffeeBean $coffeeBean
+         * @return void
+         */
+        public function deleteAction(CoffeeBean $coffeeBean) {
+            $this->coffeeBeanRepository->remove($coffeeBean);
+            $this->addFlashMessage('Deleted a coffee bean.');
+            $this->redirect('index');
+        }
 
-	}
+    }
 
 You will learn all the nitty-gritty details of persistence (that is storing and
 retrieving objects in a database), Model-View Controller and validation in
@@ -517,10 +517,10 @@ objects – and which one would you then ask for retrieving a specific coffee be
 the database? The ``CoffeeBeanRepository`` is therefore tagged with an *annotation*
 stating that only a single instance may exist at a time::
 
-	/**
-	 * @Flow\Scope("singleton")
-	 */
-	class CoffeeBeanRepository extends Repository {
+    /**
+     * @Flow\Scope("singleton")
+     */
+    class CoffeeBeanRepository extends Repository {
 
 Because PHP doesn't support the concept of annotations natively, we are using doc
 comments which are parsed by an annotation parser in TYPO3 Flow.
@@ -529,21 +529,21 @@ TYPO3 Flow's object management detects the ``Scope`` annotation and takes care o
 all the details. All you need to do in order to get the right ``CoffeeBeanRepository``
 instance is telling TYPO3 Flow to *inject* it into a class property you defined::
 
-	/**
-	 * @Flow\Inject
-	 * @var \Acme\Demo\Domain\Repository\CoffeeBeanRepository
-	 */
-	protected $coffeeBeanRepository;
+    /**
+     * @Flow\Inject
+     * @var \Acme\Demo\Domain\Repository\CoffeeBeanRepository
+     */
+    protected $coffeeBeanRepository;
 
 The ``Inject`` annotation tells TYPO3 Flow to set the ``$coffeeBeanRepository`` right
 after the ``CoffeeBeanController`` class has been instantiated.
 
 .. tip::
 
-	This feature is called *Dependency Injection* and is an important feature of TYPO3 Flow.
-	Although it is blindingly easy to use, you'll want to read some more about it later
-	in the :doc:`related section <../TheDefinitiveGuide/PartIII/ObjectManagement>` of
-	the main manual.
+    This feature is called *Dependency Injection* and is an important feature of TYPO3 Flow.
+    Although it is blindingly easy to use, you'll want to read some more about it later
+    in the :doc:`related section <../TheDefinitiveGuide/PartIII/ObjectManagement>` of
+    the main manual.
 
 TYPO3 Flow adheres to the Model-View-Controller pattern – that's why the actual output is not
 generated by the action method itself. This task is delegated to the *view*, and that is,
@@ -565,37 +565,37 @@ beans:
 
 .. code-block:: html
 
-	<ul>
-		<f:for each="{coffeeBeans}" as="coffeeBean">
-			<li>
-				{coffeeBean.name}
-			</li>
-		</f:for>
-	</ul>
+    <ul>
+        <f:for each="{coffeeBeans}" as="coffeeBean">
+            <li>
+                {coffeeBean.name}
+            </li>
+        </f:for>
+    </ul>
 
 showAction
 ~~~~~~~~~~
 
 The ``showAction`` displays a single coffee bean::
 
-	/**
-	 * @param \Acme\Demo\Domain\Model\CoffeeBean $coffeeBean The coffee bean to show
-	 * @return void
-	 */
-	public function showAction(CoffeeBean $coffeeBean) {
-		$this->view->assign('coffeeBean', $coffeeBean);
-	}
+    /**
+     * @param \Acme\Demo\Domain\Model\CoffeeBean $coffeeBean The coffee bean to show
+     * @return void
+     */
+    public function showAction(CoffeeBean $coffeeBean) {
+        $this->view->assign('coffeeBean', $coffeeBean);
+    }
 
 The corresponding template for this action is stored in this file:
 
 .. code-block:: text
 
-	Acme.Demo/Resources/Private/Templates/CoffeeBean/Show.html
+    Acme.Demo/Resources/Private/Templates/CoffeeBean/Show.html
 
 This template produces a simple representation of the ``coffeeBean`` object.
 Similar to the ``indexAction`` the coffee bean object is assigned to a Fluid variable::
 
-	$this->view->assign('coffeeBean', $coffeeBean);
+    $this->view->assign('coffeeBean', $coffeeBean);
 
 The ``showAction`` method requires a ``CoffeeBean`` object as its method argument.
 But we need to look into the template of the ``indexAction`` again to understand how
@@ -607,7 +607,7 @@ Fluid template :file:`Index.html`:
 
 .. code-block:: html
 
-	<f:link.action action="show" arguments="{coffeeBean: coffeeBean}">…</f:link.action>
+    <f:link.action action="show" arguments="{coffeeBean: coffeeBean}">…</f:link.action>
 
 The interesting part is the ``{coffeeBean: coffeeBean}`` argument assignment:
 It makes sure that the ``CoffeeBean`` object, stored in the ``coffeeBean``
@@ -618,23 +618,23 @@ the view helper will render an address like the following:
 
 .. code-block:: text
 
-	http://quickstart/acme.demo/coffeebean/show?
-		coffeeBean%5B__identity%5D=910c2440-ea61-49a2-a68c-ee108a6ee429
+    http://quickstart/acme.demo/coffeebean/show?
+        coffeeBean%5B__identity%5D=910c2440-ea61-49a2-a68c-ee108a6ee429
 
 Instead of the real PHP object, its *Universally Unique Identifier* (UUID) was included as
 a GET parameter.
 
 .. note::
 
-	That certainly is not a beautiful URL for a coffee bean – but you'll learn how to
-	create nice ones in the main manual.
+    That certainly is not a beautiful URL for a coffee bean – but you'll learn how to
+    create nice ones in the main manual.
 
 Before the ``showAction`` method is actually called, TYPO3 Flow will analyze the GET and POST
 parameters of the incoming HTTP request and convert identifiers into real objects
 again. By its UUID the coffee bean is retrieved from the ``CoffeeBeanRepository`` and
 eventually passed to the action method::
 
-	public function showAction(CoffeeBean $coffeeBean) {
+    public function showAction(CoffeeBean $coffeeBean) {
 
 newAction
 ~~~~~~~~~
@@ -648,15 +648,15 @@ createAction
 The ``createAction`` is called when a form displayed by the ``newAction`` is submitted.
 Like the ``showAction`` it expects a ``CoffeeBean`` as its argument::
 
-	/**
-	 * @param \Acme\Demo\Domain\Model\CoffeeBean $newCoffeeBean
-	 * @return void
-	 */
-	public function createAction(CoffeeBean $newCoffeeBean) {
-		$this->coffeeBeanRepository->add($newCoffeeBean);
-		$this->addFlashMessage('Created a new coffee bean.');
-		$this->redirect('index');
-	}
+    /**
+     * @param \Acme\Demo\Domain\Model\CoffeeBean $newCoffeeBean
+     * @return void
+     */
+    public function createAction(CoffeeBean $newCoffeeBean) {
+        $this->coffeeBeanRepository->add($newCoffeeBean);
+        $this->addFlashMessage('Created a new coffee bean.');
+        $this->redirect('index');
+    }
 
 This time the argument contains not an existing coffee bean but a new one. TYPO3 Flow knows
 that the expected type is ``CoffeeBean`` (by the type hint in the method and the param annotation)
@@ -675,9 +675,9 @@ for the edit form is the form object assignment:
 
 .. code-block:: html
 
-	<f:form action="update" object="{coffeeBean}" objectName="coffeeBean">
-		...
-	</f:form>
+    <f:form action="update" object="{coffeeBean}" objectName="coffeeBean">
+        ...
+    </f:form>
 
 The ``object="{coffeeBean}"`` attribute assignment tells the view helper to use the
 ``coffeeBean`` template variable as its subject. The individual form elements, such
@@ -685,7 +685,7 @@ as the text box, can now refer to the coffee bean object properties:
 
 .. code-block:: html
 
-	<f:form.textfield property="name" id="name" />
+    <f:form.textfield property="name" id="name" />
 
 On submitting the form, the user will be redirected to the ``updateAction``.
 
@@ -695,15 +695,15 @@ updateAction
 The ``updateAction`` receives the modified coffee bean through its ``$coffeeBean``
 argument::
 
-	/**
-	 * @param \Acme\Demo\Domain\Model\CoffeeBean $coffeeBean
-	 * @return void
-	 */
-	public function updateAction(CoffeeBean $coffeeBean) {
-		$this->coffeeBeanRepository->update($coffeeBean);
-		$this->addFlashMessage('Updated the coffee bean.');
-		$this->redirect('index');
-	}
+    /**
+     * @param \Acme\Demo\Domain\Model\CoffeeBean $coffeeBean
+     * @return void
+     */
+    public function updateAction(CoffeeBean $coffeeBean) {
+        $this->coffeeBeanRepository->update($coffeeBean);
+        $this->addFlashMessage('Updated the coffee bean.');
+        $this->redirect('index');
+    }
 
 Although this method looks quite similar to the ``showAction``, there is an important
 difference you should be aware of: The parameter passed to the ``showAction``
@@ -713,7 +713,7 @@ modifications submitted by the user already applied.
 Any modifications to the ``CoffeBean`` object will be lost at the end of the request
 unless you tell TYPO3 Flow explicitly to apply the changes::
 
-	$this->coffeeBeanRepository->update($coffeeBean);
+    $this->coffeeBeanRepository->update($coffeeBean);
 
 This allows for a very efficient dirty checking and is a safety measure - as it leaves
 control over the changes in your hands.

--- a/TYPO3.Flow/Documentation/StyleGuide/About.rst
+++ b/TYPO3.Flow/Documentation/StyleGuide/About.rst
@@ -17,7 +17,5 @@ In general, follow the style and usage rules in:
 * `Merriam-Webster's Collegiate Dictionary`_ (or other editions by Merriam-Webster)
 * `The Chicago Manual of Style`_
 
-
 .. _Merriam-Webster's Collegiate Dictionary:           http://www.merriam-webster.com/
 .. _The Chicago Manual of Style:                       http://www.chicagomanualofstyle.org/
-

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/Validation.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/Validation.rst
@@ -45,7 +45,7 @@ three types:
 
 .. note::
 	Base model and supplemental rules are not covered by this tutorial.
-	Detailed information is available in :doc:`Part III - Validation <../PartIII/Validation`.
+    Detailed information is available in :doc:`Part III - Validation <../PartIII/Validation>`.
 
 Rules for the base properties are defined directly in the model in form
 of annotations:

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/Validation.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/Validation.rst
@@ -33,18 +33,18 @@ When we're talking about validation, we usually refer to validating **models**.
 The rules defining how a model should be validated can be classified into
 three types:
 
--	**Base Properties** – a set of rules defining the minimum requirements
-	on the properties of a model which must be met before a model may
-	be persisted.
--	**Base Model** – a set of rules or custom validator enforcing the
-	minimum requirements on the combination of properties of a model which
-	must be met before a model may be persisted.
--	**Supplemental** – a set of rules defining additional requirements on
-	a model for a specific situation, for example for a certain
-	action method.
+-   **Base Properties** – a set of rules defining the minimum requirements
+    on the properties of a model which must be met before a model may
+    be persisted.
+-   **Base Model** – a set of rules or custom validator enforcing the
+    minimum requirements on the combination of properties of a model which
+    must be met before a model may be persisted.
+-   **Supplemental** – a set of rules defining additional requirements on
+    a model for a specific situation, for example for a certain
+    action method.
 
 .. note::
-	Base model and supplemental rules are not covered by this tutorial.
+    Base model and supplemental rules are not covered by this tutorial.
     Detailed information is available in :doc:`Part III - Validation <../PartIII/Validation>`.
 
 Rules for the base properties are defined directly in the model in form
@@ -54,53 +54,53 @@ of annotations:
 
 .. code-block:: php
 
-	/**
-	 * @Flow\Validate(type="NotEmpty")
-	 * @Flow\Validate(type="StringLength", options={ "minimum"=3, "maximum"=50 })
-	 * @var string
-	 */
-	protected $subject;
+    /**
+     * @Flow\Validate(type="NotEmpty")
+     * @Flow\Validate(type="StringLength", options={ "minimum"=3, "maximum"=50 })
+     * @var string
+     */
+    protected $subject;
 
-	/**
-	 * @Flow\Validate(type="NotEmpty")
-	 * @var string
-	 */
-	protected $author;
+    /**
+     * @Flow\Validate(type="NotEmpty")
+     * @var string
+     */
+    protected $author;
 
-	/**
-	 * @Flow\Validate(type="NotEmpty")
-	 * @ORM\ManyToOne(inversedBy="posts")
-	 * @var Blog
-	 */
-	protected $blog;
+    /**
+     * @Flow\Validate(type="NotEmpty")
+     * @ORM\ManyToOne(inversedBy="posts")
+     * @var Blog
+     */
+    protected $blog;
 
 The ``Validate`` annotations define one or more validation rules which should apply to a
 property. Multiple rules can be defined in dedicated lines by further ``Validate``
 annotations.
 
 .. note::
-	Per convention, every validator allows (passes) empty values, i.e. empty strings or
-	NULL values. This is for achieving fields which are not mandatory, but if filled in,
-	must satisfy a given validation. Consider an email address field for example which
-	is not mandatory, but has to match an email pattern as soon as filled in.
+    Per convention, every validator allows (passes) empty values, i.e. empty strings or
+    NULL values. This is for achieving fields which are not mandatory, but if filled in,
+    must satisfy a given validation. Consider an email address field for example which
+    is not mandatory, but has to match an email pattern as soon as filled in.
 
-	If you want to make a field mandatory at all, use the ``NotEmpty`` validator in addition,
-	like in the example above.
+    If you want to make a field mandatory at all, use the ``NotEmpty`` validator in addition,
+    like in the example above.
 
-	The technical background is the ``acceptsEmptyValues`` property of the AbstractValidator,
-	being ``TRUE`` per default. When writing customized validators, it's basically possible
-	to set this field to ``FALSE``, however this is not generally recommended due to the convention
-	that every validator could principally be empty.
+    The technical background is the ``acceptsEmptyValues`` property of the AbstractValidator,
+    being ``TRUE`` per default. When writing customized validators, it's basically possible
+    to set this field to ``FALSE``, however this is not generally recommended due to the convention
+    that every validator could principally be empty.
 
 .. tip::
-	Flow provides a range of built-in validators which can be found in the
-	``Flow\Validation\Validator`` sub package. The names used in the
-	``type`` attributes are just the unqualified class names of these validators.
+    Flow provides a range of built-in validators which can be found in the
+    ``Flow\Validation\Validator`` sub package. The names used in the
+    ``type`` attributes are just the unqualified class names of these validators.
 
-	It is possible and very simple to program custom validators by implementing
-	the ``TYPO3\Flow\Validation\Validator\ValidatorInterface``.
-	Such validators must, however, be referred to by their fully qualified
-	class name (i.e. including the namespace).
+    It is possible and very simple to program custom validators by implementing
+    the ``TYPO3\Flow\Validation\Validator\ValidatorInterface``.
+    Such validators must, however, be referred to by their fully qualified
+    class name (i.e. including the namespace).
 
 Make sure the above validation rules are set in your ``Post`` model, click on the
 ``Create a new post`` link below the list of posts and submit the *empty* form. If all went fine,
@@ -108,10 +108,10 @@ you should end up again in the **new post** form, with the tiny difference
 that the text boxes for title and author are now framed in red:
 
 .. figure:: Images/CreateNewPostValidationError1.png
-	:alt: Validation errors shown in form
-	:class: screenshot-detail
+    :alt: Validation errors shown in form
+    :class: screenshot-detail
 
-	Validation errors shown in form
+    Validation errors shown in form
 
 Displaying Validation Errors
 ============================
@@ -129,20 +129,20 @@ View Helper in a new partial ``FormErrors``::
 
 .. code-block:: html
 
-	<f:form.validationResults for="{for}">
-		<f:if condition="{validationResults.flattenedErrors}">
-			<dl class="errors">
-				<f:for each="{validationResults.flattenedErrors}" key="propertyName" as="errors">
-					<dt>
-						{propertyName}:
-					</dt>
-					<dd>
-						<f:for each="{errors}" as="error">{error}</f:for>
-					</dd>
-				</f:for>
-			</dl>
-		</f:if>
-	</f:form.validationResults>
+    <f:form.validationResults for="{for}">
+        <f:if condition="{validationResults.flattenedErrors}">
+            <dl class="errors">
+                <f:for each="{validationResults.flattenedErrors}" key="propertyName" as="errors">
+                    <dt>
+                        {propertyName}:
+                    </dt>
+                    <dd>
+                        <f:for each="{errors}" as="error">{error}</f:for>
+                    </dd>
+                </f:for>
+            </dl>
+        </f:if>
+    </f:form.validationResults>
 
 And include that partial to both, the ``New.html`` and the ``Edit.html`` templates just above the
 form::
@@ -151,9 +151,9 @@ form::
 
 .. code-block:: html
 
-	<f:render partial="FormErrors" arguments="{for: 'newPost'}" />
-	<f:form action="create" objectName="newPost">
-	...
+    <f:render partial="FormErrors" arguments="{for: 'newPost'}" />
+    <f:form action="create" objectName="newPost">
+    ...
 
 and::
 
@@ -161,9 +161,9 @@ and::
 
 .. code-block:: html
 
-	<f:render partial="FormErrors" arguments="{for: 'post'}" />
-	<f:form action="update" object="{post}" objectName="post">
-	...
+    <f:render partial="FormErrors" arguments="{for: 'post'}" />
+    <f:form action="update" object="{post}" objectName="post">
+    ...
 
 Similar to the ``<f:for>`` view helper ``<f:form.validationResults>`` defines a loop
 iterating over validation errors. The attribute ``as`` is optional and if it's
@@ -178,10 +178,10 @@ After saving the modified template and submitting the empty form again you
 should see some more verbose error messages:
 
 .. figure:: Images/CreateNewPostValidationError2.png
-	:alt: More verbose validation errors shown in form
-	:class: screenshot-detail
+    :alt: More verbose validation errors shown in form
+    :class: screenshot-detail
 
-	More verbose validation errors shown in form
+    More verbose validation errors shown in form
 
 Validating Existing Data
 ========================
@@ -194,7 +194,7 @@ afterwards?
 Doing so would prevent you from invoking any of the actions for that particular post.
 All you will see is an error message::
 
-	Validation failed while trying to call Acme\Blog\Controller\PostController->showAction().
+    Validation failed while trying to call Acme\Blog\Controller\PostController->showAction().
 
 
 So the problem is that Flow tries to validate the ``$post`` argument for the
@@ -209,20 +209,20 @@ additional annotation the whole mechanism works as expected:
 
 .. code-block:: php
 
-	/**
-	 * Displays a single post
-	 *
-	 * @Flow\IgnoreValidation("$post")
-	 * @param Post $post
-	 * @return void
-	 */
-	public function showAction(Post $post) {
-		$this->view->assignMultiple([
-			'post' => $post,
-			'nextPost' => $this->postRepository->findNext($post),
-			'previousPost' => $this->postRepository->findPrevious($post),
-		]);
-	}
+    /**
+     * Displays a single post
+     *
+     * @Flow\IgnoreValidation("$post")
+     * @param Post $post
+     * @return void
+     */
+    public function showAction(Post $post) {
+        $this->view->assignMultiple([
+            'post' => $post,
+            'nextPost' => $this->postRepository->findNext($post),
+            'previousPost' => $this->postRepository->findPrevious($post),
+        ]);
+    }
 
 
 Now the ``showAction`` can be called even though ``$post`` is not valid.
@@ -231,5 +231,5 @@ invalid posts can be fixed or removed.
 
 -----
 
-.. [#]	See also: `Separation of Concerns (Wikipedia)
-		<http://en.wikipedia.org/wiki/Separation_of_concerns>`_
+.. [#]  See also: `Separation of Concerns (Wikipedia)
+        <http://en.wikipedia.org/wiki/Separation_of_concerns>`_

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/View.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/View.rst
@@ -31,15 +31,15 @@ the *Acme.Blog* package:
 
 .. table:: Directory structure of a Flow package
 
-	======================	============================================================
-	Directory				Description
-	======================	============================================================
-	*Classes/*				All the .php class files of your package
-	*Documentation/*		The package's manual and other documentation
-	*Resources/*			Top folder for resources
-	*Resources/Public/*		Public resources - will be mirrored to the *Web* directory
-	*Resources/Private/*	Private resources - won't be mirrored to the *Web* directory
-	======================	============================================================
+    ======================  ============================================================
+    Directory               Description
+    ======================  ============================================================
+    *Classes/*              All the .php class files of your package
+    *Documentation/*        The package's manual and other documentation
+    *Resources/*            Top folder for resources
+    *Resources/Public/*     Public resources - will be mirrored to the *Web* directory
+    *Resources/Private/*    Private resources - won't be mirrored to the *Web* directory
+    ======================  ============================================================
 
 
 No matter what files and directories you create below ``Resources/Public/`` - all
@@ -47,15 +47,15 @@ of them will, by default, be symlinked to ``Web/_Resources/Static/Packages/Acme.
 the next hit.
 
 .. tip::
-	There are more possible directories in a package and we do have some
-	conventions for naming certain sub directories. All that is explained in
+    There are more possible directories in a package and we do have some
+    conventions for naming certain sub directories. All that is explained in
     fine detail in :doc:`Part III <../PartIII/index>`.
 
 .. important::
-	For the blog example in this tutorial we created some style sheet to make it more appealing.
-	If you'd like the examples to use those styles, then it's time to copy ``Resources/Public/``
-	from the git repository (https://github.com/neos/Acme.Blog)
-	to your blog's public resources folder (``Packages/Application/Acme.Blog/Resources/Public/``).
+    For the blog example in this tutorial we created some style sheet to make it more appealing.
+    If you'd like the examples to use those styles, then it's time to copy ``Resources/Public/``
+    from the git repository (https://github.com/neos/Acme.Blog)
+    to your blog's public resources folder (``Packages/Application/Acme.Blog/Resources/Public/``).
 
 Layouts
 =======
@@ -66,10 +66,10 @@ template view. The following figure illustrates the use of layout, template and
 partials in our blog example:
 
 .. figure:: Images/LayoutTemplatePartial.png
-	:alt: Layout, Template and Partial
-	:class: screenshot-fullsize
+    :alt: Layout, Template and Partial
+    :class: screenshot-fullsize
 
-	Layout, Template and Partial
+    Layout, Template and Partial
 
 
 A Fluid layout provides the basic layout of the output which is supposed to be
@@ -86,44 +86,44 @@ the following code:
 
 .. code-block:: html
 
-	<!DOCTYPE html>
-	<html>
-	<head lang="en">
-		<meta charset="utf-8">
-		<title>{blog.title} - Flow Blog Example</title>
-		<link rel="stylesheet" href="../../Public/Styles/App.css" type="text/css" />
-	</head>
-	<body>
+    <!DOCTYPE html>
+    <html>
+    <head lang="en">
+        <meta charset="utf-8">
+        <title>{blog.title} - Flow Blog Example</title>
+        <link rel="stylesheet" href="../../Public/Styles/App.css" type="text/css" />
+    </head>
+    <body>
 
-		<header>
-			<f:if condition="{blog}">
-				<f:link.action action="index" controller="Post">
-					<h1>{blog.title}</h1>
-				</f:link.action>
-				<p class="description">{blog.description -> f:format.crop(maxCharacters: 80)}</p>
-			</f:if>
-		</header>
+        <header>
+            <f:if condition="{blog}">
+                <f:link.action action="index" controller="Post">
+                    <h1>{blog.title}</h1>
+                </f:link.action>
+                <p class="description">{blog.description -> f:format.crop(maxCharacters: 80)}</p>
+            </f:if>
+        </header>
 
-		<div id="content">
-			<f:flashMessages class="flashmessages" />
-			<f:render section="MainContent" />
-		</div>
+        <div id="content">
+            <f:flashMessages class="flashmessages" />
+            <f:render section="MainContent" />
+        </div>
 
-		<footer>
-			<a href="http://flow.typo3.org">
-				Powered by Flow
-			</a>
-		</footer>
+        <footer>
+            <a href="http://flow.typo3.org">
+                Powered by Flow
+            </a>
+        </footer>
 
-	</body>
-	</html>
+    </body>
+    </html>
 
 .. tip::
-	If you don't want to download the stylesheet mentioned above, you can import it directly from the
-	github repository, replacing `../../Public/Styles./App.css`` with
-	``https://raw.githubusercontent.com/neos/Acme.Blog/master/Resources/Public/Styles/App.css``
-	Of course you can also just remove the whole ``<link rel="stylesheet" ...`` line if you don't care
-	about style.
+    If you don't want to download the stylesheet mentioned above, you can import it directly from the
+    github repository, replacing `../../Public/Styles./App.css`` with
+    ``https://raw.githubusercontent.com/neos/Acme.Blog/master/Resources/Public/Styles/App.css``
+    Of course you can also just remove the whole ``<link rel="stylesheet" ...`` line if you don't care
+    about style.
 
 On first sight this looks like plain HTML code, but you'll surely notice the
 various ``<f: ... >`` tags. Fluid provides a range of view helpers which are
@@ -143,7 +143,7 @@ accessor. It is very similar to some Fluid markup that we skipped over in ``<hea
 
 .. code-block:: html
 
-	<title>{blog.title} - Flow Blog Example</title>
+    <title>{blog.title} - Flow Blog Example</title>
 
 As you will see in a minute, Fluid allows your controller to define variables
 for the template view. In order to display the blog's name, you'll need to make
@@ -164,7 +164,7 @@ alternative way to address view helpers, the **view helper shorthand syntax**:
 
 .. code-block:: html
 
-	{blog.description -> f:format.crop(maxCharacters: 80)}
+    {blog.description -> f:format.crop(maxCharacters: 80)}
 
 ``{f:format.crop(...)}``` instructs Fluid to crop the given value (in this case the
 Blog's description). With the ``maxCharacters`` argument the description will be
@@ -175,14 +175,14 @@ will look something like this:
 
 .. code-block:: html
 
-	This is a very long description that will be cropped if it exceeds eighty charac...
+    This is a very long description that will be cropped if it exceeds eighty charac...
 
 If you look at the remaining markup of the layout you'll find more uses of view
 helpers, including ``flashMessages``. It generates an unordered list with
 all flash messages. Well, maybe you remember this line in the ``createAction``
 of our ``PostController``::
 
-	$this->addFlashMessage('Created a new post.');
+    $this->addFlashMessage('Created a new post.');
 
 Flash messages are a great way to display success or error messages to
 the user beyond a single request. And because they are so useful, Flow provides a
@@ -197,7 +197,7 @@ the **render** view helper:
 
 .. code-block:: html
 
-	<f:render section="MainContent" />
+    <f:render section="MainContent" />
 
 This tag tells Fluid to insert the section ``MainContent`` defined in the current
 template at this place. For this to work there must be a section with the
@@ -220,31 +220,31 @@ meaningful HTML:
 
 .. code-block:: html
 
-	<f:layout name="Default" />
+    <f:layout name="Default" />
 
-	<f:section name="MainContent">
-		<f:if condition="{blog.posts}">
-			<f:then>
-				<ul>
-					<f:for each="{blog.posts}" as="post">
-						<li class="post">
-							<f:render partial="PostActions" arguments="{post: post}"/>
-							<h2>
-								<f:link.action action="show" arguments="{post: post}">{post.subject}</f:link.action>
-							</h2>
-							<f:render partial="PostMetaData" arguments="{post: post}"/>
-						</li>
-					</f:for>
-				</ul>
-			</f:then>
-			<f:else>
-				<p>No posts created yet.</p>
-			</f:else>
-		</f:if>
-		<p>
-			<f:link.action action="new">Create a new post</f:link.action><
-		/p>
-	</f:section>
+    <f:section name="MainContent">
+        <f:if condition="{blog.posts}">
+            <f:then>
+                <ul>
+                    <f:for each="{blog.posts}" as="post">
+                        <li class="post">
+                            <f:render partial="PostActions" arguments="{post: post}"/>
+                            <h2>
+                                <f:link.action action="show" arguments="{post: post}">{post.subject}</f:link.action>
+                            </h2>
+                            <f:render partial="PostMetaData" arguments="{post: post}"/>
+                        </li>
+                    </f:for>
+                </ul>
+            </f:then>
+            <f:else>
+                <p>No posts created yet.</p>
+            </f:else>
+        </f:if>
+        <p>
+            <f:link.action action="new">Create a new post</f:link.action><
+        /p>
+    </f:section>
 
 There you have it: In the first line of your template there's a reference to
 the "Default" layout. All HTML code is wrapped in a ``<f:section>`` tag. Even
@@ -261,20 +261,20 @@ about a blog - you need to adapt the the ``PostController`` to assign the curren
 
 .. code-block:: php
 
-	/**
-	 * @return void
-	 */
-	public function indexAction() {
-		$blog = $this->blogRepository->findActive();
-		$this->view->assign('blog', $blog);
-	}
+    /**
+     * @return void
+     */
+    public function indexAction() {
+        $blog = $this->blogRepository->findActive();
+        $this->view->assign('blog', $blog);
+    }
 
 To fully understand the above code you need to know two facts:
 
--	``$this->view`` is automatically set by the action controller and
-	points to a Fluid template view.
--	if an action method returns ``NULL``, the controller will automatically
-	call ``$this->view->render()`` after executing the action.
+-   ``$this->view`` is automatically set by the action controller and
+    points to a Fluid template view.
+-   if an action method returns ``NULL``, the controller will automatically
+    call ``$this->view->render()`` after executing the action.
 
 But soon you'll see that we need the current Blog in all of our actions, so how to assign it
 to the view without repeating the same code over and over again?
@@ -284,20 +284,20 @@ With ease: We just assign it as soon as the view is initialized::
 
 .. code-block:: php
 
-	/**
-	 * @param ViewInterface $view
-	 * @return void
-	 */
-	protected function initializeView(ViewInterface $view) {
-		$blog = $this->blogRepository->findActive();
-		$this->view->assign('blog', $blog);
-	}
+    /**
+     * @param ViewInterface $view
+     * @return void
+     */
+    protected function initializeView(ViewInterface $view) {
+        $blog = $this->blogRepository->findActive();
+        $this->view->assign('blog', $blog);
+    }
 
-	/**
-	 * @return void
-	 */
-	public function indexAction() {
-	}
+    /**
+     * @return void
+     */
+    public function indexAction() {
+    }
 
 The ``initializeView`` method is called before each action, so it provides a good opportunity
 to assign values to the view that should be accessible from all actions.
@@ -309,24 +309,24 @@ After creating the folder ``Resources/Private/Partials/`` add the following two 
 
 .. code-block:: html
 
-	<p class="metadata">
-		Published on {post.date -> f:format.date(format: 'Y-m-d')} by {post.author}
-	</p>
+    <p class="metadata">
+        Published on {post.date -> f:format.date(format: 'Y-m-d')} by {post.author}
+    </p>
 
 *Resources/Private/Partials/PostActions.html*:
 
 .. code-block:: html
 
-	<ul class="actions">
-		<li>
-			<f:link.action action="edit" arguments="{post: post}">Edit</f:link.action>
-		</li>
-		<li>
-			<f:form action="delete" arguments="{post: post}">
-				<f:form.submit name="delete" value="Delete" />
-			</f:form>
-		</li>
-	</ul>
+    <ul class="actions">
+        <li>
+            <f:link.action action="edit" arguments="{post: post}">Edit</f:link.action>
+        </li>
+        <li>
+            <f:form action="delete" arguments="{post: post}">
+                <f:form.submit name="delete" value="Delete" />
+            </f:form>
+        </li>
+    </ul>
 
 The ``PostMetaData`` partial renders date and author of a post. The ``PostActions`` partial an *edit* link
 and a button to *delete* the current post. Both are used as well in the list view (``indexAction``) as well
@@ -336,10 +336,10 @@ having to duplicate markup.
 Now you should now see the list of recent posts by accessing http://dev.tutorial.local/acme.blog/post:
 
 .. figure:: Images/PostIndex.png
-	:alt: The list of blog posts
-	:class: screenshot-fullsize
+    :alt: The list of blog posts
+    :class: screenshot-fullsize
 
-	The list of blog posts
+    The list of blog posts
 
 To create new posts and edit existing ones from the web browser, we need to create Forms:
 
@@ -357,13 +357,13 @@ displaying the form:
 
 .. code-block:: php
 
-	/**
-	 * Displays the "Create Post" form
-	 *
-	 * @return void
-	 */
-	public function newAction() {
-	}
+    /**
+     * Displays the "Create Post" form
+     *
+     * @return void
+     */
+    public function newAction() {
+    }
 
 No code? What will happen is this: the action controller selects the
 ``New.html`` template and assigns it to ``$this->view`` which will automatically
@@ -379,25 +379,25 @@ the ``Resources/Private/Templates/Post/`` folder:
 
 .. code-block:: html
 
-	<f:layout name="Default" />
+    <f:layout name="Default" />
 
-	<f:section name="MainContent">
-		<h2>Create new post</h2>
-		<f:form action="create" objectName="newPost">
-			<f:form.hidden property="blog" value="{blog}" />
+    <f:section name="MainContent">
+        <h2>Create new post</h2>
+        <f:form action="create" objectName="newPost">
+            <f:form.hidden property="blog" value="{blog}" />
 
-			<label for="post-author">Author</label>
-			<f:form.textfield property="author" id="post-author" />
+            <label for="post-author">Author</label>
+            <f:form.textfield property="author" id="post-author" />
 
-			<label for="post-subject">Subject</label>
-			<f:form.textfield property="subject" id="post-subject" />
+            <label for="post-subject">Subject</label>
+            <f:form.textfield property="subject" id="post-subject" />
 
-			<label for="post-content">Content</label>
-			<f:form.textarea property="content" rows="5" cols="30" id="post-content" />
+            <label for="post-content">Content</label>
+            <f:form.textarea property="content" rows="5" cols="30" id="post-content" />
 
-			<f:form.submit name="submit" value="Publish Post" />
-		</f:form>
-	</f:section>
+            <f:form.submit name="submit" value="Publish Post" />
+        </f:form>
+    </f:section>
 
 Here is how it works: The ``<f:form>`` view helper renders a form tag. Its
 attributes are similar to the action link view helper you might have seen in
@@ -417,28 +417,28 @@ Let's look at the ``createAction`` again:
 
 .. note::
 
-	Mind that ``newPost`` is not assigned to the view in this example. Assigning
-	this object is only needed if you have set default values to your model
-	properties. So if you for example have a ``protected $hidden = TRUE``
-	definition in your model, a ``<f:form.checkbox property="hidden" />`` will not
-	be checked by default, unless you instantiate ``$newPost`` in your index
-	action and assign it to the view.
+    Mind that ``newPost`` is not assigned to the view in this example. Assigning
+    this object is only needed if you have set default values to your model
+    properties. So if you for example have a ``protected $hidden = TRUE``
+    definition in your model, a ``<f:form.checkbox property="hidden" />`` will not
+    be checked by default, unless you instantiate ``$newPost`` in your index
+    action and assign it to the view.
 
 *Classes/Acme/Blog/Controller/PostController.php*:
 
 .. code-block:: php
 
-	/**
-	 * Creates a new post
-	 *
-	 * @param Post $newPost
-	 * @return void
-	 */
-	public function createAction(Post $newPost) {
-		$this->postRepository->add($newPost);
-		$this->addFlashMessage('Created a new post.');
-		$this->redirect('index');
-	}
+    /**
+     * Creates a new post
+     *
+     * @param Post $newPost
+     * @return void
+     */
+    public function createAction(Post $newPost) {
+        $this->postRepository->add($newPost);
+        $this->addFlashMessage('Created a new post.');
+        $this->redirect('index');
+    }
 
 It's important that the ``createAction`` uses the type hint
 ``Post`` (which expands to ``\Acme\Blog\Domain\Model\Post``) and that it comes with a proper
@@ -450,18 +450,18 @@ Time to test your new ``newAction`` and its template – click on the little plu
 sign above the first post lets the ``newAction`` render this form:
 
 .. figure:: Images/CreateNewPost.png
-	:alt: Form to create a new post
-	:class: screenshot-detail
+    :alt: Form to create a new post
+    :class: screenshot-detail
 
-	Form to create a new post
+    Form to create a new post
 
 Enter some data and click the submit button:
 
 .. figure:: Images/CreatedNewPost.png
-	:alt: A new post has been created
-	:class: screenshot-fullsize
+    :alt: A new post has been created
+    :class: screenshot-fullsize
 
-	A new post has been created
+    A new post has been created
 
 You should now find your new post in the list of posts.
 
@@ -478,27 +478,27 @@ partial::
 
 .. code-block:: html
 
-	<ul class="actions">
-		<li>
-			<f:link.action action="edit" arguments="{post: post}">Edit</f:link.action>
-		</li>
-		<li>
-			<f:form action="delete" arguments="{post: post}">
-				<f:form.submit name="delete" value="Delete" />
-			</f:form>
-		</li>
-	</ul>
+    <ul class="actions">
+        <li>
+            <f:link.action action="edit" arguments="{post: post}">Edit</f:link.action>
+        </li>
+        <li>
+            <f:form action="delete" arguments="{post: post}">
+                <f:form.submit name="delete" value="Delete" />
+            </f:form>
+        </li>
+    </ul>
 
 This renders an "Edit" link that points to the ``editAction`` of the PostController.
 Below is a little form with just one button that triggers the ``deleteAction()``.
 
 .. note::
 
-	The reason why the ``deleteAction()`` is invoked via a form instead of a link is
-	because Flow follows the HTTP 1.1 specification that suggests that called "safe
-	request methods" (usually GET or HEAD requests) should not change the server state.
-	See :doc:`Part III - Validation <../PartIII/Validation>` for more details.
-	The ``editAction()`` just displays the Post edit form, so it can be called via GET requests.
+    The reason why the ``deleteAction()`` is invoked via a form instead of a link is
+    because Flow follows the HTTP 1.1 specification that suggests that called "safe
+    request methods" (usually GET or HEAD requests) should not change the server state.
+    See :doc:`Part III - Validation <../PartIII/Validation>` for more details.
+    The ``editAction()`` just displays the Post edit form, so it can be called via GET requests.
 
 Adjust the template ``Templates/Post/Edit.html`` and insert the following HTML code:
 
@@ -506,23 +506,23 @@ Adjust the template ``Templates/Post/Edit.html`` and insert the following HTML c
 
 .. code-block:: html
 
-	<f:layout name="Default" />
+    <f:layout name="Default" />
 
-	<f:section name="MainContent">
-		<h2>Edit post "{post.subject}"</h2>
-		<f:form action="update" object="{post}" objectName="post">
-			<label for="post-author">Author</label>
-			<f:form.textfield property="author" id="post-author" />
+    <f:section name="MainContent">
+        <h2>Edit post "{post.subject}"</h2>
+        <f:form action="update" object="{post}" objectName="post">
+            <label for="post-author">Author</label>
+            <f:form.textfield property="author" id="post-author" />
 
-			<label for="post-subject">Subject</label>
-			<f:form.textfield property="subject" id="post-subject" />
+            <label for="post-subject">Subject</label>
+            <f:form.textfield property="subject" id="post-subject" />
 
-			<label for="post-content">Content</label>
-			<f:form.textarea property="content" rows="5" cols="30" id="post-content" />
+            <label for="post-content">Content</label>
+            <f:form.textarea property="content" rows="5" cols="30" id="post-content" />
 
-			<f:form.submit name="submit" value="Update Post" />
-		</f:form>
-	</f:section>
+            <f:form.submit name="submit" value="Update Post" />
+        </f:form>
+    </f:section>
 
 Most of this should already look familiar. However, there is a tiny difference
 to the ``new`` form you created earlier: in this edit form you added
@@ -545,24 +545,24 @@ What's missing now is a small adjustment to the PHP code displaying the edit for
 
 .. code-block:: php
 
-	/**
-	 * Displays the "Edit Post" form
-	 *
-	 * @param Post $post
-	 * @return void
-	 */
-	public function editAction(Post $post) {
-		$this->view->assign('post', $post);
-	}
+    /**
+     * Displays the "Edit Post" form
+     *
+     * @param Post $post
+     * @return void
+     */
+    public function editAction(Post $post) {
+        $this->view->assign('post', $post);
+    }
 
 Enough theory, let's try out the edit form in practice. A click on the edit
 link of your list of posts should result in a screen similar to this:
 
 .. figure:: Images/EditPost.png
-	:alt: The edit form for a post
-	:class: screenshot-fullsize
+    :alt: The edit form for a post
+    :class: screenshot-fullsize
 
-	The edit form for a post
+    The edit form for a post
 
 When you submit the form you call the ``updateAction``:
 
@@ -570,17 +570,17 @@ When you submit the form you call the ``updateAction``:
 
 .. code-block:: php
 
-	/**
-	 * Updates a post
-	 *
-	 * @param Post $post
-	 * @return void
-	 */
-	public function updateAction(Post $post) {
-		$this->postRepository->update($post);
-		$this->addFlashMessage('Updated the post.');
-		$this->redirect('index');
-	}
+    /**
+     * Updates a post
+     *
+     * @param Post $post
+     * @return void
+     */
+    public function updateAction(Post $post) {
+        $this->postRepository->update($post);
+        $this->addFlashMessage('Updated the post.');
+        $this->redirect('index');
+    }
 
 Quite easy as well, isn't it? The ``updateAction`` expects the edited post as
 its argument and passes it to the repository's ``update`` method (note that we
@@ -588,10 +588,10 @@ used the ``PostRepository``!). Before we disclose the secret how this magic
 actually works behind the scenes try out if updating the post really works:
 
 .. figure:: Images/UpdatedPost.png
-	:alt: The post has been edited
-	:class: screenshot-detail
+    :alt: The post has been edited
+    :class: screenshot-detail
 
-	The post has been edited
+    The post has been edited
 
 A Closer Look on Updates
 ------------------------
@@ -617,11 +617,11 @@ by Fluid's form view helper:
 
 .. code-block:: html
 
-	<form action="/acme.blog/post/update" method="post">
-		...
-		<input type="hidden" name="post[__identity]" value="7825fe4b-33d9-0522-a3f2-02833f9084ab" />
-		...
-	</form>
+    <form action="/acme.blog/post/update" method="post">
+        ...
+        <input type="hidden" name="post[__identity]" value="7825fe4b-33d9-0522-a3f2-02833f9084ab" />
+        ...
+    </form>
 
 Fluid automatically renders a hidden field containing information about the
 technical identity of the form's object, if the object is an original, previously
@@ -633,18 +633,18 @@ submitted. This results in three different cases:
 
 .. table:: Create, Show, Update detection
 
-	+-------------------+---------------+---------------------------------------+
-	| Situation         | Case          | Consequence                           |
-	+===================+===============+=======================================+
-	| identity missing, | New /         | Create a completely new object and    |
-	| properties present| Create        | set the given properties              |
-	+-------------------+---------------+---------------------------------------+
-	| identity present, | Show /        | Retrieve original object with         |
-	| properties missing| Delete / ...  | given identifier                      |
-	+-------------------+---------------+---------------------------------------+
-	| identity present, | Edit /        | Retrieve original object, and set the |
-	| properties present| Update        | given properties                      |
-	+-------------------+---------------+---------------------------------------+
+    +-------------------+---------------+---------------------------------------+
+    | Situation         | Case          | Consequence                           |
+    +===================+===============+=======================================+
+    | identity missing, | New /         | Create a completely new object and    |
+    | properties present| Create        | set the given properties              |
+    +-------------------+---------------+---------------------------------------+
+    | identity present, | Show /        | Retrieve original object with         |
+    | properties missing| Delete / ...  | given identifier                      |
+    +-------------------+---------------+---------------------------------------+
+    | identity present, | Edit /        | Retrieve original object, and set the |
+    | properties present| Update        | given properties                      |
+    +-------------------+---------------+---------------------------------------+
 
 Because the edit form contained both identity and properties, Flow prepared an
 instance with the given properties for our ``updateAction``.

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/View.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/View.rst
@@ -49,7 +49,7 @@ the next hit.
 .. tip::
 	There are more possible directories in a package and we do have some
 	conventions for naming certain sub directories. All that is explained in
-	fine detail in :doc:`Part III <../Part-III/index>`.
+    fine detail in :doc:`Part III <../PartIII/index>`.
 
 .. important::
 	For the blog example in this tutorial we created some style sheet to make it more appealing.

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/ErrorAndExceptionHandling.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/ErrorAndExceptionHandling.rst
@@ -18,22 +18,22 @@ provided by TYPO3 Flow. Each exception should be identified by a unique error co
 is, by convention, the unix timestamp of the point in time when the developer
 implemented the code throwing the exception::
 
-	if ($somethingWentReallyWrong) {
-		throw new SomethingWentWrongException('An exception message', 1347145643);
-	}
+    if ($somethingWentReallyWrong) {
+        throw new SomethingWentWrongException('An exception message', 1347145643);
+    }
 
 Exceptions can contain an HTTP status code which is sent as a corresponding response
 header. The status code is simply set by defining a property with the respective
 value assigned::
 
-	class SomethingWasNotFoundException extends \TYPO3\Flow\Exception {
+    class SomethingWasNotFoundException extends \TYPO3\Flow\Exception {
 
-		/**
-   	 * @var integer
-   	 */
-   	protected $statusCode = 404;
+        /**
+     * @var integer
+     */
+    protected $statusCode = 404;
 
-	}
+    }
 
 Exception Handlers
 ------------------
@@ -56,13 +56,13 @@ The exception handler to be used can be configured through an entry in Settings.
 
 .. code-block:: yaml
 
-	TYPO3:
-	  Flow:
-	    error:
-	      exceptionHandler:
-	        # Defines the global, last-resort exception handler.
-	        # The specified class must implement \TYPO3\Flow\Error\ExceptionHandlerInterface
-	        className: 'TYPO3\Flow\Error\ProductionExceptionHandler'
+    TYPO3:
+      Flow:
+        error:
+          exceptionHandler:
+            # Defines the global, last-resort exception handler.
+            # The specified class must implement \TYPO3\Flow\Error\ExceptionHandlerInterface
+            className: 'TYPO3\Flow\Error\ProductionExceptionHandler'
 
 Reference Code
 --------------
@@ -80,10 +80,10 @@ some rare cases though, when TYPO3 Flow is not even able to write the respective
 file, no details about the exception can be provided.
 
 .. figure:: Images/Error_ReferenceCode.png
-	:alt: Exception screen with reference code
-	:class: screenshot-fullsize
+    :alt: Exception screen with reference code
+    :class: screenshot-fullsize
 
-	Exception screen with reference code
+    Exception screen with reference code
 
 Error Handler
 -------------
@@ -97,14 +97,14 @@ should be converted into exceptions. All other errors are silently ignored:
 
 .. code-block:: yaml
 
-	TYPO3:
-	  Flow:
-	    error:
-	      errorHandler:
-	        # Defines which errors should result in an exception thrown - all other error
-	        # levels will be silently ignored. Only errors that can be handled in an
-	        # user-defined error handler are affected, of course.
-	        exceptionalErrors: [%E_USER_ERROR%, %E_RECOVERABLE_ERROR%]
+    TYPO3:
+      Flow:
+        error:
+          errorHandler:
+            # Defines which errors should result in an exception thrown - all other error
+            # levels will be silently ignored. Only errors that can be handled in an
+            # user-defined error handler are affected, of course.
+            exceptionalErrors: ['%E_USER_ERROR%', '%E_RECOVERABLE_ERROR%']
 
 Custom Error Views
 ------------------
@@ -119,84 +119,84 @@ An example configuration could look like in the following Settings.yaml excerpt:
 
 .. code-block:: yaml
 
-	TYPO3:
-	  Flow:
-	    error:
-	      exceptionHandler:
-	        defaultRenderingOptions: []
+    TYPO3:
+      Flow:
+        error:
+          exceptionHandler:
+            defaultRenderingOptions: []
 
-	        renderingGroups:
+            renderingGroups:
 
-	          notFoundExceptions:
-	            matchingStatusCodes: [404]
-	            options:
-	              templatePathAndFilename: 'resource://TYPO3.Flow/Private/Templates/Error/Default.html'
-	              variables:
-	                errorDescription: 'Sorry, the page you requested was not found.'
+              notFoundExceptions:
+                matchingStatusCodes: [404]
+                options:
+                  templatePathAndFilename: 'resource://TYPO3.Flow/Private/Templates/Error/Default.html'
+                  variables:
+                    errorDescription: 'Sorry, the page you requested was not found.'
 
-	          databaseConnectionExceptions:
-	            matchingExceptionClassNames: ['TYPO3\Flow\Persistence\Doctrine\DatabaseConnectionException']
-	            options:
-	              templatePathAndFilename: 'resource://TYPO3.Flow/Private/Templates/Error/Default.html'
-	              variables:
-	                errorDescription: 'Sorry, the database connection couldn''t be established.'
+              databaseConnectionExceptions:
+                matchingExceptionClassNames: ['TYPO3\Flow\Persistence\Doctrine\DatabaseConnectionException']
+                options:
+                  templatePathAndFilename: 'resource://TYPO3.Flow/Private/Templates/Error/Default.html'
+                  variables:
+                    errorDescription: 'Sorry, the database connection couldn''t be established.'
 
 ``defaultRenderingOptions``:
-	this carries default options which can be overridden by the ``options`` key of a particular
-	rendering group; see below.
+    this carries default options which can be overridden by the ``options`` key of a particular
+    rendering group; see below.
 
 ``notFoundExceptions`` and ``databaseConnectionExceptions`` are freely chosen, descriptive
 key names, their actual naming has no further implications.
 
 ``matchingStatusCodes``:
-	an array of integer values what HTTP status codes the rendering group is for
+    an array of integer values what HTTP status codes the rendering group is for
 
 ``matchingExceptionClassNames``:
-	an array of string values what Exception types the rendering group is for. Keep in mind that, as always
-	the class name must not contain a leading slash, but must be fully qualified, of course.
+    an array of string values what Exception types the rendering group is for. Keep in mind that, as always
+    the class name must not contain a leading slash, but must be fully qualified, of course.
 
 ``options``:
 
-	``logException``:
-		a boolean telling Flow to log the exception and write a backtrace file. This is
-		on by default but switched off for exceptions with a 404 status code
+    ``logException``:
+        a boolean telling Flow to log the exception and write a backtrace file. This is
+        on by default but switched off for exceptions with a 404 status code
 
-	``renderTechnicalDetails``:
-		a boolean passed to the error template during rendering and used in the default error
-		template to include more details on the error at hand. Defaults to FALSE but is set to TRUE
-		for development context.
+    ``renderTechnicalDetails``:
+        a boolean passed to the error template during rendering and used in the default error
+        template to include more details on the error at hand. Defaults to FALSE but is set to TRUE
+        for development context.
 
-	``templatePathAndFilename``:
-		a resource string to the (Fluid) filename to use
+    ``templatePathAndFilename``:
+        a resource string to the (Fluid) filename to use
 
-	``layoutRootPath``:
-		a resource string to the layout root path
+    ``layoutRootPath``:
+        a resource string to the layout root path
 
-	``partialRootPath``:
-		a resource string to the partial root path
+    ``partialRootPath``:
+        a resource string to the partial root path
 
-	``format``:
-		the format to use, for example ``html`` or ``json``, if appropriate
+    ``format``:
+        the format to use, for example ``html`` or ``json``, if appropriate
 
-	``variables``
-		an array of additional, arbitrary variables which can be accessed in the template
+    ``variables``
+        an array of additional, arbitrary variables which can be accessed in the template
 
 The following variables will be assigned to the template an can be used there:
 
 ``exception``:
-	the Exception object which was thrown
+    the Exception object which was thrown
 
 ``renderingOptions``:
-	the complete rendering options array, as defined in the settings. This is a merge
-	of ``TYPO3.Flow.error.exceptionHandler.defaultRenderingOptions`` and the ``options``
-	array of the particular rendering group
+    the complete rendering options array, as defined in the settings. This is a merge
+    of ``TYPO3.Flow.error.exceptionHandler.defaultRenderingOptions`` and the ``options``
+    array of the particular rendering group
 
 ``statusCode``:
-	the integer value of the HTTP status code which has been thrown (``404``, ``503`` etc.)
+    the integer value of the HTTP status code which has been thrown (``404``, ``503`` etc.)
 
 ``statusMessage``:
-	the HTTP status message equivalent,  for example ``Not Found``, ``Service Unavailable`` etc.
-	If no matching status message could be found, this value is ``Unknown Status``.
+    the HTTP status message equivalent,  for example ``Not Found``, ``Service Unavailable`` etc.
+    If no matching status message could be found, this value is ``Unknown Status``.
 
 ``referenceCode``:
-	the reference code of the exception, if applicable.
+    the reference code of the exception, if applicable.

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Templating.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Templating.rst
@@ -35,22 +35,22 @@ resolves the template HTML file, and renders the template afterwards.
 Below, you'll find a snippet of a real-world template displaying a list of blog
 postings. Use it to check whether you find the template language intuitive::
 
-	{namespace f=TYPO3\Fluid\ViewHelpers}
-	<html>
-	<head><title>Blog</title></head>
-	<body>
-	<h1>Blog Postings</h1>
-	<f:for each="{postings}" as="posting">
-	  <h2>{posting.title}</h2>
-	  <div class="author">{posting.author.name} {posting.author.email}</div>
-	  <p>
-	    <f:link.action action="details" arguments="{id : posting.id}">
-	      {posting.teaser}
-	    </f:link.action>
-	  </p>
-	</f:for>
-	</body>
-	</html>
+    {namespace f=TYPO3\Fluid\ViewHelpers}
+    <html>
+    <head><title>Blog</title></head>
+    <body>
+    <h1>Blog Postings</h1>
+    <f:for each="{postings}" as="posting">
+      <h2>{posting.title}</h2>
+      <div class="author">{posting.author.name} {posting.author.email}</div>
+      <p>
+        <f:link.action action="details" arguments="{id : posting.id}">
+          {posting.teaser}
+        </f:link.action>
+      </p>
+    </f:for>
+    </body>
+    </html>
 
 * The *Namespace Import* makes the ``\TYPO3\Fluid\ViewHelper`` namespace available
   under the shorthand f.
@@ -107,10 +107,10 @@ URI to PHP namespace mapping. The YAML syntax for that is:
 
 .. code-block:: yaml
 
-	TYPO3:
-	  Fluid:
-	    namespaces:
-	      'http://some/unique/namespace': 'My\Php\Namespace'
+    TYPO3:
+      Fluid:
+        namespaces:
+          'http://some/unique/namespace': 'My\Php\Namespace'
 
 Variables and Object Accessors
 ------------------------------
@@ -123,35 +123,35 @@ snippet into your controller:
 
 .. code-block:: php
 
-	$this->view->assign('blogTitle', $blog->getTitle());
+    $this->view->assign('blogTitle', $blog->getTitle());
 
 Then, you could output the blog title in your template with the following snippet::
 
-	<h1>This blog is called {blogTitle}</h1>
+    <h1>This blog is called {blogTitle}</h1>
 
 Now, you might want to extend the output by the blog author as well. To do this,
 you could repeat the above steps, but that would be quite inconvenient and hard to read.
 
 .. Note::
 
-	The semantics between the controller and the view should be the following:
-	The controller instructs the view to "render the blog object given to it",
-	and not to "render the Blog title, and the blog posting 1, ...".
+    The semantics between the controller and the view should be the following:
+    The controller instructs the view to "render the blog object given to it",
+    and not to "render the Blog title, and the blog posting 1, ...".
 
-	Passing objects to the view instead of simple values is highly encouraged!
+    Passing objects to the view instead of simple values is highly encouraged!
 
 That is why the template language has a special syntax for object access. A nicer
 way of expressing the above is the following:
 
 .. code-block:: php
 
-	// This should go into the controller:
-	$this->view->assign('blog', $blog);
+    // This should go into the controller:
+    $this->view->assign('blog', $blog);
 
 .. code-block:: xml
 
-	<!-- This should go into the template: -->
-	<h1>This blog is called {blog.title}, written by {blog.author}</h1>
+    <!-- This should go into the template: -->
+    <h1>This blog is called {blog.title}, written by {blog.author}</h1>
 
 Instead of passing strings to the template, we are passing whole objects around
 now - which is much nicer to use both from the controller and the view side. To
@@ -162,9 +162,9 @@ and public properties.
 
 .. Tip::
 
-	Deep nesting is supported: If you want to output the email address of the blog
-	author, then you can use ``{blog.author.email}``, which is roughly equivalent
-	to ``$blog->getAuthor()->getEmail()``.
+    Deep nesting is supported: If you want to output the email address of the blog
+    author, then you can use ``{blog.author.email}``, which is roughly equivalent
+    to ``$blog->getAuthor()->getEmail()``.
 
 View Helpers
 ------------
@@ -176,8 +176,8 @@ as PHP classes (more on that later).
 
 This concept is best understood with an example::
 
-	{namespace f=TYPO3\Fluid\ViewHelpers}
-	<f:link.action controller="Administration">Administration</f:link.action>
+    {namespace f=TYPO3\Fluid\ViewHelpers}
+    <f:link.action controller="Administration">Administration</f:link.action>
 
 The example consists of two parts:
 
@@ -193,12 +193,12 @@ The ``<f:link.action />`` tag is implemented in the class ``\TYPO3\Fluid\ViewHel
 
 .. note::
 
-	The class name of such a view helper is constructed for a given tag as follows:
+    The class name of such a view helper is constructed for a given tag as follows:
 
-	#. The first part of the class name is the namespace which was imported (the namespace
-	   prefix ``f`` was expanded to its full namespace ``TYPO3\Fluid\ViewHelpers``)
-	#. The unqualified name of the tag, without the prefix, is capitalized (``Link``),
-	   and the postfix ViewHelper is appended.
+    #. The first part of the class name is the namespace which was imported (the namespace
+       prefix ``f`` was expanded to its full namespace ``TYPO3\Fluid\ViewHelpers``)
+    #. The unqualified name of the tag, without the prefix, is capitalized (``Link``),
+       and the postfix ViewHelper is appended.
 
 The tag and view helper concept is the core concept of Fluid. All output logic is
 implemented through such ViewHelpers / tags! Things like ``if/else``, ``for``, … are
@@ -206,12 +206,12 @@ all implemented using custom tags - a main difference to other templating langua
 
 .. note::
 
-	Some benefits of the class-based approach approach are:
+    Some benefits of the class-based approach approach are:
 
-	* You cannot override already existing view helpers by accident.
-	* It is very easy to write custom view helpers, which live next to the standard view helpers
-	* All user documentation for a view helper can be automatically generated from the
-	  annotations and code documentation.
+    * You cannot override already existing view helpers by accident.
+    * It is very easy to write custom view helpers, which live next to the standard view helpers
+    * All user documentation for a view helper can be automatically generated from the
+      annotations and code documentation.
 
 Most view helpers have some parameters. These can be plain strings, just like in
 ``<f:link.action controller="Administration">...</f:link.action>``, but as well
@@ -220,26 +220,26 @@ as the rest of the template, thus you can pass arrays or objects as parameters.
 
 This is often used when adding arguments to links::
 
-	<f:link.action controller="Blog" action="show" arguments="{singleBlog: blogObject}">
-	  ... read more
-	</f:link.action>
+    <f:link.action controller="Blog" action="show" arguments="{singleBlog: blogObject}">
+      ... read more
+    </f:link.action>
 
 Here, the view helper will get a parameter called ``arguments`` which is of type ``array``.
 
 .. warning::
 
-	Make sure you do not put a space before or after the opening or closing
-	brackets of an array. If you type ``arguments=" {singleBlog : blogObject}"``
-	(notice the space before the opening curly bracket), the array is automatically
-	casted to a string (as a string concatenation takes place).
+    Make sure you do not put a space before or after the opening or closing
+    brackets of an array. If you type ``arguments=" {singleBlog : blogObject}"``
+    (notice the space before the opening curly bracket), the array is automatically
+    casted to a string (as a string concatenation takes place).
 
-	This also applies when using object accessors: ``<f:do.something with="{object}" />``
-	and ``<f:do.something with=" {object}" />`` are substantially different: In
-	the first case, the view helper will receive an object as argument, while in
-	the second case, it will receive a string as argument.
+    This also applies when using object accessors: ``<f:do.something with="{object}" />``
+    and ``<f:do.something with=" {object}" />`` are substantially different: In
+    the first case, the view helper will receive an object as argument, while in
+    the second case, it will receive a string as argument.
 
-	This might first seem like a bug, but actually it is just consistent that it
-	works that way.
+    This might first seem like a bug, but actually it is just consistent that it
+    works that way.
 
 Boolean Expressions
 -------------------
@@ -250,9 +250,9 @@ postings and want to display some additional information for the currently selec
 blog posting. We assume that the currently selected blog is available in ``{currentBlogPosting}``.
 Now, let's have a look how this works::
 
-	<f:for each="{blogPosts}" as="post">
-	  <f:if condition="{post} == {currentBlogPosting}">... some special output here ...</f:if>
-	</f:for>
+    <f:for each="{blogPosts}" as="post">
+      <f:if condition="{post} == {currentBlogPosting}">... some special output here ...</f:if>
+    </f:for>
 
 In the above example, there is a bit of new syntax involved: ``{post} == {currentBlogPosting}``.
 Intuitively, this says "if the post I''m currently iterating over is the same as
@@ -284,14 +284,14 @@ ViewHelper, which is used to reference static files inside the *Public/* folder 
 a package. That's why it is often used inside ``<style>`` or ``<script>``-tags,
 leading to the following code::
 
-	<link rel="stylesheet" href="<f:uri.resource path='myCssFile.css' />" />
+    <link rel="stylesheet" href="<f:uri.resource path='myCssFile.css' />" />
 
 You will notice that this is really difficult to read, as two tags are nested into
 each other. That's where the inline notation comes into play: It allows the usage
 of ``{f:uri.resource()}`` instead of ``<f:uri.resource />``. The above example can
 be written like the following::
 
-	<link rel="stylesheet" href="{f:uri.resource(path:'myCssFile.css')}" />
+    <link rel="stylesheet" href="{f:uri.resource(path:'myCssFile.css')}" />
 
 This is readable much better, and explains the intent of the ViewHelper in a much
 better way: It is used like a helper function.
@@ -300,27 +300,27 @@ The syntax is still more flexible: In real-world templates, you will often find
 code like the following, formatting a ``DateTime`` object (stored in ``{post.date}``
 in the example below)::
 
-	<f:format.date format="d-m-Y">{post.date}</f:format.date>
+    <f:format.date format="d-m-Y">{post.date}</f:format.date>
 
 This can also be re-written using the inline notation::
 
-	{post.date -> f:format.date(format:'d-m-Y')}
+    {post.date -> f:format.date(format:'d-m-Y')}
 
 This is also a lot better readable than the above syntax.
 
 .. tip::
 
-	This can also be chained indefinitely often, so one can write::
+    This can also be chained indefinitely often, so one can write::
 
-		{post.date -> foo:myHelper() -> bar:bla()}
+        {post.date -> foo:myHelper() -> bar:bla()}
 
-	Sometimes you'll still need to further nest ViewHelpers, that is when the design
-	of the ViewHelper does not allow that chaining or provides further arguments. Have
-	in mind that each argument itself is evaluated as Fluid code, so the following
-	constructs are also possible::
+    Sometimes you'll still need to further nest ViewHelpers, that is when the design
+    of the ViewHelper does not allow that chaining or provides further arguments. Have
+    in mind that each argument itself is evaluated as Fluid code, so the following
+    constructs are also possible::
 
-		{foo: bar, baz: '{planet.manufacturer -> f:someother.helper(test: \'stuff\')}'}
-		{some: '{f:format.stuff(arg: \'foo'\)}'}
+        {foo: bar, baz: '{planet.manufacturer -> f:someother.helper(test: \'stuff\')}'}
+        {some: '{f:format.stuff(arg: \'foo'\)}'}
 
 To wrap it up: Internally, both syntax variants are handled equally, and every
 ViewHelper can be called in both ways. However, if the ViewHelper "feels" like a
@@ -334,7 +334,7 @@ Some view helpers, like the ``SelectViewHelper`` (which renders an HTML select
 dropdown box), need to get associative arrays as arguments (mapping from internal
 to displayed name). See the following example for how this works::
 
-	<f:form.select options="{edit: 'Edit item', delete: 'Delete item'}" />
+    <f:form.select options="{edit: 'Edit item', delete: 'Delete item'}" />
 
 The array syntax used here is very similar to the JSON object syntax. Thus, the
 left side of the associative array is used as key without any parsing, and the
@@ -342,46 +342,46 @@ right side can be either:
 
 * a number::
 
-	{a : 1,
-	 b : 2
-	}
+    {a : 1,
+     b : 2
+    }
 
 * a string; Needs to be in either single- or double quotes. In a double-quoted
   string, you need to escape the ``"`` with a ``\`` in front (and vice versa for single
   quoted strings). A string is again handled as Fluid Syntax, this is what you
   see in example ``c``::
 
-	{a : 'Hallo',
-	 b : "Second string with escaped \" (double quotes) but not escaped ' (single quotes)"
-	 c : "{firstName} {lastName}"
-	}
+    {a : 'Hallo',
+     b : "Second string with escaped \" (double quotes) but not escaped ' (single quotes)"
+     c : "{firstName} {lastName}"
+    }
 
 * a boolean, best represented with their integer equivalents::
 
-	{a : 'foo',
-	 notifySomebody: 1
-	 useLogging: 0
-	}
+    {a : 'foo',
+     notifySomebody: 1
+     useLogging: 0
+    }
 
 * a nested array::
 
-	{a : {
-		a1 : "bla1",
-		a2 : "bla2"
-	  },
-	 b : "hallo"
-	}
+    {a : {
+        a1 : "bla1",
+        a2 : "bla2"
+      },
+     b : "hallo"
+    }
 
 * a variable reference (=an object accessor)::
 
-	{blogTitle : blog.title,
-	 blogObject: blog
-	}
+    {blogTitle : blog.title,
+     blogObject: blog
+    }
 
 .. Note::
 
-	All these array examples will result into an associative array. If you have to supply
-	a non-associative, i.e. numerically-indexed array, you'll write ``{0: 'foo', 1: 'bar', 2: 'baz'}``.
+    All these array examples will result into an associative array. If you have to supply
+    a non-associative, i.e. numerically-indexed array, you'll write ``{0: 'foo', 1: 'bar', 2: 'baz'}``.
 
 
 Passing Data to the View
@@ -409,15 +409,15 @@ file ending of the current format (by default *.html*). A layout is a normal Flu
 template file, except there are some parts where the actual content of the target
 page should be inserted::
 
-	<html>
-	<head><title>My fancy web application</title></head>
-	<body>
-	<div id="menu">... menu goes here ...</div>
-	<div id="content">
-	  <f:render section="content" />
-	</div>
-	</body>
-	</html>
+    <html>
+    <head><title>My fancy web application</title></head>
+    <body>
+    <div id="menu">... menu goes here ...</div>
+    <div id="content">
+      <f:render section="content" />
+    </div>
+    </body>
+    </html>
 
 With this tag, a section from the target template is rendered.
 
@@ -434,11 +434,11 @@ Using a layout involves two steps:
 
 For the above layout, a minimal template would look like the following::
 
-	<f:layout name="example.html" />
+    <f:layout name="example.html" />
 
-	<f:section name="content">
-	  This HTML here will be outputted to inside the layout
-	</f:section>
+    <f:section name="content">
+      This HTML here will be outputted to inside the layout
+    </f:section>
 
 Writing Your Own ViewHelper
 ===========================
@@ -454,7 +454,7 @@ only one method to write a view helper:
 
 .. code-block:: php
 
-	public function render()
+    public function render()
 
 Rendering the View Helper
 -------------------------
@@ -478,12 +478,12 @@ You have the following possibilities to access the environment when rendering yo
 
 .. Note::
 
-	If you add variables to the ``TemplateVariableContainer``, make sure to remove
-	every variable which you added again. This is a security measure against side-effects.
+    If you add variables to the ``TemplateVariableContainer``, make sure to remove
+    every variable which you added again. This is a security measure against side-effects.
 
-	It is also not possible to add a variable to the TemplateVariableContainer if
-	a variable of the same name already exists - again to prevent side effects and
-	scope problems.
+    It is also not possible to add a variable to the TemplateVariableContainer if
+    a variable of the same name already exists - again to prevent side effects and
+    scope problems.
 
 Implementing a ``for`` ViewHelper
 ---------------------------------
@@ -493,9 +493,9 @@ functionality of PHP.
 
 A loop could be called within the template in the following way::
 
-	<f:for each="{blogPosts}" as="blogPost">
-	  <h2>{blogPost.title}</h2>
-	</f:for>
+    <f:for each="{blogPosts}" as="blogPost">
+      <h2>{blogPost.title}</h2>
+    </f:for>
 
 So, in words, what should the loop do?
 
@@ -508,33 +508,33 @@ It then should do the following (in pseudo code):
 
 .. code-block:: php
 
-	foreach ($each as $$as) {
-	  // render everything between opening and closing tag
-	}
+    foreach ($each as $$as) {
+      // render everything between opening and closing tag
+    }
 
 Implementing this is fairly straightforward, as you will see right now:
 
 .. code-block:: php
 
-	class ForViewHelper extends \TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper {
+    class ForViewHelper extends \TYPO3\Fluid\Core\ViewHelper\AbstractViewHelper {
 
-	  /**
-	   * Renders a loop
-	   *
-	   * @param array $each Array to iterate over
-	   * @param string $as Iteration variable
-	   */
-	  public function render(array $each, $as) {
-		$out = '';
-		foreach ($each as $singleElement) {
-		  $this->variableContainer->add($as, $singleElement);
-		  $out .= $this->renderChildren();
-		  $this->variableContainer->remove($as);
-		}
-		return $out;
-	  }
+      /**
+       * Renders a loop
+       *
+       * @param array $each Array to iterate over
+       * @param string $as Iteration variable
+       */
+      public function render(array $each, $as) {
+        $out = '';
+        foreach ($each as $singleElement) {
+          $this->variableContainer->add($as, $singleElement);
+          $out .= $this->renderChildren();
+          $this->variableContainer->remove($as);
+        }
+        return $out;
+      }
 
-	}
+    }
 
 * The PHPDoc is part of the code! Fluid extracts the argument data types from the PHPDoc.
 * You can simply register arguments to the view helper by adding them as method
@@ -568,28 +568,28 @@ have without the ``AbstractTagBasedViewHelper``):
 
 .. code-block:: php
 
-	class ActionViewHelper extends \TYPO3\Fluid\Core\AbstractViewHelper {
+    class ActionViewHelper extends \TYPO3\Fluid\Core\AbstractViewHelper {
 
-	  public function initializeArguments() {
-		$this->registerArgument('class', 'string', 'CSS class to add to the link');
-		$this->registerArgument('target', 'string', 'Target for the link');
-		... and more ...
-	  }
+      public function initializeArguments() {
+        $this->registerArgument('class', 'string', 'CSS class to add to the link');
+        $this->registerArgument('target', 'string', 'Target for the link');
+        ... and more ...
+      }
 
-	  public function render() {
-		$output = '<a href="..."';
-		if ($this->arguments['class']) {
-		  $output .= ' class="' . $this->arguments['class'] . '"';
-		}
-		if ($this->arguments['target']) {
-		  $output .= ' target="' . $this->arguments['target'] . '"';
-		}
-		$output .= '>';
-		... and more ...
-		return $output;
-	  }
+      public function render() {
+        $output = '<a href="..."';
+        if ($this->arguments['class']) {
+          $output .= ' class="' . $this->arguments['class'] . '"';
+        }
+        if ($this->arguments['target']) {
+          $output .= ' target="' . $this->arguments['target'] . '"';
+        }
+        $output .= '>';
+        ... and more ...
+        return $output;
+      }
 
-	}
+    }
 
 Now, the ``AbstractTagBasedViewHelper`` introduces two more methods you can use
 inside ``initializeArguments()``:
@@ -606,43 +606,43 @@ With the above methods, the ``Link\ActionViewHelper`` from above can be condense
 
 .. code-block:: php
 
-	class ActionViewHelper extends \TYPO3\\F3\Fluid\Core\AbstractViewHelper {
+    class ActionViewHelper extends \TYPO3\\F3\Fluid\Core\AbstractViewHelper {
 
-		public function initializeArguments() {
-			$this->registerUniversalTagAttributes();
-		}
+        public function initializeArguments() {
+            $this->registerUniversalTagAttributes();
+        }
 
-		/**
-		 * Render the link.
-		 *
-		 * @param string $action Target action
-		 * @param array $arguments Arguments
-		 * @param string $controller Target controller. If NULL current controllerName is used
-		 * @param string $package Target package. if NULL current package is used
-		 * @param string $subpackage Target subpackage. if NULL current subpackage is used
-		 * @param string $section The anchor to be added to the URI
-		 * @return string The rendered link
-		 */
-		public function render($action = NULL, array $arguments = array(),
-		                       $controller = NULL, $package = NULL, $subpackage = NULL,
-			                   $section = '') {
-			$uriBuilder = $this->controllerContext->getURIBuilder();
-			$uri = $uriBuilder->uriFor($action, $arguments, $controller, $package, $subpackage, $section);
-			$this->tag->addAttribute('href', $uri);
-			$this->tag->setContent($this->renderChildren());
+        /**
+         * Render the link.
+         *
+         * @param string $action Target action
+         * @param array $arguments Arguments
+         * @param string $controller Target controller. If NULL current controllerName is used
+         * @param string $package Target package. if NULL current package is used
+         * @param string $subpackage Target subpackage. if NULL current subpackage is used
+         * @param string $section The anchor to be added to the URI
+         * @return string The rendered link
+         */
+        public function render($action = NULL, array $arguments = array(),
+                               $controller = NULL, $package = NULL, $subpackage = NULL,
+                               $section = '') {
+            $uriBuilder = $this->controllerContext->getURIBuilder();
+            $uri = $uriBuilder->uriFor($action, $arguments, $controller, $package, $subpackage, $section);
+            $this->tag->addAttribute('href', $uri);
+            $this->tag->setContent($this->renderChildren());
 
-			return $this->tag->render();
-		}
+            return $this->tag->render();
+        }
 
-	}
+    }
 
 Additionally, we now already have support for all universal HTML attributes.
 
 .. tip::
 
-	The ``TagBuilder`` also makes sure that all attributes are escaped properly,
-	so to decrease the risk of Cross-Site Scripting attacks, make sure to use it
-	when building tags.
+    The ``TagBuilder`` also makes sure that all attributes are escaped properly,
+    so to decrease the risk of Cross-Site Scripting attacks, make sure to use it
+    when building tags.
 
 additionalAttributes
 ~~~~~~~~~~~~~~~~~~~~
@@ -664,9 +664,9 @@ is not part of HTML, you could do that as follows:
 
 .. code-block:: xml
 
-	<f:link.action ... additionalAttributes="{fadeDuration : 800}">
-		Link with fadeDuration set
-	</f:link.action>
+    <f:link.action additionalAttributes="{fadeDuration : 800}">
+        Link with fadeDuration set
+    </f:link.action>
 
 This attribute is available in all tags that inherit from ``TYPO3\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper``.
 
@@ -680,23 +680,23 @@ for a usage example, which should be quite self-explanatory:
 
 .. code-block:: php
 
-	class IfViewHelper extends \TYPO3\Fluid\Core\ViewHelper\AbstractConditionViewHelper {
+    class IfViewHelper extends \TYPO3\Fluid\Core\ViewHelper\AbstractConditionViewHelper {
 
-		/**
-		 * renders <f:then> child if $condition is true, otherwise renders <f:else> child.
-		 *
-		 * @param boolean $condition View helper condition
-		 * @return string the rendered string
-		 */
-		public function render($condition) {
-			if ($condition) {
-				return $this->renderThenChild();
-			} else {
-				return $this->renderElseChild();
-			}
-		}
+        /**
+         * renders <f:then> child if $condition is true, otherwise renders <f:else> child.
+         *
+         * @param boolean $condition View helper condition
+         * @return string the rendered string
+         */
+        public function render($condition) {
+            if ($condition) {
+                return $this->renderThenChild();
+            } else {
+                return $this->renderElseChild();
+            }
+        }
 
-	}
+    }
 
 By basing your condition ViewHelper on the ``AbstractConditionViewHelper``,
 you will get the following features:
@@ -727,10 +727,10 @@ Using widgets inside your templates is really simple: Just use them like standar
 ViewHelpers, and consult their documentation for usage examples. An example for
 the ``<f:widget.paginate>`` follows below::
 
-	<f:widget.paginate objects="{blogs}" as="paginatedBlogs" configuration="{itemsPerPage: 10}">
-	  // use {paginatedBlogs} as you used {blogs} before, most certainly inside
-	  // a <f:for> loop.
-	</f:widget.paginate>
+    <f:widget.paginate objects="{blogs}" as="paginatedBlogs" configuration="{itemsPerPage: 10}">
+      // use {paginatedBlogs} as you used {blogs} before, most certainly inside
+      // a <f:for> loop.
+    </f:widget.paginate>
 
 In the above example, it looks like ``{blogs}`` contains all ``Blog`` objects, thus
 you might wonder if all objects were fetched from the database. However, the blogs
@@ -805,7 +805,7 @@ To make a widget AJAX-aware, you need to do the following:
   triggers the AJAX functionality. There, you will need a URI which returns the
   AJAX response. For that, use the following ViewHelper inside the template::
 
-	<f:uri.widget ajax="TRUE" action="..." arguments="..." />
+    <f:uri.widget ajax="TRUE" action="..." arguments="..." />
 
 * Inside the template of the AJAX request, ``<f:renderChildren>`` is not available,
   because the child nodes of the Widget ViewHelper are not accessible there.
@@ -817,8 +817,8 @@ A XSD schema file for your ViewHelpers can be created by executing
 
 .. code-block:: text
 
-	./flow documenation:generatexsd <Your>\\<Package>\\ViewHelpers
-		--target-file /some/directory/your.package.xsd
+    ./flow documenation:generatexsd <Your>\\<Package>\\ViewHelpers
+        --target-file /some/directory/your.package.xsd
 
 Then import the XSD file in your favorite IDE and map it to the namespace
 ``http://typo3.org/ns/<Your/Package>/ViewHelpers``. Add the namespace to your
@@ -827,19 +827,19 @@ Fluid template by adding the ``xmlns`` attribute to the root tag (usually
 
 .. note::
 
-	You are able to use a different XML namespace pattern by specifying the
-	``-–xsd-namespace argument`` in the generatexsd command.
+    You are able to use a different XML namespace pattern by specifying the
+    ``-–xsd-namespace argument`` in the generatexsd command.
 
 If you want to use this inside partials, you can use the “section” argument of
 the render ViewHelper in order to only render the content of the partial.
 
 Partial::
 
-	<html xmlns:x=”http://typo3.org/ns/Your/Package/ViewHelpers”>
-	<f:section name=”content”>
-		<x:yourViewHelper />
-	</f:section>
+    <html xmlns:x=”http://typo3.org/ns/Your/Package/ViewHelpers”>
+    <f:section name=”content”>
+        <x:yourViewHelper />
+    </f:section>
 
 Template::
 
-	<f:render partial=”PartialName” section=”content” />
+    <f:render partial=”PartialName” section=”content” />

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartV/CodingGuideLines/PHP.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartV/CodingGuideLines/PHP.rst
@@ -23,11 +23,11 @@ CGL on One Page
 ===============
 
 .. figure:: Images/TYPO3_Flow_Coding_Guidelines_on_one_page.png
-	:alt: The Coding Guidelines on One Page
-	:class: screenshot-detail
-	:target: ../../../_downloads/TYPO3_Flow_Coding_Guidelines_on_one_page.pdf
+    :alt: The Coding Guidelines on One Page
+    :class: screenshot-detail
+    :target: ../../../_downloads/TYPO3_Flow_Coding_Guidelines_on_one_page.pdf
 
-	The Coding Guidelines on One Page
+    The Coding Guidelines on One Page
 
 The most important parts of our :download:`Coding Guidelines in a one page document
 <Pdf/TYPO3_Flow_Coding_Guidelines_on_one_page.pdf>`
@@ -89,7 +89,7 @@ PSR-2
 We follow the PSR-2 standard which is defined by PHP FIG. You can read the full standard
 on `psr-2 standard`_.
 
-.. _`_psr-2 standard`: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md
+.. _`psr-2 standard`: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md
 
 Indentation and line formatting
 _______________________________
@@ -393,8 +393,8 @@ These are the rules for naming files:
   *Acme.DataAccess*
 
 ``TYPO3.Flow/Tests/Unit/Package/PackageManagerTest.php``
-	Contains the class ``\TYPO3\Flow\\Tests\Unit\Package\PackageManagerTest`` which
-	is a PHPUnit testcase for ``Package\PackageManager``.
+    Contains the class ``\TYPO3\Flow\\Tests\Unit\Package\PackageManagerTest`` which
+    is a PHPUnit testcase for ``Package\PackageManager``.
 
 
 PHP code formatting
@@ -655,10 +655,10 @@ In some cases this is not possible, for example when iterating through an array 
 add inline @var annotations to increase readability and to activate auto-completion and syntax-highlighting::
 
  protected function someMethod(array $products) {
- 	/** @var $product \Acme\SomePackage\Domain\Model\Product */
- 	foreach ($products as $product) {
- 		$product->getTitle();
- 	}
+    /** @var $product \Acme\SomePackage\Domain\Model\Product */
+    foreach ($products as $product) {
+        $product->getTitle();
+    }
  }
 
 Method documentation
@@ -911,9 +911,9 @@ PHP in General
    if ($foo !== $bar))        // GOOD
 
   .. figure:: Images/PHP_TrueFalse.jpg
-  	:alt: Truthy and falsy are fuzzy...
+    :alt: Truthy and falsy are fuzzy...
 
-  	Truthy and falsy are fuzzy...
+    Truthy and falsy are fuzzy...
 
 * Order of methods in classes. To gain a better overview, it helps if methods in classes
   are always ordered in a certain way. We prefer the following:

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartV/ReleaseNotes/300.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartV/ReleaseNotes/300.rst
@@ -156,7 +156,7 @@ Upgrade Instructions
 This section contains instructions for upgrading your Flow 2.3 based applications to Flow 3.0.
 
 What has changed
-----------------
+================
 
 Flow 3.0 comes with numerous fixes and improvements. Here's a list of changes that might need special attention when
 upgrading.
@@ -172,7 +172,7 @@ In general make sure to run the commands::
 when upgrading (see below).
 
 Minimum PHP version requirement: 5.5
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------------------
 
 With Flow 3.0 the minimum PHP version requirement has been increased
 from `5.3.2` to `5.5.0`.
@@ -183,7 +183,7 @@ error.
 See `FLOW-217 <https://jira.neos.io/browse/FLOW-217>`_
 
 Decoupling of TYPO3.Party package
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------------
 
 With version 3.0 the Party package is no longer part of the Flow base
 distribution.
@@ -212,7 +212,7 @@ PartyService).
 See `FLOW-5 <https://jira.neos.io/browse/FLOW-5>`_
 
 Reworked Security Framework
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------
 
 The Security Framework has been revised and now introduces the concept of
 ``privileges``. It also includes a restructuring of the privilege voting process.
@@ -229,7 +229,7 @@ See `FLOW-11 <https://jira.neos.io/browse/FLOW-11>`_
 
 
 Multi-Storage / Multi-Target Resource Management
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------------------------------
 
 Flow 3.0 comes with a completely revised Resource Management which allows for storage
 and publication of persistent or static resources (assets) in the local file system
@@ -252,7 +252,7 @@ This is only important during upgrading and deployment. At runtime new resources
 See `FLOW-108 <https://jira.neos.io/browse/FLOW-108>`_
 
 Charset and collation in all MySQL migrations
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------------------------
 
 All MySQL migrations now explicitly specify charset and collation as suggested by
 `Doctrine <https://github.com/doctrine/dbal/blob/master/UPGRADE.md#creating-mysql-tables-now-defaults-to-utf-8>`_.
@@ -266,10 +266,10 @@ This can be done using the command::
 See `NEOS-800 <https://jira.neos.io/browse/NEOS-800>`_
 
 Exclude Non-Flow packages from object management by default
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------------------------------------------
 
 All "non-flow-packages" (Packages for which the composer type does not
-start with "typo3-flow-*") are now excluded from object management by default.
+start with "typo3-flow-\*") are now excluded from object management by default.
 
 Previously they had to be excluded explicitly with the
 ``TYPO3.Flow.object.excludeClasses`` setting.
@@ -309,7 +309,7 @@ command.
 See `FLOW-103 <https://jira.neos.io/browse/FLOW-103>`_
 
 Adjusted "ignoreTags" configuration syntax
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------------------------
 
 The ``TYPO3.Flow.reflection.ignoreTags`` setting syntax has been adjusted to allow for
 adding and changing tag ignore behavior from 3rd party packages.
@@ -345,7 +345,7 @@ explicitly now::
 See `FLOW-199 <https://jira.neos.io/browse/FLOW-199>`_
 
 Remove obsolete "security.enable" Setting
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------------------------
 
 The ``TYPO3.Flow.security.enable`` and all mentions and usages of it have been
 removed.
@@ -359,7 +359,7 @@ Besides the flag was never evaluated consistently.
 See `FLOW-181 <https://jira.neos.io/browse/FLOW-181>`_
 
 New annotation "InjectConfiguration"
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------------------
 
 A new annotation that allows for injection of arbitrary configuration.
 
@@ -394,7 +394,7 @@ you should consider using the new annotation instead.
 See `FLOW-148 <https://jira.neos.io/browse/FLOW-148>`_
 
 Fluid: Consistent escaping behavior
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------------------
 
 Fluid 3.0 comes with a major rework of the interceptors that are currently
 mostly used to automatically apply ``htmlspecialchars()`` to dynamic strings
@@ -451,7 +451,7 @@ through each affected ViewHelper to verify if that flag is really needed.
 See `FLOW-26 <https://jira.neos.io/browse/FLOW-26>`_
 
 Fluid: Submitted form data has precedence over value argument
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------------------------------------------
 
 The behavior of all Form ViewHelpers has been adjusted so that any submitted
 value is redisplayed even if a "value" argument has been specified.
@@ -479,7 +479,7 @@ explicitly if the ViewHelper might be bound to (sub)entities.
 See `FLOW-213 <https://jira.neos.io/browse/FLOW-213>`_
 
 Fluid: Throw exception for unresolved namespaces
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------------------------------
 
 With this change the Fluid parser now throws an exception when it comes
 across an unknown ViewHelper namespace.
@@ -501,7 +501,7 @@ Specific namespaces can be ignored like this::
 See `FLOW-150 <https://jira.neos.io/browse/FLOW-150>`_
 
 Further breaking changes
-------------------------
+========================
 
 * [BUGFIX] Generate Value Object hash from property values (see `#55953 <https://forge.typo3.org/issues/55953>`_)
 * [TASK] Do not use LoggerFactory in a static context(see `c4a9350 <https://git.typo3.org/Packages/TYPO3.Flow.git/commit/c4a935054d840a49394559a128296b2812dbfca2>`_)
@@ -512,7 +512,7 @@ Further breaking changes
 * [TASK] Remove usage of ReflectionService in ViewHelpers (see `3adb3c3 <https://git.typo3.org/Packages/TYPO3.Fluid.git/commit/3adb3c3ded8ff90bbce1a0386a6a120fe0dde322>`_)
 
 Upgrading your Web Server Configuration
----------------------------------------
+=======================================
 
 If using NGINX or custom Apache configuration, you need to remove a few lines from you Apache / NGINX configuration.
 
@@ -521,29 +521,29 @@ to `_Resources/Persistent/[40-character-hash].jpg` by having a rewrite rule in A
 
 Example of an Apache Rewrite Rule for Flow 2.x::
 
-	# Perform rewriting of persistent private resources
-	RewriteRule ^(_Resources/Persistent/[a-zA-Z0-9]+/(.+/)?[a-f0-9]{40})/.+(\..+) $1$3 [L]
+    # Perform rewriting of persistent private resources
+    RewriteRule ^(_Resources/Persistent/[a-zA-Z0-9]+/(.+/)?[a-f0-9]{40})/.+(\..+) $1$3 [L]
 
-	# Perform rewriting of persistent resource files
-	RewriteRule ^(_Resources/Persistent/.{40})/.+(\..+) $1$2 [L]
+    # Perform rewriting of persistent resource files
+    RewriteRule ^(_Resources/Persistent/.{40})/.+(\..+) $1$2 [L]
 
 
 Example of an Nginx Rewrite Rule for Flow 2.x::
 
-	location ~ "^/_Resources/Persistent/" {
-		rewrite "(.{40})/.+\.(.+)" /_Resources/Persistent/$1.$2 break;
-		rewrite "([a-z0-9]+/(.+/)?[a-f0-9]{40})/.+\.(.+)" /_Resources/Persistent/$1.$2 break;
-	}
+    location ~ "^/_Resources/Persistent/" {
+        rewrite "(.{40})/.+\.(.+)" /_Resources/Persistent/$1.$2 break;
+        rewrite "([a-z0-9]+/(.+/)?[a-f0-9]{40})/.+\.(.+)" /_Resources/Persistent/$1.$2 break;
+    }
 
 Flow 3.0 does not need these configuration blocks anymore, so they should be deleted.
 
 **In order to upgrade, please delete these rules from your Apache / Nginx Configuration in case you inserted them.**
 
 Upgrading your Packages
------------------------
+=======================
 
 Upgrading existing code
-^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------
 
 Here comes the easier part. As with earlier changes to Flow that required code changes on the user side we provide a code
 migration tool.
@@ -562,7 +562,7 @@ Make sure to run::
 to see all the other helpful options this command provides.
 
 Inside core:migrate
-"""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^
 
 The tool roughly works like this:
 
@@ -597,7 +597,7 @@ to update your database with any changes to the framework-supplied
 schema.
 
 Famous last words
------------------
+=================
 
 In a nutshell, running::
 


### PR DESCRIPTION
Removed all possible errors and warnings from documentation. This will
allow new errors to be visible as soon as they occur and to reduce the
overall errors.

Some errors lead to non working links or syntax highlighting.

Also fixed indentation at some places. As the indentation wasn't the
same everywhere.