### PR TITLE
BUGFIX: Fix calling shutdownObject() on doctrine proxy

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Object/DependencyInjection/ProxyClassBuilder.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Object/DependencyInjection/ProxyClassBuilder.php
@@ -149,7 +149,7 @@ class ProxyClassBuilder
             $wakeupMethod->addPreParentCallCode($this->buildSetInstanceCode($objectConfiguration));
             $wakeupMethod->addPreParentCallCode($this->buildSetRelatedEntitiesCode());
             $wakeupMethod->addPostParentCallCode($this->buildLifecycleInitializationCode($objectConfiguration, ObjectManagerInterface::INITIALIZATIONCAUSE_RECREATED));
-            $wakeupMethod->addPostParentCallCode($this->buildLifecycleShutdownCode($objectConfiguration));
+            $wakeupMethod->addPostParentCallCode($this->buildLifecycleShutdownCode($objectConfiguration, ObjectManagerInterface::INITIALIZATIONCAUSE_RECREATED));
 
             $sleepMethod = $proxyClass->getMethod('__sleep');
             $sleepMethod->addPostParentCallCode($this->buildSerializeRelatedEntitiesCode($objectConfiguration));
@@ -171,7 +171,7 @@ class ProxyClassBuilder
             }
 
             $constructorPostCode .= $this->buildLifecycleInitializationCode($objectConfiguration, ObjectManagerInterface::INITIALIZATIONCAUSE_CREATED);
-            $constructorPostCode .= $this->buildLifecycleShutdownCode($objectConfiguration);
+            $constructorPostCode .= $this->buildLifecycleShutdownCode($objectConfiguration, ObjectManagerInterface::INITIALIZATIONCAUSE_CREATED);
 
             $constructor = $proxyClass->getConstructor();
             $constructor->addPreParentCallCode($constructorPreCode);
@@ -676,7 +676,15 @@ class ProxyClassBuilder
             return '';
         }
         $className = $objectConfiguration->getClassName();
-        $code = "\n". '		if (get_class($this) === \'' . $className . '\') {' . "\n";
+        $code = "\n" . '		$isSameClass = get_class($this) === \'' . $className . '\';';
+        if ($cause === ObjectManagerInterface::INITIALIZATIONCAUSE_RECREATED) {
+            $code .= "\n" . '		$classParents = class_parents($this);';
+            $code .= "\n" . '		$classImplements = class_implements($this);';
+            $code .= "\n" . '		$isClassProxy = array_search(\'' . $className . '\', $classParents) !== FALSE && array_search(\'Doctrine\ORM\Proxy\Proxy\', $classImplements) !== FALSE;' . "\n";
+            $code .= "\n" . '		if ($isSameClass || $isClassProxy) {' . "\n";
+        } else {
+            $code .= "\n" . '		if ($isSameClass) {' . "\n";
+        }
         $code .= '			$this->' . $lifecycleInitializationMethodName . '(' . $cause . ');' . "\n";
         $code .= '		}' . "\n";
         return $code;
@@ -686,18 +694,28 @@ class ProxyClassBuilder
      * Builds code which registers the lifecycle shutdown method, if any.
      *
      * @param Configuration $objectConfiguration
+     * @param integer $cause a ObjectManagerInterface::INITIALIZATIONCAUSE_* constant which is the cause of the initialization command being called.
      * @return string
      */
