### PR TITLE
TASK: Cache TypeConverterMap to avoid instantiating all TypeConverters

### DIFF
--- a/TYPO3.Flow/Configuration/Caches.yaml
+++ b/TYPO3.Flow/Configuration/Caches.yaml
@@ -128,3 +128,8 @@ Flow_Session_Storage:
 Flow_Aop_RuntimeExpressions:
   frontend: TYPO3\Flow\Cache\Frontend\PhpFrontend
   backend: TYPO3\Flow\Cache\Backend\SimpleFileBackend
+
+# Caches the map of possible PropertyMappers for source and target types
+Flow_PropertyMapper:
+  frontend: TYPO3\Flow\Cache\Frontend\VariableFrontend
+  backend: TYPO3\Flow\Cache\Backend\SimpleFileBackend

--- a/TYPO3.Flow/Configuration/Development/Caches.yaml
+++ b/TYPO3.Flow/Configuration/Development/Caches.yaml
@@ -1,0 +1,3 @@
+Flow_PropertyMapper:
+  frontend: TYPO3\Flow\Cache\Frontend\VariableFrontend
+  backend: TYPO3\Flow\Cache\Backend\NullBackend

--- a/TYPO3.Flow/Configuration/Objects.yaml
+++ b/TYPO3.Flow/Configuration/Objects.yaml
@@ -244,6 +244,20 @@ TYPO3\Flow\Persistence\Doctrine\Logging\SqlLogger:
           4:
             setting: TYPO3.Flow.log.sqlLogger.backendOptions
 
+#
+# Property
+#
+
+TYPO3\Flow\Property\PropertyMapper:
+  properties:
+    cache:
+      object:
+        factoryObjectName: TYPO3\Flow\Cache\CacheManager
+        factoryMethodName: getCache
+        arguments:
+          1:
+            value: Flow_PropertyMapper
+
 #                                                                          #
 # Resource                                                                 #
 #                                                                          #


### PR DESCRIPTION
The source and target types as well as priorities for all registered
``TypeConverters`` can be cached in Production context as they are not
changing. That avoids instantiating all ``TypeConverters`` on each
request saving some time.

NEOS-1288 #resolve