### PR TITLE
BUGFIX: Use request correctly in Fluid Views

### DIFF
--- a/Neos.FluidAdaptor/Classes/View/AbstractTemplateView.php
+++ b/Neos.FluidAdaptor/Classes/View/AbstractTemplateView.php
@@ -139,6 +139,7 @@ abstract class AbstractTemplateView extends \TYPO3Fluid\Fluid\View\AbstractTempl
 
     /**
      * @param string $templatePathAndFilename
+     * @return void
      */
     public function setTemplatePathAndFilename($templatePathAndFilename)
     {
@@ -147,6 +148,7 @@ abstract class AbstractTemplateView extends \TYPO3Fluid\Fluid\View\AbstractTempl
 
     /**
      * @param ControllerContext $controllerContext
+     * @return void
      */
     public function setControllerContext(ControllerContext $controllerContext)
     {
@@ -206,6 +208,7 @@ abstract class AbstractTemplateView extends \TYPO3Fluid\Fluid\View\AbstractTempl
      * Validate options given to this view.
      *
      * @param array $options
+     * @return void
      * @throws Exception
      */
     protected function validateOptions(array $options)
@@ -232,6 +235,7 @@ abstract class AbstractTemplateView extends \TYPO3Fluid\Fluid\View\AbstractTempl
      * and sets the resulting options in this object.
      *
      * @param array $options
+     * @return void
      */
     protected function setOptions(array $options)
     {

--- a/Neos.FluidAdaptor/Classes/View/AbstractTemplateView.php
+++ b/Neos.FluidAdaptor/Classes/View/AbstractTemplateView.php
@@ -142,7 +142,7 @@ abstract class AbstractTemplateView extends \TYPO3Fluid\Fluid\View\AbstractTempl
      */
     public function setTemplatePathAndFilename($templatePathAndFilename)
     {
-        return $this->getTemplatePaths()->setTemplatePathAndFilename($templatePathAndFilename);
+        $this->getTemplatePaths()->setTemplatePathAndFilename($templatePathAndFilename);
     }
 
     /**
@@ -151,18 +151,21 @@ abstract class AbstractTemplateView extends \TYPO3Fluid\Fluid\View\AbstractTempl
     public function setControllerContext(ControllerContext $controllerContext)
     {
         $this->controllerContext = $controllerContext;
-        if ($this->getRenderingContext() instanceof RenderingContext) {
-            $this->getRenderingContext()->setControllerContext($controllerContext);
+
+        $renderingContext = $this->getRenderingContext();
+        if ($renderingContext instanceof RenderingContext) {
+            $renderingContext->setControllerContext($controllerContext);
         }
 
 
         $paths = $this->getTemplatePaths();
         $request = $controllerContext->getRequest();
-        $paths->setFormat($request->getFormat());
 
         if (!$request instanceof ActionRequest) {
             return;
         }
+
+        $paths->setFormat($request->getFormat());
 
         if ($paths->getTemplateRootPaths() === [] && $paths->getLayoutRootPaths() === [] && $paths->getPartialRootPaths() === []) {
             $paths->fillDefaultsByPackageName($request->getControllerPackageKey());

--- a/Neos.FluidAdaptor/Classes/View/StandaloneView.php
+++ b/Neos.FluidAdaptor/Classes/View/StandaloneView.php
@@ -17,7 +17,6 @@ use Neos\Flow\Http\Response;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\Controller\Arguments;
 use Neos\Flow\Mvc\Controller\ControllerContext;
-use Neos\Flow\Mvc\RequestInterface;
 use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\Utility\Files;
 use Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException;
@@ -135,7 +134,8 @@ class StandaloneView extends AbstractTemplateView
      */
     public function setFormat($format)
     {
-        $this->baseRenderingContext->getControllerContext()->getRequest()->setFormat($format);
+        $this->request->setFormat($format);
+        $this->baseRenderingContext->getTemplatePaths()->setFormat($format);
     }
 
     /**
@@ -146,17 +146,17 @@ class StandaloneView extends AbstractTemplateView
      */
     public function getFormat()
     {
-        return $this->baseRenderingContext->getControllerContext()->getRequest()->getFormat();
+        return $this->request->getFormat();
     }
 
     /**
      * Returns the current request object
      *
-     * @return RequestInterface
+     * @return ActionRequest
      */
     public function getRequest()
     {
-        return $this->baseRenderingContext->getControllerContext()->getRequest();
+        return $this->request;
     }
 
     /**
@@ -186,7 +186,7 @@ class StandaloneView extends AbstractTemplateView
      */
     public function getTemplatePathAndFilename()
     {
-        return $this->baseRenderingContext->getTemplatePaths()->getTemplatePathAndFilename();
+        return $this->baseRenderingContext->getTemplatePaths()->resolveTemplateFileForControllerAndActionAndFormat($this->request->getControllerName(), $this->request->getControllerActionName(), $this->request->getFormat());
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Functional/View/StandaloneViewTest.php
+++ b/Neos.FluidAdaptor/Tests/Functional/View/StandaloneViewTest.php
@@ -301,4 +301,29 @@ class StandaloneViewTest extends FunctionalTestCase
         $actual = trim($standaloneView->renderSection('test'));
         $this->assertSame($expected, $actual, 'Second rendering was not escaped.');
     }
+
+    /**
+     * @test
+     */
+    public function settingAndGettingFormatWorksAsExpected()
+    {
+        $formatToBeSet = 'xml';
+        $standaloneView = new StandaloneView();
+        $standaloneView->setFormat($formatToBeSet);
+
+        $this->assertSame($formatToBeSet, $standaloneView->getFormat());
+        $this->assertSame($formatToBeSet, $standaloneView->getRenderingContext()->getTemplatePaths()->getFormat());
+    }
+
+    /**
+     * @test
+     */
+    public function settingAndGettingTemplatePathAndFilenameWorksAsExpected()
+    {
+        $templatePathAndFilename = __DIR__ . '/Fixtures/NestedRenderingConfiguration/TemplateWithSection.txt';
+        $standaloneView = new StandaloneView();
+        $standaloneView->setTemplatePathAndFilename($templatePathAndFilename);
+
+        $this->assertSame($templatePathAndFilename, $standaloneView->getTemplatePathAndFilename());
+    }
 }


### PR DESCRIPTION
The refactoring of Fluid to the Adaptor left some places with invalid handling
of request and format inside of Views. The code couldn't work in it's current
state and is now adapted.

Fixes: #848
