### PR TITLE
Add a note to rescan packages to Signals and Slots

### DIFF
--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/SignalsAndSlots.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/SignalsAndSlots.rst
@@ -126,3 +126,7 @@ There is one more parameter available: ``$passSignalInformation``. It controls
 whether or not the signal information (class name and method name of the signal
 emitter, separated by ``::``) should be passed to the slot as last parameter.
 ``$passSignalInformation`` is ``TRUE`` by default.
+
+.. note::
+
+After the creation of a ``Package`` class you need to manually invoke the command ``./flow flow:package:scan`` since the bootstrap behaviour is cached in the distributions PackageStates.php and needs to be rebuild.


### PR DESCRIPTION
I'm not sure if this should make it in the docs, since https://github.com/neos/flow-development-collection/pull/341 is already pending, but if the auto-detection is not implemented soon, I would vote for it, since a cache flush does not get rid of the problem and beginners working with the docs could really have a hard time figuring this out!