### PR TITLE
FEATURE: Validate only objects that actually need validation

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/Controller/ActionController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/Controller/ActionController.php
@@ -159,6 +159,8 @@ class ActionController extends AbstractController
 
         $this->mapRequestArgumentsToControllerArguments();
 
+        // TODO: We could do the validation initialization and invocation here and then make use of change information inside the propertyMapper
+
         if ($this->view === null) {
             $this->view = $this->resolveView();
         }
@@ -297,7 +299,7 @@ class ActionController extends AbstractController
         } else {
             $validateAnnotations = array();
         }
-        $parameterValidators = $this->validatorResolver->buildMethodArgumentsValidatorConjunctions(get_class($this), $this->actionMethodName, $methodParameters, $validateAnnotations);
+        $parameterValidators = $this->validatorResolver->buildMethodArgumentsValidatorConjunctions(get_class($this), $this->actionMethodName, $methodParameters, $validateAnnotations, $validationGroups);
 
         if (isset($actionIgnoredArguments[$this->actionMethodName])) {
             $ignoredArguments = $actionIgnoredArguments[$this->actionMethodName];

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/Controller/Argument.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/Controller/Argument.php
@@ -284,6 +284,8 @@ class Argument
             return $this;
         }
         $this->value = $this->propertyMapper->convert($rawValue, $this->dataType, $this->getPropertyMappingConfiguration());
+        // TODO: Should we better resolve validation after this, so we can use the change information from property mapping to
+        //       build an optimal validator chain?
         $this->validationResults = $this->propertyMapper->getMessages();
         if ($this->validator !== null) {
             $validationMessages = $this->validator->validate($this->value);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/PersistenceManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/PersistenceManager.php
@@ -67,6 +67,7 @@ class PersistenceManager extends \TYPO3\Flow\Persistence\AbstractPersistenceMana
      */
     public function onFlush(\Doctrine\ORM\Event\OnFlushEventArgs $eventArgs)
     {
+        /* @var $unitOfWork \Doctrine\ORM\UnitOfWork */
         $unitOfWork = $this->entityManager->getUnitOfWork();
         $entityInsertions = $unitOfWork->getScheduledEntityInsertions();
 
@@ -84,12 +85,15 @@ class PersistenceManager extends \TYPO3\Flow\Persistence\AbstractPersistenceMana
 
                 $knownValueObjects[$className][$identifier] = true;
             }
+            // TODO: Should we use the same $changeSet aproach like below here?
             $this->validateObject($entity, $validatedInstancesContainer);
         }
 
         \TYPO3\Flow\Reflection\ObjectAccess::setProperty($unitOfWork, 'entityInsertions', $entityInsertions, true);
 
         foreach ($unitOfWork->getScheduledEntityUpdates() as $entity) {
+            $changeSet = $unitOfWork->getEntityChangeSet($entity);
+            // TODO: Traverse changeset and mark this object and all sub objects with changes for validation
             $this->validateObject($entity, $validatedInstancesContainer);
         }
     }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/PersistentObjectConverter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/PersistentObjectConverter.php
@@ -188,10 +188,16 @@ class PersistentObjectConverter extends ObjectConverter
 
         $objectConstructorArguments = $this->getConstructorArgumentsForClass(TypeHandling::getTypeForValue($object));
 
+        $validateObject = false;
         foreach ($convertedChildProperties as $propertyName => $propertyValue) {
+            $currentPropertyValue = ObjectAccess::getProperty($object, $propertyName);
+            if (!$validateObject) {
+                if ($currentPropertyValue !== $propertyValue) {
+                    $validateObject = true;
+                }
+            }
             // We need to check for "immutable" constructor arguments that have no setter and remove them.
             if (isset($objectConstructorArguments[$propertyName]) && !ObjectAccess::isPropertySettable($object, $propertyName)) {
-                $currentPropertyValue = ObjectAccess::getProperty($object, $propertyName);
                 if ($currentPropertyValue === $propertyValue) {
                     continue;
                 } else {
@@ -216,6 +222,9 @@ class PersistentObjectConverter extends ObjectConverter
             }
         }
 
+        if ($validateObject) {
+            // TODO: Mark $object to be (re)considered for Controller validation
+        }
         return $object;
     }
 
