### PR TITLE
TASK: Adjust unit tests mocks to new errors

### DIFF
--- a/TYPO3.Flow/Tests/Unit/Cache/Frontend/AbstractFrontendTest.php
+++ b/TYPO3.Flow/Tests/Unit/Cache/Frontend/AbstractFrontendTest.php
@@ -68,7 +68,7 @@ class AbstractFrontendTest extends \TYPO3\Flow\Tests\UnitTestCase
     public function flushByTagRejectsInvalidTags()
     {
         $identifier = 'someCacheIdentifier';
-        $backend = $this->getMock('TYPO3\Flow\Cache\Backend\BackendInterface');
+        $backend = $this->getMock('TYPO3\Flow\Cache\Backend\TaggableBackendInterface');
         $backend->expects($this->never())->method('flushByTag');
 
         $cache = $this->getMock('TYPO3\Flow\Cache\Frontend\StringFrontend', array('__construct', 'get', 'set', 'has', 'remove', 'getByTag'), array($identifier, $backend));

--- a/TYPO3.Flow/Tests/Unit/Cache/Frontend/StringFrontendTest.php
+++ b/TYPO3.Flow/Tests/Unit/Cache/Frontend/StringFrontendTest.php
@@ -111,8 +111,8 @@ class StringFrontendTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function getByTagRejectsInvalidTags()
     {
-        $backend = $this->getMock('TYPO3\Flow\Cache\Backend\BackendInterface', array(), array(), '', false);
-        $backend->expects($this->never())->method('getByTag');
+        $backend = $this->getMock('TYPO3\Flow\Cache\Backend\TaggableBackendInterface', array(), array(), '', false);
+        $backend->expects($this->never())->method('findIdentifiersByTag');
 
         $cache = new \TYPO3\Flow\Cache\Frontend\StringFrontend('StringFrontend', $backend);
         $cache->getByTag('SomeInvalid\Tag');

--- a/TYPO3.Flow/Tests/Unit/Cache/Frontend/VariableFrontendTest.php
+++ b/TYPO3.Flow/Tests/Unit/Cache/Frontend/VariableFrontendTest.php
@@ -168,8 +168,8 @@ class VariableFrontendTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function getByTagRejectsInvalidTags()
     {
-        $backend = $this->getMock('TYPO3\Flow\Cache\Backend\BackendInterface', array(), array(), '', false);
-        $backend->expects($this->never())->method('getByTag');
+        $backend = $this->getMock('TYPO3\Flow\Cache\Backend\TaggableBackendInterface', array(), array(), '', false);
+        $backend->expects($this->never())->method('findIdentifiersByTag');
 
         $cache = new \TYPO3\Flow\Cache\Frontend\VariableFrontend('VariableFrontend', $backend);
         $cache->getByTag('SomeInvalid\Tag');

--- a/TYPO3.Flow/Tests/Unit/Mvc/Routing/RouteTest.php
+++ b/TYPO3.Flow/Tests/Unit/Mvc/Routing/RouteTest.php
@@ -53,7 +53,6 @@ class RouteTest extends UnitTestCase
     public function setUp()
     {
         $this->mockObjectManager = $this->getMock('TYPO3\Flow\Object\ObjectManagerInterface');
-        $this->mockObjectManager->expects($this->any())->method('create')->will($this->returnCallback(array($this, 'objectManagerCallBack')));
         $this->route = $this->getAccessibleMock('TYPO3\Flow\Mvc\Routing\Route', array('dummy'));
         $this->route->_set('objectManager', $this->mockObjectManager);
 
@@ -73,16 +72,6 @@ class RouteTest extends UnitTestCase
         $mockHttpRequest->expects($this->any())->method('getRelativePath')->will($this->returnValue($routePath));
 
         return $this->route->matches($mockHttpRequest);
-    }
-
-    /**
-     * @return object but only mocks
-     */
-    public function objectManagerCallBack()
-    {
-        $arguments = func_get_args();
-        $objectName = array_shift($arguments);
-        return $this->getMock($objectName, array('dummy'), $arguments);
     }
 
     /*                                                                        *

--- a/TYPO3.Flow/Tests/Unit/Object/Proxy/ProxyMethodTest.php
+++ b/TYPO3.Flow/Tests/Unit/Object/Proxy/ProxyMethodTest.php
@@ -26,7 +26,6 @@ class ProxyMethodTest extends \TYPO3\Flow\Tests\UnitTestCase
 
         $mockReflectionService = $this->getMock('TYPO3\Flow\Reflection\ReflectionService', array(), array(), '', false);
         $mockReflectionService->expects($this->any())->method('hasMethod')->will($this->returnValue(true));
-        $mockReflectionService->expects($this->any())->method('getIgnoredTags')->will($this->returnValue(array('return')));
         $mockReflectionService->expects($this->any())->method('getMethodTagsValues')->with('My\Class\Name', 'myMethod')->will($this->returnValue(array(
             'param' => array('string $name')
         )));

--- a/TYPO3.Flow/Tests/Unit/Persistence/Generic/PersistenceManagerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Persistence/Generic/PersistenceManagerTest.php
@@ -260,20 +260,6 @@ class PersistenceManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
     /**
      * @test
      */
-    public function tearDownWithBackendNotSupportingTearDownDoesNothing()
-    {
-        $mockBackend = $this->getMock('TYPO3\Flow\Persistence\Generic\Backend\BackendInterface');
-        $mockBackend->expects($this->never())->method('tearDown');
-
-        $persistenceManager = new \TYPO3\Flow\Persistence\Generic\PersistenceManager();
-        $persistenceManager->injectBackend($mockBackend);
-
-        $persistenceManager->tearDown();
-    }
-
-    /**
-     * @test
-     */
     public function tearDownWithBackendSupportingTearDownDelegatesCallToBackend()
     {
         $methods = array_merge(get_class_methods('TYPO3\Flow\Persistence\Generic\Backend\BackendInterface'), array('tearDown'));

--- a/TYPO3.Flow/Tests/Unit/Resource/ResourceManagerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Resource/ResourceManagerTest.php
@@ -99,7 +99,7 @@ class ResourceManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
         $mockPackage = $this->getMock('TYPO3\Flow\Package\PackageInterface', array(), array(), '', false);
 
         $mockResourcePublisher = $this->getMock('TYPO3\Flow\Resource\Publishing\ResourcePublisher', array(), array(), '', false);
-        $mockResourcePublisher->expects($this->never())->method('publishStaticResource');
+        $mockResourcePublisher->expects($this->never())->method('publishStaticResources');
 
 
         $resourceManager = new \TYPO3\Flow\Resource\ResourceManager();

--- a/TYPO3.Flow/Tests/Unit/Security/ContextTest.php
+++ b/TYPO3.Flow/Tests/Unit/Security/ContextTest.php
@@ -391,7 +391,7 @@ class ContextTest extends UnitTestCase
             }
         ));
 
-        $securityContext = $this->getAccessibleMock('TYPO3\Flow\Security\Context', array('initialize'));
+        $securityContext = $this->getAccessibleMock('TYPO3\Flow\Security\Context', array('initialize', 'getAccount'));
         $securityContext->expects($this->any())->method('getAccount')->will($this->returnValue($account));
         $securityContext->_set('activeTokens', array($mockToken));
         $securityContext->_set('policyService', $mockPolicyService);
@@ -443,7 +443,7 @@ class ContextTest extends UnitTestCase
             }
         ));
 
