### PR TITLE
FEATURE: Use require-dev and suggest for package ordering

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageOrderResolver.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageOrderResolver.php
@@ -93,7 +93,12 @@ class PackageOrderResolver
         $unsortedPackages[$packageKey] = -1;
         $packageComposerManifest = $this->manifestData[$packageKey];
         $packageRequirements = isset($packageComposerManifest['require']) ? array_keys($packageComposerManifest['require']) : [];
-        // HINT: at this point, we do not support require-dev dependencies yet (but we could).
+        if (isset($packageComposerManifest['require-dev'])) {
+            $packageRequirements = array_merge($packageRequirements, array_keys($packageComposerManifest['require-dev']));
+        }
+        if (isset($packageComposerManifest['suggest'])) {
+            $packageRequirements = array_merge($packageRequirements, array_keys($packageComposerManifest['suggest']));
+        }
         $unresolvedDependencies = 0;
 
         foreach ($packageRequirements as $requiredComposerName) {

--- a/TYPO3.Flow/Tests/Unit/Package/PackageOrderResolverTest.php
+++ b/TYPO3.Flow/Tests/Unit/Package/PackageOrderResolverTest.php
@@ -31,13 +31,10 @@ class PackageOrderResolverTest extends \TYPO3\Flow\Tests\UnitTestCase
                         'name' => 'doctrine/orm',
                         'require' => ['doctrine/dbal' => 'dev-master'],
                     ],
-                    'symfony/component-yaml' => [
-                        'name' => 'symfony/component-yaml',
-                        'require' => [],
-                    ],
                     'typo3/flow' => [
                         'name' => 'typo3/flow',
-                        'require' => ['symfony/component-yaml' => 'dev-master', 'doctrine/orm' => 'dev-master'],
+                        'require' => ['doctrine/orm' => 'dev-master'],
+                        'require-dev' => ['symfony/component-yaml' => 'dev-master'],
                     ],
                     'doctrine/common' => [
                         'name' => 'doctrine/common',
@@ -46,10 +43,19 @@ class PackageOrderResolverTest extends \TYPO3\Flow\Tests\UnitTestCase
                     'doctrine/dbal' => [
                         'name' => 'doctrine/dbal',
                         'require' => ['doctrine/common' => 'dev-master'],
+                        'suggest' => ['my/package' => 'dev-master'],
+                    ],
+                    'my/package' => [
+                        'name' => 'my/package'
+                    ],
+                    'symfony/component-yaml' => [
+                        'name' => 'symfony/component-yaml',
+                        'require' => [],
                     ],
                 ],
                 [
                     'doctrine/common',
+                    'my/package',
                     'doctrine/dbal',
                     'doctrine/orm',
                     'symfony/component-yaml',


### PR DESCRIPTION
This change adds require-dev and suggest to the package order resolver.
This allows packages to be sure they're loaded after a package
they suggest so it is still possible to overwrite configuration.
Besides that it is now no longer required to require a package that is
meant for development only