### PR TITLE
TASK: Use generateRandomString() instead of uniqid()

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Aop/Builder/ProxyClassBuilder.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Aop/Builder/ProxyClassBuilder.php
@@ -32,6 +32,7 @@ use TYPO3\Flow\Object\Proxy\Compiler;
 use TYPO3\Flow\Reflection\ClassReflection;
 use TYPO3\Flow\Reflection\PropertyReflection;
 use TYPO3\Flow\Reflection\ReflectionService;
+use TYPO3\Flow\Utility\Algorithms;
 
 /**
  * The main class of the AOP (Aspect Oriented Programming) framework.
@@ -713,7 +714,7 @@ EOT;
             }
             foreach ($aspectContainer->getInterfaceIntroductions() as $introduction) {
                 $pointcut = $introduction->getPointcut();
-                if ($pointcut->matches($targetClassName, null, null, uniqid())) {
+                if ($pointcut->matches($targetClassName, null, null, Algorithms::generateRandomString(13))) {
                     $introductions[] = $introduction;
                 }
             }
@@ -738,7 +739,7 @@ EOT;
             }
             foreach ($aspectContainer->getPropertyIntroductions() as $introduction) {
                 $pointcut = $introduction->getPointcut();
-                if ($pointcut->matches($targetClassName, null, null, uniqid())) {
+                if ($pointcut->matches($targetClassName, null, null, Algorithms::generateRandomString(13))) {
                     $introductions[] = $introduction;
                 }
             }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Generic/Backend/AbstractBackend.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Generic/Backend/AbstractBackend.php
@@ -25,6 +25,7 @@ use TYPO3\Flow\Persistence\PersistenceManagerInterface;
 use TYPO3\Flow\Reflection\ClassSchema;
 use TYPO3\Flow\Reflection\ObjectAccess;
 use TYPO3\Flow\Reflection\ReflectionService;
+use TYPO3\Flow\Utility\Algorithms;
 use TYPO3\Flow\Utility\TypeHandling;
 use TYPO3\Flow\Validation\ValidatorResolver;
 use TYPO3\Flow\Persistence\Exception as PersistenceException;
@@ -642,7 +643,7 @@ abstract class AbstractBackend implements BackendInterface
      */
     protected function processNestedArray($parentIdentifier, array $nestedArray, \Closure $handler = null)
     {
-        $identifier = uniqid('a', true);
+        $identifier = 'a' . Algorithms::generateRandomString(23);
         $data = [
             'multivalue' => true,
             'value' => $this->processArray($nestedArray, $parentIdentifier)

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/ResourceManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/ResourceManager.php
@@ -23,6 +23,7 @@ use TYPO3\Flow\Resource\Storage\WritableStorageInterface;
 use TYPO3\Flow\Resource\Streams\StreamWrapperAdapter;
 use TYPO3\Flow\Resource\Target\TargetInterface;
 use TYPO3\Flow\Resource\Resource as PersistentResource;
+use TYPO3\Flow\Utility\Algorithms;
 use TYPO3\Flow\Utility\Environment;
 use TYPO3\Flow\Utility\Unicode\Functions as UnicodeFunctions;
 
@@ -569,7 +570,7 @@ class ResourceManager
 
         if ($openBasedirEnabled === true) {
             // Move uploaded file to a readable folder before trying to read sha1 value of file
-            $newTemporaryTargetPathAndFilename = $this->environment->getPathToTemporaryDirectory() . 'ResourceUpload.' . uniqid() . '.tmp';
+            $newTemporaryTargetPathAndFilename = $this->environment->getPathToTemporaryDirectory() . 'ResourceUpload.' . Algorithms::generateRandomString(13) . '.tmp';
             if (move_uploaded_file($temporaryTargetPathAndFilename, $newTemporaryTargetPathAndFilename) === false) {
                 throw new Exception(sprintf('The uploaded file "%s" could not be moved to the temporary location "%s".', $temporaryTargetPathAndFilename, $newTemporaryTargetPathAndFilename), 1375199056);
             }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Storage/WritableFileSystemStorage.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Storage/WritableFileSystemStorage.php
@@ -14,6 +14,7 @@ namespace TYPO3\Flow\Resource\Storage;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Resource\Resource as PersistentResource;
 use TYPO3\Flow\Resource\Storage\Exception as StorageException;
+use TYPO3\Flow\Utility\Algorithms;
 use TYPO3\Flow\Utility\Files;
 
 /**
@@ -52,7 +53,7 @@ class WritableFileSystemStorage extends FileSystemStorage implements WritableSto
      */
     public function importResource($source, $collectionName)
     {
-        $temporaryTargetPathAndFilename = $this->environment->getPathToTemporaryDirectory() . uniqid('TYPO3_Flow_ResourceImport_');
+        $temporaryTargetPathAndFilename = $this->environment->getPathToTemporaryDirectory() . 'TYPO3_Flow_ResourceImport_' . Algorithms::generateRandomString(13);
 
         if (is_resource($source)) {
             try {
@@ -89,7 +90,7 @@ class WritableFileSystemStorage extends FileSystemStorage implements WritableSto
      */
     public function importResourceFromContent($content, $collectionName)
     {
-        $temporaryTargetPathAndFilename = $this->environment->getPathToTemporaryDirectory() . uniqid('TYPO3_Flow_ResourceImport_');
+        $temporaryTargetPathAndFilename = $this->environment->getPathToTemporaryDirectory() . 'TYPO3_Flow_ResourceImport_' . Algorithms::generateRandomString(13);
         try {
             file_put_contents($temporaryTargetPathAndFilename, $content);
         } catch (\Exception $e) {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Target/FileSystemSymlinkTarget.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/Target/FileSystemSymlinkTarget.php
@@ -14,6 +14,7 @@ namespace TYPO3\Flow\Resource\Target;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Resource\CollectionInterface;
 use TYPO3\Flow\Resource\Storage\PackageStorage;
+use TYPO3\Flow\Utility\Algorithms;
 use TYPO3\Flow\Utility\Files;
 use TYPO3\Flow\Utility\Unicode\Functions as UnicodeFunctions;
 use TYPO3\Flow\Resource\Target\Exception as TargetException;
@@ -78,7 +79,7 @@ class FileSystemSymlinkTarget extends FileSystemTarget
                 Files::unlink($targetPathAndFilename);
             }
 
-            $temporaryTargetPathAndFilename = uniqid($targetPathAndFilename . '.') . '.tmp';
+            $temporaryTargetPathAndFilename = $targetPathAndFilename . '.' . Algorithms::generateRandomString(13) . '.tmp';
             symlink($sourcePathAndFilename, $temporaryTargetPathAndFilename);
             $result = rename($temporaryTargetPathAndFilename, $targetPathAndFilename);
         } catch (\Exception $exception) {
@@ -116,7 +117,7 @@ class FileSystemSymlinkTarget extends FileSystemTarget
                 Files::unlink($targetPathAndFilename);
             }
 
-            $temporaryTargetPathAndFilename = uniqid($targetPathAndFilename . '.') . '.tmp';
+            $temporaryTargetPathAndFilename = $targetPathAndFilename . '.' . Algorithms::generateRandomString(13) . '.tmp';
             symlink($sourcePath, $temporaryTargetPathAndFilename);
             $result = rename($temporaryTargetPathAndFilename, $targetPathAndFilename);
         } catch (\Exception $exception) {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Cryptography/RsaWalletServicePhp.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Cryptography/RsaWalletServicePhp.php
@@ -16,7 +16,7 @@ use TYPO3\Flow\Security\Exception as SecurityException;
 use TYPO3\Flow\Security\Exception\DecryptionNotAllowedException;
 use TYPO3\Flow\Security\Exception\InvalidKeyPairIdException;
 use TYPO3\Flow\Security\Exception\MissingConfigurationException;
-use TYPO3\Flow\Utility\Algorithms;
+use TYPO3\Flow\Utility;
 
 /**
  * Implementation of the RSAWalletServiceInterface using PHP's OpenSSL extension
@@ -371,7 +371,7 @@ class RsaWalletServicePhp implements RsaWalletServiceInterface
             return;
         }
 
-        $temporaryKeystorePathAndFilename = $this->keystorePathAndFilename . Algorithms::generateRandomString(13) . '.temp';
+        $temporaryKeystorePathAndFilename = $this->keystorePathAndFilename . Utility\Algorithms::generateRandomString(13) . '.temp';
         $result = file_put_contents($temporaryKeystorePathAndFilename, serialize($this->keys));
 
         if ($result === false) {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Cryptography/RsaWalletServicePhp.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Cryptography/RsaWalletServicePhp.php
@@ -16,6 +16,7 @@ use TYPO3\Flow\Security\Exception as SecurityException;
 use TYPO3\Flow\Security\Exception\DecryptionNotAllowedException;
 use TYPO3\Flow\Security\Exception\InvalidKeyPairIdException;
 use TYPO3\Flow\Security\Exception\MissingConfigurationException;
+use TYPO3\Flow\Utility\Algorithms;
 
 /**
  * Implementation of the RSAWalletServiceInterface using PHP's OpenSSL extension
@@ -370,7 +371,7 @@ class RsaWalletServicePhp implements RsaWalletServiceInterface
             return;
         }
 
-        $temporaryKeystorePathAndFilename = $this->keystorePathAndFilename . uniqid() . '.temp';
+        $temporaryKeystorePathAndFilename = $this->keystorePathAndFilename . Algorithms::generateRandomString(13) . '.temp';
         $result = file_put_contents($temporaryKeystorePathAndFilename, serialize($this->keys));
 
         if ($result === false) {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Cryptography/SaltedMd5HashingStrategy.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Cryptography/SaltedMd5HashingStrategy.php
@@ -11,7 +11,7 @@ namespace TYPO3\Flow\Security\Cryptography;
  * source code.
  */
 
-use TYPO3\Flow\Utility\Algorithms;
+use TYPO3\Flow\Utility;
 
 /**
  * A salted MD5 based password hashing strategy
@@ -27,7 +27,7 @@ class SaltedMd5HashingStrategy implements PasswordHashingStrategyInterface
      */
     public static function generateSaltedMd5($clearString)
     {
-        $salt = substr(md5(rand() . Algorithms::generateRandomString(23)), 0, rand(6, 10));
+        $salt = substr(md5(rand() . Utility\Algorithms::generateRandomString(23)), 0, rand(6, 10));
         return (md5(md5($clearString) . $salt) . ',' . $salt);
     }
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Cryptography/SaltedMd5HashingStrategy.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Cryptography/SaltedMd5HashingStrategy.php
@@ -11,6 +11,8 @@ namespace TYPO3\Flow\Security\Cryptography;
  * source code.
  */
 
+use TYPO3\Flow\Utility\Algorithms;
+
 /**
  * A salted MD5 based password hashing strategy
  *
@@ -25,7 +27,7 @@ class SaltedMd5HashingStrategy implements PasswordHashingStrategyInterface
      */
     public static function generateSaltedMd5($clearString)
     {
-        $salt = substr(md5(uniqid(rand(), true)), 0, rand(6, 10));
+        $salt = substr(md5(rand() . Algorithms::generateRandomString(23)), 0, rand(6, 10));
         return (md5(md5($clearString) . $salt) . ',' . $salt);
     }
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Session/TransientSession.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Session/TransientSession.php
@@ -13,6 +13,7 @@ namespace TYPO3\Flow\Session;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Core\Bootstrap;
+use TYPO3\Flow\Utility\Algorithms;
 
 /**
  * Implementation of a transient session.
@@ -72,7 +73,7 @@ class TransientSession implements SessionInterface
      */
     public function start()
     {
-        $this->sessionId = uniqid();
+        $this->sessionId = Algorithms::generateRandomString(13);
         $this->started = true;
     }
 
@@ -106,7 +107,7 @@ class TransientSession implements SessionInterface
      */
     public function renewId()
     {
-        $this->sessionId = uniqid();
+        $this->sessionId = Algorithms::generateRandomString(13);
         return $this->sessionId;
     }
 


### PR DESCRIPTION
This reduces the risk of collision on temporary filenames and other
identifiers and data.