### PR TITLE
BUGFIX: Normalize scalar type names to the built-in PHP names

### DIFF
--- a/Neos.Utility.ObjectHandling/Classes/TYPO3/Flow/Utility/TypeHandling.php
+++ b/Neos.Utility.ObjectHandling/Classes/TYPO3/Flow/Utility/TypeHandling.php
@@ -76,11 +76,11 @@ abstract class TypeHandling
     public static function normalizeType($type)
     {
         switch ($type) {
-            case 'int':
-                $type = 'integer';
+            case 'integer':
+                $type = 'int';
                 break;
-            case 'bool':
-                $type = 'boolean';
+            case 'boolean':
+                $type = 'bool';
                 break;
             case 'double':
                 $type = 'float';
@@ -108,7 +108,7 @@ abstract class TypeHandling
      */
     public static function isSimpleType($type)
     {
-        return in_array(self::normalizeType($type), ['array', 'string', 'float', 'integer', 'boolean'], true);
+        return in_array(self::normalizeType($type), ['array', 'string', 'float', 'int', 'bool'], true);
     }
 
     /**

--- a/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
@@ -33,7 +33,7 @@ class TypeHandlingTest extends \PHPUnit_Framework_TestCase
      */
     public function parseTypeThrowsExceptionOnInvalidElementTypeHint()
     {
-        TypeHandling::parseType('string<integer>');
+        TypeHandling::parseType('string<int>');
     }
 
     /**
@@ -42,13 +42,18 @@ class TypeHandlingTest extends \PHPUnit_Framework_TestCase
     public function types()
     {
         return [
-            ['int', ['type' => 'integer', 'elementType' => null]],
+            ['integer', ['type' => 'int', 'elementType' => null]],
+            ['int', ['type' => 'int', 'elementType' => null]],
+            ['boolean', ['type' => 'bool', 'elementType' => null]],
+            ['bool', ['type' => 'bool', 'elementType' => null]],
             ['string', ['type' => 'string', 'elementType' => null]],
+            ['boolean', ['type' => 'bool', 'elementType' => null]],
+            ['bool', ['type' => 'bool', 'elementType' => null]],
             ['DateTime', ['type' => 'DateTime', 'elementType' => null]],
             ['TYPO3\Foo\Bar', ['type' => 'TYPO3\Foo\Bar', 'elementType' => null]],
             ['\TYPO3\Foo\Bar', ['type' => 'TYPO3\Foo\Bar', 'elementType' => null]],
             ['\stdClass', ['type' => 'stdClass', 'elementType' => null]],
-            ['array<integer>', ['type' => 'array', 'elementType' => 'integer']],
+            ['array<integer>', ['type' => 'array', 'elementType' => 'int']],
             ['ArrayObject<string>', ['type' => 'ArrayObject', 'elementType' => 'string']],
             ['SplObjectStorage<TYPO3\Foo\Bar>', ['type' => 'SplObjectStorage', 'elementType' => 'TYPO3\Foo\Bar']],
             ['SplObjectStorage<\TYPO3\Foo\Bar>', ['type' => 'SplObjectStorage', 'elementType' => 'TYPO3\Foo\Bar']],
@@ -83,6 +88,8 @@ class TypeHandlingTest extends \PHPUnit_Framework_TestCase
         return [
             ['integer', 'integer'],
             ['int', 'int'],
+            ['boolean', 'boolean'],
+            ['bool', 'bool'],
             ['array', 'array'],
             ['ArrayObject', 'ArrayObject'],
             ['SplObjectStorage', 'SplObjectStorage'],
@@ -119,9 +126,11 @@ class TypeHandlingTest extends \PHPUnit_Framework_TestCase
     public function normalizeTypes()
     {
         return [
-            ['int', 'integer'],
+            ['int', 'int'],
+            ['integer', 'int'],
             ['double', 'float'],
-            ['bool', 'boolean'],
+            ['bool', 'bool'],
+            ['boolean', 'bool'],
             ['string', 'string']
         ];
     }

--- a/TYPO3.Eel/Classes/TYPO3/Eel/FlowQuery/Operations/Object/FilterOperation.php
+++ b/TYPO3.Eel/Classes/TYPO3/Eel/FlowQuery/Operations/Object/FilterOperation.php
@@ -277,9 +277,9 @@ class FilterOperation extends AbstractOperation
             return is_object($value);
         } elseif ($operand === 'string') {
             return is_string($value);
-        } elseif ($operand === 'integer') {
+        } elseif ($operand === 'int') {
             return is_integer($value);
-        } elseif ($operand === 'boolean') {
+        } elseif ($operand === 'bool') {
             return is_bool($value);
         } elseif ($operand === 'float') {
             return is_float($value);

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Property/PropertyMapper.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Property/PropertyMapper.php
@@ -365,9 +365,9 @@ class PropertyMapper
         } elseif (is_float($source)) {
             return ['float'];
         } elseif (is_integer($source)) {
-            return ['integer'];
+            return ['int'];
         } elseif (is_bool($source)) {
-            return ['boolean'];
+            return ['bool'];
         } elseif (is_object($source)) {
             $class = get_class($source);
             $parentClasses = class_parents($class);

--- a/TYPO3.Flow/Tests/Unit/Mvc/Controller/ArgumentTest.php
+++ b/TYPO3.Flow/Tests/Unit/Mvc/Controller/ArgumentTest.php
@@ -255,6 +255,6 @@ class ArgumentTest extends UnitTestCase
     {
         $returnedArgument = $this->simpleValueArgument->setDataType('integer');
         $this->assertSame($this->simpleValueArgument, $returnedArgument, 'The returned argument is not the original argument.');
-        $this->assertSame('integer', $this->simpleValueArgument->getDataType(), 'The got dataType is not the set dataType.');
+        $this->assertSame('int', $this->simpleValueArgument->getDataType(), 'The got dataType is not the set dataType.');
     }
 }

--- a/TYPO3.Flow/Tests/Unit/Property/PropertyMapperTest.php
+++ b/TYPO3.Flow/Tests/Unit/Property/PropertyMapperTest.php
@@ -53,9 +53,9 @@ class PropertyMapperTest extends UnitTestCase
     {
         return [
             ['someString', ['string']],
-            [42, ['integer']],
+            [42, ['int']],
             [3.5, ['float']],
-            [true, ['boolean']],
+            [true, ['bool']],
             [[], ['array']],
             [new \stdClass(), ['stdClass', 'object']]
         ];
@@ -146,17 +146,17 @@ class PropertyMapperTest extends UnitTestCase
                     ]
                 ]], 'array2string,prio10'
             ],
-            ['someStringSource', 'bool', [
+            ['someStringSource', 'boolean', [
                 'string' => [
-                    'boolean' => [
+                    'bool' => [
                         10 => $this->getMockTypeConverter('string2boolean,prio10'),
                         1 => $this->getMockTypeConverter('string2boolean,prio1')
                     ]
                 ]], 'string2boolean,prio10'
             ],
-            ['someStringSource', 'int', [
+            ['someStringSource', 'integer', [
                 'string' => [
-                    'integer' => [
+                    'int' => [
                         10 => $this->getMockTypeConverter('string2integer,prio10'),
                         1 => $this->getMockTypeConverter('string2integer,prio1')
                     ]
@@ -403,8 +403,8 @@ class PropertyMapperTest extends UnitTestCase
             'array' => [
                 'stdClass' => [10 => $this->getMockTypeConverter('array2object', true, $source, 'integer')]
             ],
-            'integer' => [
-                'integer' => [10 => $this->getMockTypeConverter('integer2integer')]
+            'int' => [
+                'int' => [10 => $this->getMockTypeConverter('integer2integer')]
             ]
         ];
         $configuration = new PropertyMappingConfiguration();
@@ -428,8 +428,8 @@ class PropertyMapperTest extends UnitTestCase
             'array' => [
                 'stdClass' => [10 => $this->getMockTypeConverter('array2object', true, $source, 'integer')]
             ],
-            'integer' => [
-                'integer' => [10 => $this->getMockTypeConverter('integer2integer')]
+            'int' => [
+                'int' => [10 => $this->getMockTypeConverter('integer2integer')]
             ]
         ];
         $configuration = new PropertyMappingConfiguration();


### PR DESCRIPTION
This adjusts `TypeHandling::normalizeType()` to return the short
notation (`bool` and `int`) for booleans and integers.
Previously it was the other way around and the short names were
converted to the longer equivalents.

Background:
Because the types were used inconsistently the `PropertyMapper` could
not find the correct type converters. Leading to errors like this one:
https://github.com/neos/neos-development-collection/issues/1732

Fixes: #1106