### PR TITLE
BUGFIX: Tests shouldn't leave folder behind

### DIFF
--- a/Neos.Flow/Tests/Unit/Cache/CacheFactoryTest.php
+++ b/Neos.Flow/Tests/Unit/Cache/CacheFactoryTest.php
@@ -61,6 +61,7 @@ class CacheFactoryTest extends UnitTestCase
         $this->mockCacheManager->expects($this->any())->method('isCachePersistent')->will($this->returnValue(false));
 
         $this->mockEnvironmentConfiguration = $this->getMockBuilder(EnvironmentConfiguration::class)
+            ->setMethods(null)
             ->setConstructorArgs([
                 __DIR__ . '~Testing',
                 'vfs://Foo/',


### PR DESCRIPTION
The ``CacheFactoryTest`` left a folder behind because it didn't
use the virtual file system because the mocked environment configuration
didn't return the right path.

This change fixes it and prevents the folder being created in the
actual filesystem.