### PR TITLE
BUGFIX: Use Unix paths in InstallerScripts

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Composer/InstallerScripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Composer/InstallerScripts.php
@@ -33,15 +33,15 @@ class InstallerScripts
     public static function postUpdateAndInstall(Event $event)
     {
         if (!defined('FLOW_PATH_ROOT')) {
-            define('FLOW_PATH_ROOT', getcwd() . '/');
+            define('FLOW_PATH_ROOT', Files::getUnixStylePath(getcwd()) . '/');
         }
 
         if (!defined('FLOW_PATH_PACKAGES')) {
-            define('FLOW_PATH_PACKAGES', getcwd() . '/Packages/');
+            define('FLOW_PATH_PACKAGES', Files::getUnixStylePath(getcwd()) . '/Packages/');
         }
 
         if (!defined('FLOW_PATH_CONFIGURATION')) {
-            define('FLOW_PATH_CONFIGURATION', getcwd() . '/Configuration/');
+            define('FLOW_PATH_CONFIGURATION', Files::getUnixStylePath(getcwd()) . '/Configuration/');
         }
 
         Files::createDirectoryRecursively('Configuration');


### PR DESCRIPTION
The Files utility used by InstallerScripts will use these constants
to transform an absolute path to a relative one. As the compared path
will always be a Unix path, the path to replace needs to be completely
Unix as well to make replacing working. This prevents "mkdir(): invalid
arguments" errors on Windows.