### PR TITLE
FEATURE: Add positional array sorting to ``*RootPaths``  in Views.yaml

### DIFF
--- a/TYPO3.Fluid/Classes/TYPO3/Fluid/View/TemplateView.php
+++ b/TYPO3.Fluid/Classes/TYPO3/Fluid/View/TemplateView.php
@@ -13,6 +13,7 @@ namespace TYPO3\Fluid\View;
 
 use TYPO3\Flow\Mvc\Controller\ControllerContext;
 use TYPO3\Flow\Utility\Files;
+use TYPO3\Flow\Utility\PositionalArraySorter;
 
 /**
  * The main template view. Should be used as view if you want Fluid Templating
@@ -101,7 +102,7 @@ class TemplateView extends AbstractTemplateView
     public function getTemplateRootPaths()
     {
         if ($this->options['templateRootPaths'] !== null) {
-            return $this->options['templateRootPaths'];
+            return $this->applyArraySorting($this->options['templateRootPaths']);
         }
         /** @var $actionRequest \TYPO3\Flow\Mvc\ActionRequest */
         $actionRequest = $this->controllerContext->getRequest();
@@ -143,7 +144,7 @@ class TemplateView extends AbstractTemplateView
     protected function getPartialRootPaths()
     {
         if ($this->options['partialRootPaths'] !== null) {
-            return $this->options['partialRootPaths'];
+            return $this->applyArraySorting($this->options['partialRootPaths']);
         }
         /** @var $actionRequest \TYPO3\Flow\Mvc\ActionRequest */
         $actionRequest = $this->controllerContext->getRequest();
@@ -185,7 +186,7 @@ class TemplateView extends AbstractTemplateView
     protected function getLayoutRootPaths()
     {
         if ($this->options['layoutRootPaths'] !== null) {
-            return $this->options['layoutRootPaths'];
+            return $this->applyArraySorting($this->options['layoutRootPaths']);
         }
         /** @var $actionRequest \TYPO3\Flow\Mvc\ActionRequest */
         $actionRequest = $this->controllerContext->getRequest();
@@ -372,6 +373,23 @@ class TemplateView extends AbstractTemplateView
             }
         }
         throw new Exception\InvalidTemplateResourceException('The partial files "' . implode('", "', $paths) . '" could not be loaded.', 1225709595);
+    }
+
+    /**
+     * Apply positional array sorting to the given array and
+     *
+     * @param array $pathes
+     * @return array
+     */
+    protected function applyArraySorting($pathes)
+    {
+        $positionalArraySorter = new PositionalArraySorter($pathes);
+        return array_map(
+            function ($path) {
+                return (is_array($path) && array_key_exists('value', $path)) ? $path['value'] : $path;
+            },
+            $positionalArraySorter->toArray()
+        );
     }
 
     /**

--- a/TYPO3.Fluid/Tests/Unit/View/TemplateViewTest.php
+++ b/TYPO3.Fluid/Tests/Unit/View/TemplateViewTest.php
@@ -590,6 +590,32 @@ class TemplateViewTest extends UnitTestCase
     /**
      * @test
      */
