### PR TITLE
TASK: Don’t list memcache as possible backend for Session handling

### DIFF
--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/SessionHandling.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/SessionHandling.rst
@@ -104,7 +104,7 @@ Session Backends
 
 The session implementation of Flow is written in pure PHP and uses the caching
 framework as its storage. This allows for storing session data in a variety of
-backends, including PDO databases, APC, Memcache and Redis.
+backends, including PDO databases, APC and Redis.
 
 The preferred storage backend for the built-in session is defined through a custom
 Caches.yaml file, placed in a package or the global configuration directory:


### PR DESCRIPTION
Since memcache backend does not implement the IterableBackendInterface it can not be used for session handling