### PR TITLE
BUGFIX: Automatic fluid namespace work with PSR-4 autoload paths

### DIFF
--- a/Neos.FluidAdaptor/Classes/Core/ViewHelper/ViewHelperResolver.php
+++ b/Neos.FluidAdaptor/Classes/Core/ViewHelper/ViewHelperResolver.php
@@ -70,7 +70,12 @@ class ViewHelperResolver extends \TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperRes
         /** @var Package $package */
         foreach ($this->packageManager->getActivePackages() as $package) {
             foreach ($package->getNamespaces() as $namespace) {
-                $this->addNamespace(strtolower($package->getPackageKey()), $namespace . '\\ViewHelpers');
+                $viewHelperNamespace = $namespace;
+                if (strpos(strrev($namespace), '\\') !== 0) {
+                    $viewHelperNamespace .= '\\';
+                }
+                $viewHelperNamespace .= 'ViewHelpers';
+                $this->addNamespace(strtolower($package->getPackageKey()), $viewHelperNamespace);
             }
         }
     }


### PR DESCRIPTION
Due to the way the namespace to ViewHelpers in packages was constructed
it resulted in rather strange errors trying to use one of the automatically
prepared namespaces in a template.
The namespaces are now constructed accordingly depending on the autoload type.
