### PR TITLE
TASK: Remove TYPO3.Welcome Subroutes

### DIFF
--- a/TYPO3.Flow/Resources/Private/Installer/Distribution/Defaults/Configuration/Routes.yaml
+++ b/TYPO3.Flow/Resources/Private/Installer/Distribution/Defaults/Configuration/Routes.yaml
@@ -8,19 +8,6 @@
 #                                                                        #
 
 ##
-# Subroutes from the Welcome package.
-#
-# If the package "Welcome" is installed, its fallback route will point to an
-# informative welcome screen.
-
--
-  name: 'Welcome'
-  uriPattern: '<WelcomeSubroutes>'
-  subRoutes:
-    WelcomeSubroutes:
-      package: TYPO3.Welcome
-
-##
 # Flow subroutes
 #
 


### PR DESCRIPTION
As a followup to https://github.com/neos/flow-welcome/pull/4 this change removes the routing rules and have them included if the TYPO3.Welcome package is active.

All this to avoud `The SubRoute Package "TYPO3.Welcome" referenced in Route "Welcome" is not available.` when you start a new installation

Solves neos/flow-development-collection#698