### PR TITLE
BUGFIX: Check for existing symlink in createDirectoryRecursively()

### DIFF
--- a/Neos.Utility.Files/Classes/TYPO3/Flow/Utility/Files.php
+++ b/Neos.Utility.Files/Classes/TYPO3/Flow/Utility/Files.php
@@ -246,7 +246,7 @@ abstract class Files
         if (is_file($path)) {
             throw new Exception('Could not create directory "' . $path . '", because a file with that name exists!', 1349340620);
         }
-        if (!is_dir($path) && $path !== '') {
+        if (!is_link($path) && !is_dir($path) && $path !== '') {
             $oldMask = umask(000);
             mkdir($path, 0777, true);
             umask($oldMask);


### PR DESCRIPTION
The `createDirectoryRecursively()` method now checks for an existing symlink before
trying to create a directory. Before it only checked for an existing directory, sometimes
leading to false negatives.

Fixes #647
