### PR TITLE
TASK: Remove a "risky test" warning

### DIFF
--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CaseViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CaseViewHelperTest.php
@@ -73,7 +73,7 @@ class CaseViewHelperTest extends ViewHelperBaseTestcase
     /**
      *
      */
-    public function testStringDataProvider()
+    public function fixtureStringDataProvider()
     {
         return [
             ['', ''],
@@ -83,7 +83,7 @@ class CaseViewHelperTest extends ViewHelperBaseTestcase
     }
 
     /**
-     * @dataProvider testStringDataProvider
+     * @dataProvider fixtureStringDataProvider
      * @test
      */
     public function viewHelperDoesNotRenderChildrenIfGivenValueIsNotNull($testString, $expected)


### PR DESCRIPTION
A data provider named testSomething() is seen as a test, leading to
a warning about a test not doing any assertions.

Don't do that.
