### PR TITLE
BUGFIX: ``ReflectionService::getClassSchema`` works with Proxies

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
@@ -1099,7 +1099,7 @@ class ReflectionService
     {
         $className = $classNameOrObject;
         if (is_object($classNameOrObject)) {
-            $className = get_class($classNameOrObject);
+            $className = TypeHandling::getTypeForValue($classNameOrObject);
         }
         $className = $this->cleanClassName($className);
 


### PR DESCRIPTION
Getting a class schema from the reflection service should work
when giving a doctrine proxy object instead of the actual entity.

Fixes: #561
