### PR TITLE
!!! TASK: More consistent translation behavior

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/I18n/EelHelper/TranslationParameterToken.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/I18n/EelHelper/TranslationParameterToken.php
@@ -178,10 +178,8 @@ class TranslationParameterToken implements ProtectedContextAwareInterface
         }
 
         $translation = $this->translator->translateById($id, $arguments, $quantity, $locale, $source, $package);
-        if ($translation === $id) {
-            if ($value) {
-                return $this->translator->translateByOriginalLabel($value, $arguments, $quantity, $locale, $source, $package);
-            }
+        if ($translation === null && $value !== null) {
+            return $this->translator->translateByOriginalLabel($value, $arguments, $quantity, $locale, $source, $package);
         }
 
         return $translation;

--- a/TYPO3.Flow/Classes/TYPO3/Flow/I18n/Translator.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/I18n/Translator.php
@@ -159,7 +159,7 @@ class Translator
      * @param \TYPO3\Flow\I18n\Locale $locale Locale to use (NULL for default one)
      * @param string $sourceName Name of file with translations, base path is $packageKey/Resources/Private/Locale/Translations/
      * @param string $packageKey Key of the package containing the source file
-     * @return string Translated message or $labelId on failure
+     * @return string Translated message or NULL on failure
      * @api
      * @see \TYPO3\Flow\I18n\Translator::translateByOriginalLabel()
      */
@@ -171,10 +171,11 @@ class Translator
         $pluralForm = $this->getPluralForm($quantity, $locale);
 
         $translatedMessage = $this->translationProvider->getTranslationById($labelId, $locale, $pluralForm, $sourceName, $packageKey);
-
         if ($translatedMessage === false) {
-            return $labelId;
-        } elseif (!empty($arguments)) {
+            return null;
+        }
+
+        if (!empty($arguments)) {
             return $this->formatResolver->resolvePlaceholders($translatedMessage, $arguments, $locale);
         }
         return $translatedMessage;

--- a/TYPO3.Flow/Tests/Functional/I18n/TranslatorTest.php
+++ b/TYPO3.Flow/Tests/Functional/I18n/TranslatorTest.php
@@ -76,4 +76,13 @@ class TranslatorTest extends \TYPO3\Flow\Tests\FunctionalTestCase
         $result = $this->translator->translateByOriginalLabel($label, array(), null, $locale, 'Main', 'TYPO3.Flow');
         $this->assertEquals($translation, $result);
     }
+
+    /**
+     * @test
+     */
+    public function translationByIdReturnsNullOnFailure()
+    {
+        $result = $this->translator->translateById('non-existing-id');
+        $this->assertNull($result);
+    }
 }

--- a/TYPO3.Flow/Tests/Unit/I18n/TranslatorTest.php
+++ b/TYPO3.Flow/Tests/Unit/I18n/TranslatorTest.php
@@ -66,7 +66,7 @@ class TranslatorTest extends \TYPO3\Flow\Tests\UnitTestCase
     /**
      * @test
      */
