### PR TITLE
BUGFIX: FileSystemTargetTest shouldn't have side effects

### DIFF
--- a/TYPO3.Flow/Tests/Unit/Resource/Target/FileSystemTargetTest.php
+++ b/TYPO3.Flow/Tests/Unit/Resource/Target/FileSystemTargetTest.php
@@ -210,6 +210,8 @@ class FileSystemTargetTest extends UnitTestCase
         vfsStream::setup('Test');
         mkdir('vfs://Test/Configuration');
         $packageManager = new PackageManager('vfs://Test/Configuration/PackageStates.php');
+        $this->inject($packageManager, 'packagesBasePath', 'vfs://Test/Packages/');
+
         $packageManager->createPackage("TYPO3.Flow");
         $packageManager->activatePackage("TYPO3.Flow");
 


### PR DESCRIPTION
The test would create a Flow package in the current installation as the
package manager in the test was not prepared with a virtual filesystem.
