### PR TITLE
BUGFIX: CurlEngine follows chain of Http headers

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Client/CurlEngine.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Client/CurlEngine.php
@@ -148,9 +148,10 @@ class CurlEngine implements RequestEngineInterface
         curl_close($curlHandle);
 
         $response = Http\Response::createFromRaw($curlResult);
-        if ($response->getStatusCode() === 100) {
+        while (substr($response->getContent(), 0, 5) === 'HTTP/' || $response->getStatusCode() === 100) {
             $response = Http\Response::createFromRaw($response->getContent(), $response);
         }
+
         return $response;
     }
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Client/CurlEngine.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Client/CurlEngine.php
@@ -148,8 +148,11 @@ class CurlEngine implements RequestEngineInterface
         curl_close($curlHandle);
 
         $response = Http\Response::createFromRaw($curlResult);
-        while (substr($response->getContent(), 0, 5) === 'HTTP/' || $response->getStatusCode() === 100) {
-            $response = Http\Response::createFromRaw($response->getContent(), $response);
+        try {
+            while (substr($response->getContent(), 0, 5) === 'HTTP/' || $response->getStatusCode() === 100) {
+                $response = Http\Response::createFromRaw($response->getContent(), $response);
+            }
+        } catch (\InvalidArgumentException $e) {
         }
 
         return $response;

--- a/TYPO3.Flow/Tests/Functional/Http/Client/CurlEngineTest.php
+++ b/TYPO3.Flow/Tests/Functional/Http/Client/CurlEngineTest.php
@@ -37,6 +37,19 @@ class CurlEngineTest extends FunctionalTestCase
     }
 
     /**
+     * Check if the curl engine can handle redirects
+     *
+     * @test
+     */
+    public function redirectsAreFollowed()
+    {
+        $this->browser->getRequestEngine()->setOption(CURLOPT_FOLLOWLOCATION, true);
+        $this->browser->setFollowRedirects(false);
+        $response = $this->browser->request('http://www.neos.io');
+        $this->assertStringStartsWith('<!DOCTYPE html>', $response->getContent());
+    }
+
+    /**
      * Check if the Curl Engine can send a GET request to www.neos.io
      *
      * @test


### PR DESCRIPTION
Under some circumstances, curl will return all the headers of the request
chain, for example when the CURLOPT_FOLLOWLOCATION option is set.
This change will make the CurlEngine follow the chain of response headers
until the final response.

Fixes #1044,  #849, #570