### PR TITLE
BUGFIX: Input field name for multiple checkbox is generated correctly

### DIFF
--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Form/AbstractFormFieldViewHelper.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Form/AbstractFormFieldViewHelper.php
@@ -81,9 +81,14 @@ abstract class AbstractFormFieldViewHelper extends AbstractFormViewHelper
         } else {
             $name = $this->arguments['name'];
         }
-        if ($this->hasArgument('value') && is_object($this->arguments['value'])) {
-            if (null !== $this->persistenceManager->getIdentifierByObject($this->arguments['value'])
-                && (!$this->persistenceManager->isNewObject($this->arguments['value']))) {
+        if ($this->hasArgument('value')) {
+            /** @var object $value */
+            $value = $this->arguments['value'];
+            $multiple = $this->hasArgument('multiple') && $this->arguments['multiple'] === true;
+            if (!$multiple
+                && is_object($value)
+                && $this->persistenceManager->getIdentifierByObject($value) !== null
+                && (!$this->persistenceManager->isNewObject($value))) {
                 $name .= '[__identity]';
             }
         }

--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Form/CheckboxViewHelper.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Form/CheckboxViewHelper.php
@@ -75,7 +75,6 @@ class CheckboxViewHelper extends AbstractFormFieldViewHelper
     {
         $this->tag->addAttribute('type', 'checkbox');
 
-        $nameAttribute = $this->getName();
         $valueAttribute = $this->getValueAttribute(true);
         $propertyValue = null;
         if ($this->hasMappingErrorOccurred()) {
@@ -92,11 +91,14 @@ class CheckboxViewHelper extends AbstractFormFieldViewHelper
             if ($checked === null) {
                 $checked = in_array($valueAttribute, $propertyValue);
             }
-            $nameAttribute .= '[]';
-        } elseif ($multiple === true) {
-            $nameAttribute .= '[]';
-        } elseif ($propertyValue !== null) {
+            $this->arguments['multiple'] = true;
+        } elseif (!$multiple && $propertyValue !== null) {
             $checked = (boolean)$propertyValue === (boolean)$valueAttribute;
+        }
+
+        $nameAttribute = $this->getName();
+        if ($this->arguments['multiple']) {
+            $nameAttribute .= '[]';
         }
 
         $this->registerFieldNameForFormTokenGeneration($nameAttribute);
@@ -111,19 +113,5 @@ class CheckboxViewHelper extends AbstractFormFieldViewHelper
 
         $this->renderHiddenFieldForEmptyValue();
         return $this->tag->render();
-    }
-
-    /**
-     * Get the name of this form element, without prefix.
-     *
-     * This is done to prevent the extra __identity being added for objects
-     * since it leading to property mapping errors and it works without it.
-     *
-     * @return string name
-     */
-    protected function getNameWithoutPrefix()
-    {
-        $name = parent::getNameWithoutPrefix();
-        return str_replace('[__identity]', '', $name);
     }
 }

--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Form/CheckboxViewHelper.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Form/CheckboxViewHelper.php
@@ -97,7 +97,7 @@ class CheckboxViewHelper extends AbstractFormFieldViewHelper
         }
 
         $nameAttribute = $this->getName();
-        if ($this->arguments['multiple']) {
+        if (isset($this->arguments['multiple']) && $this->arguments['multiple'] === true) {
             $nameAttribute .= '[]';
         }
 

--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Form/CheckboxViewHelper.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Form/CheckboxViewHelper.php
@@ -112,4 +112,18 @@ class CheckboxViewHelper extends AbstractFormFieldViewHelper
         $this->renderHiddenFieldForEmptyValue();
         return $this->tag->render();
     }
+
+    /**
+     * Get the name of this form element, without prefix.
+     *
+     * This is done to prevent the extra __identity being added for objects
+     * since it leading to property mapping errors and it works without it.
+     *
+     * @return string name
+     */
+    protected function getNameWithoutPrefix()
+    {
+        $name = parent::getNameWithoutPrefix();
+        return str_replace('[__identity]', '', $name);
+    }
 }

--- a/TYPO3.Fluid/Resources/Private/Templates/Tests/Functional/Form/Fixtures/Form/Edit.html
+++ b/TYPO3.Fluid/Resources/Private/Templates/Tests/Functional/Form/Fixtures/Form/Edit.html
@@ -4,5 +4,9 @@
 	<f:form.textfield id="name" property="name" />
 	<f:form.textfield id="email" property="author.emailAddress" />
 	<f:form.checkbox id="private" property="private" value="true" disabled="true" />
+	<f:for each="{fooPost.tags}" as="tag">
+		<f:form.checkbox property="tags" value="{tag}" />
+		<f:form.checkbox name="tags" multiple="true" value="{tag}" />
+	</f:for>
 	<f:form.submit>Abschicken</f:form.submit>
 </f:form>

