### PR TITLE
BUGFIX: Fix code example in UcfirstViewHelper docblock

### DIFF
--- a/Neos.Kickstarter/Classes/ViewHelpers/Format/UcfirstViewHelper.php
+++ b/Neos.Kickstarter/Classes/ViewHelpers/Format/UcfirstViewHelper.php
@@ -20,7 +20,7 @@ use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
  * = Examples =
  *
  * <code title="Example">
- * {textWithMixedCase -> k:ucfirst()}
+ * {textWithMixedCase -> k:format.ucfirst()}
  * </code>
  *
  * Output:


### PR DESCRIPTION
The example lacks the `format` prefix.
