### PR TITLE
FEATURE: Add String.pregSplit Eel helper

### DIFF
--- a/TYPO3.Eel/Classes/TYPO3/Eel/Helper/StringHelper.php
+++ b/TYPO3.Eel/Classes/TYPO3/Eel/Helper/StringHelper.php
@@ -207,6 +207,24 @@ class StringHelper implements ProtectedContextAwareInterface
     }
 
     /**
+     * Split a string by a separator using regular expression matching (PREG style)
+     *
+     * Examples::
+     *
+     *     String.pregSplit("foo bar   baz", "/\s+/") == ['foo', 'bar', 'baz']
+     *     String.pregSplit("first second third", "/\s+/", 2) == ['first', 'second third']
+     *
+     * @param string $string The input string
+     * @param string $pattern A PREG pattern
+     * @param integer $limit The maximum amount of items to return, in contrast to split() this will return all remaining characters in the last item (see example)
+     * @return array An array of the splitted parts, excluding the matched pattern
+     */
+    public function pregSplit($string, $pattern, $limit = null)
+    {
+        return preg_split($pattern, $string, $limit);
+    }
+
+    /**
      * Replace occurrences of a search string inside the string
      *
      * Note: this method does not perform regular expression matching, @see pregReplace().

--- a/TYPO3.Eel/Tests/Unit/Helper/StringHelperTest.php
+++ b/TYPO3.Eel/Tests/Unit/Helper/StringHelperTest.php
@@ -198,6 +198,25 @@ class StringHelperTest extends \TYPO3\Flow\Tests\UnitTestCase
         $this->assertSame($expected, $result);
     }
 
+    public function pregSplitExamples()
+    {
+        return array(
+            'matches' => array('foo bar   baz', '/\s+/', null, array('foo', 'bar', 'baz')),
+            'matches with limit' => array('first second third', '/\s+/', 2, array('first', 'second third'))
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider pregSplitExamples
+     */
+    public function pregMSplitWorks($string, $pattern, $limit, $expected)
+    {
+        $helper = new StringHelper();
+        $result = $helper->pregSplit($string, $pattern, $limit);
+        $this->assertSame($expected, $result);
+    }
+
     public function replaceExamples()
     {
         return array(


### PR DESCRIPTION
Adds a new helper method to the string helper for splitting strings with
a PREG pattern.

Example::

    String.pregSplit("foo bar   baz", "/\s+/") == ['foo', 'bar', 'baz']