### PR TITLE
TASK: Don't set a default host for persistence backend

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/EntityManagerFactory.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/EntityManagerFactory.php
@@ -97,6 +97,17 @@ class EntityManagerFactory
         $config->setProxyNamespace('TYPO3\Flow\Persistence\Doctrine\Proxies');
         $config->setAutoGenerateProxyClasses(false);
 
+        // Set default host to 127.0.0.1 if there is no other host configured and at least one other necessary option
+        if ($this->settings['backendOptions']['host'] == '') {
+            if (
+                $this->settings['backendOptions']['dbname'] != '' ||
+                $this->settings['backendOptions']['user'] != '' ||
+                $this->settings['backendOptions']['password'] != ''
+            ) {
+                $this->settings['backendOptions']['host'] = '127.0.0.1';
+            }
+        }
+
         // The following code tries to connect first, if that succeeds, all is well. If not, the platform is fetched directly from the
         // driver - without version checks to the database server (to which no connection can be made) - and is added to the config
         // which is then used to create a new connection. This connection will then return the platform directly, without trying to

--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -215,7 +215,7 @@ TYPO3:
       # Options for the default Doctrine persistence
       backendOptions:
         driver: 'pdo_mysql'
-        host: '127.0.0.1'
+        host: ''
         dbname: NULL
         user: NULL
         password: NULL


### PR DESCRIPTION
Flow won't work on a server without a running mysql service because a default host ist configured. This fix will set the default host to an empty string so flow does also run without a running  mysql service.

FLOW-379 #close