### PR TITLE
BUGFIX: Class loading errors because library packageKeys are incorrect

### DIFF
--- a/Neos.Utility.Arrays/composer.json
+++ b/Neos.Utility.Arrays/composer.json
@@ -21,5 +21,10 @@
     "psr-4": {
       "Neos\\Utility\\Arrays\\Tests\\": "Tests"
     }
+  },
+  "extra": {
+    "neos": {
+      "package-key": "Neos.Utility.Arrays"
+    }
   }
 }

--- a/Neos.Utility.Files/composer.json
+++ b/Neos.Utility.Files/composer.json
@@ -20,5 +20,10 @@
     "psr-4": {
       "TYPO3\\Flow\\Utility\\Files\\Tests\\": "Tests"
     }
+  },
+  "extra": {
+    "neos": {
+      "package-key": "Neos.Utility.Files"
+    }
   }
 }

--- a/Neos.Utility.MediaTypes/composer.json
+++ b/Neos.Utility.MediaTypes/composer.json
@@ -20,5 +20,10 @@
     "psr-4": {
       "TYPO3\\Flow\\Utility\\MediaTypes\\Tests\\": "Tests"
     }
+  },
+  "extra": {
+    "neos": {
+      "package-key": "Neos.Utility.MediaTypes"
+    }
   }
 }

--- a/Neos.Utility.ObjectHandling/composer.json
+++ b/Neos.Utility.ObjectHandling/composer.json
@@ -21,5 +21,10 @@
     "psr-4": {
       "Neos\\Utility\\ObjectHandling\\Tests\\": "Tests"
     }
+  },
+  "extra": {
+    "neos": {
+      "package-key": "Neos.Utility.ObjectHandling"
+    }
   }
 }

--- a/Neos.Utility.OpcodeCache/composer.json
+++ b/Neos.Utility.OpcodeCache/composer.json
@@ -11,5 +11,10 @@
     "psr-0": {
       "TYPO3\\Flow\\Utility": "Classes"
     }
+  },
+  "extra": {
+    "neos": {
+      "package-key": "Neos.Utility.OpcodeCache"
+    }
   }
 }

--- a/Neos.Utility.Pdo/composer.json
+++ b/Neos.Utility.Pdo/composer.json
@@ -11,5 +11,10 @@
     "psr-0": {
       "TYPO3\\Flow\\Utility": "Classes"
     }
+  },
+  "extra": {
+    "neos": {
+      "package-key": "Neos.Utility.Pdo"
+    }
   }
 }

--- a/Neos.Utility.Schema/composer.json
+++ b/Neos.Utility.Schema/composer.json
@@ -21,5 +21,10 @@
     "psr-4": {
       "TYPO3\\Flow\\Utility\\Schema\\Tests\\": "Tests"
     }
+  },
+  "extra": {
+    "neos": {
+      "package-key": "Neos.Utility.Schema"
+    }
   }
 }


### PR DESCRIPTION
The package manager derives the packageKey from the class loader configuration
if the package type is ``library``. This leads to problems with the split
libraries that share the namespace ``TYPO3\\Flow\\Utility`` because the
package state configuration for is overwritten.

Depending on the dependency order of the packages this will lead to symptoms
like class loading errors for the ``Neos.Utility.Schema`` package.

This change adds the specific packageKey to use to the composer.json to
load the libraries correctly.