### PR TITLE
BUGFIX: Adjust order of constant initializing in bootstrap process

### DIFF
--- a/Neos.Flow/Classes/Core/Bootstrap.php
+++ b/Neos.Flow/Classes/Core/Bootstrap.php
@@ -88,9 +88,6 @@ class Bootstrap
         $this->context = new ApplicationContext($context);
         $this->earlyInstances[__CLASS__] = $this;
         $this->earlyInstances[\Composer\Autoload\ClassLoader::class] = $composerAutoloader;
-
-        $this->defineConstants();
-        $this->ensureRequiredEnvironment();
     }
 
     /**
@@ -102,6 +99,9 @@ class Bootstrap
      */
     public function run()
     {
+        $this->defineConstants();
+        $this->ensureRequiredEnvironment();
+
         Scripts::initializeClassLoader($this);
         Scripts::initializeSignalSlot($this);
         Scripts::initializePackageManagement($this);

--- a/Neos.Flow/Scripts/PhpDevelopmentServerRouter.php
+++ b/Neos.Flow/Scripts/PhpDevelopmentServerRouter.php
@@ -11,6 +11,8 @@ if (strpos($_SERVER['REQUEST_URI'], '_Resources/') !== false) {
 }
 
 require(__DIR__. '/../Classes/Core/Bootstrap.php');
+$context = \Neos\Flow\Core\Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT') ?: 'Development';
+$bootstrap = new \Neos\Flow\Core\Bootstrap($context);
 
 define('FLOW_PATH_ROOT', Files::getUnixStylePath(realpath(__DIR__ . '/../../../../')) . '/');
 
@@ -21,8 +23,4 @@ $_SERVER['SCRIPT_NAME'] = '/index.php';
 // we want to have nice URLs
 putenv('FLOW_REWRITEURLS=1');
 
-
-
-$context = \Neos\Flow\Core\Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT') ?: 'Development';
-$bootstrap = new \Neos\Flow\Core\Bootstrap($context);
 $bootstrap->run();


### PR DESCRIPTION
The definition of the constants is moved to the run() method in the bootstrap
to allow predefinition of constants after creating the bootstrap instance.
This is needed  wich since the autoloader is created in bootstrap  constructor.
The autoloader in turn is needed for the calculation of constants in the DevelopmentServerRouter.
