### PR TITLE
TASK: Remove Environment dependency of ConfigurationManager

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
@@ -197,13 +197,14 @@ class Scripts
             $environment->setTemporaryDirectoryBase(FLOW_PATH_TEMPORARY_BASE);
         }
 
+        $configurationManager->setTemporaryDirectoryPath($environment->getPathToTemporaryDirectory());
+
         $lockManager = new LockManager($settings['utility']['lockStrategyClassName'], ['lockDirectory' => Files::concatenatePaths([
             $environment->getPathToTemporaryDirectory(),
             'Lock'
         ])]);
         Lock::setLockManager($lockManager);
 
-        $configurationManager->injectEnvironment($environment);
         $packageManager->injectSettings($settings);
 
         $bootstrap->getSignalSlotDispatcher()->dispatch(\TYPO3\Flow\Configuration\ConfigurationManager::class, 'configurationManagerReady', array($configurationManager));

--- a/TYPO3.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -661,11 +661,8 @@ EOD;
             ConfigurationManager::CONFIGURATION_TYPE_SETTINGS => array('settings' => array('foo' => 'bar'))
         );
 
-        $mockEnvironment = $this->getMock(\TYPO3\Flow\Utility\Environment::class, array('getPathToTemporaryDirectory'), array(), '', false);
-        $mockEnvironment->expects($this->once())->method('getPathToTemporaryDirectory')->will($this->returnValue($temporaryDirectoryPath));
-
         $configurationManager = $this->getAccessibleMock(\TYPO3\Flow\Configuration\ConfigurationManager::class, array('postProcessConfiguration'), array(), '', false);
-        $configurationManager->injectEnvironment($mockEnvironment);
+        $configurationManager->setTemporaryDirectoryPath($temporaryDirectoryPath);
         $configurationManager->_set('includeCachedConfigurationsPathAndFilename', $includeCachedConfigurationsPathAndFilename);
         $this->mockContext->expects($this->any())->method('__toString')->will($this->returnValue('FooContext'));
         $configurationManager->_set('context', $this->mockContext);


### PR DESCRIPTION
The ConfigurationManager needs only the temporary path to store cached
configurations so we can inject just that and get rid of the dependency
to the ``Environment`` Utility.