### PR TITLE
FEATURE: Configurable application token and application name

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/HelpCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/HelpCommandController.php
@@ -46,6 +46,12 @@ class HelpCommandController extends CommandController
     protected $applicationPackageKey;
 
     /**
+     * @Flow\InjectConfiguration(path = "core.applicationName")
+     * @var string
+     */
+    protected $applicationName;
+
+    /**
      * @Flow\Inject
      * @var CommandManager
      */
@@ -64,7 +70,7 @@ class HelpCommandController extends CommandController
     {
         $context = $this->bootstrap->getContext();
         $applicationPackage = $this->packageManager->getPackage($this->applicationPackageKey);
-        $this->outputLine('<b>%s %s ("%s" context)</b>', array($applicationPackage->getComposerManifest('description'), $applicationPackage->getInstalledVersion() ?: 'dev', $context));
+        $this->outputLine('<b>%s %s ("%s" context)</b>', array($this->applicationName, $applicationPackage->getInstalledVersion() ?: 'dev', $context));
         $this->outputLine('<i>usage: %s <command identifier></i>', array($this->getFlowInvocationString()));
         $this->outputLine();
         $this->outputLine('See "%s help" for a list of all available commands.', array($this->getFlowInvocationString()));

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/RequestHandler.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/RequestHandler.php
@@ -182,9 +182,9 @@ class RequestHandler implements HttpRequestHandlerInterface
         $applicationIsFlow = ($this->settings['core']['applicationPackageKey'] === 'TYPO3.Flow');
         if ($this->settings['http']['applicationToken'] === 'ApplicationName') {
             if ($applicationIsFlow) {
-                $response->getHeaders()->set('X-Powered-By', 'Flow');
+                $response->getHeaders()->set('X-Flow-Powered', 'Flow');
             } else {
-                $response->getHeaders()->set('X-Powered-By', 'Flow ' . $this->settings['core']['applicationName']);
+                $response->getHeaders()->set('X-Flow-Powered', 'Flow ' . $this->settings['core']['applicationName']);
             }
             return;
         }
@@ -203,9 +203,9 @@ class RequestHandler implements HttpRequestHandlerInterface
         }
 
         if ($applicationIsFlow) {
-            $response->getHeaders()->set('X-Powered-By', 'Flow/' . ($flowVersion ?: 'dev'));
+            $response->getHeaders()->set('X-Flow-Powered', 'Flow/' . ($flowVersion ?: 'dev'));
         } else {
-            $response->getHeaders()->set('X-Powered-By', 'Flow/' . ($flowVersion ?: 'dev') . ' ' . $this->settings['core']['applicationName'] . '/' . ($applicationVersion ?: 'dev'));
+            $response->getHeaders()->set('X-Flow-Powered', 'Flow/' . ($flowVersion ?: 'dev') . ' ' . $this->settings['core']['applicationName'] . '/' . ($applicationVersion ?: 'dev'));
         }
     }
 
@@ -215,7 +215,8 @@ class RequestHandler implements HttpRequestHandlerInterface
      * @param string $version For example "2.3.7"
      * @return string For example "2"
      */
