### PR TITLE
BUGFIX: Detect checked state for bound object collections

### DIFF
--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Form/CheckboxViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Form/CheckboxViewHelper.php
@@ -93,21 +93,17 @@ class CheckboxViewHelper extends AbstractFormFieldViewHelper
         }
         if (is_array($propertyValue)) {
             if ($checked === null) {
-                if (TypeHandling::isSimpleType(TypeHandling::getTypeForValue(current($propertyValue))) === false || Arrays::containsMultipleTypes($propertyValue)) {
-                    $checked = false;
-                    foreach ($propertyValue as $value) {
-                        if (TypeHandling::isSimpleType(TypeHandling::getTypeForValue($value))) {
-                            $checked = $valueAttribute === $value;
-                        } else {
-                            // assume an entity
-                            $checked = $valueAttribute === $this->persistenceManager->getIdentifierByObject($value);
-                        }
-                        if ($checked === true) {
-                            break;
-                        }
+                $checked = false;
+                foreach ($propertyValue as $value) {
+                    if (TypeHandling::isSimpleType(TypeHandling::getTypeForValue($value))) {
+                        $checked = $valueAttribute === $value;
+                    } else {
+                        // assume an entity
+                        $checked = $valueAttribute === $this->persistenceManager->getIdentifierByObject($value);
                     }
-                } else {
-                    $checked = in_array($valueAttribute, $propertyValue, true);
+                    if ($checked === true) {
+                        break;
+                    }
                 }
             }
             $this->arguments['multiple'] = true;

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Form/CheckboxViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Form/CheckboxViewHelper.php
@@ -78,6 +78,7 @@ class CheckboxViewHelper extends AbstractFormFieldViewHelper
     {
         $this->tag->addAttribute('type', 'checkbox');
 
+        // if value was assigned an object, it's identifier will be returned
         $valueAttribute = $this->getValueAttribute(true);
         $propertyValue = null;
         if ($this->hasMappingErrorOccurred()) {
@@ -95,7 +96,7 @@ class CheckboxViewHelper extends AbstractFormFieldViewHelper
                 if (TypeHandling::isSimpleType(TypeHandling::getTypeForValue(current($propertyValue))) === false || Arrays::containsMultipleTypes($propertyValue)) {
                     $checked = false;
                     foreach ($propertyValue as $value) {
-                        if (TypeHandling::isSimpleType(TypeHandling::getTypeForValue(current($propertyValue)))) {
+                        if (TypeHandling::isSimpleType(TypeHandling::getTypeForValue($value))) {
                             $checked = $valueAttribute === $value;
                         } else {
                             // assume an entity

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Form/CheckboxViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Form/CheckboxViewHelper.php
@@ -11,6 +11,9 @@ namespace Neos\FluidAdaptor\ViewHelpers\Form;
  * source code.
  */
 
+use Neos\Utility\Arrays;
+use Neos\Utility\TypeHandling;
+
 /**
  * View Helper which creates a simple checkbox (<input type="checkbox">).
  *
@@ -89,7 +92,22 @@ class CheckboxViewHelper extends AbstractFormFieldViewHelper
         }
         if (is_array($propertyValue)) {
             if ($checked === null) {
-                $checked = in_array($valueAttribute, $propertyValue, true);
+                if (TypeHandling::isSimpleType(TypeHandling::getTypeForValue(current($propertyValue))) === false || Arrays::containsMultipleTypes($propertyValue)) {
+                    $checked = false;
+                    foreach ($propertyValue as $value) {
+                        if (TypeHandling::isSimpleType(TypeHandling::getTypeForValue(current($propertyValue)))) {
+                            $checked = $valueAttribute === $value;
+                        } else {
+                            // assume an entity
+                            $checked = $valueAttribute === $this->persistenceManager->getIdentifierByObject($value);
+                        }
+                        if ($checked === true) {
+                            break;
+                        }
+                    }
+                } else {
+                    $checked = in_array($valueAttribute, $propertyValue, true);
+                }
             }
             $this->arguments['multiple'] = true;
         } elseif (!$multiple && $propertyValue !== null) {

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/CheckboxViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/CheckboxViewHelperTest.php
@@ -11,8 +11,12 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Form;
  * source code.
  */
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\FluidAdaptor\ViewHelpers\Fixtures\UserDomainClass;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 
+require_once(__DIR__ . '/Fixtures/Fixture_UserDomainClass.php');
 require_once(__DIR__ . '/FormFieldViewHelperBaseTestcase.php');
 
 /**
@@ -167,6 +171,38 @@ class CheckboxViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\F
         $this->viewHelper->expects($this->any())->method('getValueAttribute')->will($this->returnValue('bar'));
         $this->viewHelper->expects($this->any())->method('isObjectAccessorMode')->will($this->returnValue(true));
         $this->viewHelper->expects($this->any())->method('getPropertyValue')->will($this->returnValue(new \ArrayObject(array('foo', 'bar', 'baz'))));
+        $this->viewHelper->injectTagBuilder($this->mockTagBuilder);
+
+        $this->viewHelper->initialize();
+        $this->viewHelper->render();
+    }
+
+    /**
+     * @test
+     */
+    public function renderCorrectlySetsCheckedAttributeIfCheckboxIsBoundToAnEntityCollection()
+    {
+        $this->mockTagBuilder->expects($this->at(2))->method('addAttribute')->with('type', 'checkbox');
+        $this->mockTagBuilder->expects($this->at(3))->method('addAttribute')->with('name', 'foo[]');
+        $this->mockTagBuilder->expects($this->at(4))->method('addAttribute')->with('value', '1');
+        $this->mockTagBuilder->expects($this->at(5))->method('addAttribute')->with('checked', 'checked');
+
+        $user_kd = new UserDomainClass(1, 'Karsten', 'Dambekalns');
+        $user_bw = new UserDomainClass(2, 'Bastian', 'Waidelich');
+
+        $userCollection = new ArrayCollection([$user_kd, $user_bw]);
+
+        /** @var PersistenceManagerInterface|\PHPUnit_Framework_MockObject_MockObject $mockPersistenceManager */
+        $mockPersistenceManager = $this->createMock(PersistenceManagerInterface::class);
+        $mockPersistenceManager->expects($this->any())->method('getIdentifierByObject')->willReturnCallback(function(UserDomainClass $user) {
+            return (string)$user->getId();
+        });
+        $this->viewHelper->injectPersistenceManager($mockPersistenceManager);
+
+        $this->viewHelper->expects($this->any())->method('getName')->will($this->returnValue('foo'));
+        $this->viewHelper->expects($this->any())->method('getValueAttribute')->will($this->returnValue('1'));
+        $this->viewHelper->expects($this->any())->method('isObjectAccessorMode')->will($this->returnValue(true));
+        $this->viewHelper->expects($this->any())->method('getPropertyValue')->will($this->returnValue($userCollection));
         $this->viewHelper->injectTagBuilder($this->mockTagBuilder);
 
         $this->viewHelper->initialize();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/CheckboxViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/CheckboxViewHelperTest.php
@@ -194,7 +194,7 @@ class CheckboxViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\F
 
         /** @var PersistenceManagerInterface|\PHPUnit_Framework_MockObject_MockObject $mockPersistenceManager */
         $mockPersistenceManager = $this->createMock(PersistenceManagerInterface::class);
-        $mockPersistenceManager->expects($this->any())->method('getIdentifierByObject')->willReturnCallback(function(UserDomainClass $user) {
+        $mockPersistenceManager->expects($this->any())->method('getIdentifierByObject')->willReturnCallback(function (UserDomainClass $user) {
             return (string)$user->getId();
         });
         $this->viewHelper->injectPersistenceManager($mockPersistenceManager);


### PR DESCRIPTION
When a collection property with objects is bound to a checkbox VH,
this change makes sure to check object identifiers against the passed
value when automatically determining the `checked` state.

Fixes #1229
