### PR TITLE
!!!TASK: ViewConfiguration use only the settings of highest weighted request filter

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/ViewConfigurationManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/ViewConfigurationManager.php
@@ -83,13 +83,15 @@ class ViewConfigurationManager
             }
 
             usort($matchingConfigurations, function ($configuration1, $configuration2) {
-                return $configuration1['weight'] > $configuration2['weight'];
+                return $configuration1['weight'] < $configuration2['weight'];
             });
-
-            $viewConfiguration = [];
-            foreach ($matchingConfigurations as $key => $matchingConfiguration) {
-                $viewConfiguration = Arrays::arrayMergeRecursiveOverrule($viewConfiguration, $matchingConfiguration['configuration']);
+            
+            if (count($matchingConfigurations) > 0) {
+                $viewConfiguration = array_shift($matchingConfigurations)['configuration'];
+            } else {
+                $viewConfiguration = [];
             }
+
             $this->cache->set($cacheIdentifier, $viewConfiguration);
         }
 

--- a/TYPO3.Flow/Configuration/Testing/Views.yaml
+++ b/TYPO3.Flow/Configuration/Testing/Views.yaml
@@ -10,9 +10,10 @@
   options:
     templatePathAndFilename: resource://TYPO3.Flow/Private/Templates/Tests/Functional/Mvc/Fixtures/ViewsConfigurationTest/ChangedOnControllerLevel.html
 
-# Completely change the viewObjectName
+# Completely change the viewObjectName, the mainRequest is added to add specifity for not being overwritten from
+# the following filters
 -
-  requestFilter: 'isPackage("TYPO3.Flow") && isController("ViewsConfigurationTestC")'
+  requestFilter: 'mainRequest.isPackage("TYPO3.Flow") && isController("ViewsConfigurationTestC")'
   viewObjectName: '\TYPO3\Flow\Tests\Functional\Mvc\ViewsConfiguration\Fixtures\TemplateView'
 
 # Reset Widget Template because it's changed by the second change

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/ModelViewController.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/ModelViewController.rst
@@ -673,6 +673,12 @@ will be increased by a certain value.
 
 If the package is "My.Foo" and the Format is "html" the result will be 10001
 
+.. note::
+
+	Previously the configuration of all matching ``Views.yaml`` filters was merged.
+	From version 4.0 on only the matching filter with the highest weight is respected
+	in order to reduce ambiguity.
+
 Controller Context
 ~~~~~~~~~~~~~~~~~~
 

