### PR TITLE
!!!TASK: Remove deactivating packages from the package manager

### DIFF
--- a/Neos.Flow/Classes/Command/CacheCommandController.php
+++ b/Neos.Flow/Classes/Command/CacheCommandController.php
@@ -149,7 +149,7 @@ class CacheCommandController extends CommandController
         }
 
         $frozenPackages = [];
-        foreach (array_keys($this->packageManager->getActivePackages()) as $packageKey) {
+        foreach (array_keys($this->packageManager->getAvailablePackages()) as $packageKey) {
             if ($this->packageManager->isPackageFrozen($packageKey)) {
                 $frozenPackages[] = $packageKey;
             }

--- a/Neos.Flow/Classes/Command/PackageCommandController.php
+++ b/Neos.Flow/Classes/Command/PackageCommandController.php
@@ -133,7 +133,7 @@ class PackageCommandController extends CommandController
      */
     public function listCommand($loadingOrder = false)
     {
-        $activePackages = [];
+        $availablePackages = [];
         $frozenPackages = [];
         $longestPackageKey = 0;
         $freezeSupported = $this->bootstrap->getContext()->isDevelopment();
@@ -143,7 +143,7 @@ class PackageCommandController extends CommandController
                 $longestPackageKey = strlen($packageKey);
             }
 
-            $activePackages[$packageKey] = $package;
+            $availablePackages[$packageKey] = $package;
 
             if ($this->packageManager->isPackageFrozen($packageKey)) {
                 $frozenPackages[$packageKey] = $package;
@@ -151,12 +151,12 @@ class PackageCommandController extends CommandController
         }
 
         if ($loadingOrder === false) {
-            ksort($activePackages);
+            ksort($availablePackages);
         }
 
         $this->outputLine('PACKAGES:');
         /** @var PackageInterface $package */
-        foreach ($activePackages as $package) {
+        foreach ($availablePackages as $package) {
             $frozenState = ($freezeSupported && isset($frozenPackages[$package->getPackageKey()]) ? '* ' : '  ');
             $this->outputLine(' ' . str_pad($package->getPackageKey(), $longestPackageKey + 3) . $frozenState . str_pad($package->getInstalledVersion(), 15));
         }
@@ -204,7 +204,7 @@ class PackageCommandController extends CommandController
                 }
             }
             if ($packagesToFreeze === []) {
-                $this->outputLine('Nothing to do, all active packages were already frozen.');
+                $this->outputLine('Nothing to do, all packages were already frozen.');
                 $this->quit(0);
             }
         } elseif ($packageKey === 'blackberry') {

--- a/Neos.Flow/Classes/Command/ResourceCommandController.php
+++ b/Neos.Flow/Classes/Command/ResourceCommandController.php
@@ -207,7 +207,7 @@ class ResourceCommandController extends CommandController
         $this->outputLine('Checking if resource data exists for all known resource objects ...');
         $this->outputLine();
 
-        $mediaPackagePresent = $this->packageManager->isPackageActive('Neos.Media');
+        $mediaPackagePresent = $this->packageManager->isPackageAvailable('Neos.Media');
 
         $resourcesCount = $this->resourceRepository->countAll();
         $this->output->progressStart($resourcesCount);

--- a/Neos.Flow/Classes/Command/SchemaCommandController.php
+++ b/Neos.Flow/Classes/Command/SchemaCommandController.php
@@ -58,7 +58,7 @@ class SchemaCommandController extends CommandController
 
         if (is_null($configurationFile)) {
             $result = new Result();
-            $activePackages = $this->packageManager->getActivePackages();
+            $activePackages = $this->packageManager->getAvailablePackages();
             foreach ($activePackages as $package) {
                 $packageKey = $package->getPackageKey();
                 $packageSchemaPath = Files::concatenatePaths([$package->getResourcesPath(), 'Private/Schema']);

--- a/Neos.Flow/Classes/Composer/InstallerScripts.php
+++ b/Neos.Flow/Classes/Composer/InstallerScripts.php
@@ -43,6 +43,9 @@ class InstallerScripts
         if (!defined('FLOW_PATH_CONFIGURATION')) {
             define('FLOW_PATH_CONFIGURATION', Files::getUnixStylePath(getcwd()) . '/Configuration/');
         }
+        if (!defined('FLOW_PATH_TEMPORARY_BASE')) {
+            define('FLOW_PATH_TEMPORARY_BASE', Files::getUnixStylePath(getcwd()) . '/Data/Temporary');
+        }
 
         Files::createDirectoryRecursively('Configuration');
         Files::createDirectoryRecursively('Data');

--- a/Neos.Flow/Classes/Composer/InstallerScripts.php
+++ b/Neos.Flow/Classes/Composer/InstallerScripts.php
@@ -49,7 +49,7 @@ class InstallerScripts
 
         Files::copyDirectoryRecursively('Packages/Framework/Neos.Flow/Resources/Private/Installer/Distribution/Essentials', './', false, true);
         Files::copyDirectoryRecursively('Packages/Framework/Neos.Flow/Resources/Private/Installer/Distribution/Defaults', './', true, true);
-        $packageManager = new PackageManager();
+        $packageManager = new PackageManager(PackageManager::DEFAULT_PACKAGE_INFORMATION_CACHE_FILEPATH, FLOW_PATH_PACKAGES);
         $packageManager->rescanPackages();
 
         chmod('flow', 0755);

--- a/Neos.Flow/Classes/Configuration/ConfigurationSchemaValidator.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationSchemaValidator.php
@@ -99,7 +99,7 @@ class ConfigurationSchemaValidator
 
         // find schema files for the given type and path
         $schemaFileInfos = [];
-        $activePackages = $this->packageManager->getActivePackages();
+        $activePackages = $this->packageManager->getAvailablePackages();
         foreach ($activePackages as $package) {
             $packageKey = $package->getPackageKey();
             $packageSchemaPath = Files::concatenatePaths([$package->getResourcesPath(), 'Private/Schema']);

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -181,7 +181,7 @@ class Scripts
 
         $packageManager->initialize($bootstrap);
         if (self::useClassLoader($bootstrap)) {
-            $bootstrap->getEarlyInstance(ClassLoader::class)->setPackages($packageManager->getActivePackages());
+            $bootstrap->getEarlyInstance(ClassLoader::class)->setPackages($packageManager->getAvailablePackages());
         }
     }
 
@@ -204,7 +204,7 @@ class Scripts
         $configurationManager = new ConfigurationManager($context);
         $configurationManager->setTemporaryDirectoryPath($environment->getPathToTemporaryDirectory());
         $configurationManager->injectConfigurationSource(new YamlSource());
-        $configurationManager->setPackages($packageManager->getActivePackages());
+        $configurationManager->setPackages($packageManager->getAvailablePackages());
         if ($configurationManager->loadConfigurationCache() === false) {
             $configurationManager->refreshConfiguration();
         }
@@ -392,7 +392,7 @@ class Scripts
         $objectManager->injectConfigurationManager($configurationManager);
         $objectManager->injectConfigurationCache($cacheManager->getCache('Flow_Object_Configuration'));
         $objectManager->injectSystemLogger($systemLogger);
-        $objectManager->initialize($packageManager->getActivePackages());
+        $objectManager->initialize($packageManager->getAvailablePackages());
 
         foreach ($bootstrap->getEarlyInstances() as $objectName => $instance) {
             $objectManager->setInstance($objectName, $instance);
@@ -482,7 +482,7 @@ class Scripts
         $packagesWithConfiguredObjects = static::getListOfPackagesWithConfiguredObjects($bootstrap);
 
         /** @var PackageInterface $package */
-        foreach ($packageManager->getActivePackages() as $packageKey => $package) {
+        foreach ($packageManager->getAvailablePackages() as $packageKey => $package) {
             if ($packageManager->isPackageFrozen($packageKey)) {
                 continue;
             }

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -171,7 +171,7 @@ class Scripts
      */
     public static function initializePackageManagement(Bootstrap $bootstrap)
     {
-        $packageManager = new PackageManager();
+        $packageManager = new PackageManager(PackageManager::DEFAULT_PACKAGE_INFORMATION_CACHE_FILEPATH, FLOW_PATH_PACKAGES);
         $bootstrap->setEarlyInstance(PackageManagerInterface::class, $packageManager);
 
         // The package:rescan must happen as early as possible, compiletime alone is not enough.

--- a/Neos.Flow/Classes/I18n/Service.php
+++ b/Neos.Flow/Classes/I18n/Service.php
@@ -293,7 +293,7 @@ class Service
         $blacklistPattern = $this->getScanBlacklistPattern();
 
         /** @var PackageInterface $activePackage */
-        foreach ($this->packageManager->getActivePackages() as $activePackage) {
+        foreach ($this->packageManager->getAvailablePackages() as $activePackage) {
             $packageResourcesPath = Files::getNormalizedPath($activePackage->getResourcesPath());
 
             if (!is_dir($packageResourcesPath)) {

--- a/Neos.Flow/Classes/I18n/Xliff/Service/XliffFileProvider.php
+++ b/Neos.Flow/Classes/I18n/Xliff/Service/XliffFileProvider.php
@@ -101,7 +101,7 @@ class XliffFileProvider
             $localeChain = $this->localizationService->getLocaleChain($locale);
             // Walk locale chain in reverse, so that translations higher in the chain overwrite fallback translations
             foreach (array_reverse($localeChain) as $localeChainItem) {
-                foreach ($this->packageManager->getActivePackages() as $package) {
+                foreach ($this->packageManager->getAvailablePackages() as $package) {
                     /** @var PackageInterface $package */
                     $translationPath = $package->getResourcesPath() . $this->xliffBasePath . $localeChainItem;
                     if (is_dir($translationPath)) {

--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -62,7 +62,7 @@ class Package extends BasePackage
                 if ($step->getIdentifier() === 'neos.flow:resources') {
                     $publicResourcesFileMonitor = Monitor\FileMonitor::createFileMonitorAtBoot('Flow_PublicResourcesFiles', $bootstrap);
                     $packageManager = $bootstrap->getEarlyInstance(Package\PackageManagerInterface::class);
-                    foreach ($packageManager->getActivePackages() as $packageKey => $package) {
+                    foreach ($packageManager->getAvailablePackages() as $packageKey => $package) {
                         if ($packageManager->isPackageFrozen($packageKey)) {
                             continue;
                         }

--- a/Neos.Flow/Classes/Package/PackageManager.php
+++ b/Neos.Flow/Classes/Package/PackageManager.php
@@ -769,6 +769,7 @@ class PackageManager implements PackageManagerInterface
 
         $packageStatesCode = "<?php\n" . $fileDescription . "\nreturn " . var_export($orderedPackageStates, true) . ';';
 
+        Files::createDirectoryRecursively(dirname($this->packageInformationCacheFilePath));
         $result = @file_put_contents($this->packageInformationCacheFilePath, $packageStatesCode);
         if ($result === false) {
             throw new Exception\PackageStatesFileNotWritableException(sprintf('Flow could not update the list of installed packages because the file %s is not writable. Please, check the file system permissions and make sure that the web server can write to it.', $this->packageInformationCacheFilePath), 1382449759);

--- a/Neos.Flow/Classes/Package/PackageManager.php
+++ b/Neos.Flow/Classes/Package/PackageManager.php
@@ -140,7 +140,7 @@ class PackageManager implements PackageManagerInterface
 
     /**
      * Returns TRUE if a package is available (the package's files exist in the packages directory)
-     * or FALSE if it's not. If a package is available it doesn't mean necessarily that it's active!
+     * or FALSE if it's not.
      *
      * @param string $packageKey The key of the package to check
      * @return boolean TRUE if the package is available, otherwise FALSE
@@ -149,20 +149,6 @@ class PackageManager implements PackageManagerInterface
     public function isPackageAvailable($packageKey)
     {
         return ($this->getCaseSensitivePackageKey($packageKey) !== false);
-    }
-
-    /**
-     * Returns TRUE if a package is available or FALSE if it's not.
-     *
-     * @param string $packageKey The key of the package to check
-     * @return boolean TRUE if package is active, otherwise FALSE
-     * @api
-     * @deprecated There is no longer a package state. Use isPackageAvailable as replacement
-     * @see isPackageAvailable
-     */
-    public function isPackageActive($packageKey)
-    {
-        return $this->isPackageAvailable($packageKey);
     }
 
     /**
@@ -200,19 +186,6 @@ class PackageManager implements PackageManagerInterface
      * @api
      */
     public function getAvailablePackages()
-    {
-        return $this->packages;
-    }
-
-    /**
-     * Returns an array of PackageInterface objects of all packages.
-     *
-     * @return array <PackageInterface>
-     * @api
-     * @deprecated Inactive packages no longer exist, use self::getAvailablePackages as replacement.
-     * @see getAvailablePackages
-     */
-    public function getActivePackages()
     {
         return $this->packages;
     }
@@ -406,7 +379,7 @@ class PackageManager implements PackageManagerInterface
         }
 
         if (!$this->isPackageAvailable($packageKey)) {
-            throw new Exception\UnknownPackageException('Package "' . $packageKey . '" is not available or active.', 1331715956);
+            throw new Exception\UnknownPackageException('Package "' . $packageKey . '" is not available.', 1331715956);
         }
         if ($this->isPackageFrozen($packageKey)) {
             return;
@@ -938,7 +911,7 @@ class PackageManager implements PackageManagerInterface
     }
 
     /**
-     * Emits a signal when package states have been changed (e.g. when a package was created or activated)
+     * Emits a signal when package states have been changed (e.g. when a package was created)
      *
      * The advice is not proxyable, so the signal is dispatched manually here.
      *

--- a/Neos.Flow/Classes/Package/PackageManagerInterface.php
+++ b/Neos.Flow/Classes/Package/PackageManagerInterface.php
@@ -19,10 +19,6 @@ use Neos\Flow\Core\Bootstrap;
  */
 interface PackageManagerInterface
 {
-    const PACKAGE_STATE_INACTIVE = 'inactive';
-
-    const PACKAGE_STATE_ACTIVE = 'active';
-
     /**
      * Initializes the package manager
      *
@@ -42,15 +38,6 @@ interface PackageManagerInterface
     public function isPackageAvailable($packageKey);
 
     /**
-     * Returns TRUE if a package is activated or FALSE if it's not.
-     *
-     * @param string $packageKey The key of the package to check
-     * @return boolean TRUE if package is active, otherwise FALSE
-     * @api
-     */
-    public function isPackageActive($packageKey);
-
-    /**
      * Returns a PackageInterface object for the specified package.
      * A package is available, if the package directory contains valid meta information.
      *
@@ -68,16 +55,6 @@ interface PackageManagerInterface
      * @api
      */
     public function getAvailablePackages();
-
-    /**
-     * Returns an array of PackageInterface objects of all active packages.
-     * A package is active, if it is available and has been activated in the package
-     * manager settings.
-     *
-     * @return array<PackageInterface>
-     * @api
-     */
-    public function getActivePackages();
 
     /**
      * Returns an array of PackageInterface objects of all packages that match
@@ -120,24 +97,6 @@ interface PackageManagerInterface
      * @api
      */
     public function createPackage($packageKey, array $manifest = [], $packagesPath = null);
-
-    /**
-     * Deactivates a package if it is in the list of active packages
-     *
-     * @param string $packageKey The package to deactivate
-     * @return void
-     * @api
-     */
-    public function deactivatePackage($packageKey);
-
-    /**
-     * Activates a package
-     *
-     * @param string $packageKey The package to activate
-     * @return void
-     * @api
-     */
-    public function activatePackage($packageKey);
 
     /**
      * Freezes a package
@@ -183,9 +142,8 @@ interface PackageManagerInterface
     /**
      * Rescans available packages, order and write a new PackageStates file.
      *
-     * @param boolean $reloadPackageStates Should the package states be loaded before scanning or use the current configuration
      * @return array The found and sorted package states.
      * @api
      */
-    public function rescanPackages($reloadPackageStates = true);
+    public function rescanPackages();
 }

--- a/Neos.Flow/Classes/Package/PackageManagerInterface.php
+++ b/Neos.Flow/Classes/Package/PackageManagerInterface.php
@@ -29,7 +29,7 @@ interface PackageManagerInterface
 
     /**
      * Returns TRUE if a package is available (the package's files exist in the packages directory)
-     * or FALSE if it's not. If a package is available it doesn't mean necessarily that it's active!
+     * or FALSE if it's not.
      *
      * @param string $packageKey The key of the package to check
      * @return boolean TRUE if the package is available, otherwise FALSE

--- a/Neos.Flow/Classes/Persistence/Doctrine/Service.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Service.php
@@ -209,7 +209,7 @@ class Service
 
         $databasePlatformName = $this->getDatabasePlatformName();
         /** @var PackageInterface $package */
-        foreach ($this->packageManager->getActivePackages() as $package) {
+        foreach ($this->packageManager->getAvailablePackages() as $package) {
             $path = Files::concatenatePaths([
                 $package->getPackagePath(),
                 'Migrations',

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1959,7 +1959,7 @@ class ReflectionService
         }
 
         $useIgBinary = extension_loaded('igbinary');
-        foreach ($this->packageManager->getActivePackages() as $packageKey => $package) {
+        foreach ($this->packageManager->getAvailablePackages() as $packageKey => $package) {
             if (!$this->packageManager->isPackageFrozen($packageKey)) {
                 continue;
             }

--- a/Neos.Flow/Classes/ResourceManagement/Storage/PackageStorage.php
+++ b/Neos.Flow/Classes/ResourceManagement/Storage/PackageStorage.php
@@ -69,7 +69,7 @@ class PackageStorage extends FileSystemStorage
         }
         // $packageKeyPattern can be used in a future implementation to filter by package key
 
-        $packages = $this->packageManager->getActivePackages();
+        $packages = $this->packageManager->getAvailablePackages();
         foreach ($packages as $packageKey => $package) {
             /** @var PackageInterface $package */
             if ($directoryPattern === '*') {
@@ -159,7 +159,7 @@ class PackageStorage extends FileSystemStorage
     public function getPublicResourcePaths()
     {
         $paths = [];
-        $packages = $this->packageManager->getActivePackages();
+        $packages = $this->packageManager->getAvailablePackages();
         foreach ($packages as $packageKey => $package) {
             /** @var PackageInterface $package */
             $publicResourcesPath = Files::concatenatePaths([$package->getResourcesPath(), 'Public']);

--- a/Neos.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
+++ b/Neos.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
@@ -85,7 +85,7 @@ class ConfigurationValidationTest extends FunctionalTestCase
 
         // get all packages and select the ones we want to test
         $temporaryPackageManager = $this->objectManager->get(PackageManagerInterface::class);
-        foreach ($temporaryPackageManager->getActivePackages() as $package) {
+        foreach ($temporaryPackageManager->getAvailablePackages() as $package) {
             if (in_array($package->getPackageKey(), $this->getSchemaPackageKeys())) {
                 $schemaPackages[$package->getPackageKey()] = $package;
             }

--- a/Neos.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
+++ b/Neos.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
@@ -65,11 +65,6 @@ class ConfigurationValidationTest extends FunctionalTestCase
     protected $mockConfigurationManager;
 
     /**
-     * @var PackageManager
-     */
-    protected $mockPackageManager;
-
-    /**
      * @return void
      */
     public function setUp()
@@ -94,13 +89,9 @@ class ConfigurationValidationTest extends FunctionalTestCase
             }
         }
 
-        $this->mockPackageManager = $this->createMock(PackageManager::class);
-        $this->mockPackageManager->expects($this->any())->method('getActivePackages')->will($this->returnValue($schemaPackages));
-
         //
         // create mock configurationManager and store the original one
         //
-
         $this->originalConfigurationManager = $this->objectManager->get(ConfigurationManager::class);
 
         $yamlConfigurationSource = $this->objectManager->get(\Neos\Flow\Tests\Functional\Configuration\Fixtures\RootDirectoryIgnoringYamlSource::class);

--- a/Neos.Flow/Tests/Functional/Configuration/SchemaValidationTest.php
+++ b/Neos.Flow/Tests/Functional/Configuration/SchemaValidationTest.php
@@ -66,7 +66,7 @@ class SchemaValidationTest extends FunctionalTestCase
         $objectManager = $bootstrap->getObjectManager();
         $packageManager = $objectManager->get(PackageManagerInterface::class);
 
-        $activePackages = $packageManager->getActivePackages();
+        $activePackages = $packageManager->getAvailablePackages();
         foreach ($activePackages as $package) {
             $packageKey = $package->getPackageKey();
             if (in_array($packageKey, $this->schemaPackageKeys)) {

--- a/Neos.Flow/Tests/Functional/I18n/Xliff/Service/XliffFileProviderTest.php
+++ b/Neos.Flow/Tests/Functional/I18n/Xliff/Service/XliffFileProviderTest.php
@@ -45,7 +45,7 @@ class XliffFileProviderTest extends FunctionalTestCase
             ->disableOriginalConstructor()
             ->getMock();
         $mockPackageManager->expects($this->any())
-            ->method('getActivePackages')
+            ->method('getAvailablePackages')
             ->will($this->returnValue($packages));
         $this->inject($this->fileProvider, 'packageManager', $mockPackageManager);
 

--- a/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
@@ -46,7 +46,6 @@ class RoutingTest extends FunctionalTestCase
                 $foundRoute = true;
                 break;
             }
-            var_dump($route->getName());
         }
 
         if (!$foundRoute) {

--- a/Neos.Flow/Tests/Functional/Mvc/ViewsConfiguration/ViewsConfigurationTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/ViewsConfiguration/ViewsConfigurationTest.php
@@ -90,7 +90,7 @@ class ViewsConfigurationTest extends FunctionalTestCase
      */
     public function changeTemplatePathAndFilenameForWidget()
     {
-        if ($this->objectManager->get(PackageManagerInterface::class)->isPackageActive('Neos.FluidAdaptor') === false) {
+        if ($this->objectManager->get(PackageManagerInterface::class)->isPackageAvailable('Neos.FluidAdaptor') === false) {
             $this->markTestSkipped('No Fluid adaptor installed');
         }
 

--- a/Neos.Flow/Tests/Unit/I18n/ServiceTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/ServiceTest.php
@@ -158,7 +158,7 @@ class ServiceTest extends UnitTestCase
         $mockPackage->expects($this->any())->method('getResourcesPath')->will($this->returnValue('vfs://Foo/Bar/'));
 
         $mockPackageManager = $this->createMock(PackageManagerInterface::class);
-        $mockPackageManager->expects($this->any())->method('getActivePackages')->will($this->returnValue([$mockPackage]));
+        $mockPackageManager->expects($this->any())->method('getAvailablePackages')->will($this->returnValue([$mockPackage]));
 
         $mockLocaleCollection = $this->createMock(I18n\LocaleCollection::class);
         $mockLocaleCollection->expects($this->exactly(6))->method('addLocale');
@@ -205,7 +205,7 @@ class ServiceTest extends UnitTestCase
         $mockPackage->expects($this->any())->method('getResourcesPath')->will($this->returnValue('vfs://Foo/Bar/'));
 
         $mockPackageManager = $this->createMock(PackageManagerInterface::class);
-        $mockPackageManager->expects($this->any())->method('getActivePackages')->will($this->returnValue([$mockPackage]));
+        $mockPackageManager->expects($this->any())->method('getAvailablePackages')->will($this->returnValue([$mockPackage]));
 
         $mockLocaleCollection = $this->createMock(I18n\LocaleCollection::class);
         $mockLocaleCollection->expects($this->exactly(2))->method('addLocale');

--- a/Neos.Flow/Tests/Unit/Package/PackageManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Package/PackageManagerTest.php
@@ -79,14 +79,13 @@ class PackageManagerTest extends UnitTestCase
         mkdir('vfs://Test/Packages/Application', 0700, true);
         mkdir('vfs://Test/Configuration');
 
-        $this->packageManager = new PackageManager('vfs://Test/Configuration/PackageStates.php');
+        $this->packageManager = new PackageManager('vfs://Test/Configuration/PackageStates.php', 'vfs://Test/Packages/');
 
         $composerNameToPackageKeyMap = [
             'neos/flow' => 'Neos.Flow'
         ];
 
         $this->inject($this->packageManager, 'composerNameToPackageKeyMap', $composerNameToPackageKeyMap);
-        $this->inject($this->packageManager, 'packagesBasePath', 'vfs://Test/Packages/');
 
         $this->mockDispatcher = $this->getMockBuilder(Dispatcher::class)->disableOriginalConstructor()->getMock();
         $this->inject($this->packageManager, 'dispatcher', $this->mockDispatcher);
@@ -170,7 +169,7 @@ class PackageManagerTest extends UnitTestCase
 
         $packageManager = $this->getAccessibleMock(PackageManager::class, ['emitPackageStatesUpdated']);
         $packageManager->_set('packagesBasePath', 'vfs://Test/Packages/');
-        $packageManager->_set('packageStatesPathAndFilename', 'vfs://Test/Configuration/PackageStates.php');
+        $packageManager->_set('packageInformationCacheFilePath', 'vfs://Test/Configuration/PackageStates.php');
 
         $packageFactory = new PackageFactory($packageManager);
         $this->inject($packageManager, 'packageFactory', $packageFactory);
@@ -204,7 +203,7 @@ class PackageManagerTest extends UnitTestCase
 
         $packageManager = $this->getAccessibleMock(PackageManager::class, ['updateShortcuts', 'emitPackageStatesUpdated'], [], '', false);
         $packageManager->_set('packagesBasePath', 'vfs://Test/Packages/');
-        $packageManager->_set('packageStatesPathAndFilename', 'vfs://Test/Configuration/PackageStates.php');
+        $packageManager->_set('packageInformationCacheFilePath', 'vfs://Test/Configuration/PackageStates.php');
 
         $packageFactory = new PackageFactory($packageManager);
         $this->inject($packageManager, 'packageFactory', $packageFactory);

--- a/Neos.Flow/Tests/Unit/Package/PackageManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Package/PackageManagerTest.php
@@ -142,7 +142,7 @@ class PackageManagerTest extends UnitTestCase
      */
     public function getCaseSensitivePackageKeyReturnsTheUpperCamelCaseVersionOfAGivenPackageKeyIfThePackageIsRegistered()
     {
-        $packageManager = $this->getAccessibleMock(PackageManager::class, ['dummy']);
+        $packageManager = $this->getAccessibleMock(PackageManager::class, ['dummy'], ['', '']);
         $packageManager->_set('packageKeys', ['acme.testpackage' => 'Acme.TestPackage']);
         $this->assertEquals('Acme.TestPackage', $packageManager->getCaseSensitivePackageKey('acme.testpackage'));
     }
@@ -167,9 +167,7 @@ class PackageManagerTest extends UnitTestCase
             file_put_contents($packagePath . 'composer.json', '{"name": "' . $packageKey . '", "type": "flow-test"}');
         }
 
-        $packageManager = $this->getAccessibleMock(PackageManager::class, ['emitPackageStatesUpdated']);
-        $packageManager->_set('packagesBasePath', 'vfs://Test/Packages/');
-        $packageManager->_set('packageInformationCacheFilePath', 'vfs://Test/Configuration/PackageStates.php');
+        $packageManager = $this->getAccessibleMock(PackageManager::class, ['emitPackageStatesUpdated'], ['vfs://Test/Configuration/PackageStates.php', 'vfs://Test/Packages/']);
 
         $packageFactory = new PackageFactory($packageManager);
         $this->inject($packageManager, 'packageFactory', $packageFactory);
@@ -436,7 +434,7 @@ class PackageManagerTest extends UnitTestCase
             ]
         ];
 
-        $packageManager = $this->getAccessibleMock(PackageManager::class, ['resolvePackageDependencies']);
+        $packageManager = $this->getAccessibleMock(PackageManager::class, ['resolvePackageDependencies'], ['', '']);
         $packageManager->_set('packageStatesConfiguration', $packageStatesConfiguration);
 
         $this->assertEquals($packageKey, $packageManager->_call('getPackageKeyFromComposerName', $composerName));

--- a/Neos.Flow/Tests/Unit/ResourceManagement/Target/FileSystemTargetTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/Target/FileSystemTargetTest.php
@@ -213,7 +213,6 @@ class FileSystemTargetTest extends UnitTestCase
         $this->inject($packageManager, 'packagesBasePath', 'vfs://Test/Packages/');
 
         $packageManager->createPackage("Neos.Flow");
-        $packageManager->activatePackage("Neos.Flow");
 
         $packageStorage = new PackageStorage('testStorage');
         $packageStorage->initializeObject(ObjectManagerInterface::INITIALIZATIONCAUSE_CREATED);

--- a/Neos.Flow/Tests/Unit/ResourceManagement/Target/FileSystemTargetTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/Target/FileSystemTargetTest.php
@@ -209,8 +209,7 @@ class FileSystemTargetTest extends UnitTestCase
     {
         vfsStream::setup('Test');
         mkdir('vfs://Test/Configuration');
-        $packageManager = new PackageManager('vfs://Test/Configuration/PackageStates.php');
-        $this->inject($packageManager, 'packagesBasePath', 'vfs://Test/Packages/');
+        $packageManager = new PackageManager('vfs://Test/Configuration/PackageStates.php', 'vfs://Test/Packages/');
 
         $packageManager->createPackage("Neos.Flow");
 

--- a/Neos.FluidAdaptor/Classes/Core/ViewHelper/ViewHelperResolver.php
+++ b/Neos.FluidAdaptor/Classes/Core/ViewHelper/ViewHelperResolver.php
@@ -68,7 +68,7 @@ class ViewHelperResolver extends \TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperRes
         }
 
         /** @var Package $package */
-        foreach ($this->packageManager->getActivePackages() as $package) {
+        foreach ($this->packageManager->getAvailablePackages() as $package) {
             foreach ($package->getNamespaces() as $namespace) {
                 $viewHelperNamespace = $namespace;
                 if (strpos(strrev($namespace), '\\') !== 0) {

--- a/Neos.FluidAdaptor/Classes/Package.php
+++ b/Neos.FluidAdaptor/Classes/Package.php
@@ -45,7 +45,7 @@ class Package extends BasePackage
                 if ($step->getIdentifier() === 'neos.flow:systemfilemonitor') {
                     $templateFileMonitor = FileMonitor::createFileMonitorAtBoot('Fluid_TemplateFiles', $bootstrap);
                     $packageManager = $bootstrap->getEarlyInstance(PackageManagerInterface::class);
-                    foreach ($packageManager->getActivePackages() as $packageKey => $package) {
+                    foreach ($packageManager->getAvailablePackages() as $packageKey => $package) {
                         if ($packageManager->isPackageFrozen($packageKey)) {
                             continue;
                         }

--- a/Neos.FluidAdaptor/Classes/View/TemplatePaths.php
+++ b/Neos.FluidAdaptor/Classes/View/TemplatePaths.php
@@ -324,7 +324,7 @@ class TemplatePaths extends \TYPO3Fluid\Fluid\View\TemplatePaths
             $packageName = $this->packageManager->getPackageKeyFromComposerName($packageName);
         }
 
-        if (!$this->packageManager->isPackageActive($packageName)) {
+        if (!$this->packageManager->isPackageAvailable($packageName)) {
             return '';
         }
 
@@ -358,7 +358,7 @@ class TemplatePaths extends \TYPO3Fluid\Fluid\View\TemplatePaths
      */
     protected function getPackagePrivateResourcesPath($packageKey)
     {
-        if (!$this->packageManager->isPackageActive($packageKey)) {
+        if (!$this->packageManager->isPackageAvailable($packageKey)) {
             return null;
         }
         $packageResourcesPath = $this->packageManager->getPackage($packageKey)->getResourcesPath();


### PR DESCRIPTION
Packages no longer have state, they are either available or not
available entirely depending on the fact if they are installed.
The API is changed accordingly to reflect this change.

The implemented ``PackageManager`` still supports the
``getActivePackages`` and ``isPackageActive`` methods for
backwards compatibility but both are deprecated and removed from
the interface.

This is breaking if you rely on the functionality and requires
future changes if you use the deprecated methods.
