### PR TITLE
!!! BUGFIX: Reuse join aliases on same property paths

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/Query.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Query.php
@@ -651,9 +651,13 @@ class Query implements QueryInterface
         $propertyPathParts = explode('.', $propertyPath);
         $conditionPartsCount = count($propertyPathParts);
         for ($i = 0; $i < $conditionPartsCount - 1; $i++) {
-            $joinAlias = $propertyPathParts[$i] . $this->joinAliasCounter++;
-            $this->queryBuilder->leftJoin($previousJoinAlias . '.' . $propertyPathParts[$i], $joinAlias);
-            $this->joins[$joinAlias] = $previousJoinAlias . '.' . $propertyPathParts[$i];
+            $joinProperty = $previousJoinAlias . '.' . $propertyPathParts[$i];
+            $joinAlias = array_search($joinProperty, (array)$this->joins);
+            if ($joinAlias === false) {
+                $joinAlias = $propertyPathParts[$i] . $this->joinAliasCounter++;
+                $this->queryBuilder->leftJoin($joinProperty, $joinAlias);
+                $this->joins[$joinAlias] = $joinProperty;
+            }
             $previousJoinAlias = $joinAlias;
         }
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
@@ -160,6 +160,17 @@ If you like to do things the hard way you can get away with implementing
 ``\Neos\Flow\Persistence\RepositoryInterface`` yourself, though that is
 something the normal developer never has to do.
 
+.. note::
+
+	With the query building API it is possible to query for properties of sub-entities easily via
+	a dot-notation path. When querying multiple properties of a collection property, it is ambiguous
+	if you want to select a single sub-entity with the given matching constraints, or multiple
+	sub-entities which each matching a part of the given constraints.
+
+	Since 4.0 Flow will translate such a query to "find all entities where a single sub-entity matches all the constraints",
+	which is the more common case. If you intend a different querying logic, you should fall back to DQL or
+	native SQL queries instead.
+
 Basics of Persistence in Flow
 =============================
 

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/QueryTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/QueryTest.php
@@ -270,7 +270,7 @@ class QueryTest extends FunctionalTestCase
 
         $subEntity3 = new \TYPO3\Flow\Tests\Functional\Persistence\Fixtures\SubEntity;
         $subEntity3->setContent('foo');
