### PR TITLE
TASK: Add `useMainRequest` to the ActionViewHelpers

### DIFF
--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Link/ActionViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Link/ActionViewHelper.php
@@ -72,13 +72,14 @@ class ActionViewHelper extends AbstractTagBasedViewHelper
      * @param array $additionalParams additional query parameters that won't be prefixed like $arguments (overrule $arguments)
      * @param boolean $addQueryString If set, the current query parameters will be kept in the URI
      * @param array $argumentsToBeExcludedFromQueryString arguments to be removed from the URI. Only active if $addQueryString = TRUE
-     * @param boolean $useParentRequest If set, the parent Request will be used instead of the current one
+     * @param boolean $useParentRequest If set, the parent Request will be used instead of the current one. Note: using this argument can be a sign of undesired tight coupling, use with care
      * @param boolean $absolute By default this ViewHelper renders links with absolute URIs. If this is FALSE, a relative URI is created instead
+     * @param boolean $useMainRequest If set, the main Request will be used instead of the current one. Note: using this argument can be a sign of undesired tight coupling, use with care
      * @return string The rendered link
      * @throws ViewHelper\Exception
      * @api
      */
-    public function render($action, $arguments = array(), $controller = null, $package = null, $subpackage = null, $section = '', $format = '', array $additionalParams = array(), $addQueryString = false, array $argumentsToBeExcludedFromQueryString = array(), $useParentRequest = false, $absolute = true)
+    public function render($action, $arguments = array(), $controller = null, $package = null, $subpackage = null, $section = '', $format = '', array $additionalParams = array(), $addQueryString = false, array $argumentsToBeExcludedFromQueryString = array(), $useParentRequest = false, $absolute = true, $useMainRequest = false)
     {
         $uriBuilder = $this->controllerContext->getUriBuilder();
         if ($useParentRequest) {
@@ -88,6 +89,12 @@ class ActionViewHelper extends AbstractTagBasedViewHelper
             }
             $uriBuilder = clone $uriBuilder;
             $uriBuilder->setRequest($request->getParentRequest());
+        } elseif ($useMainRequest === true) {
+            $request = $this->controllerContext->getRequest();
+            if (!$request->isMainRequest()) {
+                $uriBuilder = clone $uriBuilder;
+                $uriBuilder->setRequest($request->getMainRequest());
+            }
         }
 
         $uriBuilder

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Uri/ActionViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Uri/ActionViewHelper.php
@@ -53,12 +53,13 @@ class ActionViewHelper extends AbstractViewHelper
      * @param boolean $absolute If set, an absolute URI is rendered
      * @param boolean $addQueryString If set, the current query parameters will be kept in the URI
      * @param array $argumentsToBeExcludedFromQueryString arguments to be removed from the URI. Only active if $addQueryString = TRUE
-     * @param boolean $useParentRequest If set, the parent Request will be used instead of the current one
+     * @param boolean $useParentRequest If set, the parent Request will be used instead of the current one. Note: using this argument can be a sign of undesired tight coupling, use with care
+     * @param boolean $useMainRequest If set, the main Request will be used instead of the current one. Note: using this argument can be a sign of undesired tight coupling, use with care
      * @return string The rendered link
      * @throws ViewHelper\Exception
      * @api
      */
-    public function render($action, array $arguments = array(), $controller = null, $package = null, $subpackage = null, $section = '', $format = '', array $additionalParams = array(), $absolute = false, $addQueryString = false, array $argumentsToBeExcludedFromQueryString = array(), $useParentRequest = false)
+    public function render($action, array $arguments = array(), $controller = null, $package = null, $subpackage = null, $section = '', $format = '', array $additionalParams = array(), $absolute = false, $addQueryString = false, array $argumentsToBeExcludedFromQueryString = array(), $useParentRequest = false, $useMainRequest = false)
     {
         $uriBuilder = $this->controllerContext->getUriBuilder();
         if ($useParentRequest === true) {
@@ -68,7 +69,14 @@ class ActionViewHelper extends AbstractViewHelper
             }
             $uriBuilder = clone $uriBuilder;
             $uriBuilder->setRequest($request->getParentRequest());
+        } elseif ($useMainRequest === true) {
+            $request = $this->controllerContext->getRequest();
+            if (!$request->isMainRequest()) {
+                $uriBuilder = clone $uriBuilder;
+                $uriBuilder->setRequest($request->getMainRequest());
+            }
         }
