### PR TITLE
!!! TASK: Rename [TYPO3][Flow][Security][Authentication]

### DIFF
--- a/Neos.Flow/Classes/Security/Authentication/Controller/AbstractAuthenticationController.php
+++ b/Neos.Flow/Classes/Security/Authentication/Controller/AbstractAuthenticationController.php
@@ -45,8 +45,8 @@ abstract class AbstractAuthenticationController extends ActionController
      *
      * <f:flashMessages />
      * <f:form action="authenticate">
-     *   <f:form.textfield name="__authentication[TYPO3][Flow][Security][Authentication][Token][UsernamePassword][username]" />
-     *   <f:form.password name="__authentication[TYPO3][Flow][Security][Authentication][Token][UsernamePassword][password]" />
+     *   <f:form.textfield name="__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][username]" />
+     *   <f:form.password name="__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][password]" />
      *   <f:form.submit value="login" />
      * </f:form>
      *

--- a/Neos.Flow/Classes/Security/Authentication/Token/PasswordToken.php
+++ b/Neos.Flow/Classes/Security/Authentication/Token/PasswordToken.php
@@ -38,7 +38,7 @@ class PasswordToken extends AbstractToken
      * are available. Sets the authentication status to AUTHENTICATION_NEEDED, if credentials have been sent.
      *
      * Note: You need to send the password in this POST parameter:
-     *       __authentication[TYPO3][Flow][Security][Authentication][Token][PasswordToken][password]
+     *       __authentication[Neos][Flow][Security][Authentication][Token][PasswordToken][password]
      *
      * @param ActionRequest $actionRequest The current action request
      * @return void
@@ -50,7 +50,7 @@ class PasswordToken extends AbstractToken
         }
 
         $postArguments = $actionRequest->getInternalArguments();
-        $password = ObjectAccess::getPropertyPath($postArguments, '__authentication.TYPO3.Flow.Security.Authentication.Token.PasswordToken.password');
+        $password = ObjectAccess::getPropertyPath($postArguments, '__authentication.Neos.Flow.Security.Authentication.Token.PasswordToken.password');
 
         if (!empty($password)) {
             $this->credentials['password'] = $password;

--- a/Neos.Flow/Classes/Security/Authentication/Token/UsernamePassword.php
+++ b/Neos.Flow/Classes/Security/Authentication/Token/UsernamePassword.php
@@ -32,8 +32,8 @@ class UsernamePassword extends AbstractToken
      * are available. Sets the authentication status to REAUTHENTICATION_NEEDED, if credentials have been sent.
      *
      * Note: You need to send the username and password in these two POST parameters:
-     *       __authentication[TYPO3][Flow][Security][Authentication][Token][UsernamePassword][username]
-     *   and __authentication[TYPO3][Flow][Security][Authentication][Token][UsernamePassword][password]
+     *       __authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][username]
+     *   and __authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][password]
      *
      * @param ActionRequest $actionRequest The current action request
      * @return void
@@ -46,8 +46,8 @@ class UsernamePassword extends AbstractToken
         }
 
         $arguments = $actionRequest->getInternalArguments();