-        $subEntity3->setContent('yup');
+        $subEntity3->setSomeProperty('yup');
         $subEntity3->setParentEntity($testEntity2);
         $testEntity2->addSubEntity($subEntity3);
         $this->persistenceManager->add($subEntity3);

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/QueryTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/QueryTest.php
@@ -243,20 +243,20 @@ class QueryTest extends FunctionalTestCase
      */
     public function subpropertyQueriesReuseJoinAlias()
     {
-        $testEntityRepository = new \TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntityRepository();
+        $testEntityRepository = new \Neos\Flow\Tests\Functional\Persistence\Fixtures\TestEntityRepository();
         $testEntityRepository->removeAll();
 
-        $testEntity = new \TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntity;
+        $testEntity = new \Neos\Flow\Tests\Functional\Persistence\Fixtures\TestEntity;
         $testEntity->setName('Flow');
 
-        $subEntity1 = new \TYPO3\Flow\Tests\Functional\Persistence\Fixtures\SubEntity;
+        $subEntity1 = new \Neos\Flow\Tests\Functional\Persistence\Fixtures\SubEntity;
         $subEntity1->setContent('foo');
         $subEntity1->setSomeProperty('nope');
         $subEntity1->setParentEntity($testEntity);
         $testEntity->addSubEntity($subEntity1);
         $this->persistenceManager->add($subEntity1);
 
-        $subEntity2 = new \TYPO3\Flow\Tests\Functional\Persistence\Fixtures\SubEntity;
+        $subEntity2 = new \Neos\Flow\Tests\Functional\Persistence\Fixtures\SubEntity;
         $subEntity2->setContent('bar');
         $subEntity2->setSomeProperty('yup');
         $subEntity2->setParentEntity($testEntity);
@@ -265,10 +265,10 @@ class QueryTest extends FunctionalTestCase
 
         $testEntityRepository->add($testEntity);
 
-        $testEntity2 = new \TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntity;
+        $testEntity2 = new \Neos\Flow\Tests\Functional\Persistence\Fixtures\TestEntity;
         $testEntity2->setName('Flow');
 
-        $subEntity3 = new \TYPO3\Flow\Tests\Functional\Persistence\Fixtures\SubEntity;
+        $subEntity3 = new \Neos\Flow\Tests\Functional\Persistence\Fixtures\SubEntity;
         $subEntity3->setContent('foo');
         $subEntity3->setSomeProperty('yup');
         $subEntity3->setParentEntity($testEntity2);
@@ -279,7 +279,7 @@ class QueryTest extends FunctionalTestCase
 
         $this->persistenceManager->persistAll();
 
-        $query = new Query(\TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntity::class);
+        $query = new Query(\Neos\Flow\Tests\Functional\Persistence\Fixtures\TestEntity::class);
         // Read as "All entities with subEntity with *both* content = 'foo' AND someProperty = 'yup'
         // isntead of "All entities with any subEntity with content 'foo' AND any subEntity with someProperty = 'yup'
         $constraint = $query->logicalAnd($query->equals('subEntities.content', 'foo'), $query->equals('subEntities.someProperty', 'yup'));

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/QueryTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/QueryTest.php
@@ -241,6 +241,56 @@ class QueryTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function subpropertyQueriesReuseJoinAlias()
+    {
+        $testEntityRepository = new \TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntityRepository();
+        $testEntityRepository->removeAll();
+
+        $testEntity = new \TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntity;
+        $testEntity->setName('Flow');
+
+        $subEntity1 = new \TYPO3\Flow\Tests\Functional\Persistence\Fixtures\SubEntity;
+        $subEntity1->setContent('foo');
+        $subEntity1->setSomeProperty('nope');
+        $subEntity1->setParentEntity($testEntity);
+        $testEntity->addSubEntity($subEntity1);
+        $this->persistenceManager->add($subEntity1);
+
+        $subEntity2 = new \TYPO3\Flow\Tests\Functional\Persistence\Fixtures\SubEntity;
+        $subEntity2->setContent('bar');
+        $subEntity2->setSomeProperty('yup');
+        $subEntity2->setParentEntity($testEntity);
+        $testEntity->addSubEntity($subEntity2);
+        $this->persistenceManager->add($subEntity2);
+
+        $testEntityRepository->add($testEntity);
+
+        $testEntity2 = new \TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntity;
+        $testEntity2->setName('Flow');
+
+        $subEntity3 = new \TYPO3\Flow\Tests\Functional\Persistence\Fixtures\SubEntity;
+        $subEntity3->setContent('foo');
+        $subEntity3->setContent('yup');
+        $subEntity3->setParentEntity($testEntity2);
+        $testEntity2->addSubEntity($subEntity3);
+        $this->persistenceManager->add($subEntity3);
+
+        $testEntityRepository->add($testEntity2);
+
+        $this->persistenceManager->persistAll();
+
+        $query = new Query(\TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntity::class);
+        // Read as "All entities with subEntity with *both* content = 'foo' AND someProperty = 'yup'
+        // isntead of "All entities with any subEntity with content 'foo' AND any subEntity with someProperty = 'yup'
+        $constraint = $query->logicalAnd($query->equals('subEntities.content', 'foo'), $query->equals('subEntities.someProperty', 'yup'));
+        $entities = $query->matching($constraint)->execute()->toArray();
+
+        $this->assertEquals(1, count($entities));
+    }
+
+    /**
+     * @test
+     */
     public function comlexQueryWithJoinsCanBeExecutedAfterDeserialization()
     {
         $postEntityRepository = new Fixtures\PostRepository();

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/SubEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/SubEntity.php
@@ -35,6 +35,11 @@ class SubEntity extends SuperEntity
     protected $date;
 
     /**
+     * @var string
+     */
+    protected $someProperty = '';
+
+    /**
      * @param TestEntity $parentEntity
      * @return void
      */
@@ -65,5 +70,21 @@ class SubEntity extends SuperEntity
     public function setDate($date)
     {
         $this->date = $date;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSomeProperty()
+    {
+        return $this->someProperty;
+    }
+
+    /**
+     * @param string $someProperty
+     */
+    public function setSomeProperty($someProperty)
+    {
+        $this->someProperty = $someProperty;
     }
 }


### PR DESCRIPTION
Previously a query object like

`$query->logicalAnd($query->equals('related.property', 'foo'), $query->equals('related.otherProperty', 'bar'));`

would generate an SQL statement with two joins to the `related` entity, one for each condition, translating to

"get all objects that have any related entity with a `property` 'foo' and any related entity with `otherProperty` 'bar'".

With this change, it will only generate a single join and reuse the join for multiple conditionals, therefore translating the above query object to the more common

"get all objects that have a related entity with both a `property` 'foo' and `otherProperty` 'bar'"

This also improves performance of such queries by avoiding unnecessary joins.
