### PR TITLE
!!!TASK: Require PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,14 @@ services:
 matrix:
   fast_finish: true
   include:
-    - php: 7.0
+    - php: 7.1
       env: DB=mysql
-    - php: 7.0
+    - php: 7.1
       env: DB=pgsql
-    - php: 7.0
+    - php: 7.1
       env: DB=mysql BEHAT=true
-    - php: 7.0
+    - php: 7.1
       env: DB=pgsql BEHAT=true
-    - php: 7.1
-      env: DB=mysql
-    - php: 7.1
-      env: DB=mysql BEHAT=true
     - php: 7.2
       env: DB=mysql
     - php: 7.2

--- a/Neos.Cache/composer.json
+++ b/Neos.Cache/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://flow.neos.io",
     "license": ["MIT"],
     "require": {
-        "php": "~7.0",
+        "php": "~7.1",
         "neos/utility-files": "*",
         "neos/utility-pdo": "*",
         "neos/utility-opcodecache": "*"

--- a/Neos.Error.Messages/composer.json
+++ b/Neos.Error.Messages/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://flow.neos.io",
     "license": "MIT",
     "require": {
-        "php": "~7.0"
+        "php": "~7.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0"

--- a/Neos.Flow.Log/composer.json
+++ b/Neos.Flow.Log/composer.json
@@ -7,7 +7,7 @@
         "MIT"
     ],
     "require": {
-        "php": "~7.0",
+        "php": "~7.1",
         "neos/utility-files": "*"
     },
     "autoload": {

--- a/Neos.Flow/Documentation/Quickstart/index.rst
+++ b/Neos.Flow/Documentation/Quickstart/index.rst
@@ -39,7 +39,7 @@ Installing Flow
 Setting up Flow is pretty straight-forward. As a minimum requirement you will need:
 
 * A web server (we recommend Apache with the *mod_rewrite* module enabled)
-* PHP 7.0.0 or later
+* PHP 7.1.0 or later
 * A database supported by Doctrine DBAL, such as MySQL
 * Command line access
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartII/Requirements.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartII/Requirements.rst
@@ -32,7 +32,7 @@ PHP
 
 Flow was one of the first PHP projects taking advantage of namespaces and
 other features introduced in PHP version 5.3. By now we started using features of
-PHP 7.0, so make sure you have **PHP 7.0.0** or later available on your web server. Make
+PHP 7.1, so make sure you have **PHP 7.1.0** or later available on your web server. Make
 sure your PHP CLI binary is the **same version**!
 
 The default settings and extensions of the PHP distribution should work fine

--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -6,7 +6,7 @@
     "license": ["MIT"],
 
     "require": {
-        "php": "~7.0",
+        "php": "~7.1",
 
         "ext-zlib": "*",
         "ext-SPL": "*",

--- a/Neos.Utility.Arrays/composer.json
+++ b/Neos.Utility.Arrays/composer.json
@@ -5,7 +5,7 @@
   "homepage": "http://flow.neos.io",
   "license": "MIT",
   "require": {
-    "php": "~7.0",
+    "php": "~7.1",
     "neos/utility-objecthandling": "*"
   },
   "require-dev": {

--- a/Neos.Utility.Files/composer.json
+++ b/Neos.Utility.Files/composer.json
@@ -5,7 +5,7 @@
   "homepage": "http://flow.neos.io",
   "license": "MIT",
   "require": {
-    "php": "~7.0",
+    "php": "~7.1",
     "neos/error-messages": "*"
   },
   "require-dev": {

--- a/Neos.Utility.Lock/composer.json
+++ b/Neos.Utility.Lock/composer.json
@@ -7,7 +7,7 @@
   "require": {
     "neos/flow": "*",
     "neos/utility-files": "*",
-    "php": "~7.0"
+    "php": "~7.1"
   },
   "require-dev": {
     "mikey179/vfsstream": "~1.6",

--- a/Neos.Utility.MediaTypes/composer.json
+++ b/Neos.Utility.MediaTypes/composer.json
@@ -5,7 +5,7 @@
   "homepage": "http://flow.neos.io",
   "license": "MIT",
   "require": {
-    "php": "~7.0"
+    "php": "~7.1"
   },
   "require-dev": {
     "mikey179/vfsstream": "~1.6",

--- a/Neos.Utility.ObjectHandling/composer.json
+++ b/Neos.Utility.ObjectHandling/composer.json
@@ -5,7 +5,7 @@
   "homepage": "http://flow.neos.io",
   "license": "MIT",
   "require": {
-    "php": "~7.0"
+    "php": "~7.1"
   },
   "require-dev": {
     "phpunit/phpunit": "~6.0",

--- a/Neos.Utility.OpcodeCache/composer.json
+++ b/Neos.Utility.OpcodeCache/composer.json
@@ -5,7 +5,7 @@
   "homepage": "http://flow.neos.io",
   "license": "MIT",
   "require": {
-    "php": "~7.0"
+    "php": "~7.1"
   },
   "autoload": {
     "psr-4": {

--- a/Neos.Utility.Pdo/composer.json
+++ b/Neos.Utility.Pdo/composer.json
@@ -5,7 +5,7 @@
   "homepage": "http://flow.neos.io",
   "license": "MIT",
   "require": {
-    "php": "~7.0"
+    "php": "~7.1"
   },
   "autoload": {
     "psr-4": {

--- a/Neos.Utility.Schema/composer.json
+++ b/Neos.Utility.Schema/composer.json
@@ -5,7 +5,7 @@
   "homepage": "http://flow.neos.io",
   "license": "MIT",
   "require": {
-    "php": "~7.0",
+    "php": "~7.1",
     "neos/error-messages": "*"
   },
   "require-dev": {

--- a/Neos.Utility.Unicode/composer.json
+++ b/Neos.Utility.Unicode/composer.json
@@ -8,7 +8,7 @@
     "bin-dir": "bin"
   },
   "require": {
-    "php": "~7.0",
+    "php": "~7.1",
     "ext-mbstring": "*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     ],
     "type": "neos-package-collection",
     "require": {
-        "php": "~7.0",
+        "php": "~7.1",
         "ext-zlib": "*",
         "ext-SPL": "*",
         "ext-json": ">=1.2.0",


### PR DESCRIPTION
This raises the PHP version requirement for framework packages to
PHP 7.1 to be able to use a bunch of useful features for us in the
future.

Eg. iterable pseudo type, nullable types, void returns and more.