--- a/TYPO3.Flow/Tests/Unit/Mvc/ViewConfigurationManagerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Mvc/ViewConfigurationManagerTest.php
@@ -1,0 +1,125 @@
+<?php
+namespace TYPO3\Flow\Tests\Unit\Mvc;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Configuration\ConfigurationManager;
+use TYPO3\Flow\Mvc\ViewConfigurationManager;
+use TYPO3\Flow\Mvc\ActionRequest;
+use TYPO3\Flow\Cache\Frontend\VariableFrontend;
+use TYPO3\Eel\CompilingEvaluator;
+
+/**
+ * Testcase for the MVC ViewConfigurationManager
+ *
+ */
+class ViewConfigurationManagerTest extends \TYPO3\Flow\Tests\UnitTestCase
+{
+
+    /**
+     * @var ViewConfigurationManager
+     */
+    protected $viewConfigurationManager;
+
+    /**
+     * @var ActionRequest|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $mockActionRequest;
+
+    /**
+     * @var ConfigurationManager|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $mockConfigurationManager;
+
+    /**
+     * @var VariableFrontend|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $mockCache;
+
+
+    public function setUp()
+    {
+        $this->viewConfigurationManager = new ViewConfigurationManager();
+
+        // eel evaluator
+        $eelEvaluator = new CompilingEvaluator();
+        $this->inject($this->viewConfigurationManager, 'eelEvaluator', $eelEvaluator);
+
+        // a dummy configuration manager is prepared
+        $this->mockConfigurationManager = $this->getMockBuilder(ConfigurationManager::class)->disableOriginalConstructor()->getMock();
+        $this->inject($this->viewConfigurationManager, 'configurationManager', $this->mockConfigurationManager);
+
+        // caching is deactivated
+        $this->mockCache = $this->getMockBuilder(VariableFrontend::class)->disableOriginalConstructor()->getMock();
+        $this->mockCache->expects($this->any())->method('get')->will($this->returnValue(false));
+        $this->inject($this->viewConfigurationManager, 'cache', $this->mockCache);
+
+        // a dummy request is prepared
+        $this->mockActionRequest = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->getMock();
+        $this->mockActionRequest->expects($this->any())->method('getControllerPackageKey')->will($this->returnValue('TYPO3.Flow'));
+        $this->mockActionRequest->expects($this->any())->method('getControllerSubpackageKey')->will($this->returnValue(''));
+        $this->mockActionRequest->expects($this->any())->method('getControllerName')->will($this->returnValue('Standard'));
+        $this->mockActionRequest->expects($this->any())->method('getControllerActionName')->will($this->returnValue('index'));
+        $this->mockActionRequest->expects($this->any())->method('getFormat')->will($this->returnValue('html'));
+        $this->mockActionRequest->expects($this->any())->method('getParentRequest')->will($this->returnValue(null));
+    }
+
+    /**
+     * @test
+     */
+    public function getViewConfigurationFindsMatchingConfigurationForRequest()
+    {
+        $matchingConfiguration = [
+            'requestFilter' => 'isPackage("TYPO3.Flow")',
+            'options' => 'a value'
+        ];
+
+        $notMatchingConfiguration = [
+            'requestFilter' => 'isPackage("Vendor.Package")',
+            'options' => 'another value'
+        ];
+
+        $viewConfigurations = [$notMatchingConfiguration, $matchingConfiguration];
+
+        $this->mockConfigurationManager->expects($this->any())->method('getConfiguration')->with('Views')->will($this->returnValue($viewConfigurations));
+        $calculatedConfiguration = $this->viewConfigurationManager->getViewConfiguration($this->mockActionRequest);
+
+        $this->assertEquals($calculatedConfiguration, $matchingConfiguration);
+    }
+
+    /**
+     * @test
+     */
+    public function getViewConfigurationUsedFilterConfigurationWithHigherWeight()
+    {
+        $matchingConfigurationOne = [
+            'requestFilter' => 'isPackage("TYPO3.Flow")',
+            'options' => 'a value'
+        ];
+
+        $matchingConfigurationTwo = [
+            'requestFilter' => 'isPackage("TYPO3.Flow") && isFormat("html")',
+            'options' => 'a value with higher weight'
+        ];
+
+        $notMatchingConfiguration = [
+            'requestFilter' => 'isPackage("Vendor.Package")',
+            'options' => 'another value'
+        ];
+
+        $viewConfigurations = [$notMatchingConfiguration, $matchingConfigurationOne, $matchingConfigurationTwo];
+
+        $this->mockConfigurationManager->expects($this->any())->method('getConfiguration')->with('Views')->will($this->returnValue($viewConfigurations));
+        $calculatedConfiguration = $this->viewConfigurationManager->getViewConfiguration($this->mockActionRequest);
+
+        $this->assertEquals($calculatedConfiguration, $matchingConfigurationTwo);
+    }
+}


### PR DESCRIPTION
Before this the higher weighted requestFilters were merged into the lower-weighted ones which placed the array-properties of the higher weighted filters last in the merged configuration. This made it impossible to add a new path templatePath that would be considered before.

This patch removes the merging of view-configurations entirely since this lead to confusion in the integration because the merging was unexpected.

This is breaking if you have multiple configurations with filters that apply to the same request and expect some option from one of the configurations to still be present despite another configuration having a higher weight.