### PR TITLE
BUGFIX: Hide the exception dump file information in CLI if the file i…

### DIFF
--- a/Neos.Flow/Classes/Error/AbstractExceptionHandler.php
+++ b/Neos.Flow/Classes/Error/AbstractExceptionHandler.php
@@ -284,7 +284,7 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
         }
         $exceptionMessage .= $this->renderExceptionDetailCli('File', str_replace(FLOW_PATH_ROOT, '', $exception->getFile()));
         $exceptionMessage .= $this->renderExceptionDetailCli('Line', $exception->getLine());
-        if ($exception instanceof FlowException) {
+        if ($exception instanceof FlowException && isset($exception->isDumpedToFile) && $exception->isDumpedToFile === true) {
             $exceptionMessage .= PHP_EOL . 'Open <b>Data/Logs/Exceptions/' . $exception->getReferenceCode() . '.txt</b> for a full stack trace.' . PHP_EOL;
         }
         return $exceptionMessage;

--- a/Neos.Flow/Classes/Log/Logger.php
+++ b/Neos.Flow/Classes/Log/Logger.php
@@ -163,6 +163,7 @@ class Logger implements SystemLoggerInterface, ThrowableLoggerInterface, Securit
             $errorDumpPathAndFilename = FLOW_PATH_DATA . 'Logs/Exceptions/' . $referenceCode . '.txt';
             file_put_contents($errorDumpPathAndFilename, $this->renderErrorInfo($error));
             $message .= ' - See also: ' . basename($errorDumpPathAndFilename);
+            $error->isDumpedToFile = true;
         } else {
             $this->log(sprintf('Could not write exception backtrace into %s because the directory could not be created or is not writable.', FLOW_PATH_DATA . 'Logs/Exceptions/'), LOG_WARNING, [], 'Flow', __CLASS__, __FUNCTION__);
         }


### PR DESCRIPTION
BUGFIX: Hide the exception dump file information in CLI if the file is unwritable.
In the command line to run a flow command, if an exception occurs, the exception handler calls the logger to log the exception and try to create the exception dump file. But during some reason the dump file can not be written, and it still print the information of the dump file path and name.
Therefore the dump file message should be hidden if the logger fails to dump the exception.

<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->


**What I did**
Hide the dump file message if the logger fails to dump the exception.

**How I did it**
Set isDumpedToFile as true for an exception object if the dump file is written in the logger class. And check the value during before printing the dump file message.  

**How to verify it**
Change the exception directory rights temporarily to disallow the creation of files. Run a command that could produce an exception. If there is an message of dump file, there must be the exception information in the file.  

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