--- a/TYPO3.Fluid/Tests/Functional/Form/Fixtures/Domain/Model/Post.php
+++ b/TYPO3.Fluid/Tests/Functional/Form/Fixtures/Domain/Model/Post.php
@@ -11,6 +11,8 @@ namespace TYPO3\Fluid\Tests\Functional\Form\Fixtures\Domain\Model;
  * source code.
  */
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use TYPO3\Flow\Annotations as Flow;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -50,6 +52,18 @@ class Post
      * @ORM\Column(nullable=true)
      */
     protected $subCategory;
+
+    /**
+     * @var Collection<Tag>
+     * @ORM\ManyToMany
+     * @ORM\JoinTable(inverseJoinColumns={@ORM\JoinColumn(unique=true)})
+     */
+    protected $tags;
+
+    public function __construct()
+    {
+        $this->tags = new ArrayCollection();
+    }
 
     /**
      * @return string
@@ -130,5 +144,29 @@ class Post
     public function getSubCategory()
     {
         return $this->subCategory;
+    }
+
+    /**
+     * @param Tag $tag
+     */
+    public function addTag(Tag $tag)
+    {
+        $this->tags->add($tag);
+    }
+
+    /**
+     * @return Collection<Tag>
+     */
+    public function getTags()
+    {
+        return $this->tags;
+    }
+
+    /**
+     * @param Collection<Tag> $tags
+     */
+    public function setTags($tags)
+    {
+        $this->tags = $tags;
     }
 }

--- a/TYPO3.Fluid/Tests/Functional/Form/Fixtures/Domain/Model/Tag.php
+++ b/TYPO3.Fluid/Tests/Functional/Form/Fixtures/Domain/Model/Tag.php
@@ -1,0 +1,53 @@
+<?php
+namespace TYPO3\Fluid\Tests\Functional\Form\Fixtures\Domain\Model;
+
+/*
+ * This file is part of the TYPO3.Fluid package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * A test entity which is used to test Fluid forms in combination with
+ * property mapping
+ *
+ * @Flow\Entity
+ */
+class Tag
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @param string $name
+     */
+    public function __construct($name = '')
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/TYPO3.Fluid/Tests/Functional/Form/FormObjectsTest.php
+++ b/TYPO3.Fluid/Tests/Functional/Form/FormObjectsTest.php
@@ -66,6 +66,19 @@ class FormObjectsTest extends \TYPO3\Flow\Tests\FunctionalTestCase
     /**
      * @test
      */
+    public function multipleCheckboxRendersCorrectFieldNameForEntities()
+    {
+        $postIdentifier = $this->setupDummyPost(true);
+
+        $this->browser->request('http://localhost/test/fluid/formobjects/edit?fooPost=' . $postIdentifier);
+        $form = $this->browser->getForm();
+        $this->assertFalse(isset($form['post']['tags']['__identity']));
+        $this->assertFalse(isset($form['tags']['__identity']));
+    }
+
+    /**
+     * @test
+     */
     public function formIsRedisplayedIfValidationErrorsOccur()
     {
         $this->browser->request('http://localhost/test/fluid/formobjects');
@@ -333,9 +346,10 @@ class FormObjectsTest extends \TYPO3\Flow\Tests\FunctionalTestCase
     }
 
     /**
+     * @param boolean $withTags
      * @return string UUID of the dummy post
      */
-    protected function setupDummyPost()
+    protected function setupDummyPost($withTags = false)
     {
         $author = new Fixtures\Domain\Model\User();
         $author->setEmailAddress('foo@bar.org');
@@ -343,6 +357,10 @@ class FormObjectsTest extends \TYPO3\Flow\Tests\FunctionalTestCase
         $post->setAuthor($author);
         $post->setName('myName');
         $post->setPrivate(true);
+        if ($withTags === true) {
+            $post->addTag(new Fixtures\Domain\Model\Tag('Tag1'));
+            $post->addTag(new Fixtures\Domain\Model\Tag('Tag2'));
+        }
         $this->persistenceManager->add($post);
         $postIdentifier = $this->persistenceManager->getIdentifierByObject($post);
         $this->persistenceManager->persistAll();


### PR DESCRIPTION
Checkboxes that were bound to collection properties or had the `multiple` attribute set,
were generating invalid input field names like this:

    <input type="checkbox" name="post[tags][__identity][]" ...>

Since the internal identity is not required for checkboxes, it is stripped from the generated name.
Also, any such checkboxes now avoid generating an empty value hidden field, as this will at most
lead to empty values being additionally submitted to the collection property.

FLOW-419 #close