### PR TITLE
TASK: Memcached cache backend compatibility with memcached

### DIFF
--- a/TYPO3.Flow/Tests/Unit/Cache/Backend/MemcacheBackendTest.php
+++ b/TYPO3.Flow/Tests/Unit/Cache/Backend/MemcacheBackendTest.php
@@ -1,0 +1,23 @@
+<?php
+namespace TYPO3\Flow\Tests\Unit\Cache\Backend;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Core\ApplicationContext;
+
+/**
+ * Testcase for the cache to memcache backend
+ *
+ * @requires extension memcache
+ */
+class MemcacheBackendTest extends MemcachedBackendTest
+{
+}

--- a/TYPO3.Flow/Tests/Unit/Cache/Backend/MemcachedBackendTest.php
+++ b/TYPO3.Flow/Tests/Unit/Cache/Backend/MemcachedBackendTest.php
@@ -16,7 +16,7 @@ use TYPO3\Flow\Core\ApplicationContext;
 /**
  * Testcase for the cache to memcached backend
  *
- * @requires extension memcache
+ * @requires extension memcached
  */
 class MemcachedBackendTest extends \TYPO3\Flow\Tests\UnitTestCase
 {


### PR DESCRIPTION
Adds support for the "memcached" extension in addition to the existing
support for the "memcache" extension.

"memcached" is a newer version with several improvements and often both
extensions aren't available simultaneously.

FLOW-440 #close