### PR TITLE
FEATURE: Allow Nullable action params to be annotated

### DIFF
--- a/Neos.Flow/Classes/Mvc/Controller/ActionController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ActionController.php
@@ -29,6 +29,7 @@ use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Property\Exception\TargetNotFoundException;
 use Neos\Flow\Property\TypeConverter\Error\TargetNotFoundError;
 use Neos\Flow\Reflection\ReflectionService;
+use Neos\Utility\TypeHandling;
 
 /**
  * An HTTP based multi-action controller.
@@ -245,6 +246,9 @@ class ActionController extends AbstractController
                 throw new InvalidArgumentTypeException('The argument type for parameter $' . $parameterName . ' of method ' . get_class($this) . '->' . $this->actionMethodName . '() could not be detected.', 1253175643);
             }
             $defaultValue = (isset($parameterInfo['defaultValue']) ? $parameterInfo['defaultValue'] : null);
+            if ($parameterInfo['optional'] === true && $defaultValue === null) {
+                $dataType = TypeHandling::stripNullableType($dataType);
+            }
             $this->arguments->addNewArgument($parameterName, $dataType, ($parameterInfo['optional'] === false), $defaultValue);
         }
     }

--- a/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
@@ -244,6 +244,17 @@ class ActionControllerTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function optionalObjectArgumentsCanBeAnnotatedNullable()
+    {
+        $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertestb/optionalannotatedobject');
+
+        $expectedResult = 'null';
+        $this->assertEquals($expectedResult, $response->getContent());
+    }
+
+    /**
+     * @test
+     */
     public function notValidatedGroupObjectArgumentsAreNotValidated()
     {
         $arguments = [
@@ -291,6 +302,7 @@ class ActionControllerTest extends FunctionalTestCase
             'required string - missing value'   => ['requiredString', null, $requiredArgumentExceptionText],
             'optional string'                   => ['optionalString', '123', '\'123\''],
             'optional string - default'         => ['optionalString', null, '\'default\''],
+            'optional string - nullable'        => ['optionalNullableString', null, 'NULL'],
             'required integer'                  => ['requiredInteger', '234', 234],
             'required integer - missing value'  => ['requiredInteger', null, $requiredArgumentExceptionText],
             'required integer - mapping error'  => ['requiredInteger', 'not an integer', 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->requiredIntegerAction().'],
@@ -299,6 +311,7 @@ class ActionControllerTest extends FunctionalTestCase
             'optional integer - default value'  => ['optionalInteger', null, 123],
             'optional integer - mapping error'  => ['optionalInteger', 'not an integer', 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->optionalIntegerAction().'],
             'optional integer - empty value'    => ['optionalInteger', '', 123],
+            'optional integer - nullable'       => ['optionalNullableInteger', null, 'NULL'],
             'required float'                    => ['requiredFloat', 34.56, 34.56],
             'required float - integer'          => ['requiredFloat', 485, '485'],
             'required float - integer2'         => ['requiredFloat', '888', '888'],
@@ -309,22 +322,18 @@ class ActionControllerTest extends FunctionalTestCase
             'optional float - default value'    => ['optionalFloat', null, 112.34],
             'optional float - mapping error'    => ['optionalFloat', 'not a float', 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->optionalFloatAction().'],
             'optional float - empty value'      => ['optionalFloat', '', 112.34],
+            'optional float - nullable'         => ['optionalNullableFloat', null, 'NULL'],
             'required date'                     => ['requiredDate', ['date' => '1980-12-13', 'dateFormat' => 'Y-m-d'], '1980-12-13'],
             'required date string'              => ['requiredDate', '1980-12-13T14:22:12+02:00', '1980-12-13'],
             'required date - missing value'     => ['requiredDate', null, $requiredArgumentExceptionText],
             'required date - mapping error'     => ['requiredDate', 'no date', 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->requiredDateAction().'],
+            'required date - empty value'       => ['requiredDate', '', 'Uncaught Exception in Flow Argument 1 passed to Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController_Original::requiredDateAction() must be an instance of DateTime, null given'],
             'optional date string'              => ['optionalDate', '1980-12-13T14:22:12+02:00', '1980-12-13'],
             'optional date - default value'     => ['optionalDate', null, 'null'],
             'optional date - mapping error'     => ['optionalDate', 'no date', 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->optionalDateAction().'],
             'optional date - missing value'     => ['optionalDate', null, 'null'],
-            'optional date - empty value'       => ['optionalDate', '', 'null']
+            'optional date - empty value'       => ['optionalDate', '', 'null'],
         ];
-
-        if (version_compare(PHP_VERSION, '6.0.0') >= 0) {
-            $data['required date - empty value'] = ['requiredDate', '', 'Uncaught Exception in Flow Argument 1 passed to Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController_Original::requiredDateAction() must be an instance of DateTime, null given'];
-        } else {
-            $data['required date - empty value'] = ['requiredDate', '', 'Uncaught Exception in Flow #1: Catchable Fatal Error: Argument 1 passed to Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController_Original::requiredDateAction() must be an instance of DateTime, null given'];
-        }
 
         return $data;
     }

--- a/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/ActionControllerTestBController.php
+++ b/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/ActionControllerTestBController.php
@@ -58,6 +58,18 @@ class ActionControllerTestBController extends ActionController
     }
 
     /**
+     * @param TestObjectArgument|null $argument
+     * @return string
+     */
+    public function optionalAnnotatedObjectAction(TestObjectArgument $argument = null)
+    {
+        if ($argument === null) {
+            return 'null';
+        }
+        return $argument->getEmailAddress();
+    }
+
+    /**
      * @param TestObjectArgument $argument
      * @Flow\ValidationGroups({"notValidatedGroup"})
      * @return string
@@ -96,6 +108,15 @@ class ActionControllerTestBController extends ActionController
     }
 
     /**
+     * @param string|null $argument
+     * @return string
+     */
+    public function optionalNullableStringAction($argument = null)
+    {
+        return var_export($argument, true);
+    }
+
+    /**
      * @param integer $argument
      * @return string
      */
@@ -114,6 +135,15 @@ class ActionControllerTestBController extends ActionController
     }
 
     /**
+     * @param integer|null $argument
+     * @return string
+     */
+    public function optionalNullableIntegerAction($argument = null)
+    {
+        return var_export($argument, true);
+    }
+
+    /**
      * @param float $argument
      * @return string
      */
@@ -127,6 +157,15 @@ class ActionControllerTestBController extends ActionController
      * @return string
      */
     public function optionalFloatAction($argument = 112.34)
+    {
+        return var_export($argument, true);
+    }
+
+    /**
+     * @param float|null $argument
+     * @return string
+     */
+    public function optionalNullableFloatAction($argument = null)
     {
         return var_export($argument, true);
     }

--- a/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
+++ b/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
@@ -150,6 +150,18 @@ abstract class TypeHandling
     }
 
     /**
+     * @param string $type
+     * @return string The original type without an optional "null" type information
+     */
+    public static function stripNullableType($type)
+    {
+        if (stripos($type, 'null') === false) {
+            return $type;
+        }
+        return preg_replace('/(\\|null|null\\|)/i', '', $type);
+    }
+
+    /**
      * Return simple type or class for object
      *
      * @param mixed $value

--- a/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
@@ -238,6 +238,9 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
 
             // Types might also contain underscores at various points.
             ['null|Doctrine\Common\Collections\Array_Collection<>', 'Doctrine\Common\Collections\Array_Collection<>'],
+
+            // This is madness. This... is... NULL!
+            ['null', 'null']
         ];
     }
 

--- a/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
@@ -213,4 +213,44 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertSame($expected, TypeHandling::isCollectionType($type), 'Failed for ' . $type);
     }
+
+    /**
+     * data provider for stripNullableTypesReturnsOnlyTheType
+     */
+    public function nullableTypes()
+    {
+        return [
+            ['integer|null', 'integer'],
+            ['null|int', 'int'],
+            ['array|null', 'array'],
+            ['ArrayObject|null', 'ArrayObject'],
+            ['null|SplObjectStorage', 'SplObjectStorage'],
+            ['Doctrine\Common\Collections\Collection|null', 'Doctrine\Common\Collections\Collection'],
+            ['Doctrine\Common\Collections\ArrayCollection|null', 'Doctrine\Common\Collections\ArrayCollection'],
+            ['array<\Some\Other\Class>|null', 'array<\Some\Other\Class>'],
+            ['ArrayObject<int>|null', 'ArrayObject<int>'],
+            ['SplObjectStorage<\object>|null', 'SplObjectStorage<\object>'],
+            ['Doctrine\Common\Collections\Collection<ElementType>|null', 'Doctrine\Common\Collections\Collection<ElementType>'],
+            ['Doctrine\Common\Collections\ArrayCollection<>|null', 'Doctrine\Common\Collections\ArrayCollection<>'],
+
+            // This is not even a use case for Flow and is bad API design, but we still should handle it correctly.
+            ['integer|null|bool', 'integer|bool'],
+
+            // Types might also contain underscores at various points.
+            ['null|Doctrine\Common\Collections\Array_Collection<>', 'Doctrine\Common\Collections\Array_Collection<>'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider nullableTypes
+     */
+    public function stripNullableTypesReturnsOnlyTheType($type, $expectedResult)
+    {
+        $this->assertEquals(
+            $expectedResult,
+            TypeHandling::stripNullableType($type),
+            'Failed for ' . $type
+        );
+    }
 }


### PR DESCRIPTION
This change allows action arguments to be annotated "|null" or "null|" when they are optional with default value `null`. Before the type conversion would fail because no matching type converter would be found.

Resolves #927