### PR TITLE
BUGFIX: Remove duplicate registration of ClassLoader

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
@@ -344,7 +344,6 @@ class ReflectionService
         foreach ($this->settings['reflection']['ignoredTags'] as $tag) {
             AnnotationReader::addGlobalIgnoredName($tag);
         }
-        AnnotationRegistry::registerLoader(array($this->classLoader, 'loadClass'));
 
         $this->initialized = true;
     }


### PR DESCRIPTION
The Flow class loader is registered in doctrines annotation reader twice.
First in ``Booting\Scripts::registerClassLoaderInAnnotationRegistry()``
then again in the ReflectionService. As this is unnecessary and is not
directly related to the ReflectionService the second registration is
removed with this change.