### PR TITLE
BUGFIX: Allow using a unix socket for mysql connection

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/EntityManagerFactory.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/EntityManagerFactory.php
@@ -126,7 +126,7 @@ class EntityManagerFactory
         $config->setAutoGenerateProxyClasses(false);
 
         // Set default host to 127.0.0.1 if there is no host configured but a dbname
-        if (empty($this->settings['backendOptions']['host']) && !empty($this->settings['backendOptions']['dbname'])) {
+        if (empty($this->settings['backendOptions']['host']) && !empty($this->settings['backendOptions']['dbname']) && empty($this->settings['backendOptions']['unix_socket'])) {
             $this->settings['backendOptions']['host'] = '127.0.0.1';
         }
 


### PR DESCRIPTION
When specifying a unix socket for mysql connection, no host parameter must be given. As the code enforces a default value for host connection parameter, this simply adds a check to skip this if a unix socket is configured.