### PR TITLE
FEATURE: Allow to use CLDR to format currency

### DIFF
--- a/Neos.Flow/Classes/I18n/Cldr/Reader/CurrencyReader.php
+++ b/Neos.Flow/Classes/I18n/Cldr/Reader/CurrencyReader.php
@@ -1,0 +1,112 @@
+<?php
+namespace Neos\Flow\I18n\Cldr\Reader;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Cache\Frontend\VariableFrontend;
+use Neos\Flow\I18n\Cldr\CldrRepository;
+
+/**
+ * A reader for data placed in "currencyData" tag in CLDR.
+ *
+ * @Flow\Scope("singleton")
+ */
+class CurrencyReader
+{
+    /**
+     * @var CldrRepository
+     */
+    protected $cldrRepository;
+
+    /**
+     * @var VariableFrontend
+     */
+    protected $cache;
+
+    /**
+     * An array of fractions data, indexed by currency code.
+     *
+     * @var array
+     */
+    protected $fractions;
+
+    /**
+     * @param CldrRepository $repository
+     * @return void
+     */
+    public function injectCldrRepository(CldrRepository $repository)
+    {
+        $this->cldrRepository = $repository;
+    }
+
+    /**
+     * Injects the Flow_I18n_Cldr_Reader_CurrencyReader cache
+     *
+     * @param VariableFrontend $cache
+     * @return void
+     */
+    public function injectCache(VariableFrontend $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Constructs the reader, loading parsed data from cache if available.
+     *
+     * @return void
+     */
+    public function initializeObject()
+    {
+        if ($this->cache->has('fractions')) {
+            $this->fractions = $this->cache->get('fractions');
+        } else {
+            $this->generateFractions();
+            $this->cache->set('fractions', $this->fractions);
+        }
+    }
+
+    /**
+     * Returns an array with keys "digits" and "rounding", each an integer.
+     *
+     * @param string $currencyCode
+     * @return array ['digits' => int, 'rounding => int]
+     */
+    public function getFraction($currencyCode)
+    {
+        if (array_key_exists($currencyCode, $this->fractions)) {
+            return $this->fractions[$currencyCode];
+        }
+
+        return $this->fractions['DEFAULT'];
+    }
+
+    /**
+     * Generates an internal representation of currency fractions which can be found
+     * in supplementalData.xml CLDR file.
+     *
+     * @return void
+     * @see CurrencyReader::$fractions
+     */
+    protected function generateFractions()
+    {
+        $model = $this->cldrRepository->getModel('supplemental/currencyData');
+        $currencyData = $model->getRawArray('currencyData');
+
+        foreach ($currencyData['fractions'] as $fractionString) {
+            $currencyCode = $model->getAttributeValue($fractionString, 'iso4217');
+            $this->fractions[$currencyCode] = [
+                'digits' => (int)$model->getAttributeValue($fractionString, 'digits'),
+                'rounding' => (int)$model->getAttributeValue($fractionString, 'rounding')
+            ];
+        }
+    }
+}

--- a/Neos.Flow/Classes/I18n/Formatter/NumberFormatter.php
+++ b/Neos.Flow/Classes/I18n/Formatter/NumberFormatter.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\I18n\Formatter;
  */
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\I18n\Cldr\Reader\CurrencyReader;
 use Neos\Flow\I18n\Cldr\Reader\NumbersReader;
 use Neos\Flow\I18n\Locale;
 
@@ -29,12 +30,27 @@ class NumberFormatter implements FormatterInterface
     protected $numbersReader;
 
     /**
+     * @var CurrencyReader
+     */
+    protected $currencyReader;
+
+    /**
      * @param NumbersReader $numbersReader
      * @return void
      */
     public function injectNumbersReader(NumbersReader $numbersReader)
     {
         $this->numbersReader = $numbersReader;
+    }
+
+
+    /**
+     * @param CurrencyReader $currencyReader
+     * @return void
+     */
+    public function injectCurrencyReader(CurrencyReader $currencyReader)
+    {
+        $this->currencyReader = $currencyReader;
     }
 
     /**
@@ -134,13 +150,24 @@ class NumberFormatter implements FormatterInterface
      * @param Locale $locale
      * @param string $currency Currency symbol (or name)
      * @param string $formatLength One of NumbersReader FORMAT_LENGTH constants
+     * @param string $currencyCode The ISO 4217 currency code of the currency to format. Used to set decimal places and rounding.
      * @return string Formatted number. Will return string-casted version of $number if there is no pattern for given $locale / $formatLength
      * @api
      */
-    public function formatCurrencyNumber($number, Locale $locale, $currency, $formatLength = NumbersReader::FORMAT_LENGTH_DEFAULT)
+    public function formatCurrencyNumber($number, Locale $locale, $currency, $formatLength = NumbersReader::FORMAT_LENGTH_DEFAULT, $currencyCode = null)
     {
         NumbersReader::validateFormatLength($formatLength);
-        return $this->doFormattingWithParsedFormat($number, $this->numbersReader->parseFormatFromCldr($locale, NumbersReader::FORMAT_TYPE_CURRENCY, $formatLength), $this->numbersReader->getLocalizedSymbolsForLocale($locale), $currency);
+        $parsedFormat = $this->numbersReader->parseFormatFromCldr($locale, NumbersReader::FORMAT_TYPE_CURRENCY, $formatLength);
+
+        if ($currencyCode !== null) {
+            // When currencyCode is set, maxDecimalDigits and rounding is overridden with CLDR data
+            $currencyFraction = $this->currencyReader->getFraction($currencyCode);
+            $parsedFormat['rounding'] = $currencyFraction['rounding'];
+            $parsedFormat['maxDecimalDigits'] = $currencyFraction['digits'];
+            $parsedFormat['minDecimalDigits'] = min($parsedFormat['minDecimalDigits'], $parsedFormat['maxDecimalDigits']);
+        }
+
+        return $this->doFormattingWithParsedFormat($number, $parsedFormat, $this->numbersReader->getLocalizedSymbolsForLocale($locale), $currency);
     }
 
     /**
@@ -229,7 +256,6 @@ class NumberFormatter implements FormatterInterface
 
         $number = str_replace(['%', '‰', '-'], [$symbols['percentSign'], $symbols['perMille'], $symbols['minusSign']], $number);
         if ($currency !== null) {
-            // @todo When currency is set, min / max DecimalDigits and rounding is overridden with CLDR data
             $number = str_replace('¤', $currency, $number);
         }
 

--- a/Neos.Flow/Configuration/Caches.yaml
+++ b/Neos.Flow/Configuration/Caches.yaml
@@ -43,6 +43,7 @@ Flow_I18n_Cldr_CldrModelCache: []
 Flow_I18n_Cldr_Reader_DatesReaderCache: []
 Flow_I18n_Cldr_Reader_NumbersReaderCache: []
 Flow_I18n_Cldr_Reader_PluralsReaderCache: []
+Flow_I18n_Cldr_Reader_CurrencyReaderCache: []
 
 # Flow_Monitor
 Flow_Monitor:

--- a/Neos.Flow/Configuration/Objects.yaml
+++ b/Neos.Flow/Configuration/Objects.yaml
@@ -114,6 +114,15 @@ Neos\Flow\I18n\Cldr\Reader\PluralsReader:
         arguments:
           1:
             value: Flow_I18n_Cldr_Reader_PluralsReaderCache
+Neos\Flow\I18n\Cldr\Reader\CurrencyReader:
+  properties:
+    cache:
+      object:
+        factoryObjectName: Neos\Flow\Cache\CacheManager
+        factoryMethodName: getCache
+        arguments:
+          1:
+            value: Flow_I18n_Cldr_Reader_CurrencyReaderCache
 
 #                                                                          #
 # Log                                                                      #

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/CurrencyReaderTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/CurrencyReaderTest.php
@@ -1,0 +1,82 @@
+<?php
+namespace Neos\Flow\Tests\Unit\I18n\Cldr\Reader;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Cache\Frontend\VariableFrontend;
+use Neos\Flow\I18n\Cldr\Reader\CurrencyReader;
+use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\I18n;
+
+/**
+ * Testcase for the CurrencyReader
+ */
+class CurrencyReaderTest extends UnitTestCase
+{
+    /**
+     * @var CurrencyReader
+     */
+    protected $reader;
+
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        $sampleCurrencyFractionsData = [
+            'fractions' => [
+                'info[@iso4217="ADP"][@digits="0"][@rounding="0"]',
+                'info[@iso4217="CHF"][@digits="2"][@rounding="5"]',
+                'info[@iso4217="DEFAULT"][@digits="2"][@rounding="0"]',
+            ],
+        ];
+
+        $mockModel = $this->getAccessibleMock(I18n\Cldr\CldrModel::class, ['getRawArray'], [['fake/path']]);
+        $mockModel->expects($this->once())->method('getRawArray')->with('currencyData')->will($this->returnValue($sampleCurrencyFractionsData));
+
+        $mockRepository = $this->createMock(I18n\Cldr\CldrRepository::class);
+        $mockRepository->expects($this->once())->method('getModel')->with('supplemental/currencyData')->will($this->returnValue($mockModel));
+
+        $mockCache = $this->getMockBuilder(VariableFrontend::class)->disableOriginalConstructor()->getMock();
+        $mockCache->expects($this->at(0))->method('has')->with('fractions')->will($this->returnValue(false));
+        $mockCache->expects($this->at(1))->method('set')->with('fractions');
+
+        $this->reader = new CurrencyReader();
+        $this->reader->injectCldrRepository($mockRepository);
+        $this->reader->injectCache($mockCache);
+        $this->reader->initializeObject();
+    }
+
+    /**
+     * Data provider for returnsCorrectPluralForm
+     *
+     * @return array
+     */
+    public function fractions()
+    {
+        return [
+            ['ADP', 0, 0],
+            ['CHF', 2, 5],
+            ['EUR', 2, 0]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider fractions
+     */
+    public function returnsCorrectFraction($currencyCode, $digits, $rounding)
+    {
+        $result = $this->reader->getFraction($currencyCode);
+        $this->assertSame($digits, $result['digits']);
+        $this->assertSame($rounding, $result['rounding']);
+    }
+}

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Format/CurrencyViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Format/CurrencyViewHelper.php
@@ -12,6 +12,7 @@ namespace Neos\FluidAdaptor\ViewHelpers\Format;
  */
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\I18n\Cldr\Reader\NumbersReader;
 use Neos\Flow\I18n\Exception as I18nException;
 use Neos\Flow\I18n\Formatter\NumberFormatter;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractLocaleAwareViewHelper;
@@ -85,6 +86,9 @@ use Neos\FluidAdaptor\Core\ViewHelper\Exception as ViewHelperException;
  * Fore more information about localization see section ``Internationalization & Localization Framework`` in the
  * Flow documentation.
  *
+ * Additionally, if ``currencyCode`` is set, rounding and decimal digits are replaced by the rules for the
+ * respective currency (e.g. JPY never has decimal digits, CHF is rounded using 5 decimals.)
+ *
  * @api
  */
 class CurrencyViewHelper extends AbstractLocaleAwareViewHelper
@@ -109,6 +113,7 @@ class CurrencyViewHelper extends AbstractLocaleAwareViewHelper
         $this->registerArgument('prependCurrency', 'boolean', '(optional) Indicates if currency symbol should be placed before or after the numeric value.', false, false);
         $this->registerArgument('separateCurrency', 'boolean', '(optional) Indicates if a space character should be placed between the number and the currency sign.', false, true);
         $this->registerArgument('decimals', 'integer', '(optional) The number of decimal places.', false, 2);
+        $this->registerArgument('currencyCode', 'string', '(optional) The ISO 4217 currency code of the currency to format. Used to set decimal places and rounding.', false, null);
     }
 
     /**
@@ -130,7 +135,7 @@ class CurrencyViewHelper extends AbstractLocaleAwareViewHelper
                 throw new InvalidVariableException('Using the Locale requires a currencySign.', 1326378320);
             }
             try {
-                $output = $this->numberFormatter->formatCurrencyNumber($stringToFormat, $useLocale, $currencySign);
+                $output = $this->numberFormatter->formatCurrencyNumber($stringToFormat, $useLocale, $currencySign, NumbersReader::FORMAT_LENGTH_DEFAULT, $this->arguments['currencyCode']);
             } catch (I18nException $exception) {
                 throw new ViewHelperException($exception->getMessage(), 1382350428, $exception);
             }


### PR DESCRIPTION
Some currencies have specific rules for their formatting, overriding
the rules that might be used to format for a given locale. The Japanese
Yen for example never has decimal digits, and the Swiss Franc is rounded
using five decimals.

This change adds support for that. The CurrencyViewHelper accepts an
optional `currencyCode` argument now and passes it down to the method
`formatCurrencyNumber` in `NumberFormatter` doing the actual work.
