### PR TITLE
TASK: Add test case for configuration validation

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/RequestPattern/ControllerObjectName.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/RequestPattern/ControllerObjectName.php
@@ -26,7 +26,7 @@ class ControllerObjectName implements RequestPatternInterface
     protected $options;
 
     /**
-     * Expects options in the form array('controllerObjectNamePatterns' => '<regularExpression>')
+     * Expects options in the form array('controllerObjectNamePattern' => '<regularExpression>')
      *
      * @param array $options
      */

--- a/TYPO3.Flow/Configuration/Policy.yaml
+++ b/TYPO3.Flow/Configuration/Policy.yaml
@@ -15,3 +15,5 @@ roles:
 
   'TYPO3.Flow:AuthenticatedUser':
     abstract: TRUE
+
+privilegeTargets: []

--- a/TYPO3.Flow/Configuration/Testing/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Testing/Settings.yaml
@@ -121,17 +121,26 @@ TYPO3:
             entryPointOptions:
               uri: 'flow/authentication'
             requestPatterns:
-              controllerObjectName: 'TYPO3\Flow\Tests\.*'
+              'TestsPattern':
+                pattern: 'ControllerObjectName'
+                patternOptions:
+                  controllerObjectNamePattern: 'TYPO3\Flow\Tests\.*'
           HttpBasicTestingProvider:
             provider: 'TYPO3\Flow\Security\Authentication\Provider\PersistedUsernamePasswordProvider'
             token: 'TYPO3\Flow\Security\Authentication\Token\UsernamePasswordHttpBasic'
             requestPatterns:
-              controllerObjectName: 'TYPO3\Flow\Tests\Functional\Security\Fixtures\Controller\HttpBasicTestController'
+              'HttpBasicTestPattern':
+                pattern: 'ControllerObjectName'
+                patternOptions:
+                  controllerObjectNamePattern: 'TYPO3\Flow\Tests\Functional\Security\Fixtures\Controller\HttpBasicTestController'
           UsernamePasswordTestingProvider:
             provider: 'TYPO3\Flow\Security\Authentication\Provider\PersistedUsernamePasswordProvider'
             token: 'TYPO3\Flow\Security\Authentication\Token\UsernamePassword'
             requestPatterns:
-              controllerObjectName: 'TYPO3\Flow\Tests\Functional\Security\Fixtures\Controller\UsernamePasswordTestController'
+              'UsernamePasswordTestControllerPattern':
+                pattern: 'ControllerObjectName'
+                patternOptions:
+                  controllerObjectNamePattern: 'TYPO3\Flow\Tests\Functional\Security\Fixtures\Controller\UsernamePasswordTestController'
 
     # Setting for functional tests to test global objects in runtime evaluations
     aop:

--- a/TYPO3.Flow/Resources/Private/Schema/Objects.schema.yaml
+++ b/TYPO3.Flow/Resources/Private/Schema/Objects.schema.yaml
@@ -19,7 +19,7 @@ additionalProperties:
           type: dictionary
           additionalProperties: FALSE
           properties:
-            'value': {type: string}
+            'value': {type: any}
             'setting': {type: string}
             'object':
               type: [dictionary, string]
@@ -45,6 +45,7 @@ additionalProperties:
           additionalProperties: FALSE
           properties:
             'setting': {type: string}
+            'value': {type: any}
             'object':
               type: [dictionary, string]
               # if string, require string to be a class name

--- a/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.mvc.schema.yaml
+++ b/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.mvc.schema.yaml
@@ -4,3 +4,8 @@ properties:
   'routes':
     type: dictionary
     patternProperties: { '/.*/': { type: [boolean, dictionary] } }
+  'view':
+    type: dictionary
+    properties:
+      'defaultImplementation':
+        type: [{type: 'null'}, {type: 'string', format: 'class-name'}]

--- a/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.persistence.schema.yaml
+++ b/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.persistence.schema.yaml
@@ -128,6 +128,10 @@ properties:
             type: dictionary
             required: TRUE
             patternProperties: { '/.*/': { type: boolean } }
