### PR TITLE
BUGFIX: Add handling of HTTP HEAD-request with curl

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Client/CurlEngine.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Client/CurlEngine.php
@@ -107,6 +107,13 @@ class CurlEngine implements RequestEngineInterface
                     ]);
                 }
             break;
+            case 'HEAD':
+                if (!is_resource($content)) {
+                    $body = $content !== '' ? $content : http_build_query($request->getArguments());
+                    curl_setopt($curlHandle, CURLOPT_POSTFIELDS, $body);
+                }
+                curl_setopt($curlHandle, CURLOPT_NOBODY, true);
+            break;
             default:
                 if (!is_resource($content)) {
                     $body = $content !== '' ? $content : http_build_query($request->getArguments());


### PR DESCRIPTION
Extended CurlEngine for request-type HEAD to set the option to not expect a body.

resolves #992 