### PR TITLE
!!! TASK: Remove special handling of test-classes from classLoader

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -84,6 +84,7 @@ class Scripts
         $bootstrap->setEarlyInstance(ClassLoader::class, $classLoader);
         if ($bootstrap->getContext()->isTesting()) {
             self::requireAutoloaderForPhpUnit();
+            $classLoader->setConsiderTestsNamespace(true);
             require_once(FLOW_PATH_FLOW . 'Tests/BaseTestCase.php');
             require_once(FLOW_PATH_FLOW . 'Tests/FunctionalTestCase.php');
         }

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -84,7 +84,6 @@ class Scripts
         $bootstrap->setEarlyInstance(ClassLoader::class, $classLoader);
         if ($bootstrap->getContext()->isTesting()) {
             self::requireAutoloaderForPhpUnit();
-            $classLoader->setConsiderTestsNamespace(true);
             require_once(FLOW_PATH_FLOW . 'Tests/BaseTestCase.php');
             require_once(FLOW_PATH_FLOW . 'Tests/FunctionalTestCase.php');
         }

--- a/Neos.Flow/Classes/Core/ClassLoader.php
+++ b/Neos.Flow/Classes/Core/ClassLoader.php
@@ -58,6 +58,11 @@ class ClassLoader
     protected $packageNamespaces = [];
 
     /**
+     * @var boolean
+     */
+    protected $considerTestsNamespace = false;
+
+    /**
      * @var array
      */
     protected $ignoredClassNames = [
@@ -227,7 +232,7 @@ class ClassLoader
     {
         /** @var Package $package */
         foreach ($activePackages as $packageKey => $package) {
-            foreach ($package->getFlattenedAutoloadConfiguration() as $configuration) {
+            foreach ($package->getFlattenedAutoloadConfiguration($this->considerTestsNamespace) as $configuration) {
                 $this->createNamespaceMapEntry($configuration['namespace'], $configuration['classPath'], $configuration['mappingType']);
             }
         }
@@ -357,6 +362,18 @@ class ClassLoader
         if ($proxyClasses !== false) {
             $this->availableProxyClasses = $proxyClasses;
         }
+    }
+
+    /**
+     * Sets the flag which enables or disables autoloading support for functional
+     * test files.
+     *
+     * @param boolean $flag
+     * @return void
+     */
+    public function setConsiderTestsNamespace($flag)
+    {
+        $this->considerTestsNamespace = $flag;
     }
 
     /**

--- a/Neos.Flow/Classes/Core/ClassLoader.php
+++ b/Neos.Flow/Classes/Core/ClassLoader.php
@@ -58,11 +58,6 @@ class ClassLoader
     protected $packageNamespaces = [];
 
     /**
-     * @var boolean
-     */
-    protected $considerTestsNamespace = false;
-
-    /**
      * @var array
      */
     protected $ignoredClassNames = [
@@ -235,12 +230,6 @@ class ClassLoader
             foreach ($package->getFlattenedAutoloadConfiguration() as $configuration) {
                 $this->createNamespaceMapEntry($configuration['namespace'], $configuration['classPath'], $configuration['mappingType']);
             }
-            // TODO: Replace with "autoload-dev" usage
-            if ($this->considerTestsNamespace) {
-                foreach ($package->getNamespaces() as $namespace) {
-                    $this->createNamespaceMapEntry($namespace, $package->getPackagePath(), self::MAPPING_TYPE_PSR4);
-                }
-            }
         }
     }
 
@@ -368,18 +357,6 @@ class ClassLoader
         if ($proxyClasses !== false) {
             $this->availableProxyClasses = $proxyClasses;
         }
-    }
-
-    /**
-     * Sets the flag which enables or disables autoloading support for functional
-     * test files.
-     *
-     * @param boolean $flag
-     * @return void
-     */
-    public function setConsiderTestsNamespace($flag)
-    {
-        $this->considerTestsNamespace = $flag;
     }
 
     /**

--- a/Neos.Flow/Classes/Package/Package.php
+++ b/Neos.Flow/Classes/Package/Package.php
@@ -304,12 +304,13 @@ class Package implements PackageInterface
     /**
      * Get a flattened array of autoload configurations that have a predictable pattern (PSR-0, PSR-4)
      *
+     * @param bool $considerTestsNamespaces
      * @return array Keys: "namespace", "classPath", "mappingType"
      */
