### PR TITLE
BUGFIX: Correct use of `void` return type in proxy classes

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Reflection/ReflectionService.php
@@ -1389,15 +1389,13 @@ class ReflectionService
         }
 
         $returnType = $method->getDeclaredReturnType();
-        if ($returnType !== null) {
-            if (!TypeHandling::isSimpleType($returnType) && !in_array($returnType, ['self', 'null', 'callable'])) {
-                $returnType = '\\' . $returnType;
-            }
-            if ($method->isDeclaredReturnTypeNullable()) {
-                $returnType = '?' . $returnType;
-            }
-            $this->classReflectionData[$className][self::DATA_CLASS_METHODS][$methodName][self::DATA_METHOD_DECLARED_RETURN_TYPE] = $returnType;
+        if ($returnType !== null && !in_array($returnType, ['self', 'null', 'callable', 'void']) && !TypeHandling::isSimpleType($returnType)) {
+            $returnType = '\\' . $returnType;
         }
+        if ($method->isDeclaredReturnTypeNullable()) {
+            $returnType = '?' . $returnType;
+        }
+        $this->classReflectionData[$className][self::DATA_CLASS_METHODS][$methodName][self::DATA_METHOD_DECLARED_RETURN_TYPE] = $returnType;
 
         foreach ($method->getParameters() as $parameter) {
             $this->reflectClassMethodParameter($className, $method, $parameter);


### PR DESCRIPTION
As `void` was not on the list of return types that would be
normalized to include a leading backslash in the reflection
data it would be output wrongly in proxy classes and so break
applications that used it.

Fixes: #1065
