### PR TITLE
BUGFIX: Correctly document usage of ``...cookie.domain`` setting

### DIFF
--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -673,9 +673,9 @@ TYPO3:
         # Allow http access only.
         httponly: TRUE
 
-        # The cookie domain. Use dot notation if cookies should be valid for
-        # all subdomains.
-        #domain: .domain.com
+        # The cookie domain. Only denote the top-level domain if cookies should be valid for
+        # all subdomains. Dot notation is not supported.
+        #domain: domain.com
         domain: NULL
 
     utility:


### PR DESCRIPTION
The cookie domain was allowed to be set with a leading dot to signal
that it should be valid for all subdomains. This was later changed in
the current RFC 6265. Our ``Session`` implementation checks for domains
without leading dot, while the comment suggested to use it. This is now
matched.

Fixes: neos/neos-development-collection#813
