### PR TITLE
BUGFIX: Accept multiple autoload paths for Flow packages

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Composer/ComposerUtility.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Composer/ComposerUtility.php
@@ -176,7 +176,9 @@ class ComposerUtility
     }
 
     /**
-     * Flushes the internal caches  for manifest files and composer lock.
+     * Flushes the internal caches for manifest files and composer lock.
+     *
+     * @return void
      */
     public static function flushCaches()
     {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Composer/ComposerUtility.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Composer/ComposerUtility.php
@@ -174,4 +174,13 @@ class ComposerUtility
 
         return $manifest;
     }
+
+    /**
+     * Flushes the internal caches  for manifest files and composer lock.
+     */
+    public static function flushCaches()
+    {
+        static::$composerLockCache = [];
+        static::$composerManifestCache = [];
+    }
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageFactory.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageFactory.php
@@ -78,8 +78,8 @@ class PackageFactory
         }
 
         $possiblePackageClassPaths = [
-            Files::concatenatePaths(array('Classes', 'Package.php')),
-            Files::concatenatePaths(array('Classes', str_replace('.', '/', $packageKey), 'Package.php'))
+            Files::concatenatePaths(['Classes', 'Package.php']),
+            Files::concatenatePaths(['Classes', str_replace('.', '/', $packageKey), 'Package.php'])
         ];
 
         $foundPackageClassPaths = array_filter($possiblePackageClassPaths, function ($packageClassPathAndFilename) use ($absolutePackagePath) {
@@ -104,6 +104,6 @@ class PackageFactory
             throw new Exception\CorruptPackageException(sprintf('The package "%s" does not contain a valid package class. Check if the file "%s" really contains a class.', $packageKey, $packageClassPathAndFilename), 1327587091);
         }
 
-        return array('className' => $packageClassName, 'pathAndFilename' => $packageClassPathAndFilename);
+        return ['className' => $packageClassName, 'pathAndFilename' => $packageClassPathAndFilename];
     }
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageFactory.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageFactory.php
@@ -11,6 +11,7 @@ namespace TYPO3\Flow\Package;
  * source code.
  */
 
+use TYPO3\Flow\Composer\ComposerUtility;
 use TYPO3\Flow\Core\ClassLoader;
 use TYPO3\Flow\Package\Exception\InvalidPackagePathException;
 use TYPO3\Flow\Utility\Files;
@@ -38,7 +39,7 @@ class PackageFactory
         $absolutePackagePath = Files::concatenatePaths(array($packagesBasePath, $packagePath)) . '/';
 
         if ($packageClassInformation === null) {
-            $packageClassInformation = $this->detectFlowPackageFilePath($packageKey, $absolutePackagePath, $autoloadConfiguration);
+            $packageClassInformation = $this->detectFlowPackageFilePath($packageKey, $absolutePackagePath);
         }
 
         $packageClassName = Package::class;
@@ -61,25 +62,41 @@ class PackageFactory
      *
      * @param string $packageKey The package key
      * @param string $absolutePackagePath Absolute path to the package
-     * @param array $autoloadDirectives
      * @return array The path to the package file and classname for this package or an empty array if none was found.
      * @throws Exception\CorruptPackageException
      * @throws InvalidPackagePathException
      */
