### PR TITLE
TASK: Provide proper error message when no request handler can be resolved

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Bootstrap.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Bootstrap.php
@@ -422,6 +422,9 @@ class Bootstrap
                 $suitableRequestHandlers[$priority] = $requestHandler;
             }
         }
+        if (empty($suitableRequestHandlers)) {
+            throw new FlowException('No suitable request handler could be found for the current request. This is most likely a setup-problem, so please check your package.json and/or try removing Configuration/PackageStates.php', 1464882543);
+        }
         ksort($suitableRequestHandlers);
         return array_pop($suitableRequestHandlers);
     }


### PR DESCRIPTION
Previously Flow would just fail with an error message:
`Warning: ksort() expects parameter 1 to be array, null given`
when for some reason no suitable request handler can be found for the current request.
This change will instead throw a useful exception and hint the user at a setup problem.