### PR TITLE
BUGFIX: Use ``exec`` everywhere instead of ``system``

### DIFF
--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartII/Requirements.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartII/Requirements.rst
@@ -41,7 +41,7 @@ and ``pdo_mysql`` are enabled, especially if you compiled PHP yourself.
 
 .. note::
 
-  Make sure the PHP functions ``system()``, ``shell_exec()``,
+  Make sure the PHP functions ``exec()``, ``shell_exec()``,
   ``escapeshellcmd()`` and ``escapeshellarg()`` are not disabled in you PHP
   installation. They are required for the system to run.
 

--- a/Neos.Flow/Scripts/Migrations/Git.php
+++ b/Neos.Flow/Scripts/Migrations/Git.php
@@ -82,7 +82,7 @@ class Git
     public static function move($source, $target)
     {
         $result = 255;
-        system('git mv ' . escapeshellarg($source) . ' ' . escapeshellarg($target), $result);
+        exec('git mv ' . escapeshellarg($source) . ' ' . escapeshellarg($target), $output, $result);
         return $result;
     }
 
@@ -94,9 +94,9 @@ class Git
     {
         $result = 255;
         if (is_dir($fileOrDirectory)) {
-            system('git rm -qr ' . escapeshellarg($fileOrDirectory), $result);
+            exec('git rm -qr ' . escapeshellarg($fileOrDirectory), $output, $result);
         } else {
-            system('git rm -q ' . escapeshellarg($fileOrDirectory), $result);
+            exec('git rm -q ' . escapeshellarg($fileOrDirectory), $output, $result);
         }
         return $result;
     }

--- a/Neos.Flow/Scripts/flow.php
+++ b/Neos.Flow/Scripts/flow.php
@@ -32,7 +32,7 @@ if (isset($argv[1]) && ($argv[1] === 'neos.flow:core:setfilepermissions' || $arg
     array_shift($argv);
     array_shift($argv);
     $returnValue = 0;
-    system(__DIR__ . '/setfilepermissions.sh ' . implode($argv, ' '), $returnValue);
+    exec(__DIR__ . '/setfilepermissions.sh ' . implode($argv, ' '), $output, $returnValue);
     exit($returnValue);
 } elseif (isset($argv[1]) && ($argv[1] === 'neos.flow:core:migrate' || $argv[1] === 'flow:core:migrate' || $argv[1] === 'core:migrate')) {
     array_shift($argv);


### PR DESCRIPTION
Instead of using both, the Flow core uses the ``exec`` function throughout
now and the requirements documentation is updated accordingly.

Fixes: #634
