### PR TITLE
TASK: Remove deprecated ``Http\Request::createActionRequest``

### DIFF
--- a/Neos.Flow/Classes/Http/Request.php
+++ b/Neos.Flow/Classes/Http/Request.php
@@ -198,19 +198,6 @@ class Request extends AbstractMessage
     }
 
     /**
-     * Creates a new Action Request request as a sub request to this HTTP request.
-     * Maps the arguments of this request to the new Action Request.
-     *
-     * @return ActionRequest
-     * @deprecated since Flow 2.3. Create the ActionRequest manually instead: $actionRequest = new ActionRequest($httpRequest)
-     */
-    public function createActionRequest()
-    {
-        $actionRequest = new ActionRequest($this);
-        return $actionRequest;
-    }
-
-    /**
      * Returns the request URI
      *
      * @return Uri

--- a/Neos.Flow/Tests/Unit/Http/RequestTest.php
+++ b/Neos.Flow/Tests/Unit/Http/RequestTest.php
@@ -252,7 +252,7 @@ class RequestTest extends UnitTestCase
         $uri = new Uri('http://flow.typo3.org');
         $request = Request::create($uri);
 
-        $subRequest = $request->createActionRequest();
+        $subRequest = new ActionRequest($request);
         $this->assertInstanceOf(ActionRequest::class, $subRequest);
         $this->assertSame($request, $subRequest->getParentRequest());
     }

--- a/Neos.Flow/Tests/Unit/Security/RequestPattern/HostTest.php
+++ b/Neos.Flow/Tests/Unit/Security/RequestPattern/HostTest.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Tests\Unit\Security\RequestPattern;
 
 use Neos\Flow\Http\Request;
 use Neos\Flow\Http\Uri;
+use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Security\RequestPattern\Host;
 use Neos\Flow\Tests\UnitTestCase;
 
@@ -42,7 +43,7 @@ class HostTest extends UnitTestCase
      */
     public function requestMatchingBasicallyWorks($uri, $pattern, $expected, $message)
     {
-        $request = Request::create(new Uri($uri))->createActionRequest();
+        $request = new ActionRequest(Request::create(new Uri($uri)));
 
         $requestPattern = new Host(['hostPattern' => $pattern]);
 


### PR DESCRIPTION
The static method was deprecated since Flow 2.3 and is due for
removal.
Instead create an instance of ``ActionRequest`` via the ``new``
keyword.