### PR TITLE
BUGFIX: Support PHP 7.0 type declarations on parameters and return types

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Object/Proxy/ProxyMethod.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Object/Proxy/ProxyMethod.php
@@ -152,11 +152,15 @@ class ProxyMethod
 
         $visibility = ($this->visibility === null ? $this->getMethodVisibilityString() : $this->visibility);
 
+        $returnType = $this->reflectionService->getMethodDeclaredReturnType($this->fullOriginalClassName, $this->methodName);
+        $returnTypeDeclaration = ($returnType !== null ? ' : ' . $returnType : '');
+
+
         $code = '';
         if ($this->addedPreParentCallCode !== '' || $this->addedPostParentCallCode !== '' || $this->methodBody !== '') {
             $code = "\n" .
                 $methodDocumentation .
-                '    ' . $staticKeyword . $visibility . ' function ' . $this->methodName . '(' . $methodParametersCode . ")\n    {\n";
+                '    ' . $staticKeyword . $visibility . ' function ' . $this->methodName . '(' . $methodParametersCode . ")$returnTypeDeclaration\n    {\n";
             if ($this->methodBody !== '') {
                 $code .= "\n" . $this->methodBody . "\n";
             } else {
@@ -247,6 +251,8 @@ class ProxyMethod
                 if ($addTypeAndDefaultValue) {
                     if ($methodParameterInfo['array'] === true) {
                         $methodParameterTypeName = 'array';
+                    } elseif ($methodParameterInfo['scalarDeclaration']) {
+                        $methodParameterTypeName = $methodParameterInfo['type'];
                     } else {
                         $methodParameterTypeName = ($methodParameterInfo['class'] === null) ? '' : '\\' . $methodParameterInfo['class'];
                     }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/MethodReflection.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/MethodReflection.php
@@ -95,6 +95,18 @@ class MethodReflection extends \ReflectionMethod
     }
 
     /**
+     * @return string The name of a type (e.g. string, \stdClass) if it was declared as a return type, null otherwise
+     */
+    public function getDeclaredReturnType()
+    {
+        if (!is_callable(array($this, 'getReturnType'))) {
+            return null;
+        }
+        $type = $this->getReturnType();
+        return $type !== null ? (string)$type : null;
+    }
+
+    /**
      * Returns an instance of the doc comment parser and
      * runs the parse() method.
      *

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ParameterReflection.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ParameterReflection.php
@@ -50,4 +50,19 @@ class ParameterReflection extends \ReflectionParameter
 
         return is_object($class) ? new ClassReflection($class->getName()) : null;
     }
+
+    /**
+     * @return string The name of a builtin type (e.g. string, int) if it was declared for the parameter (scalar type declaration), null otherwise
+     */
+    public function getBuiltinType()
+    {
+        if (!is_callable(array($this, 'getType'))) {
+            return null;
+        }
+        $type = $this->getType();
+        if ($type === null || !$type->isBuiltin()) {
+            return null;
+        }
+        return (string)$type;
+    }
 }

--- a/TYPO3.Flow/Tests/Functional/Aop/Fixtures/BaseFunctionalityTestingAspect.php
+++ b/TYPO3.Flow/Tests/Functional/Aop/Fixtures/BaseFunctionalityTestingAspect.php
@@ -202,4 +202,14 @@ class BaseFunctionalityTestingAspect
     {
         return 'Implemented';
     }
+
+    /**
+     * @Flow\Around("method(TYPO3\Flow\Tests\Functional\Aop\Fixtures\TargetClassWithPhp7Features->methodWithStaticTypeDeclarations())")
+     * @param \TYPO3\Flow\Aop\JoinPointInterface $joinPoint
+     * @return string
+     */
+    public function methodWithStaticTypeDeclarationsAdvice(\TYPO3\Flow\Aop\JoinPointInterface $joinPoint)
+    {
+        return 'This is so NaN';
+    }
 }

--- a/TYPO3.Flow/Tests/Functional/Aop/Fixtures/TargetClassWithPhp7Features.php
+++ b/TYPO3.Flow/Tests/Functional/Aop/Fixtures/TargetClassWithPhp7Features.php
@@ -1,0 +1,30 @@
+<?php
+namespace TYPO3\Flow\Tests\Functional\Aop\Fixtures;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+class TargetClassWithPhp7Features
+{
+    /**
+     * Test scalar type declarations on parameters
+     *
+     * The return type declaration causes syntax errors below PHP 7.0 but is supported by the reflection service and
+     * proxy builder in Flow.
+     *
+     * @param string $aString
+     * @param int $aNumber
+     * @return string
+     */
+    public function methodWithStaticTypeDeclarations(string $aString, int $aNumber)
+    {
+        return "{$aString} and {$aNumber}";
+    }
+}

