### PR TITLE
TASK: Remove deprecated ``hasMappingErrorOccured`` method

### DIFF
--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Form/AbstractFormFieldViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Form/AbstractFormFieldViewHelper.php
@@ -162,15 +162,6 @@ abstract class AbstractFormFieldViewHelper extends AbstractFormViewHelper
     }
 
     /**
-     * @return boolean TRUE if a mapping error occurred, FALSE otherwise
-     * @deprecated since 2.1 Use hasMappingErrorOccurred() instead
-     */
-    protected function hasMappingErrorOccured()
-    {
-        return $this->hasMappingErrorOccurred();
-    }
-
-    /**
      * Checks if a property mapping error has occurred in the last request.
      *
      * @return boolean TRUE if a mapping error occurred, FALSE otherwise


### PR DESCRIPTION
``\Neos\FluidAdaptor\ViewHelpers\Form\AbstractFormFieldViewHelper``
has a ``hasMappingErrorOccured`` which was replaced with corrected
spelling as ``hasMappingErrorOccurred`` and is deprecated since
quite some time.

The wrongly spelled method is removed by this.