### PR TITLE
BUGFIX: Support proxies forwarding the port in the Forwarded-Host header

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Component/TrustedProxiesComponent.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Component/TrustedProxiesComponent.php
@@ -50,14 +50,21 @@ class TrustedProxiesComponent implements ComponentInterface
         }
 
         $hostHeader = $this->getFirstTrustedProxyHeaderValue(self::HEADER_HOST, $trustedRequest);
+        $portFromHost = null;
         if ($hostHeader !== null) {
+            $portSeparator = strrpos($hostHeader, ':');
+            if ($portSeparator > 0) {
+                $portFromHost = substr($hostHeader, $portSeparator + 1);
+                $trustedRequest->getUri()->setPort($portFromHost);
+                $hostHeader = substr($hostHeader, 0, $portSeparator);
+            }
             $trustedRequest->getUri()->setHost($hostHeader);
         }
 
         $portHeader = $this->getFirstTrustedProxyHeaderValue(self::HEADER_PORT, $trustedRequest);
         if ($portHeader !== null) {
             $trustedRequest->getUri()->setPort($portHeader);
-        } elseif ($protocolHeader !== null) {
+        } elseif ($protocolHeader !== null && $portFromHost === null) {
             $trustedRequest->getUri()->setPort(strtolower($protocolHeader) === 'https' ? 443 : 80);
         }
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Component/TrustedProxiesComponent.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Component/TrustedProxiesComponent.php
@@ -53,7 +53,7 @@ class TrustedProxiesComponent implements ComponentInterface
         $portFromHost = null;
         if ($hostHeader !== null) {
             $portSeparatorIndex = strrpos($hostHeader, ':');
-            if ($portSeparatorIndex > 0) {
+            if ($portSeparatorIndex !== false) {
                 $portFromHost = substr($hostHeader, $portSeparatorIndex + 1);
                 $trustedRequest->getUri()->setPort($portFromHost);
                 $hostHeader = substr($hostHeader, 0, $portSeparatorIndex);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Component/TrustedProxiesComponent.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Component/TrustedProxiesComponent.php
@@ -52,11 +52,11 @@ class TrustedProxiesComponent implements ComponentInterface
         $hostHeader = $this->getFirstTrustedProxyHeaderValue(self::HEADER_HOST, $trustedRequest);
         $portFromHost = null;
         if ($hostHeader !== null) {
-            $portSeparator = strrpos($hostHeader, ':');
-            if ($portSeparator > 0) {
-                $portFromHost = substr($hostHeader, $portSeparator + 1);
+            $portSeparatorIndex = strrpos($hostHeader, ':');
+            if ($portSeparatorIndex > 0) {
+                $portFromHost = substr($hostHeader, $portSeparatorIndex + 1);
                 $trustedRequest->getUri()->setPort($portFromHost);
-                $hostHeader = substr($hostHeader, 0, $portSeparator);
+                $hostHeader = substr($hostHeader, 0, $portSeparatorIndex);
             }
             $trustedRequest->getUri()->setHost($hostHeader);
         }

--- a/TYPO3.Flow/Tests/Unit/Http/Component/TrustedProxiesComponentTest.php
+++ b/TYPO3.Flow/Tests/Unit/Http/Component/TrustedProxiesComponentTest.php
@@ -339,6 +339,46 @@ class TrustedProxiesComponentTest extends UnitTestCase
     }
 
     /**
+     * @test
+     */
+    public function hostIsOverridenIfTheHeaderIsTrusted()
+    {
+        $request = Request::create(new Uri('http://acme.com'), 'GET', array(), array(), array('HTTP_X_FORWARDED_HOST' => 'neos.io'));
+        $trustedRequest = $this->callWithRequest($request);
+        $this->assertEquals('neos.io', $trustedRequest->getUri()->getHost());
+    }
+
+    /**
+     * @test
+     */
+    public function portIsOverridenIfTheHostHeaderContainsPort()
+    {
+        $request = Request::create(new Uri('http://acme.com'), 'GET', array(), array(), array('HTTP_X_FORWARDED_HOST' => 'neos.io:443'));
+        $trustedRequest = $this->callWithRequest($request);
+        $this->assertEquals(443, $trustedRequest->getUri()->getPort());
+    }
+
+    /**
+     * @test
+     */
+    public function portIsOverridenIfTheHostHeaderContainsPortAlsoIfProtocolHeaderIsSet()
+    {
+        $request = Request::create(new Uri('http://acme.com'), 'GET', array(), array(), array('HTTP_X_FORWARDED_HOST' => 'neos.io:443', 'HTTP_X_FORWARDED_PROTO' => 'http'));
+        $trustedRequest = $this->callWithRequest($request);
+        $this->assertEquals(443, $trustedRequest->getUri()->getPort());
+    }
+
+    /**
+     * @test
+     */
+    public function portFromHostHeaderIsOverriddenByPortHeader()
+    {
+        $request = Request::create(new Uri('http://acme.com'), 'GET', array(), array(), array('HTTP_X_FORWARDED_PORT' => 8080, 'HTTP_X_FORWARDED_HOST' => 'neos.io:443'));
+        $trustedRequest = $this->callWithRequest($request);
+        $this->assertEquals(8080, $trustedRequest->getUri()->getPort());
+    }
+
+    /**
      * @return array
      */
     public function forwardHeaderTestsDataProvider()

--- a/TYPO3.Flow/Tests/Unit/Http/Component/TrustedProxiesComponentTest.php
+++ b/TYPO3.Flow/Tests/Unit/Http/Component/TrustedProxiesComponentTest.php
@@ -361,6 +361,16 @@ class TrustedProxiesComponentTest extends UnitTestCase
     /**
      * @test
      */
+    public function portIsOverridenIfTheHostHeaderContainsJustThePort()
+    {
+        $request = Request::create(new Uri('http://acme.com'), 'GET', array(), array(), array('HTTP_X_FORWARDED_HOST' => ':443'));
+        $trustedRequest = $this->callWithRequest($request);
+        $this->assertEquals(443, $trustedRequest->getUri()->getPort());
+    }
+
+    /**
+     * @test
+     */
     public function portIsOverridenIfTheHostHeaderContainsPortAlsoIfProtocolHeaderIsSet()
     {
         $request = Request::create(new Uri('http://acme.com'), 'GET', array(), array(), array('HTTP_X_FORWARDED_HOST' => 'neos.io:443', 'HTTP_X_FORWARDED_PROTO' => 'http'));


### PR DESCRIPTION
Some proxies like apache's mod_proxy set the port from the forwarded
connection in the `X-Forwarded-Host` header, e.g. `acme.com:443`.
This change adjusts the TrustedProxy component to allow setting the
forwarded port inside the Host header.
If the `X-Forwarded-Port` header is also present, that one will take
precedence though.

Fixes #1054