### PR TITLE
FEATURE: Validate only up to Aggregate boundaries

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Validation/Validator/AggregateBoundaryValidator.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Validation/Validator/AggregateBoundaryValidator.php
@@ -10,25 +10,20 @@ namespace TYPO3\Flow\Validation\Validator;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-use Doctrine\ORM\Proxy\Proxy;
 
 /**
- * A validator which will only validate up to the Aggregate boundary, or if an Aggregate relation
- * is specifically annotated to be cascade validated.
+ * A validator which will not validate Aggregates that are lazy loaded and uninitialized.
+ * Validation over Aggregate Boundaries can hence be forced by making the relation to
+ * other Aggregate Roots eager loaded.
  *
  * @api
  */
 class AggregateBoundaryValidator extends GenericObjectValidator
 {
     /**
-     * @var array
-     */
-    protected $supportedOptions = array(
-    );
-
-    /**
      * Checks if the given value is valid according to the validator, and returns
-     * the Error Messages object which occurred.
+     * the Error Messages object which occurred. Will skip validation if value is
+     * an uninitialized lazy loading proxy.
      *
      * @param mixed $value The value that should be validated
      * @return \TYPO3\Flow\Error\Result
@@ -40,7 +35,7 @@ class AggregateBoundaryValidator extends GenericObjectValidator
         if ($this->acceptsEmptyValues === false || $this->isEmpty($value) === false) {
             if (!is_object($value)) {
                 $this->addError('Object expected, %1$s given.', 1241099149, array(gettype($value)));
-            } elseif ($value instanceof Proxy && !$value->__isInitialized()) {
+            } elseif ($value instanceof \Doctrine\ORM\Proxy\Proxy && !$value->__isInitialized()) {
                 return $this->result;
             } elseif ($this->isValidatedAlready($value) === false) {
                 $this->isValid($value);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Validation/Validator/AggregateBoundaryValidator.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Validation/Validator/AggregateBoundaryValidator.php
@@ -1,0 +1,52 @@
+<?php
+namespace TYPO3\Flow\Validation\Validator;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+use Doctrine\ORM\Proxy\Proxy;
+
+/**
+ * A validator which will only validate up to the Aggregate boundary, or if an Aggregate relation
+ * is specifically annotated to be cascade validated.
+ *
+ * @api
+ */
+class AggregateBoundaryValidator extends GenericObjectValidator
+{
+    /**
+     * @var array
+     */
+    protected $supportedOptions = array(
+    );
+
+    /**
+     * Checks if the given value is valid according to the validator, and returns
+     * the Error Messages object which occurred.
+     *
+     * @param mixed $value The value that should be validated
+     * @return \TYPO3\Flow\Error\Result
+     * @api
+     */
+    public function validate($value)
+    {
+        $this->result = new \TYPO3\Flow\Error\Result();
+        if ($this->acceptsEmptyValues === false || $this->isEmpty($value) === false) {
+            if (!is_object($value)) {
+                $this->addError('Object expected, %1$s given.', 1241099149, array(gettype($value)));
+            } elseif ($value instanceof Proxy) {
+                return $this->result;
+            } elseif ($this->isValidatedAlready($value) === false) {
+                $this->isValid($value);
+            }
+        }
+
+        return $this->result;
+    }
+}

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Validation/Validator/AggregateBoundaryValidator.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Validation/Validator/AggregateBoundaryValidator.php
@@ -40,7 +40,7 @@ class AggregateBoundaryValidator extends GenericObjectValidator
         if ($this->acceptsEmptyValues === false || $this->isEmpty($value) === false) {
             if (!is_object($value)) {
                 $this->addError('Object expected, %1$s given.', 1241099149, array(gettype($value)));
-            } elseif ($value instanceof Proxy) {
+            } elseif ($value instanceof Proxy && !$value->__isInitialized()) {
                 return $this->result;
             } elseif ($this->isValidatedAlready($value) === false) {
                 $this->isValid($value);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Validation/ValidatorResolver.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Validation/ValidatorResolver.php
@@ -14,6 +14,7 @@ namespace TYPO3\Flow\Validation;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Object\Configuration\Configuration;
 use TYPO3\Flow\Utility\TypeHandling;
+use TYPO3\Flow\Validation\Validator\AggregateBoundaryValidator;
 use TYPO3\Flow\Validation\Validator\ValidatorInterface;
 use TYPO3\Flow\Validation\Validator\GenericObjectValidator;
 use TYPO3\Flow\Validation\Validator\ConjunctionValidator;
@@ -274,7 +275,12 @@ class ValidatorResolver
         $this->baseValidatorConjunctions[$indexKey] = $conjunctionValidator;
         if (!TypeHandling::isSimpleType($targetClassName) && class_exists($targetClassName)) {
             // Model based validator
-            $objectValidator = new GenericObjectValidator(array());
+            $classSchema = $this->reflectionService->getClassSchema($targetClassName);
+            if ($classSchema->isAggregateRoot()) {
+                $objectValidator = new AggregateBoundaryValidator(array());
+            } else {
+                $objectValidator = new GenericObjectValidator(array());
+            }
             $conjunctionValidator->addValidator($objectValidator);
             foreach ($this->reflectionService->getClassPropertyNames($targetClassName) as $classPropertyName) {
                 $classPropertyTagsValues = $this->reflectionService->getPropertyTagsValues($targetClassName, $classPropertyName);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Validation/ValidatorResolver.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Validation/ValidatorResolver.php
@@ -276,7 +276,7 @@ class ValidatorResolver
         if (!TypeHandling::isSimpleType($targetClassName) && class_exists($targetClassName)) {
             // Model based validator
             $classSchema = $this->reflectionService->getClassSchema($targetClassName);
-            if ($classSchema->isAggregateRoot()) {
+            if ($classSchema !== null && $classSchema->isAggregateRoot()) {
                 $objectValidator = new AggregateBoundaryValidator(array());
             } else {
                 $objectValidator = new GenericObjectValidator(array());

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Validation.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Validation.rst
@@ -192,6 +192,27 @@ The returned validator checks the following things:
 When specifying a Domain Model as an argument of a controller action, all the above validations will be
 automatically executed. This is explained in detail in the following section.
 
+Validation on Aggregates
+------------------------
+
+In Domain Driven Design, the ``Aggregate`` is to be considered a *consistency boundary*, meaning that the whole
+``Aggregate`` needs to preserve it's invariants at all times. For that reason, validation inside an ``Aggregate`` will
+cascade into all entities and force relations to be loaded. So if you have designed large ``Aggregates`` with a deep
+hierarchy of many n-ToMany relations, validation can easily become a performance bottleneck.
+
+It is therefore, but not limited to this reason, highly recommended to keep your ``Aggregates`` small. The validation
+will stop at an ``Aggregate Root``, if the relation to it is lazy and not yet loaded. Entity relations are lazy by default,
+and as long as you don't also submit parts of the related ``Aggregate``, it will not get loaded before the validation
+kicks in.
+
+.. tip:: Be careful though, that loading the related Aggregate in your Controller will still make it get validated
+		 during persistence. That is another good reason why you should try to minimize relations between Aggregates and if
+		 possible, try to stick to a simple identifier instead of an object relation.
+
+For a good read on designing Aggregates, you are highly encouraged to take a read on Vaughn Vernon's essay series
+`Effective Aggregate Design`_.
+
+
 Advanced Feature: Partial Validation
 ====================================
 
@@ -348,3 +369,5 @@ In case you do further checks on the options and any of them is invalid, an
          If you do not want to accept empty values, you need to set the class property
          $acceptsEmptyValues to FALSE.
 
+
+.. _Effective Aggregate Design: https://vaughnvernon.co/?p=838

--- a/TYPO3.Flow/Tests/Functional/Validation/ValidationTest.php
+++ b/TYPO3.Flow/Tests/Functional/Validation/ValidationTest.php
@@ -10,6 +10,7 @@ namespace TYPO3\Flow\Tests\Functional\Validation;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+use TYPO3\Flow\Reflection\ObjectAccess;
 use TYPO3\Flow\Tests\Functional\Persistence\Fixtures\SubEntity;
 use TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntity;
 use TYPO3\Flow\Tests\FunctionalTestCase;
@@ -131,5 +132,41 @@ class ValidationTest extends FunctionalTestCase
         );
         $response = $this->browser->request('http://localhost/test/validation/entity/update', 'POST', $invalidArguments);
         $this->assertSame('An error occurred while trying to call TYPO3\Flow\Tests\Functional\Mvc\Fixtures\Controller\EntityController->updateAction().' . PHP_EOL . 'Error for entity.name:  This field must contain at least 3 characters.' . PHP_EOL, $response->getContent());
+    }
+
+    /**
+     * @test
+     */
+    public function validationIsStoppedAtAggregateBoundaries()
+    {
+        $relatedEntity = new TestEntity();
+        $relatedEntity->setName('Spy');
+        $this->testEntityRepository->add($relatedEntity);
+
+        $entity = new TestEntity();
+        $entity->setName('Some Name');
+        $entity->setRelatedEntity($relatedEntity);
+        $this->testEntityRepository->add($entity);
+
+        $this->persistenceManager->persistAll();
+
+        $entityIdentifier = $this->persistenceManager->getIdentifierByObject($relatedEntity);
+        /* @var $entityManager \Doctrine\ORM\EntityManagerInterface */
+        $entityManager = ObjectAccess::getProperty($this->persistenceManager, 'entityManager', true);
+        $dql = 'UPDATE ' . TestEntity::class . " e SET e.name = 'xx' WHERE e.Persistence_Object_Identifier = '$entityIdentifier'";
+        $query = $entityManager->createQuery($dql);
+        $query->getScalarResult();
+        $this->persistenceManager->clearState();
+
+        $entityIdentifier = $this->persistenceManager->getIdentifierByObject($entity);
+
+        $invalidArguments = array(
+            'entity' => array(
+                '__identity' => $entityIdentifier,
+                'name' => 'Some other Name'
+            )
+        );
+        $response = $this->browser->request('http://localhost/test/validation/entity/update', 'POST', $invalidArguments);
+        $this->assertNotSame('An error occurred while trying to call TYPO3\Flow\Tests\Functional\Mvc\Fixtures\Controller\EntityController->updateAction().' . PHP_EOL . 'Error for entity.relatedEntity.name:  This field must contain at least 3 characters.' . PHP_EOL, $response->getContent());
     }
 }

--- a/TYPO3.Flow/Tests/Functional/Validation/ValidationTest.php
+++ b/TYPO3.Flow/Tests/Functional/Validation/ValidationTest.php
@@ -168,5 +168,6 @@ class ValidationTest extends FunctionalTestCase
         );
         $response = $this->browser->request('http://localhost/test/validation/entity/update', 'POST', $invalidArguments);
         $this->assertNotSame('An error occurred while trying to call TYPO3\Flow\Tests\Functional\Mvc\Fixtures\Controller\EntityController->updateAction().' . PHP_EOL . 'Error for entity.relatedEntity.name:  This field must contain at least 3 characters.' . PHP_EOL, $response->getContent());
+        $this->assertSame(200, $response->getStatusCode());
     }
 }

--- a/TYPO3.Flow/Tests/Unit/Validation/ValidatorResolverTest.php
+++ b/TYPO3.Flow/Tests/Unit/Validation/ValidatorResolverTest.php
@@ -466,13 +466,13 @@ class ValidatorResolverTest extends \TYPO3\Flow\Tests\UnitTestCase
         $mockReflectionService = $this->getMock(\TYPO3\Flow\Reflection\ReflectionService::class);
         $mockReflectionService->expects($this->any())->method('getAllImplementationClassNamesForInterface')->with(\TYPO3\Flow\Validation\Validator\PolyTypeObjectValidatorInterface::class)->will($this->returnValue(array()));
         $mockReflectionService->expects($this->any())->method('getClassPropertyNames')->will($this->returnValue(array('entityProperty', 'otherProperty')));
-        $mockReflectionService->expects($this->at(1))->method('getPropertyTagsValues')->with($modelClassName, 'entityProperty')->will($this->returnValue(array('var' => array($entityClassName))));
-        $mockReflectionService->expects($this->at(2))->method('isPropertyAnnotatedWith')->will($this->returnValue(false));
-        $mockReflectionService->expects($this->at(3))->method('getPropertyAnnotations')->with($modelClassName, 'entityProperty', \TYPO3\Flow\Annotations\Validate::class)->will($this->returnValue(array()));
-        $mockReflectionService->expects($this->at(4))->method('getPropertyTagsValues')->with($modelClassName, 'otherProperty')->will($this->returnValue(array('var' => array($otherClassName))));
-        $mockReflectionService->expects($this->at(5))->method('isPropertyAnnotatedWith')->will($this->returnValue(false));
-        $mockReflectionService->expects($this->at(6))->method('getPropertyAnnotations')->with($modelClassName, 'otherProperty', \TYPO3\Flow\Annotations\Validate::class)->will($this->returnValue(array()));
-        $mockReflectionService->expects($this->any())->method('getClassSchema')->will($this->returnValue(null));
+        $mockReflectionService->expects($this->at(1))->method('getClassSchema')->will($this->returnValue(null));
+        $mockReflectionService->expects($this->at(2))->method('getPropertyTagsValues')->with($modelClassName, 'entityProperty')->will($this->returnValue(array('var' => array($entityClassName))));
+        $mockReflectionService->expects($this->at(3))->method('isPropertyAnnotatedWith')->will($this->returnValue(false));
+        $mockReflectionService->expects($this->at(4))->method('getPropertyAnnotations')->with($modelClassName, 'entityProperty', \TYPO3\Flow\Annotations\Validate::class)->will($this->returnValue(array()));
+        $mockReflectionService->expects($this->at(5))->method('getPropertyTagsValues')->with($modelClassName, 'otherProperty')->will($this->returnValue(array('var' => array($otherClassName))));
+        $mockReflectionService->expects($this->at(6))->method('isPropertyAnnotatedWith')->will($this->returnValue(false));
+        $mockReflectionService->expects($this->at(7))->method('getPropertyAnnotations')->with($modelClassName, 'otherProperty', \TYPO3\Flow\Annotations\Validate::class)->will($this->returnValue(array()));
 
         $mockObjectManager->expects($this->any())->method('get')->with(\TYPO3\Flow\Reflection\ReflectionService::class)->will($this->returnValue($mockReflectionService));
         $validatorResolver = $this->getAccessibleMock(\TYPO3\Flow\Validation\ValidatorResolver::class, array('resolveValidatorObjectName', 'createValidator', 'getBaseValidatorConjunction'));
@@ -493,9 +493,10 @@ class ValidatorResolverTest extends \TYPO3\Flow\Tests\UnitTestCase
 
         $mockReflectionService = $this->getMock(\TYPO3\Flow\Reflection\ReflectionService::class);
         $mockReflectionService->expects($this->any())->method('getAllImplementationClassNamesForInterface')->will($this->returnValue(array()));
-        $mockReflectionService->expects($this->at(0))->method('getClassPropertyNames')->will($this->returnValue(array('entityProperty')));
-        $mockReflectionService->expects($this->at(1))->method('getPropertyTagsValues')->with($modelClassName, 'entityProperty')->will($this->returnValue(array('var' => array('ToBeIgnored'))));
-        $mockReflectionService->expects($this->at(2))->method('isPropertyAnnotatedWith')->with($modelClassName, 'entityProperty', \TYPO3\Flow\Annotations\IgnoreValidation::class)->will($this->returnValue(true));
+        $mockReflectionService->expects($this->at(0))->method('getClassSchema')->will($this->returnValue(null));
+        $mockReflectionService->expects($this->at(1))->method('getClassPropertyNames')->will($this->returnValue(array('entityProperty')));
+        $mockReflectionService->expects($this->at(2))->method('getPropertyTagsValues')->with($modelClassName, 'entityProperty')->will($this->returnValue(array('var' => array('ToBeIgnored'))));
+        $mockReflectionService->expects($this->at(3))->method('isPropertyAnnotatedWith')->with($modelClassName, 'entityProperty', \TYPO3\Flow\Annotations\IgnoreValidation::class)->will($this->returnValue(true));
         $mockObjectManager = $this->getMock(\TYPO3\Flow\Object\ObjectManagerInterface::class);
         $mockObjectManager->expects($this->any())->method('get')->with(\TYPO3\Flow\Reflection\ReflectionService::class)->will($this->returnValue($mockReflectionService));
 
@@ -565,16 +566,17 @@ class ValidatorResolverTest extends \TYPO3\Flow\Tests\UnitTestCase
 
         $mockReflectionService = $this->getMock(\TYPO3\Flow\Reflection\ReflectionService::class, array(), array(), '', false);
         $mockReflectionService->expects($this->any())->method('getAllImplementationClassNamesForInterface')->with(\TYPO3\Flow\Validation\Validator\PolyTypeObjectValidatorInterface::class)->will($this->returnValue(array()));
-        $mockReflectionService->expects($this->at(0))->method('getClassPropertyNames')->with($className)->will($this->returnValue(array('foo', 'bar', 'baz')));
-        $mockReflectionService->expects($this->at(1))->method('getPropertyTagsValues')->with($className, 'foo')->will($this->returnValue($propertyTagsValues['foo']));
-        $mockReflectionService->expects($this->at(2))->method('isPropertyAnnotatedWith')->will($this->returnValue(false));
-        $mockReflectionService->expects($this->at(3))->method('getPropertyAnnotations')->with(get_class($mockObject), 'foo', \TYPO3\Flow\Annotations\Validate::class)->will($this->returnValue($validateAnnotations['foo']));
-        $mockReflectionService->expects($this->at(4))->method('getPropertyTagsValues')->with($className, 'bar')->will($this->returnValue($propertyTagsValues['bar']));
-        $mockReflectionService->expects($this->at(5))->method('isPropertyAnnotatedWith')->will($this->returnValue(false));
-        $mockReflectionService->expects($this->at(6))->method('getPropertyAnnotations')->with(get_class($mockObject), 'bar', \TYPO3\Flow\Annotations\Validate::class)->will($this->returnValue($validateAnnotations['bar']));
-        $mockReflectionService->expects($this->at(7))->method('getPropertyTagsValues')->with($className, 'baz')->will($this->returnValue($propertyTagsValues['baz']));
-        $mockReflectionService->expects($this->at(8))->method('isPropertyAnnotatedWith')->will($this->returnValue(false));
-        $mockReflectionService->expects($this->at(9))->method('getPropertyAnnotations')->with(get_class($mockObject), 'baz', \TYPO3\Flow\Annotations\Validate::class)->will($this->returnValue(array()));
+        $mockReflectionService->expects($this->at(0))->method('getClassSchema')->will($this->returnValue(null));
+        $mockReflectionService->expects($this->at(1))->method('getClassPropertyNames')->with($className)->will($this->returnValue(array('foo', 'bar', 'baz')));
+        $mockReflectionService->expects($this->at(2))->method('getPropertyTagsValues')->with($className, 'foo')->will($this->returnValue($propertyTagsValues['foo']));
+        $mockReflectionService->expects($this->at(3))->method('isPropertyAnnotatedWith')->will($this->returnValue(false));
+        $mockReflectionService->expects($this->at(4))->method('getPropertyAnnotations')->with(get_class($mockObject), 'foo', \TYPO3\Flow\Annotations\Validate::class)->will($this->returnValue($validateAnnotations['foo']));
+        $mockReflectionService->expects($this->at(5))->method('getPropertyTagsValues')->with($className, 'bar')->will($this->returnValue($propertyTagsValues['bar']));
+        $mockReflectionService->expects($this->at(6))->method('isPropertyAnnotatedWith')->will($this->returnValue(false));
+        $mockReflectionService->expects($this->at(7))->method('getPropertyAnnotations')->with(get_class($mockObject), 'bar', \TYPO3\Flow\Annotations\Validate::class)->will($this->returnValue($validateAnnotations['bar']));
+        $mockReflectionService->expects($this->at(8))->method('getPropertyTagsValues')->with($className, 'baz')->will($this->returnValue($propertyTagsValues['baz']));
+        $mockReflectionService->expects($this->at(9))->method('isPropertyAnnotatedWith')->will($this->returnValue(false));
+        $mockReflectionService->expects($this->at(10))->method('getPropertyAnnotations')->with(get_class($mockObject), 'baz', \TYPO3\Flow\Annotations\Validate::class)->will($this->returnValue(array()));
         $mockObjectManager = $this->getMock(\TYPO3\Flow\Object\ObjectManagerInterface::class);
         $mockObjectManager->expects($this->any())->method('get')->with(\TYPO3\Flow\Reflection\ReflectionService::class)->will($this->returnValue($mockReflectionService));
 

--- a/TYPO3.Flow/Tests/Unit/Validation/ValidatorResolverTest.php
+++ b/TYPO3.Flow/Tests/Unit/Validation/ValidatorResolverTest.php
@@ -472,6 +472,7 @@ class ValidatorResolverTest extends \TYPO3\Flow\Tests\UnitTestCase
         $mockReflectionService->expects($this->at(4))->method('getPropertyTagsValues')->with($modelClassName, 'otherProperty')->will($this->returnValue(array('var' => array($otherClassName))));
         $mockReflectionService->expects($this->at(5))->method('isPropertyAnnotatedWith')->will($this->returnValue(false));
         $mockReflectionService->expects($this->at(6))->method('getPropertyAnnotations')->with($modelClassName, 'otherProperty', \TYPO3\Flow\Annotations\Validate::class)->will($this->returnValue(array()));
+        $mockReflectionService->expects($this->any())->method('getClassSchema')->will($this->returnValue(null));
 
         $mockObjectManager->expects($this->any())->method('get')->with(\TYPO3\Flow\Reflection\ReflectionService::class)->will($this->returnValue($mockReflectionService));
         $validatorResolver = $this->getAccessibleMock(\TYPO3\Flow\Validation\ValidatorResolver::class, array('resolveValidatorObjectName', 'createValidator', 'getBaseValidatorConjunction'));


### PR DESCRIPTION
This is one specific attempt at optimizing entity hierarchy validation, by stopping validation at unloaded Aggregate boundaries.

It is based on the idea that unloaded aggregates (doctrine proxy instances) do not carry changes, and since aggregates form a natural consistency boundary validation should not change and therefore can be stopped.

This will improve performance noticeably if you designed relatively small aggregates, but have lots of aggregate relations in your domain model.

FLOW-17 #comment This optimizes validation performance for well designed Aggregates

[snip] the following can be removed for merging: [/snip]

See also https://discuss.neos.io/t/rfc-optimized-validation-of-entities/340/5

Pro:
- simple implementation
- makes sense from a DDD perspective
- it's easy to define validation cascading through eager loading relations

Con:
- as is, only works for lazily loaded aggregate relations (which is default in doctrine)
- loading of proxies can sometimes happen unwantedly
- does not help on deep aggregates