### PR TITLE
BUGFIX: Check for valid session identifier before accessing the cache

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Session/Session.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Session/Session.php
@@ -320,7 +320,11 @@ class Session implements SessionInterface
         if ($this->sessionCookie === null || $this->request === null || $this->started === true) {
             return false;
         }
-        $sessionMetaData = $this->metaDataCache->get($this->sessionCookie->getValue());
+        $sessionIdentifier = $this->sessionCookie->getValue();
+        if ($this->metaDataCache->isValidEntryIdentifier($sessionIdentifier) === false) {
+            return false;
+        }
+        $sessionMetaData = $this->metaDataCache->get($sessionIdentifier);
         if ($sessionMetaData === false) {
             return false;
         }


### PR DESCRIPTION
Currently it is possible to change the cookie value of `Neos_Flow_Session` (`TYPO3_Flow_Session`) to an invalid cache identifier. This leads to an `InvalidArgumentException` and an error code 500. 
This pull requests checks the validity of the session identifier before attempting to access the `metaDataCache`.