### PR TITLE
BUGFIX: Remove duplicate registration of ClassLoader

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
@@ -359,7 +359,6 @@ class ReflectionService
                 AnnotationReader::addGlobalIgnoredName($tagName);
             }
         }
-        AnnotationRegistry::registerLoader([$this->classLoader, 'loadClass']);
 
         $this->initialized = true;
     }


### PR DESCRIPTION
The Flow class loader is registered in doctrines annotation reader twice.
First in ``Booting\Scripts::registerClassLoaderInAnnotationRegistry()``
then again in the ReflectionService. As this is unnecessary and is not
directly related to the ReflectionService the second registration is
removed with this change.