### PR TITLE
BUGFIX: Flow server init should not rely on Files utility

### DIFF
--- a/Neos.Flow/Scripts/PhpDevelopmentServerRouter.php
+++ b/Neos.Flow/Scripts/PhpDevelopmentServerRouter.php
@@ -1,6 +1,4 @@
 <?php
-use Neos\Utility\Files;
-
 /**
  * Entry Point (Router) for PHP's embedded HTTP server. Use ./flow server:run to execute.
  */
@@ -12,16 +10,26 @@ if (strpos($_SERVER['REQUEST_URI'], '_Resources/') !== false) {
 
 require(__DIR__. '/../Classes/Core/Bootstrap.php');
 
-define('FLOW_PATH_ROOT', Files::getUnixStylePath(realpath(__DIR__ . '/../../../../')) . '/');
+if (DIRECTORY_SEPARATOR !== '/' && trim(getenv('FLOW_ROOTPATH'), '"\' ') === '') {
+    $absoluteRootpath = dirname(realpath(__DIR__ . '/../../../'));
+    if (realpath(getcwd()) === $absoluteRootpath) {
+        $_SERVER['FLOW_ROOTPATH'] = '.';
+    } elseif (strlen(getcwd()) > strlen($absoluteRootpath)) {
+        $amountOfPathsToSkipBack = substr_count(getcwd(), DIRECTORY_SEPARATOR) - substr_count($absoluteRootpath, DIRECTORY_SEPARATOR);
+        $_SERVER['FLOW_ROOTPATH'] = implode('/', array_fill(0, $amountOfPathsToSkipBack, '..'));
+    } else {
+        $_SERVER['FLOW_ROOTPATH'] = substr($absoluteRootpath, strlen(getcwd()) + 1);
+    }
+} else {
+    $_SERVER['FLOW_ROOTPATH'] = trim(getenv('FLOW_ROOTPATH'), '"\' ') ?: dirname($_SERVER['PHP_SELF']);
+}
 
 // Script filename and script name must "emulate" index.php, to not break routing
-$_SERVER['SCRIPT_FILENAME'] = FLOW_PATH_ROOT . 'Web/index.php';
+$_SERVER['SCRIPT_FILENAME'] = $_SERVER['FLOW_ROOTPATH'] . 'Web/index.php';
 $_SERVER['SCRIPT_NAME'] = '/index.php';
 
 // we want to have nice URLs
 putenv('FLOW_REWRITEURLS=1');
-
-
 
 $context = \Neos\Flow\Core\Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT') ?: 'Development';
 $bootstrap = new \Neos\Flow\Core\Bootstrap($context);


### PR DESCRIPTION
Removes usage of Files utility in ``PhpDevelopmentServerRouter.php``
in favor of the same code to determine the root of the installation
which is used in the command line init ``flow.php``.
