### PR TITLE
BUGFIX: Adapt the core migration manager for the new package manager

### DIFF
--- a/TYPO3.Flow/Scripts/Migrations/Manager.php
+++ b/TYPO3.Flow/Scripts/Migrations/Manager.php
@@ -261,10 +261,10 @@ class Manager
         if ($appliedMigrationIdentifiers === array()) {
             return null;
         }
-        if (!isset($this->currentPackageData['composerManifest']->extra)) {
-            $this->currentPackageData['composerManifest']->extra = new \stdClass();
+        if (!isset($this->currentPackageData['composerManifest']['extra'])) {
+            $this->currentPackageData['composerManifest']['extra'] = [];
         }
-        $this->currentPackageData['composerManifest']->extra->{'applied-flow-migrations'} = array_unique($appliedMigrationIdentifiers);
+        $this->currentPackageData['composerManifest']['extra']['applied-flow-migrations'] = array_unique($appliedMigrationIdentifiers);
         $this->writeComposerManifest();
 
         $this->currentPackageData['composerManifest']['extra']['applied-flow-migrations'] = array_values(array_unique($appliedMigrationIdentifiers));


### PR DESCRIPTION
Without this change PHP can print a warning message in the CLI output: PHP Warning:  Attempt to assign property of non-object in Manager.php on line 265.

This change fix access to currentPackageData['composerManifest']['extra'] to use the array
syntax and not the stdClass, used by the previous package manager. 