### PR TITLE
!!! TASK: Add rescanPackages() to PackageManagerInterface

### DIFF
--- a/Neos.Flow/Classes/Package/PackageManager.php
+++ b/Neos.Flow/Classes/Package/PackageManager.php
@@ -655,7 +655,6 @@ class PackageManager implements PackageManagerInterface
      * @param boolean $reloadPackageStates Should the package states be loaded before scanning or use the current configuration
      * @return array The found and sorted package states.
      * @api
-     * TODO: Add to Interface with Flow 4.0
      */
     public function rescanPackages($reloadPackageStates = true)
     {

--- a/Neos.Flow/Classes/Package/PackageManagerInterface.php
+++ b/Neos.Flow/Classes/Package/PackageManagerInterface.php
@@ -179,4 +179,13 @@ interface PackageManagerInterface
      * @api
      */
     public function deletePackage($packageKey);
+
+    /**
+     * Rescans available packages, order and write a new PackageStates file.
+     *
+     * @param boolean $reloadPackageStates Should the package states be loaded before scanning or use the current configuration
+     * @return array The found and sorted package states.
+     * @api
+     */
+    public function rescanPackages($reloadPackageStates = true);
 }


### PR DESCRIPTION
This was originally scheduled for 4.0 but forgotten. It is added now,
excuse the inconvenience. But you should really not be implementing
your own PackageManager.