### PR TITLE
TASK: Change default value for maximumPathLength in EnvironmentConfiguration

### DIFF
--- a/Neos.Cache/Classes/EnvironmentConfiguration.php
+++ b/Neos.Cache/Classes/EnvironmentConfiguration.php
@@ -40,7 +40,7 @@ class EnvironmentConfiguration
      *
      * @var integer
      */
-    protected $maximumPathLength = PHP_MAXPATHLEN;
+    protected $maximumPathLength;
 
     /**
      * EnvironmentConfiguration constructor.
@@ -49,7 +49,7 @@ class EnvironmentConfiguration
      * @param string $fileCacheBasePath
      * @param integer $maximumPathLength
      */
-    public function __construct($applicationIdentifier, $fileCacheBasePath, $maximumPathLength)
+    public function __construct($applicationIdentifier, $fileCacheBasePath, $maximumPathLength = PHP_MAXPATHLEN)
     {
         $this->applicationIdentifier = $applicationIdentifier;
         $this->fileCacheBasePath = $fileCacheBasePath;


### PR DESCRIPTION
As mentioned in the github/neos/cache is the decalaration of the property maximumPathLength with a value and then requiring a value for that property inside the constructor that overwrites the declared value EVERY time a minor bug. So the parameter for the constructor should be changed to an optional with the deault value as set for declaration

<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
