### PR TITLE
BUGFIX: The ScalarTypeToObjectConverter should expose boolean instead…

### DIFF
--- a/Neos.Flow/Classes/Property/TypeConverter/ScalarTypeToObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ScalarTypeToObjectConverter.php
@@ -31,7 +31,7 @@ class ScalarTypeToObjectConverter extends AbstractTypeConverter
     /**
      * @var array
      */
-    protected $sourceTypes = ['string', 'integer', 'float', 'bool'];
+    protected $sourceTypes = ['string', 'integer', 'float', 'boolean'];
 
     /**
      * @var string


### PR DESCRIPTION

**What I did**
Fixed the ScalarTypeToObjectConverter to expose boolean as supported sourceType instead of bool
**How I did it**
Used the keyboard
**How to verify it**
The TypeConverter now works for boolean values

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
