### PR TITLE
BUGFIX: Prevent nesting level too deep error in checkbox view helper

### DIFF
--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Form/CheckboxViewHelper.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/ViewHelpers/Form/CheckboxViewHelper.php
@@ -89,7 +89,7 @@ class CheckboxViewHelper extends AbstractFormFieldViewHelper
         }
         if (is_array($propertyValue)) {
             if ($checked === null) {
-                $checked = in_array($valueAttribute, $propertyValue);
+                $checked = in_array($valueAttribute, $propertyValue, true);
             }
             $this->arguments['multiple'] = true;
         } elseif (!$multiple && $propertyValue !== null) {


### PR DESCRIPTION
To prevent a recursive comparison which can lead to this error, strict comparison is used which only compares the reference.