### PR TITLE
BUGFIX: Missing ending slash for PSR4 package

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/Package.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/Package.php
@@ -482,6 +482,9 @@ class Package implements PackageInterface
                     str_replace('\\', '/', $autoloadNamespace)
                 ]) . '/';
         }
+        if ($autoloadType === ClassLoader::MAPPING_TYPE_PSR4) {
+            $normalizedAutoloadPath = rtrim($normalizedAutoloadPath, '/') . '/';
+        }
 
         return $normalizedAutoloadPath;
     }


### PR DESCRIPTION
This change add a missing ending slash in the autoload path for PSR4 package.