### PR TITLE
TASK: Do not initialize ReflectionService on shutdown if not needed

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
@@ -341,7 +341,7 @@ class ReflectionService
     {
         $this->context = $this->environment->getContext();
 
-        if ($this->context->isProduction() && $this->reflectionDataRuntimeCache->getBackend()->isFrozen()) {
+        if ($this->hasFrozenCacheInProduction()) {
             $this->classReflectionData = $this->reflectionDataRuntimeCache->get('__classNames');
             $this->annotatedClasses = $this->reflectionDataRuntimeCache->get('__annotatedClasses');
             $this->loadFromClassSchemaRuntimeCache = true;
@@ -2043,6 +2043,9 @@ class ReflectionService
      */
     public function saveToCache()
     {
+        if ($this->hasFrozenCacheInProduction()) {
+            return;
+        }
         if (!$this->initialized) {
             $this->initialize();
         }
@@ -2176,5 +2179,13 @@ class ReflectionService
     protected function getPrecompiledReflectionStoragePath()
     {
         return Files::concatenatePaths(array($this->environment->getPathToTemporaryDirectory(), 'PrecompiledReflectionData/')) . '/';
+    }
+
+    /**
+     * @return boolean
+     */
+    protected function hasFrozenCacheInProduction()
+    {
+        return $this->context->isProduction() && $this->reflectionDataRuntimeCache->getBackend()->isFrozen();
     }
 }


### PR DESCRIPTION
The ReflectionService would be still initialized before having an early
return in the saveToCache() method. This change makes sure to not
initialize the ReflectionService which results in less cache entries
being loaded and therefore less memory consumption and I/O.

NEOS-571 #comment Optimize ReflectionService shutdown