### PR TITLE
add exec() to the list of required system functions

### DIFF
--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/Requirements.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartII/Requirements.rst
@@ -41,7 +41,7 @@ and ``pdo_mysql`` are enabled, especially if you compiled PHP yourself.
 
 .. note::
 
-  Make sure the PHP functions ``system()``, ``shell_exec()``,
+  Make sure the PHP functions ``exec()``, ``system()``, ``shell_exec()``,
   ``escapeshellcmd()`` and ``escapeshellarg()`` are not disabled in you PHP
   installation. They are required for the system to run.
 


### PR DESCRIPTION
It's used e.g. in TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
