### PR TITLE
TASK: Split ObjectAccess utility off

### DIFF
--- a/Neos.PropertyAccess/Classes/TYPO3/Flow/Reflection/Exception/PropertyNotAccessibleException.php
+++ b/Neos.PropertyAccess/Classes/TYPO3/Flow/Reflection/Exception/PropertyNotAccessibleException.php
@@ -2,7 +2,7 @@
 namespace TYPO3\Flow\Reflection\Exception;
 
 /*
- * This file is part of the TYPO3.Flow package.
+ * This file is part of the Neos.PropertyAccess package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -16,6 +16,6 @@ namespace TYPO3\Flow\Reflection\Exception;
  *
  * @api
  */
-class PropertyNotAccessibleException extends \TYPO3\Flow\Reflection\Exception
+class PropertyNotAccessibleException extends \Exception
 {
 }

--- a/Neos.PropertyAccess/Classes/TYPO3/Flow/Reflection/ObjectAccess.php
+++ b/Neos.PropertyAccess/Classes/TYPO3/Flow/Reflection/ObjectAccess.php
@@ -2,7 +2,7 @@
 namespace TYPO3\Flow\Reflection;
 
 /*
- * This file is part of the TYPO3.Flow package.
+ * This file is part of the Neos.PropertyAccess package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -12,6 +12,7 @@ namespace TYPO3\Flow\Reflection;
  */
 
 use TYPO3\Flow\Reflection\Exception\PropertyNotAccessibleException;
+use TYPO3\Flow\Utility\TypeHandling;
 
 /**
  * Provides methods to call appropriate getter/setter on an object given the
@@ -108,7 +109,7 @@ class ObjectAccess
         }
 
         $propertyExists = true;
-        $className = \TYPO3\Flow\Utility\TypeHandling::getTypeForValue($subject);
+        $className = TypeHandling::getTypeForValue($subject);
 
         if ($forceDirectAccess === true) {
             if (property_exists($className, $propertyName)) {
@@ -238,7 +239,7 @@ class ObjectAccess
         }
 
         if ($forceDirectAccess === true) {
-            $className = \TYPO3\Flow\Utility\TypeHandling::getTypeForValue($subject);
+            $className = TypeHandling::getTypeForValue($subject);
             if (property_exists($className, $propertyName)) {
                 $propertyReflection = new PropertyReflection($className, $propertyName);
                 $propertyReflection->setValue($subject, $propertyValue);
@@ -278,7 +279,7 @@ class ObjectAccess
             $className = 'stdClass';
             unset(self::$gettablePropertyNamesCache[$className]);
         } else {
-            $className = \TYPO3\Flow\Utility\TypeHandling::getTypeForValue($object);
+            $className = TypeHandling::getTypeForValue($object);
             $declaredPropertyNames = array_keys(get_class_vars($className));
         }
 
@@ -323,7 +324,7 @@ class ObjectAccess
         if ($object instanceof \stdClass) {
             $declaredPropertyNames = array_keys(get_object_vars($object));
         } else {
-            $className = \TYPO3\Flow\Utility\TypeHandling::getTypeForValue($object);
+            $className = TypeHandling::getTypeForValue($object);
             $declaredPropertyNames = array_keys(get_class_vars($className));
         }
 
@@ -352,7 +353,7 @@ class ObjectAccess
             throw new \InvalidArgumentException('$object must be an object, ' . gettype($object) . ' given.', 1259828920);
         }
 
-        $className = \TYPO3\Flow\Utility\TypeHandling::getTypeForValue($object);
+        $className = TypeHandling::getTypeForValue($object);
         if ($object instanceof \stdClass && array_search($propertyName, array_keys(get_object_vars($object))) !== false) {
             return true;
         } elseif (array_search($propertyName, array_keys(get_class_vars($className))) !== false) {
@@ -389,7 +390,7 @@ class ObjectAccess
         if (is_callable(array($object, 'has' . $uppercasePropertyName))) {
             return true;
         }
-        $className = \TYPO3\Flow\Utility\TypeHandling::getTypeForValue($object);
+        $className = TypeHandling::getTypeForValue($object);
         return (array_search($propertyName, array_keys(get_class_vars($className))) !== false);
     }
 

--- a/Neos.PropertyAccess/Readme.rst
+++ b/Neos.PropertyAccess/Readme.rst
@@ -1,0 +1,24 @@
+----------------------------
+Flow Property Access Utility
+----------------------------
+
+.. note:: This repository is a **read-only subsplit** of a package that is part of the
+          Flow framework (learn more on `flowframework.io <http://www.flowframework.io/>`_).
+
+If you want to use the Flow framework, please have a look at the `Flow documentation
+<http://flowframework.readthedocs.org/en/stable/>`_
+
+Contribute
+----------
+
+If you want to contribute to the Flow framework, please have a look at
+https://github.com/neos/flow-development-collection - it is the repository
+used for development and all pull requests should go into it.
+
+
+Dependencies
+------------
+
+This package depends on the TypeHandling utility of Flow, after that is split we can
+depend on that. Additionally the tests depend on Doctrine/ORM which is therefore
+a dev requirement requirement.

--- a/Neos.PropertyAccess/Tests/Unit/Fixture/ArrayAccessClass.php
+++ b/Neos.PropertyAccess/Tests/Unit/Fixture/ArrayAccessClass.php
@@ -1,0 +1,48 @@
+<?php
+namespace Neos\PropertyAccess\Tests\Unit\Fixture;
+
+/*
+ * This file is part of the Neos.PropertyAccess package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * ArrayAccess class for the Reflection tests
+ *
+ */
+class ArrayAccessClass implements \ArrayAccess
+{
+    protected $internalProperty = 'access through forceDirectAccess';
+
+    protected $array = array();
+
+    public function __construct(array $array)
+    {
+        $this->array = $array;
+    }
+
+    public function offsetExists($offset)
+    {
+        return array_key_exists($offset, $this->array);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->array[$offset];
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        $this->array[$offset] = $value;
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->array[$offset]);
+    }
+}