-    protected function renderMajorVersion($version) {
+    protected function renderMajorVersion($version)
+    {
         preg_match('/^(\d+)/', $version, $versionMatches);
         return isset($versionMatches[1]) ? $versionMatches[1] : '';
     }
@@ -226,7 +227,8 @@ class RequestHandler implements HttpRequestHandlerInterface
      * @param string $version For example "2.3.7"
      * @return string For example "2.3"
      */
-    protected function renderMinorVersion($version) {
+    protected function renderMinorVersion($version)
+    {
         preg_match('/^(\d+\.\d+)/', $version, $versionMatches);
         return isset($versionMatches[1]) ? $versionMatches[1] : '';
     }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/RequestHandler.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/RequestHandler.php
@@ -203,7 +203,7 @@ class RequestHandler implements HttpRequestHandlerInterface
         }
 
         if ($applicationIsFlow) {
-            $response->getHeaders()->set('X-Powered-By', 'Flow/' . $flowVersion ?: 'dev');
+            $response->getHeaders()->set('X-Powered-By', 'Flow/' . ($flowVersion ?: 'dev'));
         } else {
             $response->getHeaders()->set('X-Powered-By', 'Flow/' . ($flowVersion ?: 'dev') . ' ' . $this->settings['core']['applicationName'] . '/' . ($applicationVersion ?: 'dev'));
         }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Response.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Response.php
@@ -111,7 +111,6 @@ class Response extends AbstractMessage implements ResponseInterface
     public function __construct(Response $parentResponse = null)
     {
         $this->headers = new Headers();
-        $this->headers->set('X-Flow-Powered', 'Flow/' . FLOW_VERSION_BRANCH);
         $this->headers->set('Content-Type', 'text/html; charset=' . $this->charset);
         $this->parentResponse = $parentResponse;
     }

--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -36,10 +36,10 @@ TYPO3:
       context: ''
 
       # Key of the "main" package of the application. This package's meta data is used for displaying the application
-      # version and possibly other metadata in the X-Powered-By HTTP header, ./flow command line help and where else needed.
+      # version and possibly other metadata in the X-Flow-Powered HTTP header, ./flow command line help and where else needed.
       applicationPackageKey: 'TYPO3.Flow'
 
-      # Human-readable name of the "main" package of the application. This name is displayed in the X-Powered-By
+      # Human-readable name of the "main" package of the application. This name is displayed in the X-Flow-Powered
       # HTTP header, in the ./flow command line help and where else needed.
       applicationName: 'Flow'
 
@@ -141,7 +141,7 @@ TYPO3:
 
     http:
 
-      # Defines the "application token" which is sent by in HTTP Response "X-Powered-By" headers.
+      # Defines the "application token" which is sent by in HTTP Response "X-Flow-Powered" headers.
       #
       # The value can be one of:
       #

--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -36,8 +36,12 @@ TYPO3:
       context: ''
 
       # Key of the "main" package of the application. This package's meta data is used for displaying the application
-      # name, version etc. in the ./flow command line help and where else needed.
+      # version and possibly other metadata in the X-Powered-By HTTP header, ./flow command line help and where else needed.
       applicationPackageKey: 'TYPO3.Flow'
+
+      # Human-readable name of the "main" package of the application. This name is displayed in the X-Powered-By
+      # HTTP header, in the ./flow command line help and where else needed.
+      applicationName: 'Flow'
 
       # Path and filename of the PHP binary
       # The constant PHP_BINDIR usually contains the path, but on Windows this doesn't work reliably
@@ -137,10 +141,11 @@ TYPO3:
 
     http:
 
-      # Defines the "application token" which is sent by in HTTP Response "X-Flow-Powered" headers.
+      # Defines the "application token" which is sent by in HTTP Response "X-Powered-By" headers.
       #
       # The value can be one of:
       #
+      # - "Off" (no application token header is sent)
       # - "ApplicationName" (the application name only, determined via the TYPO3.Flow.core.applicationKey setting)
       # - "MajorVersion" (the application name + major version, e.g. "Neos/2"
       # - "MinorVersion" (the application name + minor version, e.g. "Neos/2.1"

--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -136,6 +136,17 @@ TYPO3:
       routes: []
 
     http:
+
+      # Defines the "application token" which is sent by in HTTP Response "X-Flow-Powered" headers.
+      #
+      # The value can be one of:
+      #
+      # - "ApplicationName" (the application name only, determined via the TYPO3.Flow.core.applicationKey setting)
+      # - "MajorVersion" (the application name + major version, e.g. "Neos/2"
+      # - "MinorVersion" (the application name + minor version, e.g. "Neos/2.1"
+      #
+      applicationToken: 'MinorVersion'
+
       # Defines an explicit base URI that should be used. This affects
       # resource management, routing and all other parts accessing
       # "Http\Request->getBaseUri()".

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
@@ -434,7 +434,7 @@ Sending a request and processing the response is a matter of a few lines::
 		 */
 		public function testAction() {
 			$this->browser->setRequestEngine($this->browserRequestEngine);
-			$response = $this->browser->request('http://flow.typo3.org');
+			$response = $this->browser->request('https://www.flowframework.io');
 			return ($response->hasHeader('X-Flow-Powered') ? 'yes' : 'no');
 		}
 	}

--- a/TYPO3.Flow/Tests/Unit/Fixtures/RawResponse-1.txt
+++ b/TYPO3.Flow/Tests/Unit/Fixtures/RawResponse-1.txt
@@ -1,7 +1,6 @@
 HTTP/1.1 200 OK
 Server: Apache/2.2.17 (Ubuntu)
-X-Powered-By: PHP/5.5.1-1ubuntu7.2
-X-Flow-Powered: Flow/1.2
+X-Powered-By: Flow/1.2
 Cache-Control: public, s-maxage=600
 Vary: Accept-Encoding
 Content-Encoding: gzip

--- a/TYPO3.Flow/Tests/Unit/Fixtures/RawResponse-1.txt
+++ b/TYPO3.Flow/Tests/Unit/Fixtures/RawResponse-1.txt
@@ -1,6 +1,6 @@
 HTTP/1.1 200 OK
 Server: Apache/2.2.17 (Ubuntu)
