### PR TITLE
BUGFIX: orphanRemoval must be a true integer

### DIFF
--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
@@ -635,7 +635,7 @@ metadata::
 	  /**
 	   * @var \Doctrine\Common\Collections\ArrayCollection<\TYPO3\Blog\Domain\Model\Comment>
 	   * @ORM\OneToMany(targetEntity="TYPO3\Blog\Domain\Model\Comment", mappedBy="post",
-	    cascade={"all"}, orphanRemoval="true")
+	    cascade={"all"}, orphanRemoval=true)
 	   * @ORM\OrderBy({"date" = "DESC"})
 	   */
 	  protected $comments;


### PR DESCRIPTION
Doctrine expects a true integer instead of a string (true in double quots) for the orphanRemoval property.