--- a/Neos.PropertyAccess/Tests/Unit/Fixture/DummyClassWithGettersAndSetters.php
+++ b/Neos.PropertyAccess/Tests/Unit/Fixture/DummyClassWithGettersAndSetters.php
@@ -1,0 +1,95 @@
+<?php
+namespace Neos\PropertyAccess\Tests\Unit\Fixture;
+
+/*
+ * This file is part of the Neos.PropertyAccess package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Fixture class with getters and setters
+ *
+ */
+class DummyClassWithGettersAndSetters
+{
+    protected $property;
+    protected $anotherProperty;
+    protected $property2;
+    protected $booleanProperty = true;
+    protected $anotherBooleanProperty = false;
+
+    protected $protectedProperty;
+
+    protected $unexposedProperty = 'unexposed';
+
+    public $publicProperty;
+    public $publicProperty2 = 42;
+
+    public function setProperty($property)
+    {
+        $this->property = $property;
+    }
+
+    public function getProperty()
+    {
+        return $this->property;
+    }
+
+    public function setAnotherProperty($anotherProperty)
+    {
+        $this->anotherProperty = $anotherProperty;
+    }
+
+    public function getAnotherProperty()
+    {
+        return $this->anotherProperty;
+    }
+
+    public function getProperty2()
+    {
+        return $this->property2;
+    }
+    public function setProperty2($property2)
+    {
+        $this->property2 = $property2;
+    }
+
+    protected function getProtectedProperty()
+    {
+        return '42';
+    }
+
+    protected function setProtectedProperty($value)
+    {
+        $this->protectedProperty = $value;
+    }
+
+    public function isBooleanProperty()
+    {
+        return 'method called ' . $this->booleanProperty;
+    }
+
+    public function setAnotherBooleanProperty($anotherBooleanProperty)
+    {
+        $this->anotherBooleanProperty = $anotherBooleanProperty;
+    }
+
+    public function hasAnotherBooleanProperty()
+    {
+        return $this->anotherBooleanProperty;
+    }
+
+    protected function getPrivateProperty()
+    {
+        return '21';
+    }
+
+    public function setWriteOnlyMagicProperty($value)
+    {
+    }
+}

