### PR TITLE
BUGFIX: Remove broken assets w/o executing usage checks (``flow resource:clean``)

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Command/ResourceCommandController.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Command/ResourceCommandController.php
@@ -270,7 +270,7 @@ class ResourceCommandController extends CommandController
                         $this->resourceRepository->remove($resource);
                         if (isset($relatedAssets[$resource])) {
                             foreach ($relatedAssets[$resource] as $asset) {
-                                $assetRepository->remove($asset);
+                                $assetRepository->removeWithoutUsageChecks($asset);
                                 $brokenAssetCounter++;
                             }
                         }


### PR DESCRIPTION
**What I did**

`./flow resource:clean` was broken (`Call to a member function getName() on null`) because it could not remove a resource that referenced a file that didn't exist -> ends up in an exception.

**How I did it**

`AssetRepository.removeWithoutUsageChecks()` was introduced in Neos 2.3/Flow 3.3.