### PR TITLE
FEATURE: Introduce findAllIterator() method

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/Repository.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Repository.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Neos\Flow\Persistence\Doctrine;
 
 /*
@@ -166,7 +165,6 @@ abstract class Repository extends EntityRepository implements RepositoryInterfac
             $iteration++;
         }
     }
-
 
     /**
      * Finds an object matching the given identifier.

--- a/Neos.Flow/Classes/Persistence/Doctrine/Repository.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Repository.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\Persistence\Doctrine;
  */
 
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
@@ -107,6 +108,44 @@ abstract class Repository extends EntityRepository implements RepositoryInterfac
     public function findAll()
     {
         return $this->createQuery()->execute();
+    }
+
+    /**
+     * Find all objects and return an IterableResult
+     *
+     * @return IterableResult
+     */
+    public function findAllIterator()
+    {
+        /** @var \Doctrine\ORM\QueryBuilder $queryBuilder */
+        $queryBuilder = $this->entityManager->createQueryBuilder();
+        return $queryBuilder
+            ->select('entity')
+            ->from($this->getEntityClassName(), 'entity')
+            ->getQuery()->iterate();
+    }
+
+    /**
+     * Iterate over an IterableResult and return a Generator
+     *
+     * This method is useful for batch processing a huge result set.
+     *
+     * @param IterableResult $iterator
+     * @param callable $callback
+     * @return \Generator
+     */
+    public function iterate(IterableResult $iterator, callable $callback = null)
+    {
+        $iteration = 0;
+        foreach ($iterator as $object) {
+            $object = current($object);
+            yield $object;
+            if ($callback !== null) {
+                call_user_func($callback, $iteration, $object);
+            }
+
+            $iteration++;
+        }
     }
 
     /**

--- a/Neos.Flow/Classes/Persistence/Repository.php
+++ b/Neos.Flow/Classes/Persistence/Repository.php
@@ -11,7 +11,6 @@ namespace Neos\Flow\Persistence;
  * source code.
  */
 
-use Doctrine\Common\Persistence\ObjectManager;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 
@@ -27,15 +26,6 @@ abstract class Repository implements RepositoryInterface
      * @var PersistenceManagerInterface
      */
     protected $persistenceManager;
-
-    /**
-     * Doctrine's Entity Manager. Note that "ObjectManager" is the name of the related
-     * interface ...
-     *
-     * @Flow\Inject
-     * @var ObjectManager
-     */
-    protected $entityManager;
 
     /**
      * Warning: if you think you want to set this,

--- a/Neos.Flow/Classes/Persistence/Repository.php
+++ b/Neos.Flow/Classes/Persistence/Repository.php
@@ -12,7 +12,6 @@ namespace Neos\Flow\Persistence;
  */
 
 use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 
@@ -121,44 +120,6 @@ abstract class Repository implements RepositoryInterface
     public function findAll()
     {
         return $this->createQuery()->execute();
-    }
-
-    /**
-     * Find all objects and return an IterableResult
-     *
-     * @return IterableResult
-     */
-    public function findAllIterator()
-    {
-        /** @var \Doctrine\ORM\QueryBuilder $queryBuilder */
-        $queryBuilder = $this->entityManager->createQueryBuilder();
-        return $queryBuilder
-            ->select('entity')
-            ->from($this->getEntityClassName(), 'entity')
-            ->getQuery()->iterate();
-    }
-
-    /**
-     * Iterate over an IterableResult and return a Generator
-     *
-     * This method is useful for batch processing a huge result set.
-     *
-     * @param IterableResult $iterator
-     * @param callable $callback
-     * @return \Generator
-     */
-    public function iterate(IterableResult $iterator, callable $callback = null)
-    {
-        $iteration = 0;
-        foreach ($iterator as $object) {
-            $object = current($object);
-            yield $object;
-            if ($callback !== null) {
-                call_user_func($callback, $iteration, $object);
-            }
-
-            $iteration++;
-        }
     }
 
     /**

--- a/Neos.Flow/Classes/Persistence/Repository.php
+++ b/Neos.Flow/Classes/Persistence/Repository.php
@@ -11,6 +11,8 @@ namespace Neos\Flow\Persistence;
  * source code.
  */
 
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 
@@ -26,6 +28,15 @@ abstract class Repository implements RepositoryInterface
      * @var PersistenceManagerInterface
      */
     protected $persistenceManager;
