### PR TITLE
BUGFIX: Attempt reconnect only if EntityManager is open

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/PersistenceManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/PersistenceManager.php
@@ -163,6 +163,9 @@ class PersistenceManager extends AbstractPersistenceManager
         try {
             $this->entityManager->flush();
         } catch (\Doctrine\DBAL\DBALException $exception) {
+            if (!$this->entityManager->isOpen()) {
+                throw $exception;
+            }
             $this->systemLogger->logException($exception);
             /** @var Connection $connection */
             $connection = $this->entityManager->getConnection();

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/PersistenceManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/PersistenceManager.php
@@ -22,7 +22,6 @@ use TYPO3\Flow\Persistence\Exception\ObjectValidationFailedException;
 use TYPO3\Flow\Persistence\Exception as PersistenceException;
 use TYPO3\Flow\Persistence\Exception\UnknownObjectException;
 use TYPO3\Flow\Reflection\ClassSchema;
-use TYPO3\Flow\Error\Exception;
 use TYPO3\Flow\Reflection\ObjectAccess;
 use TYPO3\Flow\Reflection\ReflectionService;
 use TYPO3\Flow\Utility\TypeHandling;
@@ -163,7 +162,7 @@ class PersistenceManager extends AbstractPersistenceManager
 
         try {
             $this->entityManager->flush();
-        } catch (Exception $exception) {
+        } catch (\Exception $exception) {
             $this->systemLogger->logException($exception);
             /** @var Connection $connection */
             $connection = $this->entityManager->getConnection();

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/PersistenceManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/PersistenceManager.php
@@ -162,7 +162,7 @@ class PersistenceManager extends AbstractPersistenceManager
 
         try {
             $this->entityManager->flush();
-        } catch (\Exception $exception) {
+        } catch (\Doctrine\DBAL\DBALException $exception) {
             $this->systemLogger->logException($exception);
             /** @var Connection $connection */
             $connection = $this->entityManager->getConnection();


### PR DESCRIPTION
If a `\Doctrine\DBAL\DBALException` is thrown in `persistAll()`, a reconnect will be attempted,
but only if `EntityManager->isOpen()` returns true. Otherwise the exception is re-thrown.

Before the connection to the server was sometimes never re-established, since only the specific
Flow\Error\Exception was caught.

Also this will prevent hiding exceptions that result in a closed EntityManager.

Fixes #870