### PR TITLE
TASK: Increase max-length for cache entries in PdoBackend

### DIFF
--- a/TYPO3.Flow/Resources/Private/Cache/SQL/DDL.sql
+++ b/TYPO3.Flow/Resources/Private/Cache/SQL/DDL.sql
@@ -6,7 +6,7 @@ CREATE TABLE "cache" (
   "context" VARCHAR(150) NOT NULL,
   "created" INTEGER UNSIGNED NOT NULL,
   "lifetime" INTEGER UNSIGNED DEFAULT '0' NOT NULL,
-  "content" TEXT,
+  "content" MEDIUMTEXT,
   PRIMARY KEY ("identifier", "cache", "context")
 );
 


### PR DESCRIPTION
When not using SQLite for the `PdoBackend` and manually creating
the cache tables by using the `DDL.sql`, the content column of the
cache table with type `TEXT` could easily lead to cropped
caching entries because of the length restriction.
Using `MEDIUMTEXT` practically prevents this issue.

See also: neos/flow-development-collection#884 and
neos/flow-development-collection#885