### PR TITLE
FEATURE: New parameter to keep output ordered by loading order instead of name

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/PackageCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/PackageCommandController.php
@@ -182,11 +182,12 @@ class PackageCommandController extends CommandController
      * Lists all locally available packages. Displays the package key, version and
      * package title and its state – active or inactive.
      *
+     * @param boolean $loadingOrder The returned packages are ordered by their loading order.
      * @return string The list of packages
      * @see typo3.flow:package:activate
      * @see typo3.flow:package:deactivate
      */
-    public function listCommand()
+    public function listCommand($loadingOrder = false)
     {
         $activePackages = [];
         $inactivePackages = [];
@@ -208,14 +209,16 @@ class PackageCommandController extends CommandController
             }
         }
 
-        ksort($activePackages);
-        ksort($inactivePackages);
+        if ($loadingOrder === false) {
+            ksort($activePackages);
+            ksort($inactivePackages);
+        }
 
         $this->outputLine('ACTIVE PACKAGES:');
         /** @var PackageInterface $package */
         foreach ($activePackages as $package) {
             $frozenState = ($freezeSupported && isset($frozenPackages[$package->getPackageKey()]) ? '* ' : '  ');
-            $this->outputLine(' ' . str_pad($package->getPackageKey(), $longestPackageKey + 3) . $frozenState . str_pad($package->getInstalledVersion(), 15));
+            $this->outputLine('git  ' . str_pad($package->getPackageKey(), $longestPackageKey + 3) . $frozenState . str_pad($package->getInstalledVersion(), 15));
         }
 
         if (count($inactivePackages) > 0) {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/PackageCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/PackageCommandController.php
@@ -218,7 +218,7 @@ class PackageCommandController extends CommandController
         /** @var PackageInterface $package */
         foreach ($activePackages as $package) {
             $frozenState = ($freezeSupported && isset($frozenPackages[$package->getPackageKey()]) ? '* ' : '  ');
-            $this->outputLine('git  ' . str_pad($package->getPackageKey(), $longestPackageKey + 3) . $frozenState . str_pad($package->getInstalledVersion(), 15));
+            $this->outputLine(' ' . str_pad($package->getPackageKey(), $longestPackageKey + 3) . $frozenState . str_pad($package->getInstalledVersion(), 15));
         }
 
         if (count($inactivePackages) > 0) {


### PR DESCRIPTION
Very helpful parameter to debug loading order of packages.

`package:list --loading-order`