### PR TITLE
BUGFIX: Fix regression introduced by test namespace change

### DIFF
--- a/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
@@ -12,7 +12,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\Core\ViewHelper;
  */
 
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractConditionViewHelper;
-use Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase;
+use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\ViewHelpers\ElseViewHelper;
 use TYPO3Fluid\Fluid\ViewHelpers\ThenViewHelper;

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/BaseViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/BaseViewHelperTest.php
@@ -14,7 +14,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers;
 use TYPO3\Flow\Http\Request;
 use TYPO3\Flow\Http\Uri;
 use Neos\FluidAdaptor\ViewHelpers\BaseViewHelper;
-use Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase;
+use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
 require_once(__DIR__ . '/ViewHelperBaseTestcase.php');
 

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/FlashMessagesViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/FlashMessagesViewHelperTest.php
@@ -18,7 +18,7 @@ require_once(__DIR__ . '/ViewHelperBaseTestcase.php');
 /**
  * Testcase for FlashMessagesViewHelper
  */
-class FlashMessagesViewHelperTest extends \Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase
+class FlashMessagesViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase
 {
     /**
      * @var \Neos\FluidAdaptor\ViewHelpers\FlashMessagesViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/AbstractFormViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/AbstractFormViewHelperTest.php
@@ -17,7 +17,7 @@ require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
  * Test for the Abstract Form view helper
  *
  */
-class AbstractFormViewHelperTest extends \Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase
+class AbstractFormViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase
 {
     /**
      * @test

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/FormFieldViewHelperBaseTestcase.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/FormFieldViewHelperBaseTestcase.php
@@ -20,6 +20,6 @@ require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
  * we also introduce it here.
  *
  */
-class FormFieldViewHelperBaseTestcase extends \Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase
+class FormFieldViewHelperBaseTestcase extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase
 {
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/FormViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/FormViewHelperTest.php
@@ -17,7 +17,7 @@ use TYPO3\Flow\Security\Context;
 use TYPO3\Flow\Security\Cryptography\HashService;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 use Neos\FluidAdaptor\ViewHelpers\FormViewHelper;
-use Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase;
+use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
 /**
  * Test for the Form view helper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/BytesViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/BytesViewHelperTest.php
@@ -13,7 +13,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Format;
 
 require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 
-use Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase;
+use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
 /**
  * Test for \Neos\FluidAdaptor\ViewHelpers\Format\BytesViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CaseViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CaseViewHelperTest.php
@@ -14,7 +14,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Format;
 require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 
 use Neos\FluidAdaptor\ViewHelpers\Format\CaseViewHelper;
-use Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase;
+use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
 /**
  * Test for \Neos\FluidAdaptor\ViewHelpers\Format\CaseViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CropViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CropViewHelperTest.php
@@ -13,7 +13,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Format;
 
 require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 
-use Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase;
+use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
 /**
  * Test for \Neos\FluidAdaptor\ViewHelpers\Format\CropViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/HtmlentitiesDecodeViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/HtmlentitiesDecodeViewHelperTest.php
@@ -17,7 +17,7 @@ require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 
 use Neos\FluidAdaptor\ViewHelpers\Fixtures\UserWithoutToString;
 use Neos\FluidAdaptor\ViewHelpers\Fixtures\UserWithToString;
-use Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase;
+use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
 /**
  * Test for \Neos\FluidAdaptor\ViewHelpers\Format\HtmlentitiesDecodeViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/HtmlentitiesViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/HtmlentitiesViewHelperTest.php
@@ -17,7 +17,7 @@ require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 
 use Neos\FluidAdaptor\ViewHelpers\Fixtures\UserWithoutToString;
 use Neos\FluidAdaptor\ViewHelpers\Fixtures\UserWithToString;
-use Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase;
+use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
 /**
  * Test for \Neos\FluidAdaptor\ViewHelpers\Format\HtmlentitiesViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/IdentifierViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/IdentifierViewHelperTest.php
@@ -13,7 +13,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Format;
 
 require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 
-use Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase;
+use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
 /**
  * Test for \Neos\FluidAdaptor\ViewHelpers\Format\IdentifierViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/JsonViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/JsonViewHelperTest.php
@@ -13,7 +13,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Format;
 
 require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 
-use Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase;
+use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
 /**
  * Test for \Neos\FluidAdaptor\ViewHelpers\Format\JsonViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/Nl2brViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/Nl2brViewHelperTest.php
@@ -13,7 +13,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Format;
 
 require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 
-use Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase;
+use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
 /**
  * Test for \Neos\FluidAdaptor\ViewHelpers\Format\Nl2brViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/PaddingViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/PaddingViewHelperTest.php
@@ -13,7 +13,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Format;
 
 require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 
-use Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase;
+use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
 /**
  * Test for Neos\FluidAdaptor\ViewHelpers\Format\PaddingViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/StripTagsViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/StripTagsViewHelperTest.php
@@ -15,7 +15,7 @@ require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 require_once(__DIR__ . '/../Fixtures/UserWithoutToString.php');
 require_once(__DIR__ . '/../Fixtures/UserWithToString.php');
 
-use Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase;
+use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 use Neos\FluidAdaptor\ViewHelpers\Fixtures\UserWithoutToString;
 use Neos\FluidAdaptor\ViewHelpers\Fixtures\UserWithToString;
 

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/UrlencodeViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/UrlencodeViewHelperTest.php
@@ -15,7 +15,7 @@ require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 
 use TYPO3\Flow\Http\Uri;
 use Neos\FluidAdaptor\ViewHelpers\Format\UrlencodeViewHelper;
-use Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase;
+use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
 /**
  * Test for \Neos\FluidAdaptor\ViewHelpers\Format\UrlencodeViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/ActionViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/ActionViewHelperTest.php
@@ -15,7 +15,7 @@ require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 
 /**
  */
-class ActionViewHelperTest extends \Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase
+class ActionViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase
 {
     /**
      * var \Neos\FluidAdaptor\ViewHelpers\Link\ActionViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/EmailViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/EmailViewHelperTest.php
@@ -15,7 +15,7 @@ require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 
 /**
  */
-class EmailViewHelperTest extends \Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase
+class EmailViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase
 {
     /**
      * var \Neos\FluidAdaptor\ViewHelpers\Link\EmailViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/ExternalViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/ExternalViewHelperTest.php
@@ -18,7 +18,7 @@ require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 /**
  * Test for \Neos\FluidAdaptor\ViewHelpers\Link\EmailViewHelper
  */
-class ExternalViewHelperTest extends \Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase
+class ExternalViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase
 {
     /**
      * @var \Neos\FluidAdaptor\ViewHelpers\Link\EmailViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/RenderChildrenViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/RenderChildrenViewHelperTest.php
@@ -20,7 +20,7 @@ require_once(__DIR__ . '/ViewHelperBaseTestcase.php');
  * Testcase for CycleViewHelper
  *
  */
-class RenderChildrenViewHelperTest extends \Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase
+class RenderChildrenViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase
 {
     /**
      * var \Neos\FluidAdaptor\ViewHelpers\RenderChildrenViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Security/IfAccessViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Security/IfAccessViewHelperTest.php
@@ -15,7 +15,7 @@ use Neos\FluidAdaptor\Core\Rendering\RenderingContext;
 use TYPO3\Flow\ObjectManagement\ObjectManagerInterface;
 use TYPO3\Flow\Security\Authorization\PrivilegeManagerInterface;
 use Neos\FluidAdaptor\ViewHelpers\Security\IfAccessViewHelper;
-use Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase;
+use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
 /**
  * Testcase for IfAccessViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Security/IfHasRoleViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Security/IfHasRoleViewHelperTest.php
@@ -19,7 +19,7 @@ use TYPO3\Flow\Security\Context;
 use TYPO3\Flow\Security\Policy\PolicyService;
 use TYPO3\Flow\Security\Policy\Role;
 use Neos\FluidAdaptor\ViewHelpers\Security\IfHasRoleViewHelper;
-use Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase;
+use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
 /**
  * Test case for IfHasRoleViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/TranslateViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/TranslateViewHelperTest.php
@@ -14,7 +14,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers;
 use TYPO3\Flow\I18n\Locale;
 use TYPO3\Flow\I18n\Translator;
 use Neos\FluidAdaptor\ViewHelpers\TranslateViewHelper;
-use Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase;
+use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
 require_once(__DIR__ . '/ViewHelperBaseTestcase.php');
 

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ActionViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ActionViewHelperTest.php
@@ -17,7 +17,7 @@ require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
  * Testcase for the action uri view helper
  *
  */
-class ActionViewHelperTest extends \Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase
+class ActionViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase
 {
     /**
      * var \Neos\FluidAdaptor\ViewHelpers\Uri\ActionViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/EmailViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/EmailViewHelperTest.php
@@ -16,7 +16,7 @@ require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 /**
  * Testcase for the email uri view helper
  */
-class EmailViewHelperTest extends \Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase
+class EmailViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase
 {
     /**
      * @var \Neos\FluidAdaptor\ViewHelpers\Uri\EmailViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ExternalViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ExternalViewHelperTest.php
@@ -17,7 +17,7 @@ require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
  * Testcase for the external uri view helper
  *
  */
-class ExternalViewHelperTest extends \Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase
+class ExternalViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase
 {
     /**
      * var \Neos\FluidAdaptor\ViewHelpers\Uri\ExternalViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ResourceViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ResourceViewHelperTest.php
@@ -23,7 +23,7 @@ require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 /**
  * Test case for the resource uri view helper
  */
-class ResourceViewHelperTest extends \Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase
+class ResourceViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase
 {
     /**
      * @var \Neos\FluidAdaptor\ViewHelpers\Uri\ResourceViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Validation/IfHasErrorsViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Validation/IfHasErrorsViewHelperTest.php
@@ -14,7 +14,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Security;
 use TYPO3\Flow\Error\Error;
 use TYPO3\Flow\Error\Result;
 use Neos\FluidAdaptor\ViewHelpers\Validation\IfHasErrorsViewHelper;
-use Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase;
+use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
 require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Validation/ResultsViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Validation/ResultsViewHelperTest.php
@@ -17,7 +17,7 @@ require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
  * Test for the Validation Results view helper
  *
  */
-class ResultsViewHelperTest extends \Neos\FluidAdaptor\ViewHelpers\ViewHelperBaseTestcase
+class ResultsViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase
 {
     /**
      * @var \Neos\FluidAdaptor\ViewHelpers\Validation\ResultsViewHelper


### PR DESCRIPTION
In neos/flow-development-collection#722 the namespace was changed but
the classes extending it were not adjusted. Cough, cough.

This fixes that.