### PR TITLE
TASK: Followup cleanup for #333 to make use of ::class

### DIFF
--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/PropertyMapping.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/PropertyMapping.rst
@@ -176,7 +176,7 @@ The following configuration options exist:
   date format::
 
 	$propertyMappingConfiguration->setTypeConverterOption(
-		'TYPO3\Flow\Property\TypeConverter\DateTimeConverter',
+		\TYPO3\Flow\Property\TypeConverter\DateTimeConverter::class,
 		\TYPO3\Flow\Property\TypeConverter\DateTimeConverter::CONFIGURATION_DATE_FORMAT,
 		'Y-m-d'
 	);
@@ -206,7 +206,7 @@ configures the ``DateTime`` converter for the ``birthDate`` property::
 	$propertyMappingConfiguration
 		->forProperty('birthDate')
 		->setTypeConverterOption(
-			'TYPO3\Flow\Property\TypeConverter\DateTimeConverter',
+			\TYPO3\Flow\Property\TypeConverter\DateTimeConverter::class,
 			\TYPO3\Flow\Property\TypeConverter\DateTimeConverter::CONFIGURATION_DATE_FORMAT,
 			'Y-m-d'
 		);
@@ -220,7 +220,7 @@ the path syntax supports an asterisk as a placeholder::
 	$propertyMappingConfiguration
 		->forProperty('items.*')
 		->setTypeConverterOption(
-			'TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter',
+			\TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter::class,
 			\TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED,
 			TRUE
 		);
@@ -231,7 +231,7 @@ on large collections::
 	$propertyMappingConfiguration
 		->forProperty('persons.*.birthDate')
 		->setTypeConvertOption(
-			'TYPO3\Flow\Property\TypeConverter\DateTimeConverter',
+			\TYPO3\Flow\Property\TypeConverter\DateTimeConverter::class,
 			\TYPO3\Flow\Property\TypeConverter\DateTimeConverter::CONFIGURATION_DATE_FORMAT,
 			'Y-m-d'
 		);
@@ -254,7 +254,7 @@ on large collections::
 			$commentConfiguration->allowAllProperties();
 			$commentConfiguration
 				->setTypeConverterOption(
-				'TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter',
+				\TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter::class,
 				\TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED,
 				TRUE
 			);

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/ResourceManagement.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/ResourceManagement.rst
@@ -320,7 +320,7 @@ Or you can define it in your property mapping configuration like this::
 	$propertyMappingConfiguration
 		->forProperty('originalResource')
 		->setTypeConverterOption(
-			'TYPO3\Flow\Resource\ResourceTypeConverter',
+			\TYPO3\Flow\Resource\ResourceTypeConverter::class,
 			\TYPO3\Flow\Resource\ResourceTypeConverter::CONFIGURATION_COLLECTION_NAME,
 			'images'
 		);

--- a/TYPO3.Flow/Tests/Functional/Mvc/ActionControllerTest.php
+++ b/TYPO3.Flow/Tests/Functional/Mvc/ActionControllerTest.php
@@ -56,7 +56,7 @@ class ActionControllerTest extends \TYPO3\Flow\Tests\FunctionalTestCase
         ));
         $route->setRoutePartsConfiguration(array(
             'entity' => array(
-                'objectType' => 'TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntity'
+                'objectType' => TestEntity::class
             )
         ));
     }

--- a/TYPO3.Flow/Tests/Functional/Mvc/Fixtures/Controller/EntityController.php
+++ b/TYPO3.Flow/Tests/Functional/Mvc/Fixtures/Controller/EntityController.php
@@ -45,14 +45,14 @@ class EntityController extends ActionController
         $propertyMappingConfiguration = $this->arguments->getArgument('entity')->getPropertyMappingConfiguration();
         $propertyMappingConfiguration
             ->allowAllProperties()
-            ->setTypeConverterOption(\TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED, true);
+            ->setTypeConverterOption(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED, true);
         $propertyMappingConfiguration
             ->forProperty('subEntities.*')
             ->allowAllProperties()
-            ->setTypeConverterOption(\TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED, true);
+            ->setTypeConverterOption(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED, true);
         $propertyMappingConfiguration
             ->forProperty('subEntities.*.date')
-            ->setTypeConverterOption(\TYPO3\Flow\Property\TypeConverter\DateTimeConverter::class, DateTimeConverter::CONFIGURATION_DATE_FORMAT, 'd.m.Y');
+            ->setTypeConverterOption(DateTimeConverter::class, DateTimeConverter::CONFIGURATION_DATE_FORMAT, 'd.m.Y');
     }
 
     /**


### PR DESCRIPTION
This change fixes the usage of class names as strings that were necessary in 2.3 branch for PHP backwards compatibility in #333 and replaces them with the recommended ::class calls.