### PR TITLE
FEATURE: Make fizzle filter operations capable of dealing with arrays

### DIFF
--- a/Neos.Eel/Classes/FlowQuery/Operations/Object/FilterOperation.php
+++ b/Neos.Eel/Classes/FlowQuery/Operations/Object/FilterOperation.php
@@ -42,11 +42,11 @@ use Neos\Utility\TypeHandling;
  * >=
  *   Value is greater than or equal to operand
  * $=
- *   Value ends with operand (string-based)
+ *   Value ends with operand (string-based) or value's last element is equal to operand (array-based)
  * ^=
- *   Value starts with operand (string-based)
+ *   Value starts with operand (string-based) or value's first element is equal to operand (array-based)
  * *=
- *   Value contains operand (string-based)
+ *   Value contains operand (string-based) or value contains an element that is equal to operand (array based)
  * instanceof
  *   Checks if the value is an instance of the operand
  * !instanceof

--- a/Neos.Eel/Classes/FlowQuery/Operations/Object/FilterOperation.php
+++ b/Neos.Eel/Classes/FlowQuery/Operations/Object/FilterOperation.php
@@ -234,11 +234,34 @@ class FilterOperation extends AbstractOperation
             case '>=':
                 return $value >= $operand;
             case '$=':
-                return strrpos($value, $operand) === strlen($value) - strlen($operand);
+                if (is_array($value)) {
+                    if ($this->evaluateOperator(end($value), '=', $operand)) {
+                        return true;
+                    }
+                    return false;
+                } else {
+                    return strrpos($value, $operand) === strlen($value) - strlen($operand);
+                }
             case '^=':
-                return strpos($value, $operand) === 0;
+                if (is_array($value)) {
+                    if ($this->evaluateOperator(reset($value), '=', $operand)) {
+                        return true;
+                    }
+                    return false;
+                } else {
+                    return strpos($value, $operand) === 0;
+                }
             case '*=':
-                return strpos($value, $operand) !== false;
+                if (is_array($value)) {
+                    foreach ($value as $item) {
+                        if ($this->evaluateOperator($item, '=', $operand)) {
+                            return true;
+                        }
+                    }
+                    return false;
+                } else {
+                    return strpos($value, $operand) !== false;
+                }
             case 'instanceof':
                 if ($this->operandIsSimpleType($operand)) {
                     return $this->handleSimpleTypeOperand($operand, $value);

--- a/Neos.Eel/Documentation/README.md
+++ b/Neos.Eel/Documentation/README.md
@@ -24,7 +24,7 @@ Syntax Examples
 * `filter('foo[attribute=bar]')`: object identifier and attribute selectors are both supported.
 * `children('foo').children('bar')`: select the bar object inside the foo object
 * `children('foo[a=b]').children('bar[c=d]')`: select the bar object inside the foo object, but only if the additional attribute matchers fit
-* `filter('[a*= b]')`, `filter('[a^= b]')`, `filter('[a$= b]')`: Substring match, beginning-of-string-match, end-of-string-match
+* `filter('[a*= b]')`, `filter('[a^= b]')`, `filter('[a$= b]')`: Substring match/Array a contains element b, beginning-of-string-match/Array a's first element is equal to b, end-of-string-match/Array a's last element is equal to b
 * `filter('[instanceof foo]')`: select the object if it is instance of foo
 * `filter('[instanceof "foo"]')`: same as above
 * `filter('[attribute instanceof object]')`: Selects an object if it has an attribute `attribute` that is an instance of `object`

--- a/Neos.Eel/Tests/Unit/FlowQuery/FlowQueryTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/FlowQueryTest.php
@@ -88,6 +88,66 @@ class FlowQueryTest extends UnitTestCase
     }
 
     /**
+     * @test
+     */
+    public function filterOperationFiltersArrays()
+    {
+        $myObject = new \stdClass();
+        $myObject->arrayProperty = ['foo','bar','baz'];
+        $myObject2 = new \stdClass();
+        $myObject2->arrayProperty = ['foo','zang','zong'];
+        $myObject3 = new \stdClass();
+        $myObject3->arrayProperty = ['zing','zang','zong'];
+
+        $query = $this->createFlowQuery([$myObject, $myObject2, $myObject3]);
+
+
+        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty *= bar]'));
+        $this->assertSame([$myObject], $query->filter('[arrayProperty *= bar]')->get());
+
+        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty *= foo]'));
+        $this->assertSame([$myObject, $myObject2], $query->filter('[arrayProperty *= foo]')->get());
+
+        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty *= ding]'));
+        $this->assertSame([], $query->filter('[arrayProperty *= ding]')->get());
+
+        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty *= fo]'));
+        $this->assertSame([], $query->filter('[arrayProperty *= fo]')->get());
+
+
+        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty ^= zing]'));
+        $this->assertSame([$myObject3], $query->filter('[arrayProperty ^= zing]')->get());
+
+        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty ^= foo]'));
+        $this->assertSame([$myObject, $myObject2], $query->filter('[arrayProperty ^= foo]')->get());
+
+        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty ^= ding]'));
+        $this->assertSame([], $query->filter('[arrayProperty ^= ding]')->get());
+
+        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty ^= zi]'));
+        $this->assertSame([], $query->filter('[arrayProperty ^= zi]')->get());
+
+        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty ^= bar]'));
+        $this->assertSame([], $query->filter('[arrayProperty ^= bar]')->get());
+
+
+        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty $= baz]'));
+        $this->assertSame([$myObject], $query->filter('[arrayProperty $= baz]')->get());
+
+        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty $= zong]'));
+        $this->assertSame([$myObject2, $myObject3], $query->filter('[arrayProperty $= zong]')->get());
+
+        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty $= ding]'));
+        $this->assertSame([], $query->filter('[arrayProperty $= ding]')->get());
+
+        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty $= az]'));
+        $this->assertSame([], $query->filter('[arrayProperty $= az]')->get());
+
+        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty $= bar]'));
+        $this->assertSame([], $query->filter('[arrayProperty $= bar]')->get());
+    }
+
+    /**
      * @return array
      */
     public function dataProviderForFilter()


### PR DESCRIPTION
This commit amends the implementation for the ``^=``, ``$=`` and ``*=`` fizzle operators by checking if the given property is an array and if so, checking whether the filter matches in the following way:

* ``*=`` matches if the array contains an item that matches the filter string exactly.

* ``^=`` matches if the array's first item matches the filter string exactly.

* ``$=`` matches if the array's last item matches the filter string exactly.

If the given property is not an array the filter operations behave the same way as before.

This commit also contains unit tests for the array-based filter operations with the following test cases:
    * a) one array item matches the filter string with the filter operator -> filter should match
    * b) multiple items match the filter string with the filter operator -> filter should match
    * c) no item matches the filter string with the filter operator -> filter should not match
    * d) a substring of an item would match filter string with the filter operator if it wasn't in an array -> filter should not match
    * e) item would match filter string if different filter operator was used -> filter should not match
