### PR TITLE
BUGFIX: Check if array is ``null`` at the beginning of JSON conversion

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/DataTypes/JsonArrayType.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/DataTypes/JsonArrayType.php
@@ -118,13 +118,12 @@ class JsonArrayType extends DoctrineJsonArrayType
      */
     public function convertToDatabaseValue($array, AbstractPlatform $platform)
     {
-        $this->initializeDependencies();
-
-        $this->encodeObjectReferences($array);
-
         if ($array === null) {
             return null;
         }
+
+        $this->initializeDependencies();
+        $this->encodeObjectReferences($array);
 
         return json_encode($array, JSON_PRETTY_PRINT | JSON_FORCE_OBJECT | JSON_UNESCAPED_UNICODE);
     }

--- a/TYPO3.Flow/Tests/Unit/Persistence/Doctrine/DataTypes/JsonArrayTypeTest.php
+++ b/TYPO3.Flow/Tests/Unit/Persistence/Doctrine/DataTypes/JsonArrayTypeTest.php
@@ -1,0 +1,60 @@
+<?php
+namespace TYPO3\Flow\Tests\Unit\Persistence\Doctrine\DataTypes;
+
+/*
+* This file is part of the TYPO3.Flow package.
+*
+* (c) Contributors of the Neos Project - www.neos.io
+*
+* This package is Open Source Software. For the full copyright and license
+* information, please view the LICENSE file which was distributed with this
+* source code.
+*/
+
+/**
+ * Testcase for \TYPO3\Flow\Persistence\Doctrine\DataTypes\JsonArrayType
+ *
+*/
+class JsonArrayTypeTest extends \TYPO3\Flow\Tests\UnitTestCase
+{
+    /**
+     * @var \TYPO3\Flow\Persistence\Doctrine\DataTypes\JsonArrayType|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $jsonArrayTypeMock;
+
+    /**
+     * @var \Doctrine\DBAL\Platforms\AbstractPlatform|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $abstractPlatformMock;
+
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->jsonArrayTypeMock = $this->getMockBuilder('TYPO3\Flow\Persistence\Doctrine\DataTypes\JsonArrayType')
+            ->setMethods(['initializeDependencies'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->abstractPlatformMock = $this->getMockBuilder('Doctrine\DBAL\Platforms\AbstractPlatform')->getMock();
+    }
+
+    /**
+     * @test
+     */
+    public function jsonConversionReturnsNullIfArrayIsNull()
+    {
+        $json = $this->jsonArrayTypeMock->convertToDatabaseValue(null, $this->abstractPlatformMock);
+        $this->assertEquals(null, $json);
+    }
+
+    /**
+     * @test
+     */
+    public function passSimpleArrayAndConvertToJson()
+    {
+        $json = $this->jsonArrayTypeMock->convertToDatabaseValue(['simplestring',1,['nestedArray']], $this->abstractPlatformMock);
+        $this->assertEquals("{\n    \"0\": \"simplestring\",\n    \"1\": 1,\n    \"2\": {\n        \"0\": \"nestedArray\"\n    }\n}", $json);
+    }
+}


### PR DESCRIPTION
Prevent an exception to be thrown if the array passed for conversion is ``null``.