### PR TITLE
BUGFIX: Add missing migrations after package renamings

### DIFF
--- a/Neos.Flow/Migrations/Mysql/Version20170110130149.php
+++ b/Neos.Flow/Migrations/Mysql/Version20170110130149.php
@@ -2,6 +2,7 @@
 namespace Neos\Flow\Persistence\Doctrine\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Platforms\MySQL57Platform;
 use Doctrine\DBAL\Schema\Schema;
 
 class Version20170110130149 extends AbstractMigration
@@ -23,8 +24,13 @@ class Version20170110130149 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
 
-        $this->addSql('DROP INDEX flow_identity_typo3_flow_security_account ON neos_flow_security_account');
-        $this->addSql('CREATE UNIQUE INDEX flow_identity_neos_flow_security_account ON neos_flow_security_account (accountidentifier, authenticationprovidername)');
+        // Renaming of indexes is only possible with MySQL version 5.7+
+        if ($this->connection->getDatabasePlatform() instanceof MySQL57Platform) {
+            $this->addSql('ALTER TABLE neos_flow_security_account RENAME INDEX flow_identity_typo3_flow_security_account TO flow_identity_neos_flow_security_account');
+        } else {
+            $this->addSql('DROP INDEX flow_identity_typo3_flow_security_account ON neos_flow_security_account');
+            $this->addSql('CREATE UNIQUE INDEX flow_identity_neos_flow_security_account ON neos_flow_security_account (accountidentifier, authenticationprovidername)');
+        }
     }
 
     /**
@@ -35,7 +41,12 @@ class Version20170110130149 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
 
-        $this->addSql('DROP INDEX flow_identity_neos_flow_security_account ON neos_flow_security_account');
-        $this->addSql('CREATE UNIQUE INDEX flow_identity_typo3_flow_security_account ON neos_flow_security_account (accountidentifier, authenticationprovidername)');
+        // Renaming of indexes is only possible with MySQL version 5.7+
+        if ($this->connection->getDatabasePlatform() instanceof MySQL57Platform) {
+            $this->addSql('ALTER TABLE neos_flow_security_account RENAME INDEX flow_identity_neos_flow_security_account TO flow_identity_typo3_flow_security_account');
+        } else {
+            $this->addSql('DROP INDEX flow_identity_neos_flow_security_account ON neos_flow_security_account');
+            $this->addSql('CREATE UNIQUE INDEX flow_identity_typo3_flow_security_account ON neos_flow_security_account (accountidentifier, authenticationprovidername)');
+        }
     }
 }

--- a/Neos.Flow/Migrations/Mysql/Version20170110130149.php
+++ b/Neos.Flow/Migrations/Mysql/Version20170110130149.php
@@ -1,0 +1,41 @@
+<?php
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version20170110130149 extends AbstractMigration
+{
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return 'Adjust foreign key and index names to the renaming of TYPO3.Flow to Neos.Flow';
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+
+        $this->addSql('DROP INDEX flow_identity_typo3_flow_security_account ON neos_flow_security_account');
+        $this->addSql('CREATE UNIQUE INDEX flow_identity_neos_flow_security_account ON neos_flow_security_account (accountidentifier, authenticationprovidername)');
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+
+        $this->addSql('DROP INDEX flow_identity_neos_flow_security_account ON neos_flow_security_account');
+        $this->addSql('CREATE UNIQUE INDEX flow_identity_typo3_flow_security_account ON neos_flow_security_account (accountidentifier, authenticationprovidername)');
+    }
+}

--- a/Neos.Flow/Migrations/Postgresql/Version20170110133146.php
+++ b/Neos.Flow/Migrations/Postgresql/Version20170110133146.php
@@ -1,0 +1,39 @@
+<?php
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version20170110133146 extends AbstractMigration
+{
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return 'Adjust foreign key and index names to the renaming of TYPO3.Flow to Neos.Flow';
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on "postgresql".');
+
+        $this->addSql('ALTER INDEX flow_identity_typo3_flow_security_account RENAME TO flow_identity_neos_flow_security_account');
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on "postgresql".');
+
+        $this->addSql('ALTER INDEX flow_identity_neos_flow_security_account RENAME TO flow_identity_typo3_flow_security_account');
+    }
+}


### PR DESCRIPTION
This adds doctrine migrations for MySQL and Postgresql to adjust
foreign key and index names to the renamed package `Neos.Flow`.

Background:
Apparently the renamed indexes/keys were not catered for in
neos/flow-development-collection@3b6d38c1b5aa5ab8a51d3f657a720d0d17ae8700

Related: neos/neos-development-collection#1374