### PR TITLE
TASK: Adjust XSD domain to neos.io

### DIFF
--- a/Neos.FluidAdaptor/Classes/Command/DocumentationCommandController.php
+++ b/Neos.FluidAdaptor/Classes/Command/DocumentationCommandController.php
@@ -45,8 +45,7 @@ class DocumentationCommandController extends CommandController
      */
     public function generateXsdCommand(
         $phpNamespace, $xsdNamespace = null, $targetFile = null, $xsdDomain = ''
-    )
-    {
+    ) {
         $xsdDomain = trim($xsdDomain);
         $parsedDomain = parse_url($xsdDomain);
         if (empty($xsdDomain) || !isset($parsedDomain['host'], $parsedDomain['scheme'])) {

--- a/Neos.FluidAdaptor/Classes/Command/DocumentationCommandController.php
+++ b/Neos.FluidAdaptor/Classes/Command/DocumentationCommandController.php
@@ -35,17 +35,17 @@ class DocumentationCommandController extends CommandController
      * file to be placed online and used by any XSD-aware editor.
      * After creating the XSD file, reference it in your IDE and import the namespace
      * in your Fluid template by adding the xmlns:* attribute(s):
-     * <html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers" ...>
+     * <html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://neos.io/ns/Neos/Neos/ViewHelpers" ...>
      *
      * @param string $phpNamespace Namespace of the Fluid ViewHelpers without leading backslash (for example 'Neos\FluidAdaptor\ViewHelpers'). NOTE: Quote and/or escape this argument as needed to avoid backslashes from being interpreted!
-     * @param string $xsdNamespace Unique target namespace used in the XSD schema (for example "http://yourdomain.org/ns/viewhelpers"). Defaults to "http://typo3.org/ns/<php namespace>".
+     * @param string $xsdNamespace Unique target namespace used in the XSD schema (for example "http://yourdomain.org/ns/viewhelpers"). Defaults to "http://neos.io/ns/<php namespace>".
      * @param string $targetFile File path and name of the generated XSD schema. If not specified the schema will be output to standard output.
      * @return void
      */
     public function generateXsdCommand($phpNamespace, $xsdNamespace = null, $targetFile = null)
     {
         if ($xsdNamespace === null) {
-            $xsdNamespace = sprintf('http://typo3.org/ns/%s', str_replace('\\', '/', $phpNamespace));
+            $xsdNamespace = sprintf('http://neos.io/ns/%s', str_replace('\\', '/', $phpNamespace));
         }
         $xsdSchema = '';
         try {

--- a/Neos.FluidAdaptor/Classes/Command/DocumentationCommandController.php
+++ b/Neos.FluidAdaptor/Classes/Command/DocumentationCommandController.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\FluidAdaptor\Command;
 
 /*
@@ -43,9 +45,8 @@ class DocumentationCommandController extends CommandController
      * @param string $xsdDomain Domain used in the XSD schema (for example "http://yourdomain.org"). Defaults to "https://neos.io".
      * @return void
      */
-    public function generateXsdCommand(
-        $phpNamespace, $xsdNamespace = null, $targetFile = null, $xsdDomain = ''
-    ) {
+    public function generateXsdCommand(string $phpNamespace, string $xsdNamespace = null, string $targetFile = null, string $xsdDomain = ''): void
+    {
         $xsdDomain = trim($xsdDomain);
         $parsedDomain = parse_url($xsdDomain);
         if (empty($xsdDomain) || !isset($parsedDomain['host'], $parsedDomain['scheme'])) {

--- a/Neos.FluidAdaptor/Classes/Command/DocumentationCommandController.php
+++ b/Neos.FluidAdaptor/Classes/Command/DocumentationCommandController.php
@@ -35,12 +35,12 @@ class DocumentationCommandController extends CommandController
      * file to be placed online and used by any XSD-aware editor.
      * After creating the XSD file, reference it in your IDE and import the namespace
      * in your Fluid template by adding the xmlns:* attribute(s):
-     * <html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers" ...>
+     * <html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="https://neos.io/ns/Neos/Neos/ViewHelpers" ...>
      *
      * @param string $phpNamespace Namespace of the Fluid ViewHelpers without leading backslash (for example 'Neos\FluidAdaptor\ViewHelpers'). NOTE: Quote and/or escape this argument as needed to avoid backslashes from being interpreted!
-     * @param string $xsdNamespace Unique target namespace used in the XSD schema (for example "http://yourdomain.org/ns/viewhelpers"). Defaults to "http://typo3.org/ns/<php namespace>".
+     * @param string $xsdNamespace Unique target namespace used in the XSD schema (for example "http://yourdomain.org/ns/viewhelpers"). Defaults to "https://neos.io/ns/<php namespace>".
      * @param string $targetFile File path and name of the generated XSD schema. If not specified the schema will be output to standard output.
-     * @param string $xsdDomain Domain used in the XSD schema (for example "http://yourdomain.org"). Defaults to "http://typo3.org".
+     * @param string $xsdDomain Domain used in the XSD schema (for example "http://yourdomain.org"). Defaults to "https://neos.io".
      * @return void
      */
     public function generateXsdCommand(
@@ -50,7 +50,7 @@ class DocumentationCommandController extends CommandController
         $xsdDomain = trim($xsdDomain);
         $parsedDomain = parse_url($xsdDomain);
         if (empty($xsdDomain) || !isset($parsedDomain['host'], $parsedDomain['scheme'])) {
-            $xsdDomain = 'http://typo3.org';
+            $xsdDomain = 'https://neos.io';
         }
         if ($xsdNamespace === null) {
             $xsdNamespace = sprintf('%s/ns/%s', $xsdDomain, str_replace('\\', '/', $phpNamespace));

--- a/Neos.FluidAdaptor/Classes/Command/DocumentationCommandController.php
+++ b/Neos.FluidAdaptor/Classes/Command/DocumentationCommandController.php
@@ -35,17 +35,25 @@ class DocumentationCommandController extends CommandController
      * file to be placed online and used by any XSD-aware editor.
      * After creating the XSD file, reference it in your IDE and import the namespace
      * in your Fluid template by adding the xmlns:* attribute(s):
-     * <html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://neos.io/ns/Neos/Neos/ViewHelpers" ...>
+     * <html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers" ...>
      *
      * @param string $phpNamespace Namespace of the Fluid ViewHelpers without leading backslash (for example 'Neos\FluidAdaptor\ViewHelpers'). NOTE: Quote and/or escape this argument as needed to avoid backslashes from being interpreted!
-     * @param string $xsdNamespace Unique target namespace used in the XSD schema (for example "http://yourdomain.org/ns/viewhelpers"). Defaults to "http://neos.io/ns/<php namespace>".
+     * @param string $xsdNamespace Unique target namespace used in the XSD schema (for example "http://yourdomain.org/ns/viewhelpers"). Defaults to "http://typo3.org/ns/<php namespace>".
      * @param string $targetFile File path and name of the generated XSD schema. If not specified the schema will be output to standard output.
+     * @param string $xsdDomain Domain used in the XSD schema (for example "http://yourdomain.org"). Defaults to "http://typo3.org".
      * @return void
      */
-    public function generateXsdCommand($phpNamespace, $xsdNamespace = null, $targetFile = null)
+    public function generateXsdCommand(
+        $phpNamespace, $xsdNamespace = null, $targetFile = null, $xsdDomain = ''
+    )
     {
+        $xsdDomain = trim($xsdDomain);
+        $parsedDomain = parse_url($xsdDomain);
+        if (empty($xsdDomain) || !isset($parsedDomain['host'], $parsedDomain['scheme'])) {
+            $xsdDomain = 'http://typo3.org';
+        }
         if ($xsdNamespace === null) {
-            $xsdNamespace = sprintf('http://neos.io/ns/%s', str_replace('\\', '/', $phpNamespace));
+            $xsdNamespace = sprintf('%s/ns/%s', $xsdDomain, str_replace('\\', '/', $phpNamespace));
         }
         $xsdSchema = '';
         try {


### PR DESCRIPTION
The XSD file generator still uses typo3.org instead of neos.io

Resolves: #1186