### PR TITLE
BUGFIX: package:rescan must happen before booting

### DIFF
--- a/TYPO3.Flow/.phpstorm.meta.php
+++ b/TYPO3.Flow/.phpstorm.meta.php
@@ -7,6 +7,9 @@ namespace PHPSTORM_META {
 	$STATIC_METHOD_TYPES = [
 		\TYPO3\Flow\Object\ObjectManagerInterface::get('') => [
 			'' == '@',
+		],
+		\TYPO3\Flow\Core\Bootstrap::getEarlyInstance('') => [
+			'' == '@',
 		]
 	];
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
@@ -11,16 +11,33 @@ namespace TYPO3\Flow\Core\Booting;
  * source code.
  */
 
+use Doctrine\Common\Annotations\AnnotationRegistry;
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Cache\CacheFactory;
+use TYPO3\Flow\Cache\CacheManager;
+use TYPO3\Flow\Configuration\ConfigurationManager;
+use TYPO3\Flow\Configuration\Source\YamlSource;
 use TYPO3\Flow\Core\Bootstrap;
 use TYPO3\Flow\Core\ClassLoader;
+use TYPO3\Flow\Core\LockManager as CoreLockManager;
+use TYPO3\Flow\Error\Debugger;
+use TYPO3\Flow\Error\ErrorHandler;
+use TYPO3\Flow\Log\Logger;
+use TYPO3\Flow\Log\LoggerFactory;
+use TYPO3\Flow\Log\SystemLoggerInterface;
 use TYPO3\Flow\Monitor\FileMonitor;
+use TYPO3\Flow\Object\CompileTimeObjectManager;
+use TYPO3\Flow\Object\ObjectManager;
 use TYPO3\Flow\Object\ObjectManagerInterface;
 use TYPO3\Flow\Package\Package;
 use TYPO3\Flow\Package\PackageInterface;
+use TYPO3\Flow\Package\PackageManager;
 use TYPO3\Flow\Package\PackageManagerInterface;
-use TYPO3\Flow\Resource\ResourceManager;
+use TYPO3\Flow\Reflection\ReflectionService;
 use TYPO3\Flow\Resource\Streams\StreamWrapperAdapter;
+use TYPO3\Flow\Session\SessionInterface;
+use TYPO3\Flow\SignalSlot\Dispatcher;
+use TYPO3\Flow\Utility\Environment;
 use TYPO3\Flow\Utility\Files;
 use TYPO3\Flow\Utility\Lock\Lock;
 use TYPO3\Flow\Utility\Lock\LockManager;
@@ -59,9 +76,9 @@ class Scripts
             ];
         }
 
-        $classLoader = new \TYPO3\Flow\Core\ClassLoader($bootstrap->getContext(), $initialClassLoaderMappings);
+        $classLoader = new ClassLoader($bootstrap->getContext(), $initialClassLoaderMappings);
         spl_autoload_register(array($classLoader, 'loadClass'), true, true);
