### PR TITLE
FEATURE: Implement 'flow:session:collectgarbage' command

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/SessionCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/SessionCommandController.php
@@ -1,0 +1,46 @@
+<?php
+namespace TYPO3\Flow\Command;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Cli\CommandController;
+use TYPO3\Flow\Session\SessionManagerInterface;
+
+/**
+ * Command controller for managing sessions
+ *
+ * @Flow\Scope("singleton")
+ */
+class SessionCommandController extends CommandController
+{
+    /**
+     * @Flow\Inject
+     * @var SessionManagerInterface
+     */
+    protected $sessionManager;
+
+    /**
+     * Collects the garbage sessions that have expired
+     *
+     * This is intended for big applications, as running garbage collection over
+     * potentially hundreds of thousands of sessions every few requests isn't
+     * something you want to do in a production environment. Setup a cronjob
+     * instead that calls this command whenever.
+     *
+     * @return void
+     */
+    public function collectGarbageCommand()
+    {
+        $count = $this->sessionManager->getCurrentSession()->collectGarbage();
+        $this->outputLine('Removed %d expired sessions.', [$count]);
+    }
+}

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Session/Session.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Session/Session.php
@@ -602,10 +602,11 @@ class Session implements SessionInterface
      * Iterates over all existing sessions and removes their data if the inactivity
      * timeout was reached.
      *
+     * @param boolean $maximumSessionsToRemove How many sessions to remove per run
      * @return integer The number of outdated entries removed
      * @api
      */
-    public function collectGarbage()
+    public function collectGarbage($maximumSessionsToRemove = 0)
     {
         if ($this->inactivityTimeout === 0) {
             return 0;
@@ -631,7 +632,7 @@ class Session implements SessionInterface
                 }
                 $this->metaDataCache->remove($sessionIdentifier);
             }
-            if ($sessionRemovalCount >= $this->garbageCollectionMaximumPerRun) {
+            if ($maximumSessionsToRemove > 0 && $sessionRemovalCount >= $maximumSessionsToRemove) {
                 break;
             }
         }
@@ -664,10 +665,12 @@ class Session implements SessionInterface
             }
             $this->started = false;
 
-            $decimals = (integer)strlen(strrchr($this->garbageCollectionProbability, '.')) - 1;
-            $factor = ($decimals > -1) ? $decimals * 10 : 1;
-            if (rand(1, 100 * $factor) <= ($this->garbageCollectionProbability * $factor)) {
-                $this->collectGarbage();
+            if ($this->garbageCollectionProbability > 0) {
+                $decimals = (integer)strlen(strrchr($this->garbageCollectionProbability, '.')) - 1;
+                $factor = ($decimals > -1) ? $decimals * 10 : 1;
+                if (rand(1, 100 * $factor) <= ($this->garbageCollectionProbability * $factor)) {
+                    $this->collectGarbage($this->garbageCollectionMaximumPerRun);
+                }
             }
         }
         $this->request = null;

--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -642,15 +642,18 @@ TYPO3:
 
         # The probability in percent of a session shutdown triggering a garbage
         # collection which removes expired session data from other sessions.
+        # Set this to 0 and use the flow:cache:collectgarbagesessions command to
+        # manually clean up expired sessions.
         #
         # Examples:
         #    1    (would be a 1% chance to clean up)
         #   20    (would be a 20% chance to clean up)
         #    0.42 (would be a 0.42 % chance to clean up)
+        #    0    (won't automatically clean up sessions)
         probability: 1
 
         # The number of invalid and expired sessions which are removed per garbage
-        # collection run.
+        # collection run. Set this to 0 to remove all expired sessions at once.
         maximumPerRun: 1000
 
       # Configuration for the session cookie:


### PR DESCRIPTION
This command is intended to trigger a manual garbage collection (via cron et al) with big Flow-based applications that have a lot of sessions.

With hundreds of thousands of sessions, even the fastest cache backend will take some time to clean them up; doing this probabilistically at the end of regular HTTP requests causes some unlucky requests to take very long, and, in some rare situations, can lead to data loss. Hence it's a better choice to do garbage collection from the CLI whenever needed.
