### PR TITLE
TASK: Require Fluid Adaptor in Flow

### DIFF
--- a/TYPO3.Flow/composer.json
+++ b/TYPO3.Flow/composer.json
@@ -23,6 +23,7 @@
         "neos/utility-schema": "*",
         "neos/utility-unicode": "*",
         "neos/error-messages": "*",
+        "neos/fluid-adaptor": "*",
         "neos/cache": "*",
 
         "typo3/eel": "*",


### PR DESCRIPTION
Despite the fact that Flow technically doesn't depend
on Fluid anymore we require it as the majority of projects
including Neos uses it anyway. Otherwise developers would
need to require it themselves in Flow projects.