### PR TITLE
FEATURE: Add Date.formatCldr helper

### DIFF
--- a/Neos.Eel/Classes/Helper/DateHelper.php
+++ b/Neos.Eel/Classes/Helper/DateHelper.php
@@ -13,7 +13,6 @@ namespace Neos\Eel\Helper;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Eel\ProtectedContextAwareInterface;
-use Neos\Flow\I18n\Exception as I18nException;
 use Neos\Flow\I18n\Formatter\DatetimeFormatter;
 use Neos\Flow\I18n\Locale;
 use Neos\Flow\I18n\Service as I18nService;
@@ -73,15 +72,20 @@ class DateHelper implements ProtectedContextAwareInterface
     /**
      * Format a date to a string with a given cldr format
      *
-     * @param \DateTime $date
+     * @param integer|string|\DateTime $date
      * @param string $cldrFormat Format string in CLDR format (see http://cldr.unicode.org/translation/date-time)
      * @param null|string $locale String locale - example (de|en|ru_RU)
-     *
      * @return string
      */
     public function formatCldr($date, $cldrFormat, $locale = null)
     {
-        if (!$date instanceof \DateTimeInterface) {
+        if ($date === 'now') {
+            $date = new \DateTime($date);
+        } elseif (is_int($date)) {
+            $timestamp = $date;
+            $date = new \DateTime();
+            $date->setTimestamp($timestamp);
+        } elseif (!$date instanceof \DateTimeInterface) {
             throw new \InvalidArgumentException('"' . $date . '" could not be parsed by \DateTime constructor.');
         }
         if (empty($cldrFormat)) {

--- a/Neos.Eel/Classes/Helper/DateHelper.php
+++ b/Neos.Eel/Classes/Helper/DateHelper.php
@@ -80,18 +80,18 @@ class DateHelper implements ProtectedContextAwareInterface
     public function formatCldr($date, $cldrFormat, $locale = null)
     {
         if ($date === 'now') {
-            $date = new \DateTime($date);
+            $date = new \DateTime();
         } elseif (is_int($date)) {
             $timestamp = $date;
             $date = new \DateTime();
             $date->setTimestamp($timestamp);
         } elseif (!$date instanceof \DateTimeInterface) {
-            throw new \InvalidArgumentException('"' . $date . '" could not be parsed by \DateTime constructor.');
+            throw new \InvalidArgumentException('The given date "' . $date . '" was neither an integer, "now" or a \DateTimeInterface instance.');
         }
         if (empty($cldrFormat)) {
             throw new \InvalidArgumentException('CLDR date formatting parameter not passed.');
         }
-        if (empty($locale)) {
+        if ($locale === null) {
             $useLocale = $this->localizationService->getConfiguration()->getCurrentLocale();
         } else {
             $useLocale = new Locale($locale);

--- a/Neos.Eel/Classes/Helper/DateHelper.php
+++ b/Neos.Eel/Classes/Helper/DateHelper.php
@@ -75,19 +75,19 @@ class DateHelper implements ProtectedContextAwareInterface
      *
      * @param \DateTime $date
      * @param string $cldrFormat Format string in CLDR format (see http://cldr.unicode.org/translation/date-time)
-     * @param string $locale String locale - example (de|en|ru_RU). Must be one of Neos\Flow\I18n\Cldr\Reader\DatesReader::FORMAT_LENGTH_*'s constants.
+     * @param null|string $locale String locale - example (de|en|ru_RU)
      *
      * @return string
      */
-    public function formatCldr($date = null, $cldrFormat = null, $locale = null)
+    public function formatCldr($date, $cldrFormat, $locale = null)
     {
-        if ($date === null) {
-            $date = new \DateTime('now');
+        if (!$date instanceof \DateTimeInterface) {
+            throw new \InvalidArgumentException('"' . $date . '" could not be parsed by \DateTime constructor.');
         }
-        if ($cldrFormat === null) {
-            $cldrFormat = 'dd MMMM yyyy HH:mm:ss';
+        if (empty($cldrFormat)) {
+            throw new \InvalidArgumentException('CLDR date formatting parameter not passed.');
         }
-        if ($locale === null) {
+        if (empty($locale)) {
             $useLocale = $this->localizationService->getConfiguration()->getCurrentLocale();
         } else {
             $useLocale = new Locale($locale);

--- a/Neos.Eel/Classes/Helper/DateHelper.php
+++ b/Neos.Eel/Classes/Helper/DateHelper.php
@@ -13,14 +13,28 @@ namespace Neos\Eel\Helper;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Eel\ProtectedContextAwareInterface;
+use Neos\Flow\I18n\Exception as I18nException;
+use Neos\Flow\I18n\Formatter\DatetimeFormatter;
+use Neos\Flow\I18n\Locale;
+use Neos\Flow\I18n\Service as I18nService;
 
 /**
  * Date helpers for Eel contexts
- *
- * @Flow\Proxy(false)
  */
 class DateHelper implements ProtectedContextAwareInterface
 {
+    /**
+     * @Flow\Inject
+     * @var DatetimeFormatter
+     */
+    protected $datetimeFormatter;
+
+    /**
+     * @Flow\Inject
+     * @var I18nService
+     */
+    protected $localizationService;
+
     /**
      * Parse a date from string with a format to a DateTime object
      *
@@ -54,6 +68,31 @@ class DateHelper implements ProtectedContextAwareInterface
             $timestamp = (integer)$date;
             return date($format, $timestamp);
         }
+    }
+
+    /**
+     * Format a date to a string with a given cldr format
+     *
+     * @param \DateTime $date
+     * @param string $cldrFormat Format string in CLDR format (see http://cldr.unicode.org/translation/date-time)
+     * @param string $locale String locale - example (de|en|ru_RU). Must be one of Neos\Flow\I18n\Cldr\Reader\DatesReader::FORMAT_LENGTH_*'s constants.
+     *
+     * @return string
+     */
+    public function formatCldr($date = null, $cldrFormat = null, $locale = null)
+    {
+        if ($date === null) {
+            $date = new \DateTime('now');
+        }
+        if ($cldrFormat === null) {
+            $cldrFormat = 'dd MMMM yyyy HH:mm:ss';
+        }
+        if ($locale === null) {
+            $useLocale = $this->localizationService->getConfiguration()->getCurrentLocale();
+        } else {
+            $useLocale = new Locale($locale);
+        }
+        return $this->datetimeFormatter->formatDateTimeWithCustomPattern($date, $cldrFormat, $useLocale);
     }
 
     /**

--- a/Neos.Eel/Tests/Unit/Helper/DateHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/DateHelperTest.php
@@ -12,6 +12,7 @@ namespace Neos\Eel\Tests\Unit;
  */
 
 use Neos\Eel\Helper\DateHelper;
+use Neos\Flow\I18n\Locale;
 
 /**
  * Tests for DateHelper
@@ -52,7 +53,6 @@ class DateHelperTest extends \Neos\Flow\Tests\UnitTestCase
         return [
             'DateTime object' => [$dateTime, 'Y-m-d H:i:s', '2013-07-03 12:34:56'],
             'timestamp as integer' => [1372856513, 'Y-m-d', '2013-07-03'],
-            'timestamp as string' => ['1372856513', 'Y-m-d', '2013-07-03'],
             'now' => ['now', 'Y-m-d', date('Y-m-d')],
             'interval' => [new \DateInterval('P1D'), '%d days', '1 days']
         ];
@@ -67,6 +67,61 @@ class DateHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new DateHelper();
         $result = $helper->format($dateOrString, $format);
         $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function formatCldrThrowsOnEmptyArguments()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $helper = new DateHelper();
+        $helper->formatCldr(null, null);
+    }
+
+    /**
+     * @test
+     */
+    public function formatCldrWorksWithEmptyLocale()
+    {
+        $locale = new Locale('en');
+        $expected = 'whatever-value';
+
+        $configurationMock = $this->createMock(\Neos\Flow\I18n\Configuration::class);
+        $configurationMock->expects($this->atLeastOnce())->method('getCurrentLocale')->willReturn($locale);
+
+        $localizationServiceMock = $this->createMock(\Neos\Flow\I18n\Service::class);
+        $localizationServiceMock->expects($this->atLeastOnce())->method('getConfiguration')->willReturn($configurationMock);
+
+        $formatMock = $this->createMock(\Neos\Flow\I18n\Formatter\DatetimeFormatter::class);
+        $formatMock->expects($this->atLeastOnce())->method('formatDateTimeWithCustomPattern')->willReturn($expected);
+
+        $helper = new DateHelper();
+        $this->inject($helper, 'datetimeFormatter', $formatMock);
+        $this->inject($helper, 'localizationService', $localizationServiceMock);
+
+        $date = \DateTime::createFromFormat('Y-m-d H:i:s', '2013-07-03 12:34:56');
+        $format = 'whatever-format';
+        $helper->formatCldr($date, $format);
+    }
+
+    /**
+     * @test
+     */
+    public function formatCldrCallsFormatService()
+    {
+        $date = \DateTime::createFromFormat('Y-m-d H:i:s', '2013-07-03 12:34:56');
+        $format = 'whatever-format';
+        $locale = 'en';
+        $expected = '2013-07-03 12:34:56';
+
+        $formatMock = $this->createMock(\Neos\Flow\I18n\Formatter\DatetimeFormatter::class);
+        $formatMock->expects($this->atLeastOnce())->method('formatDateTimeWithCustomPattern');
+
+        $helper = new DateHelper();
+        $this->inject($helper, 'datetimeFormatter', $formatMock);
+
+        $helper->formatCldr($date, $format, $locale);
     }
 
     /**


### PR DESCRIPTION
This change adds CLDR formatting capability to the Date Eel helper, to match
the functionality of the `format.date` Fluid ViewHelper.

**P.S.** This PR has taken over from https://github.com/neos/flow-development-collection/pull/920
All the history can be found the. The original code was written by @litovchenko1, I
(@zaveryukha) have added the unit tests.
