### PR TITLE
BUGFIX: After creating a package all packages should be sorted

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
@@ -424,18 +424,11 @@ class PackageManager implements PackageManagerInterface
 
         $manifest = ComposerUtility::writeComposerManifest($packagePath, $packageKey, $manifest);
 
-        $packagePath = str_replace($this->packagesBasePath, '', $packagePath);
-        $package = $this->packageFactory->create($this->packagesBasePath, $packagePath, $packageKey, $manifest['name'], (isset($manifest['autoload']) ? $manifest['autoload'] : []), null);
-
-        $refreshedPackageStatesConfiguration = $this->scanAvailablePackages($this->packageStatesConfiguration);
-        $this->savePackageStates($refreshedPackageStatesConfiguration);
+        $refreshedPackageStatesConfiguration = $this->rescanPackages(false);
         $this->packageStatesConfiguration = $refreshedPackageStatesConfiguration;
+        $this->registerPackageFromStateConfiguration($manifest['name'], $this->packageStatesConfiguration['packages'][$manifest['name']]);
 
-        $this->packages[$packageKey] = $package;
-        $this->activePackages[$packageKey] = $package;
-        $this->packageKeys[strtolower($packageKey)] = $packageKey;
-
-        return $package;
+        return $this->packages[$packageKey];
     }
 
     /**


### PR DESCRIPTION
After creating a package only a rescan of existing packages was triggered
but not a resorting. That would lead to arbitrary package loading order
which only depended on the way the filesystem would find the packages.
This has been changed to trigger a full rescan including sorting of packages.