### PR TITLE
TASK: Monitor only classes of packages with registered objects

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Object/ObjectManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Object/ObjectManager.php
@@ -464,6 +464,17 @@ class ObjectManager implements ObjectManagerInterface
     }
 
     /**
+     * Returns all current object configurations.
+     * For internal use in bootstrap only. Can change anytime.
+     *
+     * @return array
+     */
+    public function getAllObjectConfigurations()
+    {
+        return $this->objects;
+    }
+
+    /**
      * Invokes the Factory defined in the object configuration of the specified object in order
      * to build an instance. Arguments which were defined in the object configuration are
      * passed to the factory method.


### PR DESCRIPTION
With this change the amount of monitored class files is massively reduced
by only monitoring class files of packages that have active object
configurations.
This improves request time in development context noticeably.