### PR TITLE
BUGFIX: Enable flow to send multiple http-headers of the same type

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Response.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Response.php
@@ -585,7 +585,7 @@ class Response extends AbstractMessage implements ResponseInterface
             return;
         }
         foreach ($this->renderHeaders() as $header) {
-            header($header);
+            header($header, false);
         }
         foreach ($this->headers->getCookies() as $cookie) {
             header('Set-Cookie: ' . $cookie, false);

--- a/TYPO3.Flow/Tests/Unit/Http/ResponseTest.php
+++ b/TYPO3.Flow/Tests/Unit/Http/ResponseTest.php
@@ -234,15 +234,18 @@ class ResponseTest extends UnitTestCase
     public function multipleHeadersCanBeSetAsArray()
     {
         $response = new Response();
+        $response->setStatus(123, 'Custom Status');
         $response->setHeader('MyHeader', ['MyValue-1','MyValue-2','MyValue-3']);
 
         $expectedHeaders = [
-            'HTTP/1.1 200 OK',
+            'HTTP/1.1 123 Custom Status',
+            'X-Flow-Powered: Flow/' . FLOW_VERSION_BRANCH,
             'Content-Type: text/html; charset=UTF-8',
             'MyHeader: MyValue-1',
             'MyHeader: MyValue-2',
             'MyHeader: MyValue-3',
         ];
+
         $this->assertEquals($expectedHeaders, $response->renderHeaders());
     }
 

--- a/TYPO3.Flow/Tests/Unit/Http/ResponseTest.php
+++ b/TYPO3.Flow/Tests/Unit/Http/ResponseTest.php
@@ -229,6 +229,24 @@ class ResponseTest extends UnitTestCase
     }
 
     /**
+     * @test
+     */
+    public function multipleHeadersCanBeSetAsArray()
+    {
+        $response = new Response();
+        $response->setHeader('MyHeader', ['MyValue-1','MyValue-2','MyValue-3']);
+
+        $expectedHeaders = [
+            'HTTP/1.1 200 OK',
+            'Content-Type: text/html; charset=UTF-8',
+            'MyHeader: MyValue-1',
+            'MyHeader: MyValue-2',
+            'MyHeader: MyValue-3',
+        ];
+        $this->assertEquals($expectedHeaders, $response->renderHeaders());
+    }
+
+    /**
      * RFC 2616 / 3.7.1
      *
      * @test


### PR DESCRIPTION
The method setHeader accepts a value or an array of values, but until now if an arrays of values was given the renderHeaders method correctly rendered a seperate header for each value but during sending the ``header`` php-method overwrote the previously send headers because the replace argument was not given and defaults to ``true``.