### PR TITLE
BUGFIX: Log throwable errors in PHP 7

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Error/AbstractExceptionHandler.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Error/AbstractExceptionHandler.php
@@ -11,6 +11,8 @@ namespace TYPO3\Flow\Error;
  * source code.
  */
 
+use TYPO3\Flow\Log\ThrowableLoggerInterface;
+
 require_once('Exception.php');
 
 /**
@@ -76,7 +78,14 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
         if (is_object($this->systemLogger)) {
             $options = $this->resolveCustomRenderingOptions($exception);
             if (isset($options['logException']) && $options['logException']) {
-                if ($exception instanceof \Exception) {
+                if ($exception instanceof \Throwable) {
+                    if ($this->systemLogger instanceof ThrowableLoggerInterface) {
+                        $this->systemLogger->logThrowable($exception);
+                    } else {
+                        // Convert \Throwable to \Exception for non-supporting logger implementations
+                        $this->systemLogger->logException(new \Exception($exception->getMessage(), $exception->getCode()));
+                    }
+                } elseif ($exception instanceof \Exception) {
                     $this->systemLogger->logException($exception);
                 }
             }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Client/InternalRequestEngine.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Client/InternalRequestEngine.php
@@ -108,18 +108,12 @@ class InternalRequestEngine implements RequestEngineInterface
         $baseComponentChain = $objectManager->get('TYPO3\Flow\Http\Component\ComponentChain');
         $componentContext = new ComponentContext($httpRequest, $response);
 
-        if (version_compare(PHP_VERSION, '6.0.0') >= 0) {
-            try {
-                $baseComponentChain->handle($componentContext);
-            } catch (\Throwable $throwable) {
-                $this->prepareErrorResponse($throwable, $response);
-            }
-        } else {
-            try {
-                $baseComponentChain->handle($componentContext);
-            } catch (\Exception $exception) {
-                $this->prepareErrorResponse($exception, $response);
-            }
+        try {
+            $baseComponentChain->handle($componentContext);
+        } catch (\Throwable $throwable) {
+            $this->prepareErrorResponse($throwable, $response);
+        } catch (\Exception $exception) {
+            $this->prepareErrorResponse($exception, $response);
         }
         $session = $this->bootstrap->getObjectManager()->get('TYPO3\Flow\Session\SessionInterface');
         if ($session->isStarted()) {
@@ -141,7 +135,7 @@ class InternalRequestEngine implements RequestEngineInterface
     /**
      * Prepare a response in case an error occurred.
      *
-     * @param \Throwable $exception
+     * @param object $exception \Exception or \Throwable
      * @param Http\Response $response
      * @return void
      */

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Log/EarlyLogger.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Log/EarlyLogger.php
@@ -17,7 +17,7 @@ namespace TYPO3\Flow\Log;
  *
  * @api
  */
-class EarlyLogger implements SystemLoggerInterface
+class EarlyLogger implements ThrowableLoggerInterface
 {
     /**
      * @var array
@@ -28,6 +28,11 @@ class EarlyLogger implements SystemLoggerInterface
      * @var array
      */
     protected $exceptions = array();
+
+    /**
+     * @var array
+     */
+    protected $throwables = array();
 
     /**
      * Adds a backend to which the logger sends the logging data
@@ -63,6 +68,7 @@ class EarlyLogger implements SystemLoggerInterface
     {
         $this->logEntries = array();
         $this->exceptions = array();
+        $this->throwables = array();
     }
 
     /**
@@ -96,6 +102,19 @@ class EarlyLogger implements SystemLoggerInterface
     }
 
     /**
+     * Writes information about the given exception into the log.
+     *
+     * @param \Throwable $throwable The exception to log
+     * @param array $additionalData Additional data to log
+     * @return void
+     * @api
+     */
+    public function logThrowable(\Throwable $throwable, array $additionalData = array())
+    {
+        $this->throwables[] = func_get_args();
+    }
+
+    /**
      * Replays internal logs on provided logger. Use to transfer early logs to real logger when available.
      *
      * @see \TYPO3\Flow\Package\PackageManager
@@ -114,8 +133,13 @@ class EarlyLogger implements SystemLoggerInterface
             $logger->log('[Done replaying logs from instance of EarlyLogger.]');
         }
         if (count($this->exceptions) > 0) {
-            foreach ($this->logEntries as $logEntry) {
-                call_user_func_array(array($logger, 'logException'), $logEntry);
+            foreach ($this->exceptions as $exception) {
+                call_user_func_array(array($logger, 'logException'), $exception);
+            }
+        }
+        if (count($this->throwables) > 0 && $logger instanceof ThrowableLoggerInterface) {
+            foreach ($this->throwables as $throwable) {
+                call_user_func_array(array($logger, 'logThrowable'), $throwable);
             }
         }
         if ($resetLogs === true) {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Log/ThrowableLoggerInterface.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Log/ThrowableLoggerInterface.php
@@ -1,0 +1,40 @@
+<?php
+namespace TYPO3\Flow\Log;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Contract for a basic throwable logger interface
+ *
+ * The severities are (according to RFC3164) the PHP constants:
+ *   LOG_EMERG   # Emergency: system is unusable
+ *   LOG_ALERT   # Alert: action must be taken immediately
+ *   LOG_CRIT    # Critical: critical conditions
+ *   LOG_ERR     # Error: error conditions
+ *   LOG_WARNING # Warning: warning conditions
+ *   LOG_NOTICE  # Notice: normal but significant condition
+ *   LOG_INFO    # Informational: informational messages
+ *   LOG_DEBUG   # Debug: debug-level messages
+ *
+ * @api
+ */
+interface ThrowableLoggerInterface extends LoggerInterface
+{
+    /**
+     * Writes information about the given exception into the log.
+     *
+     * @param \Throwable $throwable The throwable to log
+     * @param array $additionalData Additional data to log
+     * @return void
+     * @api
+     */
+    public function logThrowable(\Throwable $throwable, array $additionalData = array());
+}

--- a/TYPO3.Flow/Tests/Unit/Aop/Pointcut/PointcutMethodNameFilterTest.php
+++ b/TYPO3.Flow/Tests/Unit/Aop/Pointcut/PointcutMethodNameFilterTest.php
@@ -94,7 +94,7 @@ class PointcutMethodNameFilterTest extends \TYPO3\Flow\Tests\UnitTestCase
                 array('arg1' => array(), 'arg2' => array(), 'arg3' => array())
         ));
 
-        $mockSystemLogger = $this->getMock('TYPO3\Flow\Log\Logger');
+        $mockSystemLogger = $this->getMock('TYPO3\Flow\Log\Logger', array('log'));
         $mockSystemLogger->expects($this->once())->method('log')->with($this->equalTo(
             'The argument "arg2" declared in pointcut does not exist in method ' . $className . '->somePublicMethod'
         ));


### PR DESCRIPTION
Throwable errors (``TypeError``, ``ParseError``, ..) introduced in PHP 7.0
are not logged in the system log. Which means these errors can only
be shown using the debug exception handler.

To fix this a new logger interface ``ThrowableLoggerInterface``
that extends the existing ``LoggerInface`` is introduced,
which adds supports throwables in addition to exceptions.

To support PHP7 in custom logger interfaces, the new interface needs
to be implemented. Otherwise throwables won't get logged.

FLOW-441 #close