### PR TITLE
BUGFIX: Fix IfHasErrorsViewHelper

### DIFF
--- a/Neos.FluidAdaptor/Classes/Core/Rendering/FlowAwareRenderingContextInterface.php
+++ b/Neos.FluidAdaptor/Classes/Core/Rendering/FlowAwareRenderingContextInterface.php
@@ -11,6 +11,9 @@ namespace Neos\FluidAdaptor\Core\Rendering;
  * source code.
  */
 
+use Neos\Flow\Mvc\Controller\ControllerContext;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+
 /**
  * Interface for rendering contexts that are Flow aware.
  *

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Validation/IfHasErrorsViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Validation/IfHasErrorsViewHelper.php
@@ -15,7 +15,9 @@ namespace Neos\FluidAdaptor\ViewHelpers\Validation;
 use Neos\Flow\Annotations as Flow;
 use Neos\Error\Messages\Result;
 use Neos\Flow\Mvc\ActionRequest;
+use Neos\FluidAdaptor\Core\Rendering\FlowAwareRenderingContextInterface;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractConditionViewHelper;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 /**
  * This view helper allows to check whether validation errors adhere to the current request.
@@ -41,29 +43,53 @@ use Neos\FluidAdaptor\Core\ViewHelper\AbstractConditionViewHelper;
  */
 class IfHasErrorsViewHelper extends AbstractConditionViewHelper
 {
+
+    /**
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('then', 'mixed', 'Value to be returned if the condition if met.', false);
+        $this->registerArgument('else', 'mixed', 'Value to be returned if the condition if not met.', false);
+        $this->registerArgument('for', 'string', 'The argument or property name or path to check for error(s). If not set any validation error leads to the "then child" to be rendered', false);
+    }
+
     /**
      * Renders <f:then> child if there are validation errors. The check can be narrowed down to
      * specific property paths.
      * If no errors are there, it renders the <f:else>-child.
      *
-     * @param string $for The argument or property name or path to check for error(s)
-     * @return string
+     * @return mixed
      * @api
      */
-    public function render($for = null)
+    public function render()
     {
+        if (self::evaluateCondition($this->arguments, $this->renderingContext)) {
+            return $this->renderThenChild();
+        } else {
+            return $this->renderElseChild();
+        }
+    }
+
+    /**
+     * @param null $arguments
+     * @param FlowAwareRenderingContextInterface|RenderingContextInterface $renderingContext
+     * @return boolean
+     */
+    protected static function evaluateCondition($arguments = null, RenderingContextInterface $renderingContext)
+    {
+
         /** @var $request ActionRequest */
-        $request = $this->controllerContext->getRequest();
+        $request = $renderingContext->getControllerContext()->getRequest();
         /** @var $validationResults Result */
         $validationResults = $request->getInternalArgument('__submittedArgumentValidationResults');
 
-        if ($validationResults !== null) {
-            // if $for is not set, ->forProperty will return the initial Result object untouched
-            $validationResults = $validationResults->forProperty($for);
-            if ($validationResults->hasErrors()) {
-                return $this->renderThenChild();
-            }
+        if ($validationResults === null) {
+            return false;
         }
-        return $this->renderElseChild();
+        if (isset($arguments['for'])) {
+            $validationResults = $validationResults->forProperty($arguments['for']);
+        }
+        return $validationResults->hasErrors();
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Security/IfHasRoleViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Security/IfHasRoleViewHelperTest.php
@@ -47,8 +47,7 @@ class IfHasRoleViewHelperTest extends ViewHelperBaseTestcase
         parent::setUp();
         $this->mockViewHelper = $this->getMockBuilder(\Neos\FluidAdaptor\ViewHelpers\Security\IfHasRoleViewHelper::class)->setMethods([
             'renderThenChild',
-            'renderElseChild',
-            'hasAccessToPrivilege'
+            'renderElseChild'
         ])->getMock();
 
         $this->mockSecurityContext = $this->getMockBuilder(\Neos\Flow\Security\Context::class)->disableOriginalConstructor()->getMock();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Validation/IfHasErrorsViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Validation/IfHasErrorsViewHelperTest.php
@@ -23,7 +23,7 @@ require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 class IfHasErrorsViewHelperTest extends ViewHelperBaseTestcase
 {
     /**
-     * @var IfHasErrorsViewHelper
+     * @var IfHasErrorsViewHelper|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $viewHelper;
 
@@ -33,8 +33,7 @@ class IfHasErrorsViewHelperTest extends ViewHelperBaseTestcase
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\ViewHelpers\Validation\IfHasErrorsViewHelper::class, array('renderThenChild', 'renderElseChild'));
-        $this->inject($this->viewHelper, 'controllerContext', $this->controllerContext);
-        //$this->inject($this->ifAccessViewHelper, 'accessDecisionManager', $this->mockAccessDecisionManager);
+        $this->injectDependenciesIntoViewHelper($this->viewHelper);
     }
 
     /**
@@ -45,9 +44,7 @@ class IfHasErrorsViewHelperTest extends ViewHelperBaseTestcase
         $result = new Result;
         $result->addError(new Error('I am an error', 1386163707));
 
-        /** @var $requestMock \PHPUnit_Framework_MockObject_MockObject */
-        $requestMock = $this->request;
-        $requestMock->expects($this->once())->method('getInternalArgument')->with('__submittedArgumentValidationResults')->will($this->returnValue($result));
+        $this->request->expects($this->once())->method('getInternalArgument')->with('__submittedArgumentValidationResults')->will($this->returnValue($result));
         $this->viewHelper->expects($this->once())->method('renderThenChild')->will($this->returnValue('ThenChild'));
         $this->assertEquals('ThenChild', $this->viewHelper->render());
     }
@@ -58,7 +55,6 @@ class IfHasErrorsViewHelperTest extends ViewHelperBaseTestcase
     public function returnsAndRendersElseChildIfNoValidationResultsArePresentAtAll()
     {
         $this->viewHelper->expects($this->once())->method('renderElseChild')->will($this->returnValue('ElseChild'));
-        ;
         $this->assertEquals('ElseChild', $this->viewHelper->render());
     }
 
@@ -70,10 +66,9 @@ class IfHasErrorsViewHelperTest extends ViewHelperBaseTestcase
         $resultMock = $this->createMock(\Neos\Error\Messages\Result::class);
         $resultMock->expects($this->once())->method('forProperty')->with('foo.bar.baz')->will($this->returnValue(new Result()));
 
-        /** @var $requestMock \PHPUnit_Framework_MockObject_MockObject */
-        $requestMock = $this->request;
-        $requestMock->expects($this->once())->method('getInternalArgument')->with('__submittedArgumentValidationResults')->will($this->returnValue($resultMock));
+        $this->request->expects($this->once())->method('getInternalArgument')->with('__submittedArgumentValidationResults')->will($this->returnValue($resultMock));
 
-        $this->viewHelper->render('foo.bar.baz');
+        $this->viewHelper->setArguments(['for' => 'foo.bar.baz']);
+        $this->viewHelper->render();
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php
@@ -23,7 +23,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 abstract class ViewHelperBaseTestcase extends \Neos\Flow\Tests\UnitTestCase
 {
     /**
-     * @var \TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer
+     * @var \TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $viewHelperVariableContainer;
 
@@ -38,22 +38,22 @@ abstract class ViewHelperBaseTestcase extends \Neos\Flow\Tests\UnitTestCase
     protected $viewHelperVariableContainerData = array();
 
     /**
-     * @var \Neos\FluidAdaptor\Core\ViewHelper\TemplateVariableContainer
+     * @var \Neos\FluidAdaptor\Core\ViewHelper\TemplateVariableContainer|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $templateVariableContainer;
 
     /**
-     * @var \Neos\Flow\Mvc\Routing\UriBuilder
+     * @var \Neos\Flow\Mvc\Routing\UriBuilder|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $uriBuilder;
 
     /**
-     * @var \Neos\Flow\Mvc\Controller\ControllerContext
+     * @var \Neos\Flow\Mvc\Controller\ControllerContext|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $controllerContext;
 
     /**
-     * @var TagBuilder
+     * @var TagBuilder|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $tagBuilder;
 
@@ -63,12 +63,12 @@ abstract class ViewHelperBaseTestcase extends \Neos\Flow\Tests\UnitTestCase
     protected $arguments;
 
     /**
-     * @var \Neos\Flow\Mvc\ActionRequest
+     * @var \Neos\Flow\Mvc\ActionRequest|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $request;
 
     /**
-     * @var \Neos\FluidAdaptor\Core\Rendering\RenderingContext
+     * @var \Neos\FluidAdaptor\Core\Rendering\RenderingContext|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $renderingContext;
 


### PR DESCRIPTION
With the move to TYPO3Fluid the behavior of the `AbstractConditionViewHelper`
has been changed (see #746).
This fix adjusts the `validation.ifHasErrors` ViewHelper accordingly and adds
some minor cosmetic fixes.
Other condition ViewHelpers have been adjusted already.

Fixes: #747