### PR TITLE
BUGFIX: DateTimeConverter accepts timestamps when configuration without format is provided

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/DateTimeConverter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/DateTimeConverter.php
@@ -143,7 +143,8 @@ class DateTimeConverter extends AbstractTypeConverter
         if ($dateAsString === '') {
             return null;
         }
-        if (ctype_digit($dateAsString) && $configuration === null && (!is_array($source) || !isset($source['dateFormat']))) {
+        $configurationForm = $configuration === null ?: $configuration->getConfigurationValue(self::class, self::CONFIGURATION_DATE_FORMAT);
+        if (ctype_digit($dateAsString) && $configurationForm === null && (!is_array($source) || !isset($source['dateFormat']))) {
             $dateFormat = 'U';
         }
         if (is_array($source) && isset($source['timezone']) && strlen($source['timezone']) !== 0) {
@@ -190,7 +191,7 @@ class DateTimeConverter extends AbstractTypeConverter
         if ($configuration === null) {
             return self::DEFAULT_DATE_FORMAT;
         }
-        $dateFormat = $configuration->getConfigurationValue(\TYPO3\Flow\Property\TypeConverter\DateTimeConverter::class, self::CONFIGURATION_DATE_FORMAT);
+        $dateFormat = $configuration->getConfigurationValue(self::class, self::CONFIGURATION_DATE_FORMAT);
         if ($dateFormat === null) {
             return self::DEFAULT_DATE_FORMAT;
         } elseif ($dateFormat !== null && !is_string($dateFormat)) {

--- a/TYPO3.Flow/Tests/Unit/Property/TypeConverter/DateTimeConverterTest.php
+++ b/TYPO3.Flow/Tests/Unit/Property/TypeConverter/DateTimeConverterTest.php
@@ -187,6 +187,38 @@ class DateTimeConverterTest extends \TYPO3\Flow\Tests\UnitTestCase
         $this->assertSame(strval($source), $date->format('U'));
     }
 
+    /**
+     * @return array
+     * @see convertFromIntegerOrDigitStringWithoutConfigurationTests()
+     * @see convertFromIntegerOrDigitStringInArrayWithoutConfigurationTests()
+     */
+    public function convertFromIntegerOrDigitStringsWithConfigurationWithoutFormatDataProvider()
+    {
+        return array(
+            array('1308174051'),
+            array(1308174051),
+        );
+    }
+
+    /**
+     * @test
+     * @param $source
+     * @dataProvider convertFromIntegerOrDigitStringsWithConfigurationWithoutFormatDataProvider
+     */
+    public function convertFromIntegerOrDigitStringWithConfigurationWithoutFormatTests($source)
+    {
+        $mockMappingConfiguration = $this->createMock(\TYPO3\Flow\Property\PropertyMappingConfigurationInterface::class);
+        $mockMappingConfiguration
+            ->expects($this->atLeastOnce())
+            ->method('getConfigurationValue')
+            ->with(\TYPO3\Flow\Property\TypeConverter\DateTimeConverter::class, \TYPO3\Flow\Property\TypeConverter\DateTimeConverter::CONFIGURATION_DATE_FORMAT)
+            ->will($this->returnValue(null));
+
+        $date = $this->converter->convertFrom($source, 'DateTime', array(), $mockMappingConfiguration);
+        $this->assertInstanceOf(\DateTime::class, $date);
+        $this->assertSame(strval($source), $date->format('U'));
+    }
+
     /** Array to DateTime testcases  **/
 
     /**


### PR DESCRIPTION
Previously, the DateTimeConverter would fail converting timestamps when a configuration for the
property existed, but did not configure the DateTimeConverter format.
This is commonly the case in REST Apis, where type conversion needs to be configured for allowing
creation and modification, but does not necessarily explicitly configure the DateTime format.