### PR TITLE
BUGFIX: Missing use statement in HelpCommandController

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/HelpCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/HelpCommandController.php
@@ -15,6 +15,7 @@ use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Cli\Command;
 use TYPO3\Flow\Cli\CommandArgumentDefinition;
 use TYPO3\Flow\Cli\CommandController;
+use TYPO3\Flow\Cli\CommandManager;
 use TYPO3\Flow\Core\Bootstrap;
 use TYPO3\Flow\Mvc\Exception\AmbiguousCommandIdentifierException;
 use TYPO3\Flow\Mvc\Exception\CommandException;


### PR DESCRIPTION
This fix a regression introduced in 3.2, the use statement for the CommandManager is missing