### PR TITLE
TASK: Use RouterInterface instead of concrete implementation

### DIFF
--- a/Neos.Flow/Classes/Command/RoutingCommandController.php
+++ b/Neos.Flow/Classes/Command/RoutingCommandController.php
@@ -19,7 +19,7 @@ use Neos\Flow\Mvc\Routing\Dto\RouteContext;
 use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
 use Neos\Flow\Mvc\Routing\Exception\InvalidControllerException;
 use Neos\Flow\Mvc\Routing\Route;
-use Neos\Flow\Mvc\Routing\RouterInterface;
+use Neos\Flow\Mvc\Routing\Router;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 
 /**
@@ -37,7 +37,7 @@ class RoutingCommandController extends CommandController
 
     /**
      * @Flow\Inject
-     * @var RouterInterface
+     * @var Router
      */
     protected $router;
 

--- a/Neos.Flow/Classes/Command/RoutingCommandController.php
+++ b/Neos.Flow/Classes/Command/RoutingCommandController.php
@@ -19,7 +19,7 @@ use Neos\Flow\Mvc\Routing\Dto\RouteContext;
 use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
 use Neos\Flow\Mvc\Routing\Exception\InvalidControllerException;
 use Neos\Flow\Mvc\Routing\Route;
-use Neos\Flow\Mvc\Routing\Router;
+use Neos\Flow\Mvc\Routing\RouterInterface;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 
 /**
@@ -37,7 +37,7 @@ class RoutingCommandController extends CommandController
 
     /**
      * @Flow\Inject
-     * @var Router
+     * @var RouterInterface
      */
     protected $router;
 

--- a/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
+++ b/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
@@ -20,7 +20,7 @@ use Neos\Flow\Http\Component\ComponentChain;
 use Neos\Flow\Http\Component\ComponentContext;
 use Neos\Flow\Http;
 use Neos\Flow\Mvc\Dispatcher;
-use Neos\Flow\Mvc\Routing\Router;
+use Neos\Flow\Mvc\Routing\RouterInterface;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Session\SessionInterface;
@@ -49,7 +49,7 @@ class InternalRequestEngine implements RequestEngineInterface
 
     /**
      * @Flow\Inject(lazy = false)
-     * @var Router
+     * @var RouterInterface
      */
     protected $router;
 

--- a/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
+++ b/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
@@ -135,7 +135,7 @@ class InternalRequestEngine implements RequestEngineInterface
     /**
      * Returns the router used by this internal request engine
      *
-     * @return Router
+     * @return RouterInterface
      */
     public function getRouter()
     {

--- a/Neos.Flow/Classes/Mvc/Routing/RoutingComponent.php
+++ b/Neos.Flow/Classes/Mvc/Routing/RoutingComponent.php
@@ -25,7 +25,7 @@ class RoutingComponent implements ComponentInterface
 {
     /**
      * @Flow\Inject
-     * @var Router
+     * @var RouterInterface
      */
     protected $router;
 

--- a/Neos.Flow/Configuration/Objects.yaml
+++ b/Neos.Flow/Configuration/Objects.yaml
@@ -200,6 +200,9 @@ Neos\Flow\Http\Component\ComponentChain:
 # MVC                                                                      #
 #                                                                          #
 
+Neos\Flow\Mvc\Routing\RouterInterface:
+  className: Neos\Flow\Mvc\Routing\Router
+
 Neos\Flow\Mvc\Routing\RouterCachingService:
   properties:
     routeCache:
@@ -291,9 +294,6 @@ Neos\Flow\Property\PropertyMapper:
 #                                                                          #
 # ResourceManagement                                                       #
 #                                                                          #
-
-Neos\Flow\Mvc\Routing\RouterInterface:
-  className: Neos\Flow\Mvc\Routing\Router
 
 Neos\Flow\ResourceManagement\ResourceManager:
   properties:

--- a/Neos.Flow/Configuration/Objects.yaml
+++ b/Neos.Flow/Configuration/Objects.yaml
@@ -292,6 +292,9 @@ Neos\Flow\Property\PropertyMapper:
 # ResourceManagement                                                       #
 #                                                                          #
 
+Neos\Flow\Mvc\Routing\RouterInterface:
+  className: Neos\Flow\Mvc\Routing\Router
+
 Neos\Flow\ResourceManagement\ResourceManager:
   properties:
     statusCache:


### PR DESCRIPTION
Currently the concrete `Router` Implementation is used instead of the more flexible `RouterInterface`.

This PR ensures the `RouterInterface` is used. 
