### PR TITLE
TASK: Allow configuration of doctrine second level cache

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/EntityManagerFactory.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/EntityManagerFactory.php
@@ -88,6 +88,7 @@ class EntityManagerFactory
     {
         $config = new Configuration();
         $config->setClassMetadataFactoryName(Mapping\ClassMetadataFactory::class);
+        $this->applySecondLevelCacheSettingsToConfiguration($config);
 
         $cache = new CacheAdapter();
         // must use ObjectManager in compile phase...
@@ -210,5 +211,41 @@ class EntityManagerFactory
         if (isset($configuredSettings['customDatetimeFunctions'])) {
             $doctrineConfiguration->setCustomDatetimeFunctions($configuredSettings['customDatetimeFunctions']);
         }
+    }
+
+    /**
+     * Apply configured settings regarding Doctrine's second level cache.
+     *
+     * @param array $configuredSettings
+     * @param Configuration $doctrineConfiguration
+     * @return void
+     */
+    protected function applySecondLevelCacheSettingsToConfiguration(array $configuredSettings, Configuration $doctrineConfiguration)
+    {
+        if (!isset($configuredSettings['enable']) || $configuredSettings['enable'] !== true) {
+            return;
+        }
+
+        $doctrineConfiguration->setSecondLevelCacheEnabled();
+        $regionsConfiguration = $doctrineConfiguration->getSecondLevelCacheConfiguration()->getRegionsConfiguration();
+        if (isset($configuredSettings['defaultLifetime'])) {
+            $regionsConfiguration->setDefaultLifetime($configuredSettings['defaultLifetime']);
+        }
+        if (isset($configuredSettings['defaultLockLifetime'])) {
+            $regionsConfiguration->setDefaultLockLifetime($configuredSettings['defaultLockLifetime']);
+        }
+
+        if (isset($configuredSettings['regions']) && is_array($configuredSettings['regions'])) {
+            foreach ($configuredSettings['regions'] as $regionName => $regionLifetime) {
+                $regionsConfiguration->setLifetime($regionName, $regionLifetime);
+            }
+        }
+
+        $cache = new CacheAdapter();
+        // must use ObjectManager in compile phase...
+        $cache->setCache($this->objectManager->get(CacheManager::class)->getCache('Flow_Persistence_Doctrine_SecondLevel'));
+
+        $factory = new \Doctrine\ORM\Cache\DefaultCacheFactory($regionsConfiguration, $cache);
+        $doctrineConfiguration->getSecondLevelCacheConfiguration()->setCacheFactory($factory);
     }
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/EntityManagerFactory.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/EntityManagerFactory.php
@@ -88,7 +88,7 @@ class EntityManagerFactory
     {
         $config = new Configuration();
         $config->setClassMetadataFactoryName(Mapping\ClassMetadataFactory::class);
-        $this->applySecondLevelCacheSettingsToConfiguration($config);
+        $this->applySecondLevelCacheSettingsToConfiguration($this->settings['doctrine']['secondLevelCache'], $config);
 
         $cache = new CacheAdapter();
         // must use ObjectManager in compile phase...

--- a/TYPO3.Flow/Configuration/Caches.yaml
+++ b/TYPO3.Flow/Configuration/Caches.yaml
@@ -89,6 +89,8 @@ Flow_Persistence_Doctrine_Results:
   backend: TYPO3\Flow\Cache\Backend\FileBackend
   backendOptions:
     defaultLifetime: 60
+Flow_Persistence_Doctrine_SecondLevel:
+  backend: TYPO3\Flow\Cache\Backend\SimpleFileBackend
 
 # Flow_Reflection*
 #

--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -359,6 +359,8 @@ TYPO3:
         eventSubscribers: []
         eventListeners: []
 
+        secondLevelCache: []
+
         # List of regular expressions table names are matched against in the doctrine service
         # to prevent them from creating corresponding migrations.
         #

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
@@ -565,6 +565,31 @@ functions.
 
 .. [#doctrineDqlFunctions] http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/dql-doctrine-query-language.html#adding-your-own-functions-to-the-dql-language
 
+Using Doctrine's Second Level Cache
+-----------------------------------
+
+Since 2.5, Doctrine provides a second level cache that further improves performance of relation queries
+beyond the result query cache.
+See the Doctrine documentation ([#doctrineSecondLevelCache]_) for more information on the second level cache.
+Flow allows you can enable and configure the second level cache through the configuration setting
+``TYPO3.Flow.persistence.doctrine.secondLevelCache``.
+
+*Example: Configuration for Doctrine second level cache*:
+
+.. code-block:: yaml
+
+	TYPO3:
+	  Flow:
+	    persistence:
+	      doctrine:
+	        secondLevelCache:
+	          enable: true
+	          defaultLifetime: 3600
+	          regions:
+	            'my_entity_region': 7200
+
+.. [#doctrineSecondLevelCache] http://docs.doctrine-project.org/en/latest/reference/second-level-cache.html
+
 Differences between Flow and plain Doctrine
 -------------------------------------------
 

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
@@ -570,8 +570,9 @@ Using Doctrine's Second Level Cache
 
 Since 2.5, Doctrine provides a second level cache that further improves performance of relation queries
 beyond the result query cache.
+
 See the Doctrine documentation ([#doctrineSecondLevelCache]_) for more information on the second level cache.
-Flow allows you can enable and configure the second level cache through the configuration setting
+Flow allows you to enable and configure the second level cache through the configuration setting
 ``TYPO3.Flow.persistence.doctrine.secondLevelCache``.
 
 *Example: Configuration for Doctrine second level cache*:

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
@@ -578,15 +578,15 @@ Flow allows you can enable and configure the second level cache through the conf
 
 .. code-block:: yaml
 
-	TYPO3:
-	  Flow:
-	    persistence:
-	      doctrine:
-	        secondLevelCache:
-	          enable: true
-	          defaultLifetime: 3600
-	          regions:
-	            'my_entity_region': 7200
+  TYPO3:
+    Flow:
+      persistence:
+        doctrine:
+          secondLevelCache:
+            enable: true
+            defaultLifetime: 3600
+            regions:
+              'my_entity_region': 7200
 
 .. [#doctrineSecondLevelCache] http://docs.doctrine-project.org/en/latest/reference/second-level-cache.html
 

--- a/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.persistence.schema.yaml
+++ b/TYPO3.Flow/Resources/Private/Schema/Settings/TYPO3.Flow.persistence.schema.yaml
@@ -91,6 +91,18 @@ properties:
             type: dictionary
             patternProperties: { '/^[A-Za-z0-9_]+$/': { type: string, format: class-name } }
             additionalProperties: FALSE
+      'secondLevelCache':
+        type: dictionary
+        required: FALSE
+        additionalProperties: FALSE
+        properties:
+          'enabled': { type: boolean }
+          'defaultLifetime': { type: number }
+          'defaultLockLifetime': { type: number }
+          'regions':
+            type: dictionary
+            required: FALSE
+            patternProperties: { '/.*/': { type: number } }
       'dbal':
         type: dictionary
         required: FALSE


### PR DESCRIPTION
This change introduces the configuration settings `TYPO3.Flow.persistence.doctrine.secondLevelCache`
which allows configuring the second level cache that is available since Doctrine ORM 2.5
Currently, this allows for enabling the second level cache, setting default lifetime and region specific
lifetimes.
The used cache can be configured as `Flow_Persistence_Doctrine_SecondLevel`.
