### PR TITLE
BUGFIX: Temporary files are correctly moved across volumes

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Storage/WritableFileSystemStorage.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Storage/WritableFileSystemStorage.php
@@ -162,10 +162,10 @@ class WritableFileSystemStorage extends FileSystemStorage implements WritableSto
         if (!file_exists(dirname($finalTargetPathAndFilename))) {
             Files::createDirectoryRecursively(dirname($finalTargetPathAndFilename));
         }
-        if (rename($temporaryFile, $finalTargetPathAndFilename) === false) {
-            unlink($temporaryFile);
+        if (copy($temporaryFile, $finalTargetPathAndFilename) === false) {
             throw new StorageException(sprintf('The temporary file of the file import could not be moved to the final target "%s".', $finalTargetPathAndFilename), 1381156103);
         }
+        unlink($temporaryFile);
 
         $this->fixFilePermissions($finalTargetPathAndFilename);
     }


### PR DESCRIPTION
PHP throws a operation not permitted warning when using rename across
volumes, which happens e.g. if you have FLOW_PATH_TEMPORARY_BASE pointing
to a different (more performant) volume.

From the php documentation:
> More explicitly, rename() may still return (bool) true, despite the warnings that result from the underlying calls to chown() or chmod(). This behavior can be misleading absent a deeper understanding of the underlying mechanics. To rename across filesystems, PHP "fakes it" by calling copy(), unlink(), chown(), and chmod() (not necessarily in that order). See PHP bug #50676 for more information.

> On UNIX-like operating systems, filesystems may be mounted with an explicit uid and/or gid (for example, with mount options "uid=someuser,gid=somegroup"). Attempting to call rename() with such a destination filesystem will cause an "Operation not permitted" warning, even though the file is indeed renamed and rename() returns (bool) true.