### PR TITLE
FEATURE: Allow automatic injection of singleton constructor arguments

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/ObjectConverter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/ObjectConverter.php
@@ -12,6 +12,7 @@ namespace TYPO3\Flow\Property\TypeConverter;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Object\Configuration\Configuration;
 use TYPO3\Flow\Property\Exception\InvalidDataTypeException;
 use TYPO3\Flow\Property\Exception\InvalidPropertyMappingConfigurationException;
 use TYPO3\Flow\Property\Exception\InvalidTargetException;
@@ -237,6 +238,8 @@ class ObjectConverter extends AbstractTypeConverter
                     unset($possibleConstructorArgumentValues[$constructorArgumentName]);
                 } elseif ($constructorArgumentReflection['optional'] === true) {
                     $constructorArguments[] = $constructorArgumentReflection['defaultValue'];
+                } elseif ($this->objectManager->getScope($constructorArgumentReflection['type']) === Configuration::SCOPE_SINGLETON) {
+                    $constructorArguments[] = $this->objectManager->get($constructorArgumentReflection['type']);
                 } else {
                     throw new InvalidTargetException('Missing constructor argument "' . $constructorArgumentName . '" for object of type "' . $objectType . '".', 1268734872);
                 }

--- a/TYPO3.Flow/Tests/Functional/Property/Fixtures/TestClassWithSingletonConstructorInjection.php
+++ b/TYPO3.Flow/Tests/Functional/Property/Fixtures/TestClassWithSingletonConstructorInjection.php
@@ -40,5 +40,4 @@ class TestClassWithSingletonConstructorInjection
     {
         return $this->singletonClass;
     }
-
 }

--- a/TYPO3.Flow/Tests/Functional/Property/Fixtures/TestClassWithSingletonConstructorInjection.php
+++ b/TYPO3.Flow/Tests/Functional/Property/Fixtures/TestClassWithSingletonConstructorInjection.php
@@ -1,0 +1,44 @@
+<?php
+namespace TYPO3\Flow\Tests\Functional\Property\Fixtures;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Tests\Functional\Object\Fixtures\InterfaceA;
+
+/**
+ * A simple class for PropertyMapper test
+ *
+ */
+class TestClassWithSingletonConstructorInjection
+{
+
+    /**
+     * @var InterfaceA
+     */
+    protected $singletonClass;
+
+    /**
+     * @param InterfaceA $singletonClass
+     */
+    public function __construct(InterfaceA $singletonClass)
+    {
+        $this->singletonClass = $singletonClass;
+    }
+
+    /**
+     * @return InterfaceA
+     */
+    public function getSingletonClass()
+    {
+        return $this->singletonClass;
+    }
+
+}

--- a/TYPO3.Flow/Tests/Functional/Property/TypeConverter/ObjectConverterTest.php
+++ b/TYPO3.Flow/Tests/Functional/Property/TypeConverter/ObjectConverterTest.php
@@ -123,4 +123,16 @@ class ObjectConverterTest extends FunctionalTestCase
         $this->assertEquals('theValue set via Setter', ObjectAccess::getProperty($convertedObject, 'propertyMeantForSetterUsage', true));
         $this->assertEquals('theValue', ObjectAccess::getProperty($convertedObject, 'propertyMeantForPublicUsage', true));
     }
+
+    /**
+     * @test
+     */
+    public function convertFromFoo()
+    {
+        $convertedObject = $this->converter->convertFrom(
+            'irrelevant',
+            \TYPO3\Flow\Tests\Functional\Property\Fixtures\TestClassWithSingletonConstructorInjection::class
+        );
+        $this->assertInstanceOf(\TYPO3\Flow\Tests\Functional\Object\Fixtures\InterfaceAImplementation::class, $convertedObject->getSingletonClass());
+    }
 }

--- a/TYPO3.Flow/Tests/Unit/Property/TypeConverter/PersistentObjectConverterTest.php
+++ b/TYPO3.Flow/Tests/Unit/Property/TypeConverter/PersistentObjectConverterTest.php
@@ -485,7 +485,7 @@ class PersistentObjectConverterTest extends UnitTestCase
 
         $this->mockReflectionService->expects($this->once())->method('hasMethod')->with(\TYPO3\Flow\Fixtures\ClassWithSettersAndConstructor::class, '__construct')->will($this->returnValue(true));
         $this->mockReflectionService->expects($this->once())->method('getMethodParameters')->with(\TYPO3\Flow\Fixtures\ClassWithSettersAndConstructor::class, '__construct')->will($this->returnValue(array(
-            'property1' => array('optional' => false)
+            'property1' => array('optional' => false, 'type' => null)
         )));
         $this->mockObjectManager->expects($this->once())->method('getClassNameByObjectName')->with(\TYPO3\Flow\Fixtures\ClassWithSettersAndConstructor::class)->will($this->returnValue(\TYPO3\Flow\Fixtures\ClassWithSettersAndConstructor::class));
         $configuration = $this->buildConfiguration(array(PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED => true));


### PR DESCRIPTION
This allows to omit singleton constructor arguments when using the
``PropertyMapper`` to convert objects.

Background:
Constructor arguments can already be omitted if there is a default
value specified in the class to convert to:

```
class SomeClass {
  public function __construct($optionaArgument = null) {
    // ..
  }
}
```

With this change this will also work for (singleton) classes:

```
class SomeClass {
  public function __construct(SomeService $someService) {
    // ..
  }
}
$someInstance = $this->propertyMapper->convert([], SomeClass::class);
```

FLOW-463 #close