### PR TITLE
TASK: Use ``refreshConfiguration`` to refresh for compile run

### DIFF
--- a/Neos.Flow/Classes/Cache/CacheManager.php
+++ b/Neos.Flow/Classes/Cache/CacheManager.php
@@ -388,8 +388,8 @@ class CacheManager
             $this->getCache($cacheName)->flush();
         }
 
-        $this->systemLogger->log('A configuration file has been changed, flushing compiled configuration cache', LOG_INFO);
-        $this->configurationManager->flushConfigurationCache();
+        $this->systemLogger->log('A configuration file has been changed, refreshing compiled configuration cache', LOG_INFO);
+        $this->configurationManager->refreshConfiguration();
 
         if ($aopProxyClassRebuildIsNeeded) {
             $this->systemLogger->log('The configuration has changed, triggering an AOP proxy class rebuild.', LOG_INFO);

--- a/Neos.Flow/Classes/Configuration/ConfigurationManager.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationManager.php
@@ -565,7 +565,6 @@ class ConfigurationManager
         $cachePathAndFilename = $this->constructConfigurationCachePath();
         if (is_file($cachePathAndFilename)) {
             $this->configurations = require($cachePathAndFilename);
-
             return true;
         }
 
@@ -574,9 +573,12 @@ class ConfigurationManager
 
     /**
      * If a cache file with previously saved configuration exists, it is removed.
+     * Internal: After this the configuration manager is left without any configuration,
+     * use refreshConfiguration if you want to reread the configuration.
      *
      * @return void
      * @throws Exception
+     * @see refreshConfiguration
      */
     public function flushConfigurationCache()
     {

--- a/Neos.Flow/Tests/Unit/Cache/CacheManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Cache/CacheManagerTest.php
@@ -227,7 +227,7 @@ class CacheManagerTest extends UnitTestCase
         $this->registerCache('Flow_Object_Classes');
         $this->registerCache('Flow_Object_Configuration');
 
-        $this->mockConfigurationManager->expects($this->once())->method('flushConfigurationCache');
+        $this->mockConfigurationManager->expects($this->once())->method('refreshConfiguration');
 
         $this->cacheManager->flushSystemCachesByChangedFiles('Flow_ConfigurationFiles', []);
     }

--- a/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -611,7 +611,7 @@ EOD;
         $cachedConfigurationsPathAndFilename = vfsStream::url('Flow/Cache/Configurations.php');
         file_put_contents($cachedConfigurationsPathAndFilename, $configurationsCode);
 
-        $configurationManager = $this->getAccessibleMock(ConfigurationManager::class, ['postProcessConfiguration', 'constructConfigurationCachePath'], [], '', false);
+        $configurationManager = $this->getAccessibleMock(ConfigurationManager::class, ['postProcessConfiguration', 'constructConfigurationCachePath', 'refreshConfiguration'], [], '', false);
         $configurationManager->expects($this->any())->method('constructConfigurationCachePath')->willReturn('notfound.php', $cachedConfigurationsPathAndFilename);
         $configurationManager->_set('configurations', ['foo' => 'untouched']);
         $configurationManager->_call('loadConfigurationCache');


### PR DESCRIPTION
Since the changes to the ``ConfigurationManager``, using
``flushConfigurationCache`` leaves an empty configuration behind
which is only helpful when you really only want to flush caches.

In case a change was detected ``refreshConfiguration`` is more
appropriate as it leaves the ConfigurationManager in a usable
state afterwards.
