### PR TITLE
BUGFIX: Fix deprecated Symfony console helper implementations

### DIFF
--- a/Neos.Flow/Classes/Cli/ConsoleOutput.php
+++ b/Neos.Flow/Classes/Cli/ConsoleOutput.php
@@ -162,10 +162,7 @@ class ConsoleOutput
      */
     public function select($question, array $choices, bool $default = null, bool $multiSelect = false, $attempts = null)
     {
-        if (is_array($question)) {
-            $question = $this->combineQuestion($question);
-        }
-        $question = new ChoiceQuestion($question, $choices, $default);
+        $question = new ChoiceQuestion($this->combineQuestion($question), $choices, $default);
         $question
             ->setMaxAttempts($attempts)
             ->setMultiselect($multiSelect)
@@ -184,10 +181,7 @@ class ConsoleOutput
      */
     public function ask($question, string $default = null): string
     {
-        if (is_array($question)) {
-            $question = $this->combineQuestion($question);
-        }
-        $question = new Question($question, $default);
+        $question = new Question($this->combineQuestion($question), $default);
 
         return $this->getQuestionHelper()->ask($this->input, $this->output, $question);
     }
@@ -203,10 +197,7 @@ class ConsoleOutput
      */
     public function askConfirmation($question, bool $default = true): bool
     {
-        if (is_array($question)) {
-            $question = $this->combineQuestion($question);
-        }
-        $question = new ConfirmationQuestion($question, $default);
+        $question = new ConfirmationQuestion($this->combineQuestion($question), $default);
 
         return $this->getQuestionHelper()->ask($this->input, $this->output, $question);
     }
@@ -221,10 +212,7 @@ class ConsoleOutput
      */
     public function askHiddenResponse($question, bool $fallback = true): string
     {
-        if (is_array($question)) {
-            $question = $this->combineQuestion($question);
-        }
-        $question = new Question($question);
+        $question = new Question($this->combineQuestion($question));
         $question
             ->setHidden(true)
             ->setHiddenFallback($fallback);
@@ -248,10 +236,7 @@ class ConsoleOutput
      */
     public function askAndValidate($question, callable $validator, int $attempts = null, string $default = null): bool
     {
-        if (is_array($question)) {
-            $question = $this->combineQuestion($question);
-        }
-        $question = new Question($question, $default);
+        $question = new Question($this->combineQuestion($question), $default);
         $question
             ->setValidator($validator)
             ->setMaxAttempts($attempts);
@@ -276,10 +261,7 @@ class ConsoleOutput
      */
     public function askHiddenResponseAndValidate($question, callable $validator, int $attempts = null, bool $fallback = true): string
     {
-        if (is_array($question)) {
-            $question = $this->combineQuestion($question);
-        }
-        $question = new Question($question);
+        $question = new Question($this->combineQuestion($question));
         $question
             ->setHidden(true)
             ->setHiddenFallback($fallback)
@@ -385,12 +367,16 @@ class ConsoleOutput
     /**
      * If question is an array, split it into multi-line string
      *
-     * @param array $question
+     * @param string|array $question
      * @return string
      */
-    protected function combineQuestion(array $question): string
+    protected function combineQuestion($question): string
     {
-        return implode(PHP_EOL, $question);
+        if (is_array($question)) {
+            return implode(PHP_EOL, $question);
+        }
+
+        return $question;
     }
 
     /**

--- a/Neos.Flow/Classes/Cli/ConsoleOutput.php
+++ b/Neos.Flow/Classes/Cli/ConsoleOutput.php
@@ -92,7 +92,7 @@ class ConsoleOutput
      * @param array $arguments Optional arguments to use for sprintf
      * @return void
      */
-    public function output($text, array $arguments = []): void
+    public function output(string $text, array $arguments = []): void
     {
         if ($arguments !== []) {
             $text = vsprintf($text, $arguments);
@@ -109,7 +109,7 @@ class ConsoleOutput
      * @see output()
      * @see outputLines()
      */
-    public function outputLine($text = '', array $arguments = []): void
+    public function outputLine(string $text = '', array $arguments = []): void
     {
         $this->output($text . PHP_EOL, $arguments);
     }
@@ -124,7 +124,7 @@ class ConsoleOutput
      * @return void
      * @see outputLine()
      */
-    public function outputFormatted($text = '', array $arguments = [], $leftPadding = 0): void
+    public function outputFormatted(string $text = '', array $arguments = [], int $leftPadding = 0): void
     {
         $lines = explode(PHP_EOL, $text);
         foreach ($lines as $line) {
@@ -139,7 +139,7 @@ class ConsoleOutput
      * @param array $rows
      * @param array $headers
      */
-    public function outputTable($rows, $headers = null): void
+    public function outputTable(array $rows, array $headers = null): void
     {
         $table = $this->getTable();
         if ($headers !== null) {
@@ -156,11 +156,11 @@ class ConsoleOutput
      * @param array $choices List of choices to pick from
      * @param boolean $default The default answer if the user enters nothing
      * @param boolean $multiSelect If TRUE the result will be an array with the selected options. Multiple options can be given separated by commas
-     * @param boolean|null $attempts Max number of times to ask before giving up (false by default, which means infinite)
+     * @param boolean|null $attempts Max number of times to ask before giving up (null by default, which means infinite)
      * @return integer|string|array The selected value or values (the key of the choices array)
      * @throws \InvalidArgumentException
      */
-    public function select($question, $choices, $default = null, $multiSelect = false, $attempts = null)
+    public function select($question, array $choices, bool $default = null, bool $multiSelect = false, $attempts = null)
     {
         if (is_array($question)) {
             $question = $this->splitQuestion($question);
@@ -182,7 +182,7 @@ class ConsoleOutput
      * @return string The user answer
      * @throws \RuntimeException If there is no data to read in the input stream
      */
-    public function ask($question, $default = null): string
+    public function ask($question, string $default = null): string
     {
         if (is_array($question)) {
             $question = $this->splitQuestion($question);
@@ -201,7 +201,7 @@ class ConsoleOutput
      * @param boolean $default The default answer if the user enters nothing
      * @return boolean true if the user has confirmed, false otherwise
      */
-    public function askConfirmation($question, $default = true): bool
+    public function askConfirmation($question, bool $default = true): bool
     {
         if (is_array($question)) {
             $question = $this->splitQuestion($question);
@@ -219,7 +219,7 @@ class ConsoleOutput
      * @return string The answer
      * @throws \RuntimeException In case the fallback is deactivated and the response can not be hidden
      */
-    public function askHiddenResponse($question, $fallback = true): string
+    public function askHiddenResponse($question, bool $fallback = true): string
     {
         if (is_array($question)) {
             $question = $this->splitQuestion($question);
@@ -241,12 +241,12 @@ class ConsoleOutput
      *
      * @param string|array $question The question to ask. If an array each array item is turned into one line of a multi-line question
      * @param callable $validator A PHP callback that gets a value and is expected to return the (transformed) value or throw an exception if it wasn't valid
-     * @param integer|boolean $attempts Max number of times to ask before giving up (false by default, which means infinite)
+     * @param integer|null $attempts Max number of times to ask before giving up (null by default, which means infinite)
      * @param string $default The default answer if none is given by the user
      * @return bool
      * @throws \Exception When any of the validators return an error
      */
-    public function askAndValidate($question, $validator, $attempts = null, $default = null): bool
+    public function askAndValidate($question, callable $validator, int $attempts = null, string $default = null): bool
     {
         if (is_array($question)) {
             $question = $this->splitQuestion($question);
@@ -268,13 +268,13 @@ class ConsoleOutput
      *
      * @param string|array $question The question to ask. If an array each array item is turned into one line of a multi-line question
      * @param callable $validator A PHP callback that gets a value and is expected to return the (transformed) value or throw an exception if it wasn't valid
-     * @param integer|null $attempts Max number of times to ask before giving up (false by default, which means infinite)
+     * @param integer|null $attempts Max number of times to ask before giving up (null by default, which means infinite)
      * @param boolean $fallback In case the response can not be hidden, whether to fallback on non-hidden question or not
      * @return string The response
      * @throws \Exception When any of the validators return an error
      * @throws \RuntimeException In case the fallback is deactivated and the response can not be hidden
      */
-    public function askHiddenResponseAndValidate($question, $validator, $attempts = null, $fallback = true): string
+    public function askHiddenResponseAndValidate($question, callable $validator, int $attempts = null, bool $fallback = true): string
     {
         if (is_array($question)) {
             $question = $this->splitQuestion($question);
@@ -295,7 +295,7 @@ class ConsoleOutput
      * @param integer $max Maximum steps. If NULL an indeterminate progress bar is rendered
      * @return void
      */
-    public function progressStart($max = null): void
+    public function progressStart(int $max = null): void
     {
         $this->getProgressBar()->start($max);
     }
@@ -307,7 +307,7 @@ class ConsoleOutput
      * @return void
      * @throws \LogicException
      */
-    public function progressAdvance($step = 1): void
+    public function progressAdvance(int $step = 1): void
     {
         $this->getProgressBar()->advance($step);
     }
@@ -319,7 +319,7 @@ class ConsoleOutput
      * @return void
      * @throws \LogicException
      */
-    public function progressSet($current): void
+    public function progressSet(int $current): void
     {
         $this->getProgressBar()->setProgress($current);
     }

--- a/Neos.Flow/Classes/Cli/ConsoleOutput.php
+++ b/Neos.Flow/Classes/Cli/ConsoleOutput.php
@@ -18,8 +18,11 @@ use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput as SymfonyConsoleOutput;
 use Symfony\Component\Console\Input\StringInput as SymfonyStringInput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
 
@@ -58,8 +61,8 @@ class ConsoleOutput
      */
     public function __construct()
     {
-        $this->output = new SymfonyConsoleOutput();
-        $this->input = new SymfonyStringInput('');
+        $this->setOutput(new SymfonyConsoleOutput());
+        $this->setInput(new SymfonyStringInput(''));
         $this->input->setInteractive(true);
         $this->output->getFormatter()->setStyle('b', new OutputFormatterStyle(null, null, ['bold']));
         $this->output->getFormatter()->setStyle('i', new OutputFormatterStyle('black', 'white'));
@@ -324,6 +327,35 @@ class ConsoleOutput
     public function progressFinish()
     {
         $this->getProgressBar()->finish();
+    }
+
+    /**
+     * @param OutputInterface $output
+     */
+    public function setOutput(OutputInterface $output) {
+        $this->output = $output;
+    }
+
+    /**
+     * @return OutputInterface
+     */
+    public function getOutput(): OutputInterface {
+        return $this->output;
+    }
+
+    /**
+     * @param InputInterface $input
+     */
+    public function setInput(InputInterface $input) {
+        $this->input = $input;
+    }
+
+
+    /**
+     * @return InputInterface
+     */
+    public function getInput():InputInterface {
+        return $this->input;
     }
 
     /**

--- a/Neos.Flow/Classes/Cli/ConsoleOutput.php
+++ b/Neos.Flow/Classes/Cli/ConsoleOutput.php
@@ -256,7 +256,7 @@ class ConsoleOutput
             ->setValidator($validator)
             ->setMaxAttempts($attempts);
 
-        return $this->getQuestionHelper()->askAndValidate($this->input, $this->output, $question);
+        return $this->getQuestionHelper()->ask($this->input, $this->output, $question);
     }
 
     /**

--- a/Neos.Flow/Classes/Cli/ConsoleOutput.php
+++ b/Neos.Flow/Classes/Cli/ConsoleOutput.php
@@ -13,10 +13,10 @@ namespace Neos\Flow\Cli;
 
 use Neos\Flow\Annotations as Flow;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Helper\HelperSet;
-use Symfony\Component\Console\Helper\ProgressHelper;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\ConsoleOutput as SymfonyConsoleOutput;
 use Symfony\Component\Console\Input\StringInput as SymfonyStringInput;
@@ -44,9 +44,9 @@ class ConsoleOutput
     protected $questionHelper;
 
     /**
-     * @var ProgressHelper
+     * @var ProgressBar
      */
-    protected $progressHelper;
+    protected $progressBar;
 
     /**
      * @var Table
@@ -289,33 +289,31 @@ class ConsoleOutput
      */
     public function progressStart($max = null)
     {
-        $this->getProgressHelper()->start($this->output, $max);
+        $this->getProgressBar()->start($max);
     }
 
     /**
      * Advances the progress output X steps
      *
      * @param integer $step Number of steps to advance
-     * @param Boolean $redraw Whether to redraw or not
      * @return void
      * @throws \LogicException
      */
-    public function progressAdvance($step = 1, $redraw = false)
+    public function progressAdvance($step = 1)
     {
-        $this->getProgressHelper()->advance($step, $redraw);
+        $this->getProgressBar()->advance($step);
     }
 
     /**
      * Sets the current progress
      *
      * @param integer $current The current progress
-     * @param Boolean $redraw Whether to redraw or not
      * @return void
      * @throws \LogicException
      */
-    public function progressSet($current, $redraw = false)
+    public function progressSet($current)
     {
-        $this->getProgressHelper()->setCurrent($current, $redraw);
+        $this->getProgressBar()->setProgress($current);
     }
 
     /**
@@ -325,7 +323,7 @@ class ConsoleOutput
      */
     public function progressFinish()
     {
-        $this->getProgressHelper()->finish();
+        $this->getProgressBar()->finish();
     }
 
     /**
@@ -357,14 +355,14 @@ class ConsoleOutput
     /**
      * Returns or initializes the symfony/console ProgressHelper
      *
-     * @return ProgressHelper
+     * @return ProgressBar
      */
-    protected function getProgressHelper()
+    protected function getProgressBar()
     {
-        if ($this->progressHelper === null) {
-            $this->progressHelper = new ProgressHelper();
+        if ($this->progressBar === null) {
+            $this->progressBar = new ProgressBar($this->output);
         }
-        return $this->progressHelper;
+        return $this->progressBar;
     }
 
     /**

--- a/Neos.Flow/Classes/Cli/ConsoleOutput.php
+++ b/Neos.Flow/Classes/Cli/ConsoleOutput.php
@@ -390,7 +390,7 @@ class ConsoleOutput
      */
     protected function splitQuestion(array $question)
     {
-        return implode('\n', $question);
+        return implode(PHP_EOL, $question);
     }
 
     /**

--- a/Neos.Flow/Classes/Cli/ConsoleOutput.php
+++ b/Neos.Flow/Classes/Cli/ConsoleOutput.php
@@ -163,7 +163,7 @@ class ConsoleOutput
     public function select($question, array $choices, bool $default = null, bool $multiSelect = false, $attempts = null)
     {
         if (is_array($question)) {
-            $question = $this->splitQuestion($question);
+            $question = $this->combineQuestion($question);
         }
         $question = new ChoiceQuestion($question, $choices, $default);
         $question
@@ -185,7 +185,7 @@ class ConsoleOutput
     public function ask($question, string $default = null): string
     {
         if (is_array($question)) {
-            $question = $this->splitQuestion($question);
+            $question = $this->combineQuestion($question);
         }
         $question = new Question($question, $default);
 
@@ -204,7 +204,7 @@ class ConsoleOutput
     public function askConfirmation($question, bool $default = true): bool
     {
         if (is_array($question)) {
-            $question = $this->splitQuestion($question);
+            $question = $this->combineQuestion($question);
         }
         $question = new ConfirmationQuestion($question, $default);
 
@@ -222,7 +222,7 @@ class ConsoleOutput
     public function askHiddenResponse($question, bool $fallback = true): string
     {
         if (is_array($question)) {
-            $question = $this->splitQuestion($question);
+            $question = $this->combineQuestion($question);
         }
         $question = new Question($question);
         $question
@@ -249,7 +249,7 @@ class ConsoleOutput
     public function askAndValidate($question, callable $validator, int $attempts = null, string $default = null): bool
     {
         if (is_array($question)) {
-            $question = $this->splitQuestion($question);
+            $question = $this->combineQuestion($question);
         }
         $question = new Question($question, $default);
         $question
@@ -277,7 +277,7 @@ class ConsoleOutput
     public function askHiddenResponseAndValidate($question, callable $validator, int $attempts = null, bool $fallback = true): string
     {
         if (is_array($question)) {
-            $question = $this->splitQuestion($question);
+            $question = $this->combineQuestion($question);
         }
         $question = new Question($question);
         $question
@@ -388,7 +388,7 @@ class ConsoleOutput
      * @param array $question
      * @return string
      */
-    protected function splitQuestion(array $question): string
+    protected function combineQuestion(array $question): string
     {
         return implode(PHP_EOL, $question);
     }

--- a/Neos.Flow/Classes/Cli/ConsoleOutput.php
+++ b/Neos.Flow/Classes/Cli/ConsoleOutput.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\ProgressHelper;
-use Symfony\Component\Console\Helper\TableHelper;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\ConsoleOutput as SymfonyConsoleOutput;
 use Symfony\Component\Console\Input\StringInput as SymfonyStringInput;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
@@ -49,9 +49,9 @@ class ConsoleOutput
     protected $progressHelper;
 
     /**
-     * @var TableHelper
+     * @var Table
      */
-    protected $tableHelper;
+    protected $table;
 
     /**
      * Creates and initializes the SymfonyConsoleOutput instance
@@ -138,12 +138,12 @@ class ConsoleOutput
      */
     public function outputTable($rows, $headers = null)
     {
-        $tableHelper = $this->getTableHelper();
+        $table = $this->getTable();
         if ($headers !== null) {
-            $tableHelper->setHeaders($headers);
+            $table->setHeaders($headers);
         }
-        $tableHelper->setRows($rows);
-        $tableHelper->render($this->output);
+        $table->setRows($rows);
+        $table->render();
     }
 
     /**
@@ -368,15 +368,15 @@ class ConsoleOutput
     }
 
     /**
-     * Returns or initializes the symfony/console TableHelper
+     * Returns or initializes the symfony/console Table
      *
-     * @return TableHelper
+     * @return Table
      */
-    protected function getTableHelper()
+    protected function getTable()
     {
-        if ($this->tableHelper === null) {
-            $this->tableHelper = new TableHelper();
+        if ($this->table === null) {
+            $this->table = new Table($this->output);
         }
-        return $this->tableHelper;
+        return $this->table;
     }
 }

--- a/Neos.Flow/Classes/Cli/ConsoleOutput.php
+++ b/Neos.Flow/Classes/Cli/ConsoleOutput.php
@@ -156,17 +156,22 @@ class ConsoleOutput
      * @param array $choices List of choices to pick from
      * @param boolean $default The default answer if the user enters nothing
      * @param boolean $multiSelect If TRUE the result will be an array with the selected options. Multiple options can be given separated by commas
-     * @param boolean|integer $attempts Max number of times to ask before giving up (false by default, which means infinite)
+     * @param boolean|null $attempts Max number of times to ask before giving up (false by default, which means infinite)
      * @return integer|string|array The selected value or values (the key of the choices array)
      * @throws \InvalidArgumentException
      */
-    public function select($question, $choices, $default = null, $multiSelect = false, $attempts = false)
+    public function select($question, $choices, $default = null, $multiSelect = false, $attempts = null)
     {
         if (is_array($question)) {
             $question = $this->splitQuestion($question);
         }
+        $question = new ChoiceQuestion($question, $choices, $default);
+        $question
+            ->setMaxAttempts($attempts)
+            ->setMultiselect($multiSelect)
+            ->setErrorMessage('Value "%s" is invalid');
 
-        return $this->getQuestionHelper()->select($this->output, $question, $choices, $default, $attempts, 'Value "%s" is invalid', $multiSelect);
+        return $this->getQuestionHelper()->ask($this->input, $this->output, $question);
     }
 
     /**

--- a/Neos.Flow/Classes/Cli/ConsoleOutput.php
+++ b/Neos.Flow/Classes/Cli/ConsoleOutput.php
@@ -337,7 +337,7 @@ class ConsoleOutput
     /**
      * @param OutputInterface $output
      */
-    public function setOutput(OutputInterface $output)
+    public function setOutput(OutputInterface $output): void
     {
         $this->output = $output;
     }
@@ -353,7 +353,7 @@ class ConsoleOutput
     /**
      * @param InputInterface $input
      */
-    public function setInput(InputInterface $input)
+    public function setInput(InputInterface $input): void
     {
         $this->input = $input;
     }
@@ -388,7 +388,7 @@ class ConsoleOutput
      * @param array $question
      * @return string
      */
-    protected function splitQuestion(array $question)
+    protected function splitQuestion(array $question): string
     {
         return implode(PHP_EOL, $question);
     }

--- a/Neos.Flow/Classes/Cli/ConsoleOutput.php
+++ b/Neos.Flow/Classes/Cli/ConsoleOutput.php
@@ -78,7 +78,7 @@ class ConsoleOutput
      *
      * @return integer
      */
-    public function getMaximumLineLength()
+    public function getMaximumLineLength(): int
     {
         return 79;
     }
@@ -92,7 +92,7 @@ class ConsoleOutput
      * @param array $arguments Optional arguments to use for sprintf
      * @return void
      */
-    public function output($text, array $arguments = [])
+    public function output($text, array $arguments = []): void
     {
         if ($arguments !== []) {
             $text = vsprintf($text, $arguments);
@@ -109,7 +109,7 @@ class ConsoleOutput
      * @see output()
      * @see outputLines()
      */
-    public function outputLine($text = '', array $arguments = [])
+    public function outputLine($text = '', array $arguments = []): void
     {
         $this->output($text . PHP_EOL, $arguments);
     }
@@ -124,7 +124,7 @@ class ConsoleOutput
      * @return void
      * @see outputLine()
      */
-    public function outputFormatted($text = '', array $arguments = [], $leftPadding = 0)
+    public function outputFormatted($text = '', array $arguments = [], $leftPadding = 0): void
     {
         $lines = explode(PHP_EOL, $text);
         foreach ($lines as $line) {
@@ -139,7 +139,7 @@ class ConsoleOutput
      * @param array $rows
      * @param array $headers
      */
-    public function outputTable($rows, $headers = null)
+    public function outputTable($rows, $headers = null): void
     {
         $table = $this->getTable();
         if ($headers !== null) {
@@ -182,7 +182,7 @@ class ConsoleOutput
      * @return string The user answer
      * @throws \RuntimeException If there is no data to read in the input stream
      */
-    public function ask($question, $default = null)
+    public function ask($question, $default = null): string
     {
         if (is_array($question)) {
             $question = $this->splitQuestion($question);
@@ -201,7 +201,7 @@ class ConsoleOutput
      * @param boolean $default The default answer if the user enters nothing
      * @return boolean true if the user has confirmed, false otherwise
      */
-    public function askConfirmation($question, $default = true)
+    public function askConfirmation($question, $default = true): bool
     {
         if (is_array($question)) {
             $question = $this->splitQuestion($question);
@@ -219,7 +219,7 @@ class ConsoleOutput
      * @return string The answer
      * @throws \RuntimeException In case the fallback is deactivated and the response can not be hidden
      */
-    public function askHiddenResponse($question, $fallback = true)
+    public function askHiddenResponse($question, $fallback = true): string
     {
         if (is_array($question)) {
             $question = $this->splitQuestion($question);
@@ -243,10 +243,10 @@ class ConsoleOutput
      * @param callable $validator A PHP callback that gets a value and is expected to return the (transformed) value or throw an exception if it wasn't valid
      * @param integer|boolean $attempts Max number of times to ask before giving up (false by default, which means infinite)
      * @param string $default The default answer if none is given by the user
-     * @return mixed
+     * @return bool
      * @throws \Exception When any of the validators return an error
      */
-    public function askAndValidate($question, $validator, $attempts = null, $default = null)
+    public function askAndValidate($question, $validator, $attempts = null, $default = null): bool
     {
         if (is_array($question)) {
             $question = $this->splitQuestion($question);
@@ -274,7 +274,7 @@ class ConsoleOutput
      * @throws \Exception When any of the validators return an error
      * @throws \RuntimeException In case the fallback is deactivated and the response can not be hidden
      */
-    public function askHiddenResponseAndValidate($question, $validator, $attempts = null, $fallback = true)
+    public function askHiddenResponseAndValidate($question, $validator, $attempts = null, $fallback = true): string
     {
         if (is_array($question)) {
             $question = $this->splitQuestion($question);
@@ -295,7 +295,7 @@ class ConsoleOutput
      * @param integer $max Maximum steps. If NULL an indeterminate progress bar is rendered
      * @return void
      */
-    public function progressStart($max = null)
+    public function progressStart($max = null): void
     {
         $this->getProgressBar()->start($max);
     }
@@ -307,7 +307,7 @@ class ConsoleOutput
      * @return void
      * @throws \LogicException
      */
-    public function progressAdvance($step = 1)
+    public function progressAdvance($step = 1): void
     {
         $this->getProgressBar()->advance($step);
     }
@@ -319,7 +319,7 @@ class ConsoleOutput
      * @return void
      * @throws \LogicException
      */
-    public function progressSet($current)
+    public function progressSet($current): void
     {
         $this->getProgressBar()->setProgress($current);
     }
@@ -329,7 +329,7 @@ class ConsoleOutput
      *
      * @return void
      */
-    public function progressFinish()
+    public function progressFinish(): void
     {
         $this->getProgressBar()->finish();
     }
@@ -372,7 +372,7 @@ class ConsoleOutput
      *
      * @return QuestionHelper
      */
-    protected function getQuestionHelper()
+    protected function getQuestionHelper(): QuestionHelper
     {
         if ($this->questionHelper === null) {
             $this->questionHelper = new QuestionHelper();
@@ -398,7 +398,7 @@ class ConsoleOutput
      *
      * @return ProgressBar
      */
-    protected function getProgressBar()
+    protected function getProgressBar(): ProgressBar
     {
         if ($this->progressBar === null) {
             $this->progressBar = new ProgressBar($this->output);
@@ -411,7 +411,7 @@ class ConsoleOutput
      *
      * @return Table
      */
-    protected function getTable()
+    protected function getTable(): Table
     {
         if ($this->table === null) {
             $this->table = new Table($this->output);

--- a/Neos.Flow/Tests/Unit/Cli/ConsoleOutputTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/ConsoleOutputTest.php
@@ -42,13 +42,14 @@ class ConsoleOutputTest extends UnitTestCase
      */
     public function setUp()
     {
-        $this->input = new ArrayInput(['test']);
+        $this->input = new ArrayInput([]);
+        $this->answerNothing();
+
         $this->output = new StreamOutput(fopen('php://memory', 'w', false));
 
         $this->consoleOutput = new ConsoleOutput();
         $this->consoleOutput->setOutput($this->output);
         $this->consoleOutput->setInput($this->input);
-        $this->consoleOutput->getInput()->setInteractive(false);
     }
 
     /**
@@ -58,7 +59,52 @@ class ConsoleOutputTest extends UnitTestCase
     {
         $string = 'simple output';
         $this->consoleOutput->output($string);
-        $this->assertSame($string, $this->getDisplay());
+
+        $this->assertSame($string, $this->returnOutput());
+    }
+
+    /**
+     * @test
+     */
+    public function questionIsAskedAnswerIsNo()
+    {
+        $this->answerNo();
+        $userAnswer = $this->consoleOutput->askConfirmation('Is this a test?');
+
+        $this->assertSame(false, $userAnswer);
+    }
+
+    /**
+     * @test
+     */
+    public function questionIsAskedAnswerIsYes()
+    {
+        $this->answerYes();
+        $userAnswer = $this->consoleOutput->askConfirmation('Are you lying?');
+
+        $this->assertSame(true, $userAnswer);
+    }
+
+    /**
+     * @test
+     */
+    public function questionIsWrittenToOutput()
+    {
+        $this->answerYes();
+        $this->consoleOutput->ask('Is this a test?');
+
+        $this->assertSame('Is this a test?', $this->returnOutput());
+    }
+
+    /**
+     * @test
+     */
+    public function multiLineAnswerIsSplitIntoMultipleLines()
+    {
+        $this->answerYes();
+        $this->consoleOutput->ask(['First line', 'Second line']);
+
+        $this->assertSame('First line'.PHP_EOL.'Second line', $this->returnOutput());
     }
 
     /**
@@ -72,49 +118,129 @@ class ConsoleOutputTest extends UnitTestCase
     /**
      * @test
      */
-    public function questionIsAskedAnswerIsNo()
+    public function tableCanBeDrawn()
     {
-        $answer = $this->consoleOutput->ask('Is this a test?');
-        \Neos\Flow\var_dump($this->getDisplay());
+        $this->consoleOutput->outputTable([
+            ['row1', 'row2'],
+            ['header 1', 'header 2']
+        ]);
 
-        $this->assertSame(false, $answer);
+        $this->assertSame(
+            '+----------+----------+' . PHP_EOL .
+            '| row1     | row2     |' . PHP_EOL .
+            '| header 1 | header 2 |' . PHP_EOL .
+            '+----------+----------+' . PHP_EOL, $this->returnOutput());
     }
 
     /**
      * @test
      */
-    public function questionIsAskedAnswerIsYes()
+    public function askAndValidate()
     {
-        $answer = $this->consoleOutput->askConfirmation('Are you lying?');
-        $this->assertSame(true, $answer);
+        $this->answerCustom(5);
+        $validator = function($number) {
+            return $number > 4;
+        };
+
+        $userAnswer = $this->consoleOutput->askAndValidate('Enter a number higher than 4', $validator);
+
+        $this->assertSame(true, $userAnswer);
     }
 
     /**
      * @test
      */
-    public function returnUserInput()
+    public function drawProgressBar()
     {
-        $answer = $this->consoleOutput->ask('Are you lying?');
-        $this->assertSame(true, $answer);
+        $this->consoleOutput->progressStart(100);
+        $this->consoleOutput->progressAdvance();
+        $progressBar = $this->consoleOutput->progressSet(50);
+        $progressBar = $this->consoleOutput->progressFinish();
+        $this->assertSame(
+            '   0/100 [>---------------------------]   0%' . PHP_EOL .
+            '   1/100 [>---------------------------]   1%' . PHP_EOL .
+            '  50/100 [==============>-------------]  50%' . PHP_EOL .
+            ' 100/100 [============================] 100%'
+            , $this->returnOutput());
     }
 
     /**
-     * Gets the display returned by the last execution of the command.
-     *
-     * @param bool $normalize Whether to normalize end of lines to \n or not
-     *
-     * @return string The display
+     * @test
      */
-    private function getDisplay($normalize = false)
+    public function selectAndChoosableAnswer()
+    {
+        $this->answerCustom('no');
+        $choices = [
+            'yes' => 'No',
+            'no' => 'Yes'
+        ];
+        $userAnswer = $this->consoleOutput->select('Is this a good test?', $choices, 2, true);
+
+        $this->assertSame(['no'], $userAnswer);
+    }
+
+    /**
+     * @test
+     */
+    public function selectAnswerIsDisplayed()
+    {
+        $this->answerCustom('1');
+        $choices = [
+            1 => 'No',
+            2 => 'Yes'
+        ];
+        $this->consoleOutput->select('Is this a good test?', $choices, 2, true);
+
+        $this->assertSame(
+            'Is this a good test?' . PHP_EOL .
+            '  [1] No' . PHP_EOL .
+            '  [2] Yes' . PHP_EOL .' > 1',
+            $this->returnOutput()
+        );
+    }
+
+    private function answerYes()
+    {
+        $this->input->setStream(self::createStream(['yes']));
+    }
+
+    private function answerNo()
+    {
+        $this->input->setStream(self::createStream(['no']));
+    }
+
+    private function answerCustom(string $answer)
+    {
+        $this->input->setStream(self::createStream([$answer]));
+    }
+
+    private function answerNothing()
+    {
+        $this->input->setStream(self::createStream([' ']));
+    }
+
+    /**
+     * @return string $streamContent
+     */
+    private function returnOutput()
     {
         rewind($this->output->getStream());
+        $streamContent = stream_get_contents($this->output->getStream());
 
-        $display = stream_get_contents($this->output->getStream());
+        return $streamContent;
+    }
 
-        if ($normalize) {
-            $display = str_replace(PHP_EOL, "\n", $display);
-        }
+    /**
+     * @param array $inputs
+     * @return bool|resource
+     */
+    private static function createStream(array $inputs)
+    {
+        $stream = fopen('php://memory', 'r+', false);
 
-        return $display;
+        fwrite($stream, implode(PHP_EOL, $inputs));
+        rewind($stream);
+
+        return $stream;
     }
 }

--- a/Neos.Flow/Tests/Unit/Cli/ConsoleOutputTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/ConsoleOutputTest.php
@@ -1,0 +1,122 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Cli;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Cli;
+use Neos\Flow\Cli\ConsoleOutput;
+use Neos\Flow\Tests\UnitTestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\StreamOutput;
+
+/**
+ * Test cases for the CLI console output
+ */
+class ConsoleOutputTest extends UnitTestCase
+{
+    /**
+     * @var Cli\ConsoleOutput
+     */
+    private $consoleOutput;
+
+    /**
+     * @var StreamOutput
+     */
+    private $output;
+
+    /**
+     * @var ArrayInput
+     */
+    private $input;
+
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->input = new ArrayInput(['test']);
+        $this->output = new StreamOutput(fopen('php://memory', 'w', false));
+
+        $this->consoleOutput = new ConsoleOutput();
+        $this->consoleOutput->setOutput($this->output);
+        $this->consoleOutput->setInput($this->input);
+        $this->consoleOutput->getInput()->setInteractive(false);
+    }
+
+    /**
+     * @test
+     */
+    public function outputSimpleOutput()
+    {
+        $string = 'simple output';
+        $this->consoleOutput->output($string);
+        $this->assertSame($string, $this->getDisplay());
+    }
+
+    /**
+     * @test
+     */
+    public function questionWasAskedFallBackToDefaultAnswer()
+    {
+        $this->assertSame('Not Sure', $this->consoleOutput->ask('Enter your name', 'Not Sure'));
+    }
+
+    /**
+     * @test
+     */
+    public function questionIsAskedAnswerIsNo()
+    {
+        $answer = $this->consoleOutput->ask('Is this a test?');
+        \Neos\Flow\var_dump($this->getDisplay());
+
+        $this->assertSame(false, $answer);
+    }
+
+    /**
+     * @test
+     */
+    public function questionIsAskedAnswerIsYes()
+    {
+
+        $answer = $this->consoleOutput->askConfirmation('Are you lying?');
+        $this->assertSame(true, $answer);
+    }
+
+    /**
+     * @test
+     */
+    public function returnUserInput()
+    {
+        $answer = $this->consoleOutput->ask('Are you lying?');
+        $this->assertSame(true, $answer);
+    }
+
+    /**
+     * Gets the display returned by the last execution of the command.
+     *
+     * @param bool $normalize Whether to normalize end of lines to \n or not
+     *
+     * @return string The display
+     */
+    private function getDisplay($normalize = false)
+    {
+        rewind($this->output->getStream());
+
+        $display = stream_get_contents($this->output->getStream());
+
+        if ($normalize) {
+            $display = str_replace(PHP_EOL, "\n", $display);
+        }
+
+        return $display;
+    }
+}
+

--- a/Neos.Flow/Tests/Unit/Cli/ConsoleOutputTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/ConsoleOutputTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\StreamOutput;
 
 /**
- * Test cases for the CLI console output
+ * Test cases for CLI console output helpers
  */
 class ConsoleOutputTest extends UnitTestCase
 {
@@ -40,7 +40,7 @@ class ConsoleOutputTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->input = new ArrayInput([]);
         $this->answerNothing();
@@ -198,28 +198,32 @@ class ConsoleOutputTest extends UnitTestCase
         );
     }
 
-    private function answerYes()
+    private function answerYes(): void
     {
         $this->input->setStream(self::createStream(['yes']));
     }
 
-    private function answerNo()
+    private function answerNo(): void
     {
         $this->input->setStream(self::createStream(['no']));
     }
 
-    private function answerCustom(string $answer)
+    private function answerCustom(string $answer): void
     {
         $this->input->setStream(self::createStream([$answer]));
     }
 
-    private function answerNothing()
+    private function answerNothing(): void
     {
         $this->input->setStream(self::createStream([' ']));
     }
 
     /**
+     * Return output the way it will be represented within the console
+     *
      * @return string $streamContent
+     * @param bool $removeControlCharacters
+     * @return bool|string
      */
     private function returnOutput()
     {

--- a/Neos.Flow/Tests/Unit/Cli/ConsoleOutputTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/ConsoleOutputTest.php
@@ -230,21 +230,33 @@ class ConsoleOutputTest extends UnitTestCase
         );
     }
 
+    /**
+     * @return void
+     */
     private function answerYes(): void
     {
         $this->input->setStream(self::createStream(['yes']));
     }
 
+    /**
+     * @return void
+     */
     private function answerNo(): void
     {
         $this->input->setStream(self::createStream(['no']));
     }
 
+    /**
+     * @param string $answer A custom string equivalent to user input in console
+     */
     private function answerCustom(string $answer): void
     {
         $this->input->setStream(self::createStream([$answer]));
     }
 
+    /**
+     * @return void
+     */
     private function answerNothing(): void
     {
         $this->input->setStream(self::createStream([' ']));


### PR DESCRIPTION
Due to the upgrade to symfony/console 4.0 some implementations for utilized CLI helpers changed. 
Unit tests were added for all console output helpers to prevent similar breakdowns in the future.

regression https://github.com/neos/flow-development-collection/pull/1179