### PR TITLE
BUGIFX: RsaWalletServicePhpTest broken depends on PHP configuration

### DIFF
--- a/TYPO3.Flow/Tests/Unit/Security/Cryptography/RsaWalletServicePhpTest.php
+++ b/TYPO3.Flow/Tests/Unit/Security/Cryptography/RsaWalletServicePhpTest.php
@@ -42,6 +42,9 @@ class RsaWalletServicePhpTest extends UnitTestCase
     {
         vfsStream::setup('Foo');
         $settings['security']['cryptography']['RSAWalletServicePHP']['keystorePath'] = 'vfs://Foo/EncryptionKey';
+        $settings['security']['cryptography']['RSAWalletServicePHP']['openSSLConfiguration']['digest_alg'] = 'sha1';
+        $settings['security']['cryptography']['RSAWalletServicePHP']['openSSLConfiguration']['private_key_bits'] = 384;
+        $settings['security']['cryptography']['RSAWalletServicePHP']['openSSLConfiguration']['private_key_type'] = OPENSSL_KEYTYPE_RSA;
 
         $this->rsaWalletService = $this->getAccessibleMock(RsaWalletServicePhp::class, ['dummy']);
         $this->rsaWalletService->injectSettings($settings);


### PR DESCRIPTION
This change fixes `RsaWalletServicePhpTest` on recent Alpine Linux with
PHP 7.2 (at least, maybe other system can be affected too). I didn't find
a clear documentation about the reason of this failure:

    1) Neos\Flow\Tests\Unit\Security\Cryptography\RsaWalletServicePhpTest::encryptingAndDecryptingBasicallyWorks
    openssl_pkey_new(): private key length is too short; it needs to be at least 384 bits, not 0

    /…/Classes/Security/Cryptography/RsaWalletServicePhp.php:92
    /…/Tests/Unit/Security/Cryptography/RsaWalletServicePhpTest.php:49

This configuration is as light as possible to not slow down the test suite too much.