### PR TITLE
TASK: Add option to sort packages by extra configuration

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageOrderResolver.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageOrderResolver.php
@@ -22,13 +22,22 @@ class PackageOrderResolver
     protected $sortedPackages;
 
     /**
+     * Array with state information of still unsorted packages.
+     * The key is a package key, the value is "-1" if it is on stack for cycle detection; otherwise it is the number of times it was attempted to sort it already.
+     *
+     * @var array
+     */
+    protected $unsortedPackages;
+
+    /**
      * @param array $packages The array of package states to order by dependencies
      * @param array $manifestData The manifests of all given packages for reading dependencies
      */
     public function __construct(array $packages, array $manifestData)
     {
-        $this->manifestData = $manifestData;
         $this->packageStates = $packages;
+        $this->manifestData = $manifestData;
+        $this->unsortedPackages = array_fill_keys(array_keys($packages), 0);
     }
 
     /**
@@ -39,21 +48,17 @@ class PackageOrderResolver
     public function sort()
     {
         if ($this->sortedPackages === null) {
-            $unsortedPackageKeys = array_fill_keys(array_keys($this->packageStates), 0);
-            $sortedPackages = array();
-
-            while (!empty($unsortedPackageKeys)) {
-                $resolved = $this->sortPackagesByDependencies(key($unsortedPackageKeys), $sortedPackages, $unsortedPackageKeys);
+            $this->sortedPackages = [];
+            reset($this->unsortedPackages);
+            while (!empty($this->unsortedPackages)) {
+                $resolved = $this->sortPackage(key($this->unsortedPackages));
                 if ($resolved) {
-                    reset($unsortedPackageKeys);
+                    reset($this->unsortedPackages);
                 } else {
-                    next($unsortedPackageKeys);
+                    next($this->unsortedPackages);
                 }
             }
-
-            $this->sortedPackages = $sortedPackages;
         }
-
 
         return $this->sortedPackages;
     }
@@ -64,75 +69,91 @@ class PackageOrderResolver
      * packages are flagged to break up cyclic dependencies.
      *
      * @param string $packageKey Package key to process
-     * @param array $sortedPackages Array to sort packages into
-     * @param array $unsortedPackages Array with state information of still unsorted packages. The key is a package key, the value is "-1" if it is on stack for cycle detection; otherwise it is the number of times it was attempted to sort it already.
      * @return boolean true if package was sorted; false otherwise.
      */
