### PR TITLE
BUGFIX: Avoid cross influence in schema migrations

### DIFF
--- a/TYPO3.Flow/Migrations/Mysql/Version20141015125841.php
+++ b/TYPO3.Flow/Migrations/Mysql/Version20141015125841.php
@@ -27,8 +27,8 @@ class Version20141015125841 extends AbstractMigration
 
         $this->addSql('ALTER TABLE typo3_flow_resource_resource DROP FOREIGN KEY FK_B4D45B32A4A851AF');
         $this->addSql('ALTER TABLE typo3_flow_resource_resource DROP FOREIGN KEY typo3_flow_resource_resource_ibfk_1');
-        $this->addSql('ALTER TABLE typo3_flow_resource_resource CHANGE resourcepointer sha1 VARCHAR(40) NOT NULL, ADD md5 VARCHAR(32) DEFAULT NULL, ADD collectionname VARCHAR(255) DEFAULT NULL, DROP publishingconfiguration, DROP fileextension, ADD mediatype VARCHAR(100) DEFAULT NULL, ADD relativepublicationpath VARCHAR(255) NOT NULL, ADD filesize NUMERIC(20, 0) DEFAULT NULL');
         $this->addSql('DROP INDEX IDX_B4D45B323CB65D1 ON typo3_flow_resource_resource');
+        $this->addSql('ALTER TABLE typo3_flow_resource_resource CHANGE resourcepointer sha1 VARCHAR(40) NOT NULL, ADD md5 VARCHAR(32) DEFAULT NULL, ADD collectionname VARCHAR(255) DEFAULT NULL, DROP publishingconfiguration, DROP fileextension, ADD mediatype VARCHAR(100) DEFAULT NULL, ADD relativepublicationpath VARCHAR(255) NOT NULL, ADD filesize NUMERIC(20, 0) DEFAULT NULL');
         $this->addSql('DROP TABLE typo3_flow_resource_resourcepointer');
     }
 

--- a/TYPO3.Flow/Migrations/Mysql/Version20150206114820.php
+++ b/TYPO3.Flow/Migrations/Mysql/Version20150206114820.php
@@ -21,7 +21,10 @@ class Version20150206114820 extends AbstractMigration
 
         if ($this->isPartyPackageInstalled()) {
             $this->addSql("ALTER TABLE typo3_flow_security_account DROP FOREIGN KEY typo3_flow_security_account_ibfk_1");
-            $this->addSql("DROP INDEX IDX_65EFB31C89954EE0 ON typo3_flow_security_account");
+            $indexes = $this->sm->listTableIndexes('typo3_flow_security_account');
+            if (array_key_exists('idx_65efb31c89954ee0', $indexes)) {
+                $this->addSql("DROP INDEX IDX_65EFB31C89954EE0 ON typo3_flow_security_account");
+            }
         }
 
         $this->addSql("ALTER TABLE typo3_flow_security_account DROP party");

--- a/TYPO3.Flow/Migrations/Mysql/Version20150309181635.php
+++ b/TYPO3.Flow/Migrations/Mysql/Version20150309181635.php
@@ -17,8 +17,11 @@ class Version20150309181635 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
-        $this->addSql("DROP INDEX flow3_identity_typo3_flow3_security_account ON typo3_flow_security_account");
-        $this->addSql("CREATE UNIQUE INDEX flow_identity_typo3_flow_security_account ON typo3_flow_security_account (accountidentifier, authenticationprovidername)");
+        $indexes = $this->sm->listTableIndexes('typo3_flow_security_account');
+        if (array_key_exists('flow3_identity_typo3_flow3_security_account', $indexes)) {
+            $this->addSql("DROP INDEX flow3_identity_typo3_flow3_security_account ON typo3_flow_security_account");
+            $this->addSql("CREATE UNIQUE INDEX flow_identity_typo3_flow_security_account ON typo3_flow_security_account (accountidentifier, authenticationprovidername)");
+        }
     }
 
     /**

--- a/TYPO3.Flow/Migrations/Postgresql/Version20141118174722.php
+++ b/TYPO3.Flow/Migrations/Postgresql/Version20141118174722.php
@@ -27,7 +27,7 @@ class Version20141118174722 extends AbstractMigration
         $this->addSql('ALTER TABLE typo3_flow_resource_resource DROP CONSTRAINT fk_b4d45b32a4a851af');
         $this->addSql('ALTER TABLE typo3_flow_resource_resource DROP CONSTRAINT fk_b4d45b323cb65d1');
 
-        $this->addSql('DROP INDEX idx_b4d45b323cb65d1');
+        $this->addSql('DROP INDEX IF EXISTS idx_b4d45b323cb65d1');
 
         $this->addSql('ALTER TABLE typo3_flow_resource_resource RENAME resourcepointer TO sha1');
         $this->addSql('ALTER TABLE typo3_flow_resource_resource ALTER sha1 TYPE VARCHAR(40), ALTER sha1 DROP DEFAULT, ALTER sha1 SET NOT NULL');

--- a/TYPO3.Flow/Migrations/Postgresql/Version20150216124452.php
+++ b/TYPO3.Flow/Migrations/Postgresql/Version20150216124452.php
@@ -19,7 +19,7 @@ class Version20150216124452 extends AbstractMigration
 
         if ($this->isPartyPackageInstalled()) {
             $this->addSql("ALTER TABLE typo3_flow_security_account DROP CONSTRAINT fk_65efb31c89954ee0");
-            $this->addSql("DROP INDEX idx_65efb31c89954ee0");
+            $this->addSql("DROP INDEX IF EXISTS idx_65efb31c89954ee0");
         }
 
         $this->addSql("ALTER TABLE typo3_flow_security_account DROP party");

--- a/TYPO3.Flow/Migrations/Postgresql/Version20150309184456.php
+++ b/TYPO3.Flow/Migrations/Postgresql/Version20150309184456.php
@@ -18,7 +18,7 @@ class Version20150309184456 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
 
         $this->addSql("ALTER TABLE typo3_flow_resource_resource ALTER relativepublicationpath DROP DEFAULT");
-        $this->addSql("ALTER INDEX flow3_identity_typo3_flow3_security_account RENAME TO flow_identity_typo3_flow_security_account");
+        $this->addSql("ALTER INDEX IF EXISTS flow3_identity_typo3_flow3_security_account RENAME TO flow_identity_typo3_flow_security_account");
     }
 
     /**
@@ -29,7 +29,7 @@ class Version20150309184456 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
 
-        $this->addSql("ALTER INDEX flow_identity_typo3_flow_security_account RENAME TO flow3_identity_typo3_flow3_security_account");
+        $this->addSql("ALTER INDEX IF EXISTS flow_identity_typo3_flow_security_account RENAME TO flow3_identity_typo3_flow3_security_account");
         $this->addSql("ALTER TABLE typo3_flow_resource_resource ALTER relativepublicationpath SET DEFAULT ''");
     }
 }


### PR DESCRIPTION
There have been cleanup migrations added in the past that interact in
breaking ways with each other. This changes the index renaming to only
happen if needed.