### PR TITLE
BUGFIX: Fix Property Mapper determination for the ObjectConverter

### DIFF
--- a/TYPO3.Flow/Tests/Unit/Property/TypeConverter/ObjectConverterTest.php
+++ b/TYPO3.Flow/Tests/Unit/Property/TypeConverter/ObjectConverterTest.php
@@ -94,4 +94,22 @@ class ObjectConverterTest extends \TYPO3\Flow\Tests\UnitTestCase
         $configuration->setTypeConverterOptions('TYPO3\Flow\Property\TypeConverter\ObjectConverter', array());
         $this->assertEquals('TheTypeOfSubObject', $this->converter->getTypeOfChildProperty('TheTargetType', 'thePropertyName', $configuration));
     }
+
+    /**
+     * @test
+     */
+    public function getTypeOfChildPropertyShouldRemoveLeadingBackslashesForAnnotationParameters()
+    {
+        $this->mockReflectionService->expects($this->any())->method('getMethodParameters')->with('TheTargetType', '__construct')->will($this->returnValue(array()));
+        $this->mockReflectionService->expects($this->any())->method('hasMethod')->with('TheTargetType', 'setThePropertyName')->will($this->returnValue(false));
+        $this->mockReflectionService->expects($this->any())->method('getClassPropertyNames')->with('TheTargetType')->will($this->returnValue(array(
+            'thePropertyName'
+        )));
+        $this->mockReflectionService->expects($this->any())->method('getPropertyTagValues')->with('TheTargetType', 'thePropertyName')->will($this->returnValue(array(
+            '\TheTypeOfSubObject'
+        )));
+        $configuration = new \TYPO3\Flow\Property\PropertyMappingConfiguration();
+        $configuration->setTypeConverterOptions(\TYPO3\Flow\Property\TypeConverter\ObjectConverter::class, array());
+        $this->assertEquals('TheTypeOfSubObject', $this->converter->getTypeOfChildProperty('TheTargetType', 'thePropertyName', $configuration));
+    }
 }


### PR DESCRIPTION
When mapping a plain object with the ``ObjectConverter``, root namespace 
properties like ``\DateTime`` do not find a converter. This is because
the leading backslash is not removed by the ``ObjectConverter`` (i.e. we
looked for a ``\DateTimeConverter`` instead of the ``DateTimeConverter``