-    public function getFlattenedAutoloadConfiguration()
+    public function getFlattenedAutoloadConfiguration($considerTestsNamespaces = false)
     {
         if ($this->flattenedAutoloadConfiguration === null) {
-            $this->explodeAutoloadConfiguration();
+            $this->explodeAutoloadConfiguration($considerTestsNamespaces);
         }
 
         return $this->flattenedAutoloadConfiguration;
@@ -418,14 +419,21 @@ class Package implements PackageInterface
     /**
      * Brings the composer autoload configuration into an easy to use format for various parts of Flow.
      *
+     * @param bool $considerTestsNamespaces
      * @return void
      */
-    protected function explodeAutoloadConfiguration()
+    protected function explodeAutoloadConfiguration($considerTestsNamespaces = false)
     {
         $this->namespaces = [];
         $this->autoloadTypes = [];
         $this->flattenedAutoloadConfiguration = [];
+
         $allAutoloadConfiguration = $this->autoloadConfiguration;
+        if ($considerTestsNamespaces) {
+            $autoloadDevConfigurations = $this->getComposerManifest('autoload-dev') ?: [];
+            $allAutoloadConfiguration = array_merge_recursive($allAutoloadConfiguration, $autoloadDevConfigurations);
+        }
+
         foreach ($allAutoloadConfiguration as $autoloadType => $autoloadConfiguration) {
             $this->autoloadTypes[] = $autoloadType;
             if (ClassLoader::isAutoloadTypeWithPredictableClassPath($autoloadType)) {

--- a/Neos.Flow/Tests/Unit/Core/ClassLoaderTest.php
+++ b/Neos.Flow/Tests/Unit/Core/ClassLoaderTest.php
@@ -122,6 +122,7 @@ class ClassLoaderTest extends UnitTestCase
         mkdir('vfs://Test/Packages/Application/Acme.MyApp/Tests/Functional/Essentials', 0770, true);
         file_put_contents('vfs://Test/Packages/Application/Acme.MyApp/Tests/Functional/Essentials/LawnMowerTest.php', '<?php ' . __CLASS__ . '::$testClassWasLoaded = TRUE; ?>');
 
+        $this->classLoader->setConsiderTestsNamespace(true);
         $this->classLoader->setPackages($this->mockPackages);
 
         $this->classLoader->loadClass('Acme\MyApp\Tests\Functional\Essentials\LawnMowerTest');

--- a/Neos.Flow/Tests/Unit/Core/ClassLoaderTest.php
+++ b/Neos.Flow/Tests/Unit/Core/ClassLoaderTest.php
@@ -67,13 +67,18 @@ class ClassLoaderTest extends UnitTestCase
         $this->classLoader = new ClassLoader();
 
         $this->mockPackage1 = $this->getMockBuilder(Package::class)->disableOriginalConstructor()->getMock();
-        $this->mockPackage1->expects($this->any())->method('getNamespaces')->will($this->returnValue(['Acme\\MyApp']));
+        $this->mockPackage1->expects($this->any())->method('getNamespaces')->will($this->returnValue(['Acme\\MyApp','Acme\\MyApp\\Tests']));
         $this->mockPackage1->expects($this->any())->method('getPackagePath')->will($this->returnValue('vfs://Test/Packages/Application/Acme.MyApp/'));
         $this->mockPackage1->expects($this->any())->method('getFlattenedAutoloadConfiguration')->will($this->returnValue([
             [
                 'namespace' => 'Acme\\MyApp',
                 'classPath' => 'vfs://Test/Packages/Application/Acme.MyApp/Classes/',
                 'mappingType' => ClassLoader::MAPPING_TYPE_PSR0
+            ],
+            [
+                'namespace' => 'Acme\\MyApp\\Tests',
+                'classPath' => 'vfs://Test/Packages/Application/Acme.MyApp/Tests/',
+                'mappingType' => ClassLoader::MAPPING_TYPE_PSR4
             ]
         ]));
 
@@ -117,7 +122,6 @@ class ClassLoaderTest extends UnitTestCase
         mkdir('vfs://Test/Packages/Application/Acme.MyApp/Tests/Functional/Essentials', 0770, true);
         file_put_contents('vfs://Test/Packages/Application/Acme.MyApp/Tests/Functional/Essentials/LawnMowerTest.php', '<?php ' . __CLASS__ . '::$testClassWasLoaded = TRUE; ?>');
 
-        $this->classLoader->setConsiderTestsNamespace(true);
         $this->classLoader->setPackages($this->mockPackages);
 
         $this->classLoader->loadClass('Acme\MyApp\Tests\Functional\Essentials\LawnMowerTest');

--- a/Neos.FluidAdaptor/composer.json
+++ b/Neos.FluidAdaptor/composer.json
@@ -11,5 +11,10 @@
 		"psr-4": {
 			"Neos\\FluidAdaptor\\": "Classes/"
 		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"Neos\\FluidAdaptor\\Tests\\": "Tests"
+		}
 	}
 }

--- a/Neos.Utility.Schema/composer.json
+++ b/Neos.Utility.Schema/composer.json
@@ -19,7 +19,7 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "TYPO3\\Flow\\Utility\\Schema\\Tests\\": "Tests"
+      "Neos\\Flow\\Utility\\Schema\\Tests\\": "Tests"
     }
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -115,6 +115,9 @@
             "Neos\\Flow\\Tests\\": [
                 "Neos.Flow/Tests"
             ],
+            "Neos\\FluidAdaptor\\Tests\\": [
+                "Neos.FluidAdaptor/Tests"
+            ],
             "Neos\\Kickstarter\\Tests\\": [
                 "Neos.Kickstarter/Tests"
             ],
@@ -133,7 +136,7 @@
             "Neos\\Utility\\ObjectHandling\\Tests\\": [
                 "Neos.Utility.ObjectHandling/Tests"
             ],
-            "TYPO3\\Flow\\Utility\\Schema\\Tests\\": [
+            "Neos\\Flow\\Utility\\Schema\\Tests\\": [
                 "Neos.Utility.Schema/Tests"
             ],
             "TYPO3\\Flow\\Utility\\Unicode\\Tests\\": [


### PR DESCRIPTION
Instead of the previous logic the autoload-dev feature of composer is used now.