### PR TITLE
BUGFIX: Tag routes with UUIDs of entities in route values

### DIFF
--- a/Neos.Flow/Classes/Mvc/Routing/RouterCachingService.php
+++ b/Neos.Flow/Classes/Mvc/Routing/RouterCachingService.php
@@ -146,7 +146,7 @@ class RouterCachingService
         }
 
         $cacheIdentifier = $this->buildResolveCacheIdentifier($resolveContext, $routeValues);
-        $tags = $this->generateRouteTags($uriConstraints->getPathConstraint(), $resolveContext->getRouteValues());
+        $tags = $this->generateRouteTags($uriConstraints->getPathConstraint(), $routeValues);
         if ($resolvedTags !== null) {
             $tags = array_unique(array_merge($resolvedTags->getTags(), $tags));
         }

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/RouterCachingServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/RouterCachingServiceTest.php
@@ -294,6 +294,24 @@ class RouterCachingServiceTest extends UnitTestCase
     /**
      * @test
      */
+    public function storeResolvedUriConstraintsConvertsObjectsToHashesToGenerateRouteTags()
+    {
+        $mockUuid = '550e8400-e29b-11d4-a716-446655440000';
+        $mockObject = new \stdClass();
+        $routeValues = ['b' => 'route values', 'someObject' => $mockObject];
+        $cacheIdentifier = 'e56bffd69837730b19089d3cf1eb7af9';
+
+        $this->mockPersistenceManager->expects($this->once())->method('getIdentifierByObject')->with($mockObject)->will($this->returnValue($mockUuid));
+
+        $resolvedUriConstraints = UriConstraints::create()->withPath('path');
+        $this->mockResolveCache->expects($this->once())->method('set')->with($cacheIdentifier, $resolvedUriConstraints, [$mockUuid, md5('path')]);
+
+        $this->routerCachingService->storeResolvedUriConstraints(new ResolveContext($this->mockUri, $routeValues, false), $resolvedUriConstraints);
+    }
+
+    /**
+     * @test
+     */
     public function storeResolvedUriConstraintsExtractsUuidsToCacheTags()
     {
         $uuid1 = '550e8400-e29b-11d4-a716-446655440000';


### PR DESCRIPTION
This is a follow up to #1126 fixing the automatic tagging of
routes in `RouterCachingService::storeResolvedUriConstraints()` that
no longer included the UUIDs of entities in route values.

Related: #1120