### PR TITLE
BUGFIX: Proxy Compiler adds newline after end of original code

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Object/Proxy/Compiler.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Object/Proxy/Compiler.php
@@ -239,7 +239,12 @@ return ' . var_export($this->storedProxyClasses, true) . ';';
 
         $proxyClassCode .= "\n" . '# PathAndFilename: ' . $pathAndFilename;
 
-        $this->classesCache->set(str_replace('\\', '_', $className), $classCode . $proxyClassCode);
+        $separator =
+            PHP_EOL . '#' .
+            PHP_EOL . '# Start of Flow generated Proxy code' .
+            PHP_EOL . '#' . PHP_EOL;
+
+        $this->classesCache->set(str_replace('\\', '_', $className), $classCode . $separator . $proxyClassCode);
     }
 
     /**


### PR DESCRIPTION
As any original class might end on a comment line without newline we need to
add a newline as part of the proxy building to avoid putting the proxy
namespace declaration within a comment. Additionally adds a marker comment
declaring the beginning of the proxy code.

Fixes: #779
