### PR TITLE
BUGFIX: Cast objects to string in HTTP headers

### DIFF
--- a/Neos.Flow/Classes/Http/Headers.php
+++ b/Neos.Flow/Classes/Http/Headers.php
@@ -110,8 +110,8 @@ class Headers
             $date = clone $values;
             $date->setTimezone(new \DateTimeZone('GMT'));
             $values = [$date->format('D, d M Y H:i:s') . ' GMT'];
-        } else {
-            $values = (array) $values;
+        } elseif (!is_array($values)) {
+            $values = [$values];
         }
 
         switch ($name) {

--- a/Neos.Flow/Tests/Unit/Fixtures/ClassWithBoolConstructor.php
+++ b/Neos.Flow/Tests/Unit/Fixtures/ClassWithBoolConstructor.php
@@ -30,4 +30,9 @@ class ClassWithBoolConstructor
     {
         $this->value = $value;
     }
+
+    public function __toString()
+    {
+        return $this->value ? 'TRUE' : 'FALSE';
+    }
 }


### PR DESCRIPTION
This adjusts `Headers::set()` so that it accepts arbitrary
objects and casts them to string when rendering the header.

Previously all values where casted to an `array` (unless
they are an instance of `\DateTimeInterface`) leading to
PHP errors when passing in other objects.