### PR TITLE
BUGFIX: Fix converter determination for the ObjectConverter

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/ObjectConverter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/ObjectConverter.php
@@ -152,7 +152,7 @@ class ObjectConverter extends AbstractTypeConverter
                     } catch (InvalidTypeException $exception) {
                         throw new \InvalidArgumentException(sprintf($exception->getMessage(), 'class "' . $targetType . '" for property "' . $propertyName . '"'), 1467699674);
                     }
-                    return $parsedType['type'];
+                    return $parsedType['type'] . ($parsedType['elementType'] !== null ? '<' . $parsedType['elementType'] . '>' : '');
                 } else {
                     throw new InvalidTargetException(sprintf('Public property "%s" had no proper type annotation (i.e. "@var") in target object of type "%s".', $propertyName, $targetType), 1406821818);
                 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/ObjectConverter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/ObjectConverter.php
@@ -126,21 +126,26 @@ class ObjectConverter extends AbstractTypeConverter
 
         $methodParameters = $this->reflectionService->getMethodParameters($targetType, '__construct');
         if (isset($methodParameters[$propertyName]) && isset($methodParameters[$propertyName]['type'])) {
-            return $methodParameters[$propertyName]['type'];
+            // This ensures that FQDNs are returned without leading backslashes. Otherwise, something like @var \DateTime
+            // would not find a property mapper. It is needed because the ObjectConverter doesn't use class schemata,
+            // but reads the annotations directly.
+            return ltrim($methodParameters[$propertyName]['type'], '\\');
         } elseif ($this->reflectionService->hasMethod($targetType, ObjectAccess::buildSetterMethodName($propertyName))) {
             $methodParameters = $this->reflectionService->getMethodParameters($targetType, ObjectAccess::buildSetterMethodName($propertyName));
             $methodParameter = current($methodParameters);
             if (!isset($methodParameter['type'])) {
                 throw new InvalidTargetException('Setter for property "' . $propertyName . '" had no type hint or documentation in target object of type "' . $targetType . '".', 1303379158);
             } else {
-                return $methodParameter['type'];
+                // ltrim: see comment above
+                return ltrim($methodParameter['type'], '\\');
             }
         } else {
             $targetPropertyNames = $this->reflectionService->getClassPropertyNames($targetType);
             if (in_array($propertyName, $targetPropertyNames)) {
                 $values = $this->reflectionService->getPropertyTagValues($targetType, $propertyName, 'var');
                 if (count($values) > 0) {
-                    return current($values);
+                    // ltrim: see comment above
+                    return ltrim(current($values), '\\');
                 } else {
                     throw new InvalidTargetException(sprintf('Public property "%s" had no proper type annotation (i.e. "@var") in target object of type "%s".', $propertyName, $targetType), 1406821818);
                 }

--- a/TYPO3.Flow/Tests/Unit/Property/TypeConverter/ObjectConverterTest.php
+++ b/TYPO3.Flow/Tests/Unit/Property/TypeConverter/ObjectConverterTest.php
@@ -94,4 +94,54 @@ class ObjectConverterTest extends \TYPO3\Flow\Tests\UnitTestCase
         $configuration->setTypeConverterOptions(\TYPO3\Flow\Property\TypeConverter\ObjectConverter::class, array());
         $this->assertEquals('TheTypeOfSubObject', $this->converter->getTypeOfChildProperty('TheTargetType', 'thePropertyName', $configuration));
     }
+
+    /**
+     * @test
+     */
+    public function getTypeOfChildPropertyShouldRemoveLeadingBackslashesForConstructorParameters()
+    {
+        $this->mockReflectionService->expects($this->any())->method('hasMethod')->with('TheTargetType', 'setThePropertyName')->will($this->returnValue(false));
+        $this->mockReflectionService->expects($this->any())->method('getMethodParameters')->with('TheTargetType', '__construct')->will($this->returnValue(array(
+            'thePropertyName' => array(
+                'type' => '\TheTypeOfSubObject',
+                'elementType' => null
+            )
+        )));
+        $configuration = new \TYPO3\Flow\Property\PropertyMappingConfiguration();
+        $configuration->setTypeConverterOptions(\TYPO3\Flow\Property\TypeConverter\ObjectConverter::class, array());
+        $this->assertEquals('TheTypeOfSubObject', $this->converter->getTypeOfChildProperty('TheTargetType', 'thePropertyName', $configuration));
+    }
+
+    /**
+     * @test
+     */
+    public function getTypeOfChildPropertyShouldRemoveLeadingBackslashesForSetterParameters()
+    {
+        $this->mockReflectionService->expects($this->at(0))->method('getMethodParameters')->with('TheTargetType', '__construct')->will($this->returnValue(array()));
+        $this->mockReflectionService->expects($this->at(1))->method('hasMethod')->with('TheTargetType', 'setThePropertyName')->will($this->returnValue(true));
+        $this->mockReflectionService->expects($this->at(2))->method('getMethodParameters')->with('TheTargetType', 'setThePropertyName')->will($this->returnValue(array(
+            array('type' => '\TheTypeOfSubObject'),
+        )));
+        $configuration = new \TYPO3\Flow\Property\PropertyMappingConfiguration();
+        $configuration->setTypeConverterOptions(\TYPO3\Flow\Property\TypeConverter\ObjectConverter::class, array());
+        $this->assertEquals('TheTypeOfSubObject', $this->converter->getTypeOfChildProperty('TheTargetType', 'thePropertyName', $configuration));
+    }
+
+    /**
+     * @test
+     */
+    public function getTypeOfChildPropertyShouldRemoveLeadingBackslashesForAnnotationParameters()
+    {
+        $this->mockReflectionService->expects($this->any())->method('getMethodParameters')->with('TheTargetType', '__construct')->will($this->returnValue(array()));
+        $this->mockReflectionService->expects($this->any())->method('hasMethod')->with('TheTargetType', 'setThePropertyName')->will($this->returnValue(false));
+        $this->mockReflectionService->expects($this->any())->method('getClassPropertyNames')->with('TheTargetType')->will($this->returnValue(array(
+            'thePropertyName'
+        )));
+        $this->mockReflectionService->expects($this->any())->method('getPropertyTagValues')->with('TheTargetType', 'thePropertyName')->will($this->returnValue(array(
+            '\TheTypeOfSubObject'
+        )));
+        $configuration = new \TYPO3\Flow\Property\PropertyMappingConfiguration();
+        $configuration->setTypeConverterOptions(\TYPO3\Flow\Property\TypeConverter\ObjectConverter::class, array());
+        $this->assertEquals('TheTypeOfSubObject', $this->converter->getTypeOfChildProperty('TheTargetType', 'thePropertyName', $configuration));
+    }
 }

--- a/TYPO3.Flow/Tests/Unit/Property/TypeConverter/ObjectConverterTest.php
+++ b/TYPO3.Flow/Tests/Unit/Property/TypeConverter/ObjectConverterTest.php
@@ -98,38 +98,6 @@ class ObjectConverterTest extends \TYPO3\Flow\Tests\UnitTestCase
     /**
      * @test
      */
-    public function getTypeOfChildPropertyShouldRemoveLeadingBackslashesForConstructorParameters()
-    {
-        $this->mockReflectionService->expects($this->any())->method('hasMethod')->with('TheTargetType', 'setThePropertyName')->will($this->returnValue(false));
-        $this->mockReflectionService->expects($this->any())->method('getMethodParameters')->with('TheTargetType', '__construct')->will($this->returnValue(array(
-            'thePropertyName' => array(
-                'type' => '\TheTypeOfSubObject',
-                'elementType' => null
-            )
-        )));
-        $configuration = new \TYPO3\Flow\Property\PropertyMappingConfiguration();
-        $configuration->setTypeConverterOptions(\TYPO3\Flow\Property\TypeConverter\ObjectConverter::class, array());
-        $this->assertEquals('TheTypeOfSubObject', $this->converter->getTypeOfChildProperty('TheTargetType', 'thePropertyName', $configuration));
-    }
-
-    /**
-     * @test
-     */
-    public function getTypeOfChildPropertyShouldRemoveLeadingBackslashesForSetterParameters()
-    {
-        $this->mockReflectionService->expects($this->at(0))->method('getMethodParameters')->with('TheTargetType', '__construct')->will($this->returnValue(array()));
-        $this->mockReflectionService->expects($this->at(1))->method('hasMethod')->with('TheTargetType', 'setThePropertyName')->will($this->returnValue(true));
-        $this->mockReflectionService->expects($this->at(2))->method('getMethodParameters')->with('TheTargetType', 'setThePropertyName')->will($this->returnValue(array(
-            array('type' => '\TheTypeOfSubObject'),
-        )));
-        $configuration = new \TYPO3\Flow\Property\PropertyMappingConfiguration();
-        $configuration->setTypeConverterOptions(\TYPO3\Flow\Property\TypeConverter\ObjectConverter::class, array());
-        $this->assertEquals('TheTypeOfSubObject', $this->converter->getTypeOfChildProperty('TheTargetType', 'thePropertyName', $configuration));
-    }
-
-    /**
-     * @test
-     */
     public function getTypeOfChildPropertyShouldRemoveLeadingBackslashesForAnnotationParameters()
     {
         $this->mockReflectionService->expects($this->any())->method('getMethodParameters')->with('TheTargetType', '__construct')->will($this->returnValue(array()));


### PR DESCRIPTION
When mapping a plain object with the ObjectConverter, root namespace 
properties like \DateTime do not find a converter. This is because
the leading backslash is not removed by the ObjectConverter (i.e. we
looked for a "\DateTimeConverter" instead of the DateTimeConverter).