### PR TITLE
TASK: Adjust schema of routes configuration

### DIFF
--- a/TYPO3.Flow/Resources/Private/Schema/Routes.schema.yaml
+++ b/TYPO3.Flow/Resources/Private/Schema/Routes.schema.yaml
@@ -15,11 +15,22 @@ items:
         '@subpackage': {type: string}
     'routeParts':
       type: dictionary
-      additionalAttributes:
-        type: dictionary
-        additionalAttributes: FALSE
-        properties:
-          'handler': {type: string, required: TRUE, format: class-name}
+      additionalProperties:
+        -
+          type: dictionary
+          additionalProperties: FALSE
+          properties:
+            'handler': {type: string, required: TRUE, format: class-name}
+            'options': {type: dictionary }
+            'toLowerCase':  {type: boolean }
+        -
+          type: dictionary
+          additionalProperties: FALSE
+          properties:
+            'objectType': {type: string, required: TRUE, format: class-name}
+            'uriPattern': {type: string}
+            'options': {type: dictionary }
+            'toLowerCase':  {type: boolean }
     'appendExceedingArguments': {type: boolean}
     'toLowerCase': {type: boolean}
     'httpMethods':


### PR DESCRIPTION
Previously the route parts were evaluated correct regardless of the configured keys because the schema used the configuration `additionalAttributes = FALSE` instead of `additionalProperties = FALSE`. This is fixed and the schema is updated 

- validate the keys in route parts strictly
- allow configuration of `objectType` and  `uriPattern ` instead of `handler`
- allow `options` and `toLowerCase` for all routeParts

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
