### PR TITLE
SECURITY: Update paragonie/random_compat to 2.x minimum

### DIFF
--- a/TYPO3.Flow/composer.json
+++ b/TYPO3.Flow/composer.json
@@ -28,7 +28,7 @@
         "typo3/eel": "~3.3.0",
 
         "ramsey/uuid": "^3.0.0",
-        "paragonie/random_compat": "^1.0",
+        "paragonie/random_compat": "^2.0",
 
         "doctrine/orm": "~2.5.0",
         "doctrine/migrations": "~1.3.0",


### PR DESCRIPTION
The `paragonie/random_compat` library could use OpenSSL, and that in turn
could lead to the use of an insecure CSPRNG (openssl_random_pseudo_bytes())

Related Information: https://github.com/paragonie/random_compat/issues/96

This change fixes #1222 by updating the dependency from `^1.0` to `^2.0`.
