### PR TITLE
TASK: Add PHP 7.1 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ matrix:
       env: DB=mysql BEHAT=true
     - php: 7.0
       env: DB=pgsql BEHAT=true
+    - php: 7.1
+      env: DB=mysql
+    - php: 7.1
+      env: DB=mysql BEHAT=true
 cache:
   directories:
     - $HOME/.composer/cache


### PR DESCRIPTION
Now that PHP 7.1 is released, we should make sure we are compatible.