### PR TITLE
BUGFIX: Exclude psr/log from reflection

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
@@ -56,39 +56,43 @@ use TYPO3\Flow\Utility\TypeHandling;
  */
 class ReflectionService
 {
-    const
-        VISIBILITY_PRIVATE = 1,
-        VISIBILITY_PROTECTED = 2,
-        VISIBILITY_PUBLIC = 3,
-        // Implementations of an interface
-        DATA_INTERFACE_IMPLEMENTATIONS = 1,
-        // Implemented interfaces of a class
-        DATA_CLASS_INTERFACES = 2,
-        // Subclasses of a class
-        DATA_CLASS_SUBCLASSES = 3,
-        // Class tag values
-        DATA_CLASS_TAGS_VALUES = 4,
-        // Class annotations
-        DATA_CLASS_ANNOTATIONS = 5,
-        DATA_CLASS_ABSTRACT = 6,
-        DATA_CLASS_FINAL = 7,
-        DATA_CLASS_METHODS = 8,
-        DATA_CLASS_PROPERTIES = 9,
-        DATA_METHOD_FINAL = 10,
-        DATA_METHOD_STATIC = 11,
-        DATA_METHOD_VISIBILITY = 12,
-        DATA_METHOD_PARAMETERS = 13,
-        DATA_PROPERTY_TAGS_VALUES = 14,
-        DATA_PROPERTY_ANNOTATIONS = 15,
-        DATA_PROPERTY_VISIBILITY = 24,
-        DATA_PARAMETER_POSITION = 16,
-        DATA_PARAMETER_OPTIONAL = 17,
-        DATA_PARAMETER_TYPE = 18,
-        DATA_PARAMETER_ARRAY = 19,
-        DATA_PARAMETER_CLASS = 20,
-        DATA_PARAMETER_ALLOWS_NULL = 21,
-        DATA_PARAMETER_DEFAULT_VALUE = 22,
-        DATA_PARAMETER_BY_REFERENCE = 23;
+    const VISIBILITY_PRIVATE = 1;
+    const VISIBILITY_PROTECTED = 2;
+    const VISIBILITY_PUBLIC = 3;
+
+    // Implementations of an interface
+    const DATA_INTERFACE_IMPLEMENTATIONS = 1;
+
+    // Implemented interfaces of a class
+    const DATA_CLASS_INTERFACES = 2;
+
+    // Subclasses of a class
+    const DATA_CLASS_SUBCLASSES = 3;
+
+    // Class tag values
+    const DATA_CLASS_TAGS_VALUES = 4;
+
+    // Class annotations
+    const DATA_CLASS_ANNOTATIONS = 5;
+    const DATA_CLASS_ABSTRACT = 6;
+    const DATA_CLASS_FINAL = 7;
+    const DATA_CLASS_METHODS = 8;
+    const DATA_CLASS_PROPERTIES = 9;
+    const DATA_METHOD_FINAL = 10;
+    const DATA_METHOD_STATIC = 11;
+    const DATA_METHOD_VISIBILITY = 12;
+    const DATA_METHOD_PARAMETERS = 13;
+    const DATA_PROPERTY_TAGS_VALUES = 14;
+    const DATA_PROPERTY_ANNOTATIONS = 15;
+    const DATA_PROPERTY_VISIBILITY = 24;
+    const DATA_PARAMETER_POSITION = 16;
+    const DATA_PARAMETER_OPTIONAL = 17;
+    const DATA_PARAMETER_TYPE = 18;
+    const DATA_PARAMETER_ARRAY = 19;
+    const DATA_PARAMETER_CLASS = 20;
+    const DATA_PARAMETER_ALLOWS_NULL = 21;
+    const DATA_PARAMETER_DEFAULT_VALUE = 22;
+    const DATA_PARAMETER_BY_REFERENCE = 23;
 
     /**
      * @var \Doctrine\Common\Annotations\Reader

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Authorization/AccessDecisionVoterInterface.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Authorization/AccessDecisionVoterInterface.php
@@ -17,10 +17,9 @@ namespace TYPO3\Flow\Security\Authorization;
  */
 interface AccessDecisionVoterInterface
 {
-    const
-        VOTE_GRANT = 1,
-        VOTE_ABSTAIN = 2,
-        VOTE_DENY = 3;
+    const VOTE_GRANT = 1;
+    const VOTE_ABSTAIN = 2;
+    const VOTE_DENY = 3;
 
     /**
      * Votes if access should be granted for the given object in the current security context

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Policy/PolicyService.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Policy/PolicyService.php
@@ -25,11 +25,10 @@ use TYPO3\Flow\Security\Exception\RoleExistsException;
  */
 class PolicyService implements \TYPO3\Flow\Aop\Pointcut\PointcutFilterInterface
 {
-    const
-        PRIVILEGE_ABSTAIN = 0,
-        PRIVILEGE_GRANT = 1,
-        PRIVILEGE_DENY = 2,
-        MATCHER_ANY = 'ANY';
+    const PRIVILEGE_ABSTAIN = 0;
+    const PRIVILEGE_GRANT = 1;
+    const PRIVILEGE_DENY = 2;
+    const MATCHER_ANY = 'ANY';
 
     /**
      * @var boolean

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Unicode/TextIterator.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Utility/Unicode/TextIterator.php
@@ -20,36 +20,35 @@ use TYPO3\Flow\Annotations as Flow;
  */
 class TextIterator implements \Iterator
 {
-    const
-        CODE_POINT = 1,
-        COMB_SEQUENCE = 2,
-        CHARACTER = 3,
-        WORD = 4,
-        LINE = 5,
-        SENTENCE = 6,
+    const CODE_POINT = 1;
+    const COMB_SEQUENCE = 2;
+    const CHARACTER = 3;
+    const WORD = 4;
+    const LINE = 5;
+    const SENTENCE = 6;
 
-        DONE = 'DONE',
+    const DONE = 'DONE';
 
-        WORD_NONE = 'WORD_NONE',
-        WORD_NONE_LIMIT = 'WORD_NONE_LIMIT',
-        WORD_NUMBER = 'WORD_NUMBER',
-        WORD_NUMBER_LIMIT = 'WORD_NUMBER_LIMIT',
-        WORD_LETTER = 'WORD_LETTER',
-        WORD_LETTER_LIMIT = 'WORD_LETTER_LIMIT',
-        WORD_KANA = 'WORD_KANA',
-        WORD_KANA_LIMIT = 'WORD_KANA_LIMIT',
+    const WORD_NONE = 'WORD_NONE';
+    const WORD_NONE_LIMIT = 'WORD_NONE_LIMIT';
+    const WORD_NUMBER = 'WORD_NUMBER';
+    const WORD_NUMBER_LIMIT = 'WORD_NUMBER_LIMIT';
+    const WORD_LETTER = 'WORD_LETTER';
+    const WORD_LETTER_LIMIT = 'WORD_LETTER_LIMIT';
+    const WORD_KANA = 'WORD_KANA';
+    const WORD_KANA_LIMIT = 'WORD_KANA_LIMIT';
 
-        LINE_SOFT = 'LINE_SOFT',
-        LINE_SOFT_LIMIT = 'LINE_SOFT_LIMIT',
-        LINE_HARD = 'LINE_HARD',
-        LINE_HARD_LIMIT = 'LINE_HARD_LIMIT',
+    const LINE_SOFT = 'LINE_SOFT';
+    const LINE_SOFT_LIMIT = 'LINE_SOFT_LIMIT';
+    const LINE_HARD = 'LINE_HARD';
+    const LINE_HARD_LIMIT = 'LINE_HARD_LIMIT';
 
-        SENTENCE_TERM = 'SENTENCE_TERM',
-        SENTENCE_TERM_LIMIT = 'SENTENCE_TERM_LIMIT',
-        SENTENCE_SEP = 'SENTENCE_SEP',
-        SENTENCE_SEP_LIMIT = 'SENTENCE_SEP_LIMIT',
+    const SENTENCE_TERM = 'SENTENCE_TERM';
+    const SENTENCE_TERM_LIMIT = 'SENTENCE_TERM_LIMIT';
+    const SENTENCE_SEP = 'SENTENCE_SEP';
+    const SENTENCE_SEP_LIMIT = 'SENTENCE_SEP_LIMIT';
 
-        REGEXP_SENTENCE_DELIMITERS = '[\.|,|!|\?|;]';
+    const REGEXP_SENTENCE_DELIMITERS = '[\.|,|!|\?|;]';
 
     /**
      * @var integer

--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -196,6 +196,7 @@ TYPO3:
         'sebastian.*': ['.*']
         'phpdocumentor.*': ['.*']
         'mikey179.vfsStream': ['.*']
+        'psr.log': ['.*']
         # workaround, should rather be deactivated
         'neos.composerplugin': ['.*']
         'Composer.Installers': ['.*']


### PR DESCRIPTION
A change in dependencies pulled in psr/log which contains a trait,
causing failures with PHP 5.3