### PR TITLE
BUGFIX: No longer pick up too much YAML in migration

### DIFF
--- a/TYPO3.Flow/Migrations/Mysql/Version20130319131400.php
+++ b/TYPO3.Flow/Migrations/Mysql/Version20130319131400.php
@@ -167,7 +167,7 @@ class Version20130319131400 extends AbstractMigration
 
         $yamlSource = new \TYPO3\Flow\Configuration\Source\YamlSource();
         foreach ($configurationPathsAndFilenames as $pathAndFilename) {
-            if (preg_match('%Packages/.+/([^/]+)/Configuration/(?:Development|Production|Policy).+%', $pathAndFilename, $matches) === 0) {
+            if (preg_match('%Packages/[^/]+/([^/]+)/Configuration/(?:Development/|Production/)?[^/]+%', $pathAndFilename, $matches) === 0) {
                 continue;
             };
             $packageKey = $matches[1];

--- a/TYPO3.Flow/Migrations/Postgresql/Version20130319131500.php
+++ b/TYPO3.Flow/Migrations/Postgresql/Version20130319131500.php
@@ -169,7 +169,7 @@ class Version20130319131500 extends AbstractMigration
 
         $yamlSource = new \TYPO3\Flow\Configuration\Source\YamlSource();
         foreach ($configurationPathsAndFilenames as $pathAndFilename) {
-            if (preg_match('%Packages/.+/([^/]+)/Configuration/(?:Development|Production|Policy).+%', $pathAndFilename, $matches) === 0) {
+            if (preg_match('%Packages/[^/]+/([^/]+)/Configuration/(?:Development/|Production/)?[^/]+%', $pathAndFilename, $matches) === 0) {
                 continue;
             };
             $packageKey = $matches[1];


### PR DESCRIPTION
The migration to adjust Role persistence reads YAML files to learn
about existing roles. It picked up "too much" sometimes, which would
lead to errors, e.g. if some YAML could not be parsed but was not at
all relevant for the task.

This change makes the check on the path of found files stricter to
avoid that.
