### PR TITLE
TASK: Adjust unit tests mocks to new errors

### DIFF
--- a/TYPO3.Flow/Tests/Unit/Cache/CacheFactoryTest.php
+++ b/TYPO3.Flow/Tests/Unit/Cache/CacheFactoryTest.php
@@ -45,7 +45,7 @@ class CacheFactoryTest extends UnitTestCase
         $this->mockEnvironment->expects($this->any())->method('getPathToTemporaryDirectory')->will($this->returnValue('vfs://Foo/'));
         $this->mockEnvironment->expects($this->any())->method('getMaximumPathLength')->will($this->returnValue(1024));
 
-        $this->mockCacheManager = $this->getMock('TYPO3\Flow\Cache\CacheManager', array('registerCache'), array(), '', false);
+        $this->mockCacheManager = $this->getMock('TYPO3\Flow\Cache\CacheManager', array('registerCache', 'isCachePersistent'), array(), '', false);
         $this->mockCacheManager->expects($this->any())->method('isCachePersistent')->will($this->returnValue(false));
     }
 


### PR DESCRIPTION
Since ``phpunit-mock-objects`` 3.1.0 errors are thrown when a mocked
method is not allowed, non-existing, final or private.

This change adjusts to that change by getting rid of such mistakes in
the tests, which are made visible due to the change.