### PR TITLE
BUGFIX: TypeHandling assumes vendor name to be uppercase

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Utility/TypeHandling.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Utility/TypeHandling.php
@@ -22,7 +22,7 @@ class TypeHandling
     /**
      * A property type parse pattern.
      */
-    const PARSE_TYPE_PATTERN = '/^\\\\?(?P<type>integer|int|float|double|boolean|bool|string|DateTime|[A-Z][a-zA-Z0-9\\\\]+|object|array|ArrayObject|SplObjectStorage|Doctrine\\\\Common\\\\Collections\\\\Collection|Doctrine\\\\Common\\\\Collections\\\\ArrayCollection)(?:<\\\\?(?P<elementType>[a-zA-Z0-9\\\\]+)>)?/';
+    const PARSE_TYPE_PATTERN = '/^\\\\?(?P<type>integer|int|float|double|boolean|bool|string|DateTime|[a-zA-Z0-9\\\\]+|object|array|ArrayObject|SplObjectStorage|Doctrine\\\\Common\\\\Collections\\\\Collection|Doctrine\\\\Common\\\\Collections\\\\ArrayCollection)(?:<\\\\?(?P<elementType>[a-zA-Z0-9\\\\]+)>)?/';
 
     /**
      * A type pattern to detect literal types.


### PR DESCRIPTION
The TypeHandling PARSE_TYPE_PATTERN assumes vendors in namespace do always
begin with uppercase letters. Reality shows, that this is not the case.
So this changes the regular expression accordingly