### PR TITLE
BUGFIX: Fix `doctrine:migrationstatus` command

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/Service.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Service.php
@@ -282,6 +282,11 @@ class Service
         }
 
         if ($showMigrations) {
+            $configuration = $this->getMigrationConfiguration();
+
+            $executedMigrations = $configuration->getMigratedVersions();
+            $availableMigrations = $configuration->getAvailableVersions();
+            $executedUnavailableMigrations = array_diff($executedMigrations, $availableMigrations);
             if ($migrations = $configuration->getMigrations()) {
                 $docCommentParser = new DocCommentParser();
 


### PR DESCRIPTION
This fixes a regression introduced with #857 that made the
`doctrine:migrationstatus` CLI command fail with a PHP notice
if the `--show-migrations` flag was used.

Fixes: #976