### PR TITLE
BUGFIX: Files::getFileContents broken in PHP 7.1

### DIFF
--- a/Neos.Utility.Files/Classes/Files.php
+++ b/Neos.Utility.Files/Classes/Files.php
@@ -306,6 +306,7 @@ abstract class Files
      * @param integer $offset (optional) Offset where reading of the file starts.
      * @param integer $maximumLength (optional) Maximum length to read. Default is -1 (no limit)
      * @return mixed The file content as a string or FALSE if the file could not be opened.
+     * @throws FilesException
      * @api
      */
     public static function getFileContents($pathAndFilename, $flags = 0, $context = null, $offset = -1, $maximumLength = -1)
@@ -314,12 +315,13 @@ abstract class Files
             $flags = FILE_USE_INCLUDE_PATH;
         }
         try {
+            $offset = $offset === -1 ? null : $offset;
             if ($maximumLength > -1) {
                 $content = file_get_contents($pathAndFilename, $flags, $context, $offset, $maximumLength);
             } else {
                 $content = file_get_contents($pathAndFilename, $flags, $context, $offset);
             }
-        } catch (ErrorException $ignoredException) {
+        } catch (FilesException $ignoredException) {
             $content = false;
         }
         return $content;

--- a/Neos.Utility.Files/Classes/Files.php
+++ b/Neos.Utility.Files/Classes/Files.php
@@ -303,19 +303,17 @@ abstract class Files
      * @param string $pathAndFilename Path and name of the file to load
      * @param integer $flags (optional) ORed flags using PHP's FILE_* constants (see manual of file_get_contents).
      * @param resource $context (optional) A context resource created by stream_context_create()
-     * @param integer $offset (optional) Offset where reading of the file starts.
+     * @param integer $offset (optional) Offset where reading of the file starts, as of PHP 7.1 supports negative offsets.
      * @param integer $maximumLength (optional) Maximum length to read. Default is -1 (no limit)
      * @return mixed The file content as a string or FALSE if the file could not be opened.
-     * @throws FilesException
      * @api
      */
-    public static function getFileContents($pathAndFilename, $flags = 0, $context = null, $offset = -1, $maximumLength = -1)
+    public static function getFileContents($pathAndFilename, $flags = 0, $context = null, $offset = null, $maximumLength = -1)
     {
         if ($flags === true) {
             $flags = FILE_USE_INCLUDE_PATH;
         }
         try {
-            $offset = $offset === -1 ? null : $offset;
             if ($maximumLength > -1) {
                 $content = file_get_contents($pathAndFilename, $flags, $context, $offset, $maximumLength);
             } else {

--- a/Neos.Utility.Files/Classes/Files.php
+++ b/Neos.Utility.Files/Classes/Files.php
@@ -319,7 +319,7 @@ abstract class Files
             } else {
                 $content = file_get_contents($pathAndFilename, $flags, $context, $offset);
             }
-        } catch (FilesException $ignoredException) {
+        } catch (ErrorException $ignoredException) {
             $content = false;
         }
         return $content;


### PR DESCRIPTION
This change set the offset to 0 (default value in `file_get_contents`.)

PHP 7.1 changed the behaviour of `file_get_contents` regarding
negative offset (support for negative offsets has been added.)

Without this change the sites `Root.fusion` is not loaded, so that
`Files::getFileContents` return an empty string. Tested on PHP 7.1.0
and 7.0.12 (worked without this fix).