### PR TITLE
BUGFIX: Fix DateTimeImmutable property mapping for custom date formats

### DIFF
--- a/Neos.Flow/Classes/Property/TypeConverter/DateTimeConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/DateTimeConverter.php
@@ -117,7 +117,7 @@ class DateTimeConverter extends AbstractTypeConverter
      * @param string $targetType must be "DateTime"
      * @param array $convertedChildProperties not used currently
      * @param PropertyMappingConfigurationInterface $configuration
-     * @return \DateTime|Error
+     * @return \DateTimeInterface|Error
      * @throws TypeConverterException
      */
     public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
@@ -166,8 +166,8 @@ class DateTimeConverter extends AbstractTypeConverter
         if ($date === false) {
             return new Error('The date "%s" was not recognized (for format "%s").', 1307719788, [$dateAsString, $dateFormat]);
         }
-        if (is_array($source)) {
-            $this->overrideTimeIfSpecified($date, $source);
+        if (is_array($source) && isset($source['hour']) && isset($source['minute']) && isset($source['second'])) {
+            $date = $this->overrideTime($date, $source);
         }
         return $date;
     }
@@ -209,18 +209,18 @@ class DateTimeConverter extends AbstractTypeConverter
     /**
      * Overrides hour, minute & second of the given date with the values in the $source array
      *
-     * @param \DateTime $date
+     * @param \DateTimeInterface $date
      * @param array $source
-     * @return void
+     * @return \DateTimeInterface
      */
-    protected function overrideTimeIfSpecified(\DateTime $date, array $source)
+    protected function overrideTime(\DateTimeInterface $date, array $source)
     {
-        if (!isset($source['hour']) && !isset($source['minute']) && !isset($source['second'])) {
-            return;
-        }
         $hour = isset($source['hour']) ? (integer)$source['hour'] : 0;
         $minute = isset($source['minute']) ? (integer)$source['minute'] : 0;
         $second = isset($source['second']) ? (integer)$source['second'] : 0;
-        $date->setTime($hour, $minute, $second);
+        if ($date instanceof \DateTime || $date instanceof \DateTimeImmutable) {
+            $date = $date->setTime($hour, $minute, $second);
+        }
+        return $date;
     }
 }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/DateTimeConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/DateTimeConverterTest.php
@@ -360,6 +360,25 @@ class DateTimeConverterTest extends UnitTestCase
     /**
      * @test
      */
+    public function convertFromAllowsToOverrideTheTimeForImmutableTargetType()
+    {
+        $source = [
+            'date' => '2011-06-16',
+            'dateFormat' => 'Y-m-d',
+            'hour' => '12',
+            'minute' => '30',
+            'second' => '59',
+        ];
+        $date = $this->converter->convertFrom($source, \DateTimeImmutable::class);
+        $this->assertSame('2011-06-16', $date->format('Y-m-d'));
+        $this->assertSame('12', $date->format('H'));
+        $this->assertSame('30', $date->format('i'));
+        $this->assertSame('59', $date->format('s'));
+    }
+
+    /**
+     * @test
+     */
     public function convertFromAllowsToOverrideTheTimezone()
     {
         $source = [
@@ -368,6 +387,24 @@ class DateTimeConverterTest extends UnitTestCase
             'timezone' => 'Atlantic/Reykjavik',
         ];
         $date = $this->converter->convertFrom($source, 'DateTime');
+        $this->assertSame('2011-06-16', $date->format('Y-m-d'));
+        $this->assertSame('12', $date->format('H'));
+        $this->assertSame('30', $date->format('i'));
+        $this->assertSame('59', $date->format('s'));
+        $this->assertSame('Atlantic/Reykjavik', $date->getTimezone()->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function convertFromAllowsToOverrideTheTimezoneForImmutableTargetType()
+    {
+        $source = [
+            'date' => '2011-06-16 12:30:59',
+            'dateFormat' => 'Y-m-d H:i:s',
+            'timezone' => 'Atlantic/Reykjavik',
+        ];
+        $date = $this->converter->convertFrom($source, \DateTimeImmutable::class);
         $this->assertSame('2011-06-16', $date->format('Y-m-d'));
         $this->assertSame('12', $date->format('H'));
         $this->assertSame('30', $date->format('i'));


### PR DESCRIPTION
This fixes support for mapping of `DateTimeImmutable` properties introduced
with #677.

Background:

If the source is an array (for example when specifying `date` as well as
`dateFormat`) the conversion fails because `DateTimeConverter::overrideTimeIfSpecified()`
still used the `DateTime` type hint.
This change adjusts the code so that it works with `DateTimeImmutable`
instances as well.

Related: #677