### PR TITLE
BUGFIX: If query is null the condition break

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Request.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Request.php
@@ -148,7 +148,7 @@ class Request extends Message
             $defaultServerEnvironment['HTTP_CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
         }
 
-        $query = $uri->getQuery();
+        $query = trim($uri->getQuery());
         $fragment = $uri->getFragment();
         $overrideValues = array(
             'REQUEST_URI' => $uri->getPath() . ($query !== '' ? '?' . $query : '') . ($fragment !== '' ? '#' . $fragment : ''),

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Request.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Request.php
@@ -148,7 +148,7 @@ class Request extends Message
             $defaultServerEnvironment['HTTP_CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
         }
 
-        $query = trim($uri->getQuery());
+        $query = (string)$uri->getQuery();
         $fragment = $uri->getFragment();
         $overrideValues = array(
             'REQUEST_URI' => $uri->getPath() . ($query !== '' ? '?' . $query : '') . ($fragment !== '' ? '#' . $fragment : ''),


### PR DESCRIPTION
This change trim the query string, without this change the condition to build the request URI is wrong when the query is null and the URI contains a question mark without request arguments.