### PR TITLE
BUGFIX: Doctrine migration SQL query safeguards

### DIFF
--- a/TYPO3.Flow/Migrations/Mysql/Version20130319131400.php
+++ b/TYPO3.Flow/Migrations/Mysql/Version20130319131400.php
@@ -63,6 +63,9 @@ class Version20130319131400 extends AbstractMigration
      */
     protected function migrateAccountRolesUp()
     {
+        if (!$this->sm->tablesExist(['typo3_flow_security_account'])) {
+            return;
+        }
         $rolesSql = array();
         $accountRolesSql = array();
         $rolesToMigrate = array();
@@ -103,6 +106,9 @@ class Version20130319131400 extends AbstractMigration
      */
     protected function migrateAccountRolesDown()
     {
+        if (!$this->sm->tablesExist(['typo3_flow_security_account_roles_join', 'typo3_flow_security_policy_role'])) {
+            return;
+        }
         $accountsWithRoles = array();
 
         $accountRolesResult = $this->connection->executeQuery('SELECT j.flow_security_account, r.identifier FROM typo3_flow_security_account_roles_join as j LEFT JOIN typo3_flow_security_policy_role AS r ON j.flow_policy_role = r.identifier');

--- a/TYPO3.Flow/Migrations/Mysql/Version20141015125841.php
+++ b/TYPO3.Flow/Migrations/Mysql/Version20141015125841.php
@@ -40,6 +40,9 @@ class Version20141015125841 extends AbstractMigration
      */
     public function postUp(Schema $schema)
     {
+        if (!$this->sm->tablesExist(['typo3_flow_resource_resource'])) {
+            return;
+        }
         $resourcesResult = $this->connection->executeQuery('SELECT persistence_object_identifier, sha1, filename FROM typo3_flow_resource_resource');
         while ($resourceInfo = $resourcesResult->fetch(\PDO::FETCH_ASSOC)) {
             $resourcePathAndFilename = FLOW_PATH_DATA . 'Persistent/Resources/' . $resourceInfo['sha1'];
@@ -99,6 +102,9 @@ class Version20141015125841 extends AbstractMigration
      */
     public function postDown(Schema $schema)
     {
+        if (!$this->sm->tablesExist(['typo3_flow_resource_resource'])) {
+            return;
+        }
         $resourcesResult = $this->connection->executeQuery('SELECT DISTINCT resourcepointer FROM typo3_flow_resource_resource');
         while ($resourceInfo = $resourcesResult->fetch(\PDO::FETCH_ASSOC)) {
             $this->connection->executeQuery(

--- a/TYPO3.Flow/Migrations/Mysql/Version20141113173712.php
+++ b/TYPO3.Flow/Migrations/Mysql/Version20141113173712.php
@@ -64,6 +64,9 @@ class Version20141113173712 extends AbstractMigration
      */
     protected function migrateAccountRolesUp()
     {
+        if (!$this->sm->tablesExist(['typo3_flow_security_account_roles_join', 'typo3_flow_security_policy_role'])) {
+            return;
+        }
         $accountsWithRoles = array();
 
         $accountRolesResult = $this->connection->executeQuery('SELECT j.flow_security_account, r.identifier FROM typo3_flow_security_account_roles_join as j LEFT JOIN typo3_flow_security_policy_role AS r ON j.flow_policy_role = r.identifier');
@@ -84,6 +87,9 @@ class Version20141113173712 extends AbstractMigration
      */
     protected function migrateAccountRolesDown()
     {
+        if (!$this->sm->tablesExist(['typo3_flow_security_account', 'typo3_flow_security_policy_role', 'typo3_flow_security_account_roles_join'])) {
+            return;
+        }
         $allRolesAndAccounts = array();
         $accountRolesResult = $this->connection->executeQuery('SELECT persistence_object_identifier, roleidentifiers FROM typo3_flow_security_account');
         while ($accountIdentifierAndRoles = $accountRolesResult->fetch(\PDO::FETCH_ASSOC)) {

--- a/TYPO3.Flow/Migrations/Mysql/Version20150611154419.php
+++ b/TYPO3.Flow/Migrations/Mysql/Version20150611154419.php
@@ -18,6 +18,10 @@ class Version20150611154419 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
+        if (!$this->sm->tablesExist(['typo3_flow_resource_resource'])) {
+            return;
+        }
+
         $resourcesResult = $this->connection->executeQuery('SELECT persistence_object_identifier, sha1, filename FROM typo3_flow_resource_resource');
         while ($resourceInfo = $resourcesResult->fetch(\PDO::FETCH_ASSOC)) {
             $resourcePathAndFilename = FLOW_PATH_DATA . 'Persistent/Resources/' . wordwrap($resourceInfo['sha1'], 5, '/', true) . '/' . $resourceInfo['sha1'];

--- a/TYPO3.Flow/Migrations/Postgresql/Version20130319131500.php
+++ b/TYPO3.Flow/Migrations/Postgresql/Version20130319131500.php
@@ -65,6 +65,9 @@ class Version20130319131500 extends AbstractMigration
      */
     protected function migrateAccountRolesUp()
     {
+        if (!$this->sm->tablesExist(['typo3_flow_security_account'])) {
+            return;
+        }
         $rolesSql = array();
         $accountRolesSql = array();
         $rolesToMigrate = array();
@@ -105,6 +108,9 @@ class Version20130319131500 extends AbstractMigration
      */
     protected function migrateAccountRolesDown()
     {
+        if (!$this->sm->tablesExist(['typo3_flow_security_account_roles_join', 'typo3_flow_security_policy_role'])) {
+            return;
+        }
         $accountsWithRoles = array();
 
         $accountRolesResult = $this->connection->executeQuery('SELECT j.flow_security_account, r.identifier FROM typo3_flow_security_account_roles_join as j LEFT JOIN typo3_flow_security_policy_role AS r ON j.flow_policy_role = r.identifier');

--- a/TYPO3.Flow/Migrations/Postgresql/Version20141118174722.php
+++ b/TYPO3.Flow/Migrations/Postgresql/Version20141118174722.php
@@ -51,6 +51,9 @@ class Version20141118174722 extends AbstractMigration
      */
     public function postUp(Schema $schema)
     {
+        if (!$this->sm->tablesExist(['typo3_flow_resource_resource'])) {
+            return;
+        }
         $resourcesResult = $this->connection->executeQuery('SELECT persistence_object_identifier, sha1, filename FROM typo3_flow_resource_resource');
         while ($resourceInfo = $resourcesResult->fetch(\PDO::FETCH_ASSOC)) {
             $resourcePathAndFilename = FLOW_PATH_DATA . 'Persistent/Resources/' . $resourceInfo['sha1'];
@@ -123,6 +126,9 @@ class Version20141118174722 extends AbstractMigration
      */
     public function postDown(Schema $schema)
     {
+        if (!$this->sm->tablesExist(['typo3_flow_resource_resource', 'typo3_flow_resource_resourcepointer'])) {
+            return;
+        }
         $resourcesResult = $this->connection->executeQuery('SELECT DISTINCT resourcepointer FROM typo3_flow_resource_resource');
         while ($resourceInfo = $resourcesResult->fetch(\PDO::FETCH_ASSOC)) {
             $this->connection->executeQuery(

--- a/TYPO3.Flow/Migrations/Postgresql/Version20150611154421.php
+++ b/TYPO3.Flow/Migrations/Postgresql/Version20150611154421.php
@@ -18,6 +18,10 @@ class Version20150611154421 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
 
+        if (!$this->sm->tablesExist(['typo3_flow_resource_resource'])) {
+            return;
+        }
+
         $resourcesResult = $this->connection->executeQuery('SELECT persistence_object_identifier, sha1, filename FROM typo3_flow_resource_resource');
         while ($resourceInfo = $resourcesResult->fetch(\PDO::FETCH_ASSOC)) {
             $resourcePathAndFilename = FLOW_PATH_DATA . 'Persistent/Resources/' . wordwrap($resourceInfo['sha1'], 5, '/', true) . '/' . $resourceInfo['sha1'];


### PR DESCRIPTION
This adds `TABLE EXISTS` checks to all places where doctrine
migrations directly executes SQL queries in order to prevent
`./flow doctrine:migrate` to fail with `--dry-run` or `--output`
flag set.

Background:
Doctrine needs to execute the migrations in order to determine
the SQL they generate - even during "dry run".
In some migrations we access the database directly in order to
migrate data.
To avoid that these queries fail if the corresponding tables haven't
been created yet, this patch adds safeguards respectively.
NOTE: There are still a few places where we perform *mutations* in
the `postUp()`/`postDown()` hooks. Those will still be executed in
"dry run" mode if the table in question exists in the database!

Fixes: #974