### PR TITLE
TASK: Remove handling for deprecated ignoreTags format

### DIFF
--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -356,10 +356,6 @@ class ReflectionService
 
         $this->annotationReader = new AnnotationReader();
         foreach ($this->settings['reflection']['ignoredTags'] as $tagName => $ignoreFlag) {
-            // Make this setting backwards compatible with old array schema (deprecated since 3.0)
-            if (is_numeric($tagName) && is_string($ignoreFlag)) {
-                AnnotationReader::addGlobalIgnoredName($ignoreFlag);
-            }
             if ($ignoreFlag === true) {
                 AnnotationReader::addGlobalIgnoredName($tagName);
             }


### PR DESCRIPTION
In earlier versions of Flow the setting
``Neos.Flow.reflection.ignoredTags`` allowed for a simple list
of tags. Due to merging and unset issues this was changed to a
key/value list, with the key being the tag name and values being
boolean to indicate ignorance of the tag.

The old format is now no longer taken into account.