### PR TITLE
TASK: Turn fq class names to use statements in kickstart templates

### DIFF
--- a/TYPO3.Kickstart/Resources/Private/Generator/Controller/ActionControllerTemplate.php.tmpl
+++ b/TYPO3.Kickstart/Resources/Private/Generator/Controller/ActionControllerTemplate.php.tmpl
@@ -6,8 +6,9 @@ namespace {packageNamespace}<f:if condition="{isInSubpackage}">\{subpackage}</f:
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Mvc\Controller\ActionController;
 
-class {controllerClassName} extends \TYPO3\Flow\Mvc\Controller\ActionController
+class {controllerClassName} extends ActionController
 {
 
     /**

--- a/TYPO3.Kickstart/Resources/Private/Generator/Controller/CommandControllerTemplate.php.tmpl
+++ b/TYPO3.Kickstart/Resources/Private/Generator/Controller/CommandControllerTemplate.php.tmpl
@@ -6,11 +6,12 @@ namespace {packageNamespace}\Command;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Cli\CommandController;
 
 /**
  * @Flow\Scope("singleton")
  */
-class {controllerClassName} extends \TYPO3\Flow\Cli\CommandController
+class {controllerClassName} extends CommandController
 {
 
     /**
@@ -27,7 +28,7 @@ class {controllerClassName} extends \TYPO3\Flow\Cli\CommandController
      * @param string $optionalArgument This argument is optional
      * @return void
      */
-    public function exampleCommand($requiredArgument, $optionalArgument = NULL)
+    public function exampleCommand($requiredArgument, $optionalArgument = null)
     {
         $this->outputLine('You called the example command and passed "%s" as the first argument.', array($requiredArgument));
     }


### PR DESCRIPTION
Hi there,

This PR is just to make the kickstart code generators more in tune with the usage of fully qualified class names throughout the rest of the codebases of Neos and Flow.