### PR TITLE
TASK: Remove deprecated ``Argument::isValid`` method

### DIFF
--- a/Neos.Flow/Classes/Mvc/Controller/Argument.php
+++ b/Neos.Flow/Classes/Mvc/Controller/Argument.php
@@ -243,16 +243,6 @@ class Argument
     }
 
     /**
-     * @return boolean TRUE if the argument is valid, FALSE otherwise
-     * @api
-     * @deprecated Will be removed for next major Flow version.
-     */
-    public function isValid()
-    {
-        return !$this->validationResults->hasErrors();
-    }
-
-    /**
      * @return array<Neos\Error\Messages\Result> Validation errors which have occured.
      * @api
      */

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/ArgumentTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/ArgumentTest.php
@@ -155,7 +155,6 @@ class ArgumentTest extends UnitTestCase
     {
         $this->setupPropertyMapperAndSetValue();
         $this->assertSame('convertedValue', $this->simpleValueArgument->getValue());
-        $this->assertTrue($this->simpleValueArgument->isValid());
     }
 
     /**
@@ -180,7 +179,6 @@ class ArgumentTest extends UnitTestCase
 
         $this->simpleValueArgument->setValidator($mockValidator);
         $this->setupPropertyMapperAndSetValue();
-        $this->assertFalse($this->simpleValueArgument->isValid());
         $this->assertEquals([$error], $this->simpleValueArgument->getValidationResults()->getErrors());
     }
 


### PR DESCRIPTION
The ``Argument::isValid`` method has been deprecated since
some time and is no longer in use.

It is therefore removed without replacement. Instead check
the validation result returned by ``Argument::getValidationResults``
for possible errors.