### PR TITLE
BUGFIX: Add translation for error message (string length)

### DIFF
--- a/TYPO3.Flow/Resources/Private/Translations/de/ValidationErrors.xlf
+++ b/TYPO3.Flow/Resources/Private/Translations/de/ValidationErrors.xlf
@@ -116,24 +116,20 @@
 				<source>The length of this text must be between {0,number} and {1,number} characters</source>
 			<target xml:lang="de">Die Länge des Textes muss zwischen {0,number} und {1,number} Zeichen liegen</target></trans-unit>
       <group id="1238108068" restype="x-gettext-plurals">
-        <trans-unit id="1238108068[0]">
-          <source/>
-          <target xml:lang="de"/>
-        </trans-unit>
-        <trans-unit id="1238108068[1]">
-          <source/>
-          <target xml:lang="de"/>
-        </trans-unit>
+        <trans-unit id="1238108068[0]" xml:space="preserve">
+					<source>This field must contain at least {0,number} character</source>
+				<target xml:lang="de">Dieses Feld muss mindestens {0,number} Zeichen enthalten</target></trans-unit>
+        <trans-unit id="1238108068[1]" xml:space="preserve">
+					<source>This field must contain at least {0,number} characters</source>
+				<target xml:lang="de">Dieses Feld muss mindestens {0,number} Zeichen enthalten</target></trans-unit>
       </group>
       <group id="1238108069" restype="x-gettext-plurals">
-        <trans-unit id="1238108069[0]">
-          <source/>
-          <target xml:lang="de"/>
-        </trans-unit>
-        <trans-unit id="1238108069[1]">
-          <source/>
-          <target xml:lang="de"/>
-        </trans-unit>
+        <trans-unit id="1238108069[0]" xml:space="preserve">
+					<source>This text may not exceed {0,number} character</source>
+				<target xml:lang="de">Die Zeichenfolge darf nicht mehr als {0,number} Zeichen enthalten</target></trans-unit>
+        <trans-unit id="1238108069[1]" xml:space="preserve">
+					<source>This text may not exceed {0,number} characters</source>
+				<target xml:lang="de">Die Zeichenfolge darf nicht mehr als {0,number} Zeichen enthalten</target></trans-unit>
       </group>
       <!-- StringValidator -->
       <trans-unit id="1238108070" xml:space="preserve" approved="yes">


### PR DESCRIPTION
The translation is broken in 3.0 and up, even though it appears to be
correctly translated in Crowdin.

This is try to fix this.