### PR TITLE
BUGFIX: Make string-based Fizzle filters treat numbers as strings

### DIFF
--- a/TYPO3.Eel/Classes/TYPO3/Eel/FlowQuery/Operations/Object/FilterOperation.php
+++ b/TYPO3.Eel/Classes/TYPO3/Eel/FlowQuery/Operations/Object/FilterOperation.php
@@ -234,11 +234,11 @@ class FilterOperation extends AbstractOperation
             case '>=':
                 return $value >= $operand;
             case '$=':
-                return strrpos($value, $operand) === strlen($value) - strlen($operand);
+                return strrpos($value, "$operand") === strlen($value) - strlen($operand);
             case '^=':
-                return strpos($value, $operand) === 0;
+                return strpos($value, "$operand") === 0;
             case '*=':
-                return strpos($value, $operand) !== false;
+                return strpos($value, "$operand") !== false;
             case 'instanceof':
                 if ($this->operandIsSimpleType($operand)) {
                     return $this->handleSimpleTypeOperand($operand, $value);

--- a/TYPO3.Eel/Classes/TYPO3/Eel/FlowQuery/Operations/Object/FilterOperation.php
+++ b/TYPO3.Eel/Classes/TYPO3/Eel/FlowQuery/Operations/Object/FilterOperation.php
@@ -234,11 +234,11 @@ class FilterOperation extends AbstractOperation
             case '>=':
                 return $value >= $operand;
             case '$=':
-                return strrpos($value, "$operand") === strlen($value) - strlen($operand);
+                return strrpos($value, (string)$operand) === strlen($value) - strlen($operand);
             case '^=':
-                return strpos($value, "$operand") === 0;
+                return strpos($value, (string)$operand) === 0;
             case '*=':
-                return strpos($value, "$operand") !== false;
+                return strpos($value, (string)$operand) !== false;
             case 'instanceof':
                 if ($this->operandIsSimpleType($operand)) {
                     return $this->handleSimpleTypeOperand($operand, $value);

--- a/TYPO3.Eel/Tests/Unit/FlowQuery/FlowQueryTest.php
+++ b/TYPO3.Eel/Tests/Unit/FlowQuery/FlowQueryTest.php
@@ -356,6 +356,35 @@ class FlowQueryTest extends UnitTestCase
     }
 
     /**
+     * @test
+     */
+    public function filterOperationFiltersNumbersCorrectly()
+    {
+        $myObject = new \stdClass();
+        $myObject->stringProperty = '1foo bar baz2';
+        $myObject2 = new \stdClass();
+        $myObject2->stringProperty = "1zing zang zong";
+        $myObject3 = new \stdClass();
+        $myObject3->stringProperty = "fing', 'fan33g', 'fong";
+        $query = $this->createFlowQuery([$myObject, $myObject2, $myObject3]);
+
+        $this->assertInstanceOf(FlowQuery::class, $query->filter('[stringProperty $= 2]'));
+        $this->assertSame([$myObject], $query->filter('[stringProperty $= 2]')->get());
+
+        $this->assertInstanceOf(FlowQuery::class, $query->filter('[stringProperty *= 33]'));
+        $this->assertSame([$myObject3], $query->filter('[stringProperty *= 33]')->get());
+
+        $this->assertInstanceOf(FlowQuery::class, $query->filter('[stringProperty *= "n33g"]'));
+        $this->assertSame([$myObject3], $query->filter('[stringProperty *= "n33g"]')->get());
+        $filterString = "2";
+        $this->assertInstanceOf(FlowQuery::class, $query->filter("[stringProperty $= " + $filterString + "]"));
+        $this->assertSame([$myObject], $query->filter("[stringProperty $= '2']")->get());
+
+        $this->assertInstanceOf(FlowQuery::class, $query->filter('[stringProperty *= 2]'));
+        $this->assertSame([$myObject], $query->filter('[stringProperty *= 2]')->get());
+    }
+
+    /**
      * @return array
      */
     public function dataProviderForChildrenAndFilterAndProperty()


### PR DESCRIPTION
This fixes #1048 by making sure that `strpos()` recieves two strings instead of a
string and a number in a Fizzle filter operation (`*=`, `^=`, `$=`), making sure that
it will look for the actual number in the string it is comparing the operand to instead
of looking for the char that is represented by the number as a unicode ordinal number.

It does this by casting the variable in which the operand is saved to string where it
is given to the strpos/strrpos function as a parameter.
