### PR TITLE
BUGFIX: Use fallback if exception handler configured wrong

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Booting/Scripts.php
@@ -212,7 +212,11 @@ class Scripts
 
         $errorHandler = new \TYPO3\Flow\Error\ErrorHandler();
         $errorHandler->setExceptionalErrors($settings['error']['errorHandler']['exceptionalErrors']);
-        $exceptionHandler = new $settings['error']['exceptionHandler']['className'];
+        if (class_exists($settings['error']['exceptionHandler']['className'])) {
+            $exceptionHandler = new $settings['error']['exceptionHandler']['className'];
+        } else {
+            $exceptionHandler = new \TYPO3\Flow\Error\ProductionExceptionHandler();
+        }
         $exceptionHandler->injectSystemLogger($bootstrap->getEarlyInstance('TYPO3\Flow\Log\SystemLoggerInterface'));
         $exceptionHandler->setOptions($settings['error']['exceptionHandler']);
     }


### PR DESCRIPTION
In case the configured exception handler class dies not exist,
the `ProductionExceptionHandler` is used instead. This allows
(force-)flushing the caches to work in more cases.