--- a/Neos.PropertyAccess/Tests/Unit/Fixture/Model/Entity.php
+++ b/Neos.PropertyAccess/Tests/Unit/Fixture/Model/Entity.php
@@ -1,0 +1,82 @@
+<?php
+namespace Neos\PropertyAccess\Tests\Unit\Fixture\Model;
+
+/*
+ * This file is part of the Neos.PropertyAccess package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A model fixture which is used for testing the class schema building
+ *
+ */
+class Entity
+{
+    /**
+     * An identity property
+     *
+     * @var string
+     */
+    protected $someIdentifier;
+
+    /**
+     * Just a normal string
+     *
+     * @var string
+     */
+    protected $someString;
+
+    /**
+     * @var integer
+     */
+    protected $someInteger;
+
+    /**
+     * @var float
+     */
+    protected $someFloat;
+
+    /**
+     * @var \DateTime
+     */
+    protected $someDate;
+
+    /**
+     * @var \SplObjectStorage
+     */
+    protected $someSplObjectStorage;
+
+    /**
+     * A transient string
+     *
+     * @var string
+     */
+    protected $someTransientString;
+
+    /**
+     * @var boolean
+     */
+    protected $someBoolean;
+
+    /**
+     * Just an empty constructor
+     *
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Just a dummy method
+     *
+     * @return void
+     */
+    public function someDummyMethod()
+    {
+    }
+}

