### PR TITLE
TASK: Fix code format in docs

### DIFF
--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Validation.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Validation.rst
@@ -1,4 +1,4 @@
-﻿==========
+==========
 Validation
 ==========
 
@@ -54,23 +54,28 @@ Domain Model arguments is triggered as explained above. So in order for the auto
 previous edit form to work, the validation inside that action needs to be suppressed, or else it would
 itself possibly fail the validation and try to redirect to previous action, ending up in an infinite loop.
 
-	class CommentController extends \Neos\Flow\Mvc\Controller\ActionController {
+.. code-block:: php
 
-		/**
-		 * @param \YourPackage\Domain\Model\Comment $comment
-		 * @Flow\IgnoreValidation("$comment")
-		 */
-		public function editAction(\YourPackage\Domain\Model\Comment $comment) {
-			// here, $comment is not necessarily a valid object
-		}
+    class CommentController extends \Neos\Flow\Mvc\Controller\ActionController
+    {
 
-		/**
-		 * @param \YourPackage\Domain\Model\Comment $comment
-		 */
-		public function updateAction(\YourPackage\Domain\Model\Comment $comment) {
-			// here, $comment is a valid object
-		}
-	}
+        /**
+         * @param \YourPackage\Domain\Model\Comment $comment
+         * @Flow\IgnoreValidation("$comment")
+         */
+        public function editAction(\YourPackage\Domain\Model\Comment $comment)
+        {
+            // here, $comment is not necessarily a valid object
+        }
+
+        /**
+         * @param \YourPackage\Domain\Model\Comment $comment
+         */
+        public function updateAction(\YourPackage\Domain\Model\Comment $comment)
+        {
+            // here, $comment is a valid object
+        }
+    }
 
 .. warning::
 
@@ -80,16 +85,17 @@ itself possibly fail the validation and try to redirect to previous action, endi
 Furthermore, it is also possible to execute *additional validators* only for specific action
 arguments using ``@Flow\Validate`` inside a controller action::
 
-	class CommentController extends \Neos\Flow\Mvc\Controller\ActionController {
+    class CommentController extends \Neos\Flow\Mvc\Controller\ActionController {
 
-		/**
-		 * @param \YourPackage\Domain\Model\Comment $comment
-		 * @Flow\Validate(argumentName="comment", type="YourPackage:SomeSpecialValidator")
-		 */
-		public function updateAction(\YourPackage\Domain\Model\Comment $comment) {
-			// here, $comment is a valid object
-		}
-	}
+        /**
+         * @param \YourPackage\Domain\Model\Comment $comment
+         * @Flow\Validate(argumentName="comment", type="YourPackage:SomeSpecialValidator")
+         */
+        public function updateAction(\YourPackage\Domain\Model\Comment $comment)
+        {
+            // here, $comment is a valid object
+        }
+    }
 
 .. tip::
 
@@ -107,20 +113,20 @@ simple type.
 All validators implement ``\Neos\Flow\Validation\Validator\ValidatorInterface``, and
 the API of every validator is demonstrated in the following code example::
 
-		// NOTE: you should always use the ValidatorResolver to create new
-		// validators, as it is demonstrated in the next section.
-	$validator = new \Neos\Flow\Validation\Validator\StringLengthValidator(array(
-		'minimum' => 10,
-		'maximum' => 20
-	));
+    // NOTE: you should always use the ValidatorResolver to create new
+    // validators, as it is demonstrated in the next section.
+    $validator = new \Neos\Flow\Validation\Validator\StringLengthValidator(array(
+        'minimum' => 10,
+        'maximum' => 20
+    ));
 
-		// $result is of type Neos\Error\Messages\Result
-	$result = $validator->validate('myExampleString');
-	$result->hasErrors(); // is FALSE, as the string is longer than 10 characters.
+    // $result is of type Neos\Error\Messages\Result
+    $result = $validator->validate('myExampleString');
+    $result->hasErrors(); // is FALSE, as the string is longer than 10 characters.
 
