### PR TITLE
Split unicode utilities

### DIFF
--- a/Neos.Utility.Unicode/Classes/TYPO3/Flow/Utility/Unicode/Exception.php
+++ b/Neos.Utility.Unicode/Classes/TYPO3/Flow/Utility/Unicode/Exception.php
@@ -1,0 +1,10 @@
+<?php
+namespace TYPO3\Flow\Utility\Unicode;
+
+/**
+ *
+ */
+class Exception extends \Exception
+{
+
+}

--- a/Neos.Utility.Unicode/Classes/TYPO3/Flow/Utility/Unicode/Functions.php
+++ b/Neos.Utility.Unicode/Classes/TYPO3/Flow/Utility/Unicode/Functions.php
@@ -2,7 +2,7 @@
 namespace TYPO3\Flow\Utility\Unicode;
 
 /*
- * This file is part of the TYPO3.Flow package.
+ * This file is part of the Neos.Utility.Unicode package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,29 +11,28 @@ namespace TYPO3\Flow\Utility\Unicode;
  * source code.
  */
 
-use TYPO3\Flow\Annotations as Flow;
 
 /**
  * A class with UTF-8 string functions, some inspired by what might be in some
  * future PHP version...
  *
- * @Flow\Scope("singleton")
  * @api
  */
