### PR TITLE
TASK: Make PHP-Templates PSR2-compatible

### DIFF
--- a/TYPO3.Kickstart/Resources/Private/Generator/Controller/ActionControllerTemplate.php.tmpl
+++ b/TYPO3.Kickstart/Resources/Private/Generator/Controller/ActionControllerTemplate.php.tmpl
@@ -19,5 +19,4 @@ class {controllerClassName} extends \TYPO3\Flow\Mvc\Controller\ActionController
             'bar', 'baz'
         ));
     }
-
 }

--- a/TYPO3.Kickstart/Resources/Private/Generator/Controller/CommandControllerTemplate.php.tmpl
+++ b/TYPO3.Kickstart/Resources/Private/Generator/Controller/CommandControllerTemplate.php.tmpl
@@ -31,5 +31,4 @@ class {controllerClassName} extends \TYPO3\Flow\Cli\CommandController
     {
         $this->outputLine('You called the example command and passed "%s" as the first argument.', array($requiredArgument));
     }
-
 }

--- a/TYPO3.Kickstart/Resources/Private/Generator/Controller/CrudControllerTemplate.php.tmpl
+++ b/TYPO3.Kickstart/Resources/Private/Generator/Controller/CrudControllerTemplate.php.tmpl
@@ -83,5 +83,4 @@ class {controllerClassName} extends ActionController
         $this->addFlashMessage('Deleted a {modelName -> k:inflect.humanizeCamelCase(lowercase: true)}.');
         $this->redirect('index');
     }
-
 }

--- a/TYPO3.Kickstart/Resources/Private/Generator/Model/EntityTemplate.php.tmpl
+++ b/TYPO3.Kickstart/Resources/Private/Generator/Model/EntityTemplate.php.tmpl
@@ -35,6 +35,5 @@ class {modelName}
     public function set{fieldName -> k:format.ucfirst()}(<f:if condition="{fieldDefinition.typeHint}">{fieldDefinition.typeHint -> f:format.raw()} </f:if>${fieldName})
     {
         $this->{fieldName} = ${fieldName};
-    }
-</f:for>
+    }</f:for>
 }

--- a/TYPO3.Kickstart/Resources/Private/Generator/Repository/RepositoryTemplate.php.tmpl
+++ b/TYPO3.Kickstart/Resources/Private/Generator/Repository/RepositoryTemplate.php.tmpl
@@ -15,5 +15,4 @@ class {repositoryClassName} extends Repository
 {
 
     // add customized methods here
-
 }


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->


The PSR2 standard says: Opening braces for classes MUST go on the next line, and **closing braces MUST go on the next line after the body.**

This is currently not implemented by the Templates and this commit is fixing it.

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
