### PR TITLE
BUGFIX: Improving argument handling of FormatResolver::resolvePlaceholders

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/I18n/FormatResolver.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/I18n/FormatResolver.php
@@ -100,8 +100,9 @@ class FormatResolver
             $locale = $this->localizationService->getConfiguration()->getDefaultLocale();
         }
 
-        while (($startOfPlaceholder = strpos($textWithPlaceholders, '{')) !== false) {
-            $endOfPlaceholder = strpos($textWithPlaceholders, '}');
+        $lastPlaceHolderAt = 0;
+        while ($lastPlaceHolderAt < strlen($textWithPlaceholders) && ($startOfPlaceholder = strpos($textWithPlaceholders, '{', $lastPlaceHolderAt)) !== false) {
+            $endOfPlaceholder = strpos($textWithPlaceholders, '}', $lastPlaceHolderAt);
             $startOfNextPlaceholder = strpos($textWithPlaceholders, '{', $startOfPlaceholder + 1);
 
             if ($endOfPlaceholder === false || ($startOfPlaceholder + 1) >= $endOfPlaceholder || ($startOfNextPlaceholder !== false && $startOfNextPlaceholder < $endOfPlaceholder)) {
@@ -127,6 +128,7 @@ class FormatResolver
             }
 
             $textWithPlaceholders = str_replace('{' . $contentBetweenBrackets . '}', $formattedPlaceholder, $textWithPlaceholders);
+            $lastPlaceHolderAt = $startOfPlaceholder + strlen($formattedPlaceholder);
         }
 
         return $textWithPlaceholders;

--- a/TYPO3.Flow/Tests/Unit/I18n/FormatResolverTest.php
+++ b/TYPO3.Flow/Tests/Unit/I18n/FormatResolverTest.php
@@ -44,6 +44,9 @@ class FormatResolverTest extends \TYPO3\Flow\Tests\UnitTestCase
 
         $result = $formatResolver->resolvePlaceholders('Foo {0,number}, bar {1,number,percent}', array(1, 2), $this->sampleLocale);
         $this->assertEquals('Foo 1.0, bar 200%', $result);
+
+        $result = $formatResolver->resolvePlaceHolders('Foo {0}{1} Bar', array('{', '}'), $this->sampleLocale);
+        $this->assertEquals('Foo {} Bar', $result);
     }
 
     /**


### PR DESCRIPTION
If placeholders will be replaced by arguments containing chars "{}",
replacing led to an exception.

This fix solves this behaviour by not visiting replaced content again.
This helps a lot translating error messages from Validators which give
their content back to their error messages - and can contain literally
anything.