### PR TITLE
FEATURE: Scalar to object converter

### DIFF
--- a/Neos.Flow/Classes/Property/TypeConverter/ScalarTypeToObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ScalarTypeToObjectConverter.php
@@ -37,9 +37,9 @@ class ScalarTypeToObjectConverter extends AbstractTypeConverter
     protected $targetType = 'object';
 
     /**
-     * @var integer
+     * @var int
      */
-    protected $priority = 1;
+    protected $priority = 10;
 
     /**
      * @Flow\Inject

--- a/Neos.Flow/Classes/Property/TypeConverter/ScalarTypeToObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ScalarTypeToObjectConverter.php
@@ -37,6 +37,11 @@ class ScalarTypeToObjectConverter extends AbstractTypeConverter
     protected $targetType = 'object';
 
     /**
+     * @var integer
+     */
+    protected $priority = 1;
+
+    /**
      * @Flow\Inject
      * @var ReflectionService
      */

--- a/Neos.Flow/Classes/Property/TypeConverter/ScalarTypeToObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ScalarTypeToObjectConverter.php
@@ -1,0 +1,75 @@
+<?php
+namespace Neos\Flow\Property\TypeConverter;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+use Neos\Flow\Reflection\ReflectionService;
+
+/**
+ * A type converter which converts a scalar type (string, boolean, float or integer) to an object by instantiating
+ * the object and passing the string as the constructor argument.
+ *
+ * This converter will only be used if the target class has a constructor with exactly one argument whose type must
+ * be the given type.
+ *
+ * @Flow\Scope("singleton")
+ */
+class ScalarTypeToObjectConverter extends AbstractTypeConverter
+{
+    /**
+     * @var array
+     */
+    protected $sourceTypes = ['string', 'integer', 'float', 'bool'];
+
+    /**
+     * @var string
+     */
+    protected $targetType = 'object';
+
+    /**
+     * @Flow\Inject
+     * @var ReflectionService
+     */
+    protected $reflectionService;
+
+    /**
+     * Only convert if the given target class has a constructor with one argument being of type given type
+     *
+     * @param string $source
+     * @param string $targetType
+     * @return bool
+     */
+    public function canConvertFrom($source, $targetType)
+    {
+        $methodParameters = $this->reflectionService->getMethodParameters($targetType, '__construct');
+        if (count($methodParameters) !== 1) {
+            return false;
+        }
+        $methodParameter = array_shift($methodParameters);
+        return $methodParameter['type'] === gettype($source);
+    }
+
+    /**
+     * Convert the given simple type to an object
+     *
+     * @param string|float|integer|bool $source
+     * @param string $targetType
+     * @param array $convertedChildProperties
+     * @param PropertyMappingConfigurationInterface|null $configuration
+     * @return object
+     */
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    {
+        return new $targetType($source);
+    }
+}

--- a/Neos.Flow/Tests/Unit/Fixtures/ClassWithIntegerConstructor.php
+++ b/Neos.Flow/Tests/Unit/Fixtures/ClassWithIntegerConstructor.php
@@ -1,0 +1,33 @@
+<?php
+namespace Neos\Flow\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A value object (POPO) with one constructor argument (integer)
+ */
+class ClassWithIntegerConstructor
+{
+    /**
+     * @var string
+     */
+    public $value;
+
+    /**
+     * ClassWithIntegerConstructor constructor.
+     *
+     * @param int $value
+     */
+    public function __construct(int $value)
+    {
+        $this->value = $value;
+    }
+}

--- a/Neos.Flow/Tests/Unit/Fixtures/ClassWithStringConstructor.php
+++ b/Neos.Flow/Tests/Unit/Fixtures/ClassWithStringConstructor.php
@@ -1,0 +1,33 @@
+<?php
+namespace Neos\Flow\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A value object (POPO) with one constructor argument (string)
+ */
+class ClassWithStringConstructor
+{
+    /**
+     * @var string
+     */
+    public $value;
+
+    /**
+     * ClassWithStringConstructor constructor.
+     *
+     * @param string $value
+     */
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+}

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/ScalarTypeToObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/ScalarTypeToObjectConverterTest.php
@@ -1,0 +1,49 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+require_once(__DIR__ . '/../../Fixtures/ClassWithStringConstructor.php');
+require_once(__DIR__ . '/../../Fixtures/ClassWithIntegerConstructor.php');
+
+use Neos\Flow\Fixtures\ClassWithIntegerConstructor;
+use Neos\Flow\Fixtures\ClassWithStringConstructor;
+use Neos\Flow\Property\TypeConverter\ScalarTypeToObjectConverter;
+use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * Test case for the ScalarTypeToObjectConverter
+ *
+ * @covers \Neos\Flow\Property\TypeConverter\ScalarTypeToObjectConverter<extended>
+ */
+class ScalarTypeToObjectConverterTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function convertFromStringToValueObject()
+    {
+        $converter = new ScalarTypeToObjectConverter();
+        $valueObject = $converter->convertFrom('Hello World!', ClassWithStringConstructor::class);
+        $this->assertEquals('Hello World!', $valueObject->value);
+    }
+
+    /**
+     * @test
+     */
+    public function convertFromIntegerToValueObject()
+    {
+        $converter = new ScalarTypeToObjectConverter();
+        $valueObject = $converter->convertFrom(42, ClassWithIntegerConstructor::class);
+        $this->assertSame(42, $valueObject->value);
+    }
+}


### PR DESCRIPTION
This introduces a simple type converter which can convert
a scalar value (string, integer, float or boolean) into an
object by passing that value to the class constructor.

This converter helps developers using Value Objects (not
managed by the persistence framework) or other Data
Transfer Objects in places where type conversion is
supported. One common case is to use Value Object class
names as a type hint for arguments in a command line
controller method.