### PR TITLE
TASK: Catch exceptions separately for published resource collections

### DIFF
--- a/Neos.Flow/Classes/Command/ResourceCommandController.php
+++ b/Neos.Flow/Classes/Command/ResourceCommandController.php
@@ -102,7 +102,7 @@ class ResourceCommandController extends CommandController
 			            $this->clearState($iteration);
 		            });
 	            } catch (Exception $exception) {
-            		$message = 'An error occurred while publishing the collection ' . $collection->getName() . ': ' . get_class($exception) . ' (Exception code: '. $exception->getCode() . ')';
+            		$message = 'An error occurred while publishing the collection ' . $collection->getName() . ': ' . get_class($exception) . ' (Exception code: '. $exception->getCode() . '):' . $exception->getMessage();
 		            $this->messageCollector->append($message);
 	            }
 

--- a/Neos.Flow/Classes/Command/ResourceCommandController.php
+++ b/Neos.Flow/Classes/Command/ResourceCommandController.php
@@ -106,7 +106,6 @@ class ResourceCommandController extends CommandController
                     $message = 'An error occurred while publishing the collection ' . $collection->getName() . ': ' . get_class($exception) . ' (Exception code: ' . $exception->getCode() . '):' . $exception->getMessage();
                     $this->messageCollector->append($message);
                 }
-
             }
 
             if ($this->messageCollector->hasMessages()) {

--- a/Neos.Flow/Classes/Command/ResourceCommandController.php
+++ b/Neos.Flow/Classes/Command/ResourceCommandController.php
@@ -102,7 +102,13 @@ class ResourceCommandController extends CommandController
                         $this->clearState($iteration);
                     });
                 } catch (Exception $exception) {
-                    $message = 'An error occurred while publishing the collection ' . $collection->getName() . ': ' . get_class($exception) . ' (Exception code: ' . $exception->getCode() . '):' . $exception->getMessage();
+                    $message = sprintf(
+                        'An error occurred while publishing the collection "%s": %s (Exception code: %u): %s',
+                        $collection->getName(),
+                        get_class($exception),
+                        $exception->getCode(),
+                        $exception->getMessage()
+                    );
                     $this->messageCollector->append($message);
                 }
             }

--- a/Neos.Flow/Classes/Command/ResourceCommandController.php
+++ b/Neos.Flow/Classes/Command/ResourceCommandController.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Neos\Flow\Command;
 
 /*
@@ -268,9 +267,9 @@ class ResourceCommandController extends CommandController
                     $brokenThumbnailCounter = 0;
                     foreach ($brokenResources as $sha1 => $resource) {
                         $this->outputLine('- delete %s (%s) from "%s" collection', [
-                                $resource->getFilename(),
-                                $resource->getSha1(),
-                                $resource->getCollectionName()
+                            $resource->getFilename(),
+                            $resource->getSha1(),
+                            $resource->getCollectionName()
                         ]);
                         $resource->disableLifecycleEvents();
                         $this->resourceRepository->remove($resource);

--- a/Neos.Flow/Classes/Command/ResourceCommandController.php
+++ b/Neos.Flow/Classes/Command/ResourceCommandController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Flow\Command;
 
 /*
@@ -94,17 +95,17 @@ class ResourceCommandController extends CommandController
             }
 
             foreach ($collections as $collection) {
-            	try{
-		            /** @var CollectionInterface $collection */
-		            $this->outputLine('Publishing resources of collection "%s"', [$collection->getName()]);
-		            $target = $collection->getTarget();
-		            $target->publishCollection($collection, function ($iteration) {
-			            $this->clearState($iteration);
-		            });
-	            } catch (Exception $exception) {
-            		$message = 'An error occurred while publishing the collection ' . $collection->getName() . ': ' . get_class($exception) . ' (Exception code: '. $exception->getCode() . '):' . $exception->getMessage();
-		            $this->messageCollector->append($message);
-	            }
+                try {
+                    /** @var CollectionInterface $collection */
+                    $this->outputLine('Publishing resources of collection "%s"', [$collection->getName()]);
+                    $target = $collection->getTarget();
+                    $target->publishCollection($collection, function ($iteration) {
+                        $this->clearState($iteration);
+                    });
+                } catch (Exception $exception) {
+                    $message = 'An error occurred while publishing the collection ' . $collection->getName() . ': ' . get_class($exception) . ' (Exception code: ' . $exception->getCode() . '):' . $exception->getMessage();
+                    $this->messageCollector->append($message);
+                }
 
             }
 
@@ -268,9 +269,9 @@ class ResourceCommandController extends CommandController
                     $brokenThumbnailCounter = 0;
                     foreach ($brokenResources as $sha1 => $resource) {
                         $this->outputLine('- delete %s (%s) from "%s" collection', [
-                            $resource->getFilename(),
-                            $resource->getSha1(),
-                            $resource->getCollectionName()
+                                $resource->getFilename(),
+                                $resource->getSha1(),
+                                $resource->getCollectionName()
                         ]);
                         $resource->disableLifecycleEvents();
                         $this->resourceRepository->remove($resource);
@@ -301,11 +302,11 @@ class ResourceCommandController extends CommandController
                     break;
                 case 'n':
                     $this->outputLine('Did not delete any resource objects.');
-                break;
+                    break;
                 case 'c':
                     $this->outputLine('Stopping. Did not delete any resource objects.');
                     $this->quit(0);
-                break;
+                    break;
             }
         }
     }

--- a/Neos.Flow/Classes/Command/ResourceCommandController.php
+++ b/Neos.Flow/Classes/Command/ResourceCommandController.php
@@ -94,12 +94,18 @@ class ResourceCommandController extends CommandController
             }
 
             foreach ($collections as $collection) {
-                /** @var CollectionInterface $collection */
-                $this->outputLine('Publishing resources of collection "%s"', [$collection->getName()]);
-                $target = $collection->getTarget();
-                $target->publishCollection($collection, function ($iteration) {
-                    $this->clearState($iteration);
-                });
+            	try{
+		            /** @var CollectionInterface $collection */
+		            $this->outputLine('Publishing resources of collection "%s"', [$collection->getName()]);
+		            $target = $collection->getTarget();
+		            $target->publishCollection($collection, function ($iteration) {
+			            $this->clearState($iteration);
+		            });
+	            } catch (Exception $exception) {
+            		$message = 'An error occurred while publishing the collection ' . $collection->getName() . ': ' . get_class($exception) . ' (Exception code: '. $exception->getCode() . ')';
+		            $this->messageCollector->append($message);
+	            }
+
             }
 
             if ($this->messageCollector->hasMessages()) {


### PR DESCRIPTION
Implement a separate try/catch blog for each collection so as many collections as possible get published. Fixes could then be done for just the broken collection without running the full command once again.

Extends the Issue: Catch errors while publishing invalid resources #958 (Error Handing for each Resource needs to be done in each Target Class. The native Flow Target Classes already take care about continuing to publish resources)