### PR TITLE
TASK: Remove requireAutoloaderForPhpUnit() from Booting\Scripts

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -92,24 +92,6 @@ class Scripts
     }
 
     /**
-     * Include the PHPUnit autoloader if PHPUnit is installed via PEAR.
-     *
-     * @return void
-     */
-    protected static function requireAutoloaderForPhpUnit()
-    {
-        if (class_exists(\PHPUnit\Framework\TestCase::class)) {
-            return;
-        }
-        if (stream_resolve_include_path('PHPUnit/Autoload.php') !== false) {
-            require_once('PHPUnit/Autoload.php');
-        } else {
-            echo PHP_EOL . 'Neos Flow Bootstrap Error: The Testing context requires PHPUnit. Looked for "PHPUnit/Autoload.php" without success.';
-            exit(1);
-        }
-    }
-
-    /**
      * Register the class loader into the Doctrine AnnotationRegistry so
      * the DocParser is able to load annation classes from packages.
      *

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -84,10 +84,7 @@ class Scripts
         spl_autoload_register([$classLoader, 'loadClass'], true, true);
         $bootstrap->setEarlyInstance(ClassLoader::class, $classLoader);
         if ($bootstrap->getContext()->isTesting()) {
-            self::requireAutoloaderForPhpUnit();
             $classLoader->setConsiderTestsNamespace(true);
-            require_once(FLOW_PATH_FLOW . 'Tests/BaseTestCase.php');
-            require_once(FLOW_PATH_FLOW . 'Tests/FunctionalTestCase.php');
         }
     }
 


### PR DESCRIPTION
This is legacy code in such a bad way...