### PR TITLE
TASK: Adapt Security ViewHelpers to support recent Fluid version

### DIFF
--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Security/IfAccessViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Security/IfAccessViewHelper.php
@@ -61,8 +61,6 @@ class IfAccessViewHelper extends AbstractConditionViewHelper
     public function initializeArguments()
     {
         parent::initializeArguments();
-        $this->registerArgument('then', 'mixed', 'Value to be returned if the condition if met.', false);
-        $this->registerArgument('else', 'mixed', 'Value to be returned if the condition if not met.', false);
         $this->registerArgument('privilegeTarget', 'string', 'Condition expression conforming to Fluid boolean rules', true);
         $this->registerArgument('parameters', 'array', 'Condition expression conforming to Fluid boolean rules', false, []);
     }

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Security/IfHasRoleViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Security/IfHasRoleViewHelper.php
@@ -84,8 +84,6 @@ class IfHasRoleViewHelper extends AbstractConditionViewHelper
         $this->registerArgument('role', 'mixed', 'The role or role identifier.', true);
         $this->registerArgument('packageKey', 'string', 'PackageKey of the package defining the role.', false, null);
         $this->registerArgument('account', Account::class, 'If specified, this subject of this check is the given Account instead of the currently authenticated account', false, null);
-        $this->registerArgument('then', 'mixed', 'Value to be returned if the condition if met.', false);
-        $this->registerArgument('else', 'mixed', 'Value to be returned if the condition if not met.', false);
     }
 
     /**


### PR DESCRIPTION
This change avoid the following exception:

    Argument "then" has already been defined, thus it should not be defined again.