### PR TITLE
TASK: Revert some accidental doc comment changes

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethod.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethod.php
@@ -131,7 +131,7 @@ class ProxyMethod
     /**
      * Sets the (exact) code which use used in as the parameters signature for this method.
      *
-     * @param string $code RouteParameters code, for example: '$foo, array $bar, \Foo\Bar\Baz $baz'
+     * @param string $code Parameters code, for example: '$foo, array $bar, \Foo\Bar\Baz $baz'
      * @return void
      */
     public function setMethodParametersCode($code)

--- a/Neos.Flow/Classes/Reflection/ClassReflection.php
+++ b/Neos.Flow/Classes/Reflection/ClassReflection.php
@@ -166,7 +166,7 @@ class ClassReflection extends \ReflectionClass
     /**
      * Returns an array of tags and their values
      *
-     * @return array RouteTags and values
+     * @return array Tags and values
      */
     public function getTagsValues()
     {

--- a/Neos.Flow/Classes/Reflection/MethodReflection.php
+++ b/Neos.Flow/Classes/Reflection/MethodReflection.php
@@ -66,7 +66,7 @@ class MethodReflection extends \ReflectionMethod
     /**
      * Returns an array of tags and their values
      *
-     * @return array RouteTags and values
+     * @return array Tags and values
      */
     public function getTagsValues()
     {

--- a/Neos.Flow/Classes/Reflection/PropertyReflection.php
+++ b/Neos.Flow/Classes/Reflection/PropertyReflection.php
@@ -58,7 +58,7 @@ class PropertyReflection extends \ReflectionProperty
     /**
      * Returns an array of tags and their values
      *
-     * @return array RouteTags and values
+     * @return array Tags and values
      */
     public function getTagsValues()
     {

--- a/Neos.Flow/Classes/Session/Session.php
+++ b/Neos.Flow/Classes/Session/Session.php
@@ -482,7 +482,7 @@ class Session implements SessionInterface
     }
 
     /**
-     * RouteTags this session with the given tag.
+     * Tags this session with the given tag.
      *
      * Note that third-party libraries might also tag your session. Therefore it is
      * recommended to use namespaced tags such as "Acme-Demo-MySpecialTag".

--- a/Neos.Flow/Classes/Session/SessionInterface.php
+++ b/Neos.Flow/Classes/Session/SessionInterface.php
@@ -90,7 +90,7 @@ interface SessionInterface
     public function putData($key, $data);
 
     /**
-     * RouteTags this session with the given tag.
+     * Tags this session with the given tag.
      *
      * Note that third-party libraries might also tag your session. Therefore it is
      * recommended to use namespaced tags such as "Acme-Demo-MySpecialTag".

--- a/Neos.Flow/Classes/Session/TransientSession.php
+++ b/Neos.Flow/Classes/Session/TransientSession.php
@@ -241,7 +241,7 @@ class TransientSession implements SessionInterface
     }
 
     /**
-     * RouteTags this session with the given tag.
+     * Tags this session with the given tag.
      *
      * Note that third-party libraries might also tag your session. Therefore it is
      * recommended to use namespaced tags such as "Acme-Demo-MySpecialTag".


### PR DESCRIPTION
This is a (cosmetic) follow-up to #1126 reverting some
doc comment changes that were introduced by accident.

Related: #1120