### PR TITLE
BUGFIX: Detect base uri in cli mode

### DIFF
--- a/Neos.Flow/Classes/ResourceManagement/Target/FileSystemTarget.php
+++ b/Neos.Flow/Classes/ResourceManagement/Target/FileSystemTarget.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\ResourceManagement\Target;
  */
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Cli\CommandRequestHandler;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Http\HttpRequestHandlerInterface;
 use Neos\Flow\Log\SystemLoggerInterface;
@@ -352,6 +353,11 @@ class FileSystemTarget implements TargetInterface
         }
 
         $requestHandler = $this->bootstrap->getActiveRequestHandler();
+
+        if ($requestHandler instanceof CommandRequestHandler) {
+            return '/' . $this->baseUri;
+        }
+
         if ($requestHandler instanceof HttpRequestHandlerInterface) {
             return $requestHandler->getHttpRequest()->getBaseUri() . $this->baseUri;
         }


### PR DESCRIPTION
When trying to render links to assets when
the request is triggered using a command controller
the base uri cannot be detected.