### PR TITLE
!!!TASK: Add PHP 7.0 scalar type hints to method arguments and return types

### DIFF
--- a/Neos.Utility.Lock/Classes/FlockLockStrategy.php
+++ b/Neos.Utility.Lock/Classes/FlockLockStrategy.php
@@ -67,7 +67,7 @@ class FlockLockStrategy implements LockStrategyInterface
      * @return void
      * @throws LockNotAcquiredException
      */
-    public function acquire($subject, $exclusiveLock)
+    public function acquire(string $subject, bool $exclusiveLock)
     {
         $this->lockFileName = Utility\Files::concatenatePaths([$this->temporaryDirectory, md5($subject)]);
         $aquiredLock = false;
@@ -88,7 +88,7 @@ class FlockLockStrategy implements LockStrategyInterface
      * @throws LockNotAcquiredException
      * return void
      */
-    protected function configureLockDirectory($lockDirectory)
+    protected function configureLockDirectory(string $lockDirectory)
     {
         Utility\Files::createDirectoryRecursively($lockDirectory);
         $this->temporaryDirectory = $lockDirectory;
@@ -101,7 +101,7 @@ class FlockLockStrategy implements LockStrategyInterface
      * @return boolean Was a lock aquired?
      * @throws LockNotAcquiredException
      */
-    protected function tryToAcquireLock($exclusiveLock)
+    protected function tryToAcquireLock(bool $exclusiveLock): bool
     {
         $this->filePointer = @fopen($this->lockFileName, 'w');
         if ($this->filePointer === false) {
@@ -132,7 +132,7 @@ class FlockLockStrategy implements LockStrategyInterface
      * @param boolean $exclusiveLock
      * @throws LockNotAcquiredException
      */
-    protected function applyFlock($exclusiveLock)
+    protected function applyFlock(bool $exclusiveLock)
     {
         $lockOption = $exclusiveLock === true ? LOCK_EX : LOCK_SH;
 
@@ -146,7 +146,7 @@ class FlockLockStrategy implements LockStrategyInterface
      *
      * @return boolean TRUE on success, FALSE otherwise
      */
-    public function release()
+    public function release(): bool
     {
         $success = true;
         if (is_resource($this->filePointer)) {
@@ -165,7 +165,7 @@ class FlockLockStrategy implements LockStrategyInterface
     /**
      * @return string
      */
-    public function getLockFileName()
+    public function getLockFileName(): string
     {
         return $this->lockFileName;
     }

--- a/Neos.Utility.Lock/Classes/Lock.php
+++ b/Neos.Utility.Lock/Classes/Lock.php
@@ -47,7 +47,7 @@ class Lock
      * @param string $subject
      * @param boolean $exclusiveLock TRUE to, acquire an exclusive (write) lock, FALSE for a shared (read) lock. An exclusive lock ist the default.
      */
-    public function __construct($subject, $exclusiveLock = true)
+    public function __construct(string $subject, bool $exclusiveLock = true)
     {
         if (self::$lockManager === null) {
             return;
@@ -59,7 +59,7 @@ class Lock
     /**
      * @return LockStrategyInterface
      */
-    public function getLockStrategy()
+    public function getLockStrategy(): LockStrategyInterface
     {
         return $this->lockStrategy;
     }
@@ -80,7 +80,7 @@ class Lock
      * Releases the lock
      * @return boolean TRUE on success, FALSE otherwise
      */
-    public function release()
+    public function release(): bool
     {
         if ($this->lockStrategy instanceof LockStrategyInterface) {
             return $this->lockStrategy->release();

--- a/Neos.Utility.Lock/Classes/LockManager.php
+++ b/Neos.Utility.Lock/Classes/LockManager.php
@@ -29,10 +29,10 @@ class LockManager
     /**
      * LockManager constructor.
      *
-     * @param $lockStrategyClassName
+     * @param string $lockStrategyClassName
      * @param array $lockStrategyOptions
      */
-    public function __construct($lockStrategyClassName, array $lockStrategyOptions = [])
+    public function __construct(string $lockStrategyClassName, array $lockStrategyOptions = [])
     {
         if (!class_exists($lockStrategyClassName)) {
             throw new \InvalidArgumentException('The given class name given as implementation of the LockStrategyInterface does not exist!', 1454694738);
@@ -45,7 +45,7 @@ class LockManager
     /**
      * @return LockStrategyInterface
      */
-    public function getLockStrategyInstance()
+    public function getLockStrategyInstance(): LockStrategyInterface
     {
         $lockStrategy = $this->lockStrategyClassName;
         return new $lockStrategy($this->lockStrategyOptions);

--- a/Neos.Utility.Lock/Classes/LockStrategyInterface.php
+++ b/Neos.Utility.Lock/Classes/LockStrategyInterface.php
@@ -23,10 +23,10 @@ interface LockStrategyInterface
      * @param boolean $exclusiveLock TRUE to, acquire an exclusive (write) lock, FALSE for a shared (read) lock.
      * @return void
      */
-    public function acquire($subject, $exclusiveLock);
+    public function acquire(string $subject, bool $exclusiveLock);
 
     /**
      * @return boolean TRUE on success, FALSE otherwise
      */
-    public function release();
+    public function release(): bool;
 }

--- a/Neos.Utility.Lock/Tests/Unit/LockTest.php
+++ b/Neos.Utility.Lock/Tests/Unit/LockTest.php
@@ -71,11 +71,11 @@ class LockTest extends \PHPUnit\Framework\TestCase
     public function writeLockLocksExclusively()
     {
         $lock = new Lock('testLock');
-        $this->assertExclusivelyLocked($lock);
+        $this->assertExclusivelyLocked('Failed to exclusively lock file.');
         $this->assertTrue($lock->release());
 
         $lock = new Lock('testLock');
-        $this->assertExclusivelyLocked($lock);
+        $this->assertExclusivelyLocked('Failed to exclusively lock file.');
         $this->assertTrue($lock->release());
     }
 
@@ -94,7 +94,7 @@ class LockTest extends \PHPUnit\Framework\TestCase
     /**
      * @param string $message
      */
-    protected function assertExclusivelyLocked($message = '')
+    protected function assertExclusivelyLocked(string $message = '')
     {
         $lockFilePointer = fopen($this->lockFileName, 'w');
         $this->assertFalse(flock($lockFilePointer, LOCK_EX | LOCK_NB), $message);


### PR DESCRIPTION
This is only breaking for classes implementing `LockStrategyInterface`, whose signature now requires scalar typehints.