@@ -254,6 +263,9 @@ class PersistentObjectConverter extends ObjectConverter
             }
         }
 
+        if ($object !== null) {
+            // TODO: Mark $object to skip Controller validation
+        }
         return $object;
     }
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Validation/Validator/GenericObjectValidator.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Validation/Validator/GenericObjectValidator.php
@@ -21,6 +21,13 @@ class GenericObjectValidator extends AbstractValidator implements ObjectValidato
     /**
      * @var array
      */
+    protected $supportedOptions = array(
+        'validationGroups' => array(array(), 'The validation groups to link to', 'array'),
+    );
+
+    /**
+     * @var array
+     */
     protected $propertyValidators = array();
 
     /**

--- a/TYPO3.Flow/Tests/Functional/Mvc/Fixtures/Controller/EntityController.php
+++ b/TYPO3.Flow/Tests/Functional/Mvc/Fixtures/Controller/EntityController.php
@@ -74,4 +74,58 @@ class EntityController extends ActionController
 
         return $message;
     }
+
+    /**
+     * @return void
+     */
+    protected function initializeValidateAction()
+    {
+        $this->arguments->getArgument('entity')->getPropertyMappingConfiguration()
+            ->allowAllProperties()
+            ->setTypeConverterOption('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED, TRUE);
+        $this->arguments->getArgument('entity')->getPropertyMappingConfiguration()
+            ->forProperty('subEntities.*')
+            ->allowAllProperties()
+            ->setTypeConverterOption('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED, TRUE);
+    }
+
+    /**
+     * @param \TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntity $entity
+     * @return string
+     */
+    public function validateAction(TestEntity $entity)
+    {
+        /* @var \TYPO3\Flow\Tests\Functional\Validation\Fixtures\SpyValidator $spyValidator */
+        $spyValidator = $this->objectManager->get('TYPO3\Flow\Tests\Functional\Validation\Fixtures\SpyValidator');
+        return sprintf('SpyValidator was executed %d times.', $spyValidator->executionCount());
+    }
+
+    /**
+     * @return void
+     */
+    protected function initializeValidatePersistenceAction()
+    {
+        $this->arguments->getArgument('entity')->getPropertyMappingConfiguration()
+            ->allowAllProperties()
+            ->setTypeConverterOption('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED, TRUE);
+        $this->arguments->getArgument('entity')->getPropertyMappingConfiguration()
+            ->forProperty('subEntities.*')
+            ->allowAllProperties()
+            ->setTypeConverterOption('TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter', PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED, TRUE);
+    }
+
+    /**
+     * @param \TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntity $entity
+     * @return string
+     */
+    public function validatePersistenceAction(TestEntity $entity)
+    {
+        $entity->setValidatedProperty('Some value set inside Action');
+        $this->testEntityRepository->update($entity);
+        $this->persistenceManager->persistAll();
+
+        /* @var \TYPO3\Flow\Tests\Functional\Validation\Fixtures\SpyValidator $spyValidator */
+        $spyValidator = $this->objectManager->get('TYPO3\Flow\Tests\Functional\Validation\Fixtures\SpyValidator');
+        return sprintf('SpyValidator was executed %d times.', $spyValidator->executionCount());
+    }
 }

--- a/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/SubEntity.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/SubEntity.php
@@ -28,6 +28,12 @@ class SubEntity extends SuperEntity
     protected $parentEntity;
 
     /**
+     * @var string
+     * @Flow\Validate(type="\TYPO3\Flow\Tests\Functional\Validation\Fixtures\SpyValidator")
+     */
+    protected $validatedProperty = '';
+
+    /**
      * @param \TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntity $parentEntity
      * @return void
      */
@@ -42,5 +48,21 @@ class SubEntity extends SuperEntity
     public function getParentEntity()
     {
         return $this->parentEntity;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValidatedProperty()
+    {
+        return $this->validatedProperty;
+    }
+
+    /**
+     * @param string $validatedProperty
+     */
+    public function setValidatedProperty($validatedProperty)
+    {
+        $this->validatedProperty = $validatedProperty;
     }
 }

--- a/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/TestEntity.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/TestEntity.php
@@ -68,6 +68,12 @@ class TestEntity
     protected $arrayProperty = array();
 
     /**
+     * @var string
+     * @Flow\Validate(type="\TYPO3\Flow\Tests\Functional\Validation\Fixtures\SpyValidator")
+     */
+    protected $validatedProperty = '';
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -199,5 +205,21 @@ class TestEntity
     public function getRelatedValueObject()
     {
         return $this->relatedValueObject;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValidatedProperty()
+    {
+        return $this->validatedProperty;
+    }
+
+    /**
+     * @param string $validatedProperty
+     */
+    public function setValidatedProperty($validatedProperty)
+    {
+        $this->validatedProperty = $validatedProperty;
     }
 }

--- a/TYPO3.Flow/Tests/Functional/Validation/Fixtures/SpyValidator.php
+++ b/TYPO3.Flow/Tests/Functional/Validation/Fixtures/SpyValidator.php
@@ -1,0 +1,57 @@
+<?php
+namespace TYPO3\Flow\Tests\Functional\Validation\Fixtures;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+
+/**
+ * Spy Validator for functional tests
+ * This validator checks that it was executed.
+ *
+ * @Flow\Scope("singleton")
+ */
+class SpyValidator extends \TYPO3\Flow\Validation\Validator\AbstractValidator
+{
+	/**
+	 * @var int How often this validator was executed in total
+	 */
+	protected $executionCount = 0;
+
+	/**
+	 * Check if $value is valid. If it is not valid, needs to add an error
+	 * to Result.
+	 *
+	 * @param mixed $value
+	 * @return void
+	 * @throws \TYPO3\Flow\Validation\Exception\InvalidValidationOptionsException if invalid validation options have been specified in the constructor
+	 */
+	protected function isValid($value)
+	{
+		$this->executionCount++;
+	}
+
+	/**
+	 * @return bool TRUE if this validator was executed
+	 */
+	public function wasExecuted()
+	{
+		return $this->executionCount > 0;
+	}
+
+	/**
+	 * @return int How often this validator was executed
+	 */
+	public function executionCount()
+	{
+		return $this->executionCount;
+	}
+}

--- a/TYPO3.Flow/Tests/Functional/Validation/ValidationTest.php
+++ b/TYPO3.Flow/Tests/Functional/Validation/ValidationTest.php
@@ -132,4 +132,212 @@ class ValidationTest extends FunctionalTestCase
         $response = $this->browser->request('http://localhost/test/validation/entity/update', 'POST', $invalidArguments);
         $this->assertSame('An error occurred while trying to call TYPO3\Flow\Tests\Functional\Mvc\Fixtures\Controller\EntityController->updateAction().' . PHP_EOL . 'Error for entity.name:  This field must contain at least 3 characters.' . PHP_EOL, $response->getContent());
     }
+
+    /**
+     * @test
+     */
+    public function validationIsNotExecutedForUnchangedObject()
+    {
+        $entity = new TestEntity();
+        $entity->setValidatedProperty('Some value');
+        $this->testEntityRepository->add($entity);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+        $this->objectManager->forgetInstance('TYPO3\Flow\Tests\Functional\Validation\Fixtures\SpyValidator');
+
+        $entityIdentifier = $this->persistenceManager->getIdentifierByObject($entity);
+
+        $arguments = array(
+            'entity' => array(
+                '__identity' => $entityIdentifier,
+            )
+        );
+
+        $response = $this->browser->request('http://localhost/test/validation/entity/validate', 'POST', $arguments);
+        $this->assertSame('SpyValidator was executed 0 times.', $response->getContent());
+    }
+
+    /**
+     * @test
+     */
+    public function validationIsExecutedForChangedObject()
+    {
+        $entity = new TestEntity();
+        $entity->setValidatedProperty('Some value');
+        $this->testEntityRepository->add($entity);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+        $this->objectManager->forgetInstance('TYPO3\Flow\Tests\Functional\Validation\Fixtures\SpyValidator');
+
+        $entityIdentifier = $this->persistenceManager->getIdentifierByObject($entity);
+
+        $arguments = array(
+            'entity' => array(
+                '__identity' => $entityIdentifier,
+                'validatedProperty' => 'Changed value',
+            )
+        );
+
+        $response = $this->browser->request('http://localhost/test/validation/entity/validate', 'POST', $arguments);
+        $this->assertSame('SpyValidator was executed 1 times.', $response->getContent());
+    }
+
+    /**
+     * @test
+     */
+    public function validationIsNotExecutedForUnchangedSubObject()
+    {
+        $entity = new TestEntity();
+        $entity->setValidatedProperty('Some value');
+        $this->testEntityRepository->add($entity);
+
+        $subEntity = new SubEntity();
+        $subEntity->setContent('Sub Entity');
+        $subEntity->setValidatedProperty('Some value');
+        $subEntity->setParentEntity($entity);
+        $entity->addSubEntity($subEntity);
+        $this->persistenceManager->add($subEntity);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+        $this->objectManager->forgetInstance('TYPO3\Flow\Tests\Functional\Validation\Fixtures\SpyValidator');
+
+        $entityIdentifier = $this->persistenceManager->getIdentifierByObject($entity);
+        $subEntityIdentifier = $this->persistenceManager->getIdentifierByObject($subEntity);
+
+        $arguments = array(
+            'entity' => array(
+                '__identity' => $entityIdentifier,
+                'validatedProperty' => 'Changed value',
+                'subEntities' => array(array(
+                    '__identity' => $subEntityIdentifier,
+                ))
+            )
+        );
+
+        $response = $this->browser->request('http://localhost/test/validation/entity/validate', 'POST', $arguments);
+        $this->assertSame('SpyValidator was executed 1 times.', $response->getContent());
+    }
+
+    /**
+     * @test
+     */
+    public function validationIsOnlyExecutedForChangedSubObject()
+    {
+        $entity = new TestEntity();
+        $entity->setValidatedProperty('Some value');
+        $this->testEntityRepository->add($entity);
+
+        $subEntity = new SubEntity();
+        $subEntity->setContent('Sub Entity');
+        $subEntity->setValidatedProperty('Some value');
+        $subEntity->setParentEntity($entity);
+        $entity->addSubEntity($subEntity);
+        $this->persistenceManager->add($subEntity);
+
+        $subEntity2 = new SubEntity();
+        $subEntity2->setContent('Sub Entity 2');
+        $subEntity2->setValidatedProperty('Some value');
+        $subEntity2->setParentEntity($entity);
+        $entity->addSubEntity($subEntity2);
+        $this->persistenceManager->add($subEntity2);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+        $this->objectManager->forgetInstance('TYPO3\Flow\Tests\Functional\Validation\Fixtures\SpyValidator');
+
+        $entityIdentifier = $this->persistenceManager->getIdentifierByObject($entity);
+        $subEntityIdentifier = $this->persistenceManager->getIdentifierByObject($subEntity);
+        $subEntity2Identifier = $this->persistenceManager->getIdentifierByObject($subEntity2);
+
+        $arguments = array(
+            'entity' => array(
+                '__identity' => $entityIdentifier,
+                'subEntities' => array(array(
+                    '__identity' => $subEntityIdentifier,
+                ), array(
+                    '__identity' => $subEntity2Identifier,
+                    'validatedProperty' => 'Changed value',
+                ))
+            )
+        );
+
+        $response = $this->browser->request('http://localhost/test/validation/entity/validate', 'POST', $arguments);
+        $this->assertSame('SpyValidator was executed 1 times.', $response->getContent());
+    }
+
+
+    /**
+     * @test
+     */
+    public function persistenceValidationIsExecutedForChangedObject()
+    {
+        $entity = new TestEntity();
+        $entity->setValidatedProperty('Some value');
+        $this->testEntityRepository->add($entity);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+        $this->objectManager->forgetInstance('TYPO3\Flow\Tests\Functional\Validation\Fixtures\SpyValidator');
+
+        $entityIdentifier = $this->persistenceManager->getIdentifierByObject($entity);
+
+        $arguments = array(
+            'entity' => array(
+                '__identity' => $entityIdentifier,
+            )
+        );
+
+        $response = $this->browser->request('http://localhost/test/validation/entity/validatePersistence', 'POST', $arguments);
+        $this->assertSame('SpyValidator was executed 2 times.', $response->getContent());
+    }
+
+    /**
+     * @test
+     */
+    public function persistenceValidationIsOnlyExecutedForChangedSubObject()
+    {
+        $entity = new TestEntity();
+        $entity->setValidatedProperty('Some value');
+        $this->testEntityRepository->add($entity);
+
+        $subEntity = new SubEntity();
+        $subEntity->setContent('Sub Entity');
+        $subEntity->setValidatedProperty('Some value');
+        $subEntity->setParentEntity($entity);
+        $entity->addSubEntity($subEntity);
+        $this->persistenceManager->add($subEntity);
+
+        $subEntity2 = new SubEntity();
+        $subEntity2->setContent('Sub Entity 2');
+        $subEntity2->setValidatedProperty('Some value');
+        $subEntity2->setParentEntity($entity);
+        $entity->addSubEntity($subEntity2);
+        $this->persistenceManager->add($subEntity2);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+        $this->objectManager->forgetInstance('TYPO3\Flow\Tests\Functional\Validation\Fixtures\SpyValidator');
+
+        $entityIdentifier = $this->persistenceManager->getIdentifierByObject($entity);
+        $subEntityIdentifier = $this->persistenceManager->getIdentifierByObject($subEntity);
+        $subEntity2Identifier = $this->persistenceManager->getIdentifierByObject($subEntity2);
+
+        $arguments = array(
+            'entity' => array(
+                '__identity' => $entityIdentifier,
+                'subEntities' => array(array(
+                    '__identity' => $subEntityIdentifier,
+                ), array(
+                    '__identity' => $subEntity2Identifier,
+                    'validatedProperty' => 'Changed value',
+                ))
+            )
+        );
+
+        $response = $this->browser->request('http://localhost/test/validation/entity/validatePersistence', 'POST', $arguments);
+        $this->assertSame('SpyValidator was executed 1 times.', $response->getContent());
+    }
 }


### PR DESCRIPTION
This change optimizes object validation, especially for large
hierarchies. Objects are only validated during persistence when
they contain changes and only validated in controller arguments
when they were submitted with set properties.

This is a second (unfinished) attempt at optimizing object hierarchy validation, which
is much more careless about edge use-cases.
Also see #334 and https://discuss.neos.io/t/rfc-optimized-validation-of-entities/340/5

Pro:
 - pretty much optimal validation performance
 - based on simple (naive) convention "what didn't change cannot fail"

Con:
 - relatively complex to implement (needs to store change state information at some place accesible for validators)
 - as is, ignores use-cases where partial object submission might fail on validators of previously submitted objects, depending for example on validation groups (see also https://neos-project.slack.com/archives/guild-validation/p1441885466000005)
 - will cause some coupling between property mapping and validation

FLOW-17 #close