### PR TITLE
!!! TASK: Add factory method to ``AuthenticationProviderInterface``

### DIFF
--- a/Neos.Flow/Classes/Security/Authentication/AuthenticationProviderInterface.php
+++ b/Neos.Flow/Classes/Security/Authentication/AuthenticationProviderInterface.php
@@ -18,14 +18,13 @@ namespace Neos\Flow\Security\Authentication;
 interface AuthenticationProviderInterface
 {
     /**
-     * Constructor
+     * Constructs an instance with the given name and options.
      *
-     * @param string $name The name of this authentication provider
-     * @param array $options Additional configuration options
-     * @return void
-     * @FIXME The constructor was certainly part of the interface for a reason
+     * @param string $name
+     * @param array $options
+     * @return self
      */
-    // public function __construct($name, array $options);
+    public static function create(string $name, array $options);
 
     /**
      * Returns TRUE if the given token can be authenticated by this provider

--- a/Neos.Flow/Classes/Security/Authentication/AuthenticationProviderManager.php
+++ b/Neos.Flow/Classes/Security/Authentication/AuthenticationProviderManager.php
@@ -309,7 +309,7 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
             }
 
             /** @var $providerInstance AuthenticationProviderInterface */
-            $providerInstance = new $providerObjectName($providerName, $providerOptions);
+            $providerInstance = $providerObjectName::create($providerName, $providerOptions);
             $this->providers[$providerName] = $providerInstance;
 
             /** @var $tokenInstance TokenInterface */

--- a/Neos.Flow/Classes/Security/Authentication/Provider/AbstractProvider.php
+++ b/Neos.Flow/Classes/Security/Authentication/Provider/AbstractProvider.php
@@ -11,7 +11,6 @@ namespace Neos\Flow\Security\Authentication\Provider;
  * source code.
  */
 
-use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Security\Authentication\AuthenticationProviderInterface;
 use Neos\Flow\Security\Authentication\TokenInterface;
 
@@ -29,6 +28,16 @@ abstract class AbstractProvider implements AuthenticationProviderInterface
      * @var array
      */
     protected $options = [];
+
+    /**
+     * @param string $name
+     * @param array $options
+     * @return AuthenticationProviderInterface
+     */
+    public static function create(string $name, array $options)
+    {
+        return new static($name, $options);
+    }
 
     /**
      * Constructor

--- a/Neos.Flow/Classes/Security/Authentication/Provider/AbstractProvider.php
+++ b/Neos.Flow/Classes/Security/Authentication/Provider/AbstractProvider.php
@@ -30,9 +30,12 @@ abstract class AbstractProvider implements AuthenticationProviderInterface
     protected $options = [];
 
     /**
+     * Factory method
+     *
      * @param string $name
      * @param array $options
      * @return AuthenticationProviderInterface
+     * @api
      */
     public static function create(string $name, array $options)
     {
@@ -40,12 +43,13 @@ abstract class AbstractProvider implements AuthenticationProviderInterface
     }
 
     /**
-     * Constructor
+     * Protected constructor, see create method
      *
      * @param string $name The name of this authentication provider
      * @param array $options Additional configuration options
+     * @see create
      */
-    public function __construct($name, array $options = [])
+    protected function __construct($name, array $options = [])
     {
         $this->name = $name;
         $this->options = $options;

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Provider/FileBasedSimpleKeyProviderTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Provider/FileBasedSimpleKeyProviderTest.php
@@ -91,7 +91,7 @@ class FileBasedSimpleKeyProviderTest extends UnitTestCase
         $this->mockToken->expects($this->once())->method('getCredentials')->will($this->returnValue(['password' => $this->testKeyClearText]));
         $this->mockToken->expects($this->once())->method('setAuthenticationStatus')->with(TokenInterface::AUTHENTICATION_SUCCESSFUL);
 
-        $authenticationProvider = new FileBasedSimpleKeyProvider('myProvider', ['keyName' => 'testKey', 'authenticateRoles' => ['Neos.Flow:TestRoleIdentifier']]);
+        $authenticationProvider = FileBasedSimpleKeyProvider::create('myProvider', ['keyName' => 'testKey', 'authenticateRoles' => ['Neos.Flow:TestRoleIdentifier']]);
         $this->inject($authenticationProvider, 'policyService', $this->mockPolicyService);
         $this->inject($authenticationProvider, 'hashService', $this->mockHashService);
         $this->inject($authenticationProvider, 'fileBasedSimpleKeyService', $this->mockFileBasedSimpleKeyService);
@@ -107,7 +107,7 @@ class FileBasedSimpleKeyProviderTest extends UnitTestCase
         $this->mockToken = $this->getMockBuilder(PasswordToken::class)->disableOriginalConstructor()->setMethods(['getCredentials'])->getMock();
         $this->mockToken->expects($this->once())->method('getCredentials')->will($this->returnValue(['password' => $this->testKeyClearText]));
 
-        $authenticationProvider = new FileBasedSimpleKeyProvider('myProvider', ['keyName' => 'testKey', 'authenticateRoles' => ['Neos.Flow:TestRoleIdentifier']]);
+        $authenticationProvider = FileBasedSimpleKeyProvider::create('myProvider', ['keyName' => 'testKey', 'authenticateRoles' => ['Neos.Flow:TestRoleIdentifier']]);
         $this->inject($authenticationProvider, 'policyService', $this->mockPolicyService);
         $this->inject($authenticationProvider, 'hashService', $this->mockHashService);
         $this->inject($authenticationProvider, 'fileBasedSimpleKeyService', $this->mockFileBasedSimpleKeyService);
@@ -126,7 +126,7 @@ class FileBasedSimpleKeyProviderTest extends UnitTestCase
         $this->mockToken->expects($this->once())->method('getCredentials')->will($this->returnValue(['password' => 'wrong password']));
         $this->mockToken->expects($this->once())->method('setAuthenticationStatus')->with(TokenInterface::WRONG_CREDENTIALS);
 
-        $authenticationProvider = new FileBasedSimpleKeyProvider('myProvider', ['keyName' => 'testKey', 'authenticateRoles' => ['Neos.Flow:TestRoleIdentifier']]);
+        $authenticationProvider = FileBasedSimpleKeyProvider::create('myProvider', ['keyName' => 'testKey', 'authenticateRoles' => ['Neos.Flow:TestRoleIdentifier']]);
         $this->inject($authenticationProvider, 'policyService', $this->mockPolicyService);
         $this->inject($authenticationProvider, 'hashService', $this->mockHashService);
         $this->inject($authenticationProvider, 'fileBasedSimpleKeyService', $this->mockFileBasedSimpleKeyService);
@@ -142,7 +142,7 @@ class FileBasedSimpleKeyProviderTest extends UnitTestCase
         $this->mockToken->expects($this->once())->method('getCredentials')->will($this->returnValue([]));
         $this->mockToken->expects($this->once())->method('setAuthenticationStatus')->with(TokenInterface::NO_CREDENTIALS_GIVEN);
 
-        $authenticationProvider = new FileBasedSimpleKeyProvider('myProvider', ['keyName' => 'testKey', 'authenticateRoles' => ['Neos.Flow:TestRoleIdentifier']]);
+        $authenticationProvider = FileBasedSimpleKeyProvider::create('myProvider', ['keyName' => 'testKey', 'authenticateRoles' => ['Neos.Flow:TestRoleIdentifier']]);
         $this->inject($authenticationProvider, 'policyService', $this->mockPolicyService);
         $this->inject($authenticationProvider, 'hashService', $this->mockHashService);
         $this->inject($authenticationProvider, 'fileBasedSimpleKeyService', $this->mockFileBasedSimpleKeyService);
@@ -155,7 +155,7 @@ class FileBasedSimpleKeyProviderTest extends UnitTestCase
      */
     public function getTokenClassNameReturnsCorrectClassNames()
     {
-        $authenticationProvider = new FileBasedSimpleKeyProvider('myProvider');
+        $authenticationProvider = FileBasedSimpleKeyProvider::create('myProvider');
         $this->assertSame($authenticationProvider->getTokenClassNames(), [PasswordToken::class]);
     }
 
@@ -167,7 +167,7 @@ class FileBasedSimpleKeyProviderTest extends UnitTestCase
     {
         $someInvalidToken = $this->createMock(TokenInterface::class);
 
-        $authenticationProvider = new FileBasedSimpleKeyProvider('myProvider');
+        $authenticationProvider = FileBasedSimpleKeyProvider::create('myProvider');
 
         $authenticationProvider->authenticate($someInvalidToken);
     }
@@ -182,7 +182,7 @@ class FileBasedSimpleKeyProviderTest extends UnitTestCase
         $mockToken2 = $this->createMock(TokenInterface::class);
         $mockToken2->expects($this->once())->method('getAuthenticationProviderName')->will($this->returnValue('someOtherProvider'));
 
-        $authenticationProvider = new FileBasedSimpleKeyProvider('myProvider');
+        $authenticationProvider = FileBasedSimpleKeyProvider::create('myProvider');
 
         $this->assertTrue($authenticationProvider->canAuthenticate($mockToken1));
         $this->assertFalse($authenticationProvider->canAuthenticate($mockToken2));

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Provider/FileBasedSimpleKeyProviderTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Provider/FileBasedSimpleKeyProviderTest.php
@@ -155,7 +155,7 @@ class FileBasedSimpleKeyProviderTest extends UnitTestCase
      */
     public function getTokenClassNameReturnsCorrectClassNames()
     {
-        $authenticationProvider = FileBasedSimpleKeyProvider::create('myProvider');
+        $authenticationProvider = FileBasedSimpleKeyProvider::create('myProvider', []);
         $this->assertSame($authenticationProvider->getTokenClassNames(), [PasswordToken::class]);
     }
 
@@ -167,7 +167,7 @@ class FileBasedSimpleKeyProviderTest extends UnitTestCase
     {
         $someInvalidToken = $this->createMock(TokenInterface::class);
 
-        $authenticationProvider = FileBasedSimpleKeyProvider::create('myProvider');
+        $authenticationProvider = FileBasedSimpleKeyProvider::create('myProvider', []);
 
         $authenticationProvider->authenticate($someInvalidToken);
     }
@@ -182,7 +182,7 @@ class FileBasedSimpleKeyProviderTest extends UnitTestCase
         $mockToken2 = $this->createMock(TokenInterface::class);
         $mockToken2->expects($this->once())->method('getAuthenticationProviderName')->will($this->returnValue('someOtherProvider'));
 
-        $authenticationProvider = FileBasedSimpleKeyProvider::create('myProvider');
+        $authenticationProvider = FileBasedSimpleKeyProvider::create('myProvider', []);
 
         $this->assertTrue($authenticationProvider->canAuthenticate($mockToken1));
         $this->assertFalse($authenticationProvider->canAuthenticate($mockToken2));

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
@@ -132,7 +132,7 @@ class PersistedUsernamePasswordProviderTest extends UnitTestCase
     {
         $someNiceToken = $this->createMock(Security\Authentication\TokenInterface::class);
 
-        $usernamePasswordProvider = new Security\Authentication\Provider\PersistedUsernamePasswordProvider('myProvider', array());
+        $usernamePasswordProvider = Security\Authentication\Provider\PersistedUsernamePasswordProvider::create('myProvider', array());
 
         $usernamePasswordProvider->authenticate($someNiceToken);
     }
@@ -147,7 +147,7 @@ class PersistedUsernamePasswordProviderTest extends UnitTestCase
         $mockToken2 = $this->createMock(Security\Authentication\TokenInterface::class);
         $mockToken2->expects($this->once())->method('getAuthenticationProviderName')->will($this->returnValue('someOtherProvider'));
 
-        $usernamePasswordProvider = new Security\Authentication\Provider\PersistedUsernamePasswordProvider('myProvider', array());
+        $usernamePasswordProvider = Security\Authentication\Provider\PersistedUsernamePasswordProvider::create('myProvider', array());
 
         $this->assertTrue($usernamePasswordProvider->canAuthenticate($mockToken1));
         $this->assertFalse($usernamePasswordProvider->canAuthenticate($mockToken2));

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
@@ -69,7 +69,9 @@ class PersistedUsernamePasswordProviderTest extends UnitTestCase
             return $callback->__invoke();
         }));
 
