### PR TITLE
BUGFIX: Ignore abstract command-controllers

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Cli/CommandManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Cli/CommandManager.php
@@ -261,7 +261,7 @@ class CommandManager
 
         $commandControllerMethodArgumentMap = [];
         foreach ($reflectionService->getAllSubClassNamesForClass(CommandController::class) as $className) {
-            if (!class_exists($className)) {
+            if (!class_exists($className) || $reflectionService->isClassAbstract($className)) {
                 continue;
             }
             $controllerObjectName = $objectManager->getObjectNameByClassName($className);


### PR DESCRIPTION
If a command controller is declared abstract the cli ignores this class because it cannot be instantiated.
The commands from derived classes will of course be available.