### PR TITLE
BUGFIX: Do not throw exception when concurrently unlinking files

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Files.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Files.php
@@ -364,9 +364,10 @@ class Files
     /**
      * A version of unlink() that works on Windows regardless on the symlink type (file/directory).
      *
-     * If this method could not unlink the specified file, it will clear the stat cache for its filename and check if
-     * the file still exist. If it does not exist, this method assumes that the file has been deleted by another process
-     * and will return TRUE. If the file still exists though, this method will return FALSE.
+     * If this method could not unlink the specified file or it doesn't exist anymore (e.g. because of a concurrent
+     * deletion), it will clear the stat cache for its filename and check if the file still exist. If it does not exist,
+     * this method assumes that the file has been deleted by another process and will return TRUE. If the file still
+     * exists though, this method will return FALSE.
      *
      * @param string $pathAndFilename Path and name of the file or directory
      * @return boolean TRUE if file/directory was removed successfully

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Files.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Files.php
@@ -377,7 +377,11 @@ class Files
         try {
             // if not on Windows, call PHPs own unlink() function
             if (DIRECTORY_SEPARATOR === '/' || is_file($pathAndFilename)) {
-                return @\unlink($pathAndFilename);
+                if (!@\unlink($pathAndFilename)) {
+                    clearstatcache();
+                    return !file_exists($pathAndFilename);
+                }
+                return true;
             }
         } catch (\Exception $exception) {
             clearstatcache();

--- a/TYPO3.Flow/Tests/Unit/Utility/FilesTest.php
+++ b/TYPO3.Flow/Tests/Unit/Utility/FilesTest.php
@@ -377,9 +377,9 @@ class FilesTest extends UnitTestCase
      * @outputBuffering enabled
      *     ... because the chmod call in ResourceManager emits a warning making this fail in strict mode
      */
-    public function unlinkReturnsFalseIfSpecifiedPathDoesNotExist()
+    public function unlinkReturnsTrueIfSpecifiedPathDoesNotExist()
     {
-        $this->assertFalse(Files::unlink('NonExistingPath'));
+        $this->assertTrue(Files::unlink('NonExistingPath'));
     }
 
     /**


### PR DESCRIPTION
Fixes a race condition where concurrent emptying of a directory causes
errors because files were already unlinked by another process.

FLOW-283 #close
FLOW-345 #close
