### PR TITLE
TASK: Fix Configuration cache usage

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Configuration/ConfigurationManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Configuration/ConfigurationManager.php
@@ -366,8 +366,12 @@ class ConfigurationManager
             break;
 
             case self::CONFIGURATION_PROCESSING_TYPE_OBJECTS:
-                $this->loadConfiguration($configurationType, $this->packages);
-                $configuration = &$this->configurations[$configurationType];
+                if (!isset($this->configurations[$configurationType]) || $this->configurations[$configurationType] === []) {
+                    $this->loadConfiguration($configurationType, $this->packages);
+                }
+                if (isset($this->configurations[$configurationType])) {
+                    $configuration = &$this->configurations[$configurationType];
+                }
             break;
         }
 
@@ -594,6 +598,11 @@ class ConfigurationManager
      */
     protected function saveConfigurationCache()
     {
+        // Make sure that all configuration types are loaded before writing configuration caches.
+        foreach (array_keys($this->configurationTypes) as $configurationType) {
+            $this->getConfiguration($configurationType);
+        }
+
         $configurationCachePath = $this->environment->getPathToTemporaryDirectory() . 'Configuration/';
         if (!file_exists($configurationCachePath)) {
             Files::createDirectoryRecursively($configurationCachePath);

--- a/TYPO3.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -670,6 +670,20 @@ EOD;
         $this->mockContext->expects($this->any())->method('__toString')->will($this->returnValue('FooContext'));
         $configurationManager->_set('context', $this->mockContext);
         $configurationManager->_set('configurations', $mockConfigurations);
+        $configurationManager->_set('configurationTypes', [
+            ConfigurationManager::CONFIGURATION_TYPE_ROUTES => array(
+                'processingType' => ConfigurationManager::CONFIGURATION_PROCESSING_TYPE_ROUTES,
+                'allowSplitSource' => false
+            ),
+            ConfigurationManager::CONFIGURATION_TYPE_CACHES => array(
+                'processingType' => ConfigurationManager::CONFIGURATION_PROCESSING_TYPE_DEFAULT,
+                'allowSplitSource' => false
+            ),
+            ConfigurationManager::CONFIGURATION_TYPE_SETTINGS => array(
+                'processingType' => ConfigurationManager::CONFIGURATION_PROCESSING_TYPE_DEFAULT,
+                'allowSplitSource' => false
+            ),
+        ]);
 
         $configurationManager->_call('saveConfigurationCache');
 


### PR DESCRIPTION
The Objects configuration was never checked against the loaded
configuration cache but still saved sometimes. If a specific configuration type
was saved depended on the fact that it was loaded at the time of writing the
configuration cache. We now make sure that Objects configurations are also used
if they are cached and that we load all configuration types before writing the
cache.