### PR TITLE
TASK: Ignore invalid cookie names instead of throwing an exception

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Headers.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Headers.php
@@ -12,7 +12,6 @@ namespace TYPO3\Flow\Http;
  */
 
 use TYPO3\Flow\Annotations as Flow;
-use TYPO3\Flow\Log\SystemLoggerInterface;
 
 /**
  * Container for HTTP header fields
@@ -33,11 +32,6 @@ class Headers
     protected $cookies = array();
 
     /**
-     * @var SystemLoggerInterface
-     */
-    protected $systemLogger;
-
-    /**
      * @var array
      */
     protected $cacheDirectives = array(
@@ -49,15 +43,6 @@ class Headers
         'no-store' => '',
         'no-transform' => ''
     );
-
-    /**
-     * @param SystemLoggerInterface $systemLogger
-     * @return void
-     */
-    public function injectSystemLogger(SystemLoggerInterface $systemLogger)
-    {
-        $this->systemLogger = $systemLogger;
-    }
 
     /**
      * Constructs a new Headers object.
@@ -467,13 +452,7 @@ class Headers
             list($name, $value) = explode('=', $cookiePair, 2);
             $trimmedName = trim($name);
 
-            if ($trimmedName === '') {
-                continue;
-            }
-
-            if (preg_match(Cookie::PATTERN_TOKEN, $trimmedName) !== 1) {
-                $this->systemLogger->log(sprintf('Cookie name %s is not RFC 2616 compliant, therefore it will be skipped', $trimmedName), LOG_INFO);
-            } else {
+            if ($trimmedName !== '' && preg_match(Cookie::PATTERN_TOKEN, $trimmedName) === 1) {
                 $this->setCookie(new Cookie($trimmedName, urldecode(trim($value, "\t ;\""))));
             }
         }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Headers.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Headers.php
@@ -450,7 +450,7 @@ class Headers
                 continue;
             }
             list($name, $value) = explode('=', $cookiePair, 2);
-            if (trim($name) !== '') {
+            if (trim($name) !== '' && preg_match(Cookie::PATTERN_TOKEN, $name) === 1) {
                 $this->setCookie(new Cookie(trim($name), urldecode(trim($value, "\t ;\""))));
             }
         }

--- a/TYPO3.Flow/Tests/Unit/Http/HeadersTest.php
+++ b/TYPO3.Flow/Tests/Unit/Http/HeadersTest.php
@@ -243,15 +243,9 @@ class HeadersTest extends UnitTestCase
     /**
      * @test
      */
-    public function cookiesWithInvalidNameAreLoggedAndSkipped()
+    public function cookiesWithInvalidNameAreIgnored()
     {
-        $mockSystemLogger = $this->getMockBuilder('TYPO3\Flow\Log\Logger')->setMethods(['log'])->getMock();
-        $mockSystemLogger->expects($this->once())->method('log')->with($this->equalTo(
-            sprintf('Cookie name %s is not RFC 2616 compliant, therefore it will be skipped', 'cookie[invalid]')
-        ));
-
         $headers = new Headers();
-        $headers->injectSystemLogger($mockSystemLogger);
         $headers->set('Cookie', ['cookie-valid=this+is+valid; cookie[invalid]=this+is+invalid']);
 
         $this->assertTrue($headers->hasCookie('cookie-valid'));

--- a/TYPO3.Flow/Tests/Unit/Http/HeadersTest.php
+++ b/TYPO3.Flow/Tests/Unit/Http/HeadersTest.php
@@ -246,7 +246,7 @@ class HeadersTest extends UnitTestCase
     public function cookiesWithInvalidNameAreIgnored()
     {
         $headers = new Headers();
-        $headers->set('Cookie', ['cookie-valid=this+is+valid; cookie[invalid]=this+is+invalid']);
+        $headers->set('Cookie', array('cookie-valid=this+is+valid; cookie[invalid]=this+is+invalid'));
 
         $this->assertTrue($headers->hasCookie('cookie-valid'));
         $this->assertFalse($headers->hasCookie('cookie[invalid]'));

--- a/TYPO3.Flow/Tests/Unit/Http/HeadersTest.php
+++ b/TYPO3.Flow/Tests/Unit/Http/HeadersTest.php
@@ -241,6 +241,24 @@ class HeadersTest extends UnitTestCase
     }
 
     /**
+     * @test
+     */
+    public function cookiesWithInvalidNameAreLoggedAndSkipped()
+    {
+        $mockSystemLogger = $this->getMockBuilder('TYPO3\Flow\Log\Logger')->setMethods(['log'])->getMock();
+        $mockSystemLogger->expects($this->once())->method('log')->with($this->equalTo(
+            sprintf('Cookie name %s is not RFC 2616 compliant, therefore it will be skipped', 'cookie[invalid]')
+        ));
+
+        $headers = new Headers();
+        $headers->injectSystemLogger($mockSystemLogger);
+        $headers->set('Cookie', ['cookie-valid=this+is+valid; cookie[invalid]=this+is+invalid']);
+
+        $this->assertTrue($headers->hasCookie('cookie-valid'));
+        $this->assertFalse($headers->hasCookie('cookie[invalid]'));
+    }
+
+    /**
      * Data provider with valid cache control headers
      */
     public function cacheControlHeaders()


### PR DESCRIPTION
This prevents the exception that is thrown when a cookie has an invalid name.

See the discussion here: https://discuss.neos.io/t/ignore-invalid-cookies-instead-of-throwing-an-exception/2234