### PR TITLE
!!! TASK: Remove deprecated ``getClassTag`` and constants

### DIFF
--- a/Neos.Cache/Classes/Frontend/FrontendInterface.php
+++ b/Neos.Cache/Classes/Frontend/FrontendInterface.php
@@ -19,16 +19,6 @@ namespace Neos\Cache\Frontend;
 interface FrontendInterface
 {
     /**
-     * "Magic" tag for class-related entries
-     */
-    const TAG_CLASS = '%CLASS%';
-
-    /**
-     * "Magic" tag for package-related entries
-     */
-    const TAG_PACKAGE = '%PACKAGE%';
-
-    /**
      * Pattern an entry identifier must match.
      */
     const PATTERN_ENTRYIDENTIFIER = '/^[a-zA-Z0-9_%\-&]{1,250}$/';

--- a/Neos.Flow/Classes/Cache/CacheManager.php
+++ b/Neos.Flow/Classes/Cache/CacheManager.php
@@ -418,24 +418,6 @@ class CacheManager
     }
 
     /**
-     * Renders a tag which can be used to mark a cache entry as "depends on this class".
-     * Whenever the specified class is modified, all cache entries tagged with the
-     * class are flushed.
-     *
-     * If an empty string is specified as class name, the returned tag means
-     * "this cache entry becomes invalid if any of the known classes changes".
-     *
-     * @param string $className The class name
-     * @return string Class Tag
-     * @api
-     * @deprecated Unused and described functionality does not exist.
-     */
-    public static function getClassTag($className = '')
-    {
-        return ($className === '') ? FrontendInterface::TAG_CLASS : FrontendInterface::TAG_CLASS . str_replace('\\', '_', $className);
-    }
-
-    /**
      * Instantiates all registered caches.
      *
      * @return void


### PR DESCRIPTION
The ``CacheManager::getClassTag`` method was unused since
quite some time and became deprecated in previous releases.
It is therefore bound for removal in this major version.
Additionally the unused tagging constants in the ``FrontendInterface``
are removed as they are also no longer needed.