### PR TITLE
TASK: Use composer autoloader as fallback to Flow autoloader

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Bootstrap.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Bootstrap.php
@@ -12,14 +12,7 @@ namespace TYPO3\Flow\Core;
  */
 
 // Those are needed before the autoloader is active
-require_once(__DIR__ . '/ApplicationContext.php');
-require_once(__DIR__ . '/../Exception.php');
-require_once(__DIR__ . '/../Utility/Files.php');
-require_once(__DIR__ . '/../Package/PackageInterface.php');
-require_once(__DIR__ . '/../Package/Package.php');
-require_once(__DIR__ . '/../Package/PackageManagerInterface.php');
-require_once(__DIR__ . '/../Package/PackageManager.php');
-require_once(__DIR__ . '/Booting/Scripts.php');
+require_once (__DIR__ . '/../../../../../../Libraries/autoload.php');
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Core\Booting\Step;
@@ -91,6 +84,7 @@ class Bootstrap
      */
     public function __construct($context)
     {
+
         $this->context = new ApplicationContext($context);
         $this->earlyInstances[__CLASS__] = $this;
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Bootstrap.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Bootstrap.php
@@ -12,7 +12,7 @@ namespace TYPO3\Flow\Core;
  */
 
 // Those are needed before the autoloader is active
-require_once (__DIR__ . '/../../../../../../Libraries/autoload.php');
+require_once(__DIR__ . '/../../../../../../Libraries/autoload.php');
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Core\Booting\Step;

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Bootstrap.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Bootstrap.php
@@ -84,7 +84,6 @@ class Bootstrap
      */
     public function __construct($context)
     {
-
         $this->context = new ApplicationContext($context);
         $this->earlyInstances[__CLASS__] = $this;
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/ClassLoader.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/ClassLoader.php
@@ -125,13 +125,12 @@ class ClassLoader
     {
         $distributionComposerManifest = json_decode(file_get_contents(FLOW_PATH_ROOT . 'composer.json'));
         $this->defaultVendorDirectory = $distributionComposerManifest->config->{'vendor-dir'};
-        $composerPath = FLOW_PATH_ROOT . $this->defaultVendorDirectory . '/composer/';
 
         foreach ($defaultPackageEntries as $entry) {
             $this->createNamespaceMapEntry($entry['namespace'], $entry['classPath'], $entry['mappingType']);
         }
 
-        $this->initializeAutoloadInformation($composerPath, $context);
+        $this->initializeAvailableProxyClasses($context);
     }
 
     /**
@@ -374,88 +373,17 @@ class ClassLoader
     }
 
     /**
-     * @param string $composerPath Path to the composer directory (with trailing slash).
-     * @param ApplicationContext $context
-     * @return void
-     */
-    protected function initializeAutoloadInformation($composerPath, ApplicationContext $context = null)
-    {
-        if (is_file($composerPath . 'autoload_classmap.php')) {
-            $classMap = include($composerPath . 'autoload_classmap.php');
-            if ($classMap !== false) {
-                $this->classMap = $classMap;
-            }
-        }
-
-        if (is_file($composerPath . 'autoload_namespaces.php')) {
-            $namespaceMap = include($composerPath . 'autoload_namespaces.php');
-            if ($namespaceMap !== false) {
-                foreach ($namespaceMap as $namespace => $paths) {
-                    if (!is_array($paths)) {
-                        $paths = [$paths];
-                    }
-                    foreach ($paths as $path) {
-                        if ($namespace === '') {
-                            $this->createFallbackPathEntry($path);
-                        } else {
-                            $this->createNamespaceMapEntry($namespace, $path);
-                        }
-                    }
-                }
-            }
-        }
-
-        if (is_file($composerPath . 'autoload_psr4.php')) {
-            $psr4Map = include($composerPath . 'autoload_psr4.php');
-            if ($psr4Map !== false) {
-                foreach ($psr4Map as $namespace => $possibleClassPaths) {
-                    if (!is_array($possibleClassPaths)) {
-                        $possibleClassPaths = [$possibleClassPaths];
-                    }
-                    foreach ($possibleClassPaths as $possibleClassPath) {
-                        if ($namespace === '') {
-                            $this->createFallbackPathEntry($possibleClassPath);
-                        } else {
-                            $this->createNamespaceMapEntry($namespace, $possibleClassPath, self::MAPPING_TYPE_PSR4);
-                        }
-                    }
-                }
-            }
-        }
-
-        if (is_file($composerPath . 'include_paths.php')) {
-            $includePaths = include($composerPath . 'include_paths.php');
-            if ($includePaths !== false) {
-                array_push($includePaths, get_include_path());
-                set_include_path(implode(PATH_SEPARATOR, $includePaths));
-            }
-        }
-
-        if (is_file($composerPath . 'autoload_files.php')) {
-            $includeFiles = include($composerPath . 'autoload_files.php');
-            if ($includeFiles !== false) {
-                foreach ($includeFiles as $file) {
-                    require_once($file);
-                }
-            }
-        }
-
-        if ($context !== null) {
-            $proxyClasses = @include(FLOW_PATH_TEMPORARY . 'AvailableProxyClasses.php');
-            if ($proxyClasses !== false) {
-                $this->availableProxyClasses = $proxyClasses;
-            }
-        }
-    }
-
-    /**
      * Initialize available proxy classes from the cached list.
      *
      * @param ApplicationContext $context
      * @return void
      */
-    public function initializeAvailableProxyClasses(ApplicationContext $context)
+    public function initializeAvailableProxyClasses(ApplicationContext $context = null)
     {
+        if ($context === null) {
+            return;
+        }
+
         $proxyClasses = @include(FLOW_PATH_DATA . 'Temporary/' . (string)$context . '/AvailableProxyClasses.php');
         if ($proxyClasses !== false) {
             $this->availableProxyClasses = $proxyClasses;


### PR DESCRIPTION
The Flow autoloader relied on much of the autoload information
that composer provides anyway. With this change we initialize
the composer autoloader first thing in the bootstrap and later
our own on top of that. That means the responsibility is kept
in the composer autoloader and we can get rid of many early include
statements which the composer autoloader fullfills instead.