-        $securityContext = $this->getAccessibleMock('TYPO3\Flow\Security\Context', array('initialize'));
+        $securityContext = $this->getAccessibleMock('TYPO3\Flow\Security\Context', array('initialize', 'getAccount'));
         $securityContext->expects($this->any())->method('getAccount')->will($this->returnValue($account));
         $securityContext->_set('activeTokens', array($mockToken));
         $securityContext->_set('policyService', $mockPolicyService);

--- a/TYPO3.Flow/Tests/Unit/Security/Policy/PolicyExpressionParserTest.php
+++ b/TYPO3.Flow/Tests/Unit/Security/Policy/PolicyExpressionParserTest.php
@@ -62,11 +62,8 @@ class PolicyExpressionParserTest extends \TYPO3\Flow\Tests\UnitTestCase
 
         );
 
-        $mockPointcutFilterComposite = $this->getMock('TYPO3\Flow\Aop\Pointcut\PointcutFilterComposite', array(), array(), '', false);
-
         $mockObjectManager = $this->getMock('TYPO3\Flow\Object\ObjectManagerInterface');
-        $mockObjectManager->expects($this->any())->method('create')->will($this->returnValue($mockPointcutFilterComposite));
-        $mockObjectManager->expects($this->any())->method('get')->will($this->returnValue($this->getMock('TYPO3\Flow\Log\SystemLoggerInterface')));
+        $mockObjectManager->expects($this->any())->method('get')->with('TYPO3\Flow\Log\SystemLoggerInterface')->will($this->returnValue($this->getMock('TYPO3\Flow\Log\SystemLoggerInterface')));
 
         $parser = new \TYPO3\Flow\Security\Policy\PolicyExpressionParser();
         $parser->injectObjectManager($mockObjectManager);

