### PR TITLE
FEATURE: Add support for embedded ValueObjects

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Annotations/ValueObject.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Annotations/ValueObject.php
@@ -23,4 +23,9 @@ namespace TYPO3\Flow\Annotations;
  */
 final class ValueObject
 {
+    /**
+     * Whether the value object should be embedded
+     * @var boolean
+     */
+    public $embedded = false;
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Annotations/ValueObject.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Annotations/ValueObject.php
@@ -24,7 +24,7 @@ namespace TYPO3\Flow\Annotations;
 final class ValueObject
 {
     /**
-     * Whether the value object should be embedded
+     * Whether the value object should be embedded.
      * @var boolean
      */
     public $embedded = false;

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Aspect/EmbeddedValueObjectPointcutFilter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Aspect/EmbeddedValueObjectPointcutFilter.php
@@ -1,0 +1,93 @@
+<?php
+namespace TYPO3\Flow\Persistence\Aspect;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Object\Configuration\Configuration as ObjectConfiguration;
+use TYPO3\Flow\Annotations as Flow;
+
+/**
+ * Pointcut filter matching embeddable value objects
+ *
+ * @Flow\Scope("singleton")
+ */
+class EmbeddedValueObjectPointcutFilter implements \TYPO3\Flow\Aop\Pointcut\PointcutFilterInterface
+{
+    /**
+     * @var \TYPO3\Flow\Reflection\ReflectionService
+     */
+    protected $reflectionService;
+
+    /**
+     * Injects the reflection service
+     *
+     * @param \TYPO3\Flow\Reflection\ReflectionService $reflectionService The reflection service
+     * @return void
+     */
+    public function injectReflectionService(\TYPO3\Flow\Reflection\ReflectionService $reflectionService)
+    {
+        $this->reflectionService = $reflectionService;
+    }
+
+    /**
+     * Checks if the specified class and method matches against the filter
+     *
+     * @param string $className Name of the class to check against
+     * @param string $methodName Name of the method to check against
+     * @param string $methodDeclaringClassName Name of the class the method was originally declared in
+     * @param mixed $pointcutQueryIdentifier Some identifier for this query - must at least differ from a previous identifier. Used for circular reference detection.
+     * @return boolean true if the class / method match, otherwise false
+     */
+    public function matches($className, $methodName, $methodDeclaringClassName, $pointcutQueryIdentifier)
+    {
+        $valueObjectAnnotation = $this->reflectionService->getClassAnnotation($className, 'TYPO3\Flow\Annotations\ValueObject');
+
+        if ($valueObjectAnnotation !== null && $valueObjectAnnotation->embedded === true) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns true if this filter holds runtime evaluations for a previously matched pointcut
+     *
+     * @return boolean true if this filter has runtime evaluations
+     */
+    public function hasRuntimeEvaluationsDefinition()
+    {
+        return false;
+    }
+
+    /**
+     * Returns runtime evaluations for a previously matched pointcut
+     *
+     * @return array Runtime evaluations
+     */
+    public function getRuntimeEvaluationsDefinition()
+    {
+        return array();
+    }
+
+    /**
+     * This method is used to optimize the matching process.
+     *
+     * @param \TYPO3\Flow\Aop\Builder\ClassNameIndex $classNameIndex
+     * @return \TYPO3\Flow\Aop\Builder\ClassNameIndex
+     */
+    public function reduceTargetClassNames(\TYPO3\Flow\Aop\Builder\ClassNameIndex $classNameIndex)
+    {
+        $classNames = $this->reflectionService->getClassNamesByAnnotation('TYPO3\Flow\Annotations\ValueObject');
+        $annotatedIndex = new \TYPO3\Flow\Aop\Builder\ClassNameIndex();
+        $annotatedIndex->setClassNames($classNames);
+        return $classNameIndex->intersect($annotatedIndex);
+    }
+}

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Aspect/EmbeddedValueObjectPointcutFilter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Aspect/EmbeddedValueObjectPointcutFilter.php
@@ -11,7 +11,6 @@ namespace TYPO3\Flow\Persistence\Aspect;
  * source code.
  */
 
-use TYPO3\Flow\Object\Configuration\Configuration as ObjectConfiguration;
 use TYPO3\Flow\Annotations as Flow;
 
 /**
@@ -48,7 +47,7 @@ class EmbeddedValueObjectPointcutFilter implements \TYPO3\Flow\Aop\Pointcut\Poin
      */
     public function matches($className, $methodName, $methodDeclaringClassName, $pointcutQueryIdentifier)
     {
-        $valueObjectAnnotation = $this->reflectionService->getClassAnnotation($className, 'TYPO3\Flow\Annotations\ValueObject');
+        $valueObjectAnnotation = $this->reflectionService->getClassAnnotation($className, Flow\ValueObject::class);
 
         if ($valueObjectAnnotation !== null && $valueObjectAnnotation->embedded === true) {
             return true;
@@ -85,7 +84,7 @@ class EmbeddedValueObjectPointcutFilter implements \TYPO3\Flow\Aop\Pointcut\Poin
      */
     public function reduceTargetClassNames(\TYPO3\Flow\Aop\Builder\ClassNameIndex $classNameIndex)
     {
-        $classNames = $this->reflectionService->getClassNamesByAnnotation('TYPO3\Flow\Annotations\ValueObject');
+        $classNames = $this->reflectionService->getClassNamesByAnnotation(Flow\ValueObject::class);
         $annotatedIndex = new \TYPO3\Flow\Aop\Builder\ClassNameIndex();
         $annotatedIndex->setClassNames($classNames);
         return $classNameIndex->intersect($annotatedIndex);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Aspect/PersistenceMagicAspect.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Aspect/PersistenceMagicAspect.php
@@ -54,7 +54,14 @@ class PersistenceMagicAspect
     }
 
     /**
-     * @Flow\Pointcut("TYPO3\Flow\Persistence\Aspect\PersistenceMagicAspect->isEntity || classAnnotatedWith(TYPO3\Flow\Annotations\ValueObject)")
+     * @Flow\Pointcut("classAnnotatedWith(TYPO3\Flow\Annotations\ValueObject) && !filter(TYPO3\Flow\Persistence\Aspect\EmbeddedValueObjectPointcutFilter)")
+     */
+    public function isNonEmbeddedValueObject()
+    {
+    }
+
+    /**
+     * @Flow\Pointcut("TYPO3\Flow\Persistence\Aspect\PersistenceMagicAspect->isEntity || TYPO3\Flow\Persistence\Aspect\PersistenceMagicAspect->isNonEmbeddedValueObject")
      */
     public function isEntityOrValueObject()
     {
@@ -98,7 +105,7 @@ class PersistenceMagicAspect
      *
      * @param \TYPO3\Flow\Aop\JoinPointInterface $joinPoint The current join point
      * @return void
-     * @Flow\After("classAnnotatedWith(TYPO3\Flow\Annotations\ValueObject) && method(.*->__construct()) && filter(TYPO3\Flow\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriver)")
+     * @Flow\After("TYPO3\Flow\Persistence\Aspect\PersistenceMagicAspect->isNonEmbeddedValueObject && method(.*->__construct()) && filter(TYPO3\Flow\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriver)")
      */
     public function generateValueHash(JoinPointInterface $joinPoint)
     {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -203,8 +203,8 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
             if ($entityAnnotation->readOnly) {
                 $metadata->markReadOnly();
             }
-        } elseif (isset($classAnnotations[\TYPO3\Flow\Annotations\ValueObject::class])) {
-            $valueObjectAnnotation = $classAnnotations[\TYPO3\Flow\Annotations\ValueObject::class];
+        } elseif (isset($classAnnotations[Flow\ValueObject::class])) {
+            $valueObjectAnnotation = $classAnnotations[Flow\ValueObject::class];
             if ($valueObjectAnnotation->embedded === true) {
                 $metadata->isEmbeddedClass = true;
             } else {
@@ -742,7 +742,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
                                         $mapping['class'] = $propertyMetaData['type'];
                                         $mapping['columnPrefix'] = $mapping['columnName'];
                                         $metadata->mapEmbedded($mapping);
-                                        return;
+                                        continue 2;
                                     }
                                     $mapping['type'] = 'object';
                                 } elseif (class_exists($propertyMetaData['type'])) {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -737,11 +737,13 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
                             break;
                         default:
                             if (strpos($propertyMetaData['type'], '\\') !== false) {
-                                if ($valueObjectAnnotation = $this->reflectionService->getClassAnnotation($propertyMetaData['type'], Flow\ValueObject::class)) {
+                                if ($this->reflectionService->isClassAnnotatedWith($propertyMetaData['type'], Flow\ValueObject::class)) {
+                                    $valueObjectAnnotation = $this->reflectionService->getClassAnnotation($propertyMetaData['type'], Flow\ValueObject::class);
                                     if ($valueObjectAnnotation->embedded === true) {
                                         $mapping['class'] = $propertyMetaData['type'];
                                         $mapping['columnPrefix'] = $mapping['columnName'];
                                         $metadata->mapEmbedded($mapping);
+                                        // Leave switch and continue with next property
                                         continue 2;
                                     }
                                     $mapping['type'] = 'object';

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -737,8 +737,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
                             break;
                         default:
                             if (strpos($propertyMetaData['type'], '\\') !== false) {
-                                if ($this->reflectionService->isClassAnnotatedWith($propertyMetaData['type'], Flow\ValueObject::class)) {
-                                    $valueObjectAnnotation = $this->reflectionService->getClassAnnotation($propertyMetaData['type'], Flow\ValueObject::class);
+                                if ($valueObjectAnnotation = $this->reflectionService->getClassAnnotation($propertyMetaData['type'], Flow\ValueObject::class)) {
                                     if ($valueObjectAnnotation->embedded === true) {
                                         $mapping['class'] = $propertyMetaData['type'];
                                         $mapping['columnPrefix'] = $mapping['columnName'];
@@ -1069,8 +1068,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
         return strpos($className, Compiler::ORIGINAL_CLASSNAME_SUFFIX) !== false ||
             (
                 !$this->reflectionService->isClassAnnotatedWith($className, Flow\Entity::class) &&
-                    (!$this->reflectionService->isClassAnnotatedWith($className, Flow\ValueObject::class) ||
-                    $this->reflectionService->getClassAnnotation($className, \TYPO3\Flow\Annotations\ValueObject::class)->embedded === true) &&
+                !$this->reflectionService->isClassAnnotatedWith($className, Flow\ValueObject::class) &&
                 !$this->reflectionService->isClassAnnotatedWith($className, 'Doctrine\ORM\Mapping\Entity') &&
                 !$this->reflectionService->isClassAnnotatedWith($className, 'Doctrine\ORM\Mapping\MappedSuperclass') &&
                 !$this->reflectionService->isClassAnnotatedWith($className, 'Doctrine\ORM\Mapping\Embeddable')

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -203,9 +203,14 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
             if ($entityAnnotation->readOnly) {
                 $metadata->markReadOnly();
             }
-        } elseif ($classSchema->getModelType() === ClassSchema::MODELTYPE_VALUEOBJECT) {
-            // also ok... but we make it read-only
-            $metadata->markReadOnly();
+        } elseif (isset($classAnnotations[\TYPO3\Flow\Annotations\ValueObject::class])) {
+            $valueObjectAnnotation = $classAnnotations[\TYPO3\Flow\Annotations\ValueObject::class];
+            if ($valueObjectAnnotation->embedded === true) {
+                $metadata->isEmbeddedClass = true;
+            } else {
+                // also ok... but we make it read-only
+                $metadata->markReadOnly();
+            }
         } elseif (isset($classAnnotations['Doctrine\ORM\Mapping\Embeddable'])) {
             $metadata->isEmbeddedClass = true;
         } else {
@@ -733,6 +738,13 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
                         default:
                             if (strpos($propertyMetaData['type'], '\\') !== false) {
                                 if ($this->reflectionService->isClassAnnotatedWith($propertyMetaData['type'], Flow\ValueObject::class)) {
+                                    $valueObjectAnnotation = $this->reflectionService->getClassAnnotation($propertyMetaData['type'], Flow\ValueObject::class);
+                                    if ($valueObjectAnnotation->embedded === true) {
+                                        $mapping['class'] = $propertyMetaData['type'];
+                                        $mapping['columnPrefix'] = $mapping['columnName'];
+                                        $metadata->mapEmbedded($mapping);
+                                        return;
+                                    }
                                     $mapping['type'] = 'object';
                                 } elseif (class_exists($propertyMetaData['type'])) {
                                     throw MappingException::missingRequiredOption($property->getName(), 'OneToOne', sprintf('The property "%s" in class "%s" has a non standard data type and doesn\'t define the type of the relation. You have to use one of these annotations: @OneToOne, @OneToMany, @ManyToOne, @ManyToMany', $property->getName(), $className));
@@ -1057,10 +1069,11 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
         return strpos($className, Compiler::ORIGINAL_CLASSNAME_SUFFIX) !== false ||
             (
                 !$this->reflectionService->isClassAnnotatedWith($className, Flow\Entity::class) &&
-                    !$this->reflectionService->isClassAnnotatedWith($className, Flow\ValueObject::class) &&
-                    !$this->reflectionService->isClassAnnotatedWith($className, 'Doctrine\ORM\Mapping\Entity') &&
-                    !$this->reflectionService->isClassAnnotatedWith($className, 'Doctrine\ORM\Mapping\MappedSuperclass') &&
-                    !$this->reflectionService->isClassAnnotatedWith($className, 'Doctrine\ORM\Mapping\Embeddable')
+                    (!$this->reflectionService->isClassAnnotatedWith($className, Flow\ValueObject::class) ||
+                    $this->reflectionService->getClassAnnotation($className, \TYPO3\Flow\Annotations\ValueObject::class)->embedded === true) &&
+                !$this->reflectionService->isClassAnnotatedWith($className, 'Doctrine\ORM\Mapping\Entity') &&
+                !$this->reflectionService->isClassAnnotatedWith($className, 'Doctrine\ORM\Mapping\MappedSuperclass') &&
+                !$this->reflectionService->isClassAnnotatedWith($className, 'Doctrine\ORM\Mapping\Embeddable')
             );
     }
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
@@ -1567,10 +1567,12 @@ class ReflectionService
         $valueObjectAnnotation = $this->getClassAnnotation($className, Flow\ValueObject::class);
         if ($valueObjectAnnotation !== null && $valueObjectAnnotation->embedded === true) {
             $skipArtificialIdentity = true;
-        } else {
-            foreach ($this->getClassPropertyNames($className) as $propertyName) {
-                $skipArtificialIdentity = $this->evaluateClassPropertyAnnotationsForSchema($classSchema, $propertyName) ? true : $skipArtificialIdentity;
-            }
+        } elseif ($this->isClassAnnotatedWith($className, 'Doctrine\ORM\Mapping\Embeddable')) {
+            $skipArtificialIdentity = true;
+        }
+
+        foreach ($this->getClassPropertyNames($className) as $propertyName) {
+            $skipArtificialIdentity = $this->evaluateClassPropertyAnnotationsForSchema($classSchema, $propertyName) ? true : $skipArtificialIdentity;
         }
 
         if ($skipArtificialIdentity !== true) {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
@@ -1563,8 +1563,14 @@ class ReflectionService
         if ($this->isClassAnnotatedWith($className, 'Doctrine\ORM\Mapping\Embeddable')) {
             $skipArtificialIdentity = true;
         }
-        foreach ($this->getClassPropertyNames($className) as $propertyName) {
-            $skipArtificialIdentity = $this->evaluateClassPropertyAnnotationsForSchema($classSchema, $propertyName) ? true : $skipArtificialIdentity;
+        /* @var $valueObjectAnnotation Flow\ValueObject */
+        $valueObjectAnnotation = $this->getClassAnnotation($className, Flow\ValueObject::class);
+        if ($valueObjectAnnotation !== null && $valueObjectAnnotation->embedded === true) {
+            $skipArtificialIdentity = true;
+        } else {
+            foreach ($this->getClassPropertyNames($className) as $propertyName) {
+                $skipArtificialIdentity = $this->evaluateClassPropertyAnnotationsForSchema($classSchema, $propertyName) ? true : $skipArtificialIdentity;
+            }
         }
 
         if ($skipArtificialIdentity !== true) {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
@@ -1560,9 +1560,6 @@ class ReflectionService
         $className = $classSchema->getClassName();
         $skipArtificialIdentity = false;
 
-        if ($this->isClassAnnotatedWith($className, 'Doctrine\ORM\Mapping\Embeddable')) {
-            $skipArtificialIdentity = true;
-        }
         /* @var $valueObjectAnnotation Flow\ValueObject */
         $valueObjectAnnotation = $this->getClassAnnotation($className, Flow\ValueObject::class);
         if ($valueObjectAnnotation !== null && $valueObjectAnnotation->embedded === true) {

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartI/ConceptsOfModernProgramming.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartI/ConceptsOfModernProgramming.rst
@@ -116,7 +116,7 @@ There are two types of domain objects, called
 If a domain object has a certain *identity* which
 stays the same as the objects changes its state, the object is an
 *entity*. Otherwise, if the identity of an object
-is built from *all properties*, it is a
+is only defined from *all properties*, it is a
 *value object*. We will now explain these two types
 of objects in detail, including practical use-cases.
 
@@ -237,6 +237,15 @@ entity or value object.
 People new to Domain-Driven Design often tend to overuse
 entities, as this is what people coming from a relational database
 background are used to.
+
+So why not just use entities all the time?
+The design/architectural answer is: because a value object might just
+be more fitting your problem at hand.
+The technical answer is: because value objects are immutable and
+therefore avoid aliasing ([#aliasing]) problems, which are common cause
+of all kinds of bugs.
+
+.. [#aliasing] https://en.wikipedia.org/wiki/Aliasing_(computing)
 
 Associations
 ~~~~~~~~~~~~

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
@@ -172,6 +172,8 @@ From Evans, the rules we need to enforce include:
   invariants.
 * Root Entities have global identity. Entities inside the boundary have local identity,
   unique only within the Aggregate.
+* Value Objects do not have identity. They are only identified by the combination of their
+  properties and are therefore immutable.
 * Nothing outside the Aggregate boundary can hold a reference to anything inside, except
   to the root Entity. The root Entity can hand references to the internal Entities to
   other objects, but they can only use them transiently (within a single method or
@@ -394,14 +396,55 @@ Doctrine supports many more annotations, for a full reference please consult the
 On Value Object handling with Doctrine
 --------------------------------------
 
-Doctrine 2 does not (yet [#]_) support value objects, thus we treat them as
-entities for the time being, with some differences:
+Doctrine 2.5 supports value objects in the form of embeddable objects [#]_. This means that
+the value object properties will directly be included in the parent entities table schema.
+However, Doctrine doesn't currently support embeddable collections [#]_.
+Therefore, Flow supports two types of value objects: readonly entities and embedded
+
+By default, Flow will use the readonly version, as that is more flexible and also works in
+collections. However, this comes with some architectural drawbacks, because the value object
+thereby is actually treated like an entity with an identifier, which contradicts the very
+definition of a value object.
+
+The behaviour of non-embedded Value Objects is as follows:
 
 * Value Objects are marked immutable as with the ``ReadOnly`` annotation of Doctrine.
-* Unless you override the type using ``Column`` Value Objects will be stored as
-  serialized object in the database.
-* Upon persisting Value Objects already present in the underlying database will be
-  deduplicated.
+* Each Value Object will internally be referenced by an identifier that is automatically
+  generated from it's property values after construction.
+* If the relation to a Value Object is annotated as OneTo* or ManyTo*, the Value Object
+  will be persisted in it's own table. Otherwise, unless you override the type using
+  ``Column`` Value Objects will be stored as serialized object in the database.
+* Upon persisting Value Objects already present in the underlying database they will be
+  deduplicated by being referenced through the identifier.
+
+For cases where a *ToMany relation to a Value Object is not needed, the embedded form is the
+more natural way to persist value objects. You can therefore set the annotation property
+``embedded`` to true, which will cause the Value Object to be embedded inside all Entities
+that reference it.
+
+The behaviour of embedded Value Objects is as follows:
+
+* Every entity having a property of type embedded Value Object will get all the properties
+  of the Value Object included in it's schema.
+* Unless you specify the ``Embedded`` Annotation on the relation property, the schema prefix
+  will be the property name.
+
+.. code-block:: php
+
+  /**
+   * @Flow\ValueObject(embedded=true)
+   */
+  class ValueObject {
+    ...
+  }
+
+  class SomeEntity {
+
+  	/**
+  	 * @var ValueObject
+  	 */
+  	protected $valueObject;
+
 
 Custom Doctrine mapping types
 -----------------------------
@@ -553,7 +596,9 @@ makes a number of things easier, compared to plain Doctrine 2.
     characters in a string property.
 
 ``OneToOne``, ``OneToMany``, ``ManyToOne``, ``ManyToMany``
-  ``targetEntity`` can be omitted, it is read from the ``@var`` annotation on the property
+  ``targetEntity`` can be omitted, it is read from the ``@var`` annotation on the property.
+  Relations to Value Objects will be ``cascade`` ``persist`` by default and relations to non
+  aggregate root entities will be ``cascade`` ``all`` by default.
 
 ``JoinTable``, ``JoinColumn``
   Can usually be left out completely, the needed information is gathered automatically
@@ -1032,7 +1077,7 @@ that connection wrapper by setting the following options in your packages ``Sett
                host: '127.0.0.1'        # adjust to your slave database host
                dbname: 'slave1'         # adjust to your database name
                user: 'user'             # adjust to your database user
-               password: 'user'         # adjust to your database password
+               password: 'pass'         # adjust to your database password
 
 With this setup, Doctrine will use one of the slave connections picked once per request randomly
 for all queries until the first writing query (e.g. insert or update) is executed. From that point
@@ -1241,7 +1286,8 @@ the array of objects being returned.
 
 .. [#] An alternative would have been to do an implicit persist call before a query, but
 	that seemed to be confusing.
-.. [#] See https://github.com/doctrine/doctrine2/pull/265 for one approach in the making.
+.. [#] https://doctrine-orm.readthedocs.org/en/latest/tutorials/embeddables.html
+.. [#] https://github.com/doctrine/doctrine2/issues/3579
 .. [#] https://doctrine-orm.readthedocs.org/en/latest/reference/events.html
 .. [#] https://doctrine-orm.readthedocs.org/en/latest/reference/filters.html#filters
 .. [#] http://www.doctrine-project.org/jira/browse/DDC-3241

--- a/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/TestEmbeddedValueObject.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/TestEmbeddedValueObject.php
@@ -24,6 +24,7 @@ class TestEmbeddedValueObject
 
     /**
      * @var string
+     * @ORM\Column(nullable=true)
      */
     protected $value;
 

--- a/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/TestEmbeddedValueObject.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/TestEmbeddedValueObject.php
@@ -1,0 +1,45 @@
+<?php
+namespace TYPO3\Flow\Tests\Functional\Persistence\Fixtures;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use TYPO3\Flow\Annotations as Flow;
+
+/**
+ * A simple embedded value object for persistence tests
+ *
+ * @Flow\ValueObject(embedded=true)
+ */
+class TestEmbeddedValueObject
+{
+
+    /**
+     * @var string
+     */
+    protected $value;
+
+    /**
+     * @param string $value The string value of this value object
+     */
+    public function __construct($value = '')
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/TestEntity.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/TestEntity.php
@@ -17,7 +17,6 @@ use Doctrine\ORM\Mapping as ORM;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Object\ObjectManagerInterface;
 use TYPO3\Flow\Tests\Functional\Persistence\Fixtures\SubEntity as ImportedSubEntity;
-use TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEmbeddedValueObject;
 
 /**
  * A simple entity for persistence tests

--- a/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/TestEntity.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/TestEntity.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Mapping as ORM;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Object\ObjectManagerInterface;
 use TYPO3\Flow\Tests\Functional\Persistence\Fixtures\SubEntity as ImportedSubEntity;
+use TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEmbeddedValueObject;
 
 /**
  * A simple entity for persistence tests
@@ -63,6 +64,11 @@ class TestEntity
     protected $description = 'This is some text';
 
     /**
+     * @var TestEmbeddedValueObject
+     */
+    protected $embeddedValueObject;
+
+    /**
      * @var array
      */
     protected $arrayProperty = array();
@@ -80,6 +86,7 @@ class TestEntity
     {
         $this->subEntities = new ArrayCollection();
         $this->embedded = new TestEmbeddable('');
+        $this->embeddedValueObject = new TestEmbeddedValueObject();
     }
 
     /**
@@ -222,5 +229,22 @@ class TestEntity
     public function setEmbedded($embedded)
     {
         $this->embedded = $embedded;
+    }
+
+    /**
+     * @param TestEmbeddedValueObject $embeddedValueObject
+     * @return void
+     */
+    public function setEmbeddedValueObject($embeddedValueObject)
+    {
+        $this->embeddedValueObject = $embeddedValueObject;
+    }
+
+    /**
+     * @return TestEmbeddedValueObject
+     */
+    public function getEmbeddedValueObject()
+    {
+        return $this->embeddedValueObject;
     }
 }

--- a/TYPO3.Flow/Tests/Functional/Persistence/PersistenceTest.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/PersistenceTest.php
@@ -256,8 +256,10 @@ class PersistenceTest extends \TYPO3\Flow\Tests\FunctionalTestCase
         /* @var $entityManager \Doctrine\Common\Persistence\ObjectManager */
         $entityManager = $this->objectManager->get('Doctrine\Common\Persistence\ObjectManager');
         $schemaTool = new \Doctrine\ORM\Tools\SchemaTool($entityManager);
-        $schema = $schemaTool->getSchemaFromMetadata(array($entityManager->getClassMetadata('TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntity')));
-        $this->assertTrue($schema->getTable('persistence_testentity')->hasColumn('embeddedvalueobjectvalue'));
+        $classMetaData = $entityManager->getClassMetadata('TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntity');
+        $this->assertTrue($classMetaData->hasField('embeddedValueObject.value'), 'ClassMetadata is not correctly embedded');
+        $schema = $schemaTool->getSchemaFromMetadata(array($classMetaData));
+        $this->assertTrue($schema->getTable('persistence_testentity')->hasColumn('embeddedvalueobjectvalue'), 'Database schema is missing embedded field');
 
         $valueObject = new TestEmbeddedValueObject('someValue');
         $testEntity = new TestEntity();

--- a/TYPO3.Flow/Tests/Functional/Persistence/PersistenceTest.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/PersistenceTest.php
@@ -678,9 +678,9 @@ class PersistenceTest extends \TYPO3\Flow\Tests\FunctionalTestCase
         $entityManager = $this->objectManager->get('Doctrine\Common\Persistence\ObjectManager');
         $schemaTool = new \Doctrine\ORM\Tools\SchemaTool($entityManager);
         $metaData = $entityManager->getClassMetadata('TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntity');
-        $this->assertTrue($metaData->hasField('embedded.value'));
+        $this->assertTrue($metaData->hasField('embedded.value'), 'ClassMetadata does not contain embedded value');
         $schema = $schemaTool->getSchemaFromMetadata(array($metaData));
-        $this->assertTrue($schema->getTable('persistence_testentity')->hasColumn('embedded_value'));
+        $this->assertTrue($schema->getTable('persistence_testentity')->hasColumn('embedded_value'), 'Database schema does not contain embedded value field');
 
         $embeddable = new TestEmbeddable('someValue');
         $testEntity = new TestEntity();

--- a/TYPO3.Flow/Tests/Functional/Persistence/PersistenceTest.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/PersistenceTest.php
@@ -11,6 +11,7 @@ namespace TYPO3\Flow\Tests\Functional\Persistence;
  * source code.
  */
 
+use TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEmbeddedValueObject;
 use TYPO3\Flow\Tests\Functional\Persistence\Fixtures\CommonObject;
 use TYPO3\Flow\Tests\Functional\Persistence\Fixtures\ExtendedTypesEntity;
 use TYPO3\Flow\Tests\Functional\Persistence\Fixtures\ExtendedTypesEntityRepository;
@@ -245,6 +246,31 @@ class PersistenceTest extends \TYPO3\Flow\Tests\FunctionalTestCase
 
         $this->assertSame($testEntities[0]->getRelatedValueObject(), $testEntities[1]->getRelatedValueObject());
         $this->assertSame($testEntities[1]->getRelatedValueObject(), $testEntities[2]->getRelatedValueObject());
+    }
+
+    /**
+     * @test
+     */
+    public function embeddedValueObjectsAreActuallyEmbedded()
+    {
+        /* @var $entityManager \Doctrine\Common\Persistence\ObjectManager */
+        $entityManager = $this->objectManager->get('Doctrine\Common\Persistence\ObjectManager');
+        $schemaTool = new \Doctrine\ORM\Tools\SchemaTool($entityManager);
+        $schema = $schemaTool->getSchemaFromMetadata(array($entityManager->getClassMetadata('TYPO3\Flow\Tests\Functional\Persistence\Fixtures\TestEntity')));
+        $this->assertTrue($schema->getTable('persistence_testentity')->hasColumn('embeddedvalueobjectvalue'));
+
+        $valueObject = new TestEmbeddedValueObject('someValue');
+        $testEntity = new TestEntity();
+        $testEntity->setEmbeddedValueObject($valueObject);
+
+        $this->testEntityRepository->add($testEntity);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        /* @var $testEntity TestEntity */
+        $testEntity = $this->testEntityRepository->findAll()->getFirst();
+        $this->assertEquals('someValue', $testEntity->getEmbeddedValueObject()->getValue());
     }
 
     /**

--- a/TYPO3.Flow/Tests/Functional/Property/Fixtures/TestEmbeddedValueobject.php
+++ b/TYPO3.Flow/Tests/Functional/Property/Fixtures/TestEmbeddedValueobject.php
@@ -1,0 +1,62 @@
+<?php
+namespace TYPO3\Flow\Tests\Functional\Property\Fixtures;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+
+/**
+ * A simple valueobject for PropertyMapper test
+ *
+ * @Flow\ValueObject(embedded=true)
+ */
+class TestEmbeddedValueobject
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     *
+     * @var integer
+     */
+    protected $age;
+
+    /**
+     *
+     * @param string $name
+     * @param integer $age
+     */
+    public function __construct($name, $age)
+    {
+        $this->name = $name;
+        $this->age = $age;
+    }
+
+    /**
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     *
+     * @return integer
+     */
+    public function getAge()
+    {
+        return $this->age;
+    }
+}

--- a/TYPO3.Flow/Tests/Functional/Property/PropertyMapperTest.php
+++ b/TYPO3.Flow/Tests/Functional/Property/PropertyMapperTest.php
@@ -104,6 +104,21 @@ class PropertyMapperTest extends \TYPO3\Flow\Tests\FunctionalTestCase
     /**
      * @test
      */
+    public function embeddedValueobjectCanBeMapped()
+    {
+        $source = array(
+            'name' => 'Christopher',
+            'age' => '28'
+        );
+
+        $result = $this->propertyMapper->convert($source, \TYPO3\Flow\Tests\Functional\Property\Fixtures\TestEmbeddedValueobject::class);
+        $this->assertSame('Christopher', $result->getName());
+        $this->assertSame(28, $result->getAge());
+    }
+
+    /**
+     * @test
+     */
     public function integerCanBeMappedToString()
     {
         $source = array(

--- a/TYPO3.Fluid/Resources/Private/Templates/Tests/Functional/Form/Fixtures/Form/Edit.html
+++ b/TYPO3.Fluid/Resources/Private/Templates/Tests/Functional/Form/Fixtures/Form/Edit.html
@@ -1,12 +1,13 @@
 <h2>My Form</h2>
 
 <f:form action="update" object="{fooPost}" objectName="post">
-	<f:form.textfield id="name" property="name" />
-	<f:form.textfield id="email" property="author.emailAddress" />
-	<f:form.checkbox id="private" property="private" value="true" disabled="true" />
-	<f:for each="{fooPost.tags}" as="tag">
-		<f:form.checkbox property="tags" value="{tag}" />
-		<f:form.checkbox name="tags" multiple="true" value="{tag}" />
-	</f:for>
-	<f:form.submit>Abschicken</f:form.submit>
+  <f:form.textfield id="name" property="name" />
+  <f:form.textfield id="email" property="author.emailAddress" />
+  <f:form.textfield id="city" property="author.location.city" />
+  <f:form.checkbox id="private" property="private" value="true" disabled="true" />
+  <f:for each="{fooPost.tags}" as="tag">
+    <f:form.checkbox property="tags" value="{tag}" />
+    <f:form.checkbox name="tags" multiple="true" value="{tag}" />
+  </f:for>
+  <f:form.submit>Abschicken</f:form.submit>
 </f:form>

--- a/TYPO3.Fluid/Tests/Functional/Form/Fixtures/Domain/Model/Location.php
+++ b/TYPO3.Fluid/Tests/Functional/Form/Fixtures/Domain/Model/Location.php
@@ -1,0 +1,45 @@
+<?php
+namespace TYPO3\Fluid\Tests\Functional\Form\Fixtures\Domain\Model;
+
+/*
+ * This file is part of the TYPO3.Fluid package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * A test value object which is used to test Fluid forms in combination with
+ * property mapping
+ *
+ * @Flow\ValueObject(embedded=true)
+ */
+class Location
+{
+    /**
+     * @var string
+     */
+    protected $city;
+
+    /**
+     * @param string $city
+     */
+    public function __construct($city = '')
+    {
+        $this->city = $city;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCity()
+    {
+        return $this->city;
+    }
+}

--- a/TYPO3.Fluid/Tests/Functional/Form/Fixtures/Domain/Model/User.php
+++ b/TYPO3.Fluid/Tests/Functional/Form/Fixtures/Domain/Model/User.php
@@ -29,6 +29,16 @@ class User
     protected $emailAddress;
 
     /**
+     * @var Location
+     */
+    protected $location;
+
+    public function __construct()
+    {
+        $this->location = new Location();
+    }
+
+    /**
      * @return string
      */
     public function getEmailAddress()
@@ -42,5 +52,21 @@ class User
     public function setEmailAddress($email)
     {
         $this->emailAddress = $email;
+    }
+
+    /**
+     * @return Location
+     */
+    public function getLocation()
+    {
+        return $this->location;
+    }
+
+    /**
+     * @param Location $location
+     */
+    public function setLocation(Location $location)
+    {
+        $this->location = $location;
     }
 }

--- a/TYPO3.Fluid/Tests/Functional/Form/FormObjectsTest.php
+++ b/TYPO3.Fluid/Tests/Functional/Form/FormObjectsTest.php
@@ -79,6 +79,18 @@ class FormObjectsTest extends \TYPO3\Flow\Tests\FunctionalTestCase
     /**
      * @test
      */
+    public function embeddedValueObjectWillNotRenderHiddenIdentityField()
+    {
+        $postIdentifier = $this->setupDummyPost(true);
+
+        $this->browser->request('http://localhost/test/fluid/formobjects/edit?fooPost=' . $postIdentifier);
+        $form = $this->browser->getForm();
+        $this->assertFalse(isset($form['post']['author']['location']['__identity']));
+    }
+
+    /**
+     * @test
+     */
     public function formIsRedisplayedIfValidationErrorsOccur()
     {
         $this->browser->request('http://localhost/test/fluid/formobjects');


### PR DESCRIPTION
This change adds support for embedded ValueObjects by using the Embeddable features
of Doctrine ORM 2.5.

All ValueObjects can be made embedded by setting the annotation option
`embedded=true`.

Depends on FLOW-260
FLOW-257 #close