-	$result = $validator->validate('short');
-	$result->hasErrors(); // is TRUE, as the string is too short.
-	$result->getFirstError()->getMessage(); // contains the human-readable error message
+    $result = $validator->validate('short');
+    $result->hasErrors(); // is TRUE, as the string is too short.
+    $result->getFirstError()->getMessage(); // contains the human-readable error message
 
 On the above example, it can be seen that validators can be *re-used* for different input.
 Furthermore, a validator does not only just return TRUE or FALSE, but instead returns
@@ -141,7 +147,7 @@ you should not instantiate them directly as it has been done in the above exampl
 you should use the ``\Neos\Flow\Validation\ValidatorResolver`` singleton to get a new instance
 of a certain validator::
 
-	$validatorResolver->createValidator($validatorType, array $validatorOptions);
+    $validatorResolver->createValidator($validatorType, array $validatorOptions);
 
 ``$validatorType`` can be one of the following:
 
@@ -177,9 +183,9 @@ The only exception is the ``NotEmpty`` validator, which disallows both ``NULL`` 
 if you want to validate that a property is e.g. an email address *and* does exist, you need to combine the two
 validators using a ``ConjunctionValidator``::
 
-	$conjunctionValidator = $validatorResolver->createValidator('Conjunction');
-	$conjunctionValidator->addValidator($validatorResolver->createValidator('NotEmpty'));
-	$conjunctionValidator->addValidator($validatorResolver->createValidator('EmailAddress'));
+    $conjunctionValidator = $validatorResolver->createValidator('Conjunction');
+    $conjunctionValidator->addValidator($validatorResolver->createValidator('NotEmpty'));
+    $conjunctionValidator->addValidator($validatorResolver->createValidator('EmailAddress'));
 
 Validating Domain Models
 ========================
@@ -188,8 +194,8 @@ It is very common that a full Domain Model should be validated instead of only a
 To make this use-case more easy, the ``ValidatorResolver`` has a method ``getBaseValidatorConjunction``
 which returns a fully-configured validator for an arbitrary Domain Object::
 
-	$commentValidator = $validatorResolver->getBaseValidatorConjunction('YourPackage\Domain\Model\Comment');
-	$result = $commentValidator->validate($comment);
+    $commentValidator = $validatorResolver->getBaseValidatorConjunction('YourPackage\Domain\Model\Comment');
+    $result = $commentValidator->validate($comment);
 
 The returned validator checks the following things:
 
@@ -200,14 +206,15 @@ The returned validator checks the following things:
   	namespace YourPackage\Domain\Model;
   	use Neos\Flow\Annotations as Flow;
 