-X-Powered-By: Flow/1.2
+X-Flow-Powered: Flow/1.2
 Cache-Control: public, s-maxage=600
 Vary: Accept-Encoding
 Content-Encoding: gzip

--- a/TYPO3.Flow/Tests/Unit/Http/HeadersTest.php
+++ b/TYPO3.Flow/Tests/Unit/Http/HeadersTest.php
@@ -81,9 +81,9 @@ class HeadersTest extends UnitTestCase
     public function headerFieldsCanExistMultipleTimes()
     {
         $headers = new Headers();
-        $headers->set('X-Powered-By', 'Flow');
-        $headers->set('X-Powered-By', 'TYPO3', false);
-        $this->assertSame(array('Flow', 'TYPO3'), $headers->get('X-Powered-By'));
+        $headers->set('X-Flow-Powered', 'Flow');
+        $headers->set('X-Flow-Powered', 'TYPO3', false);
+        $this->assertSame(array('Flow', 'TYPO3'), $headers->get('X-Flow-Powered'));
     }
 
     /**
@@ -92,7 +92,7 @@ class HeadersTest extends UnitTestCase
     public function getReturnsNullForNonExistingHeader()
     {
         $headers = new Headers();
-        $headers->set('X-Powered-By', 'Flow');
+        $headers->set('X-Flow-Powered', 'Flow');
         $this->assertFalse($headers->has('X-Empowered-By'));
         $this->assertNull($headers->get('X-Empowered-By'));
     }

--- a/TYPO3.Flow/Tests/Unit/Http/ResponseTest.php
+++ b/TYPO3.Flow/Tests/Unit/Http/ResponseTest.php
@@ -39,8 +39,7 @@ class ResponseTest extends \TYPO3\Flow\Tests\UnitTestCase
             array(file_get_contents(__DIR__ . '/../Fixtures/RawResponse-1.txt'),
                 array(
                     'Server' => 'Apache/2.2.17 (Ubuntu)',
-                    'X-Powered-By' => 'PHP/5.5.1-1ubuntu7.2',
-                    'X-Flow-Powered' => 'Flow/1.2',
+                    'X-Powered-By' => 'Flow/1.2',
                     'Cache-Control' => 'public, s-maxage=600',
                     'Vary' => 'Accept-Encoding',
                     'Content-Encoding' => 'gzip',
@@ -217,11 +216,12 @@ class ResponseTest extends \TYPO3\Flow\Tests\UnitTestCase
 
         $expectedHeaders = array(
             'HTTP/1.1 123 Custom Status',
-            'X-Flow-Powered: Flow/' . FLOW_VERSION_BRANCH,
             'Content-Type: text/html; charset=UTF-8',
             'MyHeader: MyValue',
             'OtherHeader: OtherValue',
         );
+
+
 
         $this->assertEquals($expectedHeaders, $response->renderHeaders());
     }

--- a/TYPO3.Flow/Tests/Unit/Http/ResponseTest.php
+++ b/TYPO3.Flow/Tests/Unit/Http/ResponseTest.php
@@ -39,7 +39,7 @@ class ResponseTest extends \TYPO3\Flow\Tests\UnitTestCase
             array(file_get_contents(__DIR__ . '/../Fixtures/RawResponse-1.txt'),
                 array(
                     'Server' => 'Apache/2.2.17 (Ubuntu)',
-                    'X-Powered-By' => 'Flow/1.2',
+                    'X-Flow-Powered' => 'Flow/1.2',
                     'Cache-Control' => 'public, s-maxage=600',
                     'Vary' => 'Accept-Encoding',
                     'Content-Encoding' => 'gzip',


### PR DESCRIPTION
This change introduces two news setting. One which allows for configuring
what is exposed via the default "X-Powered-By" HTTP header and a
second one which allows for configuring a human-readable application
name.

Previously, the header ("X-Flow-Powered") exposed the full version number
of Flow which may be undesirable in certain setups. Through the new
setting `core.applicationToken` now one of three options can be chosen:

- "Off" (no X-Powered-By header is sent)
- "ApplicationName" (the application name only, determined via the core.applicationKey setting)
- "MajorVersion" (the application name + major version, e.g. "Neos/2"
- "MinorVersion" (the application name + minor version, e.g. "Neos/2.1"

The new `core.applicationName` setting is used for defining a human-
friendly name, like "Neos" or "Flow", which is used for the `./flow` help
message and in the X-Powered-By header.