### PR TITLE
BUGFIX:  Use ``!empty`` instead of ``empty`` in condition

### DIFF
--- a/Neos.Flow/Classes/Http/Request.php
+++ b/Neos.Flow/Classes/Http/Request.php
@@ -653,11 +653,11 @@ class Request extends BaseRequest implements ServerRequestInterface
             $value['type']
         );
 
-        if (empty($argumentsForValue['originallySubmittedResource'])) {
+        if (!empty($argumentsForValue['originallySubmittedResource'])) {
             $file->setOriginallySubmittedResource($argumentsForValue['originallySubmittedResource']);
         }
 
-        if (empty($argumentsForValue['__collectionName'])) {
+        if (!empty($argumentsForValue['__collectionName'])) {
             $file->setCollectionName($argumentsForValue['__collectionName']);
         }
 


### PR DESCRIPTION
**What I did**
Change the condition to ``!empty``, so that NULL-values get catched and will not tried to be set, which causes further errors.

