### PR TITLE
FEATURE: Allow asynchronous execution of commands

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
@@ -637,6 +637,27 @@ class Scripts
     }
 
     /**
+     * Executes the given command as a sub-request to the Flow CLI system without waiting for the output.
+     * 
+     * Note: As the command execution is done in a separate thread potential exceptions or failures will *not* be reported
+     *
+     * @param string $commandIdentifier E.g. typo3.flow:cache:flush
+     * @param array $settings The TYPO3.Flow settings
+     * @param array $commandArguments Command arguments
+     * @return void
+     * @api
+     */
+    public static function executeCommandAsync($commandIdentifier, array $settings, array $commandArguments = array())
+    {
+        $command = self::buildSubprocessCommand($commandIdentifier, $settings, $commandArguments);
+        if (DIRECTORY_SEPARATOR === '/') {
+            exec($command . ' > /dev/null 2>/dev/null &');
+        } else {
+            pclose(popen('START /B CMD /S /C "' . $command . '" > NUL 2 > NUL &', 'r'));
+        }
+    }
+
+    /**
      * @param string $commandIdentifier E.g. typo3.flow:cache:flush
      * @param array $settings The TYPO3.Flow settings
      * @param array $commandArguments Command arguments

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
@@ -653,7 +653,7 @@ class Scripts
         if (DIRECTORY_SEPARATOR === '/') {
             exec($command . ' > /dev/null 2>/dev/null &');
         } else {
-            pclose(popen('START /B CMD /S /C "' . $command . '" > NUL 2 > NUL &', 'r'));
+            pclose(popen('START /B CMD /S /C "' . $command . '" > NUL 2> NUL &', 'r'));
         }
     }
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
@@ -638,7 +638,7 @@ class Scripts
 
     /**
      * Executes the given command as a sub-request to the Flow CLI system without waiting for the output.
-     * 
+     *
      * Note: As the command execution is done in a separate thread potential exceptions or failures will *not* be reported
      *
      * @param string $commandIdentifier E.g. typo3.flow:cache:flush

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/CommandLine.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/CommandLine.rst
@@ -585,16 +585,34 @@ class and can be used as follows:
 
 .. code-block:: php
 
+	use TYPO3\Flow\Annotations as Flow;
+	use TYPO3\Flow\Core\Booting\Scripts;
+
 	/**
-	 * Some command
-	 *
-	 * This example command runs another command
-	 *
-	 * @return string
+	 * @Flow\InjectConfiguration(package="TYPO3.Flow")
+	 * @var array
 	 */
-	public function runCommand($packageKey) {
-		\TYPO3\Flow\Core\Booting\Scripts::executeCommand('acme.foo:bar:baz', $this->settings);
+	protected $flowSettings;
+
+	public function runCommand() {
+		$success = Scripts::executeCommand('acme.foo:bar:baz', $this->flowSettings);
 	}
+
+Sometimes it can be useful to execute commands *asynchronously*, for example when triggering time-consuming
+tasks where the result is not instantly required (like sending confirmation emails, converting files, ...).
+This can be done with the ``Scripts::executeCommandAsync()*`` method:
+
+.. code-block:: php
+
+	public function runCommand() {
+		$commandArguments = ['some-argument' => 'some value'];
+		Scripts::executeCommandAsync('acme.foo:bar:baz', $this->flowSettings, $commandArguments);
+	}
+
+.. Note::
+	Because asynchronous commands are invoked in a separate thread, potential exceptions or failures will
+	*not* be reported. While this can be desired, it might require additional monitoring on the command-side
+	(e.g. a failure log).
 
 Quitting and Exit Code
 ----------------------


### PR DESCRIPTION
Adds a new convenience method `Scripts::executeCommandAsync()` that can be
used to execute commands without waiting for their result.

This is especially useful for time-consuming tasks whose result is not
(instantly) required.

Example::

     Scripts::executeCommandAsync('my.package:registration:sendconfirmationmail', $this->flowSettings, ['email' => $emailAddress]);

FLOW-458 #close