### PR TITLE
FEATURE: Add `range` method to Eel Array-helper

### DIFF
--- a/Neos.Eel/Classes/Helper/ArrayHelper.php
+++ b/Neos.Eel/Classes/Helper/ArrayHelper.php
@@ -348,6 +348,22 @@ class ArrayHelper implements ProtectedContextAwareInterface
     }
 
     /**
+     * Create an array containing a range of elements
+     *
+     * If a step value is given, it will be used as the increment between elements in the sequence.
+     * step should be given as a positive number. If not specified, step will default to 1.
+     *
+     * @param mixed $start First value of the sequence.
+     * @param mixed $end The sequence is ended upon reaching the end value.
+     * @param integer $step The increment between items, will default to 1.
+     * @return array Array of elements from start to end, inclusive.
+     */
+    public function range($start, $end, $step = 1)
+    {
+        return range($start, $end, $step);
+    }
+
+    /**
      * All methods are considered safe
      *
      * @param string $methodName

--- a/Neos.Eel/Tests/Unit/Helper/ArrayHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/ArrayHelperTest.php
@@ -444,4 +444,33 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
 
         $this->assertEquals($expected, $result);
     }
+
+    public function rangeExamples()
+    {
+        return [
+            'array from one to three' => [
+                [1, 3],
+                [1, 2, 3]
+            ],
+            'array from one to seven in steps of two' => [
+                [1, 7, 2],
+                [1, 3, 5, 7]
+            ],
+            'array of characters' => [
+                ['c', 'g'],
+                ['c', 'd', 'e', 'f', 'g']
+            ]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider rangeExamples
+     */
+    public function rangeWorks($arguments, $expected)
+    {
+        $helper = new ArrayHelper();
+        $result = call_user_func_array([$helper, 'range'], $arguments);
+        $this->assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
The range method is a wrapper around the php range function that creates a sequence of integers or characters as array. This is especially helpful to create paginations in pure fusion.