### PR TITLE
BUGFIX: Update tagFormats to match defined severities

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Log/Backend/AnsiConsoleBackend.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Log/Backend/AnsiConsoleBackend.php
@@ -58,12 +58,14 @@ class AnsiConsoleBackend extends ConsoleBackend
     {
         parent::open();
         $this->tagFormats = array(
-            'success' => self::FG_GREEN . '|' . self::END,
-            'info' => self::FG_WHITE . '|' . self::END,
-            'notice' => self::FG_YELLOW . '|' . self::END,
-            'debug' => self::FG_GRAY . '|' . self::END,
-            'error' => self::FG_WHITE . self::BG_RED . '|' . self::END,
-            'warning' => self::FG_BLACK . self::BG_YELLOW . '|' . self::END
+            'emergency' => self::FG_BLACK . self::BG_RED . '|' . self::END,
+            'alert' => self::FG_BLACK . self::BG_YELLOW . '|' . self::END,
+            'critical' => self::FG_BLACK . self::BG_CYAN . '|' . self::END,
+            'error' => self::FG_RED . '|' . self::END,
+            'warning' => self::FG_YELLOW . '|' . self::END,
+            'notice' => self::FG_WHITE . '|' . self::END,
+            'info' => self::FG_GREEN . '|' . self::END,
+            'debug' => self::FG_BLUE . '|' . self::END,
         );
     }
 


### PR DESCRIPTION
Uses the severities descriped in \TYPO3\Flow\Log\LoggerInterface