### PR TITLE
!!!TASK: Implicit joins in a query makes the result set distinct by default

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/Query.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Query.php
@@ -660,6 +660,7 @@ class Query implements QueryInterface
             }
             $previousJoinAlias = $joinAlias;
         }
+        $this->setDistinct(true);
 
         return $previousJoinAlias . '.' . $propertyPathParts[$i];
     }


### PR DESCRIPTION
Before it was possible that a query with implicit joins created a result set with duplicate entries.
This change sets the `distinct` flag on the query object to true when an implicit join is created.

This is breaking, as it might change the result sets of your queries, if you used implicit joins (dot notation subproperty queries).

Resolves #552
