### PR TITLE
TASK: Remove Parameter as it is the default value of the optional

### DIFF
--- a/Neos.Flow/Classes/Cache/CacheFactory.php
+++ b/Neos.Flow/Classes/Cache/CacheFactory.php
@@ -90,8 +90,7 @@ class CacheFactory extends \Neos\Cache\CacheFactory implements CacheFactoryInter
 
         $environmentConfiguration = new EnvironmentConfiguration(
             FLOW_PATH_ROOT . '~' . (string)$environment->getContext(),
-            $environment->getPathToTemporaryDirectory(),
-            PHP_MAXPATHLEN
+            $environment->getPathToTemporaryDirectory()
         );
 
         parent::__construct($environmentConfiguration);


### PR DESCRIPTION
The parameter is the default value of the optional parameter in the EnvironmentConfiguration class.
it is not necessary to insert it additionally.
