### PR TITLE
TASK: Allow wildcard propertymapping configuration to set defaults for trustedProperties configuration

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/Controller/ActionController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/Controller/ActionController.php
@@ -152,13 +152,13 @@ class ActionController extends AbstractController
 
         $this->initializeActionMethodArguments();
         $this->initializeActionMethodValidators();
-        $this->mvcPropertyMappingConfigurationService->initializePropertyMappingConfigurationFromRequest($this->request, $this->arguments);
 
         $this->initializeAction();
         $actionInitializationMethodName = 'initialize' . ucfirst($this->actionMethodName);
         if (method_exists($this, $actionInitializationMethodName)) {
             call_user_func(array($this, $actionInitializationMethodName));
         }
+        $this->mvcPropertyMappingConfigurationService->initializePropertyMappingConfigurationFromRequest($this->request, $this->arguments);
 
         $this->mapRequestArgumentsToControllerArguments();
 

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/PropertyMapping.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/PropertyMapping.rst
@@ -225,6 +225,17 @@ the path syntax supports an asterisk as a placeholder::
 			TRUE
 		);
 
+This also allows to easily configure TypeConverter options, like for the DateTimeConverter, for subproperties
+on large collections::
+
+	$propertyMappingConfiguration
+		->forProperty('persons.*.birthDate')
+		->setTypeConvertOption(
+			'TYPO3\Flow\Property\TypeConverter\DateTimeConverter',
+			\TYPO3\Flow\Property\TypeConverter\DateTimeConverter::CONFIGURATION_DATE_FORMAT,
+			'Y-m-d'
+		);
+
 .. admonition:: Property Mapping Configuration in the MVC stack
 
 	The most common use-case where you will want to adjust the Property Mapping Configuration

--- a/TYPO3.Flow/Tests/Functional/Mvc/ActionControllerTest.php
+++ b/TYPO3.Flow/Tests/Functional/Mvc/ActionControllerTest.php
@@ -56,7 +56,7 @@ class ActionControllerTest extends \TYPO3\Flow\Tests\FunctionalTestCase
         ));
         $route->setRoutePartsConfiguration(array(
             'entity' => array(
-                'objectType' => TestEntity::class
+                'objectType' => 'TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntity'
             )
         ));
     }

--- a/TYPO3.Flow/Tests/Functional/Mvc/ActionControllerTest.php
+++ b/TYPO3.Flow/Tests/Functional/Mvc/ActionControllerTest.php
@@ -13,6 +13,7 @@ namespace TYPO3\Flow\Tests\Functional\Mvc;
 
 use TYPO3\Flow\Http\Request;
 use TYPO3\Flow\Http\Uri;
+use TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntity;
 
 /**
  * Functional tests for the ActionController
@@ -46,12 +47,17 @@ class ActionControllerTest extends \TYPO3\Flow\Tests\FunctionalTestCase
             '@format' =>'html'
         ));
 
-        $this->registerRoute('testc', 'test/mvc/actioncontrollertestc/{entity}', array(
+        $route = $this->registerRoute('testc', 'test/mvc/actioncontrollertestc/{entity}(/{@action})', array(
             '@package' => 'TYPO3.Flow',
             '@subpackage' => 'Tests\Functional\Mvc\Fixtures',
             '@controller' => 'Entity',
             '@action' => 'show',
             '@format' =>'html'
+        ));
+        $route->setRoutePartsConfiguration(array(
+            'entity' => array(
+                'objectType' => TestEntity::class
+            )
         ));
     }
 
@@ -341,5 +347,40 @@ class ActionControllerTest extends \TYPO3\Flow\Tests\FunctionalTestCase
         $uri = str_replace('{@action}', strtolower($action), 'http://localhost/test/mvc/actioncontrollertestb/{@action}');
         $response = $this->browser->request($uri, 'POST', $arguments);
         $this->assertTrue(strpos(trim($response->getContent()), (string)$expectedResult) === 0, sprintf('The resulting string did not start with the expected string. Expected: "%s", Actual: "%s"', $expectedResult, $response->getContent()));
+    }
+
+    /**
+     * @test
+     */
+    public function trustedPropertiesConfigurationDoesNotIgnoreWildcardConfigurationInController()
+    {
+        $entity = new TestEntity();
+        $entity->setName('Foo');
+        $this->persistenceManager->add($entity);
+        $identifier = $this->persistenceManager->getIdentifierByObject($entity);
+
+        $trustedPropertiesService = new \TYPO3\Flow\Mvc\Controller\MvcPropertyMappingConfigurationService();
+        $trustedProperties = $trustedPropertiesService->generateTrustedPropertiesToken(array('entity[__identity]', 'entity[subEntities][0][content]', 'entity[subEntities][0][date]', 'entity[subEntities][1][content]', 'entity[subEntities][1][date]'));
+
+        $form = array(
+            'entity' => array(
+                '__identity' => $identifier,
+                'subEntities' => array(
+                    array(
+                        'content' => 'Bar',
+                        'date' => '1.1.2016'
+                    ),
+                    array(
+                        'content' => 'Baz',
+                        'date' => '30.12.2016'
+                    )
+                )
+            ),
+            '__trustedProperties' => $trustedProperties
+        );
+        $request = Request::create(new Uri('http://localhost/test/mvc/actioncontrollertestc/' . $identifier . '/update'), 'POST', $form);
+
+        $response = $this->browser->sendRequest($request);
+        $this->assertSame('Entity "Foo" updated', $response->getContent());
     }
 }

