### PR TITLE
BUGFIX: routing:routepath command does not use routing DTOs

### DIFF
--- a/Neos.Flow/Classes/Command/RoutingCommandController.php
+++ b/Neos.Flow/Classes/Command/RoutingCommandController.php
@@ -15,6 +15,8 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Http\Request;
+use Neos\Flow\Mvc\Routing\Dto\RouteContext;
+use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
 use Neos\Flow\Mvc\Routing\Exception\InvalidControllerException;
 use Neos\Flow\Mvc\Routing\Route;
 use Neos\Flow\Mvc\Routing\Router;
@@ -173,10 +175,11 @@ class RoutingCommandController extends CommandController
             'REQUEST_METHOD' => $method
         ];
         $httpRequest = new Request([], [], [], $server);
+        $routeContext = new RouteContext($httpRequest, RouteParameters::createEmpty());
 
         /** @var Route $route */
         foreach ($this->router->getRoutes() as $route) {
-            if ($route->matches($httpRequest) === true) {
+            if ($route->matches($routeContext) === true) {
                 $routeValues = $route->getMatchResults();
 
                 $this->outputLine('<b>Path:</b>');


### PR DESCRIPTION
Before this fix, calling `./flow routing:routepath /somePath` will result in something like

```
Argument 1 passed to Neos\Flow\Mvc\Routing\Route_Original::matches() must be an instance of Neos\Flow\Mvc\Routing\Dto\RouteContext, instance of Neos\Flow\Http\Request given, called in /flowRootPath/Data/Temporary/Development/SubContextFritjofBohm/Cache/Code/Flow_Object_Classes/Neos_Flow_Command_RoutingCommandController.php on line 179
```

With this fix, the command uses the right DTOs that were introduced with 4.3.