+
         $uriBuilder
             ->reset()
             ->setSection($section)

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/ActionViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/ActionViewHelperTest.php
@@ -183,15 +183,15 @@ class ActionViewHelperTest extends \Neos\FluidAdaptor\ViewHelpers\ViewHelperBase
      */
     public function renderUsesParentRequestIfUseMainRequestIsSet()
     {
-        $viewHelper = $this->getAccessibleMock('TYPO3\Fluid\ViewHelpers\Link\ActionViewHelper', array('renderChildren'));
+        $viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\ViewHelpers\Link\ActionViewHelper::class, array('renderChildren'));
 
-        $mainRequest = $this->getMockBuilder('TYPO3\Flow\Mvc\ActionRequest')->disableOriginalConstructor()->getMock();
+        $mainRequest = $this->getMockBuilder(\TYPO3\Flow\Mvc\ActionRequest::class)->disableOriginalConstructor()->getMock();
 
-        $this->request = $this->getMockBuilder('TYPO3\Flow\Mvc\ActionRequest')->disableOriginalConstructor()->getMock();
+        $this->request = $this->getMockBuilder(\TYPO3\Flow\Mvc\ActionRequest::class)->disableOriginalConstructor()->getMock();
         $this->request->expects($this->atLeastOnce())->method('isMainRequest')->will($this->returnValue(false));
         $this->request->expects($this->atLeastOnce())->method('getMainRequest')->will($this->returnValue($mainRequest));
 
-        $this->controllerContext = $this->getMock('TYPO3\Flow\Mvc\Controller\ControllerContext', array(), array(), '', false);
+        $this->controllerContext = $this->getMock(\TYPO3\Flow\Mvc\Controller\ControllerContext::class, array(), array(), '', false);
         $this->controllerContext->expects($this->any())->method('getUriBuilder')->will($this->returnValue($this->uriBuilder));
         $this->controllerContext->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
 

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/ActionViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/ActionViewHelperTest.php
@@ -191,7 +191,7 @@ class ActionViewHelperTest extends \Neos\FluidAdaptor\ViewHelpers\ViewHelperBase
         $this->request->expects($this->atLeastOnce())->method('isMainRequest')->will($this->returnValue(false));
         $this->request->expects($this->atLeastOnce())->method('getMainRequest')->will($this->returnValue($mainRequest));
 
-        $this->controllerContext = $this->getMock(\TYPO3\Flow\Mvc\Controller\ControllerContext::class, array(), array(), '', false);
+        $this->controllerContext = $this->getMockBuilder(\TYPO3\Flow\Mvc\Controller\ControllerContext::class)->disableOriginalConstructor()->getMock();
         $this->controllerContext->expects($this->any())->method('getUriBuilder')->will($this->returnValue($this->uriBuilder));
         $this->controllerContext->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
 

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/ActionViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/ActionViewHelperTest.php
@@ -177,4 +177,29 @@ class ActionViewHelperTest extends \Neos\FluidAdaptor\ViewHelpers\ViewHelperBase
 
         $viewHelper->render('someAction', array(), null, null, null, '', '', array(), false, array(), false, false);
     }
+
+    /**
+     * @test
+     */
+    public function renderUsesParentRequestIfUseMainRequestIsSet()
+    {
+        $viewHelper = $this->getAccessibleMock('TYPO3\Fluid\ViewHelpers\Link\ActionViewHelper', array('renderChildren'));
+
+        $mainRequest = $this->getMockBuilder('TYPO3\Flow\Mvc\ActionRequest')->disableOriginalConstructor()->getMock();
+
+        $this->request = $this->getMockBuilder('TYPO3\Flow\Mvc\ActionRequest')->disableOriginalConstructor()->getMock();
+        $this->request->expects($this->atLeastOnce())->method('isMainRequest')->will($this->returnValue(false));
+        $this->request->expects($this->atLeastOnce())->method('getMainRequest')->will($this->returnValue($mainRequest));
+
+        $this->controllerContext = $this->getMock('TYPO3\Flow\Mvc\Controller\ControllerContext', array(), array(), '', false);
+        $this->controllerContext->expects($this->any())->method('getUriBuilder')->will($this->returnValue($this->uriBuilder));
+        $this->controllerContext->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
+
+        $this->uriBuilder->expects($this->atLeastOnce())->method('setRequest')->with($mainRequest);
+
+        $this->renderingContext->setControllerContext($this->controllerContext);
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+
+        $viewHelper->render('someAction', array(), null, null, null, '', '', array(), false, array(), false, false, true);
+    }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ActionViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ActionViewHelperTest.php
@@ -141,7 +141,7 @@ class ActionViewHelperTest extends \Neos\FluidAdaptor\ViewHelpers\ViewHelperBase
         $this->request->expects($this->atLeastOnce())->method('isMainRequest')->will($this->returnValue(false));
         $this->request->expects($this->atLeastOnce())->method('getMainRequest')->will($this->returnValue($mainRequest));
 
