### PR TITLE
!!! TASK: Make ObjectManagerInterface a superset of PSR-11

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
@@ -27,7 +27,7 @@ use Psr\Container\ContainerInterface;
  * @Flow\Scope("singleton")
  * @Flow\Proxy(false)
  */
-class ObjectManager implements ObjectManagerInterface, ContainerInterface
+class ObjectManager implements ObjectManagerInterface
 {
     /**
      * The configuration context for this Flow run

--- a/Neos.Flow/Classes/ObjectManagement/ObjectManagerInterface.php
+++ b/Neos.Flow/Classes/ObjectManagement/ObjectManagerInterface.php
@@ -12,13 +12,16 @@ namespace Neos\Flow\ObjectManagement;
  */
 
 use Neos\Flow\Core\ApplicationContext;
+use Psr\Container\ContainerInterface;
 
 /**
  * Interface for the Flow Object Manager
+ * This is a superset of the PSR-11 ContainerInterface.
+ * If all you need is get and has you might want to use ContainerInterface only.
  *
  * @api
  */
-interface ObjectManagerInterface
+interface ObjectManagerInterface extends ContainerInterface
 {
     const INITIALIZATIONCAUSE_CREATED = 1;
     const INITIALIZATIONCAUSE_RECREATED = 2;
@@ -45,6 +48,15 @@ interface ObjectManagerInterface
      * @api
      */
     public function get($objectName);
+
+    /**
+     * This is the PSR-11 ContainerInterface equivalent to `isRegistered`.
+     *
+     * @param string $objectName
+     * @return bool
+     * @see isRegistered
+     */
+    public function has($objectName);
 
     /**
      * Returns TRUE if an object with the given name has already


### PR DESCRIPTION
Makes the ``ObjectManagerInterface`` fully compatible with
the PSR-11 ``ContainerInterface``.

This is a breaking change in case you implemented
``ObjectManagerInterface`` because you would have to implement the
``has`` method now in your implementation.
