### PR TITLE
BUGFIX: Type Handling should not break when classnames contain underscores, or when classnames are lowerCamelCase

### DIFF
--- a/Neos.Utility.ObjectHandling/Classes/TYPO3/Flow/Utility/TypeHandling.php
+++ b/Neos.Utility.ObjectHandling/Classes/TYPO3/Flow/Utility/TypeHandling.php
@@ -23,7 +23,7 @@ abstract class TypeHandling
     /**
      * A property type parse pattern.
      */
-    const PARSE_TYPE_PATTERN = '/^\\\\?(?P<type>integer|int|float|double|boolean|bool|string|DateTime|[A-Z][a-zA-Z0-9\\\\_]+|object|array|ArrayObject|SplObjectStorage|Doctrine\\\\Common\\\\Collections\\\\Collection|Doctrine\\\\Common\\\\Collections\\\\ArrayCollection)(?:<\\\\?(?P<elementType>[a-zA-Z0-9\\\\_]+)>)?/';
+    const PARSE_TYPE_PATTERN = '/^\\\\?(?P<type>integer|int|float|double|boolean|bool|string|DateTime|[a-zA-Z0-9\\\\_]+|object|array|ArrayObject|SplObjectStorage|Doctrine\\\\Common\\\\Collections\\\\Collection|Doctrine\\\\Common\\\\Collections\\\\ArrayCollection)(?:<\\\\?(?P<elementType>[a-zA-Z0-9\\\\_]+)>)?/';
 
     /**
      * A type pattern to detect literal types.

--- a/Neos.Utility.ObjectHandling/Classes/TYPO3/Flow/Utility/TypeHandling.php
+++ b/Neos.Utility.ObjectHandling/Classes/TYPO3/Flow/Utility/TypeHandling.php
@@ -23,7 +23,7 @@ abstract class TypeHandling
     /**
      * A property type parse pattern.
      */
-    const PARSE_TYPE_PATTERN = '/^\\\\?(?P<type>integer|int|float|double|boolean|bool|string|DateTime|[A-Z][a-zA-Z0-9\\\\]+|object|array|ArrayObject|SplObjectStorage|Doctrine\\\\Common\\\\Collections\\\\Collection|Doctrine\\\\Common\\\\Collections\\\\ArrayCollection)(?:<\\\\?(?P<elementType>[a-zA-Z0-9\\\\]+)>)?/';
+    const PARSE_TYPE_PATTERN = '/^\\\\?(?P<type>integer|int|float|double|boolean|bool|string|DateTime|[A-Z][a-zA-Z0-9\\\\_]+|object|array|ArrayObject|SplObjectStorage|Doctrine\\\\Common\\\\Collections\\\\Collection|Doctrine\\\\Common\\\\Collections\\\\ArrayCollection)(?:<\\\\?(?P<elementType>[a-zA-Z0-9\\\\_]+)>)?/';
 
     /**
      * A type pattern to detect literal types.

--- a/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
@@ -54,6 +54,10 @@ class TypeHandlingTest extends \PHPUnit_Framework_TestCase
             array('SplObjectStorage<\TYPO3\Foo\Bar>', array('type' => 'SplObjectStorage', 'elementType' => 'TYPO3\Foo\Bar')),
             array('Doctrine\Common\Collections\Collection<\TYPO3\Foo\Bar>', array('type' => 'Doctrine\Common\Collections\Collection', 'elementType' => 'TYPO3\Foo\Bar')),
             array('Doctrine\Common\Collections\ArrayCollection<\TYPO3\Foo\Bar>', array('type' => 'Doctrine\Common\Collections\ArrayCollection', 'elementType' => 'TYPO3\Foo\Bar')),
+
+            // Types might also contain underscores at various points.
+            array('Doctrine\Common\Collections\Special_Class_With_Underscores', array('type' => 'Doctrine\Common\Collections\Special_Class_With_Underscores', 'elementType' => null)),
+            array('Doctrine\Common\Collections\ArrayCollection<\TYPO3\Foo_\Bar>', array('type' => 'Doctrine\Common\Collections\ArrayCollection', 'elementType' => 'TYPO3\Foo_\Bar')),
         );
     }
 
@@ -88,6 +92,9 @@ class TypeHandlingTest extends \PHPUnit_Framework_TestCase
             array('SplObjectStorage<\object>', 'SplObjectStorage'),
             array('Doctrine\Common\Collections\Collection<ElementType>', 'Doctrine\Common\Collections\Collection'),
             array('Doctrine\Common\Collections\ArrayCollection<>', 'Doctrine\Common\Collections\ArrayCollection'),
+
+            // Types might also contain underscores at various points.
+            array('Doctrine\Common\Collections\Array_Collection<>', 'Doctrine\Common\Collections\Array_Collection'),
         );
     }
 

--- a/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
@@ -25,7 +25,7 @@ class TypeHandlingTest extends \PHPUnit_Framework_TestCase
      */
     public function parseTypeThrowsExceptionOnInvalidType()
     {
-        TypeHandling::parseType('something not a type');
+        TypeHandling::parseType('$something');
     }
 
     /**
@@ -48,12 +48,14 @@ class TypeHandlingTest extends \PHPUnit_Framework_TestCase
             array('DateTime', array('type' => 'DateTime', 'elementType' => null)),
             array('TYPO3\Foo\Bar', array('type' => 'TYPO3\Foo\Bar', 'elementType' => null)),
             array('\TYPO3\Foo\Bar', array('type' => 'TYPO3\Foo\Bar', 'elementType' => null)),
+            array('\stdClass', array('type' => 'stdClass', 'elementType' => null)),
             array('array<integer>', array('type' => 'array', 'elementType' => 'integer')),
             array('ArrayObject<string>', array('type' => 'ArrayObject', 'elementType' => 'string')),
             array('SplObjectStorage<TYPO3\Foo\Bar>', array('type' => 'SplObjectStorage', 'elementType' => 'TYPO3\Foo\Bar')),
             array('SplObjectStorage<\TYPO3\Foo\Bar>', array('type' => 'SplObjectStorage', 'elementType' => 'TYPO3\Foo\Bar')),
             array('Doctrine\Common\Collections\Collection<\TYPO3\Foo\Bar>', array('type' => 'Doctrine\Common\Collections\Collection', 'elementType' => 'TYPO3\Foo\Bar')),
             array('Doctrine\Common\Collections\ArrayCollection<\TYPO3\Foo\Bar>', array('type' => 'Doctrine\Common\Collections\ArrayCollection', 'elementType' => 'TYPO3\Foo\Bar')),
+            array('\SomeClass with appendix', array('type' => 'SomeClass', 'elementType' => null)),
 
             // Types might also contain underscores at various points.
             array('Doctrine\Common\Collections\Special_Class_With_Underscores', array('type' => 'Doctrine\Common\Collections\Special_Class_With_Underscores', 'elementType' => null)),

--- a/TYPO3.Flow/Tests/Unit/Reflection/ClassSchemaTest.php
+++ b/TYPO3.Flow/Tests/Unit/Reflection/ClassSchemaTest.php
@@ -159,8 +159,6 @@ class ClassSchemaTest extends \TYPO3\Flow\Tests\UnitTestCase
     public function invalidPropertyTypes()
     {
         return array(
-            array('stdClass'),
-            array('\someObject'),
             array('string<string>'),
             array('int<TYPO3\Flow\Baz>')
         );


### PR DESCRIPTION
While underscores in class names are not used in Flow code itself, it might
happen that TypeHandling is used outside Flow - where having underscores
in class names is perfectly valid.

This change ensures that underscores in class names are recognized properly.