### PR TITLE
BUGFIX: Fallback if custom exception rendering fails

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Error/DebugExceptionHandler.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Error/DebugExceptionHandler.php
@@ -42,7 +42,13 @@ class DebugExceptionHandler extends AbstractExceptionHandler
         }
 
         if (isset($this->renderingOptions['templatePathAndFilename'])) {
-            echo $this->buildCustomFluidView($exception, $this->renderingOptions)->render();
+            try {
+                echo $this->buildCustomFluidView($exception, $this->renderingOptions)->render();
+            } catch (\Throwable $throwable) {
+                $this->renderStatically($statusCode, $throwable);
+            } catch (\Exception $exception) {
+                $this->renderStatically($statusCode, $exception);
+            }
         } else {
             $this->renderStatically($statusCode, $exception);
         }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Error/ProductionExceptionHandler.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Error/ProductionExceptionHandler.php
@@ -42,7 +42,13 @@ class ProductionExceptionHandler extends AbstractExceptionHandler
 
         try {
             if (isset($this->renderingOptions['templatePathAndFilename'])) {
-                echo $this->buildCustomFluidView($exception, $this->renderingOptions)->render();
+                try {
+                    echo $this->buildCustomFluidView($exception, $this->renderingOptions)->render();
+                } catch (\Throwable $throwable) {
+                    $this->renderStatically($statusCode, $throwable);
+                } catch (\Exception $exception) {
+                    $this->renderStatically($statusCode, $exception);
+                }
             } else {
                 echo $this->renderStatically($statusCode, $referenceCode);
             }


### PR DESCRIPTION
If a custom exception rendering fails, the exception would not be
caught and thus difficult to debug. Instead as a fallback exceptions
thrown during rendering will be rendered statically.