### PR TITLE
TASK: Add a default .editorconfig

### DIFF
--- a/TYPO3.Flow/Resources/Private/Installer/Distribution/Defaults/.editorconfig
+++ b/TYPO3.Flow/Resources/Private/Installer/Distribution/Defaults/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.php]
+indent_type = space
+indent_size = 4
+
+[*.yaml]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/TYPO3.Flow/Resources/Private/Installer/Distribution/Defaults/.editorconfig
+++ b/TYPO3.Flow/Resources/Private/Installer/Distribution/Defaults/.editorconfig
@@ -5,13 +5,10 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-
-[*.php]
 indent_type = space
 indent_size = 4
 
 [*.yaml]
-indent_type = space
 indent_size = 2
 
 [*.md]

--- a/TYPO3.Flow/Resources/Private/Installer/Distribution/Defaults/.editorconfig
+++ b/TYPO3.Flow/Resources/Private/Installer/Distribution/Defaults/.editorconfig
@@ -11,6 +11,7 @@ indent_type = space
 indent_size = 4
 
 [*.yaml]
+indent_type = space
 indent_size = 2
 
 [*.md]


### PR DESCRIPTION
This introduces a default ``.editorconfig`` file in the root of the freshly created project.

It ensures that php follows the PSR-2 coding-style, yaml gets 2 spaces indentation and md files doesn't trim trailing whitespace.