### PR TITLE
!!!BUGFIX: I18nService ignores .xml, .php and .rss files for scanning locales

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/I18n/Utility.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/I18n/Utility.php
@@ -99,7 +99,7 @@ class Utility
 
         $filenameParts = explode('.', $filename);
 
-        if (in_array($filenameParts[count($filenameParts) - 2], array('php', 'rss', 'xml'))) {
+        if (in_array($filenameParts[count($filenameParts) - 1], array('php', 'rss', 'xml'))) {
             return false;
         } elseif (count($filenameParts) === 2 && preg_match(Locale::PATTERN_MATCH_LOCALEIDENTIFIER, $filenameParts[0]) === 1) {
             return $filenameParts[0];


### PR DESCRIPTION
The i18nService was supposed to ignore .xml, .php and .rss files when scanning for available
locales in filenames. However, the implementation suffered from a off-by-one error, which
made the check useless.

This is breaking, because it will lead to much less locales being collected for the available
locales, since the CLDR resources will no longer be considered. Also without the fix to
actually scan the Translation folders for available locales, it will even end up with a nearly
empty list of available locales.

Depends on #411