### PR TITLE
BUGFIX: Avoid type error with Message->getCode()

### DIFF
--- a/Neos.Error.Messages/Classes/Message.php
+++ b/Neos.Error.Messages/Classes/Message.php
@@ -39,7 +39,7 @@ class Message
      * The error code.
      * @var integer
      */
-    protected $code = null;
+    protected $code = 0;
 
     /**
      * The message arguments. Will be replaced in the message body.
@@ -65,7 +65,7 @@ class Message
     public function __construct(string $message, int $code = null, array $arguments = [], string $title = '')
     {
         $this->message = $message;
-        $this->code = $code;
+        $this->code = (int)$code;
         $this->arguments = $arguments;
         $this->title = $title;
     }


### PR DESCRIPTION
The `getCode()` method declares int as return type, but it can happen
that the internal code is `null`, leading to a type error.

This adjusts the code so the internal code is always an integer.
