### PR TITLE
BUGFIX: Documentation for 'UsernamePasswordHttpBasic' token outdated

### DIFF
--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Security.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Security.rst
@@ -396,7 +396,7 @@ in a POST request or set in an HTTP Basic authentication header.
 	    providers:
 	      DefaultProvider:
 	        provider: PersistedUsernamePasswordProvider
-	        tokenClass: UsernamePasswordHttpBasic
+	        token: TYPO3\Flow\Security\Authentication\Token\UsernamePasswordHttpBasic
 
 .. _Request Patterns:
 


### PR DESCRIPTION
'tokenClass' is not referenced in code anymore and
the full qualified name is required for using 'UsernamePasswordHttpBasic':
TYPO3\Flow\Security\Authentication\Token\UsernamePasswordHttpBasic