### PR TITLE
BUGFIX: Fix support for multi-type render arguments

### DIFF
--- a/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractViewHelper.php
@@ -210,10 +210,9 @@ abstract class AbstractViewHelper extends FluidAbstractViewHelper
         $i = 0;
         foreach ($methodParameters as $parameterName => $parameterInfo) {
             $dataType = null;
-            if (isset($parameterInfo['type'])) {
+            $dataType = 'mixed';
+            if (isset($parameterInfo['type']) && strpos($parameterInfo['type'], '|') === false) {
                 $dataType = isset($parameterInfo['array']) && (bool)$parameterInfo['array'] ? 'array' : $parameterInfo['type'];
-            } else {
-                throw new \Neos\FluidAdaptor\Core\Exception('Could not determine type of argument "' . $parameterName . '" of the render-method in ViewHelper "' . static::class . '". Either the methods docComment is invalid or some PHP optimizer strips off comments.', 1242292003);
             }
 
             $description = '';

--- a/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -12,6 +12,8 @@ namespace Neos\FluidAdaptor\Tests\Unit\Core\ViewHelper;
  */
 
 use Neos\Flow\Mvc\Controller\ControllerContext;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Flow\Reflection\ReflectionService;
 use Neos\FluidAdaptor\Core\ViewHelper\TemplateVariableContainer;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 use Neos\FluidAdaptor\View\TemplateView;
@@ -307,5 +309,22 @@ class AbstractViewHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $this->assertSame($viewHelper->_get('templateVariableContainer'), $templateVariableContainer);
         $this->assertSame($viewHelper->_get('viewHelperVariableContainer'), $viewHelperVariableContainer);
         $this->assertSame($viewHelper->_get('controllerContext'), $controllerContext);
+    }
+
+    /**
+     * @test
+     */
+    public function renderMethodParametersWithMultipleTypesAreRegisteredAsMixed()
+    {
+        $this->mockReflectionService->expects(self::any())->method('getMethodTagsValues')->willReturn([]);
+        $this->mockReflectionService->expects(self::any())->method('getMethodParameters')->willReturn(['someArgument' => [
+            'type' => 'array|\Iterator',
+            'optional' => false
+        ]]);
+
+        $argumentDefinitions = AbstractViewHelper::getRenderMethodArgumentDefinitions($this->mockObjectManager);
+        $this->assertCount(1, $argumentDefinitions);
+        $this->assertArrayHasKey('someArgument', $argumentDefinitions);
+        $this->assertEquals('mixed', $argumentDefinitions['someArgument'][1]);
     }
 }


### PR DESCRIPTION
ViewHelper render method arguments with multiple type
defintions in the docblock are now correctly registered
as mixed type arguments.

Fixes: #748 
