### PR TITLE
BUGFIX: Respect configured baseUri when resolving URIs

### DIFF
--- a/Neos.Flow/Classes/Mvc/Routing/Dto/ResolveContext.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Dto/ResolveContext.php
@@ -27,7 +27,7 @@ final class ResolveContext
      *
      * @var UriInterface
      */
-    private $requestUri;
+    private $baseUri;
 
     /**
      * Route values to build the URI, for example ['@action' => 'index', 'someArgument' => 'foo', ...]
@@ -51,14 +51,14 @@ final class ResolveContext
     private $uriPathPrefix;
 
     /**
-     * @param UriInterface $requestUri The currently requested URI, required to fill in parts of the result when resolving absolute URIs
+     * @param UriInterface $baseUri The base URI, retrieved from the current request URI or from configuration, if specified. Required to fill in parts of the result when resolving absolute URIs
      * @param array $routeValues Route values to build the URI, for example ['@action' => 'index', 'someArgument' => 'foo', ...]
      * @param bool $forceAbsoluteUri Whether or not an absolute URI is to be returned
      * @param string $uriPathPrefix A prefix to be prepended to any resolved URI
      */
-    public function __construct(UriInterface $requestUri, array $routeValues, bool $forceAbsoluteUri, string $uriPathPrefix = '')
+    public function __construct(UriInterface $baseUri, array $routeValues, bool $forceAbsoluteUri, string $uriPathPrefix = '')
     {
-        $this->requestUri = $requestUri;
+        $this->baseUri = $baseUri;
         $this->routeValues = $routeValues;
         $this->forceAbsoluteUri = $forceAbsoluteUri;
         $this->uriPathPrefix = $uriPathPrefix;
@@ -66,10 +66,19 @@ final class ResolveContext
 
     /**
      * @return UriInterface
+     * @deprecated This getter has been renamed. @see getBaseUri()
      */
     public function getRequestUri(): UriInterface
     {
-        return $this->requestUri;
+        return $this->getBaseUri();
+    }
+
+    /**
+     * @return UriInterface
+     */
+    public function getBaseUri(): UriInterface
+    {
+        return $this->baseUri;
     }
 
     /**

--- a/Neos.Flow/Classes/Mvc/Routing/Router.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Router.php
@@ -171,7 +171,7 @@ class Router implements RouterInterface
         $this->lastResolvedRoute = null;
         $cachedResolvedUriConstraints = $this->routerCachingService->getCachedResolvedUriConstraints($resolveContext);
         if ($cachedResolvedUriConstraints !== false) {
-            return $cachedResolvedUriConstraints->applyTo($resolveContext->getRequestUri(), $resolveContext->isForceAbsoluteUri());
+            return $cachedResolvedUriConstraints->applyTo($resolveContext->getBaseUri(), $resolveContext->isForceAbsoluteUri());
         }
 
         $this->createRoutesFromConfiguration();
@@ -180,7 +180,7 @@ class Router implements RouterInterface
         foreach ($this->routes as $route) {
             if ($route->resolves($resolveContext->getRouteValues()) === true) {
                 $uriConstraints = $route->getResolvedUriConstraints()->withPathPrefix($resolveContext->getUriPathPrefix());
-                $resolvedUri = $uriConstraints->applyTo($resolveContext->getRequestUri(), $resolveContext->isForceAbsoluteUri());
+                $resolvedUri = $uriConstraints->applyTo($resolveContext->getBaseUri(), $resolveContext->isForceAbsoluteUri());
                 $this->routerCachingService->storeResolvedUriConstraints($resolveContext, $uriConstraints, $route->getResolvedTags());
                 $this->lastResolvedRoute = $route;
                 return $resolvedUri;

--- a/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
+++ b/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
@@ -351,7 +351,7 @@ class UriBuilder
 
         $uriPathPrefix = $this->environment->isRewriteEnabled() ? '' : 'index.php/';
         $uriPathPrefix = $httpRequest->getScriptRequestPath() . $uriPathPrefix;
-        $resolveContext = new ResolveContext($httpRequest->getUri(), $arguments, $this->createAbsoluteUri, $uriPathPrefix);
+        $resolveContext = new ResolveContext($httpRequest->getBaseUri(), $arguments, $this->createAbsoluteUri, $uriPathPrefix);
         $resolvedUri = $this->router->resolve($resolveContext);
         if ($this->section !== '') {
             $resolvedUri = $resolvedUri->withFragment($this->section);

--- a/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
@@ -286,8 +286,8 @@ class RoutingTest extends FunctionalTestCase
      */
     public function resolveTests(array $routeValues, $expectedResolvedRouteName, $expectedResolvedUriPath = null)
     {
-        $requestUri = new Uri('http://localhost');
-        $resolvedUriPath = $this->router->resolve(new ResolveContext($requestUri, $routeValues, false));
+        $baseUri = new Uri('http://localhost');
+        $resolvedUriPath = $this->router->resolve(new ResolveContext($baseUri, $routeValues, false));
         $resolvedRoute = $this->router->getLastResolvedRoute();
         if ($expectedResolvedRouteName === null) {
             if ($resolvedRoute !== null) {
@@ -352,8 +352,8 @@ class RoutingTest extends FunctionalTestCase
             '@action' => 'index',
             '@format' => 'html'
         ];
-        $requestUri = new Uri('http://localhost');
-        $actualResult = $this->router->resolve(new ResolveContext($requestUri, $routeValues, false));
+        $baseUri = new Uri('http://localhost');
+        $actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, false));
 
         $this->assertSame('neos/flow/test/http/foo', (string)$actualResult);
     }
