### PR TITLE
BUGFIX: Keep format for URIs built in subrequests

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/Routing/UriBuilder.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Mvc/Routing/UriBuilder.php
@@ -455,6 +455,10 @@ class UriBuilder
                 if (!empty($requestActionName)) {
                     $requestArguments['@action'] = $requestActionName;
                 }
+                $requestFormat = $subRequest->getFormat();
+                if (!empty($requestFormat)) {
+                    $requestArguments['@format'] = $requestFormat;
+                }
 
                 if (count($requestArguments) > 0) {
                     $requestArguments = $this->addNamespaceToArguments($requestArguments, $subRequest);

--- a/TYPO3.Flow/Tests/Unit/Mvc/Routing/UriBuilderTest.php
+++ b/TYPO3.Flow/Tests/Unit/Mvc/Routing/UriBuilderTest.php
@@ -827,4 +827,39 @@ class UriBuilderTest extends UnitTestCase
         $expectedResult = $arguments;
         $this->assertEquals($expectedResult, $this->uriBuilder->getArguments());
     }
+
+    /**
+     * @test
+     */
+    public function uriForInSubRequestWillKeepFormatOfMainRequest()
+    {
+        $expectedArguments = [
+            '@format' => 'custom',
+            'SubNamespace' => ['@action' => 'someaction', '@controller' => 'somecontroller', '@package' => 'somepackage']
+        ];
+        $this->mockMainRequest->expects($this->any())->method('getFormat')->will($this->returnValue('custom'));
+
+        $this->uriBuilder->setRequest($this->mockSubRequest);
+        $this->uriBuilder->uriFor('SomeAction', [], 'SomeController', 'SomePackage');
+
+        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+    }
+
+    /**
+     * @test
+     */
+    public function uriForInSubRequestWithFormatWillNotOverrideFormatOfMainRequest()
+    {
+        $expectedArguments = [
+            '@format' => 'custom',
+            'SubNamespace' => ['@action' => 'someaction', '@controller' => 'somecontroller', '@package' => 'somepackage', '@format' => 'inner']
+        ];
+        $this->mockMainRequest->expects($this->any())->method('getFormat')->will($this->returnValue('custom'));
+
+        $this->uriBuilder->setRequest($this->mockSubRequest);
+        $this->uriBuilder->setFormat('inner');
+        $this->uriBuilder->uriFor('SomeAction', [], 'SomeController', 'SomePackage');
+
+        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+    }
 }


### PR DESCRIPTION
Adds handling for the `@format` argument when merging arguments
from the request hierarchy to keep the format when building
URIs from a sub request.

Fixes neos/neos-development-collection#1596