### PR TITLE
BUGFIX: Packages without classes should still monitor configuration and xliff

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
@@ -490,16 +490,17 @@ class Scripts
             if ($packageManager->isPackageFrozen($packageKey)) {
                 continue;
             }
+
+            self::monitorDirectoryIfItExists($fileMonitors['Flow_ConfigurationFiles'], $package->getConfigurationPath(), '\.yaml$');
+            self::monitorDirectoryIfItExists($fileMonitors['Flow_TranslationFiles'], $package->getResourcesPath() . 'Private/Translations/', '\.xlf');
+
             if (!in_array($packageKey, $packagesWithConfiguredObjects)) {
                 continue;
             }
-
             foreach ($package->getAutoloadPaths() as $autoloadPath) {
                 self::monitorDirectoryIfItExists($fileMonitors['Flow_ClassFiles'], $autoloadPath, '\.php$');
             }
 
-            self::monitorDirectoryIfItExists($fileMonitors['Flow_ConfigurationFiles'], $package->getConfigurationPath(), '\.yaml$');
-            self::monitorDirectoryIfItExists($fileMonitors['Flow_TranslationFiles'], $package->getResourcesPath() . 'Private/Translations/', '\.xlf');
             if ($context->isTesting() && $package instanceof Package) {
                 /** @var Package $package */
                 self::monitorDirectoryIfItExists($fileMonitors['Flow_ClassFiles'], $package->getFunctionalTestsPath(), '\.php$');


### PR DESCRIPTION
Packages without configured class files were exempted from monitoring to reduce
the amount of monitored files. This is fine for class files but monitoring of
configuration and xliff files should happen for all packages regardless if they
have configured class files or not.