### PR TITLE
BUGFIX: Always set package type in newly created packages

### DIFF
--- a/Neos.Flow/Classes/Package/PackageManager.php
+++ b/Neos.Flow/Classes/Package/PackageManager.php
@@ -350,12 +350,14 @@ class PackageManager implements PackageManagerInterface
         if ($this->isPackageAvailable($packageKey)) {
             throw new Exception\PackageKeyAlreadyExistsException('The package key "' . $packageKey . '" already exists', 1220722873);
         }
+        if (!isset($manifest['type'])) {
+            $manifest['type'] = PackageInterface::DEFAULT_COMPOSER_TYPE;
+        }
 
         if ($packagesPath === null) {
             $packagesPath = 'Application';
-            $packageType = isset($manifest['type']) ? $manifest['type'] : PackageInterface::DEFAULT_COMPOSER_TYPE;
-            if (is_array($this->settings['package']['packagesPathByType']) && isset($this->settings['package']['packagesPathByType'][$packageType])) {
-                $packagesPath = $this->settings['package']['packagesPathByType'][$packageType];
+            if (is_array($this->settings['package']['packagesPathByType']) && isset($this->settings['package']['packagesPathByType'][$manifest['type']])) {
+                $packagesPath = $this->settings['package']['packagesPathByType'][$manifest['type']];
             }
 
             $packagesPath = Files::getUnixStylePath(Files::concatenatePaths([$this->packagesBasePath, $packagesPath]));

--- a/Neos.Flow/Tests/Unit/Package/PackageManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Package/PackageManagerTest.php
@@ -347,6 +347,20 @@ class PackageManagerTest extends UnitTestCase
         $this->assertEquals('flow-custom-package', $composerManifest->type);
     }
 
+
+    /**
+     * @test
+     */
+    public function createPackageAlwaysSetsThePackageType()
+    {
+        $package = $this->packageManager->createPackage('Acme.YetAnotherTestPackage2');
+
+        $json = file_get_contents($package->getPackagePath() . '/composer.json');
+        $composerManifest = json_decode($json);
+
+        $this->assertEquals('neos-package', $composerManifest->type);
+    }
+
     /**
      * Checks if createPackage() creates the folders for classes, configuration, documentation, resources and tests.
      *


### PR DESCRIPTION
This fix makes sure that the package type is always set in
composer manifests created via `PackageManager::createPackage()`
in order to prevent newly created packages (i.e. via the Kickstarter)
to be ignored from Flows object management.

Fixes: #782