### PR TITLE
BUGFIX: Resource setSha1() fails on uppercase hash

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Resource.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Resource.php
@@ -339,10 +339,10 @@ class Resource implements ResourceMetaDataInterface, CacheAwareInterface
     public function setSha1($sha1)
     {
         $this->throwExceptionIfProtected();
-        if (preg_match('/[a-f0-9]{40}/', $sha1) !== 1) {
+        if (!is_string($sha1) || preg_match('/[A-Fa-f0-9]{40}/', $sha1) !== 1) {
             throw new \InvalidArgumentException('Specified invalid hash to setSha1()', 1362564220);
         }
-        $this->sha1 = $sha1;
+        $this->sha1 = strtolower($sha1);
     }
 
     /**

--- a/TYPO3.Flow/Tests/Unit/Resource/ResourceTest.php
+++ b/TYPO3.Flow/Tests/Unit/Resource/ResourceTest.php
@@ -75,4 +75,40 @@ class ResourceTest extends UnitTestCase
         $resource->setFilename('file.someunknownextension');
         $this->assertSame('application/octet-stream', $resource->getMediaType());
     }
+
+    /**
+     * @return array
+     */
+    public function invalidSha1Values()
+    {
+        return [
+          [''],
+          [null],
+          ['XYZE2DC421BE4fCD0172E5AFCEEA3970E2f3d940'],
+          [new \stdClass()],
+          [false],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidSha1Values
+     * @expectedException \InvalidArgumentException
+     */
+    public function setSha1RejectsInvalidValues($invalidValue)
+    {
+        $resource = new Resource();
+        $resource->setSha1($invalidValue);
+        $this->assertSame('d0be2dc421be4fcd0172e5afceea3970e2f3d940', $resource->getSha1());
+    }
+
+    /**
+     * @test
+     */
+    public function setSha1AcceptsUppercaseHashesAndNormalizesThemToLowercase()
+    {
+        $resource = new Resource();
+        $resource->setSha1('D0BE2DC421BE4fCD0172E5AFCEEA3970E2f3d940');
+        $this->assertSame('d0be2dc421be4fcd0172e5afceea3970e2f3d940', $resource->getSha1());
+    }
 }


### PR DESCRIPTION
This change fixes an issue with the Resource object's
`setSha1()` method which fails if the given hexadecimal
number uses uppercase characters for A-F.

On some operating systems or third party services,
uppercase hashes may be used. `setSha1()` now accepts
values containing uppercase characters and normalizes
them to lowercase. Therefore, when you set a SHA1
with an uppercase hexadecimal string, `getSha1()`
will return it in lowercase.

Related to https://github.com/flownative/flow-google-cloudstorage/issues/4