--- a/TYPO3.Flow/Tests/Functional/Mvc/Fixtures/Controller/EntityController.php
+++ b/TYPO3.Flow/Tests/Functional/Mvc/Fixtures/Controller/EntityController.php
@@ -13,6 +13,7 @@ namespace TYPO3\Flow\Tests\Functional\Mvc\Fixtures\Controller;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Mvc\Controller\ActionController;
+use TYPO3\Flow\Property\TypeConverter\DateTimeConverter;
 use TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter;
 use TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntity;
 
@@ -41,17 +42,21 @@ class EntityController extends ActionController
      */
     protected function initializeUpdateAction()
     {
-        $this->arguments->getArgument('entity')->getPropertyMappingConfiguration()
+        $propertyMappingConfiguration = $this->arguments->getArgument('entity')->getPropertyMappingConfiguration();
+        $propertyMappingConfiguration
             ->allowAllProperties()
             ->setTypeConverterOption('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED, true);
-        $this->arguments->getArgument('entity')->getPropertyMappingConfiguration()
+        $propertyMappingConfiguration
             ->forProperty('subEntities.*')
             ->allowAllProperties()
             ->setTypeConverterOption('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED, true);
+        $propertyMappingConfiguration
+            ->forProperty('subEntities.*.date')
+            ->setTypeConverterOption('TYPO3\Flow\Property\TypeConverter\DateTimeConverter', DateTimeConverter::CONFIGURATION_DATE_FORMAT, 'd.m.Y');
     }
 
     /**
-     * @param \TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntity $entity
+     * @param TestEntity $entity
      * @return string
      */
     public function updateAction(TestEntity $entity)

--- a/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/SubEntity.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/SubEntity.php
@@ -28,6 +28,12 @@ class SubEntity extends SuperEntity
     protected $parentEntity;
 
     /**
+     * @var \DateTime
+     * @ORM\Column(nullable=true)
+     */
+    protected $date;
+
+    /**
      * @param \TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntity $parentEntity
      * @return void
      */
@@ -42,5 +48,21 @@ class SubEntity extends SuperEntity
     public function getParentEntity()
     {
         return $this->parentEntity;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    /**
+     * @param \DateTime $date
+     */
+    public function setDate($date)
+    {
+        $this->date = $date;
     }
 }

--- a/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/TestEntity.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/TestEntity.php
@@ -46,7 +46,7 @@ class TestEntity
 
     /**
      * @var Collection<ImportedSubEntity>
-     * @ORM\OneToMany(mappedBy="parentEntity")
+     * @ORM\OneToMany(mappedBy="parentEntity", cascade={"all"})
      */
     protected $subEntities;
 

--- a/TYPO3.Flow/Tests/FunctionalTestCase.php
+++ b/TYPO3.Flow/Tests/FunctionalTestCase.php
@@ -368,7 +368,7 @@ abstract class FunctionalTestCase extends \TYPO3\Flow\Tests\BaseTestCase
      * @param array $defaults An array of defaults declarations
      * @param boolean $appendExceedingArguments If exceeding arguments may be appended
      * @param array $httpMethods An array of accepted http methods
-     * @return void
+     * @return Route
      * @api
      */
     protected function registerRoute($name, $uriPattern, array $defaults, $appendExceedingArguments = false, array $httpMethods = null)
@@ -382,6 +382,7 @@ abstract class FunctionalTestCase extends \TYPO3\Flow\Tests\BaseTestCase
             $route->setHttpMethods($httpMethods);
         }
         $this->router->addRoute($route);
+        return $route;
     }
 
     /**


### PR DESCRIPTION
Before, when specifying a PropertyMappingConfiguration with a wildcard inside the initializeAction() of
a controller, this configuration would not be taken into account when a Fluid form was submitted, that
set configuration for specific properties.

This change makes the trustedProperties configuration happen *after* the user configuration, which in turn
will lead to trustedProperties always only extend the user configuration and wildcard configurations to
be used as the template configuration for the following specific trustedProperties configurations.