### PR TITLE
BUGFIX: Fix DateTime tests for PHP 7.x

### DIFF
--- a/TYPO3.Flow/Tests/Functional/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
+++ b/TYPO3.Flow/Tests/Functional/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
@@ -72,7 +72,7 @@ class PersistedUsernamePasswordProviderTest extends FunctionalTestCase
         $this->assertTrue($this->authenticationToken->isAuthenticated());
 
         $account = $this->accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName('username', 'myTestProvider');
-        $this->assertEquals(new \DateTime(), $account->getLastSuccessfulAuthenticationDate());
+        $this->assertEquals((new \DateTime())->format(\DateTime::W3C), $account->getLastSuccessfulAuthenticationDate()->format(\DateTime::W3C));
         $this->assertEquals(0, $account->getFailedAuthenticationCount());
     }
 
@@ -120,7 +120,7 @@ class PersistedUsernamePasswordProviderTest extends FunctionalTestCase
         $this->persistedUsernamePasswordProvider->authenticate($this->authenticationToken);
 
         $account = $this->accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName('username', 'myTestProvider');
-        $this->assertEquals(new \DateTime(), $account->getLastSuccessfulAuthenticationDate());
+        $this->assertEquals((new \DateTime())->format(\DateTime::W3C), $account->getLastSuccessfulAuthenticationDate()->format(\DateTime::W3C));
         $this->assertEquals(0, $account->getFailedAuthenticationCount());
     }
 }

--- a/TYPO3.Flow/Tests/Unit/Persistence/Generic/DataMapperTest.php
+++ b/TYPO3.Flow/Tests/Unit/Persistence/Generic/DataMapperTest.php
@@ -385,7 +385,7 @@ class DataMapperTest extends UnitTestCase
     {
         $expected = new \DateTime();
         $dataMapper = $this->getAccessibleMock(Persistence\Generic\DataMapper::class, ['dummy']);
-        $this->assertEquals($dataMapper->_call('mapDateTime', $expected->getTimestamp()), $expected);
+        $this->assertEquals($dataMapper->_call('mapDateTime', $expected->getTimestamp())->format(\DateTime::W3C), $expected->format(\DateTime::W3C));
     }
 
     /**


### PR DESCRIPTION
This adjusts one unit test and two functional tests that
were comparing two `\DateTime` instances which, since PHP 7.1,
are not equal if the microsecond portion differs.

Background:
This is a backport of 4d77de57481c05a5018a8cc947e9da4adc9ab52c
which was only applied to branch 4.0+