### PR TITLE
TASK: Correct expected/actual order in assertion

### DIFF
--- a/Neos.Flow/Tests/Functional/Security/AuthenticationTest.php
+++ b/Neos.Flow/Tests/Functional/Security/AuthenticationTest.php
@@ -135,7 +135,10 @@ class AuthenticationTest extends FunctionalTestCase
         $request = Request::create($uri);
         $request->setHeader('Authorization', 'Basic ' . base64_encode('functional_test_account:a_very_secure_long_password'));
         $response = $this->browser->sendRequest($request);
-        $this->assertSame($response->getContent(), 'HttpBasicTestController success!' . chr(10) . 'Neos.Flow:Everybody' . chr(10) . 'Neos.Flow:AuthenticatedUser' . chr(10) . 'Neos.Flow:Administrator' . chr(10));
+        $this->assertSame(
+            'HttpBasicTestController success!' . chr(10) . 'Neos.Flow:Everybody' . chr(10) . 'Neos.Flow:AuthenticatedUser' . chr(10) . 'Neos.Flow:Administrator' . chr(10),
+            $response->getContent()
+        );
     }
 
     /**
@@ -148,7 +151,10 @@ class AuthenticationTest extends FunctionalTestCase
         $arguments['__authentication']['Neos']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['password'] = 'a_very_secure_long_password';
 
         $response = $this->browser->request('http://localhost/test/security/authentication/usernamepassword', 'POST', $arguments);
-        $this->assertSame($response->getContent(), 'UsernamePasswordTestController success!' . chr(10) . 'Neos.Flow:Everybody' . chr(10) . 'Neos.Flow:AuthenticatedUser' . chr(10) . 'Neos.Flow:Administrator' . chr(10));
+        $this->assertSame(
+            'UsernamePasswordTestController success!' . chr(10) . 'Neos.Flow:Everybody' . chr(10) . 'Neos.Flow:AuthenticatedUser' . chr(10) . 'Neos.Flow:Administrator' . chr(10),
+            $response->getContent()
+        );
     }
 
     /**


### PR DESCRIPTION
This fixes the wrong order of expected and actual parameters to an
`assertSame()` call. Can be confusing if you check test results…