### PR TITLE
BUGFIX: TypedArrayConverter correctly returns array in all cases

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/TypedArrayConverter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/TypedArrayConverter.php
@@ -76,7 +76,7 @@ class TypedArrayConverter extends AbstractTypeConverter
      */
     public function getSourceChildPropertiesToBeConverted($source)
     {
-        return $source;
+        return is_array($source) ? $source : [];
     }
 
     /**

--- a/TYPO3.Flow/Tests/Unit/Property/TypeConverter/TypedArrayConverterTest.php
+++ b/TYPO3.Flow/Tests/Unit/Property/TypeConverter/TypedArrayConverterTest.php
@@ -68,4 +68,12 @@ class TypedArrayConverterTest extends UnitTestCase
             $this->assertFalse($actualResult);
         }
     }
+
+    /**
+     * @test
+     */
+    public function getSourceChildPropertiesToBeConvertedShouldReturnEmptyArray()
+    {
+        $this->assertEquals([], $this->converter->getSourceChildPropertiesToBeConverted(''));
+    }
 }


### PR DESCRIPTION
In some cases the TypedArrayConverter::getSourceChildPropertiesToBeConverted() was not returning an array.

It is somewhat related to https://github.com/neos/neos-development-collection/pull/102 change in Neos 2.3. PropertyMapper is now used for handling all node properties and it calls `getSourceChildPropertiesToBeConverted()` method and supplies its result to `foreach()`, which could result in nasty `Warning: Invalid argument supplied for foreach()`.