-        $username = ObjectAccess::getPropertyPath($arguments, '__authentication.TYPO3.Flow.Security.Authentication.Token.UsernamePassword.username');
-        $password = ObjectAccess::getPropertyPath($arguments, '__authentication.TYPO3.Flow.Security.Authentication.Token.UsernamePassword.password');
+        $username = ObjectAccess::getPropertyPath($arguments, '__authentication.Neos.Flow.Security.Authentication.Token.UsernamePassword.username');
+        $password = ObjectAccess::getPropertyPath($arguments, '__authentication.Neos.Flow.Security.Authentication.Token.UsernamePassword.password');
 
         if (!empty($username) && !empty($password)) {
             $this->credentials['username'] = $username;

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Security.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Security.rst
@@ -126,8 +126,8 @@ Given there is a route that resolves “your/app/authenticate” to the ``authen
 
   <form action="your/app/authenticate" method="post">
      <input type="text"
-        name="__authentication[TYPO3][Flow][Security][Authentication][Token][UsernamePassword][username]" />
-     <input type="password"        name="__authentication[TYPO3][Flow][Security][Authentication][Token][UsernamePassword][password]" />
+        name="__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][username]" />
+     <input type="password"        name="__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][password]" />
      <input type="submit" value="Login" />
   </form>
 
@@ -181,8 +181,8 @@ from the ``getAuthenticationStatus()`` method of any token.
 Now you might ask yourself, how a token receives its credentials. The simple answer
 is: It's up to the token, to fetch them from somewhere. The ``UsernamePassword``
 token for example checks for a username and password in the two POST parameters:
-``__authentication[TYPO3][Flow][Security][Authentication][Token][UsernamePassword][username]`` and
-``__authentication[TYPO3][Flow][Security][Authentication][Token][UsernamePassword][password]`` (see
+``__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][username]`` and
+``__authentication[Neos][Flow][Security][Authentication][Token][UsernamePassword][password]`` (see
 :ref:`Using the authentication controller`). The framework only makes sure that
 ``updateCredentials()`` is called on every token, then the token has to set possibly
 available credentials itself, e.g. from available headers or parameters or anything else
@@ -628,9 +628,9 @@ from the HTTP POST data, look at the following program listing for details::
 
   $postArguments = $this->environment->getRawPostArguments();
   $username = \Neos\Utility\ObjectAccess::getPropertyPath($postArguments,
-      '__authentication.TYPO3.Flow.Security.Authentication.Token.UsernamePassword.username');
+      '__authentication.Neos.Flow.Security.Authentication.Token.UsernamePassword.username');
   $password = \Neos\Utility\ObjectAccess::getPropertyPath($postArguments,
-      '__authentication.TYPO3.Flow.Security.Authentication.Token.UsernamePassword.password');
+      '__authentication.Neos.Flow.Security.Authentication.Token.UsernamePassword.password');
 
 .. note::
 

--- a/Neos.Flow/Migrations/Code/Version20170125103800.php
+++ b/Neos.Flow/Migrations/Code/Version20170125103800.php
@@ -30,6 +30,8 @@ class Version20170125103800 extends AbstractMigration
     public function up()
     {
         $this->searchAndReplace('[TYPO3][Flow][Security][Authentication]', '[Neos][Flow][Security][Authentication]', ['php', 'ts2', 'fusion', 'js', 'json', 'html']);
+        $this->searchAndReplace('[\'TYPO3\'][\'Flow\'][\'Security\'][\'Authentication\']', '[\'Neos\'][\'Flow\'][\'Security\'][\'Authentication\']', ['php', 'ts2', 'fusion', 'js', 'json', 'html']);
+        $this->searchAndReplace('["TYPO3"]["Flow"]["Security"]["Authentication"]', '["Neos"]["Flow"]["Security"]["Authentication"]', ['php', 'ts2', 'fusion', 'js', 'json', 'html']);
         $this->searchAndReplace('TYPO3.Flow.Security.Authentication', 'TYPO3.Flow.Security.Authentication', ['php', 'ts2', 'fusion', 'js', 'json', 'html']);
     }
 }

--- a/Neos.Flow/Migrations/Code/Version20170125103800.php
+++ b/Neos.Flow/Migrations/Code/Version20170125103800.php
@@ -1,0 +1,35 @@
+<?php
+namespace Neos\Flow\Core\Migrations;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Migrate usages of the path [TYPO3][Flow][Security][Authentication] to [Neos][Flow][Security][Authentication]
+ */
+class Version20170125103800 extends AbstractMigration
+{
+    /**
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return 'Neos.Flow-20170125103800';
+    }
+
+    /**
+     * @return void
+     */
+    public function up()
+    {
+        $this->searchAndReplace('[TYPO3][Flow][Security][Authentication]', '[Neos][Flow][Security][Authentication]', ['php', 'ts2', 'fusion', 'js', 'json', 'html']);
+        $this->searchAndReplace('TYPO3.Flow.Security.Authentication', 'TYPO3.Flow.Security.Authentication', ['php', 'ts2', 'fusion', 'js', 'json', 'html']);
+    }
+}

