### PR TITLE
BUGFIX: Use correct namespaces in ViewHelperBaseTestCase

### DIFF
--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php
@@ -1,5 +1,5 @@
 <?php
-namespace Neos\FluidAdaptor\ViewHelpers;
+namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers;
 
 /*
  * This file is part of the Neos.FluidAdaptor package.
@@ -23,7 +23,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 abstract class ViewHelperBaseTestcase extends \TYPO3\Flow\Tests\UnitTestCase
 {
     /**
-     * @var \Neos\FluidAdaptor\Core\ViewHelper\ViewHelperVariableContainer
+     * @var \TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer
      */
     protected $viewHelperVariableContainer;
 


### PR DESCRIPTION
It seems like that during the switch to the Fluid Adaptor, some namespaces in test were not properly adapted