--- a/TYPO3.Flow/Tests/Functional/Aop/FrameworkTest.php
+++ b/TYPO3.Flow/Tests/Functional/Aop/FrameworkTest.php
@@ -257,4 +257,18 @@ class FrameworkTest extends \TYPO3\Flow\Tests\FunctionalTestCase
         $this->assertSame(null, $targetClass->introducedPublicProperty);
         $this->assertSame('thisIsADefaultValueBelieveItOrNot', $targetClass->introducedProtectedPropertyWithDefaultValue);
     }
+
+    /**
+     * @test
+     */
+    public function methodWithStaticTypeDeclarationsCanBeAdviced()
+    {
+        if (version_compare(PHP_VERSION, '7.0.0') < 0) {
+            $this->markTestSkipped('Requires PHP 7');
+        }
+
+        $targetClass = new Fixtures\TargetClassWithPhp7Features();
+
+        $this->assertSame('This is so NaN', $targetClass->methodWithStaticTypeDeclarations('The answer', 42));
+    }
 }

--- a/TYPO3.Flow/Tests/Unit/Object/Proxy/ProxyMethodTest.php
+++ b/TYPO3.Flow/Tests/Unit/Object/Proxy/ProxyMethodTest.php
@@ -71,7 +71,8 @@ class ProxyMethodTest extends \TYPO3\Flow\Tests\UnitTestCase
                 'array' => false,
                 'optional' => false,
                 'allowsNull' => true,
-                'class' => null
+                'class' => null,
+                'scalarDeclaration' => false
             ),
             'arg2' => array(
                 'position' => 1,
@@ -79,7 +80,8 @@ class ProxyMethodTest extends \TYPO3\Flow\Tests\UnitTestCase
                 'array' => true,
                 'optional' => false,
                 'allowsNull' => true,
-                'class' => null
+                'class' => null,
+                'scalarDeclaration' => false
             ),
             'arg3' => array(
                 'position' => 2,
@@ -87,7 +89,8 @@ class ProxyMethodTest extends \TYPO3\Flow\Tests\UnitTestCase
                 'array' => false,
                 'optional' => false,
                 'allowsNull' => true,
-                'class' => 'ArrayObject'
+                'class' => 'ArrayObject',
+                'scalarDeclaration' => false
             ),
             'arg4' => array(
                 'position' => 3,
@@ -96,7 +99,8 @@ class ProxyMethodTest extends \TYPO3\Flow\Tests\UnitTestCase
                 'optional' => true,
                 'allowsNull' => true,
                 'class' => null,
-                'defaultValue' => 'foo'
+                'defaultValue' => 'foo',
+                'scalarDeclaration' => false
             ),
             'arg5' => array(
                 'position' => 4,
@@ -105,7 +109,8 @@ class ProxyMethodTest extends \TYPO3\Flow\Tests\UnitTestCase
                 'optional' => true,
                 'allowsNull' => true,
                 'class' => null,
-                'defaultValue' => true
+                'defaultValue' => true,
+                'scalarDeclaration' => false
             ),
             'arg6' => array(
                 'position' => 5,
@@ -114,7 +119,8 @@ class ProxyMethodTest extends \TYPO3\Flow\Tests\UnitTestCase
                 'optional' => true,
                 'allowsNull' => true,
                 'class' => null,
-                'defaultValue' => array(0 => true, 'foo' => 'bar', 1 => null, 3 => 1, 4 => 2.3)
+                'defaultValue' => array(0 => true, 'foo' => 'bar', 1 => null, 3 => 1, 4 => 2.3),
+                'scalarDeclaration' => false
             ),
         );
 


### PR DESCRIPTION
Adds methods to the reflection service to access declared types in
a backwards compatible way (returning null for PHP < 7.0) and extends
the proxy builder to add type declarations if they were used on the
original method. This allows to use type declarations for parameters
(scalar values) or return type declarations even for advised methods.

FLOW-460 #fixes