### PR TITLE
BUGFIX: Avoid a syntax error from hiding the intended error message

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package/PackageManager.php
@@ -870,7 +870,7 @@ class PackageManager implements PackageManagerInterface
                         $composerManifest['name'],
                         $packageConfiguration['packagePath'],
                         $newPackageStatesConfiguration['packages'][$composerManifest['name']]['packagePath']),
-                    1493030262781
+                    1493030262
                 );
             }
 


### PR DESCRIPTION
The error code for the Package Manager error on duplicate packages was
a millisecond timestamp. Since this is larger than MAX_INT PHP parses
this as float, which in turn is not accepted as parameter for an
exception code.