### PR TITLE
BUGFIX: Peg generated parsers are excluded from proxy building

### DIFF
--- a/TYPO3.Eel/Classes/TYPO3/Eel/AbstractParser.php
+++ b/TYPO3.Eel/Classes/TYPO3/Eel/AbstractParser.php
@@ -22,6 +22,8 @@ WARNING: This file has been machine generated. Do not edit it, or your changes w
 /**
  * This Abstract Parser class contains definitions for absolutely basic types,
  * like quoted strings or identifiers
+ *
+ * @TYPO3\Flow\Annotations\Proxy(false)
  */
 abstract class AbstractParser extends \PhpPeg\Parser {
 /* S: / \s* / */
@@ -253,10 +255,14 @@ function match_Identifier ($stack = array()) {
 
 
 
-	public function StringLiteral_SingleQuotedStringLiteral(&$result, $sub) {
-		$result['val'] = (string)str_replace("'", "'", substr($sub['text'], 1, -1));
-	}
-	public function StringLiteral_DoubleQuotedStringLiteral(&$result, $sub) {
-		$result['val'] = (string)str_replace('\"', '"', substr($sub['text'], 1, -1));
-	}
+
+    public function StringLiteral_SingleQuotedStringLiteral(&$result, $sub)
+    {
+        $result['val'] = (string)str_replace("'", "'", substr($sub['text'], 1, -1));
+    }
+
+    public function StringLiteral_DoubleQuotedStringLiteral(&$result, $sub)
+    {
+        $result['val'] = (string)str_replace('\"', '"', substr($sub['text'], 1, -1));
+    }
 }

--- a/TYPO3.Eel/Classes/TYPO3/Eel/EelParser.php
+++ b/TYPO3.Eel/Classes/TYPO3/Eel/EelParser.php
@@ -22,6 +22,8 @@ WARNING: This file has been machine generated. Do not edit it, or your changes w
  *
  * This parser can evaluate the expression language for Flow and uses
  * the basic types from AbstractParser.
+ *
+ * @TYPO3\Flow\Annotations\Proxy(false)
  */
 class EelParser extends \TYPO3\Eel\AbstractParser {
 

--- a/TYPO3.Eel/Classes/TYPO3/Eel/FlowQuery/FizzleParser.php
+++ b/TYPO3.Eel/Classes/TYPO3/Eel/FlowQuery/FizzleParser.php
@@ -21,6 +21,8 @@ WARNING: This file has been machine generated. Do not edit it, or your changes w
  *
  * This is the parser for a CSS-like selector language for Objects and TYPO3CR Nodes.
  * You can think of it as "Sizzle for PHP" (hence the name).
+ *
+ * @TYPO3\Flow\Annotations\Proxy(false)
  */
 class FizzleParser extends \TYPO3\Eel\AbstractParser {
 /* ObjectIdentifier: / [0-9a-zA-Z_-]+ / */

--- a/TYPO3.Eel/Resources/Private/Grammar/AbstractParser.peg.inc
+++ b/TYPO3.Eel/Resources/Private/Grammar/AbstractParser.peg.inc
@@ -19,6 +19,8 @@ require_once __DIR__ . '/../../../Resources/Private/PHP/php-peg/Parser.php';
 /**
  * This Abstract Parser class contains definitions for absolutely basic types,
  * like quoted strings or identifiers
+ *
+ * @TYPO3\Flow\Annotations\Proxy(false)
  */
 abstract class AbstractParser extends \PhpPeg\Parser {
 /*!* WhiteSpace
@@ -48,7 +50,7 @@ Identifier: / [a-zA-Z_] [a-zA-Z0-9_\-]* /
         $result['val'] = (string)str_replace("'", "'", substr($sub['text'], 1, -1));
     }
 
-    public function StringLiteral_DoubleQuotedStringLiteral(&$result, $sub) 
+    public function StringLiteral_DoubleQuotedStringLiteral(&$result, $sub)
     {
         $result['val'] = (string)str_replace('\"', '"', substr($sub['text'], 1, -1));
     }

--- a/TYPO3.Eel/Resources/Private/Grammar/Eel.peg.inc
+++ b/TYPO3.Eel/Resources/Private/Grammar/Eel.peg.inc
@@ -19,6 +19,8 @@ namespace TYPO3\Eel;
  *
  * This parser can evaluate the expression language for Flow and uses
  * the basic types from AbstractParser.
+ *
+ * @TYPO3\Flow\Annotations\Proxy(false)
  */
 class EelParser extends \TYPO3\Eel\AbstractParser {
 

--- a/TYPO3.Eel/Resources/Private/Grammar/Fizzle.peg.inc
+++ b/TYPO3.Eel/Resources/Private/Grammar/Fizzle.peg.inc
@@ -18,6 +18,8 @@ namespace TYPO3\Eel\FlowQuery;
  *
  * This is the parser for a CSS-like selector language for Objects and TYPO3CR Nodes.
  * You can think of it as "Sizzle for PHP" (hence the name).
+ *
+ * @TYPO3\Flow\Annotations\Proxy(false)
  */
 class FizzleParser extends \TYPO3\Eel\AbstractParser {
 /*!* FizzleTypes


### PR DESCRIPTION
The generated parsers ``AbstractParser``, ``EelParser`` and ``FizzleParser``
are excluded from proxy building as the include statement and the general
structure of these make them unsuitable for proxy-ing. This was only a bug
before if an AOP advice targeted the mentioned classes, now this cannot
happen anymore.

Fixes: #796
