### PR TITLE
FEATURE: Allow replacement of configuration with environment-variable

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Configuration/ConfigurationManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Configuration/ConfigurationManager.php
@@ -656,13 +656,25 @@ EOD;
                 preg_match_all('/(?:%)((?:\\\?[\d\w_\\\]+\:\:)?[A-Z_0-9]+)(?:%)/', $configuration, $matches);
                 if (count($matches[1]) > 0) {
                     foreach ($matches[1] as $match) {
+                        $replace = false;
+                        $replacement = null;
                         if (defined($match)) {
+                            $replace = true;
+                            $replacement = constant($match);
+                        } elseif (strpos($match, 'ENV::') === 0) {
+                            $environmentValue = getenv(substr($match, 5));
+                            if ($environmentValue !== false) {
+                                $replace = true;
+                                $replacement = $environmentValue;
+                            }
+                        }
+                        if ($replace) {
                             if ($configurations[$key] === '%' . $match . '%') {
                                 // the constant expression spans the complete directive, assign directly to keep type
-                                $configurations[$key] = constant($match);
+                                $configurations[$key] = $replacement;
                             } else {
                                 // the constant is only a substring of the directive, replace that part accordingly
-                                $configurations[$key] = str_replace('%' . $match . '%', constant($match), $configurations[$key]);
+                                $configurations[$key] = str_replace('%' . $match . '%', $replacement, $configurations[$key]);
                             }
                         }
                     }

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Configuration.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Configuration.rst
@@ -122,14 +122,14 @@ which come with the Flow distribution for getting more examples.
   Always use *two spaces* for indentation in YAML files. The parser will not
   accept indentation using tabs.
 
-Constants
----------
+Constants and Environment
+-------------------------
 
 Sometimes it is necessary to use values in your configuration files which are defined as
-PHP constants. These values can be included by special markers which are replaced by the
-actual value during parse time. The format is ``%<CONSTANT_NAME>%`` where
-``<CONSTANT_NAME>`` is the name of a constant. Note that the constant name must be all
-uppercase.
+PHP constants or are environment variables. These values can be included by special markers
+which are replaced by the actual value during parse time. The format is ``%<CONSTANT_NAME>%``
+where ``<CONSTANT_NAME>`` is the name of a constant. Note that the constant or environment
+variable name must be all uppercase.
 
 Some examples:
 
@@ -147,6 +147,9 @@ Some examples:
   a leading namespace backslash is generally allowed as of PHP,
   but is not recommended due to CGL (stringed class names should not
   have a leading backslash).
+
+``%ENV::HOME%``
+  Will be replaced by the environment variable's value.
 
 Custom Configuration Types
 --------------------------

--- a/TYPO3.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -771,6 +771,37 @@ EOD;
     }
 
     /**
+     * @test
+     */
+    public function postProcessConfigurationReplacesEnvMarkersWithEnvironmentValues()
+    {
+        $envVarName = 'TYPO3_FLOW_TESTS_UNIT_CONFIGURATION_CONFIGURATIONMANAGERTEST_MOCKENVVAR';
+        $envVarValue = 'TYPO3_Flow_Tests_Unit_Configuration_ConfigurationManagerTest_MockEnvValue';
+
+        putenv($envVarName . '=' . $envVarValue);
+
+        $settings = array(
+            'foo' => 'bar',
+            'baz' => '%ENV::' . $envVarName . '%',
+            'inspiring' => array(
+                'people' => array(
+                    'to' => '%ENV::' . $envVarName . '%',
+                    'share' => 'foo %ENV::' . $envVarName . '% bar'
+                )
+            )
+        );
+
+        $configurationManager = $this->getAccessibleMock(\TYPO3\Flow\Configuration\ConfigurationManager::class, array('dummy'), array(), '', false);
+        $configurationManager->_callRef('postProcessConfiguration', $settings);
+
+        $this->assertSame($envVarValue, $settings['baz']);
+        $this->assertSame($envVarValue, $settings['inspiring']['people']['to']);
+        $this->assertSame('foo ' . $envVarValue . ' bar', $settings['inspiring']['people']['share']);
+
+        putenv($envVarName);
+    }
+
+    /**
      * We expect that the context specific routes are loaded *first*
      *
      * @test


### PR DESCRIPTION
Currently configuration can be replaced with constants via the ``%CONST_NAME%``syntax.
This change adds a special prefix ENV:: to the configuration post-processing that replaces markers of the form ``%ENV::ENV_VAR_NAME%`` with the content of the environment variable if one is defined

FLOW-212  #close