### PR TITLE
TASK: Add documentation for using PdoBackend with MySQL

### DIFF
--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
@@ -356,6 +356,15 @@ to clean up hard disk space or memory.
 	not with a capable database like Oracle. We appreciate any feedback for real life use
 	cases of this cache.
 
+.. warning::
+
+	When using MySQL with the PDO backend, you have to create the needed caching tables manually.
+	The table definition for MySQL is the same as the definition for SQLite, which can be
+	found in ``TYPO3.Flow/Resources/Private/Cache/SQL/DDL.sql``.
+	For some cache entries, especially for the content cache, the length of ``TEXT`` (64kb) on
+	the column ``content`` can be too short and would lead to croped caching entries.
+	At least ``MEDIUMTEXT`` should be used.
+
 Options
 ~~~~~~~
 

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
@@ -363,11 +363,11 @@ to clean up hard disk space or memory.
   file ``TYPO3.Flow/Resources/Private/Cache/SQL/DDL.sql``. It works unchanged for
   MySQL, for other RDBMS you might need to adjust the DDL manually.
 
-.. warning::
+.. note::
 
-  For some cache entries, especially for the content cache, the length of ``TEXT`` (64kb
-  on MySQL) on the column ``content`` can be too short and might lead to cropped
-  cache entries. At least ``MEDIUMTEXT`` should be used in those cases.
+  When *not using SQLite* the maximum length of each cache entry is restricted.
+  The default in ``TYPO3.Flow/Resources/Private/Cache/SQL/DDL.sql``
+  is ``MEDIUMTEXT`` (16mb on MySQL), which should be sufficient in most cases.
 
 Options
 ~~~~~~~

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
@@ -358,7 +358,7 @@ to clean up hard disk space or memory.
 
 .. note::
 
-  When _not using SQLite_, you have to create the needed caching tables manually.
+  When *not using SQLite*, you have to create the needed caching tables manually.
   The table definition (as used automatically for SQLite) can be found in the
   file ``TYPO3.Flow/Resources/Private/Cache/SQL/DDL.sql``. It works unchanged for
   MySQL, for other RDBMS you might need to adjust the DDL manually.

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
@@ -359,14 +359,14 @@ to clean up hard disk space or memory.
 .. note::
 
 	When _not using SQLite_, you have to create the needed caching tables manually.
-	The table definition (as used automatically for SQLite) can be found in
-  ``TYPO3.Flow/Resources/Private/Cache/SQL/DDL.sql``. It works unchanged for MySQL,
-  for other RDBMS you might need to adjust the DDL manually.
+	The table definition (as used automatically for SQLite) can be found in the
+  file ``TYPO3.Flow/Resources/Private/Cache/SQL/DDL.sql``. It works unchanged for
+  MySQL, for other RDBMS you might need to adjust the DDL manually.
 
 .. warning::
 
-	For some cache entries, especially for the content cache, the length of ``TEXT``
-  (64kb on MySQL) on the column ``content`` can be too short and might lead to cropped
+	For some cache entries, especially for the content cache, the length of ``TEXT`` (64kb
+  on MySQL) on the column ``content`` can be too short and might lead to cropped
   cache entries. At least ``MEDIUMTEXT`` should be used in those cases.
 
 Options

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
@@ -356,14 +356,18 @@ to clean up hard disk space or memory.
 	not with a capable database like Oracle. We appreciate any feedback for real life use
 	cases of this cache.
 
+.. note::
+
+	When _not using SQLite_, you have to create the needed caching tables manually.
+	The table definition (as used automatically for SQLite) can be found in
+  ``TYPO3.Flow/Resources/Private/Cache/SQL/DDL.sql``. It works unchanged for MySQL,
+  for other RDBMS you might need to adjust the DDL manually.
+
 .. warning::
 
-	When using MySQL with the PDO backend, you have to create the needed caching tables manually.
-	The table definition for MySQL is the same as the definition for SQLite, which can be
-	found in ``TYPO3.Flow/Resources/Private/Cache/SQL/DDL.sql``.
-	For some cache entries, especially for the content cache, the length of ``TEXT`` (64kb) on
-	the column ``content`` can be too short and would lead to croped caching entries.
-	At least ``MEDIUMTEXT`` should be used.
+	For some cache entries, especially for the content cache, the length of ``TEXT``
+  (64kb on MySQL) on the column ``content`` can be too short and might lead to cropped
+  cache entries. At least ``MEDIUMTEXT`` should be used in those cases.
 
 Options
 ~~~~~~~

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
@@ -352,20 +352,20 @@ to clean up hard disk space or memory.
 
 .. note::
 
-	There is currently very little production experience with this  backend, especially
-	not with a capable database like Oracle. We appreciate any feedback for real life use
-	cases of this cache.
+  There is currently very little production experience with this  backend, especially
+  not with a capable database like Oracle. We appreciate any feedback for real life use
+  cases of this cache.
 
 .. note::
 
-	When _not using SQLite_, you have to create the needed caching tables manually.
-	The table definition (as used automatically for SQLite) can be found in the
+  When _not using SQLite_, you have to create the needed caching tables manually.
+  The table definition (as used automatically for SQLite) can be found in the
   file ``TYPO3.Flow/Resources/Private/Cache/SQL/DDL.sql``. It works unchanged for
   MySQL, for other RDBMS you might need to adjust the DDL manually.
 
 .. warning::
 
-	For some cache entries, especially for the content cache, the length of ``TEXT`` (64kb
+  For some cache entries, especially for the content cache, the length of ``TEXT`` (64kb
   on MySQL) on the column ``content`` can be too short and might lead to cropped
   cache entries. At least ``MEDIUMTEXT`` should be used in those cases.
 


### PR DESCRIPTION
When using the PdoBackend with MySQL for caching,
the needed caching tables have to be created manually.
This adds a hint on creating the tables to the documentation
on the PdoBackend.

Solving the documentation part of neos/flow-development-collection#884

This depends on #886 