### PR TITLE
BUGFIX: Set orphanRemoval for non-AggregateRoots

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -606,11 +606,12 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
                 } elseif ($this->isAggregateRoot($mapping['targetEntity'], $className) === false) {
                     $mapping['cascade'] = ['all'];
                 }
-                if ($oneToOneAnnotation->orphanRemoval !== null) {
-                    $mapping['orphanRemoval'] = $oneToOneAnnotation->orphanRemoval;
-                } elseif ($this->isAggregateRoot($mapping['targetEntity'], $className) === false &&
-                          $this->isValueObject($mapping['targetEntity'], $className) === false) {
+                // We need to apply our value for non-aggregate roots first, because Doctrine sets a default value for orphanRemoval (see #1127)
+                if ($this->isAggregateRoot($mapping['targetEntity'], $className) === false &&
+                    $this->isValueObject($mapping['targetEntity'], $className) === false) {
                     $mapping['orphanRemoval'] = true;
+                } elseif ($oneToOneAnnotation->orphanRemoval !== null) {
+                    $mapping['orphanRemoval'] = $oneToOneAnnotation->orphanRemoval;
                 }
                 $mapping['fetch'] = $this->getFetchMode($className, $oneToOneAnnotation->fetch);
                 $metadata->mapOneToOne($mapping);
@@ -629,11 +630,12 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
                     $mapping['cascade'] = ['all'];
                 }
                 $mapping['indexBy'] = $oneToManyAnnotation->indexBy;
-                if ($oneToManyAnnotation->orphanRemoval !== null) {
-                    $mapping['orphanRemoval'] = $oneToManyAnnotation->orphanRemoval;
-                } elseif ($this->isAggregateRoot($mapping['targetEntity'], $className) === false &&
+                // We need to apply our value for non-aggregate roots first, because Doctrine sets a default value for orphanRemoval (see #1127)
+                if ($this->isAggregateRoot($mapping['targetEntity'], $className) === false &&
                     $this->isValueObject($mapping['targetEntity'], $className) === false) {
                     $mapping['orphanRemoval'] = true;
+                } elseif ($oneToManyAnnotation->orphanRemoval !== null) {
+                    $mapping['orphanRemoval'] = $oneToManyAnnotation->orphanRemoval;
                 }
                 $mapping['fetch'] = $this->getFetchMode($className, $oneToManyAnnotation->fetch);
 


### PR DESCRIPTION
After fixing the issue #1079, orphan removal is per default false for properties from classes which are no aggregate roots, because the default value for orphan removal in the ManyToMany, OneToOne and OneToMany annotations is "false".
Unfortunately we can not prevent the default value in the annotation, so we can not rely on the property not being set to fall back to our defaults.
This change Fixes that by switching the check for orphanRemoval annotation value fallbacks and always apply our default value for non-aggregate root non-value objects.

Fixes #1127