### PR TITLE
TASK: Remove doctrine/orm dependency

### DIFF
--- a/Neos.Utility.ObjectHandling/composer.json
+++ b/Neos.Utility.ObjectHandling/composer.json
@@ -8,7 +8,6 @@
     "php": ">=5.5.0"
   },
   "require-dev": {
-    "doctrine/orm": "~2.4.0",
     "phpunit/phpunit": "~4.8 || ~5.2.0"
   },
   "autoload": {


### PR DESCRIPTION
As the doctrine classes are only used for type checks in
``instanceof`` and ``is_subclass_of`` and both work with
non existing classes we can drop the dependency on
``doctrine/orm`` in this package.