### PR TITLE
BUGFIX: Call of non existing core command issues proper error

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/HelpCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/HelpCommandController.php
@@ -50,6 +50,7 @@ class HelpCommandController extends CommandController
 
     /**
      * @param Bootstrap $bootstrap
+     * @return void
      */
     public function injectBootstrap(Bootstrap $bootstrap)
     {
@@ -58,6 +59,7 @@ class HelpCommandController extends CommandController
 
     /**
      * @param PackageManagerInterface $packageManager
+     * @return void
      */
     public function injectPackageManager(PackageManagerInterface $packageManager)
     {
@@ -66,6 +68,7 @@ class HelpCommandController extends CommandController
 
     /**
      * @param array $settings
+     * @return void
      */
     public function injectSettings(array $settings)
     {
@@ -74,6 +77,7 @@ class HelpCommandController extends CommandController
 
     /**
      * @param CommandManager $commandManager
+     * @return void
      */
     public function injectCommandManager(CommandManager $commandManager)
     {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/HelpCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/HelpCommandController.php
@@ -29,28 +29,56 @@ use TYPO3\Flow\Package\PackageManagerInterface;
 class HelpCommandController extends CommandController
 {
     /**
-     * @Flow\Inject
      * @var PackageManagerInterface
      */
     protected $packageManager;
 
     /**
-     * @Flow\Inject
      * @var Bootstrap
      */
     protected $bootstrap;
 
     /**
-     * @Flow\InjectConfiguration(path = "core.applicationPackageKey")
      * @var string
      */
     protected $applicationPackageKey;
 
     /**
-     * @Flow\Inject
      * @var CommandManager
      */
     protected $commandManager;
+
+    /**
+     * @param Bootstrap $bootstrap
+     */
+    public function injectBootstrap(Bootstrap $bootstrap)
+    {
+        $this->bootstrap = $bootstrap;
+    }
+
+    /**
+     * @param PackageManagerInterface $packageManager
+     */
+    public function injectPackageManager(PackageManagerInterface $packageManager)
+    {
+        $this->packageManager = $packageManager;
+    }
+
+    /**
+     * @param array $settings
+     */
+    public function injectSettings(array $settings)
+    {
+        $this->applicationPackageKey = $settings['core']['applicationPackageKey'];
+    }
+
+    /**
+     * @param CommandManager $commandManager
+     */
+    public function injectCommandManager(CommandManager $commandManager)
+    {
+        $this->commandManager = $commandManager;
+    }
 
     /**
      * Displays a short, general help message


### PR DESCRIPTION
And exception was thrown when a non existing core command was being
invoked, eg. due to a spelling mistake.
The exception stems from the fact that all core commands are considered
compiletime commands but handling of non existing command calls is
done by the ``HelpCommandController`` which itself was not compiletime
compatible. This change adapts it to use inject methods which resolves
the problem.

Note that in upmerges the injections must be adapted to changing dependencies.

Fixes: #794
