### PR TITLE
TASK: Remove use of func_get_args() in PropertyMappingConfiguration methods

### DIFF
--- a/Neos.Flow/Classes/Property/PropertyMappingConfiguration.php
+++ b/Neos.Flow/Classes/Property/PropertyMappingConfiguration.php
@@ -148,9 +148,9 @@ class PropertyMappingConfiguration implements PropertyMappingConfigurationInterf
      * @return PropertyMappingConfiguration this
      * @api
      */
-    public function allowProperties()
+    public function allowProperties(string ...$propertyNames)
     {
-        foreach (func_get_args() as $propertyName) {
+        foreach ($propertyNames as $propertyName) {
             $this->propertiesToBeMapped[$propertyName] = $propertyName;
         }
         return $this;
@@ -165,9 +165,9 @@ class PropertyMappingConfiguration implements PropertyMappingConfigurationInterf
      * @return PropertyMappingConfiguration this
      * @api
      */
-    public function skipProperties()
+    public function skipProperties(string ...$propertyNames)
     {
-        foreach (func_get_args() as $propertyName) {
+        foreach ($propertyNames as $propertyName) {
             $this->propertiesToSkip[$propertyName] = $propertyName;
         }
         return $this;
@@ -182,11 +182,11 @@ class PropertyMappingConfiguration implements PropertyMappingConfigurationInterf
      * @return PropertyMappingConfiguration this
      * @api
      */
-    public function allowAllPropertiesExcept()
+    public function allowAllPropertiesExcept(string ...$propertyNames)
     {
         $this->mapUnknownProperties = true;
 
-        foreach (func_get_args() as $propertyName) {
+        foreach ($propertyNames as $propertyName) {
             $this->propertiesNotToBeMapped[$propertyName] = $propertyName;
         }
         return $this;

--- a/Neos.Flow/Classes/Property/PropertyMappingConfiguration.php
+++ b/Neos.Flow/Classes/Property/PropertyMappingConfiguration.php
@@ -145,6 +145,7 @@ class PropertyMappingConfiguration implements PropertyMappingConfigurationInterf
      *
      * Example: allowProperties('title', 'content', 'author')
      *
+     * @param string ...$propertyNames
      * @return PropertyMappingConfiguration this
      * @api
      */
@@ -162,6 +163,7 @@ class PropertyMappingConfiguration implements PropertyMappingConfigurationInterf
      *
      * Example: skipProperties('unused', 'dummy')
      *
+     * @param string ...$propertyNames
      * @return PropertyMappingConfiguration this
      * @api
      */
@@ -179,6 +181,7 @@ class PropertyMappingConfiguration implements PropertyMappingConfigurationInterf
      *
      * Example: allowAllPropertiesExcept('password', 'userGroup')
      *
+     * @param string ...$propertyNames
      * @return PropertyMappingConfiguration this
      * @api
      */


### PR DESCRIPTION
This changes `allowProperties()`, `skipProperties()` and `allowAllPropertiesExcept()`
to declare a string-typed `$propertyNames` argument instead of using `func_get_args()`.