### PR TITLE
BUGFIX: ObjectAccess supports property bag implementation classes

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ObjectAccess.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ObjectAccess.php
@@ -286,13 +286,13 @@ class ObjectAccess
         if (!isset(self::$gettablePropertyNamesCache[$className])) {
             foreach (get_class_methods($object) as $methodName) {
                 if (is_callable([$object, $methodName])) {
-                    if (substr($methodName, 0, 2) === 'is') {
+                    if (substr($methodName, 0, 2) === 'is' && strlen($methodName) > 2) {
                         $declaredPropertyNames[] = lcfirst(substr($methodName, 2));
                     }
-                    if (substr($methodName, 0, 3) === 'get') {
+                    if (substr($methodName, 0, 3) === 'get' && strlen($methodName) > 3) {
                         $declaredPropertyNames[] = lcfirst(substr($methodName, 3));
                     }
-                    if (substr($methodName, 0, 3) === 'has') {
+                    if (substr($methodName, 0, 3) === 'has' && strlen($methodName) > 3) {
                         $declaredPropertyNames[] = lcfirst(substr($methodName, 3));
                     }
                 }
@@ -329,7 +329,7 @@ class ObjectAccess
         }
 
         foreach (get_class_methods($object) as $methodName) {
-            if (substr($methodName, 0, 3) === 'set' && is_callable([$object, $methodName])) {
+            if (substr($methodName, 0, 3) === 'set' && strlen($methodName) > 3 && is_callable([$object, $methodName])) {
                 $declaredPropertyNames[] = lcfirst(substr($methodName, 3));
             }
         }

--- a/TYPO3.Flow/Tests/Unit/Reflection/Fixture/DummyClassWithGettersAndSetters.php
+++ b/TYPO3.Flow/Tests/Unit/Reflection/Fixture/DummyClassWithGettersAndSetters.php
@@ -30,6 +30,8 @@ class DummyClassWithGettersAndSetters
     public $publicProperty;
     public $publicProperty2 = 42;
 
+    protected $propertyBag = [];
+
     public function setProperty($property)
     {
         $this->property = $property;
@@ -91,5 +93,20 @@ class DummyClassWithGettersAndSetters
 
     public function setWriteOnlyMagicProperty($value)
     {
+    }
+
+    public function has($property)
+    {
+        return isset($this->propertyBag[$property]);
+    }
+
+    public function get($property)
+    {
+        return isset($this->propertyBag[$property]) ? $this->propertyBag[$property] : null;
+    }
+
+    public function set($property, $value)
+    {
+        $this->propertyBag[$property] = $value;
     }
 }


### PR DESCRIPTION
Before any class that would implement any of the methods `get()`, `has()`, `set()` or `is()` would make
ObjectAccess fail when attempting to get/set empty propertyNames. Those methods are commonly
used when implementing the propertyBag pattern.

This change fixes that by making sure that the accessor methods are actually longer than the plain prefixes.