### PR TITLE
TASK: Simplify EnvironmentConfiguration object instantiation

### DIFF
--- a/Neos.Flow/Classes/Cache/CacheFactory.php
+++ b/Neos.Flow/Classes/Cache/CacheFactory.php
@@ -90,8 +90,7 @@ class CacheFactory extends \Neos\Cache\CacheFactory implements CacheFactoryInter
 
         $environmentConfiguration = new EnvironmentConfiguration(
             FLOW_PATH_ROOT . '~' . (string)$environment->getContext(),
-            $environment->getPathToTemporaryDirectory(),
-            PHP_MAXPATHLEN
+            $environment->getPathToTemporaryDirectory()
         );
 
         parent::__construct($environmentConfiguration);


### PR DESCRIPTION
in the environmental class "Neos\Cache\EnvironmentConfiguration" is a minor bug (PR #810). in the moment the bug is fixed the parameter $maximumPathLength has not to be set if its equal to the php constant PHP_MAXPATHLEN. In this case it can be removed from the constructor call

<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
