### PR TITLE
TASK: Use string for "virtual" namespace name

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/EntityManagerFactory.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/EntityManagerFactory.php
@@ -119,7 +119,7 @@ class EntityManagerFactory
         $proxyDirectory = Files::concatenatePaths([$this->environment->getPathToTemporaryDirectory(), 'Doctrine/Proxies']);
         Files::createDirectoryRecursively($proxyDirectory);
         $config->setProxyDir($proxyDirectory);
-        $config->setProxyNamespace(Proxies::class);
+        $config->setProxyNamespace('TYPO3\Flow\Persistence\Doctrine\Proxies');
         $config->setAutoGenerateProxyClasses(false);
 
         // Set default host to 127.0.0.1 if there is no host configured but a dbname


### PR DESCRIPTION
This reverts the use of the `::class` constant for the ORM proxy
namespace configuration, since that is not "real" and is not
even a "class" but just a "namespace prefix".