-    protected function buildLifecycleShutdownCode(Configuration $objectConfiguration)
+    protected function buildLifecycleShutdownCode(Configuration $objectConfiguration, $cause)
     {
         $lifecycleShutdownMethodName = $objectConfiguration->getLifecycleShutdownMethodName();
         if (!$this->reflectionService->hasMethod($objectConfiguration->getClassName(), $lifecycleShutdownMethodName)) {
             return '';
         }
         $className = $objectConfiguration->getClassName();
-        $code = "\n". '		if (get_class($this) === \'' . $className . '\') {' . "\n";
-        $code .= '		\TYPO3\Flow\Core\Bootstrap::$staticObjectManager->registerShutdownObject($this, \'' . $lifecycleShutdownMethodName . '\');' . PHP_EOL;
+        $code = "\n" . '		$isSameClass = get_class($this) === \'' . $className . '\';';
+        if ($cause === ObjectManagerInterface::INITIALIZATIONCAUSE_RECREATED) {
+            $code .= "\n" . '		$classParents = class_parents($this);';
+            $code .= "\n" . '		$classImplements = class_implements($this);';
+            $code .= "\n" . '		$isClassProxy = array_search(\'' . $className . '\', $classParents) !== FALSE && array_search(\'Doctrine\ORM\Proxy\Proxy\', $classImplements) !== FALSE;' . "\n";
+            $code .= "\n" . '		if ($isSameClass || $isClassProxy) {' . "\n";
+        } else {
+            $code .= "\n" . '		if ($isSameClass) {' . "\n";
+        }
+        $code .= '			\TYPO3\Flow\Core\Bootstrap::$staticObjectManager->registerShutdownObject($this, \'' . $lifecycleShutdownMethodName . '\');' . PHP_EOL;
         $code .= '		}' . "\n";
+
         return $code;
     }
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Object/DependencyInjection/ProxyClassBuilder.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Object/DependencyInjection/ProxyClassBuilder.php
@@ -666,7 +666,7 @@ class ProxyClassBuilder
      * Builds code which calls the lifecycle initialization method, if any.
      *
      * @param Configuration $objectConfiguration
-     * @param integer $cause a ObjectManagerInterface::INITIALIZATIONCAUSE_* constant which is the cause of the initialization command being called.
+     * @param int $cause a ObjectManagerInterface::INITIALIZATIONCAUSE_* constant which is the cause of the initialization command being called.
      * @return string
      */
     protected function buildLifecycleInitializationCode(Configuration $objectConfiguration, $cause)
@@ -694,7 +694,7 @@ class ProxyClassBuilder
      * Builds code which registers the lifecycle shutdown method, if any.
      *
      * @param Configuration $objectConfiguration
-     * @param integer $cause a ObjectManagerInterface::INITIALIZATIONCAUSE_* constant which is the cause of the initialization command being called.
+     * @param int $cause a ObjectManagerInterface::INITIALIZATIONCAUSE_* constant which is the cause of the initialization command being called.
      * @return string
      */
     protected function buildLifecycleShutdownCode(Configuration $objectConfiguration, $cause)

--- a/TYPO3.Flow/Tests/Functional/Object/Fixtures/PrototypeClassG.php
+++ b/TYPO3.Flow/Tests/Functional/Object/Fixtures/PrototypeClassG.php
@@ -27,7 +27,7 @@ class PrototypeClassG
     protected $name = '';
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $destructed = false;
 
