### PR TITLE
TASK: Fix error message to correctly refer to composer.json

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Bootstrap.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Bootstrap.php
@@ -442,7 +442,7 @@ class Bootstrap
             }
         }
         if (empty($suitableRequestHandlers)) {
-            throw new FlowException('No suitable request handler could be found for the current request. This is most likely a setup-problem, so please check your package.json and/or try removing Configuration/PackageStates.php', 1464882543);
+            throw new FlowException('No suitable request handler could be found for the current request. This is most likely a setup-problem, so please check your composer.json and/or try removing Configuration/PackageStates.php', 1464882543);
         }
         ksort($suitableRequestHandlers);
         return array_pop($suitableRequestHandlers);


### PR DESCRIPTION
This misleading message was introduced in a0a1453d87053e2c17b954804c61c5c03fa00c89
due to too much javascript work being done.