### PR TITLE
FEATURE: NodeType Configuration enhancements

### DIFF
--- a/Neos.Flow/Classes/Configuration/PostProcessor/ConfigurationPostProcessorInterface.php
+++ b/Neos.Flow/Classes/Configuration/PostProcessor/ConfigurationPostProcessorInterface.php
@@ -1,0 +1,35 @@
+<?php
+namespace Neos\Flow\Configuration\PostProcessor;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Symfony\Component\Yaml\Yaml;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Configuration\Exception\ParseErrorException;
+use Neos\Flow\Utility\Arrays;
+
+/**
+ * Post processor for configurations
+ *
+ * @api
+ */
+interface ConfigurationPostProcessorInterface
+{
+
+    /**
+     * Post process configuration
+     *
+     * @param array $configuration input configuration
+     * @return void
+     */
+    public function process(array &$configuration);
+
+}

--- a/Neos.Flow/Classes/Configuration/Source/YamlSource.php
+++ b/Neos.Flow/Classes/Configuration/Source/YamlSource.php
@@ -15,7 +15,7 @@ use Symfony\Component\Yaml\Yaml;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Configuration\Exception\ParseErrorException;
 use Neos\Flow\Error\Exception;
-use Neos\Utility\Arrays;
+use Neos\Flow\Utility\Arrays;
 
 /**
  * Configuration source based on YAML files
@@ -24,7 +24,7 @@ use Neos\Utility\Arrays;
  * @Flow\Proxy(FALSE)
  * @api
  */
-class YamlSource
+class YamlSource implements YamlSourceInterface
 {
     /**
      * Will be set if the PHP YAML Extension is installed.

--- a/Neos.Flow/Classes/Configuration/Source/YamlSource.php
+++ b/Neos.Flow/Classes/Configuration/Source/YamlSource.php
@@ -15,7 +15,7 @@ use Symfony\Component\Yaml\Yaml;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Configuration\Exception\ParseErrorException;
 use Neos\Flow\Error\Exception;
-use Neos\Flow\Utility\Arrays;
+use Neos\Utility\Arrays;
 
 /**
  * Configuration source based on YAML files

--- a/Neos.Flow/Classes/Configuration/Source/YamlSourceInterface.php
+++ b/Neos.Flow/Classes/Configuration/Source/YamlSourceInterface.php
@@ -1,0 +1,57 @@
+<?php
+namespace Neos\Flow\Configuration\Source;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Symfony\Component\Yaml\Yaml;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Configuration\Exception\ParseErrorException;
+use Neos\Flow\Utility\Arrays;
+
+/**
+ * Configuration source based on YAML files
+ *
+ * @api
+ */
+interface YamlSourceInterface
+{
+
+    /**
+     * Checks for the specified configuration file and returns TRUE if it exists.
+     *
+     * @param string $pathAndFilename Full path and filename of the file to load, excluding the file extension (ie. ".yaml")
+     * @param boolean $allowSplitSource If TRUE, the type will be used as a prefix when looking for configuration files
+     * @return boolean
+     */
+    public function has($pathAndFilename, $allowSplitSource = false);
+
+    /**
+     * Loads the specified configuration file and returns its content as an
+     * array. If the file does not exist or could not be loaded, an empty
+     * array is returned
+     *
+     * @param string $pathAndFilename Full path and filename of the file to load, excluding the file extension (ie. ".yaml")
+     * @param boolean $allowSplitSource If TRUE, the type will be used as a prefix when looking for configuration files
+     * @return array
+     * @throws ParseErrorException
+     */
+    public function load($pathAndFilename, $allowSplitSource = false);
+
+    /**
+     * Save the specified configuration array to the given file in YAML format.
+     *
+     * @param string $pathAndFilename Full path and filename of the file to write to, excluding the dot and file extension (i.e. ".yaml")
+     * @param array $configuration The configuration to save
+     * @return void
+     */
+    public function save($pathAndFilename, array $configuration);
+
+}

--- a/Neos.Flow/Configuration/Objects.yaml
+++ b/Neos.Flow/Configuration/Objects.yaml
@@ -387,6 +387,11 @@ Neos\Flow\Session\SessionManager:
           1:
             value: Flow_Session_MetaData
 
+Neos\Flow\Configuration\ConfigurationManager:
+  properties:
+    configurationSource:
+      object: 'Neos\Flow\Configuration\Source\YamlSource'
+
 #                                                                          #
 # Utility                                                                  #
 #                                                                          #


### PR DESCRIPTION
Allow to change the YAML Configuration interpretation according to the RFC
https://discuss.neos.io/t/rfc-enable-inheritance-for-nodetype-properties/1607

This PR need the PR https://github.com/neos/neos-development-collection/pull/1292 to work.

Please look at https://github.com/webexcess/WebExcess.InheritProperties for a now possible implementation.