### PR TITLE
BUGFIX: Fix regression with frozen reflection service

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
@@ -2186,6 +2186,6 @@ class ReflectionService
      */
     protected function hasFrozenCacheInProduction()
     {
-        return $this->context->isProduction() && $this->reflectionDataRuntimeCache->getBackend()->isFrozen();
+        return $this->environment->getContext()->isProduction() && $this->reflectionDataRuntimeCache->getBackend()->isFrozen();
     }
 }


### PR DESCRIPTION
The commit 409a45aaf9550b2df790c9730b7f002bd609624b introduced a change
for early return inside the reflection service that did not catch a case
where the context was not initialized from the environment.