--- a/Neos.Flow/Tests/Functional/Security/AuthenticationTest.php
+++ b/Neos.Flow/Tests/Functional/Security/AuthenticationTest.php
@@ -144,8 +144,8 @@ class AuthenticationTest extends FunctionalTestCase
     public function successfulAuthenticationCallsOnAuthenticationSuccessMethod()
     {
         $arguments = [];
-        $arguments['__authentication']['TYPO3']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['username'] = 'functional_test_account';
-        $arguments['__authentication']['TYPO3']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['password'] = 'a_very_secure_long_password';
+        $arguments['__authentication']['Neos']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['username'] = 'functional_test_account';
+        $arguments['__authentication']['Neos']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['password'] = 'a_very_secure_long_password';
 
         $response = $this->browser->request('http://localhost/test/security/authentication/usernamepassword', 'POST', $arguments);
         $this->assertSame($response->getContent(), 'UsernamePasswordTestController success!' . chr(10) . 'Neos.Flow:Everybody' . chr(10) . 'Neos.Flow:AuthenticatedUser' . chr(10) . 'Neos.Flow:Administrator' . chr(10));
@@ -178,8 +178,8 @@ class AuthenticationTest extends FunctionalTestCase
     public function successfulAuthenticationDoesStartASessionIfTokenRequiresIt()
     {
         $arguments = [];
-        $arguments['__authentication']['TYPO3']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['username'] = 'functional_test_account';
-        $arguments['__authentication']['TYPO3']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['password'] = 'a_very_secure_long_password';
+        $arguments['__authentication']['Neos']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['username'] = 'functional_test_account';
+        $arguments['__authentication']['Neos']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['password'] = 'a_very_secure_long_password';
 
         $response = $this->browser->request('http://localhost/test/security/authentication/usernamepassword', 'POST', $arguments);
         $this->assertNotEmpty($response->getCookies());

--- a/Neos.Flow/Tests/Functional/Security/CsrfProtectionTest.php
+++ b/Neos.Flow/Tests/Functional/Security/CsrfProtectionTest.php
@@ -74,8 +74,8 @@ class CsrfProtectionTest extends FunctionalTestCase
         $this->markTestIncomplete('Needs to be implemented');
 
         $arguments = [];
-        $arguments['__authentication']['TYPO3']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['username'] = 'admin';
-        $arguments['__authentication']['TYPO3']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['password'] = 'password';
+        $arguments['__authentication']['Neos']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['username'] = 'admin';
+        $arguments['__authentication']['Neos']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['password'] = 'password';
 
         $request = Request::create(new Uri('http://localhost/test/security/authentication/usernamepassword/authenticate'), 'POST', $arguments);
         $response = $this->browser->sendRequest($request);

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Token/PasswordTokenTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Token/PasswordTokenTest.php
@@ -56,7 +56,7 @@ class PasswordTokenTest extends UnitTestCase
     public function credentialsAreSetCorrectlyFromPostArguments()
     {
         $arguments = [];
-        $arguments['__authentication']['TYPO3']['Flow']['Security']['Authentication']['Token']['PasswordToken']['password'] = 'verysecurepassword';
+        $arguments['__authentication']['Neos']['Flow']['Security']['Authentication']['Token']['PasswordToken']['password'] = 'verysecurepassword';
 
         $this->mockHttpRequest->expects($this->atLeastOnce())->method('getMethod')->will($this->returnValue('POST'));
         $this->mockActionRequest->expects($this->atLeastOnce())->method('getInternalArguments')->will($this->returnValue($arguments));
@@ -73,7 +73,7 @@ class PasswordTokenTest extends UnitTestCase
     public function updateCredentialsSetsTheCorrectAuthenticationStatusIfNewCredentialsArrived()
     {
         $arguments = [];
-        $arguments['__authentication']['TYPO3']['Flow']['Security']['Authentication']['Token']['PasswordToken']['password'] = 'verysecurepassword';
+        $arguments['__authentication']['Neos']['Flow']['Security']['Authentication']['Token']['PasswordToken']['password'] = 'verysecurepassword';
 
         $this->mockHttpRequest->expects($this->atLeastOnce())->method('getMethod')->will($this->returnValue('POST'));
         $this->mockActionRequest->expects($this->atLeastOnce())->method('getInternalArguments')->will($this->returnValue($arguments));
@@ -89,7 +89,7 @@ class PasswordTokenTest extends UnitTestCase
     public function updateCredentialsIgnoresAnythingOtherThanPostRequests()
     {
         $arguments = [];
-        $arguments['__authentication']['TYPO3']['Flow']['Security']['Authentication']['Token']['PasswordToken']['password'] = 'verysecurepassword';
+        $arguments['__authentication']['Neos']['Flow']['Security']['Authentication']['Token']['PasswordToken']['password'] = 'verysecurepassword';
 
         $this->mockHttpRequest->expects($this->atLeastOnce())->method('getMethod')->will($this->returnValue('POST'));
         $this->mockActionRequest->expects($this->atLeastOnce())->method('getInternalArguments')->will($this->returnValue($arguments));

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Token/UsernamePasswordTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Token/UsernamePasswordTest.php
@@ -57,8 +57,8 @@ class UsernamePasswordTest extends UnitTestCase
     public function credentialsAreSetCorrectlyFromPostArguments()
     {
         $arguments = [];
-        $arguments['__authentication']['TYPO3']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['username'] = 'johndoe';
-        $arguments['__authentication']['TYPO3']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['password'] = 'verysecurepassword';
+        $arguments['__authentication']['Neos']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['username'] = 'johndoe';
+        $arguments['__authentication']['Neos']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['password'] = 'verysecurepassword';
 
         $this->mockHttpRequest->expects($this->atLeastOnce())->method('getMethod')->will($this->returnValue('POST'));
         $this->mockActionRequest->expects($this->atLeastOnce())->method('getInternalArguments')->will($this->returnValue($arguments));
@@ -75,8 +75,8 @@ class UsernamePasswordTest extends UnitTestCase
     public function updateCredentialsSetsTheCorrectAuthenticationStatusIfNewCredentialsArrived()
     {
         $arguments = [];
-        $arguments['__authentication']['TYPO3']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['username'] = 'Neos.Flow';
-        $arguments['__authentication']['TYPO3']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['password'] = 'verysecurepassword';
+        $arguments['__authentication']['Neos']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['username'] = 'Neos.Flow';
+        $arguments['__authentication']['Neos']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['password'] = 'verysecurepassword';
 
         $this->mockHttpRequest->expects($this->atLeastOnce())->method('getMethod')->will($this->returnValue('POST'));
         $this->mockActionRequest->expects($this->atLeastOnce())->method('getInternalArguments')->will($this->returnValue($arguments));
@@ -92,8 +92,8 @@ class UsernamePasswordTest extends UnitTestCase
     public function updateCredentialsIgnoresAnythingOtherThanPostRequests()
     {
         $arguments = [];
-        $arguments['__authentication']['TYPO3']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['username'] = 'Neos.Flow';
-        $arguments['__authentication']['TYPO3']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['password'] = 'verysecurepassword';
+        $arguments['__authentication']['Neos']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['username'] = 'Neos.Flow';
+        $arguments['__authentication']['Neos']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['password'] = 'verysecurepassword';
 
         $this->mockHttpRequest->expects($this->atLeastOnce())->method('getMethod')->will($this->returnValue('POST'));
         $this->mockActionRequest->expects($this->atLeastOnce())->method('getInternalArguments')->will($this->returnValue($arguments));
@@ -118,8 +118,8 @@ class UsernamePasswordTest extends UnitTestCase
     public function tokenCanBeCastToString()
     {
         $arguments = [];
-        $arguments['__authentication']['TYPO3']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['username'] = 'Neos.Flow';
-        $arguments['__authentication']['TYPO3']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['password'] = 'verysecurepassword';
+        $arguments['__authentication']['Neos']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['username'] = 'Neos.Flow';
+        $arguments['__authentication']['Neos']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['password'] = 'verysecurepassword';
 
         $this->mockHttpRequest->expects($this->atLeastOnce())->method('getMethod')->will($this->returnValue('POST'));
         $this->mockActionRequest->expects($this->atLeastOnce())->method('getInternalArguments')->will($this->returnValue($arguments));


### PR DESCRIPTION
This change adjusts the path used for the POST argument
used for authentication with username and password to the
new vendor namespace.

Any application - and especially its Fluid templates and
JavaScript - relying on the old path needs to be updated.

This change provides a core migration which carries out
these changes.

Resolves #837