### PR TITLE
BUGFIX: Injected configuration should also be ignored in class schema

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
@@ -1607,6 +1607,10 @@ class ReflectionService
             return false;
         }
 
+        if ($this->isPropertyAnnotatedWith($className, $propertyName, Flow\InjectConfiguration::class)) {
+            return false;
+        }
+
         if (!$this->isPropertyTaggedWith($className, $propertyName, 'var')) {
             return false;
         }


### PR DESCRIPTION
Injected properties were always ignored in the persistence class schema as
it makes no sense to persist injected properties. Same is obviously true for
injected configuration, but this was never done so this change ignores
properties with a ``InjectConfiguration`` annotation.

This may be breaking if you use ``InjectConfiguration`` on a property that you
actually want to persist (which is not a good idea anyway). You would need to
add another property with the inject annotation and pass the value over to the
persisted property in ``initializeObject`` for example.
