### PR TITLE
BUGFIX: Doctrine DataTypes should not be proxied

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/DataTypes/JsonArrayType.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/DataTypes/JsonArrayType.php
@@ -2,7 +2,6 @@
 namespace TYPO3\Flow\Persistence\Doctrine\DataTypes;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Types;
 use Doctrine\DBAL\Types\JsonArrayType as DoctrineJsonArrayType;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Core\Bootstrap;
@@ -14,7 +13,9 @@ use TYPO3\Flow\Utility\TypeHandling;
 /**
  * Extends the default doctrine JsonArrayType to work with entities.
  *
- * TOOD: If doctrine supports a Postgres 9.4 platform we could default to jsonb.
+ * TODO: If doctrine supports a Postgres 9.4 platform we could default to jsonb.
+ *
+ * @Flow\Proxy(false)
  */
 class JsonArrayType extends DoctrineJsonArrayType
 {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/DataTypes/ObjectArray.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/DataTypes/ObjectArray.php
@@ -13,6 +13,8 @@ use TYPO3\Flow\Utility\TypeHandling;
 /**
  * A datatype that replaces references to entities in arrays with a type/identifier tuple
  * and strips singletons from the data to be stored.
+ *
+ * @Flow\Proxy(false)
  */
 class ObjectArray extends Types\ArrayType
 {


### PR DESCRIPTION
Since 3.3 the doctrine types often ended up being proxied, due to a change in proxy generation
on aspected parent classes. This would throw an exception because the DBAL\Types base classes
constructor is private and hence cannot be called from the proxied constructor.

This works around that issue by making sure the custom DBAL Types are not proxied.

Fixes #516