### PR TITLE
TASK: Fix use of deprecated events in InstallerScripts

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Composer/InstallerScripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Composer/InstallerScripts.php
@@ -13,8 +13,8 @@ namespace TYPO3\Flow\Composer;
 
 use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Operation\UpdateOperation;
-use Composer\Script\CommandEvent;
-use Composer\Script\PackageEvent;
+use Composer\Script\Event;
+use Composer\Installer\PackageEvent;
 use TYPO3\Flow\Utility\Files;
 
 /**
@@ -26,10 +26,10 @@ class InstallerScripts
      * Make sure required paths and files are available outside of Package
      * Run on every Composer install or update - must be configured in root manifest
      *
-     * @param CommandEvent $event
+     * @param Event $event
      * @return void
      */
-    public static function postUpdateAndInstall(CommandEvent $event)
+    public static function postUpdateAndInstall(Event $event)
     {
         Files::createDirectoryRecursively('Configuration');
         Files::createDirectoryRecursively('Data');
@@ -43,7 +43,7 @@ class InstallerScripts
     /**
      * Calls actions and install scripts provided by installed packages.
      *
-     * @param \Composer\Script\PackageEvent $event
+     * @param PackageEvent $event
      * @return void
      * @throws Exception\UnexpectedOperationException
      */


### PR DESCRIPTION
The CommandEvent and PackageEvent used in InstallerScripts are
deprecated since early 2015.