### PR TITLE
TASK: Improve documentation on Object-OrientedProgramming

### DIFF
--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartI/Object-OrientedProgramming.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartI/Object-OrientedProgramming.rst
@@ -72,7 +72,7 @@ Classes and Objects
 
 Let's now take a step back and imagine there'd be a blueprint for ships
 in general. We now focus not the ship but this blueprint. It is called
-**class**, in this case is is the class ``Ship``. In PHP this is written as
+**class**, in this case it is the class ``Ship``. In PHP this is written as
 follows;
 
 PHP Code::

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartI/Object-OrientedProgramming.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartI/Object-OrientedProgramming.rst
@@ -114,7 +114,7 @@ PHP Code::
 Our ship now has a name (``$name``\ ), a number of coaches (``$coaches``\ ) and a
 speed (``$speed``\ ). In addition we built in a variable, containing the status
 of the engine (``$engineStatus``\ ). A real ship, of course, has much more
-properties, all important somehow – for our our abstraction these few will be
+properties, all important somehow – for our abstraction these few will be
 sufficient though. We'll focus on why every property is marked with the key
 word ``public`` further down.
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartII/Configuration.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartII/Configuration.rst
@@ -62,6 +62,9 @@ Directory						Description
 *Configuration/Production/*		Configuration for the ``Production`` context
 ============================	==================================================
 
+.. note::
+	Setting Up Context with Virtual Host and change Context from «Development» to «Production» is explained in the previous chapter «Installation».
+
 Configuring Flow
 ================
 


### PR DESCRIPTION
Two small typo
1. doubled «is is» to «it is»
2. doubled «our our» to «our»