### PR TITLE
TASK: #899 Make Fizzle filter nested object properties

### DIFF
--- a/Neos.Eel/Classes/AbstractParser.php
+++ b/Neos.Eel/Classes/AbstractParser.php
@@ -253,6 +253,49 @@ function match_Identifier ($stack = array()) {
 }
 
 
+/* PropertyPath: Identifier ( '.' Identifier )* */
+protected $match_PropertyPath_typestack = array('PropertyPath');
+function match_PropertyPath ($stack = array()) {
+	$matchrule = "PropertyPath"; $result = $this->construct($matchrule, $matchrule, null);
+	$_41 = NULL;
+	do {
+		$matcher = 'match_'.'Identifier'; $key = $matcher; $pos = $this->pos;
+		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+		if ($subres !== FALSE) { $this->store( $result, $subres ); }
+		else { $_41 = FALSE; break; }
+		while (true) {
+			$res_40 = $result;
+			$pos_40 = $this->pos;
+			$_39 = NULL;
+			do {
+				if (substr($this->string,$this->pos,1) == '.') {
+					$this->pos += 1;
+					$result["text"] .= '.';
+				}
+				else { $_39 = FALSE; break; }
+				$matcher = 'match_'.'Identifier'; $key = $matcher; $pos = $this->pos;
+				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+				if ($subres !== FALSE) { $this->store( $result, $subres ); }
+				else { $_39 = FALSE; break; }
+				$_39 = TRUE; break;
+			}
+			while(0);
+			if( $_39 === FALSE) {
+				$result = $res_40;
+				$this->pos = $pos_40;
+				unset( $res_40 );
+				unset( $pos_40 );
+				break;
+			}
+		}
+		$_41 = TRUE; break;
+	}
+	while(0);
+	if( $_41 === TRUE ) { return $this->finalise($result); }
+	if( $_41 === FALSE) { return FALSE; }
+}
+
+
 
 
 

