### PR TITLE
FEATURE: Skip unknown properties for ObjectConverter

### DIFF
--- a/Neos.Flow/Classes/Property/PropertyMapper.php
+++ b/Neos.Flow/Classes/Property/PropertyMapper.php
@@ -187,6 +187,9 @@ class PropertyMapper
             }
 
             $targetPropertyType = $typeConverter->getTypeOfChildProperty($targetType, $targetPropertyName, $configuration);
+            if ($targetPropertyType === null) {
+                continue;
+            }
 
             $subConfiguration = $configuration->getConfigurationFor($targetPropertyName);
 

--- a/Neos.Flow/Classes/Property/TypeConverter/ObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ObjectConverter.php
@@ -160,6 +160,11 @@ class ObjectConverter extends AbstractTypeConverter
                 }
             }
         }
+
+        if ($configuration->shouldSkipUnknownProperties() || $configuration->shouldSkip($propertyName)) {
+            return null;
+        }
+
         throw new InvalidTargetException(sprintf('Property "%s" has neither a setter or constructor argument, nor is public, in target object of type "%s".', $propertyName, $targetType), 1303379126);
     }
 

--- a/Neos.Flow/Tests/Functional/Property/PropertyMapperTest.php
+++ b/Neos.Flow/Tests/Functional/Property/PropertyMapperTest.php
@@ -21,7 +21,7 @@ use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Flow\Tests\Functional\Property\Fixtures;
 
 /**
- * Testcase for Property Mapper
+ * Test case for Property Mapper
  */
 class PropertyMapperTest extends FunctionalTestCase
 {
@@ -142,7 +142,7 @@ class PropertyMapperTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function targetTypeForEntityCanBeOverridenIfConfigured()
+    public function targetTypeForEntityCanBeOverriddenIfConfigured()
     {
         $source = [
             '__type' => Fixtures\TestEntitySubclass::class,
@@ -161,7 +161,7 @@ class PropertyMapperTest extends FunctionalTestCase
      * @test
      * @expectedException \Neos\Flow\Property\Exception
      */
-    public function overridenTargetTypeForEntityMustBeASubclass()
+    public function overriddenTargetTypeForEntityMustBeASubclass()
     {
         $source = [
             '__type' => Fixtures\TestClass::class,
@@ -177,7 +177,7 @@ class PropertyMapperTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function targetTypeForSimpleObjectCanBeOverridenIfConfigured()
+    public function targetTypeForSimpleObjectCanBeOverriddenIfConfigured()
     {
         $source = [
             '__type' => Fixtures\TestSubclass::class,
@@ -195,7 +195,7 @@ class PropertyMapperTest extends FunctionalTestCase
      * @test
      * @expectedException \Neos\Flow\Property\Exception
      */
-    public function overridenTargetTypeForSimpleObjectMustBeASubclass()
+    public function overriddenTargetTypeForSimpleObjectMustBeASubclass()
     {
         $source = [
             '__type' => Fixtures\TestEntity::class,
@@ -259,7 +259,7 @@ class PropertyMapperTest extends FunctionalTestCase
     }
 
     /**
-     * Testcase for http://forge.typo3.org/issues/36988 - needed for Neos
+     * Test case for http://forge.typo3.org/issues/36988 - needed for Neos
      * editing
      *
      * @test
@@ -274,7 +274,7 @@ class PropertyMapperTest extends FunctionalTestCase
     }
 
     /**
-     * Testcase for http://forge.typo3.org/issues/39445
+     * Test case for http://forge.typo3.org/issues/39445
      *
      * @test
      */
@@ -309,7 +309,7 @@ class PropertyMapperTest extends FunctionalTestCase
     }
 
     /**
-     * Testcase for #32829
+     * Test case for #32829
      *
      * @test
      */

--- a/Neos.Flow/Tests/Functional/Property/PropertyMapperTest.php
+++ b/Neos.Flow/Tests/Functional/Property/PropertyMapperTest.php
@@ -288,6 +288,26 @@ class PropertyMapperTest extends FunctionalTestCase
     }
 
     /**
+     * ObjectConverter->getTypeOfChildProperty will return null if the given property is unknown and skipUnknownPropertiers()
+     * is set. This test makes sure that doMapping() will skip such a property.
+     *
+     * @test
+     */
+    public function skipPropertyIfTypeConverterReturnsNullForChildPropertyType()
+    {
+        $source = [
+            'name' => 'Smilla',
+            'unknownProperty' => 'Oh Harvey!'
+        ];
+
+        $configuration = $this->propertyMapper->buildPropertyMappingConfiguration();
+        $configuration->skipUnknownProperties();
+
+        $mappingResult = $this->propertyMapper->convert($source, Fixtures\TestClass::class, $configuration);
+        $this->assertInstanceOf(Fixtures\TestClass::class, $mappingResult);
+    }
+
+    /**
      * Add and persist a test entity, and return the identifier of the newly created
      * entity.
      *

--- a/Neos.Flow/Tests/Functional/Property/TypeConverter/ObjectConverterTest.php
+++ b/Neos.Flow/Tests/Functional/Property/TypeConverter/ObjectConverterTest.php
@@ -129,6 +129,22 @@ class ObjectConverterTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function getTypeOfChildPropertyReturnsNullIfPropertyDoesNotExistAndCanBeIgnored()
+    {
+        $configuration = new PropertyMappingConfiguration();
+        $configuration->skipUnknownProperties();
+
+        $result = $this->converter->getTypeOfChildProperty(
+            Fixtures\TestClass::class,
+            'someUnknownProperty',
+            $configuration
+        );
+        $this->assertNull($result);
+    }
+
+    /**
+     * @test
+     */
     public function convertFromAllowsAutomaticInjectionOfSingletonConstructorArguments()
     {
         $convertedObject = $this->converter->convertFrom(

--- a/Neos.Flow/Tests/Functional/Property/TypeConverter/ObjectConverterTest.php
+++ b/Neos.Flow/Tests/Functional/Property/TypeConverter/ObjectConverterTest.php
@@ -129,10 +129,26 @@ class ObjectConverterTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function getTypeOfChildPropertyReturnsNullIfPropertyDoesNotExistAndCanBeIgnored()
+    public function getTypeOfChildPropertyReturnsNullIfPropertyDoesNotExistAndSkipUnknownPropertiesIsSet()
     {
         $configuration = new PropertyMappingConfiguration();
         $configuration->skipUnknownProperties();
+
+        $result = $this->converter->getTypeOfChildProperty(
+            Fixtures\TestClass::class,
+            'someUnknownProperty',
+            $configuration
+        );
+        $this->assertNull($result);
+    }
+
+    /**
+     * @test
+     */
+    public function getTypeOfChildPropertyReturnsNullIfPropertyDoesNotExistAndPropertyIsFlaggedToBeSkippedSpecifically()
+    {
+        $configuration = new PropertyMappingConfiguration();
+        $configuration->skipProperties('someUnknownProperty');
 
         $result = $this->converter->getTypeOfChildProperty(
             Fixtures\TestClass::class,


### PR DESCRIPTION
This change enables the ObjectConverter (for simple PHP objects)
to acknowledge the `skipUnknownProperties` flag of the property
mapping configuration and thus ignore properties from the source
which don't exist in the target.

If a source array contains properties "foo" and "bar" and the
target class constructor only contains "foo", the array can now
be mapped if `skipUnknownProperties` is set in the respective
property mapping configuration.