### PR TITLE
Bugfix accessing empty array

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/PropertyMapper.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/PropertyMapper.php
@@ -394,7 +394,7 @@ class PropertyMapper
             $typeConverter = $this->objectManager->get($typeConverterClassName);
             foreach ($typeConverter->getSupportedSourceTypes() as $supportedSourceType) {
                 if (isset($typeConverterMap[$supportedSourceType][$typeConverter->getSupportedTargetType()][$typeConverter->getPriority()])) {
-                    throw new Exception\DuplicateTypeConverterException('There exist at least two converters which handle the conversion from "' . $supportedSourceType . '" to "' . $typeConverter->getSupportedTargetType() . '" with priority "' . $typeConverter->getPriority() . '": ' . get_class($this->typeConverters[$supportedSourceType][$typeConverter->getSupportedTargetType()][$typeConverter->getPriority()]) . ' and ' . get_class($typeConverter), 1297951378);
+                    throw new Exception\DuplicateTypeConverterException('There exist at least two converters which handle the conversion from "' . $supportedSourceType . '" to "' . $typeConverter->getSupportedTargetType() . '" with priority "' . $typeConverter->getPriority() . '": ' . $typeConverterMap[$supportedSourceType][$typeConverter->getSupportedTargetType()][$typeConverter->getPriority()] . ' and ' . get_class($typeConverter), 1297951378);
                 }
                 $typeConverterMap[$supportedSourceType][$typeConverter->getSupportedTargetType()][$typeConverter->getPriority()] = $typeConverterClassName;
             }
@@ -403,8 +403,8 @@ class PropertyMapper
         return $typeConverterMap;
     }
 
-/**
- * Returns a multi-dimensional array with the Type Converters available in the system.
+    /**
+     * Returns a multi-dimensional array with the Type Converters available in the system.
      *
      * It has the following structure:
      *


### PR DESCRIPTION
As ``$this->typeConverters`` is not filled during this method, as this method will provide the necessary information, we need to access ``$typeConverterMap`` which contains the class name already.

**What I did**
Fix accessing empty array.

**How I did it**
Accessing method internal existing array containing the necessary information.

**How to verify it**
Register two TypeConverters for same conersion with same priority.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
I could not find any information about Flow at the given url.