### PR TITLE
TASK: Improve Doctrine CLI tooling

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/DoctrineCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/DoctrineCommandController.php
@@ -409,7 +409,6 @@ class DoctrineCommandController extends CommandController
         $this->outputLine('<info>%s</info>', [$status]);
         $this->outputLine();
         if ($migrationClassPathAndFilename) {
-
             $choices = ['Don\'t Move'];
             $packages = [null];
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/DoctrineCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/DoctrineCommandController.php
@@ -237,18 +237,23 @@ class DoctrineCommandController extends CommandController
      * Displays the migration configuration as well as the number of
      * available, executed and pending migrations.
      *
+     * @param boolean $showMigrations Output a list of all migrations and their status
+     * @param boolean $showDescriptions Show descriptions for the migrations (enables versions display)
      * @return void
      * @see typo3.flow:doctrine:migrate
      * @see typo3.flow:doctrine:migrationexecute
      * @see typo3.flow:doctrine:migrationgenerate
      * @see typo3.flow:doctrine:migrationversion
      */
-    public function migrationStatusCommand()
+    public function migrationStatusCommand($showMigrations = false, $showDescriptions = false)
     {
         // "driver" is used only for Doctrine, thus we (mis-)use it here
         // additionally, when no path is set, skip this step, assuming no DB is needed
         if ($this->settings['backendOptions']['driver'] !== null && $this->settings['backendOptions']['host'] !== null) {
-            $this->outputLine($this->doctrineService->getMigrationStatus());
+            if ($showDescriptions) {
+                $showMigrations = true;
+            }
+            $this->outputLine($this->doctrineService->getMigrationStatus($showMigrations, $showDescriptions));
         } else {
             $this->outputLine('Doctrine migration status not available, the driver and host backend options are not set in /Configuration/Settings.yaml.');
             $this->quit(1);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/DoctrineCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/DoctrineCommandController.php
@@ -13,6 +13,7 @@ namespace TYPO3\Flow\Command;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Util\Debug;
+use Doctrine\DBAL\Migrations\MigrationException;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Cli\CommandController;
 use TYPO3\Flow\Error\Debugger;
@@ -331,7 +332,7 @@ class DoctrineCommandController extends CommandController
     }
 
     /**
-     * Mark/unmark a migration as migrated
+     * Mark/unmark migrations as migrated
      *
      * If <u>all</u> is given as version, all available migrations are marked
      * as requested.
@@ -349,14 +350,14 @@ class DoctrineCommandController extends CommandController
     public function migrationVersionCommand($version, $add = false, $delete = false)
     {
         // "driver" is used only for Doctrine, thus we (mis-)use it here
-        // additionally, when no path is set, skip this step, assuming no DB is needed
+        // additionally, when no host is set, skip this step, assuming no DB is needed
         if ($this->settings['backendOptions']['driver'] !== null && $this->settings['backendOptions']['host'] !== null) {
             if ($add === false && $delete === false) {
                 throw new \InvalidArgumentException('You must specify whether you want to --add or --delete the specified version.');
             }
             try {
                 $this->doctrineService->markAsMigrated($version, $add ?: false);
-            } catch (\Doctrine\DBAL\Migrations\MigrationException $exception) {
+            } catch (MigrationException $exception) {
                 $this->outputLine($exception->getMessage());
                 $this->quit(1);
             }
@@ -384,7 +385,7 @@ class DoctrineCommandController extends CommandController
     public function migrationGenerateCommand($diffAgainstCurrent = true)
     {
         // "driver" is used only for Doctrine, thus we (mis-)use it here
-        // additionally, when no path is set, skip this step, assuming no DB is needed
+        // additionally, when no host is set, skip this step, assuming no DB is needed
         if ($this->settings['backendOptions']['driver'] === null || $this->settings['backendOptions']['host'] === null) {
             $this->outputLine('Doctrine migration generation has been SKIPPED, the driver and host backend options are not set in /Configuration/Settings.yaml.');
             $this->quit(1);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/Service.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/Service.php
@@ -417,7 +417,7 @@ class Service
             }
             return $output;
         } else {
-            return strip_tags(implode(PHP_EOL, $this->output));
+            return implode(PHP_EOL, $this->output);
         }
     }
 
@@ -476,12 +476,12 @@ class Service
 
             if ($markAsMigrated === true) {
                 if ($configuration->hasVersionMigrated($version) === true) {
-                    throw new MigrationException(sprintf('The version "%s" already exists in the version table.', $version));
+                    throw new MigrationException(sprintf('The version "%s" is already marked as executed.', $version));
                 }
                 $version->markMigrated();
             } else {
                 if ($configuration->hasVersionMigrated($version) === false) {
-                    throw new MigrationException(sprintf('The version "%s" does not exist in the version table.', $version));
+                    throw new MigrationException(sprintf('The version "%s" is already marked as not executed.', $version));
                 }
                 $version->markNotMigrated();
             }


### PR DESCRIPTION
This does some code style cleanup in the codebase and makes use of the improvements in Doctrine Migrations 1.3.

The output of `doctrine:migrationstatus` is improved vastly (shows executed but no longer available migrations, shorter default output, can show migration descriptions, color support).

Migration generation has been improved and the error handling and output of `doctrine:migrate` have been improved.

FLOW-292 #close
