### PR TITLE
!!! TASK: Remove deprecated support for relative uri paths

### DIFF
--- a/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
+++ b/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
@@ -63,12 +63,6 @@ class UriBuilder
     protected $createAbsoluteUri = false;
 
     /**
-     * @Flow\InjectConfiguration("compatibility.uriBuilder.createRelativePaths")
-     * @var boolean
-     */
-    protected $createRelativePaths = false;
-
-    /**
      * @var boolean
      */
     protected $addQueryString = false;
@@ -195,29 +189,6 @@ class UriBuilder
     public function getCreateAbsoluteUri()
     {
         return $this->createAbsoluteUri;
-    }
-
-    /**
-     * By default relative URIs are prefixed with the current script request path creating absolute paths starting with a slash
-     * If this is set to FALSE, relative paths are created as it used to be the default behavior before Flow 2.0.
-     *
-     * @param boolean $createRelativePaths
-     * @return UriBuilder the current UriBuilder to allow method chaining
-     * @api
-     */
-    public function setCreateRelativePaths($createRelativePaths)
-    {
-        $this->createRelativePaths = $createRelativePaths;
-        return $this;
-    }
-
-    /**
-     * @return boolean
-     * @api
-     */
-    public function getCreateRelativePaths()
-    {
-        return $this->createRelativePaths;
     }
 
     /**
@@ -383,8 +354,6 @@ class UriBuilder
         $httpRequest = $this->request->getHttpRequest();
         if ($this->createAbsoluteUri === true) {
             $uri = $httpRequest->getBaseUri() . $uri;
-        } elseif (!$this->createRelativePaths) {
-            $uri = $httpRequest->getScriptRequestPath() . $uri;
         }
         if ($this->section !== '') {
             $uri .= '#' . $this->section;

--- a/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
+++ b/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
@@ -354,6 +354,8 @@ class UriBuilder
         $httpRequest = $this->request->getHttpRequest();
         if ($this->createAbsoluteUri === true) {
             $uri = $httpRequest->getBaseUri() . $uri;
+        } else {
+            $uri = $httpRequest->getScriptRequestPath() . $uri;
         }
         if ($this->section !== '') {
             $uri .= '#' . $this->section;

--- a/Neos.Flow/Configuration/Settings.yaml
+++ b/Neos.Flow/Configuration/Settings.yaml
@@ -18,16 +18,8 @@ Neos:
 
         securityContext: Neos\Flow\Security\Context
 
-    compatibility:
-
-      uriBuilder:
-
-        # A compatibility flag that affects the behavior of the UriBuilder when creating relative URIs:
-        # TRUE: The UriBuilder creates relative path like "some/path", a base tag is required in the respective HTML head
-        # FALSE: The UriBuilder prefixes the path with the scripts request path: "/document/root/some/path", no base tag will be required
-        #
-        # NOTE: This flag will be obsolete with version 2.2 and removed in version 3.0 of Flow
-        createRelativePaths: FALSE
+    # A section for compatibility flags that are deprecated.
+    compatibility: []
 
     core:
 

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/UriBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/UriBuilderTest.php
@@ -749,23 +749,6 @@ class UriBuilderTest extends UnitTestCase
     /**
      * @test
      */
-    public function buildDoesNotPrependsScriptRequestPathIfCreateRelativePathsCompatibilityFlagIsTrue()
-    {
-        $this->mockHttpRequest->expects($this->never())->method('getScriptRequestPath');
-        $this->mockRouter->expects($this->once())->method('resolve')->will($this->returnValue('resolvedUri'));
-
-        $this->uriBuilder->setCreateAbsoluteUri(false);
-        $this->uriBuilder->setCreateRelativePaths(true);
-
-        $expectedResult = 'resolvedUri';
-        $actualResult = $this->uriBuilder->build();
-
-        $this->assertEquals($expectedResult, $actualResult);
-    }
-
-    /**
-     * @test
-     */
     public function buildPrependsIndexFileIfRewriteUrlsIsOff()
     {
         $this->mockRouter->expects($this->once())->method('resolve')->will($this->returnValue('resolvedUri'));


### PR DESCRIPTION
Removed the long-deprecated compat flag for relative uri paths and the according code in the UriBuilder and UriBuilder test.