+      'cacheImplementation':
+        type:
+          - { type: 'null' }
+          - { type: string, format: class-name }
   'cacheAllQueryResults':
     type: boolean
     required: TRUE

--- a/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.persistence.schema.yaml
+++ b/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.persistence.schema.yaml
@@ -132,6 +132,17 @@ properties:
         type:
           - { type: 'null' }
           - { type: string, format: class-name }
+      'migrations':
+        type: dictionary
+        properties:
+          'generate':
+            type: dictionary
+            properties:
+              'defaultFilterExpression':
+                type:
+                  - { type: 'null' }
+                  - { type: string }
+
   'cacheAllQueryResults':
     type: boolean
     required: TRUE

--- a/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.persistence.schema.yaml
+++ b/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.persistence.schema.yaml
@@ -15,10 +15,12 @@ properties:
         -
           type: string
           format: ip-address
+        -
+          type: null
       'charset': { type: string }
-      'dbname': { type: string }
-      'user': { type: string }
-      'password':  { type: string }
+      'dbname': { type: ['string','null'] }
+      'user': { type: ['string','null'] }
+      'password':  { type: ['string','null'] }
       'path': { type: string }
       'wrapperClass': { type: string, format: class-name }
       'master':
@@ -60,7 +62,9 @@ properties:
     properties:
       'enable': { type: boolean, required: TRUE }
       'sqlLogger': { type: [string, 'null'], required: TRUE }
-      'eventSubscribers': { type: array, items: { type: string, format: class-name } }
+      'eventSubscribers':
+        type: dictionary
+        additionalProperties: { type: string, format: class-name }
       'eventListeners':
         type: dictionary
         additionalProperties:

--- a/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.security.schema.yaml
+++ b/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.security.schema.yaml
@@ -45,6 +45,7 @@ properties:
             'token': { type: string }
             'entryPoint': { type: string }
             'entryPointOptions': { type: dictionary }
+            'token': { type: string, format: class-name }
       'authenticationStrategy':
         type: string
         required: TRUE

--- a/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.security.schema.yaml
+++ b/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.security.schema.yaml
@@ -76,7 +76,6 @@ properties:
         required: TRUE
         properties:
           'default': { type: string, required: TRUE }
-          'fallback': { type: string, required: TRUE }
 
       'Pbkdf2HashingStrategy':
         type: dictionary

--- a/TYPO3.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
+++ b/TYPO3.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
@@ -46,7 +46,7 @@ class ConfigurationValidationTest extends FunctionalTestCase
     /**
      * @var array<string>
      */
