### PR TITLE
TASK: Make Now immutable

### DIFF
--- a/Neos.Flow/Classes/Utility/Now.php
+++ b/Neos.Flow/Classes/Utility/Now.php
@@ -23,8 +23,7 @@ use Neos\Flow\Annotations as Flow;
  *
  * @Flow\Scope("singleton")
  * @api
- * TODO: Change to \DateTimeImmutable for next major version after 3.0
  */
-class Now extends \DateTime
+class Now extends \DateTimeImmutable
 {
 }


### PR DESCRIPTION
This simply replaces Now's base class \DateTime with \DateTimeImmutable as planned since 4.0