### PR TITLE
BUGFIX: Make CLI subprocesses work on Windows

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/CoreCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/CoreCommandController.php
@@ -364,7 +364,7 @@ class CoreCommandController extends CommandController
      */
     protected function launchSubProcess()
     {
-        $systemCommand = 'FLOW_ROOTPATH=' . FLOW_PATH_ROOT . ' FLOW_PATH_TEMPORARY_BASE=' . FLOW_PATH_TEMPORARY_BASE . ' ' . 'FLOW_CONTEXT=' . $this->bootstrap->getContext() . ' ' . PHP_BINDIR . '/php -c ' . php_ini_loaded_file() . ' ' . FLOW_PATH_FLOW . 'Scripts/flow.php' . ' --start-slave';
+        $systemCommand = 'FLOW_ROOTPATH=' . FLOW_PATH_ROOT . ' FLOW_PATH_TEMPORARY_BASE=' . FLOW_PATH_TEMPORARY_BASE . ' ' . 'FLOW_CONTEXT=' . $this->bootstrap->getContext() . ' ' . PHP_BINARY . ' -c ' . php_ini_loaded_file() . ' ' . FLOW_PATH_FLOW . 'Scripts/flow.php' . ' --start-slave';
         $descriptorSpecification = [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'a']];
         $subProcess = proc_open($systemCommand, $descriptorSpecification, $pipes);
         if (!is_resource($subProcess)) {

--- a/TYPO3.Flow/Tests/Behavior/Features/Bootstrap/SubProcess/SubProcess.php
+++ b/TYPO3.Flow/Tests/Behavior/Features/Bootstrap/SubProcess/SubProcess.php
@@ -86,7 +86,7 @@ class SubProcess
      */
     protected function launchSubProcess()
     {
-        $systemCommand = 'FLOW_ROOTPATH=' . FLOW_PATH_ROOT . ' FLOW_PATH_TEMPORARY_BASE=' . escapeshellarg(FLOW_PATH_TEMPORARY_BASE) . ' FLOW_CONTEXT=' . (string)$this->context . ' ' . PHP_BINDIR . '/php -c ' . php_ini_loaded_file() . ' ' . FLOW_PATH_FLOW . 'Scripts/flow.php' . ' --start-slave';
+        $systemCommand = 'FLOW_ROOTPATH=' . FLOW_PATH_ROOT . ' FLOW_PATH_TEMPORARY_BASE=' . escapeshellarg(FLOW_PATH_TEMPORARY_BASE) . ' FLOW_CONTEXT=' . (string)$this->context . ' ' . PHP_BINARY . ' -c ' . php_ini_loaded_file() . ' ' . FLOW_PATH_FLOW . 'Scripts/flow.php' . ' --start-slave';
         $descriptorSpecification = [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'a']];
         $this->subProcess = proc_open($systemCommand, $descriptorSpecification, $this->pipes);
         if (!is_resource($this->subProcess)) {


### PR DESCRIPTION
On Windows, the PHP_BINDIR constant will resolve to "C:\php" no matter what the actual php directory is, because this constant is decided at compile time. However, the PHP_BINARY constant will resolve to the current executable that runs the script at runtime, which at least for CLI will be the PHP executable.

This is a backport of #1010