-  	class Comment {
+  	class Comment
+    {
 
-  		/**
-  		 * @Flow\Validate(type="NotEmpty")
-  		 */
-  		protected $text;
+  	    /**
+  	     * @Flow\Validate(type="NotEmpty")
+  	     */
+  	    protected $text;
 
-  		// Add getters and setters here
+  	    // Add getters and setters here
   	}
 
   It also correctly builds up validators for ``Collections`` or ``arrays``, if they are properly
@@ -266,43 +273,47 @@ A validator is only executed if at least one validation group overlap.
 
 The following example demonstrates this::
 
-	class Comment {
-		/**
-		 * @Flow\Validate(type="NotEmpty")
-		 */
-		protected $prop1;
+    class Comment
+    {
 
-		/**
-		 * @Flow\Validate(type="NotEmpty", validationGroups={"Default"})
-		 */
-		protected $prop2;
+        /**
+         * @Flow\Validate(type="NotEmpty")
+         */
+        protected $prop1;
 
-		/**
-		 * @Flow\Validate(type="NotEmpty", validationGroups={"Persistence"})
-		 */
-		protected $prop3;
+        /**
+         * @Flow\Validate(type="NotEmpty", validationGroups={"Default"})
+         */
+        protected $prop2;
 
-		/**
-		 * @Flow\Validate(type="NotEmpty", validationGroups={"Controller"})
-		 */
-		protected $prop4;
+        /**
+         * @Flow\Validate(type="NotEmpty", validationGroups={"Persistence"})
+         */
+        protected $prop3;
 
-		/**
-		 * @Flow\Validate(type="NotEmpty", validationGroups={"createAction"})
-		 */
-		protected $prop5;
-	}
+        /**
+         * @Flow\Validate(type="NotEmpty", validationGroups={"Controller"})
+         */
+        protected $prop4;
 
-	class CommentController extends \Neos\Flow\Mvc\Controller\ActionController {
+        /**
+         * @Flow\Validate(type="NotEmpty", validationGroups={"createAction"})
+         */
+        protected $prop5;
+    }
 
-		/**
-		 * @param Comment $comment
-		 * @Flow\ValidationGroups({"createAction"})
-		 */
-		public function createAction(Comment $comment) {
-			...
-		}
-	}
+    class CommentController extends \Neos\Flow\Mvc\Controller\ActionController
+    {
+
+        /**
+         * @param Comment $comment
+         * @Flow\ValidationGroups({"createAction"})
+         */
+        public function createAction(Comment $comment)
+        {
+            ...
+        }
+    }
 
 * validation for prop1 and prop2 are the same, as the "Default" validation group is added if none is specified
 * validation for prop1 and prop2 are executed both on persisting and inside the controller
@@ -338,37 +349,39 @@ Usually, when writing your own validator, you will not directly implement ``Vali
 rather subclass ``AbstractValidator``. You only need to specify any options your validator might use and
 implement the ``isValid()`` method then::
 
-	/**
-	 * A validator for checking items against foos.
-	 */
-	class MySpecialValidator extends \Neos\Flow\Validation\Validator\AbstractValidator {
+    /**
+     * A validator for checking items against foos.
+     */
+    class MySpecialValidator extends \Neos\Flow\Validation\Validator\AbstractValidator
+    {
 
-		/**
-		 * @var array
-		 */
-		protected $supportedOptions = array(
-			'foo' => array(NULL, 'The foo value to accept as valid', 'mixed', TRUE)
-		);
+        /**
+         * @var array
+         */
+        protected $supportedOptions = array(
+            'foo' => array(NULL, 'The foo value to accept as valid', 'mixed', TRUE)
+        );
 
-		/**
-		 * Check if the given value is a valid foo item. What constitutes a valid foo
-		 is determined through the 'foo' option.
-		 *
-		 * @param mixed $value
-		 * @return void
-		 */
-		protected function isValid($value) {
-			if (!isset($this->options['foo'])) {
-				throw new \Neos\Flow\Validation\Exception\InvalidValidationOptionsException(
-					'The option "foo" for this validator needs to be specified', 12346788
-				);
-			}
+        /**
+         * Check if the given value is a valid foo item. What constitutes a valid foo
+         is determined through the 'foo' option.
+         *
+         * @param mixed $value
+         * @return void
+         */
+        protected function isValid($value)
+        {
+            if (!isset($this->options['foo'])) {
+                throw new \Neos\Flow\Validation\Exception\InvalidValidationOptionsException(
+                    'The option "foo" for this validator needs to be specified', 12346788
+                );
+            }
 
-			if ($value !== $this->options['foo']) {
-				$this->addError('The value must be equal to "%s"', 435346321, array($this->options['foo']));
-			}
-		}
-	}
+            if ($value !== $this->options['foo']) {
+                $this->addError('The value must be equal to "%s"', 435346321, array($this->options['foo']));
+            }
+        }
+    }
 
 In the above example, the ``isValid()`` method has been implemented, and the parameter ``$value`` is the
 data we want to check for validity. In case the data is valid, nothing needs to be done.


### PR DESCRIPTION
- Add code-block syntax to format php code as php code.
- Fix indentation in code example 
- Indent using spaces instead of tabs.
- Fix position of curly braces.