### PR TITLE
BUGFIX: Avoid type-casting errors if the validation of complex types fails

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Utility/SchemaValidator.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Utility/SchemaValidator.php
@@ -78,7 +78,7 @@ class SchemaValidator
                 }
             }
             if ($isValid === false) {
-                $result->addError($this->createError('None of the given schemas matched ' . $value));
+                $result->addError($this->createError('None of the given schemas matched ' . $this->renderValue($value)));
             }
         } elseif ($this->isSchema($schema)) {
             if (isset($schema['type'])) {
@@ -92,7 +92,7 @@ class SchemaValidator
             if (isset($schema['disallow'])) {
                 $subresult = $this->validate($value, array('type' => $schema['disallow']));
                 if ($subresult->hasErrors() === false) {
-                    $result->addError($this->createError('Disallow rule matched for "' . $value . '"'));
+                    $result->addError($this->createError('Disallow rule matched for "' . $this->renderValue($value) . '"'));
                 }
             }
 
@@ -105,7 +105,7 @@ class SchemaValidator
                     }
                 }
                 if ($isValid === false) {
-                    $result->addError($this->createError('"' . $value . '" is not in enum-rule "' . implode(', ', $schema['enum']) . '"'));
+                    $result->addError($this->createError('"' . $this->renderValue($value) . '" is not in enum-rule "' . implode(', ', $schema['enum']) . '"'));
                 }
             }
         }
@@ -571,6 +571,17 @@ class SchemaValidator
     }
 
     /**
+     * Create a string information for the given value
+     *
+     * @param mixed $value
+     * @return string
+     */
+    protected function renderValue($value)
+    {
+        return is_scalar($value) ? (string)$value : 'type=' . gettype($value);
+    }
+
+    /**
      * Create Error Object
      *
      * @param string $expectation
@@ -580,7 +591,8 @@ class SchemaValidator
     protected function createError($expectation, $value = null)
     {
         if ($value !== null) {
-            $error = new \TYPO3\Flow\Error\Error('expected: %s found: %s', 1328557141, array($expectation, $value), 'Validation Error');
+            $error = new \TYPO3\Flow\Error\Error('expected: %s found: %s', 1328557141, array($expectation, $this->renderValue($value)),
+                'Validation Error');
         } else {
             $error = new \TYPO3\Flow\Error\Error($expectation, 1328557141, array(), 'Validation Error');
         }

--- a/TYPO3.Flow/Tests/Unit/Utility/SchemaValidatorTest.php
+++ b/TYPO3.Flow/Tests/Unit/Utility/SchemaValidatorTest.php
@@ -101,7 +101,8 @@ class SchemaValidatorTest extends \TYPO3\Flow\Tests\UnitTestCase
     {
         return array(
             array('string', true),
-            array(123, false)
+            array(123, false),
+            array(array(1,2,3), false)
         );
     }
 
@@ -112,7 +113,7 @@ class SchemaValidatorTest extends \TYPO3\Flow\Tests\UnitTestCase
     public function validateHandlesDisallowProperty($value, $expectSuccess)
     {
         $schema = array(
-            'disallow' => 'integer'
+            'disallow' => array('integer','array')
         );
         $this->assertSuccess($this->configurationValidator->validate($value, $schema), $expectSuccess);
     }
@@ -126,7 +127,8 @@ class SchemaValidatorTest extends \TYPO3\Flow\Tests\UnitTestCase
             array(1, true),
             array(2, true),
             array(null, false),
-            array(4, false)
+            array(4, false),
+            array(array(1,2,3), false)
         );
     }
 
@@ -185,9 +187,49 @@ class SchemaValidatorTest extends \TYPO3\Flow\Tests\UnitTestCase
     }
 
     /**
-     * @test
+     * @return array
      */
-    public function validateHandlesMultipleTypes()
+    public function validateHandlesMultipleTypesDataProvider()
+    {
+        return array(
+            [['property' => 'value'], true],
+            ['value', true],
+            [false, false],
+            [123, false],
+            [array(1,2,3), false]
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider validateHandlesMultipleTypesDataProvider
+     */
+    public function validateHandlesMultipleTypes($value, $expectSuccess)
+    {
+        $schema = array('dictionary', 'string');
+
+        $result = $this->configurationValidator->validate($value, $schema);
+        $this->assertSuccess($result, $expectSuccess);
+    }
+
+    /**
+     * @test
+     * @dataProvider validateHandlesMultipleTypesDataProvider
+     */
+    public function validateHandlesMultipleTypesInSchemaType($value, $expectSuccess)
+    {
+        $schema = array(
+            'type' => array('dictionary', 'string')
+        );
+        $result = $this->configurationValidator->validate($value, $schema);
+        $this->assertSuccess($result, $expectSuccess);
+    }
+
+    /**
+     * @test
+     * @dataProvider validateHandlesMultipleTypesDataProvider
+     */
+    public function validateHandlesMultipleTypesInSubProperty($value, $expectSuccess)
     {
         $schema = array(
             'type' => 'dictionary',
@@ -197,23 +239,8 @@ class SchemaValidatorTest extends \TYPO3\Flow\Tests\UnitTestCase
                 )
             )
         );
-
-        $result = $this->configurationValidator->validate(array(
-            'foo' => array(
-                'property' => 'value'
-            )
-        ), $schema);
-        $this->assertSuccess($result);
-
-        $result = $this->configurationValidator->validate(array(
-            'foo' => 'value'
-        ), $schema);
-        $this->assertSuccess($result);
-
-        $result = $this->configurationValidator->validate(array(
-            'foo' => false
-        ), $schema);
-        $this->assertError($result);
+        $result = $this->configurationValidator->validate(['foo' => $value], $schema);
+        $this->assertSuccess($result, $expectSuccess);
     }
 
     /// INTEGER ///


### PR DESCRIPTION
If an error is created in some cases the value was added to the result-message without checking for the type beforehand, that could lead to php errors if the value could not be casted to a string.

This change centralizes the rendering of the value in a  'renderValue' - method.