### PR TITLE
BUGFIX: Always set subpackage key when setting package key in forward

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/Controller/AbstractController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/Controller/AbstractController.php
@@ -196,8 +196,6 @@ abstract class AbstractController implements ControllerInterface
         }
         if ($packageKey !== null) {
             $nextRequest->setControllerPackageKey($packageKey);
-        }
-        if ($subpackageKey !== null) {
             $nextRequest->setControllerSubpackageKey($subpackageKey);
         }
 

--- a/TYPO3.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
@@ -194,7 +194,7 @@ class AbstractControllerTest extends UnitTestCase
     /**
      * @test
      */
-    public function forwardSetsAndResetsSubpackageKeyIfNeeded()
+    public function forwardSetsSubpackageKeyIfNeeded()
     {
         $mockPersistenceManager = $this->getMock('TYPO3\Flow\Persistence\PersistenceManagerInterface');
         $mockPersistenceManager->expects($this->any())->method('convertObjectsToIdentityArrays')->will($this->returnArgument(0));
@@ -212,6 +212,19 @@ class AbstractControllerTest extends UnitTestCase
             $controller->_call('forward', 'theTarget', 'Bar', 'MyPackage\MySubPackage', array('foo' => 'bar'));
         } catch (\TYPO3\Flow\Mvc\Exception\ForwardException $exception) {
         }
+    }
+
+    /**
+     * @test
+     */
+    public function forwardResetsSubpackageKeyIfNotSetInPackageKey()
+    {
+        $mockPersistenceManager = $this->getMock('TYPO3\Flow\Persistence\PersistenceManagerInterface');
+        $mockPersistenceManager->expects($this->any())->method('convertObjectsToIdentityArrays')->will($this->returnArgument(0));
+
+        $controller = $this->getAccessibleMock('TYPO3\Flow\Mvc\Controller\AbstractController', array('processRequest'));
+        $this->inject($controller, 'persistenceManager', $mockPersistenceManager);
+        $controller->_call('initializeController', $this->mockActionRequest, $this->mockHttpResponse);
 
         $this->mockActionRequest->expects($this->atLeastOnce())->method('setControllerActionName')->with('theTarget');
         $this->mockActionRequest->expects($this->atLeastOnce())->method('setControllerName')->with('Bar');

--- a/TYPO3.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
@@ -216,7 +216,7 @@ class AbstractControllerTest extends UnitTestCase
         $this->mockActionRequest->expects($this->atLeastOnce())->method('setControllerActionName')->with('theTarget');
         $this->mockActionRequest->expects($this->atLeastOnce())->method('setControllerName')->with('Bar');
         $this->mockActionRequest->expects($this->atLeastOnce())->method('setControllerPackageKey')->with('MyPackage');
-        $this->mockActionRequest->expects($this->never())->method('setControllerSubpackageKey');
+        $this->mockActionRequest->expects($this->atLeastOnce())->method('setControllerSubpackageKey')->with(null);
 
         try {
             $controller->_call('forward', 'theTarget', 'Bar', 'MyPackage', array('foo' => 'bar'));


### PR DESCRIPTION
The subpackage key is directly derived from the package key in the forward
method. Previously, if the subpackage key was not provided, it would not be
set in the next request.
Therefore to forward to a non-subpackage from a subpackage it was required
to specify the package key with trailing backslashes, so the subpackage key
would resolve to an empty string.

With this change it is possible by just specifying the actual package key
to forward to.