-    public function detectFlowPackageFilePath($packageKey, $absolutePackagePath, array $autoloadDirectives = [])
+    public function detectFlowPackageFilePath($packageKey, $absolutePackagePath)
     {
         if (!is_dir($absolutePackagePath)) {
             throw new InvalidPackagePathException(sprintf('The given package path "%s" is not a readable directory.', $absolutePackagePath), 1445904440);
         }
-        if (isset($autoloadDirectives[ClassLoader::MAPPING_TYPE_PSR4])) {
-            $packageClassPathAndFilename = Files::concatenatePaths(array('Classes', 'Package.php'));
-        } else {
-            $packageClassPathAndFilename = Files::concatenatePaths(array('Classes', str_replace('.', '/', $packageKey), 'Package.php'));
-        }
-        $absolutePackageClassPath = Files::concatenatePaths(array($absolutePackagePath, $packageClassPathAndFilename));
-        if (!is_file($absolutePackageClassPath)) {
+
+        $composerManifest = ComposerUtility::getComposerManifest($absolutePackagePath);
+        if (!ComposerUtility::isFlowPackageType(isset($composerManifest['type']) ? $composerManifest['type'] : '')) {
             return [];
         }
+
+        $possiblePackageClassPaths = [
+            Files::concatenatePaths(array('Classes', 'Package.php')),
+            Files::concatenatePaths(array('Classes', str_replace('.', '/', $packageKey), 'Package.php'))
+        ];
+
+        $foundPackageClassPaths = array_filter($possiblePackageClassPaths, function ($packageClassPathAndFilename) use ($absolutePackagePath) {
+            $absolutePackageClassPath = Files::concatenatePaths([$absolutePackagePath, $packageClassPathAndFilename]);
+            return is_file($absolutePackageClassPath);
+        });
+
+        if ($foundPackageClassPaths === []) {
+            return [];
+        }
+
+        if (count($foundPackageClassPaths) > 1) {
+            throw new Exception\CorruptPackageException(sprintf('The package "%s" contains multiple possible "Package.php" files. Please make sure that only one "Package.php" exists in the autoload root(s) of your Flow package.', $packageKey), 1457454840);
+        }
+
+        $packageClassPathAndFilename = reset($foundPackageClassPaths);
+        $absolutePackageClassPath = Files::concatenatePaths([$absolutePackagePath, $packageClassPathAndFilename]);
 
         $packageClassContents = file_get_contents($absolutePackageClassPath);
         $packageClassName = (new PhpAnalyzer($packageClassContents))->extractFullyQualifiedClassName();

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
@@ -933,7 +933,7 @@ class PackageManager implements PackageManagerInterface
             'packagePath' => str_replace($this->packagesBasePath, '', $packagePath),
             'composerName' => $composerManifest['name'],
             'autoloadConfiguration' => $autoload,
-            'packageClassInformation' => $this->packageFactory->detectFlowPackageFilePath($packageKey, $packagePath, $autoload)
+            'packageClassInformation' => $this->packageFactory->detectFlowPackageFilePath($packageKey, $packagePath)
         ];
     }
 

--- a/TYPO3.Flow/Tests/Unit/Package/PackageFactoryTest.php
+++ b/TYPO3.Flow/Tests/Unit/Package/PackageFactoryTest.php
@@ -61,7 +61,7 @@ class PackageFactoryTest extends UnitTestCase
         $packagePath = 'vfs://Packages/Some/Path/Some.Package/';
         $packageFilePath = $packagePath . 'Classes/Some/Package/Package.php';
         mkdir(dirname($packageFilePath), 0777, true);
-        file_put_contents($packagePath . 'composer.json', '{"name": "some/package", "type": "flow-test", "autoload": { "psr-0": { "Foo": "bar" }}}');
+        file_put_contents($packagePath . 'composer.json', '{"name": "some/package", "type": "neos-test", "autoload": { "psr-0": { "Foo": "bar" }}}');
         file_put_contents($packageFilePath, '<?php // no class');
 
         $this->packageFactory->create('vfs://Packages/', 'Some/Path/Some.Package/', 'Some.Package', 'some/package');
@@ -76,7 +76,7 @@ class PackageFactoryTest extends UnitTestCase
         $packagePath = 'vfs://Packages/Some/Path/Some.Package/';
         $packageFilePath = $packagePath . 'Classes/Some/Package/Package.php';
         mkdir(dirname($packageFilePath), 0777, true);
-        file_put_contents($packagePath . 'composer.json', '{"name": "some/package", "type": "flow-test", "autoload": { "psr-0": { "Foo": "bar" }}}');
+        file_put_contents($packagePath . 'composer.json', '{"name": "some/package", "type": "neos-test", "autoload": { "psr-0": { "Foo": "bar" }}}');
         file_put_contents($packageFilePath, '<?php namespace TYPO3\\Flow\\Fixtures { class CustomPackage1 {}}');
 
         require($packageFilePath);
@@ -92,7 +92,7 @@ class PackageFactoryTest extends UnitTestCase
         $packagePath = 'vfs://Packages/Some/Path/Some.Package/';
         $packageFilePath = $packagePath . 'Classes/Some/Package/Package.php';
         mkdir(dirname($packageFilePath), 0777, true);
-        file_put_contents($packagePath . 'composer.json', '{"name": "some/package", "type": "flow-test", "autoload": { "psr-0": { "Foo": "bar" }}}');
+        file_put_contents($packagePath . 'composer.json', '{"name": "some/package", "type": "neos-test", "autoload": { "psr-0": { "Foo": "bar" }}}');
         file_put_contents($packageFilePath, '<?php namespace TYPO3\\Flow\\Fixtures { class CustomPackage2 extends \\TYPO3\\Flow\\Package\\Package {}}');
 
         require($packageFilePath);
