### PR TITLE
FEATURE: Support for protected static compiled methods

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
@@ -671,6 +671,7 @@ class ReflectionService
      *
      * @param string $annotationClassName The annotation class name for a method annotation
      * @return array An array of class names
+     * @api
      */
     public function getClassesContainingMethodsAnnotatedWith($annotationClassName)
     {
@@ -679,6 +680,22 @@ class ReflectionService
         }
 
         return isset($this->classesByMethodAnnotations[$annotationClassName]) ? array_keys($this->classesByMethodAnnotations[$annotationClassName]) : [];
+    }
+
+    /**
+     * Returns all names of methods of the given class that are annotated with the given annotation class
+     *
+     * @param string $className Name of the class containing the method(s)
+     * @param string $annotationClassName The annotation class name for a method annotation
+     * @return array An array of method names
+     * @api
+     */
+    public function getMethodsAnnotatedWith($className, $annotationClassName)
+    {
+        if (!$this->initialized) {
+            $this->initialize();
+        }
+        return isset($this->classesByMethodAnnotations[$annotationClassName][$className]) ? $this->classesByMethodAnnotations[$annotationClassName][$className] : [];
     }
 
     /**
@@ -1380,7 +1397,11 @@ class ReflectionService
         $this->classReflectionData[$className][self::DATA_CLASS_METHODS][$methodName][self::DATA_METHOD_VISIBILITY] = $visibility;
 
         foreach ($this->getMethodAnnotations($className, $methodName) as $methodAnnotation) {
-            $this->classesByMethodAnnotations[get_class($methodAnnotation)][$className] = $methodName;
+            $annotationClassName = get_class($methodAnnotation);
+            if (!isset($this->classesByMethodAnnotations[$annotationClassName][$className])) {
+                $this->classesByMethodAnnotations[$annotationClassName][$className] = [];
+            }
+            $this->classesByMethodAnnotations[$annotationClassName][$className][] = $methodName;
         }
 
         $returnType = $method->getDeclaredReturnType();

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/ObjectManagement.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/ObjectManagement.rst
@@ -1321,7 +1321,7 @@ and so on, the performance in production context can be improved::
 	 * @return array Array of method parameters by action name
 	 * @Flow\CompileStatic
 	 */
-	static public function getActionMethodParameters($objectManager) {
+	static protected function getActionMethodParameters($objectManager) {
 		$reflectionService = $objectManager->get('TYPO3\Flow\Reflection\ReflectionService');
 		$className = get_called_class();
 		$methodParameters = $reflectionService->getMethodParameters($className, get_class_methods($className));


### PR DESCRIPTION
With this change static methods annotated `@Flow\CompileStatic` can now
be `protected` allowing for more concise public APIs.

If the annotated method is `private` or not `static` an exception is
thrown during compile time in `Production` context.

As a side-effect this change adds a new API method `ReflectionService:: getMethodsAnnotatedWith()`
that allows for retrieval of all method names of a class that are annotated with a
given annotation.

Related: #662