### PR TITLE
TASK: Use version of composer.json as fallback for installed version of packages

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/Package.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/Package.php
@@ -465,7 +465,7 @@ class Package implements PackageInterface
     public function getInstalledVersion()
     {
         $installedVersion = PackageManager::getPackageVersion($this->composerName);
-        return  $installedVersion === '' ? $installedVersion : $this->getPackageMetaData()->getVersion();
+        return  $installedVersion !== '' ? $installedVersion : $this->getPackageMetaData()->getVersion();
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/Package.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/Package.php
@@ -456,7 +456,7 @@ class Package implements PackageInterface
     }
 
     /**
-     * Get the installed package version (from composer) and as fallback the version given by package meta data.
+     * Get the installed package version (from composer) and as fallback the version given by composer manifest.
      *
      * @return string
      * @api

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/Package.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/Package.php
@@ -456,7 +456,7 @@ class Package implements PackageInterface
     }
 
     /**
-     * Get the installed package version (from composer)
+     * Get the installed package version (from composer) and as fallback the version given by package meta data.
      *
      * @return string
      * @api
@@ -464,7 +464,8 @@ class Package implements PackageInterface
      */
     public function getInstalledVersion()
     {
-        return PackageManager::getPackageVersion($this->composerName);
+        $installedVersion = PackageManager::getPackageVersion($this->composerName);
+        return  $installedVersion === '' ? $installedVersion : $this->getPackageMetaData()->getVersion();
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/Package.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/Package.php
@@ -464,8 +464,7 @@ class Package implements PackageInterface
      */
     public function getInstalledVersion()
     {
-        $installedVersion = PackageManager::getPackageVersion($this->composerName);
-        return  $installedVersion !== '' ? $installedVersion : $this->getPackageMetaData()->getVersion();
+        return PackageManager::getPackageVersion($this->composerName) ?: $this->getPackageMetaData()->getVersion();
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/Package.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/Package.php
@@ -464,7 +464,7 @@ class Package implements PackageInterface
      */
     public function getInstalledVersion()
     {
-        return PackageManager::getPackageVersion($this->composerName) ?: $this->getPackageMetaData()->getVersion();
+        return PackageManager::getPackageVersion($this->composerName) ?: $this->getComposerManifest('version');
     }
 
     /**

--- a/TYPO3.Flow/Tests/Unit/Package/PackageTest.php
+++ b/TYPO3.Flow/Tests/Unit/Package/PackageTest.php
@@ -293,4 +293,16 @@ class PackageTest extends UnitTestCase
         $package = new Package('Some.Package', 'some/package', 'vfs://Packages/Some/Path/Some.Package/', []);
         $package->getComposerManifest();
     }
+
+    /**
+     * @test
+     */
+    public function getInstalledVersionReturnsFallback()
+    {
+        /** @var Package|\PHPUnit_Framework_MockObject_MockObject $package */
+        $package = $this->getMock(\TYPO3\Flow\Package\Package::class, ['getComposerManifest'], ['Some.Package', 'some/package', 'vfs://Packages/Some/Path/Some.Package/', []]);
+        $package->method('getComposerManifest')->willReturn('1.2.3');
+
+        $this->assertEquals('1.2.3', $package->getInstalledVersion('some/package'));
+    }
 }


### PR DESCRIPTION
In case of missing the installed version of a package, we provide the given version out of the composer.json of the package.

FLOW-455 #close