-    public function returnsOriginalLabelWhenTranslationNotAvailable()
+    public function translateByOriginalLabelReturnsOriginalLabelWhenTranslationNotAvailable()
     {
         $mockTranslationProvider = $this->getMock(\TYPO3\Flow\I18n\TranslationProvider\XliffTranslationProvider::class);
         $mockTranslationProvider->expects($this->once())->method('getTranslationByOriginalLabel')->with('original label', $this->defaultLocale, null, 'source', 'packageKey')->will($this->returnValue(false));
@@ -80,15 +80,15 @@ class TranslatorTest extends \TYPO3\Flow\Tests\UnitTestCase
     /**
      * @test
      */
-    public function returnsIdWhenTranslationNotAvailable()
+    public function translateByIdReturnsNullWhenTranslationNotAvailable()
     {
         $mockTranslationProvider = $this->getMock(\TYPO3\Flow\I18n\TranslationProvider\XliffTranslationProvider::class);
-        $mockTranslationProvider->expects($this->once())->method('getTranslationById')->with('id', $this->defaultLocale, null, 'source', 'packageKey')->will($this->returnValue('translated'));
+        $mockTranslationProvider->expects($this->once())->method('getTranslationById')->with('id', $this->defaultLocale, null, 'source', 'packageKey')->will($this->returnValue(false));
 
         $this->translator->injectTranslationProvider($mockTranslationProvider);
 
         $result = $this->translator->translateById('id', array(), null, $this->defaultLocale, 'source', 'packageKey');
-        $this->assertEquals('translated', $result);
+        $this->assertNull($result);
     }
 
     /**
@@ -97,12 +97,12 @@ class TranslatorTest extends \TYPO3\Flow\Tests\UnitTestCase
     public function translateByIdReturnsTranslationWhenNoArgumentsAreGiven()
     {
         $mockTranslationProvider = $this->getMock(\TYPO3\Flow\I18n\TranslationProvider\XliffTranslationProvider::class);
-        $mockTranslationProvider->expects($this->once())->method('getTranslationById')->with('id', $this->defaultLocale, null, 'source', 'packageKey')->will($this->returnValue(false));
+        $mockTranslationProvider->expects($this->once())->method('getTranslationById')->with('id', $this->defaultLocale, null, 'source', 'packageKey')->will($this->returnValue('translatedId'));
 
         $this->translator->injectTranslationProvider($mockTranslationProvider);
 
         $result = $this->translator->translateById('id', array(), null, $this->defaultLocale, 'source', 'packageKey');
-        $this->assertEquals('id', $result);
+        $this->assertEquals('translatedId', $result);
     }
 
     /**
@@ -147,5 +147,61 @@ class TranslatorTest extends \TYPO3\Flow\Tests\UnitTestCase
 
         $result = $this->translator->translateById('id', array(1.0), null, null, 'source', 'packageKey');
         $this->assertEquals('Formatted and translated label', $result);
+    }
+
+    /**
+     * @return array
+     */
+    public function translateByOriginalLabelDataProvider()
+    {
+        return [
+            ['originalLabel' => 'Some label', 'translatedLabel' => 'Translated label', 'expectedResult' => 'Translated label'],
+            ['originalLabel' => 'Some label', 'translatedLabel' => false, 'expectedResult' => 'Some label'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider translateByOriginalLabelDataProvider
+     * @param string $originalLabel
+     * @param string $translatedLabel
+     * @param string $expectedResult
+     */
+    public function translateByOriginalLabelTests($originalLabel, $translatedLabel, $expectedResult)
+    {
+        $mockTranslationProvider = $this->getMock(\TYPO3\Flow\I18n\TranslationProvider\XliffTranslationProvider::class);
+        $mockTranslationProvider->expects($this->once())->method('getTranslationByOriginalLabel')->with($originalLabel)->will($this->returnValue($translatedLabel));
+
+        $this->translator->injectTranslationProvider($mockTranslationProvider);
+        $actualResult = $this->translator->translateByOriginalLabel($originalLabel);
+        $this->assertSame($expectedResult, $actualResult);
+    }
+
+    /**
+     * @return array
+     */
+    public function translateByIdDataProvider()
+    {
+        return [
+            ['id' => 'some.id', 'translatedId' => 'Translated id', 'expectedResult' => 'Translated id'],
+            ['id' => 'some.id', 'translatedId' => false, 'expectedResult' => null],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider translateByIdDataProvider
+     * @param string $id
+     * @param string $translatedId
+     * @param string $expectedResult
+     */
+    public function translateByIdTests($id, $translatedId, $expectedResult)
+    {
+        $mockTranslationProvider = $this->getMock(\TYPO3\Flow\I18n\TranslationProvider\XliffTranslationProvider::class);
+        $mockTranslationProvider->expects($this->once())->method('getTranslationById')->with($id)->will($this->returnValue($translatedId));
+
+        $this->translator->injectTranslationProvider($mockTranslationProvider);
+        $actualResult = $this->translator->translateById($id);
+        $this->assertSame($expectedResult, $actualResult);
     }
 }

--- a/TYPO3.Fluid/Tests/Unit/ViewHelpers/Form/SelectViewHelperTest.php
+++ b/TYPO3.Fluid/Tests/Unit/ViewHelpers/Form/SelectViewHelperTest.php
@@ -613,7 +613,7 @@ class SelectViewHelperTest extends \TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\Form
 
         $mockTranslator = $this->getMock(\TYPO3\Flow\I18n\Translator::class);
         if ($by === 'label') {
-            $mockTranslator->expects($this->once())->method('translateByOriginalLabel')->will($this->returnCallback(function($label) use ($translatedLabel) {
+            $mockTranslator->expects($this->once())->method('translateByOriginalLabel')->will($this->returnCallback(function ($label) use ($translatedLabel) {
                 return $translatedLabel !== null ? $translatedLabel : $label;
             }));
         } else {

--- a/TYPO3.Fluid/Tests/Unit/ViewHelpers/Form/SelectViewHelperTest.php
+++ b/TYPO3.Fluid/Tests/Unit/ViewHelpers/Form/SelectViewHelperTest.php
@@ -541,6 +541,92 @@ class SelectViewHelperTest extends \TYPO3\Fluid\Tests\Unit\ViewHelpers\Form\Form
 
     /**
      * @test
+     * @expectedException \TYPO3\Fluid\Core\ViewHelper\Exception
+     */
+    public function getTranslatedLabelThrowsExceptionForInvalidLocales()
+    {
+        $this->arguments['translate'] = array('locale' => 'invalid-locale');
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
+
+        $this->viewHelper->_call('getTranslatedLabel', 'value1', 'label1');
+    }
+
+    /**
+     * @test
+     * @expectedException \TYPO3\Fluid\Core\ViewHelper\Exception
+     */
+    public function getTranslatedLabelThrowsExceptionForUnknownTranslateBy()
+    {
+        $this->arguments['translate'] = array('by' => 'foo');
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
+
+        $this->viewHelper->_call('getTranslatedLabel', 'value1', 'label1');
+    }
+
+    public function getTranslatedLabelDataProvider()
+    {
+        return [
+
+            ## translate by id
+
+            # using value
+            ['by' => 'id', 'using' => 'value', 'translatedId' => 'Translated id', 'translatedLabel' => 'Translated label', 'expectedResult' => 'Translated id'],
+            ['by' => 'id', 'using' => 'value', 'translatedId' => 'Translated id', 'translatedLabel' => null, 'expectedResult' => 'Translated id'],
+            ['by' => 'id', 'using' => 'value', 'translatedId' => null, 'translatedLabel' => 'Translated label', 'expectedResult' => 'Some label'],
+            ['by' => 'id', 'using' => 'value', 'translatedId' => null, 'translatedLabel' => null, 'expectedResult' => 'Some label'],
+
+            # using label
+            ['by' => 'id', 'using' => 'label', 'translatedId' => 'Translated id', 'translatedLabel' => 'Translated label', 'expectedResult' => 'Translated id'],
+            ['by' => 'id', 'using' => 'label', 'translatedId' => 'Translated id', 'translatedLabel' => null, 'expectedResult' => 'Translated id'],
+            ['by' => 'id', 'using' => 'label', 'translatedId' => null, 'translatedLabel' => 'Translated label', 'expectedResult' => 'Some label'],
+            ['by' => 'id', 'using' => 'label', 'translatedId' => null, 'translatedLabel' => null, 'expectedResult' => 'Some label'],
+
+            ## translate by label
+
+            # using value
+            ['by' => 'label', 'using' => 'value', 'translatedId' => 'Translated id', 'translatedLabel' => 'Translated label', 'expectedResult' => 'Translated label'],
+            ['by' => 'label', 'using' => 'value', 'translatedId' => 'Translated id', 'translatedLabel' => null, 'expectedResult' => 'someValue'],
+            ['by' => 'label', 'using' => 'value', 'translatedId' => null, 'translatedLabel' => 'Translated label', 'expectedResult' => 'Translated label'],
+            ['by' => 'label', 'using' => 'value', 'translatedId' => null, 'translatedLabel' => null, 'expectedResult' => 'someValue'],
+
+            # using label
+            ['by' => 'label', 'using' => 'label', 'translatedId' => 'Translated id', 'translatedLabel' => 'Translated label', 'expectedResult' => 'Translated label'],
+            ['by' => 'label', 'using' => 'label', 'translatedId' => 'Translated id', 'translatedLabel' => null, 'expectedResult' => 'Some label'],
+            ['by' => 'label', 'using' => 'label', 'translatedId' => null, 'translatedLabel' => 'Translated label', 'expectedResult' => 'Translated label'],
+            ['by' => 'label', 'using' => 'label', 'translatedId' => null, 'translatedLabel' => null, 'expectedResult' => 'Some label'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider getTranslatedLabelDataProvider
+     * @param string $by
+     * @param string $using
+     * @param string $translatedId
+     * @param string $translatedLabel
+     * @param string $expectedResult
+     */
+    public function getTranslatedLabelTests($by, $using, $translatedId, $translatedLabel, $expectedResult)
+    {
+        $this->arguments['translate'] = ['by' => $by, 'using' => $using, 'prefix' => 'somePrefix.'];
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
+
+        $mockTranslator = $this->getMock(\TYPO3\Flow\I18n\Translator::class);
+        if ($by === 'label') {
+            $mockTranslator->expects($this->once())->method('translateByOriginalLabel')->will($this->returnCallback(function($label) use ($translatedLabel) {
+                return $translatedLabel !== null ? $translatedLabel : $label;
+            }));
+        } else {
+            $mockTranslator->expects($this->once())->method('translateById')->will($this->returnValue($translatedId));
+        }
+        $this->inject($this->viewHelper, 'translator', $mockTranslator);
+
+        $actualResult = $this->viewHelper->_call('getTranslatedLabel', 'someValue', 'Some label');
+        $this->assertSame($expectedResult, $actualResult);
+    }
+
+    /**
+     * @test
      */
     public function optionsContainPrependedItemWithEmptyValueIfPrependOptionLabelIsSet()
     {


### PR DESCRIPTION
This patch adjusts the behavior of id-based translations in order to make it deterministic and consistent.

It mainly adjusts `Translator::translateById()` to return `NULL` if the given `id` couldn't be translated. Previously it returned the `id` making it impossible to detect that case.

This has an effect to the two related Fluid ViewHelpers in certain conditions:

`{f:translate(id: 'some.id', value: 'default')}`:

previously returned the *translated* default value if the `id` wasn't translated, possibly leading to unexpected behavior.
Now it will just return the raw default value ("default" in the example above instead of "translatedDefault").

Besides the `TranslateViewHelper` has been tweaked to always return an empty string rather than `NULL` if neither id nor value could be resolved.

`<f:form.select translate="{by:'id', by:'value', prefix: 'prefix.'}" />`:

Previously this would render

`<option value="...">prefix.someValue</option>`

if the id could not be translated.
With `by:'label'` it would return the prefixed label instead.

Now we always render the actual key (= label) of the option in that case:

`<option value="...">Original Option</option>`

FLOW-456 #close