### PR TITLE
BUGFIX: Fix support for PHP 7.1

### DIFF
--- a/Neos.Utility.Files/Classes/TYPO3/Flow/Utility/Files.php
+++ b/Neos.Utility.Files/Classes/TYPO3/Flow/Utility/Files.php
@@ -302,12 +302,12 @@ abstract class Files
      * @param string $pathAndFilename Path and name of the file to load
      * @param integer $flags (optional) ORed flags using PHP's FILE_* constants (see manual of file_get_contents).
      * @param resource $context (optional) A context resource created by stream_context_create()
-     * @param integer $offset (optional) Offset where reading of the file starts.
+     * @param integer $offset (optional) Offset where reading of the file starts, as of PHP 7.1 supports negative offsets.
      * @param integer $maximumLength (optional) Maximum length to read. Default is -1 (no limit)
      * @return mixed The file content as a string or FALSE if the file could not be opened.
      * @api
      */
-    public static function getFileContents($pathAndFilename, $flags = 0, $context = null, $offset = -1, $maximumLength = -1)
+    public static function getFileContents($pathAndFilename, $flags = 0, $context = null, $offset = null, $maximumLength = -1)
     {
         if ($flags === true) {
             $flags = FILE_USE_INCLUDE_PATH;


### PR DESCRIPTION
With PHP 7.1 the behavior of `file_get_contents()` has been changed
allowing negative offsets to be specified.

This change adjusts the signature of `TYPO3\Flow\Utility\Files::getFileContents()`
accordingly.

*Note:* This is a backport of #821 which has only been applied to the 4.0 branch

Fixes: neos/neos-development-collection#1301, #847