### PR TITLE
BUGIX: Remove temporary file in importTemporaryFile()

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Storage/WritableFileSystemStorage.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Storage/WritableFileSystemStorage.php
@@ -120,28 +120,30 @@ class WritableFileSystemStorage extends FileSystemStorage implements WritableSto
     /**
      * Imports the given temporary file into the storage and creates the new resource object.
      *
-     * @param string $temporaryFile
+     * Note: the temporary file is (re-)moved by this method.
+     *
+     * @param string $temporaryPathAndFileName
      * @param string $collectionName
      * @return Resource
      * @throws Exception
      */
-    protected function importTemporaryFile($temporaryFile, $collectionName)
+    protected function importTemporaryFile($temporaryPathAndFileName, $collectionName)
     {
-        $this->fixFilePermissions($temporaryFile);
-        $sha1Hash = sha1_file($temporaryFile);
-        $finalTargetPathAndFilename = $this->getStoragePathAndFilenameByHash($sha1Hash);
+        $this->fixFilePermissions($temporaryPathAndFileName);
+        $sha1Hash = sha1_file($temporaryPathAndFileName);
+        $targetPathAndFilename = $this->getStoragePathAndFilenameByHash($sha1Hash);
 
-        if (!is_file($finalTargetPathAndFilename)) {
-            $this->moveTemporaryFileToFinalDestination($temporaryFile, $finalTargetPathAndFilename);
+        if (!is_file($targetPathAndFilename)) {
+            $this->moveTemporaryFileToFinalDestination($temporaryPathAndFileName, $targetPathAndFilename);
         } else {
             unlink($temporaryPathAndFileName);
         }
 
         $resource = new Resource();
-        $resource->setFileSize(filesize($finalTargetPathAndFilename));
+        $resource->setFileSize(filesize($targetPathAndFilename));
         $resource->setCollectionName($collectionName);
         $resource->setSha1($sha1Hash);
-        $resource->setMd5(md5_file($finalTargetPathAndFilename));
+        $resource->setMd5(md5_file($targetPathAndFilename));
 
         return $resource;
     }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Storage/WritableFileSystemStorage.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Storage/WritableFileSystemStorage.php
@@ -133,6 +133,8 @@ class WritableFileSystemStorage extends FileSystemStorage implements WritableSto
 
         if (!is_file($finalTargetPathAndFilename)) {
             $this->moveTemporaryFileToFinalDestination($temporaryFile, $finalTargetPathAndFilename);
+        } else {
+            unlink($temporaryPathAndFileName);
         }
 
         $resource = new Resource();


### PR DESCRIPTION
The temporary file used to be gone after importing, but since it only is
moved when the target does not yet exist, this changed. Now the file is
unlinked in that case.

FLOW-378 #close