### PR TITLE
TASK: Pass affected entities to flush as array, not one-by-one

### DIFF
--- a/Neos.Flow/Classes/Mvc/Routing/ObjectPathMappingRepository.php
+++ b/Neos.Flow/Classes/Mvc/Routing/ObjectPathMappingRepository.php
@@ -96,9 +96,7 @@ class ObjectPathMappingRepository extends Repository
     {
         foreach ($this->entityManager->getUnitOfWork()->getIdentityMap() as $className => $entities) {
             if ($className === $this->entityClassName) {
-                foreach ($entities as $entityToPersist) {
-                    $this->entityManager->flush($entityToPersist);
-                }
+                $this->entityManager->flush($entities);
                 return;
             }
         }


### PR DESCRIPTION
The `ObjectPathMappingRepository.persistEntities()` method looped over
the entities and passed them to `flush()` one-by-one. They can be passed
as the array at hand directly.
