### PR TITLE
BUGFIX: Annotate logoutAction with SkipCsrfProtection

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Authentication/Controller/AbstractAuthenticationController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Authentication/Controller/AbstractAuthenticationController.php
@@ -101,6 +101,7 @@ abstract class AbstractAuthenticationController extends ActionController
      * method to do the actual logout.
      *
      * @return void
+     * @Flow\SkipCsrfProtection
      */
     public function logoutAction()
     {


### PR DESCRIPTION
Sometimes (especially in Neos) on logout the CSRF token is missing (`CsrfTokenMissing` interceptor). No harm in ignoring it here.