-    protected $configurationPackageKeys = ['TYPO3.Flow', 'TYPO3.Fluid', 'TYPO3.Eel', 'TYPO3.Kickstart'];
+    protected $configurationPackageKeys = ['TYPO3.Flow', 'Neos.FluidAdaptor', 'TYPO3.Eel', 'TYPO3.Kickstart'];
 
     /**
      *

--- a/TYPO3.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
+++ b/TYPO3.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
@@ -94,7 +94,7 @@ class ConfigurationValidationTest extends FunctionalTestCase
             }
         }
 
-        $this->mockPackageManager = $this->getMock(PackageManager::class, ['getActivePackages']);
+        $this->mockPackageManager = $this->createMock(PackageManager::class);
         $this->mockPackageManager->expects($this->any())->method('getActivePackages')->will($this->returnValue($schemaPackages));
 
         //

--- a/TYPO3.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
+++ b/TYPO3.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
@@ -1,0 +1,216 @@
+<?php
+namespace TYPO3\Flow\Tests\Functional\Configuration;
+
+/*                                                                        *
+ * This script belongs to the TYPO3 Flow framework.                       *
+ *                                                                        *
+ * It is free software; you can redistribute it and/or modify it under    *
+ * the terms of the GNU Lesser General Public License, either version 3   *
+ * of the License, or (at your option) any later version.                 *
+ *                                                                        *
+ * The TYPO3 project - inspiring people to share!                         *
+ *                                                                        */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Configuration\ConfigurationManager;
+use TYPO3\Flow\Configuration\ConfigurationSchemaValidator;
+use TYPO3\Flow\Package\PackageManagerInterface;
+use TYPO3\Flow\Package\PackageManager;
+use TYPO3\Flow\Core\ApplicationContext;
+use TYPO3\Flow\Error\Error;
+use TYPO3\Flow\Error\Result;
+use TYPO3\Flow\Reflection\ObjectAccess;
+use TYPO3\Flow\Tests\FunctionalTestCase;
+
+/**
+ * Testcase for Configuration Validation
+ */
+class ConfigurationValidationTest extends FunctionalTestCase
+{
+
+    /**
+     * @var array<string>
+     */
+    protected $contextNames = ['Development', 'Production', 'Testing'];
+
+    /**
+     * @var array<string>
+     */
+    protected $configurationTypes = ['Caches', 'Objects', 'Policy', 'Routes', 'Settings'];
+
+    /**
+     * @var array<string>
+     */
+    protected $schemaPackageKeys = ['TYPO3.Flow'];
+
+    /**
+     * @var array<string>
+     */
+    protected $configurationPackageKeys = ['TYPO3.Flow', 'TYPO3.Fluid', 'TYPO3.Eel', 'TYPO3.Kickstart'];
+
+    /**
+     *
+     * @var ConfigurationSchemaValidator
+     */
+    protected $configurationSchemaValidator;
+
+    /**
+     * @var ConfigurationManager
+     */
+    protected $mockConfigurationManager;
+
+    /**
+     * @var PackageManager
+     */
+    protected $mockPackageManager;
+
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        //
+        // create a mock packageManager that only returns the the packages that contain schema files
+        //
+
+        $schemaPackages = [];
+        $configurationPackages = [];
+
+        // get all packages and select the ones we want to test
+        $temporaryPackageManager = $this->objectManager->get(PackageManagerInterface::class);
+        foreach ($temporaryPackageManager->getActivePackages() as $package) {
+            if (in_array($package->getPackageKey(), $this->getSchemaPackageKeys())) {
+                $schemaPackages[$package->getPackageKey()] = $package;
+            }
+            if (in_array($package->getPackageKey(), $this->getConfigurationPackageKeys())) {
+                $configurationPackages[$package->getPackageKey()] = $package;
+            }
+        }
+
+        $this->mockPackageManager = $this->getMock(PackageManager::class, ['getActivePackages']);
+        $this->mockPackageManager->expects($this->any())->method('getActivePackages')->will($this->returnValue($schemaPackages));
+
+        //
+        // create mock configurationManager
+        //
+
+        $yamlConfigurationSource = $this->objectManager->get(\TYPO3\Flow\Tests\Functional\Configuration\Fixtures\RootDirectoryIgnoringYamlSource::class);
+
+        $this->mockConfigurationManager = $this->objectManager->get(ConfigurationManager::class);
+        $this->mockConfigurationManager->setPackages($configurationPackages);
+        $this->inject($this->mockConfigurationManager, 'configurationSource', $yamlConfigurationSource);
+
+        //
+        // create the configurationSchemaValidator
+        //
+
+        $this->configurationSchemaValidator = $this->objectManager->get(ConfigurationSchemaValidator::class);
+        $this->inject($this->configurationSchemaValidator, 'configurationManager', $this->mockConfigurationManager);
+    }
+
+    /**
+     * @return void
+     */
+    public function tearDown()
+    {
+        $this->injectApplicationContextIntoConfigurationManager($this->objectManager->getContext());
+        parent::tearDown();
+    }
+
+    /**
+     * @param ApplicationContext $context
+     * @return void
+     */
+    protected function injectApplicationContextIntoConfigurationManager(ApplicationContext $context)
+    {
+        ObjectAccess::setProperty($this->mockConfigurationManager, 'configurations',
+            [ConfigurationManager::CONFIGURATION_TYPE_SETTINGS => []], true);
+        ObjectAccess::setProperty($this->mockConfigurationManager, 'context', $context, true);
+        ObjectAccess::setProperty($this->mockConfigurationManager, 'orderedListOfContextNames', [(string)$context],
+            true);
+        ObjectAccess::setProperty($this->mockConfigurationManager, 'includeCachedConfigurationsPathAndFilename',
+            FLOW_PATH_CONFIGURATION . (string)$context . '/IncludeCachedConfigurations.php', true);
+    }
+
+    /**
+     * @return array
+     */
+    public function configurationValidationDataProvider()
+    {
+        $result = [];
+        foreach ($this->getContextNames() as $contextName) {
+            foreach ($this->getConfigurationTypes() as $configurationType) {
+                $result[] = ['contextName' => $contextName, 'configurationType' => $configurationType];
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * @param string $contextName
+     * @param string $configurationType
+     * @test
+     * @dataProvider configurationValidationDataProvider
+     */
+    public function configurationValidationTests($contextName, $configurationType)
+    {
+        $this->injectApplicationContextIntoConfigurationManager(new ApplicationContext($contextName));
+        $schemaFiles = [];
+        $validationResult = $this->configurationSchemaValidator->validate($configurationType, null, $schemaFiles);
+        $this->assertValidationResultContainsNoErrors($validationResult);
+    }
+
+    /**
+     * @param Result $validationResult
+     * @return void
+     */
+    protected function assertValidationResultContainsNoErrors(Result $validationResult)
+    {
+        if ($validationResult->hasErrors()) {
+            $errors = $validationResult->getFlattenedErrors();
+            /** @var Error $error */
+            $output = '';
+            foreach ($errors as $path => $pathErrors) {
+                foreach ($pathErrors as $error) {
+                    $output .= sprintf('%s -> %s' . PHP_EOL, $path, $error->render());
+                }
+            }
+            $this->fail($output);
+        }
+        $this->assertFalse($validationResult->hasErrors());
+    }
+
+    /**
+     * @return array<string>
+     */
+    protected function getContextNames()
+    {
+        return $this->contextNames;
+    }
+
+    /**
+     * @return array<string>
+     */
+    protected function getConfigurationTypes()
+    {
+        return $this->configurationTypes;
+    }
+
+    /**
+     * @return array<string>
+     */
+    protected function getSchemaPackageKeys()
+    {
+        return $this->schemaPackageKeys;
+    }
+
+    /**
+     * @return array<string>
+     */
+    protected function getConfigurationPackageKeys()
+    {
+        return $this->configurationPackageKeys;
+    }
+}

--- a/TYPO3.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
+++ b/TYPO3.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
@@ -1,15 +1,15 @@
 <?php
 namespace TYPO3\Flow\Tests\Functional\Configuration;
 
-/*                                                                        *
- * This script belongs to the TYPO3 Flow framework.                       *
- *                                                                        *
- * It is free software; you can redistribute it and/or modify it under    *
- * the terms of the GNU Lesser General Public License, either version 3   *
- * of the License, or (at your option) any later version.                 *
- *                                                                        *
- * The TYPO3 project - inspiring people to share!                         *
- *                                                                        */
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Configuration\ConfigurationManager;

--- a/TYPO3.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
+++ b/TYPO3.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
@@ -57,6 +57,11 @@ class ConfigurationValidationTest extends FunctionalTestCase
     /**
      * @var ConfigurationManager
      */
+    protected $originalConfigurationManager;
+
+    /**
+     * @var ConfigurationManager
+     */
     protected $mockConfigurationManager;
 
     /**
@@ -93,14 +98,18 @@ class ConfigurationValidationTest extends FunctionalTestCase
         $this->mockPackageManager->expects($this->any())->method('getActivePackages')->will($this->returnValue($schemaPackages));
 
         //
-        // create mock configurationManager
+        // create mock configurationManager and store the original one
         //
+
+        $this->originalConfigurationManager = $this->objectManager->get(ConfigurationManager::class);
 
         $yamlConfigurationSource = $this->objectManager->get(\TYPO3\Flow\Tests\Functional\Configuration\Fixtures\RootDirectoryIgnoringYamlSource::class);
 
-        $this->mockConfigurationManager = $this->objectManager->get(ConfigurationManager::class);
+        $this->mockConfigurationManager = clone ($this->originalConfigurationManager);
         $this->mockConfigurationManager->setPackages($configurationPackages);
         $this->inject($this->mockConfigurationManager, 'configurationSource', $yamlConfigurationSource);
+
+        $this->objectManager->setInstance(ConfigurationManager::class, $this->mockConfigurationManager);
 
         //
         // create the configurationSchemaValidator
@@ -115,6 +124,7 @@ class ConfigurationValidationTest extends FunctionalTestCase
      */
     public function tearDown()
     {
+        $this->objectManager->setInstance(ConfigurationManager::class, $this->originalConfigurationManager);
         $this->injectApplicationContextIntoConfigurationManager($this->objectManager->getContext());
         parent::tearDown();
     }

--- a/TYPO3.Flow/Tests/Functional/Configuration/Fixtures/RootDirectoryIgnoringYamlSource.php
+++ b/TYPO3.Flow/Tests/Functional/Configuration/Fixtures/RootDirectoryIgnoringYamlSource.php
@@ -1,6 +1,15 @@
 <?php
-
 namespace TYPO3\Flow\Tests\Functional\Configuration\Fixtures;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
 
 use TYPO3\Flow\Annotations as Flow;
 

--- a/TYPO3.Flow/Tests/Functional/Configuration/Fixtures/RootDirectoryIgnoringYamlSource.php
+++ b/TYPO3.Flow/Tests/Functional/Configuration/Fixtures/RootDirectoryIgnoringYamlSource.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace TYPO3\Flow\Tests\Functional\Configuration\Fixtures;
+
+use TYPO3\Flow\Annotations as Flow;
+
+class RootDirectoryIgnoringYamlSource extends \TYPO3\Flow\Configuration\Source\YamlSource
+{
+    /**
+     * Loads the specified configuration file and returns its content as an
+     * array. If the file does not exist or could not be loaded, an empty
+     * array is returned
+     *
+     * @param string $pathAndFilename Full path and filename of the file to load, excluding the file extension (ie. ".yaml")
+     * @param boolean $allowSplitSource If TRUE, the type will be used as a prefix when looking for configuration files
+     * @return array
+     * @throws \TYPO3\Flow\Configuration\Exception\ParseErrorException
+     */
+
+    public function load($pathAndFilename, $allowSplitSource = false)
+    {
+        if (strpos($pathAndFilename, FLOW_PATH_CONFIGURATION) === 0) {
+            return [];
+        } else {
+            return parent::load($pathAndFilename, $allowSplitSource);
+        }
+    }
+}


### PR DESCRIPTION
Add functional test that validates the different configuration-types of the neos-core in different contexts.

The packages where the validated configuration is loaded from are limited to avoid failing of functional tests if the local configuration has errors. Also the list of packages that is used to find schema files is limited: 

- contexts: ``Development``, ``Production``, ``Testing``
- configurationTypes: = ``Caches``, ``Objects``, ``Policy``, ``Routes``, ``Settings`` 
- configurationPackageKeys:  ``TYPO3.Flow``, ``TYPO3.Fluid``, ``TYPO3.Eel``, ``TYPO3.Kickstart``
- schemaPackageKeys: ``TYPO3.Flow``

The supported contexts, configurationTypes, configurationPackageKeys and schemaPackageKeys are defined as class variables to be overwritten in tests-classed derived from this one.
