### PR TITLE
FEATURE: Internal TypeConverters

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/PropertyMapper.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/PropertyMapper.php
@@ -318,6 +318,10 @@ class PropertyMapper
             }
 
             /** @var TypeConverterInterface $converter */
+            if ($converter->getPriority() < 0) {
+                continue;
+            }
+
             if ($converter->canConvertFrom($source, $targetType)) {
                 return $converter;
             }

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/PropertyMapping.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/PropertyMapping.rst
@@ -418,6 +418,7 @@ each ``TypeConverter`` which influence the resolving process:
   If two type converters have the same source and target type, precedence
   is given to the one with higher priority. All standard TypeConverters
   have a priority lower than 100.
+  A priority of -1 disables automatic resolution for the given TypeConverter!
 
 ``canConvertFrom($source, $targetType)``
   Is called as last check, when source and target types fit together. Here, the
@@ -430,7 +431,7 @@ When a type converter has to be found, the following algorithm is applied:
 
 2. The inheritance hierarchy of the target type is traversed in reverse order (from
    most specific to generic) until a TypeConverter is found. If two type converters
-   work on the same class, the one with highest priority is used.
+   work on the same class, the one with highest positive priority is used.
 
 3. If no type converter could be found for the direct inheritance hierarchy, it is
    checked if there is a TypeConverter for one of the interfaces the target class
@@ -491,3 +492,9 @@ possibilities what can be returned in ``convertFrom()``:
 	Inside a type converter it is not allowed to use an (injected) instance
 	of ``TYPO3\Flow\Property\PropertyMapper`` because it can lead to an
 	infinite recursive invocation.
+
+.. note::
+
+	With version 4.0 TypeConverters with a negative priority will be skipped by the
+	``PropertyMapper`` by default. The ``PropertyMappingConfiguration`` can be used to
+	explicitly use such converter anyways.


### PR DESCRIPTION
Creating a new TypeConverter can have major side-effects on existing applications.
This change allows TypeConverters to have a negative priority in order to mark them
"internal".
Internal TypeConverters will be skipped from PropertyMapping by default.

To use them explicitly the ``PropertyMappingConfiguration`` can be used::

    $configuration = new PropertyMappingConfiguration();
    $configuration->setTypeConverter(new SomeInternalTypeConverter());
    $this->propertyMapper->convert($source, $targetType, $configuration);

Resolves: #695