@@ -41,7 +41,6 @@ class PrototypeClassG
 
     /**
      * @param string $name
-     * @return void
      */
     public function setName($name)
     {
@@ -49,7 +48,7 @@ class PrototypeClassG
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function isDestructed()
     {
@@ -57,7 +56,7 @@ class PrototypeClassG
     }
 
     /**
-     * @param boolean $destructed
+     * @param bool $destructed
      */
     public function setDestructed($destructed)
     {

--- a/TYPO3.Flow/Tests/Functional/Object/Fixtures/PrototypeClassG.php
+++ b/TYPO3.Flow/Tests/Functional/Object/Fixtures/PrototypeClassG.php
@@ -1,0 +1,71 @@
+<?php
+namespace TYPO3\Flow\Tests\Functional\Object\Fixtures;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+
+/**
+ * A class of scope prototype
+ *
+ * @Flow\Scope("prototype")
+ * @Flow\Entity
+ */
+class PrototypeClassG
+{
+    /**
+     * @var string
+     */
+    protected $name = '';
+
+    /**
+     * @var boolean
+     */
+    protected $destructed = false;
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return void
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isDestructed()
+    {
+        return $this->destructed;
+    }
+
+    /**
+     * @param boolean $destructed
+     */
+    public function setDestructed($destructed)
+    {
+        $this->destructed = $destructed;
+    }
+
+    public function shutdownObject()
+    {
+        $this->setDestructed(true);
+    }
+}

--- a/TYPO3.Flow/Tests/Functional/Object/ObjectManagerTest.php
+++ b/TYPO3.Flow/Tests/Functional/Object/ObjectManagerTest.php
@@ -51,4 +51,21 @@ class ObjectManagerTest extends FunctionalTestCase
 
         $this->assertSame($objectByInterface, $objectByClassName);
     }
+
+    /**
+     * @test
+     */
+    public function shutdownObjectMethodIsCalledAfterRegistrationViaConstructor()
+    {
+        $entity = new Fixtures\PrototypeClassG();
+        $entity->setName('Shutdown');
+
+        /**
+         * When shutting down the ObjectManager shutdownObject() on Fixtures\TestEntityWithShutdown is called
+         * and sets $destructed property to TRUE
+         */
+        \TYPO3\Flow\Core\Bootstrap::$staticObjectManager->shutdown();
+
+        $this->assertTrue($entity->isDestructed());
+    }
 }

--- a/TYPO3.Flow/Tests/Functional/Persistence/Doctrine/LazyLoadingTest.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/Doctrine/LazyLoadingTest.php
@@ -26,12 +26,12 @@ class LazyLoadingTest extends FunctionalTestCase
     protected static $testablePersistenceEnabled = true;
 
     /**
-     * @var Fixtures\TestEntityRepository;
+     * @var Fixtures\TestEntityRepository
      */
     protected $testEntityRepository;
 
     /**
-     * @var Fixtures\PostRepository;
+     * @var Fixtures\PostRepository
      */
     protected $postRepository;
 
@@ -125,14 +125,14 @@ class LazyLoadingTest extends FunctionalTestCase
          */
         $post = $this->persistenceManager->getObjectByIdentifier($postIdentifier, Fixtures\Post::class);
 
-        /**
+        /*
          * The CleanupObject is just a helper object to test that shutdownObject() on the Fixtures\Image is called
          */
         $cleanupObject = new Fixtures\CleanupObject();
         $this->assertFalse($cleanupObject->getState());
         $post->getImage()->setRelatedObject($cleanupObject);
 
-        /**
+        /*
          * When shutting down the ObjectManager shutdownObject() on Fixtures\Image is called
          * and toggles the state on the cleanupObject
          */

--- a/TYPO3.Flow/Tests/Functional/Persistence/Doctrine/LazyLoadingTest.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/Doctrine/LazyLoadingTest.php
@@ -31,6 +31,11 @@ class LazyLoadingTest extends FunctionalTestCase
     protected $testEntityRepository;
 
     /**
+     * @var Fixtures\PostRepository;
+     */
+    protected $postRepository;
+
+    /**
      * @return void
      */
     public function setUp()
@@ -39,6 +44,7 @@ class LazyLoadingTest extends FunctionalTestCase
         if (!$this->persistenceManager instanceof PersistenceManager) {
             $this->markTestSkipped('Doctrine persistence is not enabled');
         }
+        $this->postRepository = $this->objectManager->get(Fixtures\PostRepository::class);
         $this->testEntityRepository = $this->objectManager->get(Fixtures\TestEntityRepository::class);
     }
 
@@ -92,5 +98,46 @@ class LazyLoadingTest extends FunctionalTestCase
         $loadedRelatedEntity = $loadedEntity->getRelatedEntity();
 
         $this->assertEquals($loadedRelatedEntity->sayHello(), 'Hello Andi!');
