### PR TITLE
FEATURE: Allow use of PDO backend for caches

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Cache/Backend/PdoBackend.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Cache/Backend/PdoBackend.php
@@ -158,7 +158,7 @@ class PdoBackend extends AbstractBackend implements TaggableBackendInterface, It
 
         // Convert hexadecimal data into binary string,
         // because it is not allowed to store null bytes in PostgreSQL.
-        if($fetchedColumn !== false && $this->pdoDriver === 'pgsql') {
+        if ($fetchedColumn !== false && $this->pdoDriver === 'pgsql') {
             $fetchedColumn = hex2bin($fetchedColumn);
         }
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/DoctrineCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/DoctrineCommandController.php
@@ -419,6 +419,16 @@ class DoctrineCommandController extends CommandController
      *
      * would only create a migration touching tables starting with "acme_com".
      *
+     * It is also possible to set a default filter expression within the settings.
+     *
+     * TYPO3:
+     *   Flow:
+     *     persistence:
+     *       doctrine:
+     *         migrations:
+     *           generate:
+     *             defaultFilterExpression: '/^acme_com/'
+     *
      * @param boolean $diffAgainstCurrent Whether to base the migration on the current schema structure
      * @param string $filterExpression Only include tables/sequences matching the filter expression regexp
      * @return void

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/DoctrineCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/DoctrineCommandController.php
@@ -436,6 +436,11 @@ class DoctrineCommandController extends CommandController
             $this->quit(1);
         }
 
+        // use default filter expression from settings
+        if (isset($this->settings['doctrine']['migrations']['generate']['defaultFilterExpression']) && $filterExpression === null) {
+            $filterExpression = $this->settings['doctrine']['migrations']['generate']['defaultFilterExpression'];
+        }
+
         list($status, $migrationClassPathAndFilename) = $this->doctrineService->generateMigration($diffAgainstCurrent, $filterExpression);
 
         $this->outputLine('<info>%s</info>', [$status]);

--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -308,6 +308,12 @@ TYPO3:
         eventSubscribers: []
         eventListeners: []
 
+        # Use default filter expression to ignore other packages when generating migrations
+        # E.g. '/^acme_package/'
+        migrations:
+          generate:
+            defaultFilterExpression:
+
     reflection:
 
       # A list of tags to be ignored during reflection

--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -312,7 +312,7 @@ TYPO3:
         # E.g. '/^acme_package/'
         migrations:
           generate:
-            defaultFilterExpression:
+            defaultFilterExpression: ~
 
     reflection:
 


### PR DESCRIPTION
This pull request contains two features:

1. Make PdoBackend iterable so it can be used for caches
2. Use default filter expression to ignore other packages when generating migrations

I tested this with PostgreSQL as a backend for sessions.