### PR TITLE
BUGFIX: Integer argumentName should not result in an exception

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/ActionRequest.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/ActionRequest.php
@@ -469,11 +469,12 @@ class ActionRequest implements RequestInterface
      */
     public function setArgument($argumentName, $value)
     {
-        if (!is_string($argumentName) || strlen($argumentName) === 0) {
+        $argumentName = (string)$argumentName;
+        if (empty($argumentName)) {
             throw new Exception\InvalidArgumentNameException('Invalid argument name (must be a non-empty string).', 1210858767);
         }
 
-        if (substr($argumentName, 0, 2) === '__') {
+        if (strpos($argumentName, '__') === 0) {
             $this->internalArguments[$argumentName] = $value;
             return;
         }
@@ -482,7 +483,7 @@ class ActionRequest implements RequestInterface
             throw new Exception\InvalidArgumentTypeException('You are not allowed to store objects in the request arguments. Please convert the object of type "' . get_class($value) . '" given for argument "' . $argumentName . '" to a simple type first.', 1302783022);
         }
 
-        if (substr($argumentName, 0, 2) === '--') {
+        if (strpos($argumentName, '--') === 0) {
             $this->pluginArguments[substr($argumentName, 2)] = $value;
             return;
         }

--- a/TYPO3.Flow/Tests/Unit/Mvc/ActionRequestTest.php
+++ b/TYPO3.Flow/Tests/Unit/Mvc/ActionRequestTest.php
@@ -604,4 +604,15 @@ class ActionRequestTest extends UnitTestCase
         $expectedResult = ['pluginArgument' => 'action request'];
         $this->assertSame($expectedResult, $this->actionRequest->getPluginArguments());
     }
+
+    /**
+     * @test
+     */
+    public function settingAnArgumentWithIntegerNameWillCastToString()
+    {
+        $argumentValue = 'amnesia spray';
+        $this->actionRequest->setArgument(123, $argumentValue);
+        $this->assertTrue($this->actionRequest->hasArgument('123'));
+        $this->assertEquals($argumentValue, $this->actionRequest->getArgument('123'));
+    }
 }


### PR DESCRIPTION
This prevents an exception in case an argument name is evaluated to
another simple type (integer) but can be converted to string easily.

Fixes: #612
