### PR TITLE
BUGFIX: Http RequestHandler returns correct instance of Request and Response

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Component/ComponentContext.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Component/ComponentContext.php
@@ -21,7 +21,10 @@ use TYPO3\Flow\Http\Response;
  * An instance of this class will be passed to each component of the chain allowing them to read/write parameters to/from it.
  * Besides handling of the chain is interrupted as soon as the "cancelled" flag is set.
  *
+ * The instance will be created before the bootstrap, so AOP/DI proxying is not possible.
+ *
  * @api
+ * @Flow\Proxy(false)
  */
 class ComponentContext
 {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/RequestHandler.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/RequestHandler.php
@@ -46,6 +46,11 @@ class RequestHandler implements HttpRequestHandlerInterface
     protected $baseComponentChain;
 
     /**
+     * @var Component\ComponentContext
+     */
+    protected $componentContext;
+
+    /**
      * The "http" settings
      *
      * @var array
@@ -111,8 +116,8 @@ class RequestHandler implements HttpRequestHandlerInterface
             $this->request->setBaseUri(new Uri($this->settings['http']['baseUri']));
         }
 
-        $componentContext = new ComponentContext($this->request, $this->response);
-        $this->baseComponentChain->handle($componentContext);
+        $this->componentContext = new ComponentContext($this->request, $this->response);
+        $this->baseComponentChain->handle($this->componentContext);
         $this->response = $this->baseComponentChain->getResponse();
 
         $this->response->send();
@@ -129,7 +134,7 @@ class RequestHandler implements HttpRequestHandlerInterface
      */
     public function getHttpRequest()
     {
-        return $this->request;
+        return $this->componentContext->getHttpRequest();
     }
 
     /**
@@ -140,7 +145,7 @@ class RequestHandler implements HttpRequestHandlerInterface
      */
     public function getHttpResponse()
     {
-        return $this->response;
+        return $this->componentContext->getHttpResponse();
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/RequestHandler.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/RequestHandler.php
@@ -108,6 +108,7 @@ class RequestHandler implements HttpRequestHandlerInterface
         // Create the request very early so the Resource Management has a chance to grab it:
         $this->request = Request::createFromEnvironment();
         $this->response = new Response();
+        $this->componentContext = new ComponentContext($this->request, $this->response);
 
         $this->boot();
         $this->resolveDependencies();
@@ -116,7 +117,6 @@ class RequestHandler implements HttpRequestHandlerInterface
             $this->request->setBaseUri(new Uri($this->settings['http']['baseUri']));
         }
 
-        $this->componentContext = new ComponentContext($this->request, $this->response);
         $this->baseComponentChain->handle($this->componentContext);
         $this->response = $this->baseComponentChain->getResponse();
 


### PR DESCRIPTION
Before the Http RequestHandler would always return the initial instance of the `Request` and `Response`
before the ComponentChain.
Since the ComponentChain is supposed to possibly replace the Request and Response instances, this
lead to cases where retrieving the current Request from the RequestHandler would not match the actual
Request that is in place inside the MVC Controller for example.

This change fixes that by always delegating the request and response getters to the ComponentContext.

Also, this change fixes a regression introduced with 3.3 when generating URLs behind a https offload proxy. The UriBuilder was using the untouched Request instance ending up with generating URLs like `https://acme.com:80`.