-class Functions
+abstract class Functions
 {
+
     /**
      * Converts the first character of each word to uppercase and all remaining characters
      * to lowercase.
      *
-     * @param  string $str The string to convert
+     * @param  string $string The string to convert
      * @return string The converted string
      * @api
      */
-    public static function strtotitle($str)
+    public static function strtotitle($string)
     {
         $result = '';
-        $splitIntoLowerCaseWords = preg_split("/([\n\r\t ])/", self::strtolower($str), -1, PREG_SPLIT_DELIM_CAPTURE);
+        $splitIntoLowerCaseWords = preg_split("/([\n\r\t ])/", self::strtolower($string), -1, PREG_SPLIT_DELIM_CAPTURE);
         foreach ($splitIntoLowerCaseWords as $delimiterOrValue) {
             $result .= self::strtoupper(self::substr($delimiterOrValue, 0, 1)) . self::substr($delimiterOrValue, 1);
         }
@@ -41,7 +40,7 @@ class Functions
     }
 
     /**
-     * PHP6 variant of substr()
+     * Unicode variant of substr()
      *
      * @param string $string The string to crop
      * @param integer $start Position of the left boundary
@@ -71,7 +70,7 @@ class Functions
     }
 
     /**
-     * PHP6 variant of strtoupper()
+     * Unicode variant of strtoupper()
      *
      * @param  string $string The string to uppercase
      * @return string The processed string
@@ -83,7 +82,7 @@ class Functions
     }
 
     /**
-     * PHP6 variant of strtolower()
+     * Unicode variant of strtolower()
      *
      * @param  string $string The string to lowercase
      * @return string The processed string
@@ -95,7 +94,7 @@ class Functions
     }
 
     /**
-     * PHP6 variant of strlen() - assumes that the string is a Unicode string, not binary
+     * Uniocde variant of strlen() - assumes that the string is a Unicode string, not binary
      *
      * @param  string $string The string to count the characters of
      * @return integer The number of characters
@@ -107,7 +106,7 @@ class Functions
     }
 
     /**
-     * PHP6 variant of ucfirst() - assumes that the string is a Unicode string, not binary
+     * Unicode variant of ucfirst() - assumes that the string is a Unicode string, not binary
      *
      * @param  string $string The string whose first letter should be uppercased
      * @return string The same string, first character uppercased
@@ -119,7 +118,7 @@ class Functions
     }
 
     /**
-     * PHP6 variant of lcfirst() - assumes that the string is a Unicode string, not binary
+     * Unicode variant of lcfirst() - assumes that the string is a Unicode string, not binary
      *
      * @param  string $string The string whose first letter should be lowercased
      * @return string The same string, first character lowercased
@@ -131,7 +130,7 @@ class Functions
     }
 
     /**
-     * PHP6 variant of strpos() - assumes that the string is a Unicode string, not binary
+     * Unicode variant of strpos() - assumes that the string is a Unicode string, not binary
      *
      * @param string $haystack UTF-8 string to search in
      * @param string $needle UTF-8 string to search for
@@ -145,7 +144,7 @@ class Functions
     }
 
     /**
-     * PHP6 variant of pathinfo()
+     * Unicode variant of pathinfo()
      * pathinfo() function is not unicode-friendly
      * if setlocale is not set. It's sufficient to set it
      * to any UTF-8 locale to correctly handle unicode strings.

--- a/Neos.Utility.Unicode/Classes/TYPO3/Flow/Utility/Unicode/TextIterator.php
+++ b/Neos.Utility.Unicode/Classes/TYPO3/Flow/Utility/Unicode/TextIterator.php
@@ -2,7 +2,7 @@
 namespace TYPO3\Flow\Utility\Unicode;
 
 /*
- * This file is part of the TYPO3.Flow package.
+ * This file is part of the Neos.Utility.Unicode package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,12 +11,9 @@ namespace TYPO3\Flow\Utility\Unicode;
  * source code.
  */
 
-use TYPO3\Flow\Annotations as Flow;
-
 /**
  * A PHP-based port of PHP6's built in TextIterator
  *
- * @Flow\Scope("singleton")
  */
 class TextIterator implements \Iterator
 {
@@ -77,7 +74,7 @@ class TextIterator implements \Iterator
     protected $iteratorCacheIterator;
 
     /**
-     * @var \TYPO3\Flow\Utility\Unicode\TextIteratorElement
+     * @var TextIteratorElement
      */
     protected $previousElement;
 
@@ -86,12 +83,12 @@ class TextIterator implements \Iterator
      *
      * @param string $subject
      * @param integer $iteratorType The type of iterator
-     * @throws \TYPO3\Flow\Error\Exception
+     * @throws Exception
      */
     public function __construct($subject, $iteratorType = self::CHARACTER)
     {
         if ($iteratorType < 1 || $iteratorType > 6) {
-            throw new \TYPO3\Flow\Error\Exception('Fatal error: Invalid iterator type in TextIterator constructor', 1210849014);
+            throw new Exception('Fatal error: Invalid iterator type in TextIterator constructor', 1210849014);
         }
 
         $this->iteratorType = $iteratorType;
@@ -273,7 +270,7 @@ class TextIterator implements \Iterator
      */
     public function getRuleStatus()
     {
-        throw new \TYPO3\Flow\Utility\Unicode\UnsupportedFeatureException('getRuleStatus() is not supported.', 1210849057);
+        throw new UnsupportedFeatureException('getRuleStatus() is not supported.', 1210849057);
     }
 
     /**
@@ -281,7 +278,7 @@ class TextIterator implements \Iterator
      */
     public function getRuleStatusArray()
     {
-        throw new \TYPO3\Flow\Utility\Unicode\UnsupportedFeatureException('getRuleStatusArray() is not supported.', 1210849076);
+        throw new UnsupportedFeatureException('getRuleStatusArray() is not supported.', 1210849076);
     }
 
     /**
@@ -289,7 +286,7 @@ class TextIterator implements \Iterator
      */
     public function getAvailableLocales()
     {
-        throw new \TYPO3\Flow\Utility\Unicode\UnsupportedFeatureException('getAvailableLocales() is not supported.', 1210849105);
+        throw new UnsupportedFeatureException('getAvailableLocales() is not supported.', 1210849105);
     }
 
     /**
@@ -312,14 +309,14 @@ class TextIterator implements \Iterator
     private function generateIteratorElements()
     {
         if ($this->subject == '') {
-            $this->iteratorCache->append(new \TYPO3\Flow\Utility\Unicode\TextIteratorElement(self::DONE, -1));
+            $this->iteratorCache->append(new TextIteratorElement(self::DONE, -1));
             return;
         }
 
         if ($this->iteratorType == self::CODE_POINT) {
-            throw new \TYPO3\Flow\Utility\Unicode\UnsupportedFeatureException('Unsupported iterator type.', 1210849150);
+            throw new UnsupportedFeatureException('Unsupported iterator type.', 1210849150);
         } elseif ($this->iteratorType == self::COMB_SEQUENCE) {
-            throw new \TYPO3\Flow\Utility\Unicode\UnsupportedFeatureException('Unsupported iterator type.', 1210849151);
+            throw new UnsupportedFeatureException('Unsupported iterator type.', 1210849151);
         } elseif ($this->iteratorType == self::CHARACTER) {
             $this->parseSubjectByCharacter();
         } elseif ($this->iteratorType == self::WORD) {
@@ -330,7 +327,7 @@ class TextIterator implements \Iterator
             $this->parseSubjectBySentence();
         }
 
-        $this->iteratorCache->append(new \TYPO3\Flow\Utility\Unicode\TextIteratorElement(self::DONE, -1));
+        $this->iteratorCache->append(new TextIteratorElement(self::DONE, -1));
         $this->iteratorCacheIterator = $this->iteratorCache->getIterator();
     }
 
@@ -345,7 +342,7 @@ class TextIterator implements \Iterator
             if ($currentCharacter == '') {
                 continue;
             }
-            $this->iteratorCache->append(new \TYPO3\Flow\Utility\Unicode\TextIteratorElement($currentCharacter, $i, 1, false));
+            $this->iteratorCache->append(new TextIteratorElement($currentCharacter, $i, 1, false));
             $i++;
         }
     }
@@ -354,6 +351,7 @@ class TextIterator implements \Iterator
      * Helper function to do the splitting by word. Note: punctuation marks are
      * treated as words, spaces as boundary elements
      *
+     * @return void
      */
     private function parseSubjectByWord()
     {
@@ -364,17 +362,17 @@ class TextIterator implements \Iterator
             $haveProcessedCurrentWord = false;
 
             if (preg_match_all('/' . self::REGEXP_SENTENCE_DELIMITERS . '/', $currentWord, $delimitersMatches)) {
-                $this->iteratorCache->append(new \TYPO3\Flow\Utility\Unicode\TextIteratorElement(' ', $i, 1, true));
+                $this->iteratorCache->append(new TextIteratorElement(' ', $i, 1, true));
 
                 $j = 0;
                 $splittedWord = preg_split('/' . self::REGEXP_SENTENCE_DELIMITERS . '/', $currentWord);
                 foreach ($splittedWord as $currentPart) {
                     if ($currentPart != '') {
-                        $this->iteratorCache->append(new \TYPO3\Flow\Utility\Unicode\TextIteratorElement($currentPart, $i, \TYPO3\Flow\Utility\Unicode\Functions::strlen($currentPart), false));
-                        $i += \TYPO3\Flow\Utility\Unicode\Functions::strlen($currentPart);
+                        $this->iteratorCache->append(new TextIteratorElement($currentPart, $i, Functions::strlen($currentPart), false));
+                        $i += Functions::strlen($currentPart);
                     }
                     if ($j < count($delimitersMatches[0])) {
-                        $this->iteratorCache->append(new \TYPO3\Flow\Utility\Unicode\TextIteratorElement($delimitersMatches[0][$j], $i, 1, true));
+                        $this->iteratorCache->append(new TextIteratorElement($delimitersMatches[0][$j], $i, 1, true));
                     }
                     $i++;
                     $j++;
@@ -383,15 +381,15 @@ class TextIterator implements \Iterator
             }
 
             if (!$isFirstIteration && !$haveProcessedCurrentWord) {
-                $this->iteratorCache->append(new \TYPO3\Flow\Utility\Unicode\TextIteratorElement(' ', $i, 1, true));
+                $this->iteratorCache->append(new TextIteratorElement(' ', $i, 1, true));
                 $i++;
             } else {
                 $isFirstIteration = false;
             }
 
             if (!$haveProcessedCurrentWord) {
-                $this->iteratorCache->append(new \TYPO3\Flow\Utility\Unicode\TextIteratorElement($currentWord, $i, \TYPO3\Flow\Utility\Unicode\Functions::strlen($currentWord), false));
-                $i += \TYPO3\Flow\Utility\Unicode\Functions::strlen($currentWord);
+                $this->iteratorCache->append(new TextIteratorElement($currentWord, $i, Functions::strlen($currentWord), false));
+                $i += Functions::strlen($currentWord);
             }
 
             unset($delimitersMatches);
@@ -403,6 +401,7 @@ class TextIterator implements \Iterator
      * belongs to the preceding sentence.
      * "\n" is boundary element.
      *
+     * @return void
      */
     private function parseSubjectByLine()
     {
@@ -410,11 +409,11 @@ class TextIterator implements \Iterator
         $j = 0;
         $lines = explode("\n", $this->subject);
         foreach ($lines as $currentLine) {
-            $this->iteratorCache->append(new \TYPO3\Flow\Utility\Unicode\TextIteratorElement($currentLine, $i, \TYPO3\Flow\Utility\Unicode\Functions::strlen($currentLine), false));
-            $i += \TYPO3\Flow\Utility\Unicode\Functions::strlen($currentLine);
+            $this->iteratorCache->append(new TextIteratorElement($currentLine, $i, Functions::strlen($currentLine), false));
+            $i += Functions::strlen($currentLine);
 
             if (count($lines) - 1 > $j) {
-                $this->iteratorCache->append(new \TYPO3\Flow\Utility\Unicode\TextIteratorElement("\n", $i, 1, true));
+                $this->iteratorCache->append(new TextIteratorElement("\n", $i, 1, true));
                 $i++;
             }
             $j++;
@@ -426,6 +425,7 @@ class TextIterator implements \Iterator
      * mark belongs to the preceding sentence. Whitespace between sentences is
      * marked as boundary.
      *
+     * @return void
      */
     private function parseSubjectBySentence()
     {
@@ -437,7 +437,7 @@ class TextIterator implements \Iterator
         $splittedSentence = preg_split('/' . self::REGEXP_SENTENCE_DELIMITERS . '/', $this->subject);
 
         if (count($splittedSentence) == 1) {
-            $this->iteratorCache->append(new \TYPO3\Flow\Utility\Unicode\TextIteratorElement($splittedSentence[0], 0, \TYPO3\Flow\Utility\Unicode\Functions::strlen($splittedSentence[0]), false));
+            $this->iteratorCache->append(new TextIteratorElement($splittedSentence[0], 0, Functions::strlen($splittedSentence[0]), false));
             return;
         }
 
@@ -449,16 +449,16 @@ class TextIterator implements \Iterator
                 $whiteSpace .= ' ';
             }
             if ($whiteSpace != '') {
-                $this->iteratorCache->append(new \TYPO3\Flow\Utility\Unicode\TextIteratorElement($whiteSpace, $i, $count, true));
+                $this->iteratorCache->append(new TextIteratorElement($whiteSpace, $i, $count, true));
             }
             $i += $count;
 
             if ($currentPart != '' && $j < count($delimitersMatches[0])) {
-                $this->iteratorCache->append(new \TYPO3\Flow\Utility\Unicode\TextIteratorElement($currentPart . $delimitersMatches[0][$j], $i, \TYPO3\Flow\Utility\Unicode\Functions::strlen($currentPart . $delimitersMatches[0][$j]), false));
-                $i += \TYPO3\Flow\Utility\Unicode\Functions::strlen($currentPart . $delimitersMatches[0][$j]);
+                $this->iteratorCache->append(new TextIteratorElement($currentPart . $delimitersMatches[0][$j], $i, Functions::strlen($currentPart . $delimitersMatches[0][$j]), false));
+                $i += Functions::strlen($currentPart . $delimitersMatches[0][$j]);
                 $j++;
             } elseif ($j < count($delimitersMatches[0])) {
-                $this->iteratorCache->append(new \TYPO3\Flow\Utility\Unicode\TextIteratorElement($delimitersMatches[0][$j], $i, 1, true));
+                $this->iteratorCache->append(new TextIteratorElement($delimitersMatches[0][$j], $i, 1, true));
                 $i++;
                 $j++;
             }
@@ -468,7 +468,7 @@ class TextIterator implements \Iterator
     /**
      * Helper function to get the current element from the cache.
      *
-     * @return \TYPO3\Flow\Utility\Unicode\TextIteratorElement The current element of the cache
+     * @return TextIteratorElement The current element of the cache
      */
     private function getCurrentElement()
     {

--- a/Neos.Utility.Unicode/Classes/TYPO3/Flow/Utility/Unicode/TextIteratorElement.php
+++ b/Neos.Utility.Unicode/Classes/TYPO3/Flow/Utility/Unicode/TextIteratorElement.php
@@ -2,7 +2,7 @@
 namespace TYPO3\Flow\Utility\Unicode;
 
 /*
- * This file is part of the TYPO3.Flow package.
+ * This file is part of the Neos.Utility.Unicode package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,12 +11,9 @@ namespace TYPO3\Flow\Utility\Unicode;
  * source code.
  */
 
-use TYPO3\Flow\Annotations as Flow;
-
 /**
  * A PHP-based port of PHP6's built in TextIterator
  *
- * @Flow\Scope("singleton")
  */
 class TextIteratorElement
 {

--- a/Neos.Utility.Unicode/Classes/TYPO3/Flow/Utility/Unicode/UnsupportedFeatureException.php
+++ b/Neos.Utility.Unicode/Classes/TYPO3/Flow/Utility/Unicode/UnsupportedFeatureException.php
@@ -2,7 +2,7 @@
 namespace TYPO3\Flow\Utility\Unicode;
 
 /*
- * This file is part of the TYPO3.Flow package.
+ * This file is part of the Neos.Utility.Unicode package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -11,12 +11,9 @@ namespace TYPO3\Flow\Utility\Unicode;
  * source code.
  */
 
-use TYPO3\Flow\Annotations as Flow;
-
 /**
  * Exception thrown if a feature is not supported by the PHP6 backport code.
  *
- * @Flow\Scope("singleton")
  * @api
  */
 class UnsupportedFeatureException extends \Exception

--- a/Neos.Utility.Unicode/Readme.rst
+++ b/Neos.Utility.Unicode/Readme.rst
@@ -14,10 +14,3 @@ Contribute
 If you want to contribute to the Flow framework, please have a look at
 https://github.com/neos/flow-development-collection - it is the repository
 used for development and all pull requests should go into it.
-
-
-Dependencies
-------------
-Strictly this package currently depends on the "typo3/flow" package due to
-the usage of BaseTestCase in the unit tests. That is the only dependency though and
-therefore this package is generally usable without flow.

--- a/Neos.Utility.Unicode/Readme.rst
+++ b/Neos.Utility.Unicode/Readme.rst
@@ -1,0 +1,23 @@
+----------------------
+Neos Unicode Utilities
+----------------------
+
+.. note:: This repository is a **read-only subsplit** of a package that is part of the
+          Flow framework (learn more on `flow.typo3.org <http://flow.typo3.org/>`_).
+
+If you want to use the Flow framework, please have a look at the `Flow documentation
+<http://flowframework.readthedocs.org/en/stable/>`_
+
+Contribute
+----------
+
+If you want to contribute to the Flow framework, please have a look at
+https://github.com/neos/flow-development-collection - it is the repository
+used for development and all pull requests should go into it.
+
+
+Dependencies
+------------
+Strictly this package currently depends on the "typo3/flow" package due to
+the usage of BaseTestCase in the unit tests. That is the only dependency though and
+therefore this package is generally usable without flow.

--- a/Neos.Utility.Unicode/Tests/Unit/FunctionsTest.php
+++ b/Neos.Utility.Unicode/Tests/Unit/FunctionsTest.php
@@ -1,8 +1,8 @@
 <?php
-namespace TYPO3\Flow\Tests\Unit\Utility\Unicode;
+namespace Neos\Utitlity\Unicode\Tests\Unit;
 
 /*
- * This file is part of the TYPO3.Flow package.
+ * This file is part of the Neos.Utility.Unicode package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -245,9 +245,9 @@ class FunctionsTest extends \TYPO3\Flow\Tests\UnitTestCase
     public function pathinfoWorksWithCertainSpecialChars()
     {
         $testString = 'кириллическийПуть/кириллическоеИмя.расширение';
-        $this->assertEquals('кириллическийПуть', \TYPO3\Flow\Utility\Unicode\Functions::pathinfo($testString, PATHINFO_DIRNAME), 'pathinfo() did not return the correct dirname for a unicode path.');
-        $this->assertEquals('кириллическоеИмя.расширение', \TYPO3\Flow\Utility\Unicode\Functions::pathinfo($testString, PATHINFO_BASENAME), 'pathinfo() did not return the correct basename for a unicode path.');
-        $this->assertEquals('расширение', \TYPO3\Flow\Utility\Unicode\Functions::pathinfo($testString, PATHINFO_EXTENSION), 'pathinfo() did not return the correct extension for a unicode path.');
-        $this->assertEquals('кириллическоеИмя', \TYPO3\Flow\Utility\Unicode\Functions::pathinfo($testString, PATHINFO_FILENAME), 'pathinfo() did not return the correct filename for a unicode path.');
+        $this->assertEquals('кириллическийПуть', Functions::pathinfo($testString, PATHINFO_DIRNAME), 'pathinfo() did not return the correct dirname for a unicode path.');
+        $this->assertEquals('кириллическоеИмя.расширение', Functions::pathinfo($testString, PATHINFO_BASENAME), 'pathinfo() did not return the correct basename for a unicode path.');
+        $this->assertEquals('расширение', Functions::pathinfo($testString, PATHINFO_EXTENSION), 'pathinfo() did not return the correct extension for a unicode path.');
+        $this->assertEquals('кириллическоеИмя', Functions::pathinfo($testString, PATHINFO_FILENAME), 'pathinfo() did not return the correct filename for a unicode path.');
     }
 }

--- a/Neos.Utility.Unicode/Tests/Unit/FunctionsTest.php
+++ b/Neos.Utility.Unicode/Tests/Unit/FunctionsTest.php
@@ -17,7 +17,7 @@ use TYPO3\Flow\Utility\Unicode\Functions;
  * Testcase for the PHP6 Functions backport
  *
  */
-class FunctionsTest extends \TYPO3\Flow\Tests\UnitTestCase
+class FunctionsTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * Checks if strtotitle() at least works with latin characters.

--- a/Neos.Utility.Unicode/Tests/Unit/TextIteratorTest.php
+++ b/Neos.Utility.Unicode/Tests/Unit/TextIteratorTest.php
@@ -17,7 +17,7 @@ use TYPO3\Flow\Utility\Unicode\TextIterator;
  * Testcase for the TextIterator port
  *
  */
-class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
+class TextIteratorTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * Checks if a new instance with the default iterator type can be created

--- a/Neos.Utility.Unicode/Tests/Unit/TextIteratorTest.php
+++ b/Neos.Utility.Unicode/Tests/Unit/TextIteratorTest.php
@@ -1,8 +1,8 @@
 <?php
-namespace TYPO3\Flow\Tests\Unit\Utility\Unicode;
+namespace Neos\Utitlity\Tests\Unit;
 
 /*
- * This file is part of the TYPO3.Flow package.
+ * This file is part of the Neos.Utility.Unicode package.
  *
  * (c) Contributors of the Neos Project - www.neos.io
  *
@@ -10,6 +10,8 @@ namespace TYPO3\Flow\Tests\Unit\Utility\Unicode;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+
+use TYPO3\Flow\Utility\Unicode\TextIterator;
 
 /**
  * Testcase for the TextIterator port
@@ -24,8 +26,8 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function canCreateIteratorOfDefaultType()
     {
-        $iterator = new \TYPO3\Flow\Utility\Unicode\TextIterator('Some string');
-        $this->assertInstanceOf(\TYPO3\Flow\Utility\Unicode\TextIterator::class, $iterator);
+        $iterator = new TextIterator('Some string');
+        $this->assertInstanceOf(TextIterator::class, $iterator);
     }
 
     /**
@@ -35,8 +37,8 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function instantiatingCharacterIteratorWorks()
     {
-        $characterIterator = new \TYPO3\Flow\Utility\Unicode\TextIterator('Some string', \TYPO3\Flow\Utility\Unicode\TextIterator::CHARACTER);
-        $this->assertInstanceOf(\TYPO3\Flow\Utility\Unicode\TextIterator::class, $characterIterator);
+        $characterIterator = new TextIterator('Some string', TextIterator::CHARACTER);
+        $this->assertInstanceOf(TextIterator::class, $characterIterator);
     }
 
     /**
@@ -46,8 +48,8 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function instantiatingWordIteratorWorks()
     {
-        $wordIterator = new \TYPO3\Flow\Utility\Unicode\TextIterator('Some string', \TYPO3\Flow\Utility\Unicode\TextIterator::WORD);
-        $this->assertInstanceOf(\TYPO3\Flow\Utility\Unicode\TextIterator::class, $wordIterator);
+        $wordIterator = new TextIterator('Some string', TextIterator::WORD);
+        $this->assertInstanceOf(TextIterator::class, $wordIterator);
     }
 
 
@@ -58,8 +60,8 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function instantiatingSentenceIteratorWorks()
     {
-        $sentenceIterator = new \TYPO3\Flow\Utility\Unicode\TextIterator('Some string', \TYPO3\Flow\Utility\Unicode\TextIterator::SENTENCE);
-        $this->assertInstanceOf(\TYPO3\Flow\Utility\Unicode\TextIterator::class, $sentenceIterator);
+        $sentenceIterator = new TextIterator('Some string', TextIterator::SENTENCE);
+        $this->assertInstanceOf(TextIterator::class, $sentenceIterator);
     }
 
     /**
@@ -69,8 +71,8 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function instantiatingLineIteratorWorks()
     {
-        $lineIterator = new \TYPO3\Flow\Utility\Unicode\TextIterator('Some string', \TYPO3\Flow\Utility\Unicode\TextIterator::LINE);
-        $this->assertInstanceOf(\TYPO3\Flow\Utility\Unicode\TextIterator::class, $lineIterator);
+        $lineIterator = new TextIterator('Some string', TextIterator::LINE);
+        $this->assertInstanceOf(TextIterator::class, $lineIterator);
     }
 
 
@@ -82,9 +84,9 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
     public function instantiatingIteratorWithInvalidTypeThrowsError()
     {
         try {
-            new \TYPO3\Flow\Utility\Unicode\TextIterator('Some string', 948);
+            new TextIterator('Some string', 948);
             $this->fail('Constructor did not reject invalid TextIterator type.');
-        } catch (\TYPO3\Flow\Error\Exception $exception) {
+        } catch (\TYPO3\Flow\Utility\Unicode\Exception $exception) {
             $this->assertContains('Invalid iterator type in TextIterator constructor', $exception->getMessage(), 'Wrong error message.');
         }
     }
@@ -96,7 +98,7 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function characterIterationBasicallyWorks()
     {
-        $iterator = new \TYPO3\Flow\Utility\Unicode\TextIterator('This is a test string. Let\'s iterate it by character...', \TYPO3\Flow\Utility\Unicode\TextIterator::CHARACTER);
+        $iterator = new TextIterator('This is a test string. Let\'s iterate it by character...', TextIterator::CHARACTER);
         $iterator->rewind();
         $result = '';
         foreach ($iterator as $currentCharacter) {
@@ -112,7 +114,7 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function wordIterationBasicallyWorks()
     {
-        $iterator = new \TYPO3\Flow\Utility\Unicode\TextIterator('This is a test string. Let\'s iterate it by word...', \TYPO3\Flow\Utility\Unicode\TextIterator::WORD);
+        $iterator = new TextIterator('This is a test string. Let\'s iterate it by word...', TextIterator::WORD);
         $iterator->rewind();
         $result = '';
         foreach ($iterator as $currentWord) {
@@ -128,7 +130,7 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function sentenceIterationBasicallyWorks()
     {
-        $iterator = new \TYPO3\Flow\Utility\Unicode\TextIterator('This is a test string. Let\'s iterate it by sentence...', \TYPO3\Flow\Utility\Unicode\TextIterator::SENTENCE);
+        $iterator = new TextIterator('This is a test string. Let\'s iterate it by sentence...', TextIterator::SENTENCE);
         $iterator->rewind();
         $result = '';
         foreach ($iterator as $currentSentence) {
@@ -144,7 +146,7 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function lineIterationBasicallyWorks()
     {
-        $iterator = new \TYPO3\Flow\Utility\Unicode\TextIterator("This is a test string. \nLet's iterate \nit by line...", \TYPO3\Flow\Utility\Unicode\TextIterator::LINE);
+        $iterator = new TextIterator("This is a test string. \nLet's iterate \nit by line...", TextIterator::LINE);
         $iterator->rewind();
         $result = '';
         foreach ($iterator as $currentLine) {
@@ -160,7 +162,7 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function offsetInCharacterIterationBasicallyWorks()
     {
-        $iterator = new \TYPO3\Flow\Utility\Unicode\TextIterator('This is a test string. Let\'s iterate it by character...', \TYPO3\Flow\Utility\Unicode\TextIterator::CHARACTER);
+        $iterator = new TextIterator('This is a test string. Let\'s iterate it by character...', TextIterator::CHARACTER);
         foreach ($iterator as $currentCharacter) {
             if ($currentCharacter == 'L') {
                 break;
@@ -176,7 +178,7 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function offsetInWordIterationBasicallyWorks()
     {
-        $iterator = new \TYPO3\Flow\Utility\Unicode\TextIterator('This is a test string. Let\'s iterate it by word...', \TYPO3\Flow\Utility\Unicode\TextIterator::WORD);
+        $iterator = new TextIterator('This is a test string. Let\'s iterate it by word...', TextIterator::WORD);
         foreach ($iterator as $currentWord) {
             if ($currentWord == 'iterate') {
                 break;
@@ -192,7 +194,7 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function offsetInSentenceIterationBasicallyWorks()
     {
-        $iterator = new \TYPO3\Flow\Utility\Unicode\TextIterator('This is a test string. Let\'s iterate it by word...', \TYPO3\Flow\Utility\Unicode\TextIterator::SENTENCE);
+        $iterator = new TextIterator('This is a test string. Let\'s iterate it by word...', TextIterator::SENTENCE);
         foreach ($iterator as $currentSentence) {
             if ($currentSentence == 'Let\'s iterate it by word.') {
                 break;
@@ -208,7 +210,7 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function firstBasicallyWorks()
     {
-        $iterator = new \TYPO3\Flow\Utility\Unicode\TextIterator('This is a test string. Let\'s iterate it by word...', \TYPO3\Flow\Utility\Unicode\TextIterator::WORD);
+        $iterator = new TextIterator('This is a test string. Let\'s iterate it by word...', TextIterator::WORD);
         $iterator->next();
         $this->assertEquals($iterator->first(), 'This', 'Wrong element returned by first().');
     }
@@ -220,7 +222,7 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function lastBasicallyWorks()
     {
-        $iterator = new \TYPO3\Flow\Utility\Unicode\TextIterator('This is a test string. Let\'s iterate it by word', \TYPO3\Flow\Utility\Unicode\TextIterator::WORD);
+        $iterator = new TextIterator('This is a test string. Let\'s iterate it by word', TextIterator::WORD);
         $iterator->rewind();
         $this->assertEquals($iterator->last(), 'word', 'Wrong element returned by last().');
     }
@@ -232,7 +234,7 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function getAllBasicallyWorks()
     {
-        $iterator = new \TYPO3\Flow\Utility\Unicode\TextIterator('This is a test string.', \TYPO3\Flow\Utility\Unicode\TextIterator::WORD);
+        $iterator = new TextIterator('This is a test string.', TextIterator::WORD);
 
         $expectedResult = array(
             0 => 'This',
@@ -257,7 +259,7 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function isBoundaryInCharacterIterationBasicallyWorks()
     {
-        $iterator = new \TYPO3\Flow\Utility\Unicode\TextIterator('This is a test string. Let\'s iterate it by character', \TYPO3\Flow\Utility\Unicode\TextIterator::CHARACTER);
+        $iterator = new TextIterator('This is a test string. Let\'s iterate it by character', TextIterator::CHARACTER);
         $iterator->rewind();
         while ($iterator->valid()) {
             $this->assertFalse($iterator->isBoundary(), 'Character iteration has no boundary elements.');
@@ -272,7 +274,7 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function isBoundaryInWordIterationBasicallyWorks()
     {
-        $iterator = new \TYPO3\Flow\Utility\Unicode\TextIterator('This is a test string. Let\'s iterate it by word', \TYPO3\Flow\Utility\Unicode\TextIterator::WORD);
+        $iterator = new TextIterator('This is a test string. Let\'s iterate it by word', TextIterator::WORD);
         $iterator->rewind();
         $this->assertFalse($iterator->isBoundary(), 'This element was a boundary element.');
 
@@ -287,7 +289,7 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function isBoundaryInSentenceIterationBasicallyWorks()
     {
-        $iterator = new \TYPO3\Flow\Utility\Unicode\TextIterator('This is a test string. Let\'s iterate it by sentence', \TYPO3\Flow\Utility\Unicode\TextIterator::SENTENCE);
+        $iterator = new TextIterator('This is a test string. Let\'s iterate it by sentence', TextIterator::SENTENCE);
         $iterator->rewind();
         $this->assertFalse($iterator->isBoundary(), 'This element was a boundary element.');
 
@@ -302,7 +304,7 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function isBoundaryInLineIterationBasicallyWorks()
     {
-        $iterator = new \TYPO3\Flow\Utility\Unicode\TextIterator("This is a test string. \nLet\'s iterate \nit by line", \TYPO3\Flow\Utility\Unicode\TextIterator::LINE);
+        $iterator = new TextIterator("This is a test string. \nLet\'s iterate \nit by line", TextIterator::LINE);
         $iterator->rewind();
         $this->assertFalse($iterator->isBoundary(), 'This element was a boundary element.');
 
@@ -317,7 +319,7 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function followingBasicallyWorks()
     {
-        $iterator = new \TYPO3\Flow\Utility\Unicode\TextIterator('This is a test string. Let\'s iterate it by word', \TYPO3\Flow\Utility\Unicode\TextIterator::WORD);
+        $iterator = new TextIterator('This is a test string. Let\'s iterate it by word', TextIterator::WORD);
 
         $this->assertEquals($iterator->following(11), 14, 'Wrong offset for the following element returned.');
     }
@@ -329,7 +331,7 @@ class TextIteratorTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function precedingBasicallyWorks()
     {
-        $iterator = new \TYPO3\Flow\Utility\Unicode\TextIterator('This is a test string. Let\'s iterate it by word', \TYPO3\Flow\Utility\Unicode\TextIterator::WORD);
+        $iterator = new TextIterator('This is a test string. Let\'s iterate it by word', TextIterator::WORD);
 
         $this->assertEquals($iterator->preceding(11), 10, 'Wrong offset for the preceding element returned.' . $iterator->preceding(11));
     }

--- a/Neos.Utility.Unicode/composer.json
+++ b/Neos.Utility.Unicode/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "neos/utility-unicode",
+    "type": "typo3-flow-framework",
+    "description": "Flow Unicode Utilities",
+    "homepage": "http://flow.typo3.org",
+    "license": ["MIT"],
+
+    "require": {
+        "php": ">=5.5.0",
+        "ext-mbstring": "*"
+    },
+    "autoload": {
+        "psr-0": {
+            "TYPO3\\Flow\\Utility\\Unicode": "Classes"
+        }
+    }
+}

--- a/Neos.Utility.Unicode/composer.json
+++ b/Neos.Utility.Unicode/composer.json
@@ -1,10 +1,9 @@
 {
     "name": "neos/utility-unicode",
-    "type": "typo3-flow-framework",
+    "type": "library",
     "description": "Flow Unicode Utilities",
     "homepage": "http://flow.typo3.org",
     "license": ["MIT"],
-
     "require": {
         "php": ">=5.5.0",
         "ext-mbstring": "*"
@@ -12,6 +11,11 @@
     "autoload": {
         "psr-0": {
             "TYPO3\\Flow\\Utility\\Unicode": "Classes"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "TYPO3\\Flow\\Utility\\Unicode\\Tests\\": "Tests"
         }
     }
 }

--- a/TYPO3.Flow/composer.json
+++ b/TYPO3.Flow/composer.json
@@ -11,8 +11,9 @@
         "ext-zlib": "*",
         "ext-SPL": "*",
         "ext-json": ">=1.2.0",
-        "ext-mbstring": "*",
         "ext-reflection": "*",
+
+        "neos/utility-unicode": "*",
 
         "typo3/fluid": "*",
         "typo3/eel": "*",

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
     "type": "neos-package-collection",
     "require": {
         "php": ">=5.5.0",
+        "ext-mbstring": "*",
         "ext-zlib": "*",
         "ext-SPL": "*",
         "ext-json": ">=1.2.0",
-        "ext-mbstring": "*",
         "ext-reflection": "*",
         "ramsey/uuid": "^3.0.0",
         "paragonie/random_compat": "^1.0",
@@ -23,6 +23,7 @@
         "neos/composer-plugin": "^1.0.1"
     },
     "replace": {
+        "neos/utility-unicode": "self.version",
         "typo3/eel": "self.version",
         "typo3/flow": "self.version",
         "typo3/fluid": "self.version",
@@ -36,6 +37,7 @@
     },
     "autoload": {
         "psr-0": {
+            "TYPO3\\Flow\\Utility\\Unicode": "Neos.Utility.Unicode/Classes",
             "TYPO3\\Eel": "TYPO3.Eel/Classes",
             "TYPO3\\Flow": "TYPO3.Flow/Classes",
             "TYPO3\\Fluid": "TYPO3.Fluid/Classes",


### PR DESCRIPTION
Moves the unicode utilities of Flow to a separate package
retaining the original class namespace for backwards compatibility.
Additionally a few dependencies were cut without changing functionality.