### PR TITLE
BUGFIX: Allow SliceOperation to work on \Iterator

### DIFF
--- a/TYPO3.Eel/Classes/TYPO3/Eel/FlowQuery/Operations/SliceOperation.php
+++ b/TYPO3.Eel/Classes/TYPO3/Eel/FlowQuery/Operations/SliceOperation.php
@@ -39,7 +39,7 @@ class SliceOperation extends AbstractOperation
     public function evaluate(FlowQuery $flowQuery, array $arguments)
     {
         $context = $flowQuery->getContext();
-        if (is_object($context) && $context instanceof \Iterator) {
+        if ($context instanceof \Iterator) {
             $context = iterator_to_array($context);
         }
         if (isset($arguments[0]) && isset($arguments[1])) {

--- a/TYPO3.Eel/Classes/TYPO3/Eel/FlowQuery/Operations/SliceOperation.php
+++ b/TYPO3.Eel/Classes/TYPO3/Eel/FlowQuery/Operations/SliceOperation.php
@@ -39,7 +39,9 @@ class SliceOperation extends AbstractOperation
     public function evaluate(FlowQuery $flowQuery, array $arguments)
     {
         $context = $flowQuery->getContext();
-
+        if (is_object($context) && $context instanceof \Iterator) {
+            $context = iterator_to_array($context);
+        }
         if (isset($arguments[0]) && isset($arguments[1])) {
             $context = array_slice($context, (integer)$arguments[0], (integer)$arguments[1] - (integer)$arguments[0]);
         } elseif (isset($arguments[0])) {


### PR DESCRIPTION
The Eel slice operation only works with arrays so far. Since the FlowQuery
context can be anything that implements `\Iterator`, we now convert iterators
to arrays if they are passed in as the context.