-    protected function sortPackagesByDependencies($packageKey, array &$sortedPackages, array &$unsortedPackages)
+    protected function sortPackage($packageKey)
     {
         if (!isset($this->packageStates[$packageKey])) {
             // Package does not exist; so that means it is just skipped; but that's to the outside as if sorting was successful.
             return true;
         }
 
-        /** @var array $packageState */
-        $packageState = $this->packageStates[$packageKey];
-
+        if (!isset($this->unsortedPackages[$packageKey])) {
+            // Safeguard: Package is not unsorted anymore.
+            return true;
+        }
+        $iterationForPackage = $this->unsortedPackages[$packageKey];
         // $iterationForPackage will be -1 if the package is already worked on in a stack, in that case we will return instantly.
-        $iterationForPackage = $unsortedPackages[$packageKey];
-
         if ($iterationForPackage === -1) {
             return false;
         }
 
-        if (!isset($unsortedPackages[$packageKey])) {
-            // Safeguard: Package is not unsorted anymore.
+        $this->unsortedPackages[$packageKey] = -1;
+        $packageComposerManifest = $this->manifestData[$packageKey];
+        $unresolvedDependencies = 0;
+
+        $packageRequirements = isset($packageComposerManifest['require']) ? array_keys($packageComposerManifest['require']) : [];
+        $unresolvedDependencies += $this->sortListBefore($packageKey, $packageRequirements);
+
+        if (isset($packageComposerManifest['extra']['neos']['loading-order']['after']) && is_array($packageComposerManifest['extra']['neos']['loading-order']['after'])) {
+            $sortingConfiguration = $packageComposerManifest['extra']['neos']['loading-order']['after'];
+            $unresolvedDependencies += $this->sortListBefore($packageKey, $sortingConfiguration);
+        }
+
+        /** @var array $packageState */
+        $packageState = $this->packageStates[$packageKey];
+        $this->unsortedPackages[$packageKey] = $iterationForPackage + 1;
+        if ($unresolvedDependencies === 0) {
+            // we are validly able to sort the package to this position.
+            unset($this->unsortedPackages[$packageKey]);
+            $this->sortedPackages[$packageKey] = $packageState;
             return true;
         }
 
-        $unsortedPackages[$packageKey] = -1;
-        $packageComposerManifest = $this->manifestData[$packageKey];
-        $packageRequirements = isset($packageComposerManifest['require']) ? array_keys($packageComposerManifest['require']) : [];
-        // HINT: at this point, we do not support require-dev dependencies yet (but we could).
-        $unresolvedDependencies = 0;
+        if ($this->unsortedPackages[$packageKey] > 20) {
+            // SECOND case: ERROR case. This happens with MANY cyclic dependencies, in this case we just degrade by arbitarily sorting the package; and continue. Alternative would be throwing an Exception.
+            unset($this->unsortedPackages[$packageKey]);
 
-        foreach ($packageRequirements as $requiredComposerName) {
-            if (!$this->packageRequirementIsComposerPackage($requiredComposerName)) {
+            // In order to be able to debug this kind of error (if we hit it), we at least try to write to PackageStates.php
+            // so if people send it to us, we have some chance of finding the error.
+            $packageState['error-sorting-limit-reached'] = true;
+            $this->sortedPackages[$packageKey] = $packageState;
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Tries to sort packages from the given list before the named package key.
+     * Ignores non existing packages and any composer key without "/" (eg. "php").
+     *
+     * @param string $packageKey
+     * @param string[] $packagesToLoadBefore
+     * @return int
+     */
+    protected function sortListBefore($packageKey, array $packagesToLoadBefore)
+    {
+        $unresolvedDependencies = 0;
+        foreach ($packagesToLoadBefore as $composerNameToLoadBefore) {
+            if (!$this->packageRequirementIsComposerPackage($composerNameToLoadBefore)) {
                 continue;
             }
 
-            if (isset($sortedPackages[$packageKey])) {
+            if (isset($this->sortedPackages[$packageKey])) {
                 // "Success" case: a required package is already sorted in front of our current $packageKey.
                 continue;
             }
 
-            if (isset($unsortedPackages[$requiredComposerName])) {
-                $resolved = $this->sortPackagesByDependencies($requiredComposerName, $sortedPackages, $unsortedPackages);
+            if (isset($this->unsortedPackages[$composerNameToLoadBefore])) {
+                $resolved = $this->sortPackage($composerNameToLoadBefore);
                 if (!$resolved) {
                     $unresolvedDependencies++;
                 }
             }
         }
 
-        $unsortedPackages[$packageKey] = $iterationForPackage + 1;
-
-        if ($unresolvedDependencies === 0) {
-            // we are validly able to sort the package to this position.
-            unset($unsortedPackages[$packageKey]);
-            $sortedPackages[$packageKey] = $packageState;
-            return true;
-        } elseif ($unsortedPackages[$packageKey] > 20) {
-            // SECOND case: ERROR case. This happens with MANY cyclic dependencies, in this case we just degrade by arbitarily sorting the package; and continue. Alternative would be throwing an Exception.
-            unset($unsortedPackages[$packageKey]);
-
-            // In order to be able to debug this kind of error (if we hit it), we at least try to write to PackageStates.php
-            // so if people send it to us, we have some chance of finding the error.
-            $packageState['error-sorting-limit-reached'] = true;
-            $sortedPackages[$packageKey] = $packageState;
-            return true;
-        }
-
-        return false;
+        return $unresolvedDependencies;
     }
 
     /**

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/PackageManagement.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/PackageManagement.rst
@@ -171,11 +171,37 @@ and maintained by the Neos and Flow core teams start with ``TYPO3.*`` (for histo
 reasons) or ``Neos.*``. In your company we suggest that you use your company name as vendor
 namespace.
 
+To define the package key for your package we recommend you set the "extra.neos.package-key"
+option in your composer.json as in the following example:
+
+*composer.json*::
+
+ "extra": {
+     "neos": {
+         "package-key": "Vendor.PackageKey"
+     }
+ }
+
+
 Loading Order
 =============
 
 The loading order of packages follows the dependency chain as defined in the composer
-manifests involved.
+manifests involved, solely taking the "require" part into consideration.
+Additionally you can configure packages that should be loaded before by adding an array
+of composer package names to "extra.neos.loading-order.after" as in this example:
+
+*composer.json*::
+
+ "extra": {
+     "neos": {
+         "loading-order": {
+             "after": [
+                  "some/package"
+             ]
+         }
+     }
+ }
 
 Activating and Deactivating Packages
 ====================================


### PR DESCRIPTION
Adds a way to configure packages to be loaded before via `composer.json`
besides using require in a backwards compatible way.

The configuration option is documented and additionally package key
configuration is clarified.
