### PR TITLE
FEATURE: Support allowable tags in ``stripTags`` Eel String helper

### DIFF
--- a/TYPO3.Eel/Classes/TYPO3/Eel/Helper/StringHelper.php
+++ b/TYPO3.Eel/Classes/TYPO3/Eel/Helper/StringHelper.php
@@ -370,11 +370,12 @@ class StringHelper implements ProtectedContextAwareInterface
      * This is a wrapper for the strip_tags() PHP function.
      *
      * @param string $string The string to strip
+     * @param string $allowableTags Specify tags which should not be stripped
      * @return string The string with tags stripped
      */
-    public function stripTags($string)
+    public function stripTags($string, $allowableTags = null)
     {
-        return strip_tags($string);
+        return strip_tags($string, $allowableTags);
     }
 
     /**

--- a/TYPO3.Eel/Tests/Unit/Helper/StringHelperTest.php
+++ b/TYPO3.Eel/Tests/Unit/Helper/StringHelperTest.php
@@ -435,7 +435,9 @@ class StringHelperTest extends \TYPO3\Flow\Tests\UnitTestCase
     public function stripTagsExamples()
     {
         return array(
-            'strip tags' => array('<a href="#">here</a>', 'here')
+            'strip tags' => array('<a href="#">here</a>', null, 'here'),
+            'strip tags with allowed tags' => array('<p><strong>important text</strong></p>', '<strong>', '<strong>important text</strong>'),
+            'strip tags with multiple allowed tags' => array('<div><p><strong>important text</strong></p></div>', '<strong>, <p>', '<p><strong>important text</strong></p>')
         );
     }
 
@@ -443,10 +445,10 @@ class StringHelperTest extends \TYPO3\Flow\Tests\UnitTestCase
      * @test
      * @dataProvider stripTagsExamples
      */
-    public function stripTagsWorks($string, $expected)
+    public function stripTagsWorks($string, $allowedTags, $expected)
     {
         $helper = new StringHelper();
-        $result = $helper->stripTags($string);
+        $result = $helper->stripTags($string, $allowedTags);
         $this->assertSame($expected, $result);
     }
 


### PR DESCRIPTION
Now the ``stripTags`` string eel helper will accept a second optional argument in form of a list of allowed tags which will not be stripped from the string.