### PR TITLE
BUGFIX: Get package with case insensitive name

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
@@ -200,7 +200,7 @@ class PackageManager implements \TYPO3\Flow\Package\PackageManagerInterface
         if (!$this->isPackageAvailable($packageKey)) {
             throw new \TYPO3\Flow\Package\Exception\UnknownPackageException('Package "' . $packageKey . '" is not available. Please check if the package exists and that the package key is correct (package keys are case sensitive).', 1166546734);
         }
-        return $this->packages[$packageKey];
+        return $this->packages[$this->getCaseSensitivePackageKey($packageKey)];
     }
 
     /**


### PR DESCRIPTION
While `isPackageAvailable` checks the package name
case insensitive in the packageKeys array, it then
tries to return the package object assuming a correct
case sensitive package name.

If the correct pacakage key is Vendor.CustomerProject
and you request Vendor.Customerproject the check 
succeeds but returns no object.
