### PR TITLE
FEATURE: Allow property mapping of DateTimeImmutables

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/DateTimeConverter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/DateTimeConverter.php
@@ -82,7 +82,7 @@ class DateTimeConverter extends AbstractTypeConverter
     /**
      * @var string
      */
-    protected $targetType = 'DateTime';
+    protected $targetType = \DateTimeInterface::class;
 
     /**
      * @var integer
@@ -117,7 +117,7 @@ class DateTimeConverter extends AbstractTypeConverter
      * @param string $targetType must be "DateTime"
      * @param array $convertedChildProperties not used currently
      * @param PropertyMappingConfigurationInterface $configuration
-     * @return \DateTime
+     * @return \DateTime|Error
      * @throws TypeConverterException
      */
     public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/StringConverter.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/TypeConverter/StringConverter.php
@@ -76,7 +76,7 @@ class StringConverter extends AbstractTypeConverter
     /**
      * @var array<string>
      */
-    protected $sourceTypes = ['string', 'integer', 'float', 'boolean', 'array', 'DateTime'];
+    protected $sourceTypes = ['string', 'integer', 'float', 'boolean', 'array', \DateTimeInterface::class];
 
     /**
      * @var string

--- a/TYPO3.Flow/Tests/Unit/Property/TypeConverter/DateTimeConverterTest.php
+++ b/TYPO3.Flow/Tests/Unit/Property/TypeConverter/DateTimeConverterTest.php
@@ -34,7 +34,7 @@ class DateTimeConverterTest extends \TYPO3\Flow\Tests\UnitTestCase
     public function checkMetadata()
     {
         $this->assertEquals(array('string', 'integer', 'array'), $this->converter->getSupportedSourceTypes(), 'Source types do not match');
-        $this->assertEquals('DateTime', $this->converter->getSupportedTargetType(), 'Target type does not match');
+        $this->assertEquals(\DateTimeInterface::class, $this->converter->getSupportedTargetType(), 'Target type does not match');
         $this->assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
     }
 
@@ -68,6 +68,14 @@ class DateTimeConverterTest extends \TYPO3\Flow\Tests\UnitTestCase
     /**
      * @test
      */
+    public function canConvertFromReturnsTrueITargetTypeIsADateTimeImmutable()
+    {
+        $this->assertTrue($this->converter->canConvertFrom('', \DateTimeImmutable::class));
+    }
+
+    /**
+     * @test
+     */
     public function convertFromReturnsErrorIfGivenStringCantBeConverted()
     {
         $error = $this->converter->convertFrom('1980-12-13', 'DateTime');
@@ -83,6 +91,16 @@ class DateTimeConverterTest extends \TYPO3\Flow\Tests\UnitTestCase
         $date = $this->converter->convertFrom($expectedResult, 'DateTime');
         $actualResult = $date->format('Y-m-d\TH:i:sP');
         $this->assertSame($expectedResult, $actualResult);
+    }
+
+    /**
+     * @test
+     */
+    public function convertFromProperlyConvertsToDateTimeImmutable()
+    {
+        $expectedResult = '1980-12-13T20:15:07+01:23';
+        $date = $this->converter->convertFrom($expectedResult, \DateTimeImmutable::class);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $date);
     }
 
     /**

--- a/TYPO3.Flow/Tests/Unit/Property/TypeConverter/StringConverterTest.php
+++ b/TYPO3.Flow/Tests/Unit/Property/TypeConverter/StringConverterTest.php
@@ -11,6 +11,7 @@ namespace TYPO3\Flow\Tests\Unit\Property\TypeConverter;
  * source code.
  */
 
+use TYPO3\Flow\Property\PropertyMappingConfiguration;
 use TYPO3\Flow\Property\TypeConverter\StringConverter;
 
 /**
@@ -35,7 +36,7 @@ class StringConverterTest extends \TYPO3\Flow\Tests\UnitTestCase
      */
     public function checkMetadata()
     {
-        $this->assertEquals(array('string', 'integer', 'float', 'boolean', 'array', 'DateTime'), $this->converter->getSupportedSourceTypes(), 'Source types do not match');
+        $this->assertEquals(array('string', 'integer', 'float', 'boolean', 'array', \DateTimeInterface::class), $this->converter->getSupportedSourceTypes(), 'Source types do not match');
         $this->assertEquals('string', $this->converter->getSupportedTargetType(), 'Target type does not match');
         $this->assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
     }
@@ -47,6 +48,29 @@ class StringConverterTest extends \TYPO3\Flow\Tests\UnitTestCase
     {
         $this->assertEquals('myString', $this->converter->convertFrom('myString', 'string'));
     }
+
+    /**
+     * @test
+     */
+    public function convertFromConvertsDateTimeObjects()
+    {
+        $date = new \DateTime('1980-12-13');
+        $propertyMappingConfiguration = new PropertyMappingConfiguration();
+        $propertyMappingConfiguration->setTypeConverterOption(StringConverter::class, StringConverter::CONFIGURATION_DATE_FORMAT, 'd.m.Y');
+        $this->assertEquals('13.12.1980', $this->converter->convertFrom($date, 'string', [], $propertyMappingConfiguration));
+    }
+
+    /**
+     * @test
+     */
+    public function convertFromConvertsDateTimeImmutableObjects()
+    {
+        $date = new \DateTimeImmutable('1980-12-13');
+        $propertyMappingConfiguration = new PropertyMappingConfiguration();
+        $propertyMappingConfiguration->setTypeConverterOption(StringConverter::class, StringConverter::CONFIGURATION_DATE_FORMAT, 'd.m.Y');
+        $this->assertEquals('13.12.1980', $this->converter->convertFrom($date, 'string', [], $propertyMappingConfiguration));
+    }
+
 
     /**
      * @test


### PR DESCRIPTION
This extends `DateTimeConverter` and `StringConverter` so that they support
any class implementing the `\DateTimeInterface` (including `\DateTimeImmutable`).

Resolves: #677