### PR TITLE
FEATURE: Add `remove` flowQuery operation

### DIFF
--- a/Neos.Eel/Classes/FlowQuery/Operations/AddOperation.php
+++ b/Neos.Eel/Classes/FlowQuery/Operations/AddOperation.php
@@ -15,7 +15,9 @@ use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Flow\Annotations as Flow;
 
 /**
- * Add another $flowQuery object to the current one.
+ * Adds the given items to the current context.
+ * The operation accepts one argument that may be an Array, a FlowQuery
+ * or an Object.
  */
 class AddOperation extends AbstractOperation
 {

--- a/Neos.Eel/Classes/FlowQuery/Operations/RemoveOperation.php
+++ b/Neos.Eel/Classes/FlowQuery/Operations/RemoveOperation.php
@@ -1,0 +1,59 @@
+<?php
+namespace Neos\Eel\FlowQuery\Operations;
+
+/*
+ * This file is part of the Neos.Eel package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Eel\FlowQuery\FlowQuery;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * Removes the given items from the current context.
+ * The operation accepts one argument that may be an Array, a FlowQuery
+ * or an Object.
+ */
+class RemoveOperation extends AbstractOperation
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @var string
+     */
+    protected static $shortName = 'remove';
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param FlowQuery $flowQuery the FlowQuery object
+     * @param array $arguments the elements to remove (as array in index 0)
+     * @return void
+     */
+    public function evaluate(FlowQuery $flowQuery, array $arguments)
+    {
+        $valuesToRemove = [];
+        if (isset($arguments[0])) {
+            if (is_array($arguments[0]) || $arguments[0] instanceof \Traversable) {
+                foreach ($arguments[0] as $item) {
+                    $valuesToRemove[] = $item;
+                }
+            } else {
+                $valuesToRemove[] = $arguments[0];
+            }
+        }
+        $context = $flowQuery->getContext();
+        $newContext = [];
+        foreach ($context as $item) {
+            if (in_array($item, $valuesToRemove, true) === false) {
+                $newContext[] = $item;
+            }
+        }
+        $flowQuery->setContext($newContext);
+    }
+}

--- a/Neos.Eel/Classes/FlowQuery/Operations/RemoveOperation.php
+++ b/Neos.Eel/Classes/FlowQuery/Operations/RemoveOperation.php
@@ -39,21 +39,20 @@ class RemoveOperation extends AbstractOperation
     {
         $valuesToRemove = [];
         if (isset($arguments[0])) {
-            if (is_array($arguments[0]) || $arguments[0] instanceof \Traversable) {
-                foreach ($arguments[0] as $item) {
-                    $valuesToRemove[] = $item;
-                }
+            if (is_array($arguments[0])) {
+                $valuesToRemove = $arguments[0];
+            } elseif ($arguments[0] instanceof \Traversable) {
+                $valuesToRemove = iterator_to_array($arguments[0]);
             } else {
                 $valuesToRemove[] = $arguments[0];
             }
         }
-        $context = $flowQuery->getContext();
-        $newContext = [];
-        foreach ($context as $item) {
-            if (in_array($item, $valuesToRemove, true) === false) {
-                $newContext[] = $item;
+        $filteredContext = array_filter(
+            $flowQuery->getContext(),
+            function ($item) use ($valuesToRemove) {
+                return in_array($item, $valuesToRemove, true) === false;
             }
-        }
-        $flowQuery->setContext($newContext);
+        );
+        $flowQuery->setContext($filteredContext);
     }
 }

--- a/Neos.Eel/Tests/Unit/FlowQuery/Operations/RemoveOperationTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/Operations/RemoveOperationTest.php
@@ -1,0 +1,85 @@
+<?php
+namespace Neos\Eel\Tests\Unit\FlowQuery\Operations;
+
+/*
+ * This file is part of the Neos.Eel package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Eel\FlowQuery\FlowQuery;
+use Neos\Eel\FlowQuery\Operations\AddOperation;
+use Neos\Eel\FlowQuery\Operations\RemoveOperation;
+
+/**
+ * RemoveOperation test
+ */
+class RemoveOperationTest extends \Neos\Flow\Tests\UnitTestCase
+{
+    /**
+     * This corresponds to ${q(node).remove(q(someOtherNode))}
+     *
+     * @test
+     */
+    public function removeWithFlowQueryArgumentRemovesFromCurrentContext()
+    {
+        $object1 = new \stdClass();
+        $object2 = new \stdClass();
+
+        $flowQuery = new FlowQuery([$object1, $object2]);
+
+        $flowQueryArgument = new FlowQuery([$object2]);
+        $arguments = [$flowQueryArgument];
+
+        $operation = new RemoveOperation();
+        $operation->evaluate($flowQuery, $arguments);
+
+        $this->assertSame([$object1], $flowQuery->getContext());
+    }
+
+    /**
+     * This corresponds to ${q(node).remove(someOtherNode)}
+     *
+     * @test
+     */
+    public function removeWithNodeArgumentRemovesFromCurrentContext()
+    {
+        $object1 = new \stdClass();
+        $object2 = new \stdClass();
+
+        $flowQuery = new FlowQuery([$object1, $object2]);
+
+        $nodeArgument = $object2;
+        $arguments = [$nodeArgument];
+
+        $operation = new RemoveOperation();
+        $operation->evaluate($flowQuery, $arguments);
+
+        $this->assertSame([$object1], $flowQuery->getContext());
+    }
+
+    /**
+     * This corresponds to ${q(node).remove([someOtherNode, ...]))}
+     *
+     * @test
+     */
+    public function removeWithArrayArgumentRemovesFromCurrentContext()
+    {
+        $object1 = new \stdClass();
+        $object2 = new \stdClass();
+
+        $flowQuery = new FlowQuery([$object1, $object2]);
+
+        $arrayArgument = [$object2];
+        $arguments = [$arrayArgument];
+
+        $operation = new RemoveOperation();
+        $operation->evaluate($flowQuery, $arguments);
+
+        $this->assertSame([$object1], $flowQuery->getContext());
+    }
+}


### PR DESCRIPTION
The operation removes the given items from the current FlowQuery context. To do so it accepts a single argument that may be an array, an object or a FlowQuery.
