### PR TITLE
Complete code examples with necessary use statement

### DIFF
--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/ObjectManagement.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/ObjectManagement.rst
@@ -101,7 +101,9 @@ The scope of an object is determined from its configuration (see also :ref:`sect
 The recommended way to specify the scope is the ``@scope`` annotation::
 
 	namespace MyCompany\MyPackage;
-
+	
+  use TYPO3\Flow\Annotations as Flow;
+  
 	/**
 	 * A sample class
 	 *
@@ -544,6 +546,8 @@ For these cases Flow provides support for *Property Injection*:
 *Example: Example for Property Injection* ::
 
 	namespace MyCompany\MyPackage;
+  
+  use TYPO3\Flow\Annotations as Flow;
 
 	class Foo {
 
@@ -600,7 +604,9 @@ dependencies to other objects:
 *Example: Passing a dependency around* ::
 
 	namespace MyCompany\MyPackage;
-
+  
+  use TYPO3\Flow\Annotations as Flow;
+  
 	class Foo {
 
 		/**
@@ -641,6 +647,8 @@ There are two ways to solve this:
 
 	namespace MyCompany\MyPackage;
 
+  use TYPO3\Flow\Annotations as Flow;
+
 	class Foo {
 
 		/**
@@ -669,6 +677,8 @@ calling ``_activateDependency()`` will fail.
 *Example: Turning off lazy dependency injection* ::
 
 	namespace MyCompany\MyPackage;
+
+  use TYPO3\Flow\Annotations as Flow;
 
 	class Foo {
 
@@ -726,6 +736,8 @@ setting value into a class property:
 .. code-block:: php
 
 	namespace Acme\Demo;
+
+  use TYPO3\Flow\Annotations as Flow;
 
 	class SomeClass {
 


### PR DESCRIPTION
The examples contain namespace and full class body, so they seem to be complete and executable. But for usage of `@Flow` the use statement is necessary.