--- a/Neos.PropertyAccess/Tests/Unit/Fixture/Model/EntityWithDoctrineProxy.php
+++ b/Neos.PropertyAccess/Tests/Unit/Fixture/Model/EntityWithDoctrineProxy.php
@@ -1,0 +1,124 @@
+<?php
+namespace Neos\PropertyAccess\Tests\Unit\Fixture\Model;
+
+use Doctrine\ORM\Proxy\Proxy;
+
+/**
+ * A class that is a Doctrine proxy
+ */
+class EntityWithDoctrineProxy extends Entity implements Proxy
+{
+    /**
+     * @var \Closure the callback responsible for loading properties in the proxy object. This callback is called with
+     *      three parameters, being respectively the proxy object to be initialized, the method that triggered the
+     *      initialization process and an array of ordered parameters that were passed to that method.
+     *
+     * @see \Doctrine\Common\Persistence\Proxy::__setInitializer
+     */
+    public $__initializer__;
+
+    /**
+     * @var \Closure the callback responsible of loading properties that need to be copied in the cloned object
+     *
+     * @see \Doctrine\Common\Persistence\Proxy::__setCloner
+     */
+    public $__cloner__;
+
+    /**
+     * @var boolean flag indicating if this object was already initialized
+     *
+     * @see \Doctrine\Common\Persistence\Proxy::__isInitialized
+     */
+    public $__isInitialized__ = false;
+
+    /**
+     * @var array properties to be lazy loaded, with keys being the property
+     *            names and values being their default values
+     *
+     * @see \Doctrine\Common\Persistence\Proxy::__getLazyProperties
+     */
+    public static $lazyPropertiesDefaults = array();
+
+
+    /**
+     * @param \Closure $initializer
+     * @param \Closure $cloner
+     */
+    public function __construct($initializer = null, $cloner = null)
+    {
+        $this->__initializer__ = $initializer;
+        $this->__cloner__ = $cloner;
+    }
+
+    /**
+     * Forces initialization of the proxy
+     */
+    public function __load()
+    {
+        $this->__initializer__ && $this->__initializer__->__invoke($this, '__load', array());
+    }
+
+    /**
+     * {@inheritDoc}
+     * @internal generated method: use only when explicitly handling proxy specific loading logic
+     */
+    public function __isInitialized()
+    {
+        return $this->__isInitialized__;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @internal generated method: use only when explicitly handling proxy specific loading logic
+     */
+    public function __setInitialized($initialized)
+    {
+        $this->__isInitialized__ = $initialized;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @internal generated method: use only when explicitly handling proxy specific loading logic
+     */
+    public function __setInitializer(\Closure $initializer = null)
+    {
+        $this->__initializer__ = $initializer;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @internal generated method: use only when explicitly handling proxy specific loading logic
+     */
+    public function __getInitializer()
+    {
+        return $this->__initializer__;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @internal generated method: use only when explicitly handling proxy specific loading logic
+     */
+    public function __setCloner(\Closure $cloner = null)
+    {
+        $this->__cloner__ = $cloner;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @internal generated method: use only when explicitly handling proxy specific cloning logic
+     */
+    public function __getCloner()
+    {
+        return $this->__cloner__;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @internal generated method: use only when explicitly handling proxy specific loading logic
+     * @static
+     */
+    public function __getLazyProperties()
+    {
+        return self::$lazyPropertiesDefaults;
+    }
+}

--- a/Neos.PropertyAccess/Tests/Unit/ObjectAccessTest.php
+++ b/Neos.PropertyAccess/Tests/Unit/ObjectAccessTest.php
@@ -1,8 +1,8 @@
 <?php
-namespace TYPO3\Flow\Tests\Unit\Reflection;
+namespace Neos\PropertyAccess\Tests\Unit;
 
 /*
- * This file is part of the TYPO3.Flow package.
+ * This file is part of the Neos.PropertyAccess package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,21 +11,23 @@ namespace TYPO3\Flow\Tests\Unit\Reflection;
  * source code.
  */
 
+use Neos\PropertyAccess\Tests\Unit\Fixture\DummyClassWithGettersAndSetters;
+use Neos\PropertyAccess\Tests\Unit\Fixture\Model\EntityWithDoctrineProxy;
+use Neos\PropertyAccess\Tests\Unit\Fixture\ArrayAccessClass;
 use TYPO3\Flow\Reflection\ObjectAccess;
 
 require_once('Fixture/DummyClassWithGettersAndSetters.php');
 require_once('Fixture/ArrayAccessClass.php');
-require_once('Fixture/Model/Entity.php');
 require_once('Fixture/Model/EntityWithDoctrineProxy.php');
 
 /**
  * Testcase for Object Access
  *
  */
-class ObjectAccessTest extends \TYPO3\Flow\Tests\UnitTestCase
+class ObjectAccessTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var \TYPO3\Flow\Tests\Reflection\Fixture\DummyClassWithGettersAndSetters
+     * @var DummyClassWithGettersAndSetters
      */
     protected $dummyObject;
 
@@ -33,7 +35,7 @@ class ObjectAccessTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function setUp()
     {
-        $this->dummyObject = new \TYPO3\Flow\Tests\Reflection\Fixture\DummyClassWithGettersAndSetters();
+        $this->dummyObject = new DummyClassWithGettersAndSetters();
         $this->dummyObject->setProperty('string1');
         $this->dummyObject->setAnotherProperty(42);
         $this->dummyObject->shouldNotBePickedUp = true;
@@ -270,7 +272,7 @@ class ObjectAccessTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function getPropertyCanAccessPropertiesOfAnObjectImplementingArrayAccess()
     {
-        $arrayAccessInstance = new \TYPO3\Flow\Tests\Reflection\Fixture\ArrayAccessClass(array('key' => 'value'));
+        $arrayAccessInstance = new ArrayAccessClass(array('key' => 'value'));
         $expectedResult = 'value';
         $actualResult = ObjectAccess::getProperty($arrayAccessInstance, 'key');
         $this->assertEquals($expectedResult, $actualResult, 'getPropertyPath does not work with Array Access property.');
@@ -281,7 +283,7 @@ class ObjectAccessTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function getPropertyRespectsForceDirectAccessForArrayAccess()
     {
-        $arrayAccessInstance = new \TYPO3\Flow\Tests\Reflection\Fixture\ArrayAccessClass(array('key' => 'value'));
+        $arrayAccessInstance = new ArrayAccessClass(array('key' => 'value'));
         $actualResult = ObjectAccess::getProperty($arrayAccessInstance, 'internalProperty', true);
         $this->assertEquals('access through forceDirectAccess', $actualResult, 'getPropertyPath does not respect ForceDirectAccess for ArrayAccess implementations.');
     }
@@ -399,7 +401,8 @@ class ObjectAccessTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function getGettablePropertiesHandlesDoctrineProxy()
     {
-        $proxyObject = new \TYPO3\Flow\Tests\Reflection\Fixture\Model\EntityWithDoctrineProxy();
+        $proxyObject = new EntityWithDoctrineProxy();
+
         $expectedProperties = array();
         $actualProperties = ObjectAccess::getGettableProperties($proxyObject);
         $this->assertEquals($expectedProperties, $actualProperties, 'expectedProperties did not return the right values for the properties.');
@@ -476,7 +479,7 @@ class ObjectAccessTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function getPropertyPathCanRecursivelyGetPropertiesOfAnObject()
     {
-        $alternativeObject = new \TYPO3\Flow\Tests\Reflection\Fixture\DummyClassWithGettersAndSetters();
+        $alternativeObject = new DummyClassWithGettersAndSetters();
         $alternativeObject->setProperty('test');
         $this->dummyObject->setProperty2($alternativeObject);
 
@@ -490,7 +493,7 @@ class ObjectAccessTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function getPropertyPathReturnsNullForNonExistingPropertyPath()
     {
-        $alternativeObject = new \TYPO3\Flow\Tests\Reflection\Fixture\DummyClassWithGettersAndSetters();
+        $alternativeObject = new DummyClassWithGettersAndSetters();
         $alternativeObject->setProperty(new \stdClass());
         $this->dummyObject->setProperty2($alternativeObject);
 

--- a/Neos.PropertyAccess/composer.json
+++ b/Neos.PropertyAccess/composer.json
@@ -1,0 +1,26 @@
+{
+    "name": "neos/property-access",
+    "type": "library",
+    "description": "Flow array/object property access utilities",
+    "homepage": "http://flow.typo3.org",
+    "license": [
+        "MIT"
+    ],
+    "require": {
+        "php": ">=5.5.0",
+        "typo3/flow": "*"
+    },
+    "require-dev": {
+        "doctrine/orm": "~2.4.0"
+    },
+    "autoload": {
+        "psr-0": {
+            "TYPO3\\Flow\\Reflection": "Classes"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Neos\\PropertyAccess\\Tests\\": "Tests"
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "neos/composer-plugin": "^1.0.1"
     },
     "replace": {
+        "neos/property-access": "self.version",
         "typo3/eel": "self.version",
         "typo3/flow": "self.version",
         "typo3/fluid": "self.version",
@@ -36,6 +37,7 @@
     },
     "autoload": {
         "psr-0": {
+            "TYPO3\\Flow\\Reflection": "Neos.PropertyAccess/Classes",
             "TYPO3\\Eel": "TYPO3.Eel/Classes",
             "TYPO3\\Flow": "TYPO3.Flow/Classes",
             "TYPO3\\Fluid": "TYPO3.Fluid/Classes",


### PR DESCRIPTION
Separates the ObjectAccess utility to a new package and cuts
dependencies to Flow.

Last dependency is the TypeHandling utility which first needs to
be split as well.