### PR TITLE
BUGFIX: Remove duplicate "htmlspecialchars"

### DIFF
--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Form/UploadViewHelper.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Form/UploadViewHelper.php
@@ -105,7 +105,7 @@ class UploadViewHelper extends AbstractFormFieldViewHelper
             if ($this->hasArgument('id')) {
                 $resourceIdentityAttribute = ' id="' . htmlspecialchars($this->arguments['id']) . '-resource-identity"';
             }
-            $output .= '<input type="hidden" name="'. htmlspecialchars($nameAttribute) . '[originallySubmittedResource][__identity]" value="' . $this->persistenceManager->getIdentifierByObject($resource) . '"' . htmlspecialchars($resourceIdentityAttribute) . ' />';
+            $output .= '<input type="hidden" name="'. htmlspecialchars($nameAttribute) . '[originallySubmittedResource][__identity]" value="' . $this->persistenceManager->getIdentifierByObject($resource) . '"' . $resourceIdentityAttribute . ' />';
         }
 
         if ($this->hasArgument('collection') && $this->arguments['collection'] !== false && $this->arguments['collection'] !== '') {


### PR DESCRIPTION
Removes a duplicate "htmlspecialchars" on the
id-Attribute of the "orginallySubmittedResource"
hidden-field.