### PR TITLE
BUG: Avoid a syntax error from hiding the intended error message

### DIFF
--- a/Neos.Flow/Classes/Package/PackageManager.php
+++ b/Neos.Flow/Classes/Package/PackageManager.php
@@ -754,7 +754,7 @@ class PackageManager implements PackageManagerInterface
                         $composerManifest['name'],
                         $packageConfiguration['packagePath'],
                         $newPackageStatesConfiguration['packages'][$composerManifest['name']]['packagePath']),
-                    1493030262781
+                    1493030262
                 );
             }
 


### PR DESCRIPTION
The error code for the Package Manager error on duplicate packages was
a millisecond timestamp. Since this is larger than MAX_INT PHP parses
this as float, which in turn is not accepted as parameter for an
exception code.