### PR TITLE
BUGFIX: Restore XLIFF translation fallback

### DIFF
--- a/Neos.Flow/Classes/I18n/Xliff/Service/XliffFileProvider.php
+++ b/Neos.Flow/Classes/I18n/Xliff/Service/XliffFileProvider.php
@@ -94,11 +94,12 @@ class XliffFileProvider
      */
     public function getMergedFileData($fileId, Locale $locale): array
     {
-        if (!isset($this->files[$fileId][$locale->__toString()])) {
+        if (!isset($this->files[$fileId][(string)$locale])) {
             $parsedData = [
                 'fileIdentifier' => $fileId
             ];
             $localeChain = $this->localizationService->getLocaleChain($locale);
+            // Walk locale chain in reverse, so that translations higher in the chain overwrite fallback translations
             foreach (array_reverse($localeChain) as $localeChainItem) {
                 foreach ($this->packageManager->getActivePackages() as $package) {
                     /** @var PackageInterface $package */
@@ -112,11 +113,11 @@ class XliffFileProvider
             if (is_dir($generalTranslationPath)) {
                 $this->readDirectoryRecursively(FLOW_PATH_DATA . 'Translations', $parsedData, $fileId);
             }
-            $this->files[$fileId][$locale->__toString()] = $parsedData;
+            $this->files[$fileId][(string)$locale] = $parsedData;
             $this->cache->set('translationFiles', $this->files);
         }
 
-        return $this->files[$fileId][$locale->__toString()];
+        return $this->files[$fileId][(string)$locale];
     }
 
     /**

--- a/Neos.Flow/Classes/I18n/Xliff/Service/XliffFileProvider.php
+++ b/Neos.Flow/Classes/I18n/Xliff/Service/XliffFileProvider.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\I18n\Xliff\Service;
 
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\I18n;
 use Neos\Flow\I18n\Locale;
 use Neos\Flow\I18n\Xliff\Model\FileAdapter;
 use Neos\Flow\I18n\Xliff\V12\XliffParser as V12XliffParser;
@@ -33,6 +34,12 @@ class XliffFileProvider
      * @var PackageManagerInterface
      */
     protected $packageManager;
+
+    /**
+     * @Flow\Inject
+     * @var I18n\Service
+     */
+    protected $localizationService;
 
     /**
      * @Flow\Inject
@@ -87,26 +94,29 @@ class XliffFileProvider
      */
     public function getMergedFileData($fileId, Locale $locale): array
     {
-        if (!isset($this->files[$fileId][$locale->getLanguage()])) {
+        if (!isset($this->files[$fileId][$locale->__toString()])) {
             $parsedData = [
                 'fileIdentifier' => $fileId
             ];
-            foreach ($this->packageManager->getActivePackages() as $package) {
-                /** @var PackageInterface $package */
-                $translationPath = $package->getResourcesPath() . $this->xliffBasePath . $locale->getLanguage();
-                if (is_dir($translationPath)) {
-                    $this->readDirectoryRecursively($translationPath, $parsedData, $fileId, $package->getPackageKey());
+            $localeChain = $this->localizationService->getLocaleChain($locale);
+            foreach (array_reverse($localeChain) as $localeChainItem) {
+                foreach ($this->packageManager->getActivePackages() as $package) {
+                    /** @var PackageInterface $package */
+                    $translationPath = $package->getResourcesPath() . $this->xliffBasePath . $localeChainItem;
+                    if (is_dir($translationPath)) {
+                        $this->readDirectoryRecursively($translationPath, $parsedData, $fileId, $package->getPackageKey());
+                    }
                 }
             }
             $generalTranslationPath = FLOW_PATH_DATA . 'Translations';
             if (is_dir($generalTranslationPath)) {
                 $this->readDirectoryRecursively(FLOW_PATH_DATA . 'Translations', $parsedData, $fileId);
             }
-            $this->files[$fileId][$locale->getLanguage()] = $parsedData;
+            $this->files[$fileId][$locale->__toString()] = $parsedData;
             $this->cache->set('translationFiles', $this->files);
         }
 
-        return $this->files[$fileId][$locale->getLanguage()];
+        return $this->files[$fileId][$locale->__toString()];
     }
 
     /**


### PR DESCRIPTION
This modification fixes the translation fallback mechanism and the ability to read regionalized language variants.

Issues fixed:

* Translation fallback did not work. `Neos.Flow.i18n.fallbackRule.order` was ignored when looking for XLIFF files
* When using a regional `Neos.Flow.i18n.defaultLocale` (e.g. `de_AT` for an Austrian version of `de`), XLIFF files were never read from  a directory with the full `defaultLocale` name, but only from the base language directory. In the example, files in `Packages/Application/Vendor.Package/Resources/Private/Translations/de_AT` were never read, only from`Packages/Application/Vendor.Package/Resources/Private/Translations/de`.
