### PR TITLE
BUGFIX: Allow TypeConverters to use the short name for bool and int

### DIFF
--- a/Neos.Flow/Classes/Property/PropertyMapper.php
+++ b/Neos.Flow/Classes/Property/PropertyMapper.php
@@ -229,8 +229,8 @@ class PropertyMapper
         $truncatedTargetType = TypeHandling::truncateElementType($normalizedTargetType);
         $converter = null;
 
-        $sourceTypes = $this->determineSourceTypes($source);
-        foreach ($sourceTypes as $sourceType) {
+        $normalizedSourceTypes = $this->determineSourceTypes($source);
+        foreach ($normalizedSourceTypes as $sourceType) {
             if (TypeHandling::isSimpleType($truncatedTargetType)) {
                 if (isset($this->typeConverters[$sourceType][$truncatedTargetType])) {
                     $converter = $this->findEligibleConverterWithHighestPriority($this->typeConverters[$sourceType][$truncatedTargetType], $source, $normalizedTargetType);
@@ -244,7 +244,7 @@ class PropertyMapper
             }
         }
 
-        throw new Exception\TypeConverterException('No converter found which can be used to convert from "' . implode('" or "', $sourceTypes) . '" to "' . $normalizedTargetType . '".');
+        throw new Exception\TypeConverterException('No converter found which can be used to convert from "' . implode('" or "', $normalizedSourceTypes) . '" to "' . $normalizedTargetType . '".');
     }
 
     /**
@@ -260,7 +260,7 @@ class PropertyMapper
     {
         $targetClass = TypeHandling::truncateElementType($targetType);
         if (!class_exists($targetClass) && !interface_exists($targetClass)) {
-            throw new Exception\InvalidTargetException(sprintf('Could not find a suitable type converter for "%s" because no such the class/interface "%s" does not exist.', $targetType, $targetClass), 1297948764);
+            throw new Exception\InvalidTargetException(sprintf('Could not find a suitable type converter for "%s" because the class / interface "%s" does not exist.', $targetType, $targetClass), 1297948764);
         }
 
         if (!isset($this->typeConverters[$sourceType])) {
@@ -395,12 +395,15 @@ class PropertyMapper
         $typeConverterMap = [];
         $typeConverterClassNames = static::getTypeConverterImplementationClassNames($this->objectManager);
         foreach ($typeConverterClassNames as $typeConverterClassName) {
+            /** @var TypeConverterInterface $typeConverter */
             $typeConverter = $this->objectManager->get($typeConverterClassName);
             foreach ($typeConverter->getSupportedSourceTypes() as $supportedSourceType) {
-                if (isset($typeConverterMap[$supportedSourceType][$typeConverter->getSupportedTargetType()][$typeConverter->getPriority()])) {
-                    throw new Exception\DuplicateTypeConverterException('There exist at least two converters which handle the conversion from "' . $supportedSourceType . '" to "' . $typeConverter->getSupportedTargetType() . '" with priority "' . $typeConverter->getPriority() . '": ' . $typeConverterMap[$supportedSourceType][$typeConverter->getSupportedTargetType()][$typeConverter->getPriority()] . ' and ' . get_class($typeConverter), 1297951378);
+                $normalizedSourceType = TypeHandling::normalizeType($supportedSourceType);
+                $normalizedTargetType = TypeHandling::normalizeType($typeConverter->getSupportedTargetType());
+                if (isset($typeConverterMap[$normalizedSourceType][$normalizedTargetType][$typeConverter->getPriority()])) {
+                    throw new Exception\DuplicateTypeConverterException('There exist at least two converters which handle the conversion from "' . $supportedSourceType . '" to "' . $normalizedTargetType . '" with priority "' . $typeConverter->getPriority() . '": ' . $typeConverterMap[$supportedSourceType][$normalizedTargetType][$typeConverter->getPriority()] . ' and ' . get_class($typeConverter), 1297951378);
                 }
-                $typeConverterMap[$supportedSourceType][$typeConverter->getSupportedTargetType()][$typeConverter->getPriority()] = $typeConverterClassName;
+                $typeConverterMap[$normalizedSourceType][$normalizedTargetType][$typeConverter->getPriority()] = $typeConverterClassName;
             }
         }
 

--- a/Neos.Flow/Classes/Property/TypeConverter/ScalarTypeToObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ScalarTypeToObjectConverter.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
 use Neos\Flow\Reflection\ReflectionService;
+use Neos\Utility\TypeHandling;
 
 /**
  * A type converter which converts a scalar type (string, boolean, float or integer) to an object by instantiating
@@ -70,7 +71,7 @@ class ScalarTypeToObjectConverter extends AbstractTypeConverter
             return false;
         }
         $methodParameter = array_shift($methodParameters);
-        return $methodParameter['type'] === gettype($source);
+        return TypeHandling::normalizeType($methodParameter['type']) === gettype($source);
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/Property/Fixtures/BoolToIntConverter.php
+++ b/Neos.Flow/Tests/Functional/Property/Fixtures/BoolToIntConverter.php
@@ -1,0 +1,50 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Property\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Error\Messages\Error;
+use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+use Neos\Flow\Property\TypeConverter\AbstractTypeConverter;
+
+class BoolToIntConverter extends AbstractTypeConverter
+{
+    /**
+     * NOTE: Using the short version "bool" instead of "boolean" on purpose!
+     *
+     * @var array
+     */
+    protected $sourceTypes = ['bool'];
+
+    /**
+     * NOTE: Using the short version "int" instead of "integer" on purpose!
+     *
+     * @var string
+     */
+    protected $targetType = 'int';
+
+    /**
+     * @var int
+     */
+    protected $priority = 10;
+
+    /**
+     * @param mixed $source
+     * @param string $targetType
+     * @param array $convertedChildProperties
+     * @param PropertyMappingConfigurationInterface|null $configuration
+     * @return bool|Error
+     */
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    {
+        return $source ? 42 : -42;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Property/Fixtures/TestClass.php
+++ b/Neos.Flow/Tests/Functional/Property/Fixtures/TestClass.php
@@ -11,12 +11,10 @@ namespace Neos\Flow\Tests\Functional\Property\Fixtures;
  * source code.
  */
 
-use Doctrine\ORM\Mapping as ORM;
 use Neos\Flow\Tests\Functional\Property\TypeConverter;
 
 /**
  * A simple class for PropertyMapper test
- *
  */
 class TestClass
 {
@@ -34,6 +32,11 @@ class TestClass
      * @var boolean
      */
     protected $signedCla;
+
+    /**
+     * @var bool
+     */
+    protected $signedClaBool;
 
     /**
      * This has no var annotation by intention.
@@ -120,12 +123,29 @@ class TestClass
     }
 
     /**
+     * @return bool
+     */
+    public function getSignedClaBool()
+    {
+        return $this->signedClaBool;
+    }
+
+    /**
      * @param boolean $signedCla
      * @return void
      */
     public function setSignedCla($signedCla)
     {
         $this->signedCla = $signedCla;
+    }
+
+    /**
+     * @param bool $signedClaBool
+     * @return void
+     */
+    public function setSignedClaBool($signedClaBool)
+    {
+        $this->signedClaBool = $signedClaBool;
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/Property/PropertyMapperTest.php
+++ b/Neos.Flow/Tests/Functional/Property/PropertyMapperTest.php
@@ -84,7 +84,8 @@ class PropertyMapperTest extends FunctionalTestCase
         $source = [
             'name' => 'Christopher',
             'size' => '187',
-            'signedCla' => true
+            'signedCla' => true,
+            'signedClaBool' => true
         ];
 
         $result = $this->propertyMapper->convert($source, Fixtures\TestClass::class);
@@ -438,5 +439,14 @@ class PropertyMapperTest extends FunctionalTestCase
 
         $this->assertNull($defaultConfiguration->getConfigurationFor('foo')->getConfigurationValue(\Neos\Flow\Property\TypeConverter\PersistentObjectConverter::class, \Neos\Flow\Property\TypeConverter\PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED));
         $this->assertNull($defaultConfiguration->getConfigurationFor('foo')->getConfigurationValue(\Neos\Flow\Property\TypeConverter\PersistentObjectConverter::class, \Neos\Flow\Property\TypeConverter\PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED));
+    }
+
+    /**
+     * @test
+     */
+    public function foo()
+    {
+        $actualResult = $this->propertyMapper->convert(true, 'int');
+        $this->assertSame(42, $actualResult);
     }
 }

--- a/Neos.Flow/Tests/Unit/Fixtures/ClassWithBoolConstructor.php
+++ b/Neos.Flow/Tests/Unit/Fixtures/ClassWithBoolConstructor.php
@@ -1,0 +1,33 @@
+<?php
+namespace Neos\Flow\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A value object (POPO) with one constructor argument (bool)
+ */
+class ClassWithBoolConstructor
+{
+    /**
+     * @var bool
+     */
+    public $value;
+
+    /**
+     * ClassWithBoolConstructor constructor.
+     *
+     * @param bool $value
+     */
+    public function __construct(bool $value)
+    {
+        $this->value = $value;
+    }
+}


### PR DESCRIPTION
This re-applies the original fix (#1083) with some adjustments
in order to prevent regressions:

* The `StringConverter` is no longer incorrectly adjusted
* The `PropertyMapper` now normalizes source and target types
  to build the "typeConverterMap"

As a result, TypeConverters can now specify short and long version
in the source/target type definition.

Background:

The original fix was mainly an adjustment to `ScalarTypeToObjectConverter`
to normalize the constructor param type in order to allow simple types
to be mapped to classes with a single `bool` or `int` constructor argument.
But it also adjusted the `StringConverter` breaking the Neos export (see
neos/neos-development-collection#1732).

Credits to @monofone for the original patch!

Related: #1083
Related: #1109