### PR TITLE
BUGFIX: Adjust Documentation to renamed routing cache

### DIFF
--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Routing.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Routing.rst
@@ -309,7 +309,7 @@ and the method ``resolveValue()`` needs to return an URL segment when being pass
 
  .. code-block:: yaml
 
-  Flow_Mvc_Routing_FindMatchResults:
+  Flow_Mvc_Routing_Route:
     backend: TYPO3\Flow\Cache\Backend\NullBackend
   Flow_Mvc_Routing_Resolve:
     backend: TYPO3\Flow\Cache\Backend\NullBackend

--- a/TYPO3.Flow/Resources/Private/Installer/Distribution/Essentials/Configuration/Development/Caches.yaml.example
+++ b/TYPO3.Flow/Resources/Private/Installer/Distribution/Essentials/Configuration/Development/Caches.yaml.example
@@ -10,7 +10,7 @@
 
 # Uncomment the following lines to disable the routing cache when you are developing
 # something with the routing itself.
-#Flow_Mvc_Routing_FindMatchResults:
+#Flow_Mvc_Routing_Route:
 #  backend: TYPO3\Flow\Cache\Backend\NullBackend
 #Flow_Mvc_Routing_Resolve:
 #  backend: TYPO3\Flow\Cache\Backend\NullBackend


### PR DESCRIPTION
A follow-up to Ibc55b5a4939b42b7cf2a08ada52985aa04bb7b04
adjusting the Routing documentation and example configuration
to the Routing Cache that was renamed with Iac1bd27cd1f2869e597b696c896633f14703ec40