### PR TITLE
TASK: Error Message accepts null as message title

### DIFF
--- a/Neos.Error.Messages/Classes/Message.php
+++ b/Neos.Error.Messages/Classes/Message.php
@@ -57,15 +57,15 @@ class Message
      * Constructs this error
      *
      * @param string $message An english error message which is used if no other error message can be resolved
-     * @param integer $code A unique error code
+     * @param integer|null $code A unique error code
      * @param array $arguments Array of arguments to be replaced in message
-     * @param string $title optional title for the message
+     * @param string|null $title optional title for the message
      * @api
      */
-    public function __construct(string $message, int $code = null, array $arguments = [], string $title = '')
+    public function __construct(string $message, int $code = null, array $arguments = [], string $title = null)
     {
         $this->message = $message;
-        $this->code = (int)$code;
+        $this->code = $code;
         $this->arguments = $arguments;
         $this->title = $title;
     }
@@ -84,10 +84,10 @@ class Message
     /**
      * Returns the error code
      *
-     * @return integer The error code
+     * @return integer|null The error code
      * @api
      */
-    public function getCode(): int
+    public function getCode()
     {
         return $this->code;
     }
@@ -102,10 +102,10 @@ class Message
     }
 
     /**
-     * @return string
+     * @return string|null
      * @api
      */
-    public function getTitle(): string
+    public function getTitle()
     {
         return $this->title;
     }

--- a/Neos.Error.Messages/Classes/Message.php
+++ b/Neos.Error.Messages/Classes/Message.php
@@ -62,7 +62,7 @@ class Message
      * @param string|null $title optional title for the message
      * @api
      */
-    public function __construct(string $message, int $code = null, array $arguments = [], string $title = null)
+    public function __construct(string $message, int $code = null, array $arguments = [], $title = '')
     {
         $this->message = $message;
         $this->code = $code;
@@ -79,6 +79,15 @@ class Message
     public function getMessage(): string
     {
         return $this->message;
+    }
+
+    /**
+     * @return bool
+     * @api
+     */
+    public function hasCode(): bool
+    {
+        return $this->code !== null;
     }
 
     /**
@@ -99,6 +108,15 @@ class Message
     public function getArguments(): array
     {
         return $this->arguments;
+    }
+
+    /**
+     * @return bool
+     * @api
+     */
+    public function hasTitle(): bool
+    {
+        return $this->title !== null && $this->title !== '';
     }
 
     /**


### PR DESCRIPTION
Also, this allow the code of the message to be null in `getCode()`, since
that is the more sane behaviour from an API point of view.

Fixes neos/neos-development-collection#1666