### PR TITLE
BUGFIX: Exclude sebastian.* and phpdocumentor.* from reflection

### DIFF
--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -193,6 +193,8 @@ TYPO3:
         'doctrine.*': ['.*']
         'symfony.*': ['.*']
         'phpunit.*': ['.*']
+        'sebastian.*': ['.*']
+        'phpdocumentor.*': ['.*']
         'mikey179.vfsStream': ['.*']
         # workaround, should rather be deactivated
         'neos.composerplugin': ['.*']


### PR DESCRIPTION
This fixes reflection failures caused by some classes in those libraries:

phpunit/phpunit depends on phpspec/prophecy, which depends on phpdocumentor/reflection-docblock.
Now prophecy changed that dependency from `~2.0` to `^2.0|^3.0.2` when going from 1.6.0 to 1.6.1.
reflection-docblock 3.x includes (new) code which fails reflection (namespace does not match file path).