### PR TITLE
BUGFIX: PackageManager uses incorrect packageKey for split libraries

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
@@ -1196,7 +1196,7 @@ class PackageManager implements PackageManagerInterface
     {
         $packageKey = '';
 
-        if ($packageType !== null && ComposerUtility::isFlowPackageType($packageType)) {
+        if (($packageType !== null && ComposerUtility::isFlowPackageType($packageType)) || ($packageType === 'library' && substr($composerName, 0, 5) === 'neos/')) {
             $lastSegmentOfPackagePath = substr(trim($packagePath, '/'), strrpos(trim($packagePath, '/'), '/') + 1);
             if (strpos($lastSegmentOfPackagePath, '.') !== false) {
                 $packageKey = $lastSegmentOfPackagePath;


### PR DESCRIPTION
The class loader derives the packageKey from the namespace declaration
for non-Flow packages. This is a problem for the split library package
which then share the same packageKey (being ``TYPO3.Flow.Utility``).

This change adds special handling for packages of type ``library`` and
a composer name starting with ``neos/``.