### PR TITLE
BUGFIX: Require latest version of neos/composer-plugin

### DIFF
--- a/TYPO3.Flow/composer.json
+++ b/TYPO3.Flow/composer.json
@@ -25,7 +25,7 @@
         "symfony/dom-crawler": "~2.5.0",
         "symfony/console": "~2.0",
 
-        "neos/composer-plugin": "2.0.0"
+        "neos/composer-plugin": "^2.0.0"
     },
     "suggest": {
         "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",

--- a/TYPO3.Flow/composer.json
+++ b/TYPO3.Flow/composer.json
@@ -25,7 +25,7 @@
         "symfony/dom-crawler": "~2.5.0",
         "symfony/console": "~2.0",
 
-        "neos/composer-plugin": "^1.0.1"
+        "neos/composer-plugin": "2.0.0"
     },
     "suggest": {
         "ext-curl": "To use the \\TYPO3\\Flow\\Http\\Client\\CurlEngine",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/yaml": "~2.5.0",
         "symfony/dom-crawler": "~2.5.0",
         "symfony/console": "~2.0",
-        "neos/composer-plugin": "^1.0.1"
+        "neos/composer-plugin": "^2.0.0"
     },
     "replace": {
         "typo3/eel": "self.version",


### PR DESCRIPTION
Require version 2.x of the ``composer-plugin`` package. Previous versions
use the ``excludeClasses`` setting which has been deprecated with Flow 3.0.