### PR TITLE
FEATURE: add Date.formatCldr helper

### DIFF
--- a/Neos.Eel/Classes/Helper/DateHelper.php
+++ b/Neos.Eel/Classes/Helper/DateHelper.php
@@ -75,19 +75,19 @@ class DateHelper implements ProtectedContextAwareInterface
      *
      * @param \DateTime $date
      * @param string $cldrFormat Format string in CLDR format (see http://cldr.unicode.org/translation/date-time)
-     * @param string $locale String locale - example (de|en|ru_RU). Must be one of Neos\Flow\I18n\Cldr\Reader\DatesReader::FORMAT_LENGTH_*'s constants.
+     * @param null|string $locale String locale - example (de|en|ru_RU)
      *
      * @return string
      */
-    public function formatCldr($date = null, $cldrFormat = null, $locale = null)
+    public function formatCldr($date, $cldrFormat, $locale = null)
     {
-        if ($date === null) {
-            $date = new \DateTime('now');
+        if (!$date instanceof \DateTimeInterface) {
+            throw new \InvalidArgumentException('"' . $date . '" could not be parsed by \DateTime constructor.');
         }
-        if ($cldrFormat === null) {
-            $cldrFormat = 'dd MMMM yyyy HH:mm:ss';
+        if (empty($cldrFormat)) {
+            throw new \InvalidArgumentException('CLDR date formatting parameter not passed.');
         }
-        if ($locale === null) {
+        if (empty($locale)) {
             $useLocale = $this->localizationService->getConfiguration()->getCurrentLocale();
         } else {
             $useLocale = new Locale($locale);

--- a/Neos.Eel/Classes/Helper/DateHelper.php
+++ b/Neos.Eel/Classes/Helper/DateHelper.php
@@ -13,14 +13,28 @@ namespace Neos\Eel\Helper;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Eel\ProtectedContextAwareInterface;
+use Neos\Flow\I18n\Exception as I18nException;
+use Neos\Flow\I18n\Formatter\DatetimeFormatter;
+use Neos\Flow\I18n\Locale;
+use Neos\Flow\I18n\Service as I18nService;
 
 /**
  * Date helpers for Eel contexts
- *
- * @Flow\Proxy(false)
  */
 class DateHelper implements ProtectedContextAwareInterface
 {
+    /**
+     * @Flow\Inject
+     * @var DatetimeFormatter
+     */
+    protected $datetimeFormatter;
+
+    /**
+     * @Flow\Inject
+     * @var I18nService
+     */
+    protected $localizationService;
+
     /**
      * Parse a date from string with a format to a DateTime object
      *
@@ -54,6 +68,31 @@ class DateHelper implements ProtectedContextAwareInterface
             $timestamp = (integer)$date;
             return date($format, $timestamp);
         }
+    }
+
+    /**
+     * Format a date to a string with a given cldr format
+     *
+     * @param \DateTime $date
+     * @param string $cldrFormat Format string in CLDR format (see http://cldr.unicode.org/translation/date-time)
+     * @param string $locale String locale - example (de|en|ru_RU). Must be one of Neos\Flow\I18n\Cldr\Reader\DatesReader::FORMAT_LENGTH_*'s constants.
+     *
+     * @return string
+     */
+    public function formatCldr($date = null, $cldrFormat = null, $locale = null)
+    {
+        if ($date === null) {
+            $date = new \DateTime('now');
+        }
+        if ($cldrFormat === null) {
+            $cldrFormat = 'dd MMMM yyyy HH:mm:ss';
+        }
+        if ($locale === null) {
+            $useLocale = $this->localizationService->getConfiguration()->getCurrentLocale();
+        } else {
+            $useLocale = new Locale($locale);
+        }
+        return $this->datetimeFormatter->formatDateTimeWithCustomPattern($date, $cldrFormat, $useLocale);
     }
 
     /**


### PR DESCRIPTION
**What I did**

This change adds CLDR formatting capabillity to Date Eel helper,
to match functionality of format.date Fluid ViewHelper.

**How to verify it**

Just use `${Date.formatCldr(someDateObject, 'dd MMMM yyyy HH:mm:ss', 'de')}` to test. Also test different combinations with missing arguments.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
