### PR TITLE
TASK: Add a distinct exception for existing, but invalid composer manifests

### DIFF
--- a/Neos.Flow/Classes/Composer/ComposerUtility.php
+++ b/Neos.Flow/Classes/Composer/ComposerUtility.php
@@ -101,6 +101,10 @@ class ComposerUtility
         $json = file_get_contents($manifestPathAndFilename);
         $composerManifest = json_decode($json, true);
 
+        if($composerManifest === null){
+            throw new Exception\InvalidPackageManifestException(sprintf('The composer manifest file found at "%s" could not be parsed. Check for JSON syntax errors!', $manifestPathAndFilename), 1493909988);
+        }
+
         self::$composerManifestCache[$manifestPathAndFilename] = $composerManifest;
         return $composerManifest;
     }

--- a/Neos.Flow/Classes/Composer/Exception/InvalidPackageManifestException.php
+++ b/Neos.Flow/Classes/Composer/Exception/InvalidPackageManifestException.php
@@ -1,0 +1,21 @@
+<?php
+namespace Neos\Flow\Composer\Exception;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * An "package manifest could not be converted to JSON" exception
+ *
+ * @api
+ */
+class InvalidPackageManifestException extends \Neos\Flow\Package\Exception
+{
+}


### PR DESCRIPTION
Since I just ran into that one and it took me a while to figure out why Flow was throwing a "Composer Manifest does not contain a "name" field", I added a distinct exception for the case when a composer manifest does exist, but cannot be parsed from JSON.