### PR TITLE
BUGFIX: Don’t use scalar type hint string for RedisBackend

### DIFF
--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -459,7 +459,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      * @param string $value
      * @return string
      */
-    private function uncompress(string $value): string
+    private function uncompress($value)
     {
         if (empty($value)) {
             return $value;

--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -456,8 +456,10 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
     }
 
     /**
+     *
+     * TODO: No return type declaration for now, as it needs to return false as well.
      * @param string $value
-     * @return string
+     * @return mixed
      */
     private function uncompress($value)
     {


### PR DESCRIPTION
The scalar type hint for `compress()` forced the return value of uncompress() to an emtpy string if there is no value in redis. This has to be false.