### PR TITLE
BUGFIX: Annotation reader breaks partial index creation

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -232,7 +232,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
                         $index['flags'] = $indexAnnotation->flags;
                     }
                     if (!empty($indexAnnotation->options)) {
-                        $index['options'] = $indexAnnotation->flags;
+                        $index['options'] = $indexAnnotation->options;
                     }
                     if (!empty($indexAnnotation->name)) {
                         $primaryTable['indexes'][$indexAnnotation->name] = $index;


### PR DESCRIPTION
The `FlowAnnotationDriver` uses a wrong property of a loaded `Index` annotation object, preventing partial indexes being created on DB platforms supporting it, and breaking schema generation if there are `flags` specified in the `@ORM\Index` annotation, too.

```
/**
 * @Flow\Entity
 * @ORM\Table(indexes={
 *     @ORM\Index(name="foreignrelation_null_idx", columns={"foreignrelation"}, options={"where":"foreignrelation IS NULL"})
 * })
 */
```