-        $bootstrap->setEarlyInstance(\TYPO3\Flow\Core\ClassLoader::class, $classLoader);
+        $bootstrap->setEarlyInstance(ClassLoader::class, $classLoader);
         if ($bootstrap->getContext()->isTesting()) {
             self::requireAutoloaderForPhpUnit();
             $classLoader->setConsiderTestsNamespace(true);
@@ -97,7 +114,7 @@ class Scripts
      */
     public static function registerClassLoaderInAnnotationRegistry(Bootstrap $bootstrap)
     {
-        \Doctrine\Common\Annotations\AnnotationRegistry::registerLoader(array($bootstrap->getEarlyInstance(\TYPO3\Flow\Core\ClassLoader::class), 'loadClass'));
+        AnnotationRegistry::registerLoader(array($bootstrap->getEarlyInstance(ClassLoader::class), 'loadClass'));
     }
 
     /**
@@ -108,8 +125,8 @@ class Scripts
      */
     public static function initializeClassLoaderClassesCache(Bootstrap $bootstrap)
     {
-        $classesCache = $bootstrap->getEarlyInstance(\TYPO3\Flow\Cache\CacheManager::class)->getCache('Flow_Object_Classes');
-        $bootstrap->getEarlyInstance(\TYPO3\Flow\Core\ClassLoader::class)->injectClassesCache($classesCache);
+        $classesCache = $bootstrap->getEarlyInstance(CacheManager::class)->getCache('Flow_Object_Classes');
+        $bootstrap->getEarlyInstance(ClassLoader::class)->injectClassesCache($classesCache);
     }
 
     /**
@@ -127,15 +144,15 @@ class Scripts
             return;
         }
 
-        $bootstrap->getEarlyInstance(\TYPO3\Flow\Cache\CacheManager::class)->flushCaches();
-        $environment = $bootstrap->getEarlyInstance(\TYPO3\Flow\Utility\Environment::class);
-        \TYPO3\Flow\Utility\Files::emptyDirectoryRecursively($environment->getPathToTemporaryDirectory());
+        $bootstrap->getEarlyInstance(CacheManager::class)->flushCaches();
+        $environment = $bootstrap->getEarlyInstance(Environment::class);
+        Files::emptyDirectoryRecursively($environment->getPathToTemporaryDirectory());
 
         echo 'Force-flushed caches for "' . $bootstrap->getContext() . '" context.' . PHP_EOL;
 
         // In production the site will be locked as this is a compiletime request so we need to take care to remove that lock again.
         if ($bootstrap->getContext()->isProduction()) {
-            $bootstrap->getEarlyInstance(\TYPO3\Flow\Core\LockManager::class)->unlockSite();
+            $bootstrap->getEarlyInstance(CoreLockManager::class)->unlockSite();
         }
 
         exit(0);
@@ -149,7 +166,7 @@ class Scripts
      */
     public static function initializeSignalSlot(Bootstrap $bootstrap)
     {
-        $bootstrap->setEarlyInstance(\TYPO3\Flow\SignalSlot\Dispatcher::class, new \TYPO3\Flow\SignalSlot\Dispatcher());
+        $bootstrap->setEarlyInstance(Dispatcher::class, new Dispatcher());
     }
 
     /**
@@ -161,10 +178,16 @@ class Scripts
      */
     public static function initializePackageManagement(Bootstrap $bootstrap)
     {
-        $packageManager = new \TYPO3\Flow\Package\PackageManager();
-        $bootstrap->setEarlyInstance(\TYPO3\Flow\Package\PackageManagerInterface::class, $packageManager);
+        $packageManager = new PackageManager();
+        $bootstrap->setEarlyInstance(PackageManagerInterface::class, $packageManager);
+
+        // The package:rescan must happen as early as possible, compiletime alone is not enough.
+        if (isset($_SERVER['argv'][1]) && in_array($_SERVER['argv'][1], ['typo3.flow:package:rescan', 'flow:package:rescan'])) {
+            $packageManager->rescanPackages();
+        }
+
         $packageManager->initialize($bootstrap);
-        $bootstrap->getEarlyInstance(\TYPO3\Flow\Core\ClassLoader::class)->setPackages($packageManager->getActivePackages());
+        $bootstrap->getEarlyInstance(ClassLoader::class)->setPackages($packageManager->getActivePackages());
     }
 
     /**
@@ -177,16 +200,16 @@ class Scripts
     public static function initializeConfiguration(Bootstrap $bootstrap)
     {
         $context = $bootstrap->getContext();
-        $packageManager = $bootstrap->getEarlyInstance(\TYPO3\Flow\Package\PackageManagerInterface::class);
+        $packageManager = $bootstrap->getEarlyInstance(PackageManagerInterface::class);
 
-        $configurationManager = new \TYPO3\Flow\Configuration\ConfigurationManager($context);
-        $configurationManager->injectConfigurationSource(new \TYPO3\Flow\Configuration\Source\YamlSource());
+        $configurationManager = new ConfigurationManager($context);
+        $configurationManager->injectConfigurationSource(new YamlSource());
         $configurationManager->loadConfigurationCache();
         $configurationManager->setPackages($packageManager->getActivePackages());
 
-        $settings = $configurationManager->getConfiguration(\TYPO3\Flow\Configuration\ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow');
+        $settings = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow');
 
-        $environment = new \TYPO3\Flow\Utility\Environment($context);
+        $environment = new Environment($context);
         if (isset($settings['utility']['environment']['temporaryDirectoryBase'])) {
             $defaultTemporaryDirectoryBase = FLOW_PATH_DATA . '/Temporary';
             if (FLOW_PATH_TEMPORARY_BASE !== $defaultTemporaryDirectoryBase) {
@@ -207,10 +230,10 @@ class Scripts
 
         $packageManager->injectSettings($settings);
 
-        $bootstrap->getSignalSlotDispatcher()->dispatch(\TYPO3\Flow\Configuration\ConfigurationManager::class, 'configurationManagerReady', array($configurationManager));
+        $bootstrap->getSignalSlotDispatcher()->dispatch(ConfigurationManager::class, 'configurationManagerReady', array($configurationManager));
 
-        $bootstrap->setEarlyInstance(\TYPO3\Flow\Configuration\ConfigurationManager::class, $configurationManager);
-        $bootstrap->setEarlyInstance(\TYPO3\Flow\Utility\Environment::class, $environment);
+        $bootstrap->setEarlyInstance(ConfigurationManager::class, $configurationManager);
+        $bootstrap->setEarlyInstance(Environment::class, $environment);
     }
 
     /**
@@ -221,16 +244,16 @@ class Scripts
      */
     public static function initializeSystemLogger(Bootstrap $bootstrap)
     {
-        $configurationManager = $bootstrap->getEarlyInstance(\TYPO3\Flow\Configuration\ConfigurationManager::class);
-        $settings = $configurationManager->getConfiguration(\TYPO3\Flow\Configuration\ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow');
+        $configurationManager = $bootstrap->getEarlyInstance(ConfigurationManager::class);
+        $settings = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow');
 
         if (!isset($settings['log']['systemLogger']['logger'])) {
-            $settings['log']['systemLogger']['logger'] = \TYPO3\Flow\Log\Logger::class;
+            $settings['log']['systemLogger']['logger'] = Logger::class;
         }
-        $loggerFactory = new \TYPO3\Flow\Log\LoggerFactory();
-        $bootstrap->setEarlyInstance(\TYPO3\Flow\Log\LoggerFactory::class, $loggerFactory);
+        $loggerFactory = new LoggerFactory();
+        $bootstrap->setEarlyInstance(LoggerFactory::class, $loggerFactory);
         $systemLogger = $loggerFactory->create('SystemLogger', $settings['log']['systemLogger']['logger'], $settings['log']['systemLogger']['backend'], $settings['log']['systemLogger']['backendOptions']);
-        $bootstrap->setEarlyInstance(\TYPO3\Flow\Log\SystemLoggerInterface::class, $systemLogger);
+        $bootstrap->setEarlyInstance(SystemLoggerInterface::class, $systemLogger);
     }
 
     /**
@@ -241,13 +264,13 @@ class Scripts
      */
     public static function initializeErrorHandling(Bootstrap $bootstrap)
     {
-        $configurationManager = $bootstrap->getEarlyInstance(\TYPO3\Flow\Configuration\ConfigurationManager::class);
-        $settings = $configurationManager->getConfiguration(\TYPO3\Flow\Configuration\ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow');
+        $configurationManager = $bootstrap->getEarlyInstance(ConfigurationManager::class);
+        $settings = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow');
 
-        $errorHandler = new \TYPO3\Flow\Error\ErrorHandler();
+        $errorHandler = new ErrorHandler();
         $errorHandler->setExceptionalErrors($settings['error']['errorHandler']['exceptionalErrors']);
         $exceptionHandler = new $settings['error']['exceptionHandler']['className'];
-        $exceptionHandler->injectSystemLogger($bootstrap->getEarlyInstance(\TYPO3\Flow\Log\SystemLoggerInterface::class));
+        $exceptionHandler->injectSystemLogger($bootstrap->getEarlyInstance(SystemLoggerInterface::class));
         $exceptionHandler->setOptions($settings['error']['exceptionHandler']);
     }
 
@@ -259,19 +282,19 @@ class Scripts
      */
     public static function initializeCacheManagement(Bootstrap $bootstrap)
     {
-        $configurationManager = $bootstrap->getEarlyInstance(\TYPO3\Flow\Configuration\ConfigurationManager::class);
-        $environment = $bootstrap->getEarlyInstance(\TYPO3\Flow\Utility\Environment::class);
+        $configurationManager = $bootstrap->getEarlyInstance(ConfigurationManager::class);
+        $environment = $bootstrap->getEarlyInstance(Environment::class);
 
-        $cacheManager = new \TYPO3\Flow\Cache\CacheManager();
-        $cacheManager->setCacheConfigurations($configurationManager->getConfiguration(\TYPO3\Flow\Configuration\ConfigurationManager::CONFIGURATION_TYPE_CACHES));
+        $cacheManager = new CacheManager();
+        $cacheManager->setCacheConfigurations($configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_CACHES));
         $cacheManager->injectConfigurationManager($configurationManager);
-        $cacheManager->injectSystemLogger($bootstrap->getEarlyInstance(\TYPO3\Flow\Log\SystemLoggerInterface::class));
+        $cacheManager->injectSystemLogger($bootstrap->getEarlyInstance(SystemLoggerInterface::class));
         $cacheManager->injectEnvironment($environment);
 
-        $cacheFactory = new \TYPO3\Flow\Cache\CacheFactory($bootstrap->getContext(), $cacheManager, $environment);
+        $cacheFactory = new CacheFactory($bootstrap->getContext(), $cacheManager, $environment);
 
-        $bootstrap->setEarlyInstance(\TYPO3\Flow\Cache\CacheManager::class, $cacheManager);
-        $bootstrap->setEarlyInstance(\TYPO3\Flow\Cache\CacheFactory::class, $cacheFactory);
+        $bootstrap->setEarlyInstance(CacheManager::class, $cacheManager);
+        $bootstrap->setEarlyInstance(CacheFactory::class, $cacheFactory);
     }
 
     /**
@@ -283,10 +306,10 @@ class Scripts
      */
     public static function initializeProxyClasses(Bootstrap $bootstrap)
     {
-        $objectConfigurationCache = $bootstrap->getEarlyInstance(\TYPO3\Flow\Cache\CacheManager::class)->getCache('Flow_Object_Configuration');
+        $objectConfigurationCache = $bootstrap->getEarlyInstance(CacheManager::class)->getCache('Flow_Object_Configuration');
 
-        $configurationManager = $bootstrap->getEarlyInstance(\TYPO3\Flow\Configuration\ConfigurationManager::class);
-        $settings = $configurationManager->getConfiguration(\TYPO3\Flow\Configuration\ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow');
+        $configurationManager = $bootstrap->getEarlyInstance(ConfigurationManager::class);
+        $settings = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow');
 
         // The compile sub command will only be run if the code cache is completely empty:
         if ($objectConfigurationCache->has('allCompiledCodeUpToDate') === false) {
@@ -303,9 +326,9 @@ class Scripts
         // Check if code was updated, if not something went wrong
         if ($objectConfigurationCache->has('allCompiledCodeUpToDate') === false) {
             if (DIRECTORY_SEPARATOR === '/') {
-                $phpBinaryPathAndFilename = '"' . escapeshellcmd(\TYPO3\Flow\Utility\Files::getUnixStylePath($settings['core']['phpBinaryPathAndFilename'])) . '"';
+                $phpBinaryPathAndFilename = '"' . escapeshellcmd(Files::getUnixStylePath($settings['core']['phpBinaryPathAndFilename'])) . '"';
             } else {
-                $phpBinaryPathAndFilename = escapeshellarg(\TYPO3\Flow\Utility\Files::getUnixStylePath($settings['core']['phpBinaryPathAndFilename']));
+                $phpBinaryPathAndFilename = escapeshellarg(Files::getUnixStylePath($settings['core']['phpBinaryPathAndFilename']));
             }
             $command = sprintf('%s -c %s -v', $phpBinaryPathAndFilename, escapeshellarg(php_ini_loaded_file()));
             exec($command, $output, $result);
@@ -340,11 +363,11 @@ class Scripts
      */
     public static function initializeObjectManagerCompileTimeCreate(Bootstrap $bootstrap)
     {
-        $objectManager = new \TYPO3\Flow\Object\CompileTimeObjectManager($bootstrap->getContext());
-        $bootstrap->setEarlyInstance(\TYPO3\Flow\Object\ObjectManagerInterface::class, $objectManager);
+        $objectManager = new CompileTimeObjectManager($bootstrap->getContext());
+        $bootstrap->setEarlyInstance(ObjectManagerInterface::class, $objectManager);
         Bootstrap::$staticObjectManager = $objectManager;
 
-        $signalSlotDispatcher = $bootstrap->getEarlyInstance(\TYPO3\Flow\SignalSlot\Dispatcher::class);
+        $signalSlotDispatcher = $bootstrap->getEarlyInstance(Dispatcher::class);
         $signalSlotDispatcher->injectObjectManager($objectManager);
 
         foreach ($bootstrap->getEarlyInstances() as $objectName => $instance) {
@@ -361,13 +384,13 @@ class Scripts
     public static function initializeObjectManagerCompileTimeFinalize(Bootstrap $bootstrap)
     {
         $objectManager = $bootstrap->getObjectManager();
-        $configurationManager = $bootstrap->getEarlyInstance(\TYPO3\Flow\Configuration\ConfigurationManager::class);
-        $reflectionService = $objectManager->get(\TYPO3\Flow\Reflection\ReflectionService::class);
-        $cacheManager = $bootstrap->getEarlyInstance(\TYPO3\Flow\Cache\CacheManager::class);
-        $systemLogger = $bootstrap->getEarlyInstance(\TYPO3\Flow\Log\SystemLoggerInterface::class);
-        $packageManager = $bootstrap->getEarlyInstance(\TYPO3\Flow\Package\PackageManagerInterface::class);
+        $configurationManager = $bootstrap->getEarlyInstance(ConfigurationManager::class);
+        $reflectionService = $objectManager->get(ReflectionService::class);
+        $cacheManager = $bootstrap->getEarlyInstance(CacheManager::class);
+        $systemLogger = $bootstrap->getEarlyInstance(SystemLoggerInterface::class);
+        $packageManager = $bootstrap->getEarlyInstance(PackageManagerInterface::class);
 
-        $objectManager->injectAllSettings($configurationManager->getConfiguration(\TYPO3\Flow\Configuration\ConfigurationManager::CONFIGURATION_TYPE_SETTINGS));
+        $objectManager->injectAllSettings($configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS));
         $objectManager->injectReflectionService($reflectionService);
         $objectManager->injectConfigurationManager($configurationManager);
         $objectManager->injectConfigurationCache($cacheManager->getCache('Flow_Object_Configuration'));
@@ -378,7 +401,7 @@ class Scripts
             $objectManager->setInstance($objectName, $instance);
         }
 
-        \TYPO3\Flow\Error\Debugger::injectObjectManager($objectManager);
+        Debugger::injectObjectManager($objectManager);
     }
 
     /**
@@ -389,22 +412,22 @@ class Scripts
      */
     public static function initializeObjectManager(Bootstrap $bootstrap)
     {
-        $configurationManager = $bootstrap->getEarlyInstance(\TYPO3\Flow\Configuration\ConfigurationManager::class);
-        $objectConfigurationCache = $bootstrap->getEarlyInstance(\TYPO3\Flow\Cache\CacheManager::class)->getCache('Flow_Object_Configuration');
+        $configurationManager = $bootstrap->getEarlyInstance(ConfigurationManager::class);
+        $objectConfigurationCache = $bootstrap->getEarlyInstance(CacheManager::class)->getCache('Flow_Object_Configuration');
 
-        $objectManager = new \TYPO3\Flow\Object\ObjectManager($bootstrap->getContext());
+        $objectManager = new ObjectManager($bootstrap->getContext());
         Bootstrap::$staticObjectManager = $objectManager;
 
-        $objectManager->injectAllSettings($configurationManager->getConfiguration(\TYPO3\Flow\Configuration\ConfigurationManager::CONFIGURATION_TYPE_SETTINGS));
+        $objectManager->injectAllSettings($configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS));
         $objectManager->setObjects($objectConfigurationCache->get('objects'));
 
         foreach ($bootstrap->getEarlyInstances() as $objectName => $instance) {
             $objectManager->setInstance($objectName, $instance);
         }
 
-        $objectManager->get(\TYPO3\Flow\SignalSlot\Dispatcher::class)->injectObjectManager($objectManager);
-        \TYPO3\Flow\Error\Debugger::injectObjectManager($objectManager);
-        $bootstrap->setEarlyInstance(\TYPO3\Flow\Object\ObjectManagerInterface::class, $objectManager);
+        $objectManager->get(Dispatcher::class)->injectObjectManager($objectManager);
+        Debugger::injectObjectManager($objectManager);
+        $bootstrap->setEarlyInstance(ObjectManagerInterface::class, $objectManager);
     }
 
     /**
@@ -415,25 +438,25 @@ class Scripts
      */
     public static function initializeReflectionService(Bootstrap $bootstrap)
     {
-        $cacheManager = $bootstrap->getEarlyInstance(\TYPO3\Flow\Cache\CacheManager::class);
-        $configurationManager = $bootstrap->getEarlyInstance(\TYPO3\Flow\Configuration\ConfigurationManager::class);
-        $settings = $configurationManager->getConfiguration(\TYPO3\Flow\Configuration\ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow');
+        $cacheManager = $bootstrap->getEarlyInstance(CacheManager::class);
+        $configurationManager = $bootstrap->getEarlyInstance(ConfigurationManager::class);
+        $settings = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow');
 
-        $reflectionService = new \TYPO3\Flow\Reflection\ReflectionService();
+        $reflectionService = new ReflectionService();
 
-        $reflectionService->injectSystemLogger($bootstrap->getEarlyInstance(\TYPO3\Flow\Log\SystemLoggerInterface::class));
-        $reflectionService->injectClassLoader($bootstrap->getEarlyInstance(\TYPO3\Flow\Core\ClassLoader::class));
+        $reflectionService->injectSystemLogger($bootstrap->getEarlyInstance(SystemLoggerInterface::class));
+        $reflectionService->injectClassLoader($bootstrap->getEarlyInstance(ClassLoader::class));
         $reflectionService->injectSettings($settings);
-        $reflectionService->injectPackageManager($bootstrap->getEarlyInstance(\TYPO3\Flow\Package\PackageManagerInterface::class));
+        $reflectionService->injectPackageManager($bootstrap->getEarlyInstance(PackageManagerInterface::class));
         $reflectionService->setStatusCache($cacheManager->getCache('Flow_Reflection_Status'));
         $reflectionService->setReflectionDataCompiletimeCache($cacheManager->getCache('Flow_Reflection_CompiletimeData'));
         $reflectionService->setReflectionDataRuntimeCache($cacheManager->getCache('Flow_Reflection_RuntimeData'));
         $reflectionService->setClassSchemataRuntimeCache($cacheManager->getCache('Flow_Reflection_RuntimeClassSchemata'));
-        $reflectionService->injectSettings($configurationManager->getConfiguration(\TYPO3\Flow\Configuration\ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow'));
-        $reflectionService->injectEnvironment($bootstrap->getEarlyInstance(\TYPO3\Flow\Utility\Environment::class));
+        $reflectionService->injectSettings($configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow'));
+        $reflectionService->injectEnvironment($bootstrap->getEarlyInstance(Environment::class));
 
-        $bootstrap->setEarlyInstance(\TYPO3\Flow\Reflection\ReflectionService::class, $reflectionService);
-        $bootstrap->getObjectManager()->setInstance(\TYPO3\Flow\Reflection\ReflectionService::class, $reflectionService);
+        $bootstrap->setEarlyInstance(ReflectionService::class, $reflectionService);
+        $bootstrap->getObjectManager()->setInstance(ReflectionService::class, $reflectionService);
     }
 
     /**
@@ -459,7 +482,7 @@ class Scripts
 
         $context = $bootstrap->getContext();
         /** @var PackageManagerInterface $packageManager */
-        $packageManager = $bootstrap->getEarlyInstance(\TYPO3\Flow\Package\PackageManagerInterface::class);
+        $packageManager = $bootstrap->getEarlyInstance(PackageManagerInterface::class);
         $packagesWithConfiguredObjects = static::getListOfPackagesWithConfiguredObjects($bootstrap);
 
         /** @var PackageInterface $package */
@@ -537,12 +560,12 @@ class Scripts
      */
     protected static function compileDoctrineProxies(Bootstrap $bootstrap)
     {
-        $cacheManager = $bootstrap->getEarlyInstance(\TYPO3\Flow\Cache\CacheManager::class);
+        $cacheManager = $bootstrap->getEarlyInstance(CacheManager::class);
         $objectConfigurationCache = $cacheManager->getCache('Flow_Object_Configuration');
         $coreCache = $cacheManager->getCache('Flow_Core');
-        $systemLogger = $bootstrap->getEarlyInstance(\TYPO3\Flow\Log\SystemLoggerInterface::class);
-        $configurationManager = $bootstrap->getEarlyInstance(\TYPO3\Flow\Configuration\ConfigurationManager::class);
-        $settings = $configurationManager->getConfiguration(\TYPO3\Flow\Configuration\ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow');
+        $systemLogger = $bootstrap->getEarlyInstance(SystemLoggerInterface::class);
+        $configurationManager = $bootstrap->getEarlyInstance(ConfigurationManager::class);
+        $settings = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.Flow');
 
         if ($objectConfigurationCache->has('doctrineProxyCodeUpToDate') === false && $coreCache->has('doctrineSetupRunning') === false) {
             $coreCache->set('doctrineSetupRunning', 'White Russian', array(), 60);
@@ -562,7 +585,7 @@ class Scripts
     public static function initializeSession(Bootstrap $bootstrap)
     {
         if (FLOW_SAPITYPE === 'Web') {
-            $bootstrap->getObjectManager()->get(\TYPO3\Flow\Session\SessionInterface::class)->resume();
+            $bootstrap->getObjectManager()->get(SessionInterface::class)->resume();
         }
     }
 
@@ -668,9 +691,9 @@ class Scripts
             }
         }
         if (DIRECTORY_SEPARATOR === '/') {
-            $phpBinaryPathAndFilename = '"' . escapeshellcmd(\TYPO3\Flow\Utility\Files::getUnixStylePath($settings['core']['phpBinaryPathAndFilename'])) . '"';
+            $phpBinaryPathAndFilename = '"' . escapeshellcmd(Files::getUnixStylePath($settings['core']['phpBinaryPathAndFilename'])) . '"';
         } else {
-            $phpBinaryPathAndFilename = escapeshellarg(\TYPO3\Flow\Utility\Files::getUnixStylePath($settings['core']['phpBinaryPathAndFilename']));
+            $phpBinaryPathAndFilename = escapeshellarg(Files::getUnixStylePath($settings['core']['phpBinaryPathAndFilename']));
         }
         $command .= $phpBinaryPathAndFilename;
         if (!isset($settings['core']['subRequestPhpIniPathAndFilename']) || $settings['core']['subRequestPhpIniPathAndFilename'] !== false) {


### PR DESCRIPTION
If the user issued a ``typo3.flow:package:rescan`` command this should
happen very early in the compiletime boot sequence as otherwise the
ObjectManager will try to load a non existing package if the rescan was
issued after a package was removed from the installation.

With this change package rescans are possible in all package state
situations in case you manipulate the packages without using composer
or our ``PackageManager``.

Additionally adds a bunch of use statements to the ``Bootstrap``.