### PR TITLE
BUGFIX: Catch ConnectionExceptions in `PersistenceManager::persistAll()`

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/PersistenceManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/PersistenceManager.php
@@ -13,6 +13,7 @@ namespace TYPO3\Flow\Persistence\Doctrine;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\ORM\Tools\SchemaTool;
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Log\SystemLoggerInterface;
@@ -162,10 +163,14 @@ class PersistenceManager extends AbstractPersistenceManager
 
         /** @var Connection $connection */
         $connection = $this->entityManager->getConnection();
-        if ($connection->ping() === false) {
-            $this->systemLogger->log('Reconnecting the Doctrine EntityManager to the persistence backend.', LOG_INFO);
-            $connection->close();
-            $connection->connect();
+        try {
+            if ($connection->ping() === false) {
+                $this->systemLogger->log('Reconnecting the Doctrine EntityManager to the persistence backend.', LOG_INFO);
+                $connection->close();
+                $connection->connect();
+            }
+        } catch (ConnectionException $exception) {
+            $this->systemLogger->logException($exception);
         }
 
         $this->entityManager->flush();

--- a/TYPO3.Flow/Tests/Unit/Persistence/Doctrine/PersistenceManagerTest.php
+++ b/TYPO3.Flow/Tests/Unit/Persistence/Doctrine/PersistenceManagerTest.php
@@ -12,12 +12,12 @@ namespace TYPO3\Flow\Tests\Unit\Persistence\Doctrine;
  */
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\UnitOfWork;
 use TYPO3\Flow\Log\SystemLoggerInterface;
 use TYPO3\Flow\Persistence\Doctrine\PersistenceManager;
 use TYPO3\Flow\Tests\UnitTestCase;
-use TYPO3\Flow\Error as FlowError;
 
 /**
  * Testcase for the doctrine persistence manager
@@ -177,6 +177,15 @@ class PersistenceManagerTest extends UnitTestCase
         $this->mockConnection->expects($this->never())->method('close');
         $this->mockConnection->expects($this->never())->method('connect');
 
+        $this->persistenceManager->persistAll();
+    }
+
+    /**
+     * @test
+     */
+    public function persistAllCatchesConnectionExceptions()
+    {
+        $this->mockPing->willThrowException($this->getMockBuilder(ConnectionException::class)->disableOriginalConstructor()->getMock());
         $this->persistenceManager->persistAll();
     }
 }


### PR DESCRIPTION
This adds a `try/catch` block around the `$connection->ping()` call that
throws an exception if no database credentials are configured (which is
the case when you do a fresh install of Flow or Neos).

Fixes: #1663