--- a/Neos.Eel/Classes/FlowQuery/FizzleParser.php
+++ b/Neos.Eel/Classes/FlowQuery/FizzleParser.php
@@ -374,7 +374,7 @@ function match_PathFilter ($stack = array()) {
   '[' S
       (
           ( Operator:( 'instanceof' | '!instanceof' ) S ( Operand:StringLiteral | Operand:UnquotedOperand ) S )
-          | ( :Identifier S
+          | ( :PropertyPath S
               (
                   Operator:( 'instanceof' | '!instanceof' | PrefixMatch | SuffixMatch | SubstringMatch | ExactMatch | NotEqualMatch | LessThanOrEqualMatch | LessThanMatch | GreaterThanOrEqualMatch | GreaterThanMatch )
                   S ( Operand:StringLiteral | Operand:NumberLiteral | Operand:BooleanLiteral | Operand:UnquotedOperand ) S
@@ -484,10 +484,10 @@ function match_AttributeFilter ($stack = array()) {
 				$this->pos = $pos_55;
 				$_138 = NULL;
 				do {
-					$matcher = 'match_'.'Identifier'; $key = $matcher; $pos = $this->pos;
+					$matcher = 'match_'.'PropertyPath'; $key = $matcher; $pos = $this->pos;
 					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 					if ($subres !== FALSE) {
-						$this->store( $result, $subres, "Identifier" );
+						$this->store( $result, $subres, "PropertyPath" );
 					}
 					else { $_138 = FALSE; break; }
 					$matcher = 'match_'.'S'; $key = $matcher; $pos = $this->pos;
@@ -813,11 +813,11 @@ function match_AttributeFilter ($stack = array()) {
 
 function AttributeFilter__construct (&$result) {
 		$result['Operator'] = NULL;
-		$result['Identifier'] = NULL;
+		$result['PropertyPath'] = NULL;
 	}
 
-function AttributeFilter_Identifier (&$result, $sub) {
-		$result['Identifier'] = $sub['text'];
+function AttributeFilter_PropertyPath (&$result, $sub) {
+		$result['PropertyPath'] = $sub['text'];
 	}
 
 function AttributeFilter_Operator (&$result, $sub) {

--- a/Neos.Eel/Classes/FlowQuery/FizzleParser.php
+++ b/Neos.Eel/Classes/FlowQuery/FizzleParser.php
@@ -814,10 +814,12 @@ function match_AttributeFilter ($stack = array()) {
 function AttributeFilter__construct (&$result) {
 		$result['Operator'] = NULL;
 		$result['PropertyPath'] = NULL;
+		$result['Identifier'] = NULL;
 	}
 
 function AttributeFilter_PropertyPath (&$result, $sub) {
 		$result['PropertyPath'] = $sub['text'];
+		$result['Identifier'] = $result['PropertyPath'];
 	}
 
 function AttributeFilter_Operator (&$result, $sub) {

--- a/Neos.Eel/Classes/FlowQuery/Operations/Object/FilterOperation.php
+++ b/Neos.Eel/Classes/FlowQuery/Operations/Object/FilterOperation.php
@@ -172,8 +172,8 @@ class FilterOperation extends AbstractOperation
      */
     protected function matchesAttributeFilter($element, array $attributeFilter)
     {
-        if ($attributeFilter['Identifier'] !== null) {
-            $value = $this->getPropertyPath($element, $attributeFilter['Identifier']);
+        if ($attributeFilter['PropertyPath'] !== null) {
+            $value = $this->getPropertyPath($element, $attributeFilter['PropertyPath']);
         } else {
             $value = $element;
         }

--- a/Neos.Eel/Resources/Private/Grammar/AbstractParser.peg.inc
+++ b/Neos.Eel/Resources/Private/Grammar/AbstractParser.peg.inc
@@ -12,7 +12,7 @@ namespace Neos\Eel;
  * source code.
  */
 
-require_once __DIR__ . '/../../../Resources/Private/PHP/php-peg/Parser.php';
+require_once __DIR__ . '/../Resources/Private/PHP/php-peg/Parser.php';
 
 /*!* !insert_autogen_warning */
 
@@ -42,6 +42,7 @@ StringLiteral: SingleQuotedStringLiteral | DoubleQuotedStringLiteral
 BooleanLiteral: 'true' | 'TRUE' | 'false' | 'FALSE'
 
 Identifier: / [a-zA-Z_] [a-zA-Z0-9_\-]* /
+PropertyPath: Identifier ( '.' Identifier )*
 */
 
 

--- a/Neos.Eel/Resources/Private/Grammar/Fizzle.peg.inc
+++ b/Neos.Eel/Resources/Private/Grammar/Fizzle.peg.inc
@@ -68,7 +68,7 @@ AttributeFilter:
   '[' S
       (
           ( Operator:( 'instanceof' | '!instanceof' ) S ( Operand:StringLiteral | Operand:UnquotedOperand ) S )
-          | ( :Identifier S
+          | ( :PropertyPath S
               (
                   Operator:( 'instanceof' | '!instanceof' | PrefixMatch | SuffixMatch | SubstringMatch | ExactMatch | NotEqualMatch | LessThanOrEqualMatch | LessThanMatch | GreaterThanOrEqualMatch | GreaterThanMatch )
                   S ( Operand:StringLiteral | Operand:NumberLiteral | Operand:BooleanLiteral | Operand:UnquotedOperand ) S
@@ -78,10 +78,10 @@ AttributeFilter:
   S ']'
 	function __construct(&$result) {
 		$result['Operator'] = NULL;
-		$result['Identifier'] = NULL;
+		$result['PropertyPath'] = NULL;
 	}
-	function Identifier(&$result, $sub) {
-		$result['Identifier'] = $sub['text'];
+	function PropertyPath(&$result, $sub) {
+		$result['PropertyPath'] = $sub['text'];
 	}
 	function Operator(&$result, $sub) {
 		$result['Operator'] = $sub['text'];

--- a/Neos.Eel/Tests/Unit/FlowQuery/FizzleParserTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/FizzleParserTest.php
@@ -56,14 +56,14 @@ class FizzleParserTest extends \Neos\Flow\Tests\UnitTestCase
         $this->assertSame('foo', $actual['PropertyNameFilter']);
 
         $this->assertSame('[baz]', $actual['AttributeFilters'][0]['text']);
-        $this->assertSame('baz', $actual['AttributeFilters'][0]['Identifier']);
+        $this->assertSame('baz', $actual['AttributeFilters'][0]['PropertyPath']);
         $this->assertSame('[foo  =  asdf]', $actual['AttributeFilters'][1]['text']);
-        $this->assertSame('foo', $actual['AttributeFilters'][1]['Identifier']);
+        $this->assertSame('foo', $actual['AttributeFilters'][1]['PropertyPath']);
         $this->assertSame('=', $actual['AttributeFilters'][1]['Operator']);
         $this->assertSame('asdf', $actual['AttributeFilters'][1]['Operand']);
 
         $actual = $parser->match('Filter', '[baz]');
-        $this->assertSame('baz', $actual['AttributeFilters'][0]['Identifier']);
+        $this->assertSame('baz', $actual['AttributeFilters'][0]['PropertyPath']);
 
         $parser->assertDoesntMatch('Filter', '*');
     }

--- a/Neos.Eel/Tests/Unit/FlowQuery/FizzleParserTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/FizzleParserTest.php
@@ -50,6 +50,7 @@ class FizzleParserTest extends \Neos\Flow\Tests\UnitTestCase
         $parser->assertMatches('Filter', 'foo[baz]');
         $parser->assertMatches('Filter', 'foo[baz][bar]');
         $parser->assertMatches('Filter', 'foo[baz]');
+        $parser->assertMatches('Filter', 'foo[bar.baz]');
         $parser->assertMatches('Filter', '[baz][foo="asdf"]');
 
         $actual = $parser->match('Filter', 'foo[baz][foo  =  asdf]');
@@ -64,6 +65,7 @@ class FizzleParserTest extends \Neos\Flow\Tests\UnitTestCase
 
         $actual = $parser->match('Filter', '[baz]');
         $this->assertSame('baz', $actual['AttributeFilters'][0]['PropertyPath']);
+        $this->assertSame('baz', $actual['AttributeFilters'][0]['Identifier'], 'Identifier key is added for compatibility');
 
         $parser->assertDoesntMatch('Filter', '*');
     }

--- a/Neos.Eel/Tests/Unit/FlowQuery/FlowQueryTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/FlowQueryTest.php
@@ -114,6 +114,10 @@ class FlowQueryTest extends UnitTestCase
         $myObject7 = new \stdClass();
         $myObject7->aNumber = 142;
 
+        $myObject8 = new \stdClass();
+        $myObject8->resource = new \stdClass();
+        $myObject8->resource->fileExtension = "pdf";
+
         return [
             'Property existance test works' => [
                 'sourceObjects' => [$myObject, $myObject2],
@@ -134,6 +138,11 @@ class FlowQueryTest extends UnitTestCase
                 'sourceObjects' => [$myObject, $myObject2, $myObject3, $myObject4],
                 'filter' => '[myProperty=asdf]',
                 'expectedResult' => [$myObject]
+            ],
+            'Exact match of property path is supported' => [
+                'sourceObjects' => [$myObject, $myObject2, $myObject3, $myObject4, $myObject8],
+                'filter' => '[resource.fileExtension=pdf]',
+                'expectedResult' => [$myObject8]
             ],
             'Boolean matches' => [
                 'sourceObjects' => [$myObject, $myObject2, $myObject3, $myObject4, $myObject5, $myObject6],


### PR DESCRIPTION
**What I did**
Implements #899. I extended the FlowQuery grammar to filter nested object properties.

**How I did it**
 It was not possible to just extend the `Identifier` rule in `AbstractParser.peg.inc` since that led to a lot of regressions in the Eel parser. Thus, a new rule `PropertyPath` was necessary.

**How to verify it**
Unit-Tests in Neos.Eel run successfully.

