### PR TITLE
BUGFIX: Use Unix paths in InstallerScripts

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Composer/InstallerScripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Composer/InstallerScripts.php
@@ -89,12 +89,12 @@ class InstallerScripts
     {
         $essentialsPath = $installerResourcesDirectory . 'Distribution/Essentials';
         if (is_dir($essentialsPath)) {
-            Files::copyDirectoryRecursively($essentialsPath, getcwd() . '/', false, true);
+            Files::copyDirectoryRecursively($essentialsPath, Files::getUnixStylePath(getcwd()) . '/', false, true);
         }
 
         $defaultsPath = $installerResourcesDirectory . 'Distribution/Defaults';
         if (is_dir($defaultsPath)) {
-            Files::copyDirectoryRecursively($defaultsPath, getcwd() . '/', true, true);
+            Files::copyDirectoryRecursively($defaultsPath, Files::getUnixStylePath(getcwd()) . '/', true, true);
         }
     }
 


### PR DESCRIPTION
The Files utility used by InstallerScripts will use these constants
to transform an absolute path to a relative one. As the compared path
will always be a Unix path, the path to replace needs to be completely
Unix as well to make replacing working. This prevents "mkdir(): invalid
arguments" errors on Windows.

Similar to neos/flow-development-collection#399 , but then for the 3.0
version.