### PR TITLE
FEATURE: Implement 'flow:cache:collectgarbagesessions' command

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/CacheCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/CacheCommandController.php
@@ -20,6 +20,7 @@ use TYPO3\Flow\Core\LockManager;
 use TYPO3\Flow\Object\ObjectManager;
 use TYPO3\Flow\Object\ObjectManagerInterface;
 use TYPO3\Flow\Package\PackageManagerInterface;
+use TYPO3\Flow\Session\SessionManagerInterface;
 use TYPO3\Flow\Utility\Environment;
 
 /**
@@ -60,6 +61,11 @@ class CacheCommandController extends CommandController
      * @var Environment
      */
     protected $environment;
+
+    /**
+     * @var SessionManagerInterface
+     */
+    protected $sessionManager;
 
     /**
      * @param CacheManager $cacheManager
@@ -113,6 +119,15 @@ class CacheCommandController extends CommandController
     public function injectEnvironment(Environment $environment)
     {
         $this->environment = $environment;
+    }
+
+    /**
+     * @param SessionManagerInterface $sessionManager
+     * @return void
+     */
+    public function injectSessionManager(SessionManagerInterface $sessionManager)
+    {
+        $this->sessionManager = $sessionManager;
     }
 
     /**
@@ -226,6 +241,22 @@ class CacheCommandController extends CommandController
     {
         $this->emitWarmupCaches();
         $this->outputLine('Warmed up caches.');
+    }
+
+    /**
+     * Collects the garbage sessions that have expired
+     *
+     * This is intended for big applications, as running garbage collection over
+     * potentially hundreds of thousands of sessions every few requests isn't
+     * something you want to do in a production environment. Setup a cronjob
+     * instead that calls this command at night (or once every few hours).
+     *
+     * @return void
+     */
+    public function collectGarbageSessionsCommand()
+    {
+        $count = $this->sessionManager->getCurrentSession()->collectGarbage();
+        $this->outputLine('Removed %d expired sessions.', [$count]);
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Session/Session.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Session/Session.php
@@ -602,10 +602,11 @@ class Session implements SessionInterface
      * Iterates over all existing sessions and removes their data if the inactivity
      * timeout was reached.
      *
+     * @param boolean $maximumSessionsToRemove How many sessions to remove per run
      * @return integer The number of outdated entries removed
      * @api
      */
-    public function collectGarbage()
+    public function collectGarbage($maximumSessionsToRemove = 0)
     {
         if ($this->inactivityTimeout === 0) {
             return 0;
@@ -631,7 +632,7 @@ class Session implements SessionInterface
                 }
                 $this->metaDataCache->remove($sessionIdentifier);
             }
-            if ($sessionRemovalCount >= $this->garbageCollectionMaximumPerRun) {
+            if ($maximumSessionsToRemove > 0 && $sessionRemovalCount >= $maximumSessionsToRemove) {
                 break;
             }
         }
@@ -664,10 +665,12 @@ class Session implements SessionInterface
             }
             $this->started = false;
 
-            $decimals = (integer)strlen(strrchr($this->garbageCollectionProbability, '.')) - 1;
-            $factor = ($decimals > -1) ? $decimals * 10 : 1;
-            if (rand(1, 100 * $factor) <= ($this->garbageCollectionProbability * $factor)) {
-                $this->collectGarbage();
+            if ($this->garbageCollectionProbability > 0) {
+                $decimals = (integer)strlen(strrchr($this->garbageCollectionProbability, '.')) - 1;
+                $factor = ($decimals > -1) ? $decimals * 10 : 1;
+                if (rand(1, 100 * $factor) <= ($this->garbageCollectionProbability * $factor)) {
+                    $this->collectGarbage($this->garbageCollectionMaximumPerRun);
+                }
             }
         }
         $this->request = null;

--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -642,15 +642,18 @@ TYPO3:
 
         # The probability in percent of a session shutdown triggering a garbage
         # collection which removes expired session data from other sessions.
+        # Set this to 0 and use the flow:cache:collectgarbagesessions command to
+        # manually clean up expired sessions.
         #
         # Examples:
         #    1    (would be a 1% chance to clean up)
         #   20    (would be a 20% chance to clean up)
         #    0.42 (would be a 0.42 % chance to clean up)
+        #    0    (won't automatically clean up sessions)
         probability: 1
 
         # The number of invalid and expired sessions which are removed per garbage
-        # collection run.
+        # collection run. Set this to 0 to remove all expired sessions at once.
         maximumPerRun: 1000
 
       # Configuration for the session cookie:


### PR DESCRIPTION
This command is intended to trigger a manual garbage collection (via cron et al) with big Flow-based applications that have a lot of sessions.

With hundreds of thousands of sessions, even the fastest cache backend will take some time to clean them up; doing this probabilistically at the end of regular HTTP requests causes some unlucky requests to take very long, and, in some rare situations, can lead to data loss. Hence it's a better choice to do garbage collection from the CLI whenever needed.