### PR TITLE
!!!TASK: Only scan Private/Translations for available locales

### DIFF
--- a/Neos.Flow/Configuration/Settings.I18n.yaml
+++ b/Neos.Flow/Configuration/Settings.I18n.yaml
@@ -31,7 +31,7 @@ Neos:
         #   Resources, except any 'node_modules' sub-folder in either one.
         includePaths:
           '/Public/': TRUE
-          '/Private/': TRUE
+          '/Private/Translations/': TRUE
 
         excludePatterns:
           '/node_modules/': TRUE

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Internationalization.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Internationalization.rst
@@ -38,8 +38,8 @@ use the i18n service API to obtain these verified ``Locale`` objects.
   the ``Neos.Flow.i18n.scan.includePaths`` setting. This is useful to restrict the scanning
   to specific paths when you have a big file structure in your package ``Resources``.
   You can also blacklist folders through ``Neos.Flow.i18n.scan.excludePatterns``.
-  By default all folders except 'node_modules', 'bower_components' and any folder starting
-  with a dot will be scanned.
+  By default the ``Public`` and ``Private/Translations`` folders, except 'node_modules',
+  'bower_components' and any folder starting with a dot will be scanned.
 
 Locales are organized in a hierarchy. For example, *en* is a parent of *en_US* which is a
 parent of *en_US_POSIX*. Thanks to the hierarchical relation resources can be

--- a/Neos.Flow/Tests/Unit/I18n/ServiceTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/ServiceTest.php
@@ -142,9 +142,10 @@ class ServiceTest extends UnitTestCase
      */
     public function initializeCorrectlyGeneratesAvailableLocales()
     {
+        mkdir('vfs://Foo/Bar/Public', 0777, true);
         mkdir('vfs://Foo/Bar/Private/Translations', 0777, true);
         foreach (['en', 'sr_Cyrl_RS'] as $localeIdentifier) {
-            file_put_contents('vfs://Foo/Bar/Private/foobar.' . $localeIdentifier . '.baz', 'FooBar');
+            file_put_contents('vfs://Foo/Bar/Public/foobar.' . $localeIdentifier . '.baz', 'FooBar');
         }
         foreach (['en_GB', 'sr'] as $localeIdentifier) {
             file_put_contents('vfs://Foo/Bar/Private/Translations/' . $localeIdentifier . '.xlf', 'FooBar');
@@ -167,7 +168,7 @@ class ServiceTest extends UnitTestCase
                                 'defaultLocale' => 'sv_SE',
                                 'fallbackRule' => ['strict' => false, 'order' => []],
                                 'scan' => [
-                                    'includePaths' => ['/Private/' => true],
+                                    'includePaths' => ['/Private/Translations/' => true],
                                     'excludePatterns' => [],
                                 ]
         ]];
@@ -214,7 +215,7 @@ class ServiceTest extends UnitTestCase
                                 'defaultLocale' => 'sv_SE',
                                 'fallbackRule' => ['strict' => false, 'order' => []],
                                 'scan' => [
-                                    'includePaths' => ['/Private/' => true, '/Public/' => true],
+                                    'includePaths' => ['/Private/Translations/' => true, '/Public/' => true],
                                     'excludePatterns' => ['/node_modules/' => true, '/\..*/' => true]
                                 ]
         ]];

--- a/Neos.Flow/Tests/Unit/I18n/ServiceTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/ServiceTest.php
@@ -162,7 +162,7 @@ class ServiceTest extends UnitTestCase
         $mockPackageManager->expects($this->any())->method('getAvailablePackages')->will($this->returnValue([$mockPackage]));
 
         $mockLocaleCollection = $this->createMock(I18n\LocaleCollection::class);
-        $mockLocaleCollection->expects($this->exactly(6))->method('addLocale');
+        $mockLocaleCollection->expects($this->exactly(4))->method('addLocale');
 
         $mockSettings = ['i18n' => [
                                 'defaultLocale' => 'sv_SE',


### PR DESCRIPTION
Before the full `Resources/Private` folder was scanned for available locales, which also included
for example the CLDR, which ended up filling the available locales with much more locales than
are actually considered "available" in a normal Flow application.
This will therefore allow applications to define available locales easily from the Translations
provided.

This is breaking, because it will end up with less available locales by default, since only the
locales of Flow Translations are considered available, instead of all of CLDR locales.

Related to #1232