### PR TITLE
BUGFIX: Add expire to cache tags

### DIFF
--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -272,9 +272,8 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
         $ttl = $this->redis->ttl($tag);
         if ($ttl === -1 || $lifetime === self::UNLIMITED_LIFETIME) {
             return self::UNLIMITED_LIFETIME;
-        } else {
-            return max($ttl, $lifetime);
         }
+        return max($ttl, $lifetime);
     }
 
     /**

--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -141,7 +141,9 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
         $this->redis->rPush($this->buildKey('entries'), $entryIdentifier);
         foreach ($tags as $tag) {
             $this->redis->sAdd($this->buildKey('tag:' . $tag), $entryIdentifier);
+            $this->redis->expire($this->buildKey('tag:' . $tag), $lifetime);
             $this->redis->sAdd($this->buildKey('tags:' . $entryIdentifier), $tag);
+            $this->redis->expire($this->buildKey('tags:' . $entryIdentifier), $lifetime);
         }
         $this->redis->exec();
     }

--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -132,7 +132,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
             $setOptions['ex'] = $lifetime;
         }
 
-        $redisTags = array_reduce($tags, function($redisTags, $tag) use ($lifetime, $entryIdentifier) {
+        $redisTags = array_reduce($tags, function ($redisTags, $tag) use ($lifetime, $entryIdentifier) {
             $expire = $this->calculateExpires($this->buildKey('tag:' . $tag), $lifetime);
             $redisTags[] = ['key' => $this->buildKey('tag:' . $tag), 'value' => $entryIdentifier, 'expire' => $expire];
 


### PR DESCRIPTION
The tags are never garbage collected from redis when the cache entry expires. So we need to set the same cache lifetime to the cache tags.

**What I did**
Add the same cache lifetime of the entry to the cache tags.

**How to verify it**
Configure a redis cache with a very low cache lifetime (60s).
Use `redis-cli info` to check if the database is empty.
Add a entry to redis and use the same command to verify that the entry and tags are present. This should look the `db1:keys=5,expires=5,avg_ttl=59225`. Wait 60s and and all entries should removed from the database.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