+    }
+
+    /**
+     * @test
+     */
+    public function shutdownObjectMethodIsRegisterdForDoctrineProxy()
+    {
+        $image = new Fixtures\Image();
+        $post = new Fixtures\Post();
+        $post->setImage($image);
+
+        $this->postRepository->add($post);
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        $postIdentifier = $this->persistenceManager->getIdentifierByObject($post);
+
+        unset($post);
+        unset($image);
+
+        /*
+         * When hydrating the post a DoctrineProxy is generated for the image.
+         * On this proxy __wakeup() is called and the shutdownObject lifecycle method
+         * needs to be registered in the ObjectManager
+         */
+        $post = $this->persistenceManager->getObjectByIdentifier($postIdentifier, Fixtures\Post::class);
+
+        /**
+         * The CleanupObject is just a helper object to test that shutdownObject() on the Fixtures\Image is called
+         */
+        $cleanupObject = new Fixtures\CleanupObject();
+        $this->assertFalse($cleanupObject->getState());
+        $post->getImage()->setRelatedObject($cleanupObject);
+
+        /**
+         * When shutting down the ObjectManager shutdownObject() on Fixtures\Image is called
+         * and toggles the state on the cleanupObject
+         */
+        \TYPO3\Flow\Core\Bootstrap::$staticObjectManager->shutdown();
+
+        $this->assertTrue($cleanupObject->getState());
     }
 }

--- a/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/CleanupObject.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/CleanupObject.php
@@ -1,0 +1,30 @@
+<?php
+namespace TYPO3\Flow\Tests\Functional\Persistence\Fixtures;
+
+/***************************************************************
+ *  (c) 2016 networkteam GmbH - all rights reserved
+ ***************************************************************/
+
+/**
+ * Class CleanupObject
+ */
+class CleanupObject
+{
+    /**
+     * @var boolean
+     */
+    protected $state = false;
+
+    public function toggleState()
+    {
+        $this->state = !$this->state;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getState()
+    {
+        return $this->state;
+    }
+}

--- a/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/CleanupObject.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/CleanupObject.php
@@ -1,13 +1,16 @@
 <?php
 namespace TYPO3\Flow\Tests\Functional\Persistence\Fixtures;
 
-/***************************************************************
- *  (c) 2016 networkteam GmbH - all rights reserved
- ***************************************************************/
-
-/**
- * Class CleanupObject
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
  */
+
 class CleanupObject
 {
     /**

--- a/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/Image.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/Image.php
@@ -28,6 +28,12 @@ class Image
     protected $data;
 
     /**
+     * @Flow\Transient
+     * @var CleanupObject
+     */
+    protected $relatedObject;
+
+    /**
      * @return string
      */
     public function getData()
@@ -42,5 +48,28 @@ class Image
     public function setData($data)
     {
         $this->data = $data;
+    }
+
+    /**
+     * @return CleanupObject
+     */
+    public function getRelatedObject()
+    {
+        return $this->relatedObject;
+    }
+
+    /**
+     * @param CleanupObject $relatedObject
+     */
+    public function setRelatedObject($relatedObject)
+    {
+        $this->relatedObject = $relatedObject;
+    }
+
+    public function shutdownObject()
+    {
+        if ($this->relatedObject instanceof CleanupObject) {
+            $this->relatedObject->toggleState();
+        }
     }
 }

--- a/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/Image.php
+++ b/TYPO3.Flow/Tests/Functional/Persistence/Fixtures/Image.php
@@ -61,7 +61,7 @@ class Image
     /**
      * @param CleanupObject $relatedObject
      */
-    public function setRelatedObject($relatedObject)
+    public function setRelatedObject(CleanupObject $relatedObject = null)
     {
         $this->relatedObject = $relatedObject;
     }


### PR DESCRIPTION
This change fixes #613 by creating the code to also call `shutdownObject()` on Doctrine Proxies. The proxy generation did not took into account that in `__wakeup()` the current Object can be an Instance of a Doctrine Proxy and therefore did not registered the `shutdownObject()` method on the ObjectManager.

As stated in #613 the temporary files from `Resource::createTemporaryLocalCopy()` where not removed, but with this fix they will be removed as expected.

Thanks to @monofone and @hlubek for support in finding the bug and implementing the solution and tests.

