### PR TITLE
BUGFIX: Pass signal information once, not once more for each slot

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/SignalSlot/Dispatcher.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/SignalSlot/Dispatcher.php
@@ -107,6 +107,7 @@ class Dispatcher
         }
 
         foreach ($this->slots[$signalClassName][$signalName] as $slotInformation) {
+            $finalSignalArguments = $signalArguments;
             if (isset($slotInformation['object'])) {
                 $object = $slotInformation['object'];
             } elseif (substr($slotInformation['method'], 0, 2) === '::') {
@@ -130,12 +131,12 @@ class Dispatcher
                 $object = $this->objectManager->get($slotInformation['class']);
             }
             if ($slotInformation['passSignalInformation'] === true) {
-                $signalArguments[] = $signalClassName . '::' . $signalName;
+                $finalSignalArguments[] = $signalClassName . '::' . $signalName;
             }
             if (!method_exists($object, $slotInformation['method'])) {
                 throw new Exception\InvalidSlotException('The slot method ' . get_class($object) . '->' . $slotInformation['method'] . '() does not exist.', 1245673368);
             }
-            call_user_func_array([$object, $slotInformation['method']], $signalArguments);
+            call_user_func_array([$object, $slotInformation['method']], $finalSignalArguments);
         }
     }
 


### PR DESCRIPTION
Signals can pass arguments to slots. These are amended with signal information,
if desired.

Because slots are hadled in a loop, and the passed signal arguments array was
used in that loop, the addition of the signal information was done mutliple
times, if requested.

This change makes sure that the signal information is only added once.
