### PR TITLE
TASK: Add additional detection of changed package files

### DIFF
--- a/Neos.Flow/Classes/Package/Exception/PackageClassMissingException.php
+++ b/Neos.Flow/Classes/Package/Exception/PackageClassMissingException.php
@@ -1,0 +1,20 @@
+<?php
+namespace Neos\Flow\Package\Exception;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * "Package Class Missing" Exception
+ *
+ */
+class PackageClassMissingException extends \Neos\Flow\Package\Exception
+{
+}


### PR DESCRIPTION
`Package.php` files are used for specific Flow bootstrap behavior
in packages and the information if such a file exists is cached in
`PackageStates.php`. In development it can happen that a new file
is created or an existing one removed and that should be detected.

This change adds detection for change (creation) and removal of
`Package.php` files.
