### PR TITLE
BUGFIX: Fix TypeError in RedisBackendTest

### DIFF
--- a/Neos.Cache/Tests/Unit/Backend/RedisBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/RedisBackendTest.php
@@ -66,6 +66,11 @@ class RedisBackendTest extends BaseTestCase
 
         $this->backend = new RedisBackend($mockEnvironmentConfiguration, ['redis' => $this->redis]);
         $this->backend->setCache($this->cache);
+
+        // set this to false manually, since the check in isFrozen leads to null (instead of a boolean)
+        // as the exists call is not mocked (and cannot easily be mocked, as it is used for different
+        // things.)
+        $this->inject($this->backend, 'frozen', false);
     }
 
     /**
@@ -194,6 +199,7 @@ class RedisBackendTest extends BaseTestCase
      */
     public function writingOperationsThrowAnExceptionIfCacheIsFrozen($method)
     {
+        $this->inject($this->backend, 'frozen', null);
         $this->redis->expects($this->once())
             ->method('exists')
             ->with('Foo_Cache:frozen')


### PR DESCRIPTION
Some tests failed with

    Return value of Neos\Cache\Backend\RedisBackend::isFrozen() must
    be of the type boolean, null returned

after the introduction of return type declarations.
