### PR TITLE
TASK: Update standalone Fluid to 2.3.x

### DIFF
--- a/Neos.FluidAdaptor/Classes/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
+++ b/Neos.FluidAdaptor/Classes/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
@@ -65,38 +65,6 @@ class NamespaceDetectionTemplateProcessor extends FluidNamespaceDetectionTemplat
     }
 
     /**
-     * Register all namespaces that are declared inside the template string
-     *
-     * @param string $templateSource
-     * @return void
-     */
-    public function registerNamespacesFromTemplateSource($templateSource)
-    {
-        $viewHelperResolver = $this->renderingContext->getViewHelperResolver();
-        if (preg_match_all(static::SPLIT_PATTERN_TEMPLATE_OPEN_NAMESPACETAG, $templateSource, $matchedVariables, PREG_SET_ORDER) > 0) {
-            foreach ($matchedVariables as $namespaceMatch) {
-                $viewHelperNamespace = $this->renderingContext->getTemplateParser()->unquoteString($namespaceMatch[2]);
-                $phpNamespace = $viewHelperResolver->resolvePhpNamespaceFromFluidNamespace($viewHelperNamespace);
-                if (stristr($phpNamespace, '/') === false) {
-                    $viewHelperResolver->addNamespace($namespaceMatch[1], $phpNamespace);
-                }
-            }
-        }
-
-        $templateSource = preg_replace_callback(static::NAMESPACE_DECLARATION, function (array $matches) use ($viewHelperResolver) {
-            $identifier = $matches['identifier'];
-            $namespace = isset($matches['phpNamespace']) ? $matches['phpNamespace'] : null;
-            if (strlen($namespace) === 0) {
-                $namespace = null;
-            }
-            $viewHelperResolver->addNamespace($identifier, $namespace);
-            return '';
-        }, $templateSource);
-
-        return $templateSource;
-    }
-
-    /**
      * Encodes areas enclosed in CDATA to prevent further parsing by the Fluid engine.
      * CDATA sections will appear as they are in the final rendered result.
      *

--- a/Neos.FluidAdaptor/composer.json
+++ b/Neos.FluidAdaptor/composer.json
@@ -8,7 +8,7 @@
 		"neos/cache": "*",
 		"neos/utility-files": "*",
 		"neos/utility-objecthandling": "*",
-		"typo3fluid/fluid": "~2.1.3"
+		"typo3fluid/fluid": "~2.3.4"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,13 @@
         "symfony/dom-crawler": "~2.8.0",
         "symfony/console": "~2.8",
         "neos/composer-plugin": "^2.0.0",
-        "typo3fluid/fluid": "~2.1.3",
+        "typo3fluid/fluid": "~2.3.4",
         "ext-mbstring": "*"
     },
     "replace": {
+        "typo3/eel": "self.version",
+        "typo3/flow": "self.version",
+        "typo3/kickstart": "self.version",
         "neos/cache": "self.version",
         "neos/eel": "self.version",
         "neos/error-messages": "self.version",
@@ -103,6 +106,7 @@
     "require-dev": {
         "mikey179/vfsstream": "~1.6",
         "phpunit/phpunit": "~6.0",
+        "neos/flow": "*",
         "doctrine/orm": "~2.5.0",
         "doctrine/common": ">=2.4,<2.8-dev"
     },


### PR DESCRIPTION
Pulling in the latest improvements in Fluid.

One major improvement is the addition of an escaping toggle: 

```
{escaping off}
```

In a template, layout or partial. When toggled off it causes the template parser to skip escaping of all outputs from ViewHelpers, variable outputs etc.

For legacy reasons the feature is added with backwards compatibility for the original escaping modifier. Therefore, the following values are all equally possible and mean the same:

```
{escaping off}
{escapingEnabled off}
{escaping false}
{escaping=false}
{escaping=off}
{escaping = off}
{escapingEnabled = off}
{escapingEnabled = false}
{escapingEnabled off}
{escapingEnabled false}
```