@@ -383,8 +383,8 @@ class RoutingTest extends FunctionalTestCase
             ]
         ];
         $this->router->setRoutesConfiguration($routesConfiguration);
-        $requestUri = new Uri('http://localhost');
-        $actualResult = $this->router->resolve(new ResolveContext($requestUri, $routeValues, false));
+        $baseUri = new Uri('http://localhost');
+        $actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, false));
         $this->assertSame('custom/uri/pattern', (string)$actualResult);
 
         // reset router configuration for following tests

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/RouterTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/RouterTest.php
@@ -60,7 +60,7 @@ class RouterTest extends UnitTestCase
     /**
      * @var UriInterface|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $mockRequestUri;
+    protected $mockBaseUri;
 
     /**
      * @return void
@@ -79,8 +79,8 @@ class RouterTest extends UnitTestCase
 
         $this->mockHttpRequest = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
 
-        $this->mockRequestUri = $this->getMockBuilder(UriInterface::class)->getMock();
-        $this->mockHttpRequest->expects($this->any())->method('getUri')->will($this->returnValue($this->mockRequestUri));
+        $this->mockBaseUri = $this->getMockBuilder(UriInterface::class)->getMock();
+        $this->mockHttpRequest->expects($this->any())->method('getBaseUri')->will($this->returnValue($this->mockBaseUri));
 
         $this->mockActionRequest = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->getMock();
     }
@@ -105,7 +105,7 @@ class RouterTest extends UnitTestCase
 
         // this we actually want to know
         $router->expects($this->once())->method('createRoutesFromConfiguration');
-        $router->resolve(new ResolveContext($this->mockRequestUri, [], false));
+        $router->resolve(new ResolveContext($this->mockBaseUri, [], false));
     }
 
     /**
@@ -194,7 +194,7 @@ class RouterTest extends UnitTestCase
         $router->expects($this->once())->method('createRoutesFromConfiguration');
         $router->_set('routes', $mockRoutes);
 
-        $resolvedUri = $router->resolve(new ResolveContext($this->mockRequestUri, $routeValues, false));
+        $resolvedUri = $router->resolve(new ResolveContext($this->mockBaseUri, $routeValues, false));
         $this->assertSame('route2', $resolvedUri->getPath());
     }
 
@@ -219,7 +219,7 @@ class RouterTest extends UnitTestCase
 
         $router->_set('routes', $mockRoutes);
 
-        $router->resolve(new ResolveContext($this->mockRequestUri, [], false));
+        $router->resolve(new ResolveContext($this->mockBaseUri, [], false));
     }
 
     /**
@@ -242,7 +242,7 @@ class RouterTest extends UnitTestCase
 
 
         $routeValues = ['some' => 'route values'];
-        $resolveContext = new ResolveContext($this->mockRequestUri, $routeValues, false);
+        $resolveContext = new ResolveContext($this->mockBaseUri, $routeValues, false);
         $mockRoute1 = $this->getMockBuilder(Route::class)->getMock();
         $mockRoute1->expects($this->once())->method('resolves')->with($routeValues)->will($this->returnValue(false));
         $mockRoute2 = $this->getMockBuilder(Route::class)->getMock();
@@ -269,7 +269,7 @@ class RouterTest extends UnitTestCase
         $routeValues = ['some' => 'route values'];
         $mockCachedResolvedUriConstraints = UriConstraints::create()->withPath('cached/path');
 
-        $resolveContext = new ResolveContext($this->mockRequestUri, $routeValues, false);
+        $resolveContext = new ResolveContext($this->mockBaseUri, $routeValues, false);
 
         $mockRouterCachingService = $this->getMockBuilder(RouterCachingService::class)->getMock();
         $mockRouterCachingService->expects($this->any())->method('getCachedResolvedUriConstraints')->with($resolveContext)->will($this->returnValue($mockCachedResolvedUriConstraints));
@@ -292,7 +292,7 @@ class RouterTest extends UnitTestCase
         $routeValues = ['some' => 'route values'];
         $mockResolvedUriConstraints = UriConstraints::create()->withPath('resolved/path');
 
-        $resolveContext = new ResolveContext($this->mockRequestUri, $routeValues, false);
+        $resolveContext = new ResolveContext($this->mockBaseUri, $routeValues, false);
 
         $mockRoute1 = $this->getMockBuilder(Route::class)->getMock();
         $mockRoute1->expects($this->once())->method('resolves')->with($routeValues)->will($this->returnValue(false));


### PR DESCRIPTION
This fixes a regression intdroduced with #1126 that prevented
the configured `baseUri` from being respected when building
URIs using the `UriBuilder`.

Background:

Instead of using the *Request URI* as base for generated URIs
this fix uses the *Request Base URI*.
Usually the result is the same, but not if a different `baseUri` is
configured from the one being requested.

Fixes: #1184