### PR TITLE
BUGFIX: ClassLoader should load AvailableProxies from TEMPORARY_BASE

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/ClassLoader.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/ClassLoader.php
@@ -373,7 +373,7 @@ class ClassLoader
             return;
         }
 
-        $proxyClasses = @include(FLOW_PATH_DATA . 'Temporary/' . (string)$context . '/AvailableProxyClasses.php');
+        $proxyClasses = @include(FLOW_PATH_TEMPORARY_BASE . '/' . (string)$context . '/AvailableProxyClasses.php');
         if ($proxyClasses !== false) {
             $this->availableProxyClasses = $proxyClasses;
         }


### PR DESCRIPTION
If you have an old version of the AvailableProxyClasses in FLOW_PATH_DATA
and you change FLOW_PATH_TEMPORARY_BASE, always the old proxy classes
get loaded.

Resolves: #866