### PR TITLE
BUGFIX: Safeguard for unmananged constructor injections

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/ObjectConverter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/ObjectConverter.php
@@ -238,7 +238,7 @@ class ObjectConverter extends AbstractTypeConverter
                     unset($possibleConstructorArgumentValues[$constructorArgumentName]);
                 } elseif ($constructorArgumentReflection['optional'] === true) {
                     $constructorArguments[] = $constructorArgumentReflection['defaultValue'];
-                } elseif ($this->objectManager->getScope($constructorArgumentReflection['type']) === Configuration::SCOPE_SINGLETON) {
+                } elseif ($this->objectManager->isRegistered($constructorArgumentReflection['type']) && $this->objectManager->getScope($constructorArgumentReflection['type']) === Configuration::SCOPE_SINGLETON) {
                     $constructorArguments[] = $this->objectManager->get($constructorArgumentReflection['type']);
                 } else {
                     throw new InvalidTargetException('Missing constructor argument "' . $constructorArgumentName . '" for object of type "' . $objectType . '".', 1268734872);

--- a/TYPO3.Flow/Tests/Functional/Property/Fixtures/TestClassWithThirdPartyClassConstructorInjection.php
+++ b/TYPO3.Flow/Tests/Functional/Property/Fixtures/TestClassWithThirdPartyClassConstructorInjection.php
@@ -19,9 +19,9 @@ class TestClassWithThirdPartyClassConstructorInjection
 {
 
     /**
-     * @param \Some\UnknownCLass $someDependency
+     * @param \Some\UnknownClass $someDependency
      */
-    public function __construct(\Some\UnknownCLass $someDependency)
+    public function __construct(\Some\UnknownClass $someDependency)
     {
     }
 

--- a/TYPO3.Flow/Tests/Functional/Property/Fixtures/TestClassWithThirdPartyClassConstructorInjection.php
+++ b/TYPO3.Flow/Tests/Functional/Property/Fixtures/TestClassWithThirdPartyClassConstructorInjection.php
@@ -1,0 +1,28 @@
+<?php
+namespace TYPO3\Flow\Tests\Functional\Property\Fixtures;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A simple class for PropertyMapper test
+ *
+ */
+class TestClassWithThirdPartyClassConstructorInjection
+{
+
+    /**
+     * @param \Some\UnknownCLass $someDependency
+     */
+    public function __construct(\Some\UnknownCLass $someDependency)
+    {
+    }
+
+}

--- a/TYPO3.Flow/Tests/Functional/Property/Fixtures/TestClassWithThirdPartyClassConstructorInjection.php
+++ b/TYPO3.Flow/Tests/Functional/Property/Fixtures/TestClassWithThirdPartyClassConstructorInjection.php
@@ -24,5 +24,4 @@ class TestClassWithThirdPartyClassConstructorInjection
     public function __construct(\Some\UnknownClass $someDependency)
     {
     }
-
 }

--- a/TYPO3.Flow/Tests/Functional/Property/TypeConverter/ObjectConverterTest.php
+++ b/TYPO3.Flow/Tests/Functional/Property/TypeConverter/ObjectConverterTest.php
@@ -127,12 +127,24 @@ class ObjectConverterTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function convertFromFoo()
+    public function convertFromAllowsAutomaticInjectionOfSingletonConstructorArguments()
     {
         $convertedObject = $this->converter->convertFrom(
             'irrelevant',
             \TYPO3\Flow\Tests\Functional\Property\Fixtures\TestClassWithSingletonConstructorInjection::class
         );
         $this->assertInstanceOf(\TYPO3\Flow\Tests\Functional\Object\Fixtures\InterfaceAImplementation::class, $convertedObject->getSingletonClass());
+    }
+
+    /**
+     * @test
+     * @expectedException \TYPO3\Flow\Property\Exception\InvalidTargetException
+     */
+    public function convertFromThrowsMeaningfulExceptionWhenTheTargetExpectsAnUnknownDependencyThatIsNotSpecifiedInTheSource()
+    {
+        $this->converter->convertFrom(
+            'irrelevant',
+            \TYPO3\Flow\Tests\Functional\Property\Fixtures\TestClassWithThirdPartyClassConstructorInjection::class
+        );
     }
 }


### PR DESCRIPTION
This adds an additional check to ``ObjectConverter::buildObject()``
in order to prevent misleading errors when trying to convert objects
with constructor injections that are unknown to the ``ObjectManager``.

FLOW-463 #related