### PR TITLE
FEATURE: Add PHPs json_encode options to stringify eel helper

### DIFF
--- a/Neos.Eel/Classes/Helper/JsonHelper.php
+++ b/Neos.Eel/Classes/Helper/JsonHelper.php
@@ -24,6 +24,10 @@ class JsonHelper implements ProtectedContextAwareInterface
     /**
      * JSON encode the given value
      *
+     * Usage example for options:
+     *
+     * Json.stringify(value, ['JSON_UNESCAPED_UNICODE', 'JSON_FORCE_OBJECT'])
+     *
      * @param mixed $value
      * @param array $options Array of option constant names as strings
      * @return string

--- a/Neos.Eel/Classes/Helper/JsonHelper.php
+++ b/Neos.Eel/Classes/Helper/JsonHelper.php
@@ -25,11 +25,13 @@ class JsonHelper implements ProtectedContextAwareInterface
      * JSON encode the given value
      *
      * @param mixed $value
+     * @param array $options Array of option constant names as strings
      * @return string
      */
-    public function stringify($value)
+    public function stringify($value, array $options = []): string
     {
-        return json_encode($value);
+        $optionSum = array_sum(array_map('constant', $options));
+        return json_encode($value, $optionSum);
     }
 
     /**


### PR DESCRIPTION
This feature adds the possibility to pass option constants to the Json.stringify Eel helper. This is needed for example if you want to have unescaped UTF8 characters in the output.

The usage looks like this:

    @process.jsonStringify = ${Json.stringify(value, ['JSON_UNESCAPED_UNICODE', 'JSON_FORCE_OBJECT'])}

It may look a bit weird on the first look to pass PHP options to a Javascript-like function. But its a PHP method in the end that does the encoding, so the PHP constants are the right options here. 