--- a/TYPO3.Flow/Tests/Unit/Security/Policy/PolicyServiceTest.php
+++ b/TYPO3.Flow/Tests/Unit/Security/Policy/PolicyServiceTest.php
@@ -1202,7 +1202,6 @@ class PolicyServiceTest extends \TYPO3\Flow\Tests\UnitTestCase
         ));
 
         $mockRoleRepository = $this->getMock('TYPO3\Flow\Security\Policy\RoleRepository');
-        $mockRoleRepository->expects($this->any())->method('isConnected')->will($this->returnValue(true));
 
         $mockPersistenceManager = $this->getMock('TYPO3\Flow\Persistence\PersistenceManagerInterface');
         $mockPersistenceManager->expects($this->any())->method('isConnected')->will($this->returnValue(true));

--- a/TYPO3.Flow/Tests/Unit/Validation/Validator/CollectionValidatorTest.php
+++ b/TYPO3.Flow/Tests/Unit/Validation/Validator/CollectionValidatorTest.php
@@ -26,7 +26,7 @@ class CollectionValidatorTest extends \TYPO3\Flow\Tests\Unit\Validation\Validato
     public function setUp()
     {
         parent::setUp();
-        $this->mockValidatorResolver = $this->getMock('TYPO3\Flow\Validation\ValidatorResolver', array(), array(), '', false);
+        $this->mockValidatorResolver = $this->getMock('TYPO3\Flow\Validation\ValidatorResolver', array('createValidator', 'buildBaseValidatorConjunction'), array(), '', false);
         $this->validator->_set('validatorResolver', $this->mockValidatorResolver);
     }
 

--- a/TYPO3.Fluid/Tests/Unit/ViewHelpers/Form/AbstractFormFieldViewHelperTest.php
+++ b/TYPO3.Fluid/Tests/Unit/ViewHelpers/Form/AbstractFormFieldViewHelperTest.php
@@ -32,9 +32,8 @@ class AbstractFormFieldViewHelperTest extends \TYPO3\Fluid\Tests\Unit\ViewHelper
 			public function __clone() {}
 		}');
         $object = $this->getMock($fullClassName);
-        $object->expects($this->any())->method('Flow_Persistence_isNew')->will($this->returnValue(false));
 
-        $formViewHelper = $this->getAccessibleMock('TYPO3\Fluid\ViewHelpers\Form\AbstractFormFieldViewHelper', array('dummy'), array(), '', false);
+        $formViewHelper = $this->getAccessibleMock('TYPO3\Fluid\ViewHelpers\Form\AbstractFormFieldViewHelper', array('isObjectAccessorMode'), array(), '', false);
         $this->injectDependenciesIntoViewHelper($formViewHelper);
         $formViewHelper->injectPersistenceManager($mockPersistenceManager);
 


### PR DESCRIPTION
Since ``phpunit-mock-objects`` 3.1.0 errors are thrown when a mocked
method is not allowed, non-existing, final or private.

This change adjusts to that change by getting rid of such mistakes in
the tests, which are made visible due to the change.