### PR TITLE
TASK: throw InvalidConfigurationException if there are no secondLevelCache settings for doctrine

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/EntityManagerFactory.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/EntityManagerFactory.php
@@ -76,6 +76,9 @@ class EntityManagerFactory
         if (!is_array($this->settings['backendOptions'])) {
             throw new InvalidConfigurationException(sprintf('The TYPO3.Flow.persistence.backendOptions settings need to be an array, %s given.', gettype($this->settings['backendOptions'])), 1426149224);
         }
+        if (!is_array($this->settings['doctrine']['secondLevelCache'])) {
+            throw new InvalidConfigurationException(sprintf('The TYPO3.Flow.persistence.doctrine.secondLevelCache settings need to be an array, %s given.', gettype($this->settings['doctrine']['secondLevelCache'])), 1491305513);
+        }
     }
 
     /**


### PR DESCRIPTION
#When using more than one doctrine backend, you have to make sure to set TYPO3.Flow.persistence.doctrine.secondLevelCache, or else you will get "An error occurred in the Database Abstraction Layer." as an exception which doesn't tell you much. By throwing an approriate exception we make clearer what the problem is.