### PR TITLE
BUGFIX: Fix ObjectAccessorNode::getPropertyPath for is/has access in PHP7

### DIFF
--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/Core/Parser/SyntaxTree/ObjectAccessorNode.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/Core/Parser/SyntaxTree/ObjectAccessorNode.php
@@ -93,9 +93,13 @@ class ObjectAccessorNode extends AbstractNode
             try {
                 $subject = ObjectAccess::getProperty($subject, $propertyName);
             } catch (PropertyNotAccessibleException $exception) {
-                if (is_object($subject) && preg_match('/^(is|has)([A-Z].*)/', $propertyName, $matches) > 0) {
+                if (is_object($subject)
+                    && preg_match('/^(is|has)([A-Z].*)/', $propertyName, $matches) > 0
+                    && is_callable([$subject, $propertyName])) {
                     try {
                         $subject = $subject->$propertyName();
+                    } catch (\Throwable $exception) {
+                        $subject = null;
                     } catch (\Exception $exception) {
                         $subject = null;
                     }

--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/Core/Parser/SyntaxTree/ObjectAccessorNode.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/Core/Parser/SyntaxTree/ObjectAccessorNode.php
@@ -96,13 +96,7 @@ class ObjectAccessorNode extends AbstractNode
                 if (is_object($subject)
                     && preg_match('/^(is|has)([A-Z].*)/', $propertyName, $matches) > 0
                     && is_callable([$subject, $propertyName])) {
-                    try {
-                        $subject = $subject->$propertyName();
-                    } catch (\Throwable $exception) {
-                        $subject = null;
-                    } catch (\Exception $exception) {
-                        $subject = null;
-                    }
+                    $subject = $subject->$propertyName();
                 } else {
                     $subject = null;
                 }

--- a/TYPO3.Fluid/Tests/Functional/Core/ParserIntegrationTest.php
+++ b/TYPO3.Fluid/Tests/Functional/Core/ParserIntegrationTest.php
@@ -150,7 +150,7 @@ class ParserIntegrationTest extends FunctionalTestCase
         $post = new Post();
         $post->setPrivate(true);
         $this->view->assignMultiple(array('post' => $post));
-        $this->view->setTemplateSource('{post.isNonExisting}');
+        $this->view->setTemplateSource('<f:if condition="{post.isNonExisting}">Wrong!</f:if>');
 
         $actual = $this->view->render();
         $this->assertSame('', $actual);

--- a/TYPO3.Fluid/Tests/Functional/Core/ParserIntegrationTest.php
+++ b/TYPO3.Fluid/Tests/Functional/Core/ParserIntegrationTest.php
@@ -141,4 +141,18 @@ class ParserIntegrationTest extends FunctionalTestCase
         $actual = $this->view->render();
         $this->assertSame('', $actual);
     }
+
+    /**
+     * @test
+     */
+    public function nonExistingIsMethodWillNotThrowError()
+    {
+        $post = new Post();
+        $post->setPrivate(true);
+        $this->view->assignMultiple(array('post' => $post));
+        $this->view->setTemplateSource('{post.isNonExisting}');
+
+        $actual = $this->view->render();
+        $this->assertSame('', $actual);
+    }
 }


### PR DESCRIPTION
This fixes the try/catch for undefined Fluid variables which start with "is" or "has".
Currently, exceptions here are not being caught because an `\Error` is being thrown.
Since non-callable method call should not be attempted in the first place, this change
adds a is_callable check. Therefore a try/catch block is no longer necessary, as any exception thrown inside the callable method should bubble up.

Specific example: a fluid section/partial with an optional argument called "isSomething"

- if rendered while defining isSomething in the arguments, there's no problem
- if rendered without isSomething in the arguments (implicit falsy), we then get
  `Call to undefined method TYPO3\Fluid\Core\ViewHelper\TemplateVariableContainer::isSomething()`

Related to: #108, #343, #348, whythecode/flow-development-collection#1