-        $this->controllerContext = $this->getMock(\TYPO3\Flow\Mvc\Controller\ControllerContext::class, array(), array(), '', false);
+        $this->controllerContext = $this->getMockBuilder(\TYPO3\Flow\Mvc\Controller\ControllerContext::class)->disableOriginalConstructor()->getMock();
         $this->controllerContext->expects($this->any())->method('getUriBuilder')->will($this->returnValue($this->uriBuilder));
         $this->controllerContext->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
 

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ActionViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ActionViewHelperTest.php
@@ -133,15 +133,15 @@ class ActionViewHelperTest extends \Neos\FluidAdaptor\ViewHelpers\ViewHelperBase
      */
     public function renderUsesParentRequestIfUseMainRequestIsSet()
     {
-        $viewHelper = new \TYPO3\Fluid\ViewHelpers\Uri\ActionViewHelper();
+        $viewHelper = new \Neos\FluidAdaptor\ViewHelpers\Uri\ActionViewHelper();
 
-        $mainRequest = $this->getMockBuilder('TYPO3\Flow\Mvc\ActionRequest')->disableOriginalConstructor()->getMock();
+        $mainRequest = $this->getMockBuilder(\TYPO3\Flow\Mvc\ActionRequest::class)->disableOriginalConstructor()->getMock();
 
-        $this->request = $this->getMockBuilder('TYPO3\Flow\Mvc\ActionRequest')->disableOriginalConstructor()->getMock();
+        $this->request = $this->getMockBuilder(\TYPO3\Flow\Mvc\ActionRequest::class)->disableOriginalConstructor()->getMock();
         $this->request->expects($this->atLeastOnce())->method('isMainRequest')->will($this->returnValue(false));
         $this->request->expects($this->atLeastOnce())->method('getMainRequest')->will($this->returnValue($mainRequest));
 
-        $this->controllerContext = $this->getMock('TYPO3\Flow\Mvc\Controller\ControllerContext', array(), array(), '', false);
+        $this->controllerContext = $this->getMock(\TYPO3\Flow\Mvc\Controller\ControllerContext::class, array(), array(), '', false);
         $this->controllerContext->expects($this->any())->method('getUriBuilder')->will($this->returnValue($this->uriBuilder));
         $this->controllerContext->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
 

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ActionViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ActionViewHelperTest.php
@@ -127,4 +127,29 @@ class ActionViewHelperTest extends \Neos\FluidAdaptor\ViewHelpers\ViewHelperBase
 
         $viewHelper->render('someAction', array(), null, null, null, '', '', array(), false, false, array(), true);
     }
+
+    /**
+     * @test
+     */
+    public function renderUsesParentRequestIfUseMainRequestIsSet()
+    {
+        $viewHelper = new \TYPO3\Fluid\ViewHelpers\Uri\ActionViewHelper();
+
+        $mainRequest = $this->getMockBuilder('TYPO3\Flow\Mvc\ActionRequest')->disableOriginalConstructor()->getMock();
+
+        $this->request = $this->getMockBuilder('TYPO3\Flow\Mvc\ActionRequest')->disableOriginalConstructor()->getMock();
+        $this->request->expects($this->atLeastOnce())->method('isMainRequest')->will($this->returnValue(false));
+        $this->request->expects($this->atLeastOnce())->method('getMainRequest')->will($this->returnValue($mainRequest));
+
+        $this->controllerContext = $this->getMock('TYPO3\Flow\Mvc\Controller\ControllerContext', array(), array(), '', false);
+        $this->controllerContext->expects($this->any())->method('getUriBuilder')->will($this->returnValue($this->uriBuilder));
+        $this->controllerContext->expects($this->any())->method('getRequest')->will($this->returnValue($this->request));
+
+        $this->uriBuilder->expects($this->atLeastOnce())->method('setRequest')->with($mainRequest);
+
+        $this->renderingContext->setControllerContext($this->controllerContext);
+        $this->injectDependenciesIntoViewHelper($viewHelper);
+
+        $viewHelper->render('someAction', array(), null, null, null, '', '', array(), false, false, array(), false, true);
+    }
 }


### PR DESCRIPTION
With this change it is possible to use the main Request instead of the current Request.
Note: using this argument can be a sign of undesired tight coupling, use with care