+
+    /**
+     * Doctrine's Entity Manager. Note that "ObjectManager" is the name of the related
+     * interface ...
+     *
+     * @Flow\Inject
+     * @var ObjectManager
+     */
+    protected $entityManager;
 
     /**
      * Warning: if you think you want to set this,
@@ -110,6 +121,44 @@ abstract class Repository implements RepositoryInterface
     public function findAll()
     {
         return $this->createQuery()->execute();
+    }
+
+    /**
+     * Find all objects and return an IterableResult
+     *
+     * @return IterableResult
+     */
+    public function findAllIterator()
+    {
+        /** @var \Doctrine\ORM\QueryBuilder $queryBuilder */
+        $queryBuilder = $this->entityManager->createQueryBuilder();
+        return $queryBuilder
+            ->select('entity')
+            ->from($this->getEntityClassName(), 'entity')
+            ->getQuery()->iterate();
+    }
+
+    /**
+     * Iterate over an IterableResult and return a Generator
+     *
+     * This method is useful for batch processing a huge result set.
+     *
+     * @param IterableResult $iterator
+     * @param callable $callback
+     * @return \Generator
+     */
+    public function iterate(IterableResult $iterator, callable $callback = null)
+    {
+        $iteration = 0;
+        foreach ($iterator as $object) {
+            $object = current($object);
+            yield $object;
+            if ($callback !== null) {
+                call_user_func($callback, $iteration, $object);
+            }
+
+            $iteration++;
+        }
     }
 
     /**

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
@@ -196,7 +196,6 @@ From Evans, the rules we need to enforce include:
 * When a change to any object within the Aggregate boundary is committed, all invariants
   of the whole Aggregate must be satisfied.
 
-
 On the relationship between adding and retrieving
 -------------------------------------------------
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
@@ -196,6 +196,7 @@ From Evans, the rules we need to enforce include:
 * When a change to any object within the Aggregate boundary is committed, all invariants
   of the whole Aggregate must be satisfied.
 
+
 On the relationship between adding and retrieving
 -------------------------------------------------
 
@@ -260,6 +261,18 @@ For these cases it is possible to whitelist specific objects via the Persistence
 
 Be very careful and think twice before using this method since many security measures are
 not active during "safe" request methods.
+
+Dealing with big result sets
+----------------------------
+
+If the amount of the stored data increases, receiving all objects using a ``findAll()`` may
+consume a lot more memory than available. In this cases, you can use the ``findAllIterator()``.
+This method returns an ``IterableResult``over which you can iterate, getting only one object at a time::
+
+    $iterator = $this->postRepository->findAllIterator();
+    foreach ($this->postRepository->iterate($iterator) as $post) {
+        // Iterate over all posts
+    }
 
 Conventions for File and Class Names
 ====================================

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/RepositoryTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/RepositoryTest.php
@@ -230,6 +230,33 @@ class RepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function findAllIteratorReturnsSubTypesOfTheManagedType()
+    {
+        $this->superEntityRepository = $this->objectManager->get(Fixtures\SuperEntityRepository::class);
+
+        $superEntity = new Fixtures\SuperEntity();
+        $superEntity->setContent('this is the super entity');
+        $this->superEntityRepository->add($superEntity);
+
+        $subEntity = new Fixtures\SubEntity();
+        $subEntity->setContent('this is the sub entity');
+        $this->superEntityRepository->add($subEntity);
+
+        $this->persistenceManager->persistAll();
+
+        $iterator = $this->superEntityRepository->findAllIterator();
+        $expectedCount = 0;
+
+        foreach ($this->superEntityRepository->iterate($iterator) as $entity) {
+            $expectedCount++;
+        }
+
+        $this->assertEquals(2, $expectedCount);
+    }
+
+    /**
+     * @test
+     */
     public function findByIdentifierReturnsSubTypesOfTheManagedType()
     {
         $this->superEntityRepository = $this->objectManager->get(Fixtures\SuperEntityRepository::class);

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/SubSubEntityRepository.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/SubSubEntityRepository.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
  * source code.
  */
 
-use Neos\Flow\Persistence\Repository;
+use Neos\Flow\Persistence\Doctrine\Repository;
 use Neos\Flow\Annotations as Flow;
 
 /**

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/SuperEntityRepository.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/SuperEntityRepository.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
  * source code.
  */
 
-use Neos\Flow\Persistence\Repository;
+use Neos\Flow\Persistence\Doctrine\Repository;
 use Neos\Flow\Annotations as Flow;
 
 /**


### PR DESCRIPTION
> If the amount of the stored data increases, receiving all objects using a ``findAll()`` may
> consume a lot more memory than available. In this cases, you should use the ``findAllIterator()``.
> This method returns an ``IterableResult``over which you can iterate, getting only one object at a time.

As this pattern is used a lot in Neos repositories, it would make sense to move it to the base repository class.
