### PR TITLE
BUGFIX: Undead core migrations unearthed and renamed

### DIFF
--- a/Neos.Flow/Migrations/Code/Version20131003152300.php
+++ b/Neos.Flow/Migrations/Code/Version20131003152300.php
@@ -35,8 +35,8 @@ class Version20131003152300 extends AbstractMigration
     public function up()
     {
         $this->searchAndReplace(
-            'Neos\Flow\Persistence\Doctrine\DatabaseConnectionException',
-            'Neos\Flow\Persistence\Doctrine\Exception\DatabaseConnectionException'
+            'TYPO3\Flow\Persistence\Doctrine\DatabaseConnectionException',
+            'TYPO3\Flow\Persistence\Doctrine\Exception\DatabaseConnectionException'
         );
     }
 }

--- a/Neos.Flow/Migrations/Code/Version20161115140400.php
+++ b/Neos.Flow/Migrations/Code/Version20161115140400.php
@@ -26,7 +26,7 @@ class Version20161115140400 extends AbstractMigration
      */
     public function up()
     {
-        $this->searchAndReplace('Neos\Flow\Resource', 'Neos\Flow\ResourceManagement');
+        $this->searchAndReplace('TYPO3\Flow\Resource', 'TYPO3\Flow\ResourceManagement');
         $this->searchAndReplaceRegex('/ResourceManagement\\\\Resource(?![a-zA-Z])/', 'ResourceManagement\\PersistentResource');
         $this->searchAndReplaceRegex('/(?<![a-zA-Z])Resource::class/', 'PersistentResource::class');
 

--- a/Neos.Flow/Migrations/Code/Version20161115140430.php
+++ b/Neos.Flow/Migrations/Code/Version20161115140430.php
@@ -27,6 +27,6 @@ class Version20161115140430 extends AbstractMigration
      */
     public function up()
     {
-        $this->searchAndReplace('Neos\Flow\Object\\', 'Neos\Flow\ObjectManagement\\');
+        $this->searchAndReplace('TYPO3\Flow\Object\\', 'TYPO3\Flow\ObjectManagement\\');
     }
 }


### PR DESCRIPTION
This fixes a problem with old core migrations which were touched
accidentally during the Neos vendor namespace change. These migrations
shouldn't have been touched since they are executed before the
vendor name change.

Now the old migrations may rest in peace with their old vendor name.