### PR TITLE
TASK: Revert changed return type of `UriBuilder`-resolved URIs

### DIFF
--- a/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
+++ b/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
@@ -17,7 +17,6 @@ use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\RequestInterface;
 use Neos\Flow\Mvc\Routing\Dto\ResolveContext;
 use Neos\Utility\Arrays;
-use Psr\Http\Message\UriInterface;
 
 /**
  * An URI Builder
@@ -340,7 +339,7 @@ class UriBuilder
      * Builds the URI
      *
      * @param array $arguments optional URI arguments. Will be merged with $this->arguments with precedence to $arguments
-     * @return UriInterface
+     * @return string the (absolute or relative) URI as string
      * @api
      */
     public function build(array $arguments = [])
@@ -359,7 +358,7 @@ class UriBuilder
         }
 
         $this->lastArguments = $arguments;
-        return $resolvedUri;
+        return (string)$resolvedUri;
     }
 
     /**

--- a/Neos.Flow/Classes/Security/Authentication/EntryPoint/WebRedirect.php
+++ b/Neos.Flow/Classes/Security/Authentication/EntryPoint/WebRedirect.php
@@ -61,7 +61,7 @@ class WebRedirect extends AbstractEntryPoint
 
         $response->setContent(sprintf('<html><head><meta http-equiv="refresh" content="0;url=%s"/></head></html>', htmlentities($uri, ENT_QUOTES, 'utf-8')));
         $response->setStatus(303);
-        $response->setHeader('Location', (string) $uri);
+        $response->setHeader('Location', $uri);
     }
 
     /**


### PR DESCRIPTION
This partly reverts #1126 by casting the resolved URI so that
`UriBuilder::uriFor()` and `UriBuilder::build()` returns a
`string` again rather than an instance of `UriInterface`.

Background:
Even though `UriInterface` is mostly casted to a string implicitly,
this change was considered "too dangerous" for a minor release
because it breaks code that relies on the previous return type
(i.e. when serializing the resolved URI).

For the next major release we can re-consider this change.

Related: #1120