-        $this->persistedUsernamePasswordProvider = $this->getAccessibleMock(Security\Authentication\Provider\PersistedUsernamePasswordProvider::class, array('dummy'), array('myProvider', array()));
+        $this->persistedUsernamePasswordProvider = $this->getAccessibleMock(Security\Authentication\Provider\PersistedUsernamePasswordProvider::class, array('dummy'), [], '', false);
+        $this->persistedUsernamePasswordProvider->_set('name', 'myProvider');
+        $this->persistedUsernamePasswordProvider->_set('options', []);
         $this->persistedUsernamePasswordProvider->_set('hashService', $this->mockHashService);
         $this->persistedUsernamePasswordProvider->_set('accountRepository', $this->mockAccountRepository);
         $this->persistedUsernamePasswordProvider->_set('persistenceManager', $this->mockPersistenceManager);


### PR DESCRIPTION
There was a long standing comment about having the constructor be part
of the interface but that was deactivated back in the day as the proxy
constructor was incompatible with the interface then. A interface
defined way of creating an ``AuthenticationProvider`` makes sense though
therefore we introduce a static ``create`` method that returns a fresh
instance of the class in question. This removes the implicit knowledge
about the constructor in the code.

This is breaking if you implemented your own
``AuthenticationProviderInterface`` without making use of the
``AbstractProvider`` which provides a basic ``create`` method.
You may need to add this create method in your implementation.
