### PR TITLE
BUGFIX: Fix ObjectAccessorNode::getPropertyPath for is/has access in PHP7

### DIFF
--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/Core/Parser/SyntaxTree/ObjectAccessorNode.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/Core/Parser/SyntaxTree/ObjectAccessorNode.php
@@ -93,9 +93,13 @@ class ObjectAccessorNode extends AbstractNode
             try {
                 $subject = ObjectAccess::getProperty($subject, $propertyName);
             } catch (PropertyNotAccessibleException $exception) {
-                if (is_object($subject) && preg_match('/^(is|has)([A-Z].*)/', $propertyName, $matches) > 0) {
+                if (is_object($subject)
+                    && preg_match('/^(is|has)([A-Z].*)/', $propertyName, $matches) > 0
+                    && is_callable([$subject, $propertyName])) {
                     try {
                         $subject = $subject->$propertyName();
+                    } catch (\Throwable $exception) {
+                        $subject = null;
                     } catch (\Exception $exception) {
                         $subject = null;
                     }

--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/Core/Parser/SyntaxTree/ObjectAccessorNode.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/Core/Parser/SyntaxTree/ObjectAccessorNode.php
@@ -96,13 +96,7 @@ class ObjectAccessorNode extends AbstractNode
                 if (is_object($subject)
                     && preg_match('/^(is|has)([A-Z].*)/', $propertyName, $matches) > 0
                     && is_callable([$subject, $propertyName])) {
-                    try {
-                        $subject = $subject->$propertyName();
-                    } catch (\Throwable $exception) {
-                        $subject = null;
-                    } catch (\Exception $exception) {
-                        $subject = null;
-                    }
+                    $subject = $subject->$propertyName();
                 } else {
                     $subject = null;
                 }


### PR DESCRIPTION
Related to: #108, #343

This fixes the try/catch for undefined Fluid variables which start with "is" or "has".
Currently, exceptions here are not being caught because an `\Error` is being thrown.
As a safety measure for PHP7, we're now catching any `\Throwable` as well.
Also added is_callable check.

Specific example: a fluid section/partial with an optional argument called "isSomething"
- if rendered while defining isSomething in the arguments, there's no problem
- if rendered without isSomething in the arguments (implicit falsy), we then get `Call to undefined method TYPO3\Fluid\Core\ViewHelper\TemplateVariableContainer::isSomething()`