### PR TITLE
TASK: Re-enable PersistenceMagicAspectTest

### DIFF
--- a/Neos.Flow/Tests/Functional/Persistence/Aspect/PersistenceMagicAspectTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Aspect/PersistenceMagicAspectTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Functional\Persistence\Aspect;
  * source code.
  */
 
-use Neos\Flow\Persistence\Generic\PersistenceManager;
+use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures;
 use Neos\Flow\Tests\FunctionalTestCase;
 


### PR DESCRIPTION
These tests were skipped since it was adapted to new namespaces
because a wrong use statement was added back then.

This brings back 14 tests by fixing that.