### PR TITLE
TASK: Fix FlowQuery Tests for PHP 7.1

### DIFF
--- a/TYPO3.Eel/Tests/Unit/FlowQuery/FlowQueryTest.php
+++ b/TYPO3.Eel/Tests/Unit/FlowQuery/FlowQueryTest.php
@@ -376,9 +376,9 @@ class FlowQueryTest extends UnitTestCase
 
         $this->assertInstanceOf(FlowQuery::class, $query->filter('[stringProperty *= "n33g"]'));
         $this->assertSame([$myObject3], $query->filter('[stringProperty *= "n33g"]')->get());
-        $filterString = "2";
-        $this->assertInstanceOf(FlowQuery::class, $query->filter("[stringProperty $= " + $filterString + "]"));
-        $this->assertSame([$myObject], $query->filter("[stringProperty $= '2']")->get());
+
+        $this->assertInstanceOf(FlowQuery::class, $query->filter('[stringProperty $= "2"]'));
+        $this->assertSame([$myObject], $query->filter('[stringProperty $= "2"]')->get());
 
         $this->assertInstanceOf(FlowQuery::class, $query->filter('[stringProperty *= 2]'));
         $this->assertSame([$myObject], $query->filter('[stringProperty *= 2]')->get());


### PR DESCRIPTION
The newly added test in https://github.com/neos/flow-development-collection/pull/1085 made the test fail in PHP 7.1 due to wrongly trying to concat strings with `+`.