### PR TITLE
BUGFIX: Fix duplicate configuration keys in schema files

### DIFF
--- a/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.persistence.schema.yaml
+++ b/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.persistence.schema.yaml
@@ -128,13 +128,6 @@ properties:
             type: dictionary
             required: TRUE
             patternProperties: { '/.*/': { type: boolean } }
-      'cacheImplementation':
-        type:
-          - { type: 'null' }
-          - { type: string, format: class-name }
-      'migrations':
-        type: dictionary
-        properties:
           'generate':
             type: dictionary
             properties:
@@ -142,6 +135,10 @@ properties:
                 type:
                   - { type: 'null' }
                   - { type: string }
+      'cacheImplementation':
+        type:
+          - { type: 'null' }
+          - { type: string, format: class-name }
 
   'cacheAllQueryResults':
     type: boolean

--- a/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.security.schema.yaml
+++ b/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.security.schema.yaml
@@ -42,7 +42,6 @@ properties:
                 properties:
                   'pattern': { type: string, required: TRUE }
                   'patternOptions': { type: dictionary }
-            'token': { type: string }
             'entryPoint': { type: string }
             'entryPointOptions': { type: dictionary }
             'token': { type: string, format: class-name }


### PR DESCRIPTION
The latest symfony yaml parser is much more strict. This PR fixes duplicate keys in schema files.