### PR TITLE
BUGFIX: catch NoMatchingRouteException to fix the RedirectHandler

### DIFF
--- a/Neos.Flow/Classes/Mvc/Routing/RoutingComponent.php
+++ b/Neos.Flow/Classes/Mvc/Routing/RoutingComponent.php
@@ -14,6 +14,7 @@ namespace Neos\Flow\Mvc\Routing;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\Component\ComponentContext;
 use Neos\Flow\Http\Component\ComponentInterface;
+use Neos\Flow\Mvc\Exception\NoMatchingRouteException;
 use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
 use Neos\Flow\Mvc\Routing\Dto\RouteContext;
 
@@ -57,7 +58,13 @@ class RoutingComponent implements ComponentInterface
             $parameters = RouteParameters::createEmpty();
         }
         $routeContext = new RouteContext($componentContext->getHttpRequest(), $parameters);
-        $matchResults = $this->router->route($routeContext);
+
+        try {
+            $matchResults = $this->router->route($routeContext);
+        } catch (NoMatchingRouteException $exception) {
+            $matchResults = null;
+        }
+
         $componentContext->setParameter(RoutingComponent::class, 'matchResults', $matchResults);
     }
 }


### PR DESCRIPTION
**What I did**
When no route is found the NoMatchingRouteException is now thrown, which breaks up the http component chain, so the RedirectHandlerComponent is never reached.
This change swallows the exception.

**How to verify it**

Install the redirect handler extension and make sure the redirects work.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
