### PR TITLE
TASK: Update Installation Doc

### DIFF
--- a/TYPO3.Flow/Documentation/Quickstart/index.rst
+++ b/TYPO3.Flow/Documentation/Quickstart/index.rst
@@ -106,7 +106,7 @@ group. On a Linux machine this can be done by typing:
 
 *command line*::
 
-    sudo usermod -a -G _www john
+    sudo usermod -a -G www-data john
 
 On a Mac you can add a user to the web group with the following command:
 
@@ -425,7 +425,7 @@ can you imagine what they do? ::
 
     use Acme\Demo\Domain\Model\CoffeeBean;
     use Acme\Demo\Domain\Repository\CoffeeBeanRepository;
-    
+
     class CoffeeBeanController extends ActionController {
 
         /**

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/Installation.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/Installation.rst
@@ -96,7 +96,7 @@ be done by typing:
 
 .. code-block:: none
 
-	sudo usermod -a -G _www john
+	sudo usermod -a -G www-data john
 
 On a Mac you can add a user to the web group with the following command:
 


### PR DESCRIPTION
Changing the web group name in the instructions on linux from the mac web group name to a more common linux one.