### PR TITLE
BUGFIX: Annotation reader breaks partial index creation

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -231,7 +231,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
                         $index['flags'] = $indexAnnotation->flags;
                     }
                     if (!empty($indexAnnotation->options)) {
-                        $index['options'] = $indexAnnotation->flags;
+                        $index['options'] = $indexAnnotation->options;
                     }
                     if (!empty($indexAnnotation->name)) {
                         $primaryTable['indexes'][$indexAnnotation->name] = $index;


### PR DESCRIPTION
The `FlowAnnotationDriver` uses a wrong property of a loaded `Index` annotation object, preventing partial indexes being created on DB platforms supporting it.

Retargeted follow-up to #1074