### PR TITLE
BUGFIX: Consider accounts with ``expirationDate`` in the future as active

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Account.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Account.php
@@ -100,7 +100,7 @@ class Account
     protected $objectManager;
 
     /**
-     * @Flow\Inject
+     * @Flow\Inject(lazy=false)
      * @var Now
      */
     protected $now;

--- a/TYPO3.Flow/Tests/Functional/Security/AccountTest.php
+++ b/TYPO3.Flow/Tests/Functional/Security/AccountTest.php
@@ -52,7 +52,7 @@ class AccountTest extends FunctionalTestCase
      */
     public function expiredAccountIsInActive()
     {
-        $this->account->setExpirationDate((new \DateTime("now"))->sub(new \DateInterval("PT1M")));
+        $this->account->setExpirationDate((new \DateTime("now"))->sub(new \DateInterval("PT1H")));
         $this->assertFalse($this->account->isActive());
     }
 
@@ -61,7 +61,7 @@ class AccountTest extends FunctionalTestCase
      */
     public function notYetExpiredAccountIsInActive()
     {
-        $this->account->setExpirationDate((new \DateTime("now"))->add(new \DateInterval("PT1M")));
+        $this->account->setExpirationDate((new \DateTime("now"))->add(new \DateInterval("PT1H")));
         $this->assertTrue($this->account->isActive());
     }
 }

--- a/TYPO3.Flow/Tests/Functional/Security/AccountTest.php
+++ b/TYPO3.Flow/Tests/Functional/Security/AccountTest.php
@@ -31,7 +31,8 @@ class AccountTest extends FunctionalTestCase
      */
     protected $account;
 
-    public function setUp() {
+    public function setUp()
+    {
         parent::setUp();
 
         $this->account = $this->objectManager->get(Account::class);
@@ -51,7 +52,7 @@ class AccountTest extends FunctionalTestCase
      */
     public function expiredAccountIsInActive()
     {
-        $this->account->setExpirationDate( (new \DateTime("now"))->sub(new \DateInterval("PT1M")));
+        $this->account->setExpirationDate((new \DateTime("now"))->sub(new \DateInterval("PT1M")));
         $this->assertFalse($this->account->isActive());
     }
 
@@ -60,7 +61,7 @@ class AccountTest extends FunctionalTestCase
      */
     public function notYetExpiredAccountIsInActive()
     {
-        $this->account->setExpirationDate( (new \DateTime("now"))->add(new \DateInterval("PT1M")));
+        $this->account->setExpirationDate((new \DateTime("now"))->add(new \DateInterval("PT1M")));
         $this->assertTrue($this->account->isActive());
     }
 }

--- a/TYPO3.Flow/Tests/Functional/Security/AccountTest.php
+++ b/TYPO3.Flow/Tests/Functional/Security/AccountTest.php
@@ -1,0 +1,66 @@
+<?php
+namespace TYPO3\Flow\Tests\Functional\Security;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Security\Account;
+use TYPO3\Flow\Tests\FunctionalTestCase;
+
+/**
+ * Testcase for the account factory
+ *
+ */
+class AccountTest extends FunctionalTestCase
+{
+    /**
+     * @var boolean
+     */
+    protected $testableSecurityEnabled = true;
+
+    /**
+     * @var Account
+     */
+    protected $account;
+
+    public function setUp() {
+        parent::setUp();
+
+        $this->account = $this->objectManager->get(Account::class);
+    }
+
+    /**
+     * @test
+     */
+    public function freshAccountIsActive()
+    {
+        $this->account->setExpirationDate(null);
+        $this->assertTrue($this->account->isActive());
+    }
+
+    /**
+     * @test
+     */
+    public function expiredAccountIsInActive()
+    {
+        $this->account->setExpirationDate( (new \DateTime("now"))->sub(new \DateInterval("PT1M")));
+        $this->assertFalse($this->account->isActive());
+    }
+
+    /**
+     * @test
+     */
+    public function notYetExpiredAccountIsInActive()
+    {
+        $this->account->setExpirationDate( (new \DateTime("now"))->add(new \DateInterval("PT1M")));
+        $this->assertTrue($this->account->isActive());
+    }
+}


### PR DESCRIPTION
**What I did**

I fixed ``Account::isActive()`` behavior when an expirationDate is set.

**How I did it**

The "Now" injection is now non-lazy, thus the comparison of DateTime objects works.

**How to verify it**

Run the new functional test ``TYPO3.Flow/Tests/Functional/Security/AccountTest.php``

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)

Resolves #873
