### PR TITLE
BUGFIX: Cleanup of reflection freezing

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -452,14 +452,12 @@ class Scripts
         $reflectionService = new ReflectionService();
 
         $reflectionService->injectSystemLogger($bootstrap->getEarlyInstance(SystemLoggerInterface::class));
-        $reflectionService->injectClassLoader($bootstrap->getEarlyInstance(ClassLoader::class));
         $reflectionService->injectSettings($settings);
         $reflectionService->injectPackageManager($bootstrap->getEarlyInstance(PackageManagerInterface::class));
         $reflectionService->setStatusCache($cacheManager->getCache('Flow_Reflection_Status'));
         $reflectionService->setReflectionDataCompiletimeCache($cacheManager->getCache('Flow_Reflection_CompiletimeData'));
         $reflectionService->setReflectionDataRuntimeCache($cacheManager->getCache('Flow_Reflection_RuntimeData'));
         $reflectionService->setClassSchemataRuntimeCache($cacheManager->getCache('Flow_Reflection_RuntimeClassSchemata'));
-        $reflectionService->injectSettings($configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.Flow'));
         $reflectionService->injectEnvironment($bootstrap->getEarlyInstance(Environment::class));
 
         $bootstrap->setEarlyInstance(ReflectionService::class, $reflectionService);

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -106,11 +106,6 @@ class ReflectionService
     protected $annotationReader;
 
     /**
-     * @var ClassLoader
-     */
-    protected $classLoader;
-
-    /**
      * @var array
      */
     protected $availableClassNames = [];
@@ -297,15 +292,6 @@ class ReflectionService
     public function injectSystemLogger(SystemLoggerInterface $systemLogger)
     {
         $this->systemLogger = $systemLogger;
-    }
-
-    /**
-     * @param ClassLoader $classLoader
-     * @return void
-     */
-    public function injectClassLoader(ClassLoader $classLoader)
-    {
-        $this->classLoader = $classLoader;
     }
 
     /**
@@ -2027,9 +2013,9 @@ class ReflectionService
         if (!$this->initialized) {
             $this->initialize();
         }
-        $package = $this->packageManager->getPackage($packageKey);
-
-        $packageNamespace = $package->getNamespace() . '\\';
+        if (empty($this->availableClassNames)) {
+            $this->availableClassNames = $this->reflectionDataRuntimeCache->get('__availableClassNames');
+        }
 
         $reflectionData = [
             'classReflectionData' => $this->classReflectionData,
@@ -2038,13 +2024,13 @@ class ReflectionService
             'classesByMethodAnnotations' => $this->classesByMethodAnnotations
         ];
 
-        $reflectionData['classReflectionData'] = $this->filterArrayByClassesInNamespace($reflectionData['classReflectionData'], $packageNamespace);
-        $reflectionData['classSchemata'] = $this->filterArrayByClassesInNamespace($reflectionData['classSchemata'], $packageNamespace);
-        $reflectionData['annotatedClasses'] = $this->filterArrayByClassesInNamespace($reflectionData['annotatedClasses'], $packageNamespace);
+        $reflectionData['classReflectionData'] = $this->filterArrayByClassesInNamespace($reflectionData['classReflectionData'], $packageKey);
+        $reflectionData['classSchemata'] = $this->filterArrayByClassesInNamespace($reflectionData['classSchemata'], $packageKey);
+        $reflectionData['annotatedClasses'] = $this->filterArrayByClassesInNamespace($reflectionData['annotatedClasses'], $packageKey);
 
         $reflectionData['classesByMethodAnnotations'] = isset($reflectionData['classesByMethodAnnotations']) ? $reflectionData['classesByMethodAnnotations'] : [];
-        $methodAnnotationsFilters = function ($className) use ($packageNamespace) {
-            return strpos($className, $packageNamespace) === 0;
+        $methodAnnotationsFilters = function ($className) use ($packageKey) {
+            return (isset($this->availableClassNames[$packageKey]) && in_array($className, $this->availableClassNames[$packageKey]));
         };
 
         foreach ($reflectionData['classesByMethodAnnotations'] as $annotationClassName => $classNames) {
@@ -2063,17 +2049,14 @@ class ReflectionService
      * Filter an array of entries were keys are class names by being in the given package namespace.
      *
      * @param array $array
-     * @param string $packageNamespace
+     * @param string $packageKey
      * @return array
      */
-    protected function filterArrayByClassesInNamespace(array $array, $packageNamespace)
+    protected function filterArrayByClassesInNamespace(array $array, $packageKey)
     {
-        // TODO: With PHP 5.6 the closure function can get the key for filtering.
-        return array_filter($array, function ($item) use (&$array, $packageNamespace) {
-            $className = key($array);
-            next($array);
-            return strpos($className, $packageNamespace) === 0;
-        });
+        return array_filter($array, function ($className) use ($packageKey) {
+            return (isset($this->availableClassNames[$packageKey]) && in_array($className, $this->availableClassNames[$packageKey]));
+        }, ARRAY_FILTER_USE_KEY);
     }
 
     /**
@@ -2125,6 +2108,10 @@ class ReflectionService
 
         if (!($this->reflectionDataCompiletimeCache instanceof FrontendInterface)) {
             throw new Exception('A cache must be injected before initializing the Reflection Service.', 1232044697);
+        }
+
+        if (!empty($this->availableClassNames)) {
+            $this->reflectionDataRuntimeCache->set('__availableClassNames', $this->availableClassNames);
         }
 
         if ($this->updatedReflectionData !== []) {

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -2024,9 +2024,9 @@ class ReflectionService
             'classesByMethodAnnotations' => $this->classesByMethodAnnotations
         ];
 
-        $reflectionData['classReflectionData'] = $this->filterArrayByClassesInNamespace($reflectionData['classReflectionData'], $packageKey);
-        $reflectionData['classSchemata'] = $this->filterArrayByClassesInNamespace($reflectionData['classSchemata'], $packageKey);
-        $reflectionData['annotatedClasses'] = $this->filterArrayByClassesInNamespace($reflectionData['annotatedClasses'], $packageKey);
+        $reflectionData['classReflectionData'] = $this->filterArrayByClassesInPackageNamespace($reflectionData['classReflectionData'], $packageKey);
+        $reflectionData['classSchemata'] = $this->filterArrayByClassesInPackageNamespace($reflectionData['classSchemata'], $packageKey);
+        $reflectionData['annotatedClasses'] = $this->filterArrayByClassesInPackageNamespace($reflectionData['annotatedClasses'], $packageKey);
 
         $reflectionData['classesByMethodAnnotations'] = isset($reflectionData['classesByMethodAnnotations']) ? $reflectionData['classesByMethodAnnotations'] : [];
         $methodAnnotationsFilters = function ($className) use ($packageKey) {
@@ -2052,7 +2052,7 @@ class ReflectionService
      * @param string $packageKey
      * @return array
      */
-    protected function filterArrayByClassesInNamespace(array $array, $packageKey)
+    protected function filterArrayByClassesInPackageNamespace(array $array, $packageKey)
     {
         return array_filter($array, function ($className) use ($packageKey) {
             return (isset($this->availableClassNames[$packageKey]) && in_array($className, $this->availableClassNames[$packageKey]));


### PR DESCRIPTION
The reflection freezing process still used a removed method from packages,
this has been refactored as the information needed is already available and
just needed to be cached.

Additionally a bit of clean up was done while looking at it.

Fixes: #743