@@ -109,7 +109,7 @@ class PackageFactoryTest extends UnitTestCase
         $packagePath = 'vfs://Packages/Some/Path/Some.Package/';
         $packageFilePath = $packagePath . 'Classes/Package.php';
         mkdir(dirname($packageFilePath), 0777, true);
-        $rawComposerManifest = '{"name": "some/package", "type": "flow-test", "autoload": { "psr-4": { "Foo": "bar" }}}';
+        $rawComposerManifest = '{"name": "some/package", "type": "neos-test", "autoload": { "psr-4": { "Foo": "bar" }}}';
         $composerManifest = json_decode($rawComposerManifest, true);
         file_put_contents($packagePath . 'composer.json', $rawComposerManifest);
         file_put_contents($packageFilePath, '<?php namespace TYPO3\\Flow\\Fixtures { class CustomPackage3 extends \\TYPO3\\Flow\\Package\\Package {}}');
@@ -127,7 +127,7 @@ class PackageFactoryTest extends UnitTestCase
     {
         $packagePath = 'vfs://Packages/Some/Path/Some.Package/';
         mkdir($packagePath, 0777, true);
-        file_put_contents($packagePath . 'composer.json', '{"name": "some/package", "type": "flow-test"}');
+        file_put_contents($packagePath . 'composer.json', '{"name": "some/package", "type": "neos-test"}');
 
         $package = $this->packageFactory->create('vfs://Packages/', 'Some/Path/Some.Package/', 'Some.Package', 'some/package');
         $this->assertSame(\TYPO3\Flow\Package\Package::class, get_class($package));

--- a/TYPO3.Flow/Tests/Unit/Package/PackageFactoryTest.php
+++ b/TYPO3.Flow/Tests/Unit/Package/PackageFactoryTest.php
@@ -12,6 +12,7 @@ namespace TYPO3\Flow\Tests\Unit\Package;
  */
 
 use org\bovigo\vfs\vfsStream;
+use TYPO3\Flow\Composer\ComposerUtility;
 use TYPO3\Flow\Package\PackageFactory;
 use TYPO3\Flow\Package\PackageManager;
 use TYPO3\Flow\Reflection\ObjectAccess;
@@ -36,6 +37,7 @@ class PackageFactoryTest extends UnitTestCase
      */
     public function setUp()
     {
+        ComposerUtility::flushCaches();
         vfsStream::setup('Packages');
         $this->mockPackageManager = $this->getMockBuilder(\TYPO3\Flow\Package\PackageManager::class)->disableOriginalConstructor()->getMock();
         ObjectAccess::setProperty($this->mockPackageManager, 'composerManifestData', array(), true);

--- a/TYPO3.Flow/Tests/Unit/Package/PackageManagerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Package/PackageManagerTest.php
@@ -51,6 +51,7 @@ class PackageManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     protected function setUp()
     {
+        ComposerUtility::flushCaches();
         vfsStream::setup('Test');
         $this->mockBootstrap = $this->getMockBuilder(Bootstrap::class)->disableOriginalConstructor()->getMock();
         $this->mockBootstrap->expects($this->any())->method('getSignalSlotDispatcher')->will($this->returnValue($this->getMock(\TYPO3\Flow\SignalSlot\Dispatcher::class)));

--- a/TYPO3.Flow/Tests/Unit/Package/PackageTest.php
+++ b/TYPO3.Flow/Tests/Unit/Package/PackageTest.php
@@ -11,6 +11,7 @@ namespace TYPO3\Flow\Tests\Unit\Package;
  * source code.
  */
 
+use TYPO3\Flow\Composer\ComposerUtility;
 use TYPO3\Flow\Package\Package;
 use org\bovigo\vfs\vfsStream;
 use TYPO3\Flow\Package\PackageManager;
@@ -32,6 +33,7 @@ class PackageTest extends UnitTestCase
      */
     public function setUp()
     {
+        ComposerUtility::flushCaches();
         vfsStream::setup('Packages');
         $this->mockPackageManager = $this->getMockBuilder(\TYPO3\Flow\Package\PackageManager::class)->disableOriginalConstructor()->getMock();
         ObjectAccess::setProperty($this->mockPackageManager, 'composerManifestData', array(), true);


### PR DESCRIPTION
Flow packages with a PSR-4 and a PSR-0 autoload path will only search for a ``Package.php``
file in the PSR-4 class path, which breaks if the ``Package.php`` is actually in the PSR-0 path.
With this change Flow will search in both paths with a preference on the PSR-4 path as PSR-0
is deprecated. Additionally only Flow package types will be searched for ``Package.php`` files.
If both paths contain a ``Package.php`` file Flow will throw an Exception because we cannot
know which one to load.