### PR TITLE
BUGFIX: Port is set correctly when Trusted Proxy only sends protocol override

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Component/TrustedProxiesComponent.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Component/TrustedProxiesComponent.php
@@ -58,7 +58,7 @@ class TrustedProxiesComponent implements ComponentInterface
         if ($portHeader !== null) {
             $trustedRequest->getUri()->setPort($portHeader);
         } elseif ($protocolHeader !== null) {
-            $trustedRequest->getUri()->setPort($protocolHeader === 'https' ? 443 : 80);
+            $trustedRequest->getUri()->setPort(strtolower($protocolHeader) === 'https' ? 443 : 80);
         }
 
         $componentContext->replaceHttpRequest($trustedRequest);

--- a/TYPO3.Flow/Tests/Unit/Http/Component/TrustedProxiesComponentTest.php
+++ b/TYPO3.Flow/Tests/Unit/Http/Component/TrustedProxiesComponentTest.php
@@ -440,6 +440,12 @@ class TrustedProxiesComponentTest extends UnitTestCase
                 'requestUri' => 'https://acme.com',
                 'expectedUri' => 'https://acme.com:80',
             ),
+            array(
+                'forwardedProtocol' => 'HTTPS',
+                'forwardedPort' => null,
+                'requestUri' => 'http://acme.com',
+                'expectedUri' => 'https://acme.com',
+            ),
         );
     }
 


### PR DESCRIPTION
Before the port of the request URI was not set correctly if the Trusted Proxy would 
send an `X-Forwarded-Proto: HTTPS` header without also specifying a forwarded port.
This resulted in generated URLs like "https://acme.com:80".

The change fixes that by doing a case insensitive check for the protocol to be
'https' and set port 443 accordingly.