### PR TITLE
!!! BUGFIX: fix Entity Security depending on more than just roles

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/EntityManagerFactory.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/EntityManagerFactory.php
@@ -19,7 +19,6 @@ use Doctrine\DBAL\Logging\SQLLogger;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Query\Filter\SQLFilter;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Cache\CacheManager;
 use TYPO3\Flow\Configuration\Exception\InvalidConfigurationException;
@@ -59,11 +58,6 @@ class EntityManagerFactory
      * @var array
      */
     protected $settings = [];
-
-    /**
-     * @var SQLFilter[]
-     */
-    protected $enabledFilterInstances = [];
 
     /**
      * Injects the Flow settings, the persistence part is kept
@@ -152,7 +146,7 @@ class EntityManagerFactory
         if (isset($this->settings['doctrine']['filters']) && is_array($this->settings['doctrine']['filters'])) {
             foreach ($this->settings['doctrine']['filters'] as $filterName => $filterClass) {
                 $config->addFilter($filterName, $filterClass);
-                $this->enabledFilterInstances[$filterName] = $entityManager->getFilters()->enable($filterName);
+                $entityManager->getFilters()->enable($filterName);
             }
         }
 
@@ -161,17 +155,6 @@ class EntityManagerFactory
         }
 
         return $entityManager;
-    }
-
-    /**
-     * Returns the active and instanciated SQL Filters. Needed to lateron call setParameter() on custom
-     * SQL filter instances before doing queries.
-     *
-     * @return SQLFilter[] the SQL filters, indexed by filter name as given in Settings.yaml
-     */
-    public function getEnabledFilterInstances()
-    {
-        return $this->enabledFilterInstances;
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/EntityManagerFactory.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/EntityManagerFactory.php
@@ -19,6 +19,7 @@ use Doctrine\DBAL\Logging\SQLLogger;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Query\Filter\SQLFilter;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Cache\CacheManager;
 use TYPO3\Flow\Configuration\Exception\InvalidConfigurationException;
@@ -58,6 +59,11 @@ class EntityManagerFactory
      * @var array
      */
     protected $settings = [];
+
+    /**
+     * @var SQLFilter[]
+     */
+    protected $enabledFilterInstances = [];
 
     /**
      * Injects the Flow settings, the persistence part is kept
@@ -146,7 +152,7 @@ class EntityManagerFactory
         if (isset($this->settings['doctrine']['filters']) && is_array($this->settings['doctrine']['filters'])) {
             foreach ($this->settings['doctrine']['filters'] as $filterName => $filterClass) {
                 $config->addFilter($filterName, $filterClass);
-                $entityManager->getFilters()->enable($filterName);
+                $this->enabledFilterInstances[$filterName] = $entityManager->getFilters()->enable($filterName);
             }
         }
 
@@ -155,6 +161,17 @@ class EntityManagerFactory
         }
 
         return $entityManager;
+    }
+
+    /**
+     * Returns the active and instanciated SQL Filters. Needed to lateron call setParameter() on custom
+     * SQL filter instances before doing queries.
+     *
+     * @return SQLFilter[] the SQL filters, indexed by filter name as given in Settings.yaml
+     */
+    public function getEnabledFilterInstances()
+    {
+        return $this->enabledFilterInstances;
     }
 
     /**

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Context.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Context.php
@@ -12,8 +12,10 @@ namespace TYPO3\Flow\Security;
  */
 
 use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Cache\CacheAwareInterface;
 use TYPO3\Flow\Log\SecurityLoggerInterface;
 use TYPO3\Flow\Mvc\RequestInterface;
+use TYPO3\Flow\Object\ObjectManagerInterface;
 use TYPO3\Flow\Security\Authentication\TokenInterface;
 use TYPO3\Flow\Security\Policy\Role;
 use TYPO3\Flow\Mvc\ActionRequest;
@@ -191,6 +193,20 @@ class Context
      * @var string
      */
     protected $contextHash = null;
+
+    /**
+     * @Flow\Inject
+     * @var ObjectManagerInterface
+     */
+    protected $objectManager;
+
+    /**
+     * Array of registered global objects that can be accessed as operands
+     *
+     * @Flow\InjectConfiguration("aop.globalObjects")
+     * @var array
+     */
+    protected $globalObjects = [];
 
     /**
      * Inject the authentication manager
@@ -837,7 +853,18 @@ class Context
             $this->initialize();
         }
         if ($this->contextHash === null) {
-            $this->contextHash = md5(implode('|', array_keys($this->getRoles())));
+            $contextHashSoFar = implode('|', array_keys($this->getRoles()));
+
+            $this->withoutAuthorizationChecks(function () use (&$contextHashSoFar) {
+                foreach ($this->globalObjects as $globalObjectsRegisteredClassName) {
+                    if (is_subclass_of($globalObjectsRegisteredClassName, CacheAwareInterface::class)) {
+                        $globalObject = $this->objectManager->get($globalObjectsRegisteredClassName);
+                        $contextHashSoFar .= '<' . $globalObject->getCacheEntryIdentifier();
+                    }
+                }
+            });
+
+            $this->contextHash = md5($contextHashSoFar);
         }
         return $this->contextHash;
     }

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
@@ -496,6 +496,20 @@ Filter System.
   ``@Flow\Proxy(false)`` to your filter class to prevent Flow from building a proxy,
   which causes this error.
 
+.. warning:: Custom SqlFilter implementations - watch out for data privacy issues!
+
+  If using custom SqlFilters, you have to be aware that the SQL filter is cached by doctrine, thus your SqlFilter might
+  not be called as often as you might expect. This may lead to displaying data which is not normally visible to the user!
+
+  Basically you are not allowed to call `setParameter` inside `addFilterConstraint`; but setParameter must be called *before*
+  the SQL query is actually executed. Currently, there's no standard Doctrine way to provide this; so you manually can receive
+  the filter instance from `$entityManager->getFilters()->getEnabledFilters()` and call `setParameter()` then.
+
+  Alternatively, you can register a global context object in `TYPO3.Flow.aop.globalObjects` and use it to provide additional
+  identifiers for the caching by letting these global objects implement `CacheAwareInterface`; effectively seggregating the
+  Doctrine cache some more.
+
+
 Custom Doctrine DQL functions
 -----------------------------
 

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Security.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Security.rst
@@ -1143,7 +1143,7 @@ all privilege targets that are not granted to the current user.
 
   Basically you are not allowed to call `setParameter` inside `addFilterConstraint`; but setParameter must be called *before*
   the SQL query is actually executed. Currently, there's no standard Doctrine way to provide this; so you manually can receive
-  the filter instance from `EntityManagerFactory::getEnabledFilterInstances()` and call `setParameter()` then.
+  the filter instance from `$entityManager->getFilters()->getEnabledFilters()` and call `setParameter()` then.
 
   Alternatively, you can use the mechanism from above, where you register a global context object in `TYPO3.Flow.aop.globalObjects`
   and use it to provide additional identifiers for the caching; effectively seggregating the Doctrine cache some more.

--- a/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Security.rst
+++ b/TYPO3.Flow/Documentation/TheDefinitiveGuide/PartIII/Security.rst
@@ -1070,6 +1070,57 @@ entities. The following examples, taken from the functional tests, show some mor
    ``isType("Acme\MyPackage\EntityB")`` will never match. This is a limitation of the underlying Doctrine filter API.
 
 
+.. warning:: Custom Global Objects should implement CacheAwareInterface
+
+  If you have custom global objects (as exposed through `TYPO3.Flow.aop.globalObjects`) which depend on the current
+  user (security context), ensure they implement `CacheAwareInterface` and change depending on the relevant access
+  restrictions you want to provide.
+
+  The cache identifier for the global object will be included in the Security Context Hash, ensuring that the Doctrine
+  query cache and all other places caching with security in mind will correctly create separate cache entries for the
+  different access restrictions you want to create.
+
+  As an example, if your user has a "company" assigned, and depending on the company, your should only see your
+  "own" records, you need to: Implement a custom context object, register it in `TYPO3.Flow.aop.globalObjects`
+  and make it implement `CacheAwareInterface`::
+
+    /**
+     * @Flow\Scope("singleton")
+     */
+    class UserInformationContext implements CacheAwareInterface
+    {
+        /**
+         * @Flow\Inject
+         * @var Context
+         */
+        protected $securityContext;
+
+        /**
+         * @Flow\Inject
+         * @var PersistenceManagerInterface
+         */
+        protected $persistenceManager;
+
+        /**
+         * @return Company
+         */
+        public function getCompany() {
+            $account = $this->securityContext->getAccount();
+            $company = // find your $company depending on the account;
+            return $company;
+        }
+
+        /**
+         * @return string
+         */
+        public function getCacheEntryIdentifier()
+        {
+            $company = $this->getCompany();
+
+            return $this->persistenceManager->getIdentifierByObject($company);
+        }
+
+
 Internal workings of entity restrictions (EntityPrivilege)
 ----------------------------------------------------------------------
 
@@ -1085,6 +1136,17 @@ privilege target, this role will be able to retrieve the respective objects from
 override any GRANT permission, nothing new here. Internally we add SQL where conditions excluding matching entities for
 all privilege targets that are not granted to the current user.
 
+.. warning:: Custom SqlFilter implementations - watch out for data privacy issues!
+
+  If using custom SqlFilters, you have to be aware that the SQL filter is cached by doctrine, thus your SqlFilter might
+  not be called as often as you might expect. This may lead to displaying data which is not normally visible to the user!
+
+  Basically you are not allowed to call `setParameter` inside `addFilterConstraint`; but setParameter must be called *before*
+  the SQL query is actually executed. Currently, there's no standard Doctrine way to provide this; so you manually can receive
+  the filter instance from `EntityManagerFactory::getEnabledFilterInstances()` and call `setParameter()` then.
+
+  Alternatively, you can use the mechanism from above, where you register a global context object in `TYPO3.Flow.aop.globalObjects`
+  and use it to provide additional identifiers for the caching; effectively seggregating the Doctrine cache some more.
 
 Creating your custom privilege
 ==================================


### PR DESCRIPTION
## Problem Description

If you had used entity security and wanted to secure entities not just
based on the user's role, but on some property of the user (like the company
he belongs to), entity security did not work properly together with doctrine
caching.

## Visible Error

If you had Entity Constraints which did not only rely
on different user roles, but needed the domain model to build up SQL 
constraints (through entity security), the query
cache in production cached the SQL queries "wrongly", so you were able to
see data from other accounts.

## Bugfix

Inside the Doctrine CacheAdapter, we already namespace the full Doctrine
cache with the SecurityContext's ContextHash. However, only roles were
the source of the ContextHash.

We now make it possible to add custom sources to the calculation of the
ContextHash, by making aop.globalObjects able to contribute to the context
hash calculation if they implement CacheAwareInterface.


## Custom SQL Filters / Root Cause Analysis

It is not effective to call "setParameter" in the addFilterConstraint method
of an SqlFilter; as this will interfere with Doctrine's query caching:
Doctrine tries to avoid building queries as much as possible. It also
takes the applied SqlFilters *and their parameters* into account when
building cache identifiers, and if it has a matching cache entry, it will
not call "addFilterConstraint". Thus, "setParameter" must be called as early
as possible; way before the "addFilterConstraint" method might be called.

We did not manage to find the fully right spot to do it inside the Framework,
that's why we chose the more minimally-invasive solution here.

## Breakingness

This change is only breaking if:

- You used Entity Security AND custom context objects registered in
  `TYPO3.Flow.aop.globalObjects`:

  In this case, your global objects should very likely implement
  CacheAwareInterface.

- You used custom SQL Filters:

  Basically you are not allowed to call `setParameter` inside `addFilterConstraint`;
  but setParameter must be called *before* the SQL query is actually executed.
  Currently, there's no standard Doctrine way to provide this; so you manually
  can receive the filter instance from `$entityManager->getFilters()->getEnabledFilters()`
  and call `setParameter()` then.

  Alternatively, you can influence the Doctrine caching by registering a global context
  object in `TYPO3.Flow.aop.globalObjects` and use it to provide additional identifiers
  for the caching; effectively seggregating the Doctrine cache some more.

## Thanks

Thanks to Kay Strobach for sponsoring working on this issue!