### PR TITLE
FEATURE: Add support for configuring trusted proxies

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Request.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Request.php
@@ -429,7 +429,7 @@ class Request extends AbstractMessage
      * If the argument is the string '*', all proxies are trusted.
      *
      * This is primarily useful for testing. If you want to set trusted headers, use the configuration setting
-     * "TYPO3.Flow.http.trustedProxies.headers" instead.
+     * "TYPO3.Flow.http.trustedProxies.proxies" instead.
      *
      * @param array|string $trustedProxies
      * @return void
@@ -507,7 +507,7 @@ class Request extends AbstractMessage
      * If no proxies are trusted or no client IP header is trusted, this is the remote address of the machine
      * directly connected to the server.
      *
-     * @return string The most trusted client's IP address
+     * @return string|bool The most trusted client's IP address or FALSE if no remote address can be found
      * @api
      */
     public function getTrustedClientIpAddress()

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Request.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Request.php
@@ -92,8 +92,19 @@ class Request extends AbstractMessage
     public function __construct(array $get, array $post, array $files, array $server)
     {
         if (self::$trustedProxiesSettings === null) {
-            $configurationManager = Bootstrap::$staticObjectManager->get(ConfigurationManager::class);
-            self::$trustedProxiesSettings = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow.http.trustedProxies');
+            self::$trustedProxiesSettings = [
+                'proxies' => '*',
+                'headers' => [
+                    self::HEADER_CLIENT_IP => 'X-Forwarded-For',
+                    self::HEADER_HOST => 'X-Forwarded-Host',
+                    self::HEADER_PORT => 'X-Forwarded-Port',
+                    self::HEADER_PROTOCOL => 'X-Forwarded-Proto'
+                ]
+            ];
+            if (Bootstrap::$staticObjectManager !== null) {
+                $configurationManager = Bootstrap::$staticObjectManager->get(ConfigurationManager::class);
+                self::$trustedProxiesSettings = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow.http.trustedProxies');
+            }
         }
 
         $this->headers = Headers::createFromServer($server);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Request.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Request.php
@@ -17,7 +17,7 @@ use TYPO3\Flow\Core\Bootstrap;
 use TYPO3\Flow\Mvc\ActionRequest;
 use TYPO3\Flow\Utility\Arrays;
 use TYPO3\Flow\Utility\MediaTypes;
-use TYPO3\Flow\Security\RequestPattern\Ip as IpPattern;
+use TYPO3\Flow\Utility\Ip as IpUtility;
 
 /**
  * Represents an HTTP request
@@ -486,9 +486,8 @@ class Request extends AbstractMessage
         if (self::$trustedProxiesSettings['proxies'] === '*') {
             return true;
         }
-        $ipMatcher = new IpPattern();
         foreach (self::$trustedProxiesSettings['proxies'] as $ipPattern) {
-            if ($ipMatcher->cidrMatch($ipAddress, $ipPattern)) {
+            if (IpUtility::cidrMatch($ipAddress, $ipPattern)) {
                 return true;
             }
         }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Request.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Request.php
@@ -12,9 +12,12 @@ namespace TYPO3\Flow\Http;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Configuration\ConfigurationManager;
+use TYPO3\Flow\Core\Bootstrap;
 use TYPO3\Flow\Mvc\ActionRequest;
 use TYPO3\Flow\Utility\Arrays;
 use TYPO3\Flow\Utility\MediaTypes;
+use TYPO3\Flow\Security\RequestPattern\Ip as IpPattern;
 
 /**
  * Represents an HTTP request
@@ -24,6 +27,11 @@ use TYPO3\Flow\Utility\MediaTypes;
  */
 class Request extends AbstractMessage
 {
+    const HEADER_CLIENT_IP = 'clientIp';
+    const HEADER_HOST = 'host';
+    const HEADER_PORT = 'port';
+    const HEADER_PROTOCOL = 'proto';
+
     /**
      * @var string
      */
@@ -59,6 +67,18 @@ class Request extends AbstractMessage
     protected $inputStreamUri = 'php://input';
 
     /**
+     * @var bool
+     */
+    protected $trustedProxy;
+
+    /**
+     * The "Trusted Proxies" settings from configuration.
+     *
+     * @var array
+     */
+    protected static $trustedProxiesSettings;
+
+    /**
      * Constructs a new Request object based on the given environment data.
      *
      * @param array $get Data similar to that which is typically provided by $_GET
@@ -71,7 +91,13 @@ class Request extends AbstractMessage
      */
     public function __construct(array $get, array $post, array $files, array $server)
     {
+        if (self::$trustedProxiesSettings === null) {
+            $configurationManager = Bootstrap::$staticObjectManager->get(ConfigurationManager::class);
+            self::$trustedProxiesSettings = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow.http.trustedProxies');
+        }
+
         $this->headers = Headers::createFromServer($server);
+        $this->server = $server;
         $method = isset($server['REQUEST_METHOD']) ? $server['REQUEST_METHOD'] : 'GET';
         if ($method === 'POST') {
             if (isset($post['__method'])) {
@@ -84,27 +110,34 @@ class Request extends AbstractMessage
         }
         $this->setMethod($method);
 
-        if ($this->headers->has('X-Forwarded-Proto')) {
-            $protocol = $this->headers->get('X-Forwarded-Proto');
+        $protocolHeader = $this->getTrustedProxyHeaderValues(self::HEADER_PROTOCOL);
+        if ($protocolHeader !== null) {
+            $protocol = reset($protocolHeader);
         } else {
             $protocol = isset($server['SSL_SESSION_ID']) || (isset($server['HTTPS']) && ($server['HTTPS'] === 'on' || strcmp($server['HTTPS'], '1') === 0)) ? 'https' : 'http';
         }
-        $host = isset($server['HTTP_HOST']) ? $server['HTTP_HOST'] : 'localhost';
+        $hostHeader = $this->getTrustedProxyHeaderValues(self::HEADER_HOST);
+        if ($hostHeader !== null) {
+            $host = reset($hostHeader);
+        } else {
+            $host = isset($server['HTTP_HOST']) ? $server['HTTP_HOST'] : 'localhost';
+        }
         $requestUri = isset($server['REQUEST_URI']) ? $server['REQUEST_URI'] : '/';
         if (substr($requestUri, 0, 10) === '/index.php') {
             $requestUri = '/' . ltrim(substr($requestUri, 10), '/');
         }
         $this->uri = new Uri($protocol . '://' . $host . $requestUri);
 
-        if ($this->headers->has('X-Forwarded-Port')) {
-            $this->uri->setPort($this->headers->get('X-Forwarded-Port'));
-        } elseif ($this->headers->has('X-Forwarded-Proto')) {
+        $portHeader = $this->getTrustedProxyHeaderValues(self::HEADER_PORT);
+        if ($portHeader !== null) {
+            $port = reset($portHeader);
+            $this->uri->setPort($port);
+        } elseif ($protocolHeader !== null) {
             $this->uri->setPort($protocol === 'https' ? 443 : 80);
         } elseif (isset($server['SERVER_PORT'])) {
             $this->uri->setPort($server['SERVER_PORT']);
         }
 
-        $this->server = $server;
         $this->arguments = $this->buildUnifiedArguments($get, $post, $files);
     }
 
@@ -370,6 +403,137 @@ class Request extends AbstractMessage
             $this->content = file_get_contents($this->inputStreamUri);
         }
         return $this->content;
+    }
+
+    /**
+     * Set a trusted proxy header.
+     *
+     * This is primarily useful for testing. If you want to set trusted headers, use the configuration setting
+     * "TYPO3.Flow.http.trustedProxies.headers" instead.
+     *
+     * @param string $type One of the HEADER_* constants
+     * @param string $name The header name to trust or an empty string to not trust this header
+     * @return void
+     */
+    public static function setTrustedProxyHeader($type, $name)
+    {
+        if (!in_array($type, array(self::HEADER_CLIENT_IP, self::HEADER_HOST, self::HEADER_PORT, self::HEADER_PROTOCOL))) {
+            return;
+        }
+        self::$trustedProxiesSettings['headers'][$type] = strval($name);
+    }
+
+    /**
+     * Set the trusted proxies IP addresses.
+     * If the argument is an empty array, no proxies are trusted.
+     * If the argument is the string '*', all proxies are trusted.
+     *
+     * This is primarily useful for testing. If you want to set trusted headers, use the configuration setting
+     * "TYPO3.Flow.http.trustedProxies.headers" instead.
+     *
+     * @param array|string $trustedProxies
+     * @return void
+     */
+    public static function setTrustedProxies($trustedProxies)
+    {
+        if (is_string($trustedProxies) && $trustedProxies !== '*' && $trustedProxies !== '') {
+            $trustedProxies = [$trustedProxies];
+        }
+        if (!is_array($trustedProxies) && $trustedProxies !== '*') {
+            $trustedProxies = [];
+        }
+        self::$trustedProxiesSettings['proxies'] = $trustedProxies;
+    }
+
+    /**
+     * Get the values of trusted proxy header.
+     *
+     * @param string $type One of the HEADER_* constants
+     * @return array|null An array of the values for this header type or NULL if this header type should not be trusted
+     */
+    protected function getTrustedProxyHeaderValues($type)
+    {
+        $trustedHeader = isset(self::$trustedProxiesSettings['headers'][$type]) ? self::$trustedProxiesSettings['headers'][$type] : '';
+
+        if ($trustedHeader !== '' && $this->isFromTrustedProxy() && $this->headers->has($trustedHeader)) {
+            return array_map('trim', explode(',', $this->headers->get($trustedHeader)));
+        }
+        return null;
+    }
+
+    /**
+     * Check if the given IP address is from a trusted proxy.
+     *
+     * @param string $ipAddress
+     * @return bool
+     */
+    protected function ipIsTrustedProxy($ipAddress)
+    {
+        if (filter_var($ipAddress, FILTER_VALIDATE_IP) === false) {
+            return false;
+        }
+        if (self::$trustedProxiesSettings['proxies'] === '*') {
+            return true;
+        }
+        $ipMatcher = new IpPattern();
+        foreach (self::$trustedProxiesSettings['proxies'] as $ipPattern) {
+            if ($ipMatcher->cidrMatch($ipAddress, $ipPattern)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Check if this request is coming from a trusted Proxy.
+     *
+     * @return bool
+     * @api
+     */
+    public function isFromTrustedProxy()
+    {
+        if ($this->trustedProxy === null) {
+            $remoteAddress = isset($this->server['REMOTE_ADDR']) ? $this->server['REMOTE_ADDR'] : '0.0.0.0';
+            $this->trustedProxy = $this->ipIsTrustedProxy($remoteAddress);
+        }
+        return $this->trustedProxy;
+    }
+
+    /**
+     * Get the most trusted client's IP address.
+     *
+     * This is the right-most address in the trusted client IP header, that is not a trusted proxy address.
+     * If all proxies are trusted, this is the left-most address in the header.
+     * If no proxies are trusted or no client IP header is trusted, this is the remote address of the machine
+     * directly connected to the server.
+     *
+     * @return string The most trusted client's IP address
+     * @api
+     */
+    public function getTrustedClientIpAddress()
+    {
+        if (!isset($this->server['REMOTE_ADDR'])) {
+            return false;
+        }
+
+        $trustedIpHeader = $this->getTrustedProxyHeaderValues(self::HEADER_CLIENT_IP);
+        if ($trustedIpHeader === null || self::$trustedProxiesSettings['proxies'] === []) {
+            return $this->server['REMOTE_ADDR'];
+        }
+
+        if (self::$trustedProxiesSettings['proxies'] === '*') {
+            return reset($trustedIpHeader);
+        }
+
+        foreach (array_reverse($trustedIpHeader) as $headerIpAddress) {
+            $portPosition = strpos($headerIpAddress, ':');
+            $ipAddress = $portPosition !== false ? substr($headerIpAddress, 0, $portPosition) : $headerIpAddress;
+            if (!$this->ipIsTrustedProxy($ipAddress)) {
+                break;
+            }
+        }
+
+        return $ipAddress;
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/RequestPattern/Ip.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/RequestPattern/Ip.php
@@ -14,6 +14,7 @@ namespace TYPO3\Flow\Security\RequestPattern;
 use TYPO3\Flow\Mvc\ActionRequest;
 use TYPO3\Flow\Mvc\RequestInterface;
 use TYPO3\Flow\Security\RequestPatternInterface;
+use TYPO3\Flow\Utility\Ip as IpUtility;
 
 /**
  * This class holds a CIDR IP pattern an decides, if a \TYPO3\Flow\Mvc\RequestInterface object matches against this pattern,
@@ -59,51 +60,6 @@ class Ip implements RequestPatternInterface
     }
 
     /**
-     * Matches a CIDR range pattern against an IP
-     *
-     * @param string $ip The IP to match
-     * @param string $range The CIDR range pattern to match against
-     * @return boolean TRUE if the pattern matched, FALSE otherwise
-     */
-    public function cidrMatch($ip, $range)
-    {
-        if (strpos($range, '/') === false) {
-            $bits = null;
-            $subnet = $range;
-        } else {
-            list($subnet, $bits) = explode('/', $range);
-        }
-
-        $ip = inet_pton($ip);
-        $subnet = inet_pton($subnet);
-        if ($ip === false || $subnet === false) {
-            return false;
-        }
-
-        if (strlen($ip) > strlen($subnet)) {
-            $subnet = str_pad($subnet, strlen($ip), chr(0), STR_PAD_LEFT);
-        } elseif (strlen($subnet) > strlen($ip)) {
-            $ip = str_pad($ip, strlen($subnet), chr(0), STR_PAD_LEFT);
-        }
-
-        if ($bits === null) {
-            return ($ip === $subnet);
-        } else {
-            for ($i = 0; $i < strlen($ip); $i++) {
-                $mask = 0;
-                if ($bits > 0) {
-                    $mask = ($bits >= 8) ? 255 : (256 - (1 << (8 - $bits)));
-                    $bits -= 8;
-                }
-                if ((ord($ip[$i]) & $mask) !== (ord($subnet[$i]) & $mask)) {
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
-    /**
      * Matches a \TYPO3\Flow\Mvc\RequestInterface against the set IP pattern rules
      *
      * @param RequestInterface $request The request that should be matched
@@ -114,6 +70,6 @@ class Ip implements RequestPatternInterface
         if (!$request instanceof ActionRequest) {
             return false;
         }
-        return (boolean)$this->cidrMatch($request->getHttpRequest()->getClientIpAddress(), $this->ipPattern);
+        return IpUtility::cidrMatch($request->getHttpRequest()->getClientIpAddress(), $this->ipPattern);
     }
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/RequestPattern/Ip.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/RequestPattern/Ip.php
@@ -65,7 +65,7 @@ class Ip implements RequestPatternInterface
      * @param string $range The CIDR range pattern to match against
      * @return boolean TRUE if the pattern matched, FALSE otherwise
      */
-    protected function cidrMatch($ip, $range)
+    public function cidrMatch($ip, $range)
     {
         if (strpos($range, '/') === false) {
             $bits = null;

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Ip.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Ip.php
@@ -1,0 +1,75 @@
+<?php
+namespace TYPO3\Flow\Utility;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A utility class for dealing with IP addresses.
+ *
+ */
+abstract class Ip
+{
+    /**
+     * Matches a CIDR range pattern against an IP
+     *
+     * The range can contain IPv4 and IPv6 addresses (including IPv6 wrapped IPv4 addresses).
+     * @see http://tools.ietf.org/html/rfc4632
+     * @see http://tools.ietf.org/html/rfc4291#section-2.3
+     *
+     * Example: 127.0.0.0/24 will match all IP addresses from 127.0.0.0 to 127.0.0.255
+     *          127.0.0.0/31 and 127.0.0.1/31 will both match the IP addresses 127.0.0.0 and 127.0.0.1
+     *          127.0.0.254/31 and 127.0.0.255/31 will both match the IP addresses 127.0.0.254 and 127.0.0.255
+     *          1:2::3:4 will match the IPv6 address written as 1:2:0:0:0:0:3:4 or 1:2::3:4
+     *          ::7F00:1 will match the address written as 127.0.0.1, ::127.0.0.1 or ::7F00:1
+     *          ::1 (IPv6 loopback) will *not* match the address 127.0.0.1
+     *
+     * @param string $ip The IP to match
+     * @param string $range The CIDR range pattern to match against
+     * @return boolean TRUE if the pattern matched, FALSE otherwise
+     */
+    public static function cidrMatch($ip, $range)
+    {
+        if (strpos($range, '/') === false) {
+            $bits = null;
+            $subnet = $range;
+        } else {
+            list($subnet, $bits) = explode('/', $range);
+        }
+
+        $ip = inet_pton($ip);
+        $subnet = inet_pton($subnet);
+        if ($ip === false || $subnet === false) {
+            return false;
+        }
+
+        if (strlen($ip) > strlen($subnet)) {
+            $subnet = str_pad($subnet, strlen($ip), chr(0), STR_PAD_LEFT);
+        } elseif (strlen($subnet) > strlen($ip)) {
+            $ip = str_pad($ip, strlen($subnet), chr(0), STR_PAD_LEFT);
+        }
+
+        if ($bits === null) {
+            return ($ip === $subnet);
+        } else {
+            for ($i = 0; $i < strlen($ip); $i++) {
+                $mask = 0;
+                if ($bits > 0) {
+                    $mask = ($bits >= 8) ? 255 : (256 - (1 << (8 - $bits)));
+                    $bits -= 8;
+                }
+                if ((ord($ip[$i]) & $mask) !== (ord($subnet[$i]) & $mask)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -189,7 +189,10 @@ TYPO3:
         # Defines Proxy servers which are trusted for setting request headers
         # By default all proxies are trusted ('*')
         # If you have some reverse proxies or CDN running in front of your server, you should provide
-        # an array list of those servers' addresses or address ranges (in CIDR notation) here:
+        # an array list of those servers' addresses or address ranges (in CIDR notation) here.
+        #
+        # If you do definitely not have any reverse proxy or CDN in front of your server, you should not
+        # trust any proxies and set this option to "[]", ie. an empty list.
         #
         # proxies:
         #   - '216.246.40.0/24'

--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -184,6 +184,25 @@ TYPO3:
               position: 'end'
               component: 'TYPO3\Flow\Http\Component\StandardsComplianceComponent'
 
+      trustedProxies:
+
+        # Defines Proxy servers which are trusted for setting request headers
+        # By default all proxies are trusted ('*')
+        # If you have some reverse proxies or CDN running in front of your server, you should provide
+        # an array list of those servers' addresses or address ranges (in CIDR notation) here:
+        #
+        # proxies:
+        #   - '216.246.40.0/24'
+        #   - '216.246.100.0/24'
+        proxies: '*'
+
+        # Defines request headers which are trusted from proxies to override important request information
+        headers:
+          clientIp: 'X-Forwarded-For'
+          host: 'X-Forwarded-Host'
+          port: 'X-Forwarded-Port'
+          proto: 'X-Forwarded-Proto'
+
     log:
 
       # Settings for Flow's default loggers

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
@@ -278,6 +278,44 @@ By sending a ``POST`` request and specifying the ``__method`` argument, the requ
 
 Additionally Flow respects the ``X-HTTP-Method`` respectively ``X-HTTP-Method-Override`` header.
 
+Trusted Proxies
+~~~~~~~~~~~~~~~
+
+If your server is behind a reverse proxy or a CDN, some of the request informations like the the host name, the port,
+the protocol and the original client IP address are provided via additional request headers.
+Since those headers can also easily be sent by an adversary, possibly bypassing security measurements, you should make
+sure that those headers are only accepted from trusted proxies.
+
+For this, you can configure a list of proxy IP address ranges in CIDR notation that are allowed to provide such headers,
+and which headers specifically are accepted for overriding those request informations::
+
+	TYPO3:
+	  Flow:
+	    http:
+	      trustedProxies:
+	        proxies:
+	          - '216.246.40.0/24'
+	          - '216.246.100.0/24'
+
+	        headers:
+	          clientIp: 'X-Forwarded-For'
+	          host: 'X-Forwarded-Host'
+	          port: 'X-Forwarded-Port'
+	          proto: 'X-Forwarded-Proto'
+
+This would mean that only the ``X-Forwarded-*`` headers are accepted and only as long as those come from one of the
+IP ranges ``216.246.40.0-255`` or ``216.246.100.0-255``.
+By default, all proxies are trusted (``trustedProxies.proxies`` set to ``'*'``) and only the ``X-Forwarded-*`` headers
+are accepted. If you know that your installation will not run behind a proxy server, you should change settings to this::
+
+	TYPO3:
+	  Flow:
+	    http:
+	      trustedProxies:
+	        proxies: []
+
+With this, no headers will be trusted and only the direct request informations will be used.
+
 Response
 --------
 

--- a/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.http.schema.yaml
+++ b/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.http.schema.yaml
@@ -26,3 +26,22 @@ properties:
               'componentOptions': { type: dictionary }
               'chain':
                 type: dictionary
+  'trustedProxies':
+    type: [dictionary]
+    required: true
+    additionalProperties: false
+    properties:
+      'proxies':
+        type: [string, dictionary]
+        required: true
+        additionalProperties:
+          type: string
+      'headers':
+        type: [dictionary]
+        required: true
+        additionalProperties: false
+        properties:
+          'clientIp': { type: string, required: true }
+          'host': { type: string, required: true }
+          'port': { type: string, required: true }
+          'proto': { type: string, required: true }

--- a/TYPO3.Flow/Tests/Unit/Http/BrowserTest.php
+++ b/TYPO3.Flow/Tests/Unit/Http/BrowserTest.php
@@ -11,6 +11,7 @@ namespace TYPO3\Flow\Tests\Unit\Http;
  * source code.
  */
 
+use TYPO3\Flow\Http\Request;
 use TYPO3\Flow\Http\Response;
 use TYPO3\Flow\Http\Uri;
 
@@ -31,6 +32,18 @@ class BrowserTest extends \TYPO3\Flow\Tests\UnitTestCase
     {
         parent::setUp();
         $this->browser = new \TYPO3\Flow\Http\Client\Browser();
+        $requestReflection = new \ReflectionClass(Request::class);
+        $trustedProxiesSettings = $requestReflection->getProperty('trustedProxiesSettings');
+        $trustedProxiesSettings->setAccessible(true);
+        $trustedProxiesSettings->setValue([
+            'proxies' => '*',
+            'headers' => [
+                Request::HEADER_CLIENT_IP => 'X-Forwarded-For',
+                Request::HEADER_HOST => 'X-Forwarded-Host',
+                Request::HEADER_PORT => 'X-Forwarded-Port',
+                Request::HEADER_PROTOCOL => 'X-Forwarded-Proto'
+            ]
+        ]);
     }
 
     /**


### PR DESCRIPTION
This change introduces a configuration setting `TYPO3.Flow.http.trustedProxies.proxies`
for so called "Trusted Proxies", which is a list of IP address ranges that are trusted
to provide header overrides for some import request meta informations like the host,
port, protocol and client IP.

        proxies:
          - '216.246.40.0/24'
          - '216.246.100.0/24'

Also the header names that are trusted for those informations can be set via the configuration
option `TYPO3.Flow.http.trustedProxies.headers` and default to this:

        headers:
          clientIp: 'X-Forwarded-For'
          host: 'X-Forwarded-Host'
          port: 'X-Forwarded-Port'
          proto: 'X-Forwarded-Proto'

To get the most trusted client IP adress, the Http Request provides a new method
`getTrustedClientIpAddress()` which resolves the clientIp header, matching against
trusted proxy addresses. So this might not always end up as the actual user IP address.

By default all IP addresses are trusted to stay mostly backwards compatible, but a more
safe setting would be to trust no proxies by default:

        proxies: []

FLOW-414 #close