### PR TITLE
TASK: Adjust documentation recommendations to ComponentChain

### DIFF
--- a/TYPO3.Flow/Configuration/Objects.yaml
+++ b/TYPO3.Flow/Configuration/Objects.yaml
@@ -164,9 +164,6 @@ TYPO3\Flow\Http\Component\ComponentChain:
     1:
       setting: TYPO3.Flow.http.chain
 
-TYPO3\Flow\Http\HttpRequestHandlerInterface:
-  className: TYPO3\Flow\Http\RequestHandler
-
 #                                                                          #
 # MVC                                                                      #
 #                                                                          #

--- a/TYPO3.Flow/Configuration/Objects.yaml
+++ b/TYPO3.Flow/Configuration/Objects.yaml
@@ -164,6 +164,9 @@ TYPO3\Flow\Http\Component\ComponentChain:
     1:
       setting: TYPO3.Flow.http.chain
 
+TYPO3\Flow\Http\HttpRequestHandlerInterface:
+  className: TYPO3\Flow\Http\RequestHandler
+
 #                                                                          #
 # MVC                                                                      #
 #                                                                          #

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
@@ -252,8 +252,11 @@ Such a request is always bound to an ``Http\Request``::
 
 	...
 
-	$httpRequest = $this->bootstrap->getActiveRequestHandler()->getHttpRequest();
-	$actionRequest = new ActionRequest($httpRequest);
+  $requestHandler = $this->bootstrap->getActiveRequestHandler();
+  if ($requestHandler instanceof HttpRequestHandlerInterface) {
+    $actionRequest = new ActionRequest($requestHandler->getHttpRequest());
+    // ...
+  }
 
 Arguments
 ~~~~~~~~~

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
@@ -212,6 +212,16 @@ You can, in theory, create a new ``Request`` instance by simply using the ``new`
 arguments to the constructor. However, there are two static factory methods which make life much easier. We recommend
 using these instead of the low-level constructor method.
 
+.. warning::
+
+	You should only create a ``Request`` manually if you want to send out requests or if you know exactly what you are
+	doing. Creating a new ``Request`` will completely bypass all ``HTTP Components`` and might therefore lead to
+	unexpected results, like the trusted proxy headers ``X-Forwarded-*`` not being applied and the ``Request`` providing
+	wrong protocol, host or client IP address.
+	If you need access to the **current** HTTP ``Request`` or ``Response``, instead inject a ``HttpRequestHandlerInterface`` and
+	get the ``Request`` and ``Response`` from there. Alternatively, you can also get the active ``RequestHandler`` from the
+	``Bootstrap``.
+
 create()
 ~~~~~~~~
 
@@ -226,6 +236,8 @@ The second method, ``createFromEnvironment()``, take the environment provided by
 functions into account. It creates a ``Request`` instance which reflects the current HTTP request received from the web
 server. This method is best used if you need a ``Request`` object with all properties set according to the current
 server environment and incoming HTTP request.
+Note though, that you should not expect this ``Request`` to match the current ``Request``, since the latter will still
+have been affected by some ``HTTP Components``. If you need the **current** Request, get it from the ``RequestHandler`` instead.
 
 Creating an ActionRequest
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -233,7 +245,15 @@ Creating an ActionRequest
 In order to dispatch a request to a controller, you need an ``ActionRequest``.
 Such a request is always bound to an ``Http\Request``::
 
-	$httpRequest = Request::createFromEnvironment();
+	/**
+	 * @var HttpRequestHandlerInterface
+	 * @Flow\Inject
+	 */
+	protected $requestHandler;
+
+	...
+
+	$httpRequest = $this->requestHandler->getHttpRequest();
 	$actionRequest = new ActionRequest($httpRequest);
 
 Arguments

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
@@ -215,12 +215,11 @@ using these instead of the low-level constructor method.
 .. warning::
 
 	You should only create a ``Request`` manually if you want to send out requests or if you know exactly what you are
-	doing. Creating a new ``Request`` will completely bypass all ``HTTP Components`` and might therefore lead to
+	doing. The created ``Request`` will not have any ``HTTP Components`` affect him and might therefore lead to
 	unexpected results, like the trusted proxy headers ``X-Forwarded-*`` not being applied and the ``Request`` providing
 	wrong protocol, host or client IP address.
-	If you need access to the **current** HTTP ``Request`` or ``Response``, instead inject a ``HttpRequestHandlerInterface`` and
-	get the ``Request`` and ``Response`` from there. Alternatively, you can also get the active ``RequestHandler`` from the
-	``Bootstrap``.
+	If you need access to the **current** HTTP ``Request`` or ``Response``, instead inject the ``Bootstrap`` and
+	get the ``HttpRequest`` and ``HttpResponse`` through the ``getActiveRequestHandler()``.
 
 create()
 ~~~~~~~~
@@ -246,14 +245,14 @@ In order to dispatch a request to a controller, you need an ``ActionRequest``.
 Such a request is always bound to an ``Http\Request``::
 
 	/**
-	 * @var HttpRequestHandlerInterface
+	 * @var Bootstrap
 	 * @Flow\Inject
 	 */
-	protected $requestHandler;
+	protected $bootstrap;
 
 	...
 
-	$httpRequest = $this->requestHandler->getHttpRequest();
+	$httpRequest = $this->bootstrap->getActiveRequestHandler()->getHttpRequest();
 	$actionRequest = new ActionRequest($httpRequest);
 
 Arguments

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
@@ -244,9 +244,9 @@ Creating an ActionRequest
 In order to dispatch a request to a controller, you need an ``ActionRequest``.
 Such a request is always bound to an ``Http\Request``::
 
-    use Neos\Flow\Core\Bootstrap;
-    use Neos\Flow\Http\HttpRequestHandlerInterface;
-    use Neos\Flow\Mvc\ActionRequest;
+    use TYPO3\Flow\Core\Bootstrap;
+    use TYPO3\Flow\Http\HttpRequestHandlerInterface;
+    use TYPO3\Flow\Mvc\ActionRequest;
 
     // ...
 

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
@@ -244,19 +244,25 @@ Creating an ActionRequest
 In order to dispatch a request to a controller, you need an ``ActionRequest``.
 Such a request is always bound to an ``Http\Request``::
 
-	/**
-	 * @var Bootstrap
-	 * @Flow\Inject
-	 */
-	protected $bootstrap;
+    use Neos\Flow\Core\Bootstrap;
+    use Neos\Flow\Http\HttpRequestHandlerInterface;
+    use Neos\Flow\Mvc\ActionRequest;
 
-	...
-
-  $requestHandler = $this->bootstrap->getActiveRequestHandler();
-  if ($requestHandler instanceof HttpRequestHandlerInterface) {
-    $actionRequest = new ActionRequest($requestHandler->getHttpRequest());
     // ...
-  }
+
+    /**
+     * @var Bootstrap
+     * @Flow\Inject
+     */
+    protected $bootstrap;
+
+    // ...
+
+    $requestHandler = $this->bootstrap->getActiveRequestHandler();
+    if ($requestHandler instanceof HttpRequestHandlerInterface) {
+        $actionRequest = new ActionRequest($requestHandler->getHttpRequest());
+        // ...
+    }
 
 Arguments
 ~~~~~~~~~


### PR DESCRIPTION
The documentation still recommended to create Requests through the `createFromEnvironment`
factory method, but that completely bypasses the HTTP components and hence leads to unexpected
results.
This change adjusts documentation and clearly states, that the factory method should not be used
to access the **current** request and response. Instead it is suggested to use the `RequestHandler`
for that purpose only.
