### PR TITLE
BUGFIX: FileSystemTarget publishes resources in public root

### DIFF
--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -455,6 +455,7 @@ TYPO3:
           storage: 'defaultStaticResourcesStorage'
           target: 'localWebDirectoryStaticResourcesTarget'
           pathPatterns:
+            - '*/Resources/Public/'
             - '*/Resources/Public/*'
 
         # Collection which contains all persistent resources


### PR DESCRIPTION
Due to the defined resource paths (which are not taken into account
for the FileSystemSymlinkTarget) only files in subdirectories of
the public resource path were published. This change adds the public
path itself and adjusts the PackageStorage to take into account
an empty relative publication path. Additionally does a slight
refactoring to make the whole class easier to follow.

Fixes: #1055
