### PR TITLE
BUGFIX: Allow file uploads without arguments for value

### DIFF
--- a/Neos.Flow/Classes/Http/Request.php
+++ b/Neos.Flow/Classes/Http/Request.php
@@ -653,11 +653,11 @@ class Request extends BaseRequest implements ServerRequestInterface
             $value['type']
         );
 
-        if (isset($argumentsForValue['originallySubmittedResource'])) {
+        if (empty($argumentsForValue['originallySubmittedResource'])) {
             $file->setOriginallySubmittedResource($argumentsForValue['originallySubmittedResource']);
         }
 
-        if (isset($argumentsForValue['__collectionName'])) {
+        if (empty($argumentsForValue['__collectionName'])) {
             $file->setCollectionName($argumentsForValue['__collectionName']);
         }
 

--- a/Neos.Flow/Classes/Http/Request.php
+++ b/Neos.Flow/Classes/Http/Request.php
@@ -653,11 +653,11 @@ class Request extends BaseRequest implements ServerRequestInterface
             $value['type']
         );
 
-        if ($argumentsForValue['originallySubmittedResource']) {
+        if (isset($argumentsForValue['originallySubmittedResource'])) {
             $file->setOriginallySubmittedResource($argumentsForValue['originallySubmittedResource']);
         }
 
-        if ($argumentsForValue['__collectionName']) {
+        if (isset($argumentsForValue['__collectionName'])) {
             $file->setCollectionName($argumentsForValue['__collectionName']);
         }
 


### PR DESCRIPTION
I created an image upload for our Flow application. After updating Flow, it stopped working, because two array keys do not exist. To fix this error I suggest making these keys optional.

`$argumentsForValue['originallySubmittedResource']` and `$argumentsForValue['__collectionName']` must not exist. The file upload should not break, if these array keys are missing.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch]
