### PR TITLE
BUGFIX: Configured scope for interfaces is not overwritten

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
@@ -142,7 +142,7 @@ class ConfigurationBuilder
 
         // If an implementation class could be determined for an interface object configuration, set the scope for the
         // interface object configuration to the scope found in the implementation class configuration, but
-        // only if the interface doesn't have a specifically configured scope (eg. is prototype so far)
+        // only if the interface doesn't have a specifically configured scope (i.e. is prototype so far)
         foreach (array_keys($interfaceNames) as $interfaceName) {
             $implementationClassName = $objectConfigurations[$interfaceName]->getClassName();
             if ($implementationClassName !== '' && isset($objectConfigurations[$implementationClassName]) && $objectConfigurations[$interfaceName]->getScope() === Configuration::SCOPE_PROTOTYPE) {

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
@@ -141,10 +141,11 @@ class ConfigurationBuilder
         }
 
         // If an implementation class could be determined for an interface object configuration, set the scope for the
-        // interface object configuration to the scope found in the implementation class configuration:
+        // interface object configuration to the scope found in the implementation class configuration, but
+        // only if the interface doesn't have a specifically configured scope (eg. is prototype so far)
         foreach (array_keys($interfaceNames) as $interfaceName) {
             $implementationClassName = $objectConfigurations[$interfaceName]->getClassName();
-            if ($implementationClassName !== '' && isset($objectConfigurations[$implementationClassName])) {
+            if ($implementationClassName !== '' && isset($objectConfigurations[$implementationClassName]) && $objectConfigurations[$interfaceName]->getScope() === Configuration::SCOPE_PROTOTYPE) {
                 $objectConfigurations[$interfaceName]->setScope($objectConfigurations[$implementationClassName]->getScope());
             }
         }


### PR DESCRIPTION
Currently the behaviour of a `Scope` annotation on an interface depends
on the amount of implementations. If there are multiple implementations
for the interface, then the configured interface scope is used all the time.
When there is only a single implementation, then that implementation will
override the configured interface scope.

This breaks for example in case of the `SystemLoggerInterface`. This
interface is marked singleton but the implementation is not because it is
reused for other loggers. The expected result is that the configured scope
of the interface is kept.

This change adjusts the behaviour and makes sure the `Scope` defined in
an interface is always respected.