### PR TITLE
TASK: Cleanup removed ``PersistenceManagerInterface::initialize``

### DIFF
--- a/Neos.Flow/Classes/Core/Bootstrap.php
+++ b/Neos.Flow/Classes/Core/Bootstrap.php
@@ -398,24 +398,6 @@ class Bootstrap
     }
 
     /**
-     * @return PersistenceManagerInterface
-     * @throws FlowException
-     * @internal This method is a workaround for not creating an additional factory until PersistenceManagerInterface::initialize is no longer supported.
-     * TODO: Remove when PersistenceManagerInterface::initialize is not supported anymore.
-     */
-    public function initializePersistenceManager()
-    {
-        $persistenceManagerImplementation = $this->getObjectManager()->getClassNameByObjectName(PersistenceManagerInterface::class);
-        /** @var PersistenceManagerInterface $persistenceManager */
-        $persistenceManager = new $persistenceManagerImplementation();
-        if (is_callable([$persistenceManager, 'initialize'])) {
-            $persistenceManager->initialize();
-        }
-
-        return $persistenceManager;
-    }
-
-    /**
      * Iterates over the registered request handlers and determines which one fits best.
      *
      * @return RequestHandlerInterface A request handler

--- a/Neos.Flow/Classes/Persistence/Generic/PersistenceManager.php
+++ b/Neos.Flow/Classes/Persistence/Generic/PersistenceManager.php
@@ -122,7 +122,7 @@ class PersistenceManager extends AbstractPersistenceManager
      * @return void
      * @throws MissingBackendException
      */
-    public function initialize()
+    public function initializeObject()
     {
         if (!$this->backend instanceof Backend\BackendInterface) {
             throw new MissingBackendException('A persistence backend must be set prior to initializing the persistence manager.', 1215508456);

--- a/Neos.Flow/Classes/Persistence/PersistenceManagerInterface.php
+++ b/Neos.Flow/Classes/Persistence/PersistenceManagerInterface.php
@@ -28,13 +28,6 @@ interface PersistenceManagerInterface
      */
     public function injectSettings(array $settings);
 
-    /*
-     * The "initialize" method has been deprecated and was already removed from the interface.
-     * It is still called until the next major Flow version, but you should replace it by
-     * using "initializeObject" instead.
-     * TODO: Remove for next major Flow version.
-     */
-
     /**
      * Commits new objects and changes to objects in the current persistence session into the backend.
      *

--- a/Neos.Flow/Configuration/Objects.yaml
+++ b/Neos.Flow/Configuration/Objects.yaml
@@ -229,8 +229,6 @@ Doctrine\Common\Persistence\ObjectManager:
 
 Neos\Flow\Persistence\PersistenceManagerInterface:
   className: Neos\Flow\Persistence\Doctrine\PersistenceManager
-  factoryObjectName: Neos\Flow\Core\Bootstrap
-  factoryMethodName: initializePersistenceManager
 
 Neos\Flow\Persistence\Doctrine\Logging\SqlLogger:
   properties:

--- a/Neos.Flow/Tests/Unit/Persistence/Generic/PersistenceManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Generic/PersistenceManagerTest.php
@@ -29,21 +29,6 @@ class PersistenceManagerTest extends UnitTestCase
     /**
      * @test
      */
-    public function initializeInitializesBackendWithBackendOptions()
-    {
-        $mockBackend = $this->createMock(Generic\Backend\BackendInterface::class);
-        $mockBackend->expects($this->once())->method('initialize')->with(['Foo' => 'Bar']);
-
-        $manager = new Generic\PersistenceManager();
-        $manager->injectBackend($mockBackend);
-
-        $manager->injectSettings(['persistence' => ['backendOptions' => ['Foo' => 'Bar']]]);
-        $manager->initialize();
-    }
-
-    /**
-     * @test
-     */
     public function persistAllPassesAddedObjectsToBackend()
     {
         $entity2 = new Fixture\Model\Entity2();


### PR DESCRIPTION
The method was deprecated and removed from the interface some time
ago and now will finally not be called anymore. That also allows
removal of the PersistenceManager factory method in ``Bootstrap``.