### PR TITLE
TASK: Improve documentation on Configuration and Installation

### DIFF
--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartII/Installation.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartII/Installation.rst
@@ -124,30 +124,8 @@ from the web. For testing purposes on your local machine it is okay (but not
 very convenient) to do without a virtual host, but don't try that on a public
 server!
 
-Setting Up a Virtual Host
--------------------------
-
-Assuming that you chose Apache 2 as your web server, simply create a new virtual
-host by adding the following directions to your Apache configuration
-(``conf/extra/httpd-vhosts.conf`` on many systems; make sure it is actually
-loaded with ``Include`` in ``httpd.conf``):
-
-*httpd.conf*:
-
-.. code-block:: none
-
-	<VirtualHost *:80>
-		DocumentRoot /var/apache2/htdocs/tutorial/Web/
-		ServerName dev.tutorial.local
-	</VirtualHost>
-
-This virtual host will later be accessible via the URL http://dev.tutorial.local.
-
-.. note::
-	Flow runs per default in the ``Development`` context. That's why the *ServerName*
-	in this example is  *dev.*tutorial.local. Later you will add another virtual
-	host for the ``Production`` context. The concept of contexts is explained in the
-	next section *Configuration*.
+Configure AllowOverride and MultiViews
+--------------------------------------
 
 Because Flow provides an ``.htaccess`` file with ``mod_rewrite`` rules in it,
 you need to make sure that the directory grants the neccessary rights:
@@ -173,6 +151,9 @@ with Flow contains this code already
 
 	</IfModule>
 
+Configure server-side scripts
+-----------------------------
+
 Important: Disallow execution of server-side scripts below `Web/_Resources`. If users
 can upload (PHP) scripts they can otherwise be executed on the server. This should almost
 never be allowed, so make sure to disable PHP (or other script handlers) for anything below
@@ -197,11 +178,33 @@ Configure a Context
 As you'll learn soon, Flow can be launched in different **contexts**, the most
 popular being ``Production``, ``Development`` and ``Testing``. Although there
 are various ways to choose the current context, the most convenient is to setup
-a dedicated virtual host defining an environment variable. Just add the
-following virtual host to your Apache configuration:
+a dedicated virtual host defining an environment variable.
+
+Setting Up a Virtual Host for Context «Development»
+---------------------------------------------------
+
+Assuming that you chose Apache 2 as your web server, simply create a new virtual
+host by adding the following directions to your Apache configuration
+(``conf/extra/httpd-vhosts.conf`` on many systems; make sure it is actually
+loaded with ``Include`` in ``httpd.conf``):
 
 *httpd.conf*:
 
+.. code-block:: none
+
+	<VirtualHost *:80>
+		DocumentRoot /var/apache2/htdocs/tutorial/Web/
+		ServerName dev.tutorial.local
+	</VirtualHost>
+
+This virtual host will later be accessible via the URL http://dev.tutorial.local.
+
+.. note::
+	Flow runs per default in the ``Development`` context. That's why the ServerName
+	in this example is dev.tutorial.local.
+  
+Setting Up a Virtual Host for Context «Production»
+--------------------------------------------------
 .. code-block:: none
 
 	<VirtualHost *:80>
@@ -221,20 +224,22 @@ machine. Add the following line to your */etc/hosts* file
 .. code-block:: none
 
 	127.0.0.1 tutorial.local dev.tutorial.local
+  
+Change Context to «Production» without Virtual Host
+---------------------------------------------------
 
-.. tip::
-	If you decided to skip setting up virtual hosts earlier on, you can
-	enable the ``Production`` context by editing the ``.htaccess`` file in the
-	``Web`` directory and remove the comment sign in front of the ``SetEnv``
-	line:
-
+If you decided to skip setting up virtual hosts earlier on, you can enable the ``Production`` context by editing the ``.htaccess`` file in the``Web`` directory and remove the comment sign in front of the ``SetEnv`` line:
+  
 *.htaccess*:
 
 .. code-block:: none
 
 	# You can specify a default context by activating this option:
 	SetEnv FLOW_CONTEXT Production
-
+  
+.. note::
+	The concept of contexts and why do you want contexts, is explained in the	next chapter «Configuration».
+  
 Welcome to Flow
 ---------------
 


### PR DESCRIPTION
Have Add a note to chapter «Installation» and change the sequence in chaper «Configuration» for better usable/find the context-part, not to skip because of note I moved this to the end and add more subtitle about context for better SERP-Result.

More Details  about the reason in slack-channel «guilde-documentation»
