### PR TITLE
BUGFIX: Don't flush persistent caches when package state changes

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package.php
@@ -125,8 +125,10 @@ class Package extends BasePackage
             }
         });
 
-        $dispatcher->connect(\TYPO3\Flow\Package\PackageManager::class, 'packageStatesUpdated', function () use ($dispatcher) {
-            $dispatcher->connect(\TYPO3\Flow\Core\Bootstrap::class, 'bootstrapShuttingDown', \TYPO3\Flow\Cache\CacheManager::class, 'flushCaches');
+        $dispatcher->connect(\TYPO3\Flow\Package\PackageManager::class, 'packageStatesUpdated', function () use ($dispatcher, $bootstrap) {
+            $dispatcher->connect(\TYPO3\Flow\Core\Bootstrap::class, 'bootstrapShuttingDown', function() use ($bootstrap) {
+                $bootstrap->getObjectManager()->get(\TYPO3\Flow\Cache\CacheManager::class)->flushCaches();
+            });
         });
     }
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package.php
@@ -126,7 +126,7 @@ class Package extends BasePackage
         });
 
         $dispatcher->connect(\TYPO3\Flow\Package\PackageManager::class, 'packageStatesUpdated', function () use ($dispatcher, $bootstrap) {
-            $dispatcher->connect(\TYPO3\Flow\Core\Bootstrap::class, 'bootstrapShuttingDown', function() use ($bootstrap) {
+            $dispatcher->connect(\TYPO3\Flow\Core\Bootstrap::class, 'bootstrapShuttingDown', function () use ($bootstrap) {
                 $bootstrap->getObjectManager()->get(\TYPO3\Flow\Cache\CacheManager::class)->flushCaches();
             });
         });


### PR DESCRIPTION
Previously the `bootstrapShuttingDown` signal was connected with the
`CacheManager::flushCaches()` method directly passing arguments of the
signal on. The first parameter, being the Boostrap `runLevel` flag was
casted to `true`, so that all caches were flushed.

This is fixed by explicitly calling `CacheManager::flushCaches()` in
a closure.

Fixes: #994