### PR TITLE
FEATURE: Make it possible to ignore annotations for a whole namespace

### DIFF
--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -352,6 +352,12 @@ class ReflectionService
             }
         }
 
+        foreach ($this->settings['reflection']['ignoredNamespaces'] as $namespace => $ignoreFlag) {
+            if ($ignoreFlag === true) {
+                AnnotationReader::addGlobalIgnoredNamespace($namespace);
+            }
+        }
+
         $this->initialized = true;
     }
 

--- a/Neos.Flow/Configuration/Settings.yaml
+++ b/Neos.Flow/Configuration/Settings.yaml
@@ -369,7 +369,7 @@ Neos:
 
     reflection:
 
-      # A list of tags to be ignored during reflection
+      # A list of annotation tags to be ignored during reflection
       ignoredTags:
         'api': TRUE
         'package': TRUE
@@ -404,6 +404,9 @@ Neos:
         'AfterStep': TRUE
         'WithoutSecurityChecks': TRUE
         'covers': TRUE
+
+      # A list of annotation namespaces to be ignored during reflection
+      ignoredNamespaces: []
 
       # If enabled, the Reflection Service notes all incorrect or inconsistent usage
       # of @param annotations in the default log.


### PR DESCRIPTION
This change introduces a new configuration option `Neos.Flow.reflection.ignoredNamespaces`. This option can be used to configure doctrine’s AnnotationReader to ignore a whole namespace.

This configuration would ignore `@Foo\Bar` as well as `@Foo\Baz`:
```
Neos:
  Flow:
    reflection:
      ignoredNamepsaces:
        'Foo': true
```

Resolves #980