### PR TITLE
BUGFIX: Force PropertyMapper to correctly handle bool in constructor

### DIFF
--- a/Neos.Flow/Classes/Property/PropertyMapper.php
+++ b/Neos.Flow/Classes/Property/PropertyMapper.php
@@ -260,7 +260,7 @@ class PropertyMapper
     {
         $targetClass = TypeHandling::truncateElementType($targetType);
         if (!class_exists($targetClass) && !interface_exists($targetClass)) {
-            throw new Exception\InvalidTargetException(sprintf('Could not find a suitable type converter for "%s" because no such the class/interface "%s" does not exist.', $targetType, $targetClass), 1297948764);
+            throw new Exception\InvalidTargetException(sprintf('Could not find a suitable type converter for "%s" because the class / interface "%s" does not exist.', $targetType, $targetClass), 1297948764);
         }
 
         if (!isset($this->typeConverters[$sourceType])) {
@@ -371,7 +371,7 @@ class PropertyMapper
         } elseif (is_integer($source)) {
             return ['integer'];
         } elseif (is_bool($source)) {
-            return ['boolean'];
+            return ['bool'];
         } elseif (is_object($source)) {
             $class = get_class($source);
             $parentClasses = class_parents($class);

--- a/Neos.Flow/Classes/Property/PropertyMapper.php
+++ b/Neos.Flow/Classes/Property/PropertyMapper.php
@@ -229,8 +229,8 @@ class PropertyMapper
         $truncatedTargetType = TypeHandling::truncateElementType($normalizedTargetType);
         $converter = null;
 
-        $sourceTypes = $this->determineSourceTypes($source);
-        foreach ($sourceTypes as $sourceType) {
+        $normalizedSourceTypes = $this->determineSourceTypes($source);
+        foreach ($normalizedSourceTypes as $sourceType) {
             if (TypeHandling::isSimpleType($truncatedTargetType)) {
                 if (isset($this->typeConverters[$sourceType][$truncatedTargetType])) {
                     $converter = $this->findEligibleConverterWithHighestPriority($this->typeConverters[$sourceType][$truncatedTargetType], $source, $normalizedTargetType);
@@ -244,7 +244,7 @@ class PropertyMapper
             }
         }
 
-        throw new Exception\TypeConverterException('No converter found which can be used to convert from "' . implode('" or "', $sourceTypes) . '" to "' . $normalizedTargetType . '".');
+        throw new Exception\TypeConverterException('No converter found which can be used to convert from "' . implode('" or "', $normalizedSourceTypes) . '" to "' . $normalizedTargetType . '".');
     }
 
     /**
@@ -371,7 +371,7 @@ class PropertyMapper
         } elseif (is_integer($source)) {
             return ['integer'];
         } elseif (is_bool($source)) {
-            return ['bool'];
+            return ['boolean'];
         } elseif (is_object($source)) {
             $class = get_class($source);
             $parentClasses = class_parents($class);

--- a/Neos.Flow/Classes/Property/TypeConverter/ScalarTypeToObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ScalarTypeToObjectConverter.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
 use Neos\Flow\Reflection\ReflectionService;
+use Neos\Utility\TypeHandling;
 
 /**
  * A type converter which converts a scalar type (string, boolean, float or integer) to an object by instantiating
@@ -70,7 +71,7 @@ class ScalarTypeToObjectConverter extends AbstractTypeConverter
             return false;
         }
         $methodParameter = array_shift($methodParameters);
-        return $methodParameter['type'] === gettype($source);
+        return TypeHandling::normalizeType($methodParameter['type']) === gettype($source);
     }
 
     /**

--- a/Neos.Flow/Classes/Property/TypeConverter/StringConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/StringConverter.php
@@ -76,7 +76,7 @@ class StringConverter extends AbstractTypeConverter
     /**
      * @var array<string>
      */
-    protected $sourceTypes = ['string', 'integer', 'float', 'boolean', 'array', \DateTimeInterface::class];
+    protected $sourceTypes = ['string', 'integer', 'float', 'bool', 'array', \DateTimeInterface::class];
 
     /**
      * @var string

--- a/Neos.Flow/Tests/Functional/Property/Fixtures/TestClass.php
+++ b/Neos.Flow/Tests/Functional/Property/Fixtures/TestClass.php
@@ -11,12 +11,10 @@ namespace Neos\Flow\Tests\Functional\Property\Fixtures;
  * source code.
  */
 
-use Doctrine\ORM\Mapping as ORM;
 use Neos\Flow\Tests\Functional\Property\TypeConverter;
 
 /**
  * A simple class for PropertyMapper test
- *
  */
 class TestClass
 {
@@ -34,6 +32,11 @@ class TestClass
      * @var boolean
      */
     protected $signedCla;
+
+    /**
+     * @var bool
+     */
+    protected $signedClaBool;
 
     /**
      * This has no var annotation by intention.
@@ -120,12 +123,29 @@ class TestClass
     }
 
     /**
+     * @return bool
+     */
+    public function getSignedClaBool()
+    {
+        return $this->signedClaBool;
+    }
+
+    /**
      * @param boolean $signedCla
      * @return void
      */
     public function setSignedCla($signedCla)
     {
         $this->signedCla = $signedCla;
+    }
+
+    /**
+     * @param bool $signedClaBool
+     * @return void
+     */
+    public function setSignedClaBool($signedClaBool)
+    {
+        $this->signedClaBool = $signedClaBool;
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/Property/PropertyMapperTest.php
+++ b/Neos.Flow/Tests/Functional/Property/PropertyMapperTest.php
@@ -84,7 +84,8 @@ class PropertyMapperTest extends FunctionalTestCase
         $source = [
             'name' => 'Christopher',
             'size' => '187',
-            'signedCla' => true
+            'signedCla' => true,
+            'signedClaBool' => true
         ];
 
         $result = $this->propertyMapper->convert($source, Fixtures\TestClass::class);

--- a/Neos.Flow/Tests/Unit/Fixtures/ClassWithBoolConstructor.php
+++ b/Neos.Flow/Tests/Unit/Fixtures/ClassWithBoolConstructor.php
@@ -1,0 +1,33 @@
+<?php
+namespace Neos\Flow\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A value object (POPO) with one constructor argument (bool)
+ */
+class ClassWithBoolConstructor
+{
+    /**
+     * @var bool
+     */
+    public $value;
+
+    /**
+     * ClassWithBoolConstructor constructor.
+     *
+     * @param bool $value
+     */
+    public function __construct(bool $value)
+    {
+        $this->value = $value;
+    }
+}

--- a/Neos.Flow/Tests/Unit/Property/PropertyMapperTest.php
+++ b/Neos.Flow/Tests/Unit/Property/PropertyMapperTest.php
@@ -51,7 +51,7 @@ class PropertyMapperTest extends UnitTestCase
             ['someString', ['string']],
             [42, ['integer']],
             [3.5, ['float']],
-            [true, ['bool']],
+            [true, ['boolean']],
             [[], ['array']],
             [new \stdClass(), ['stdClass', 'object']]
         ];

--- a/Neos.Flow/Tests/Unit/Property/PropertyMapperTest.php
+++ b/Neos.Flow/Tests/Unit/Property/PropertyMapperTest.php
@@ -51,7 +51,7 @@ class PropertyMapperTest extends UnitTestCase
             ['someString', ['string']],
             [42, ['integer']],
             [3.5, ['float']],
-            [true, ['boolean']],
+            [true, ['bool']],
             [[], ['array']],
             [new \stdClass(), ['stdClass', 'object']]
         ];

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/StringConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/StringConverterTest.php
@@ -37,7 +37,7 @@ class StringConverterTest extends UnitTestCase
      */
     public function checkMetadata()
     {
-        $this->assertEquals(array('string', 'integer', 'float', 'boolean', 'array', \DateTimeInterface::class), $this->converter->getSupportedSourceTypes(), 'Source types do not match');
+        $this->assertEquals(array('string', 'integer', 'float', 'bool', 'array', \DateTimeInterface::class), $this->converter->getSupportedSourceTypes(), 'Source types do not match');
         $this->assertEquals('string', $this->converter->getSupportedTargetType(), 'Target type does not match');
         $this->assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
     }


### PR DESCRIPTION
**What I did**
Found a bug in the propertymapping when mapping from scalar bool to object. Fixed it in the Typeconverter and added tests 

**How I did it**
Fixed the ScalarTypeToObjectConverter for bool scalar type.

**How to verify it**
A ValueObject with the constructor signature containing `__construct(bool $value)` can be build from a scalar boolean value.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