+    public function getTemplateRootPathsReturnsPathesSortedByPosition()
+    {
+        $templateView = new TemplateView();
+
+        $templateRootPaths = [
+            'foo' => '/foo/bar',
+            'bar' => 'bar',
+            'baz' => ['value' => 'baz', 'position' => 'start'],
+            'bam' => ['value' => 'bam', 'position' => 'before bar']
+        ];
+        $templateView->setOption('templateRootPaths', $templateRootPaths);
+
+        $expectedResult = [
+            'baz' => 'baz',
+            'foo' => '/foo/bar',
+            'bam' => 'bam',
+            'bar' => 'bar'
+        ];
+
+        $actual = $templateView->getTemplateRootPaths();
+        $this->assertSame($expectedResult, $actual, 'The sorting was not applied correctly to template root pathes.');
+    }
+
+    /**
+     * @test
+     */
     public function getPartialRootPathsReturnsUserSpecifiedPartialPath()
     {
         $templateView = $this->getAccessibleMock(\TYPO3\Fluid\View\TemplateView::class, array('dummy'));
@@ -604,6 +630,32 @@ class TemplateViewTest extends UnitTestCase
     /**
      * @test
      */
+    public function getPartialRootPathsReturnsPathesSortedByPosition()
+    {
+        $templateView = $this->getAccessibleMock(\TYPO3\Fluid\View\TemplateView::class, array('dummy'));
+
+        $templateRootPaths = [
+            'foo' => '/foo/bar',
+            'bar' => 'bar' ,
+            'baz' => ['value' => 'baz', 'position' => 'start'],
+            'bam' => ['value' => 'bam', 'position' => 'before bar']
+        ];
+        $templateView->setOption('partialRootPaths', $templateRootPaths);
+
+        $expectedResult = [
+            'baz' => 'baz',
+            'foo' => '/foo/bar',
+            'bam' => 'bam',
+            'bar' => 'bar'
+        ];
+
+        $actual = $templateView->_call('getPartialRootPaths');
+        $this->assertSame($expectedResult, $actual, 'The sorting was not applied correctly to partial root pathes.');
+    }
+
+    /**
+     * @test
+     */
     public function getLayoutRootPathsReturnsUserSpecifiedPartialPaths()
     {
         $templateView = $this->getAccessibleMock(\TYPO3\Fluid\View\TemplateView::class, array('dummy'));
@@ -613,6 +665,58 @@ class TemplateViewTest extends UnitTestCase
 
         $actual = $templateView->_call('getLayoutRootPaths');
         $this->assertEquals($layoutRootPaths, $actual, 'A set layout root path was not returned correctly.');
+    }
+
+    /**
+     * @test
+     */
+    public function getLayoutRootPathsReturnsPathesSortedByPosition()
+    {
+        $templateView = $this->getAccessibleMock(\TYPO3\Fluid\View\TemplateView::class, array('dummy'));
+
+        $templateRootPaths = [
+            'foo' => '/foo/bar',
+            'bar' => 'bar' ,
+            'baz' => ['value' => 'baz', 'position' => 'start'],
+            'bam' => ['value' => 'bam', 'position' => 'before bar']
+        ];
+        $templateView->setOption('layoutRootPaths', $templateRootPaths);
+
+        $expectedResult = [
+            'baz' => 'baz',
+            'foo' => '/foo/bar',
+            'bam' => 'bam',
+            'bar' => 'bar'
+        ];
+
+        $actual = $templateView->_call('getLayoutRootPaths');
+        $this->assertSame($expectedResult, $actual, 'The sorting was not applied correctly to layout root pathes.');
+    }
+
+    /**
+     * @test
+     */
+    public function applyArraySorting()
+    {
+        $templateView = $this->getAccessibleMock(\TYPO3\Fluid\View\TemplateView::class, array('dummy'));
+
+        $array = [
+            'foo' => '/foo/bar',
+            'bar' => 'bar' ,
+            'baz' => ['value' => 'baz', 'position' => 'start'],
+            'bam' => ['value' => 'bam', 'position' => 'before bar']
+        ];
+
+        $expected = [
+            'baz' => 'baz',
+            'foo' => '/foo/bar',
+            'bam' => 'bam',
+            'bar' => 'bar'
+        ];
+
+        $actual = $templateView->_call('applyArraySorting', $array);
+
+        $this->assertSame($expected, $actual, 'The sorting was not applied correctly.');
     }
 
     /**


### PR DESCRIPTION
Add positional array sorting to `templateRootPaths`, `partialRootPaths` and `layoutRootPaths` in Views.yaml

The configurations of all patching requestFilters in Views.yaml are merged with the higher weighted filters applied last.  Since this process does not handle the order of the pathes the order in the resulting configuration can be a surprise. Especially keys added by higher weighted filters end up after the previously existing ones and thus are evaluated at last. This makes it hard to override a single templates by an external package.

This patch solves this by applying the positional array-sorter to those values while still supporting the old syntax. That way the order of the pathes can be controlled explicitly by the integrator.

Example:

```
-
  requestFilter: '...'
  options:
    templateRootPaths:
      'Vendor.Package':
        'position': 'before Vendor.OtherPackage'
        'value': 'resource://Vendor.Package/Private/Templates'
```
