### PR TITLE
TASK: Remove references to excludeClasses from object management

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/CompileTimeObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/CompileTimeObjectManager.php
@@ -262,7 +262,7 @@ class CompileTimeObjectManager extends ObjectManager
     {
         foreach ($filterConfiguration as $packageKey => $filterExpressions) {
             if (!array_key_exists($packageKey, $classNames)) {
-                $this->systemLogger->log('The package "' . $packageKey . '" specified in the setting "Neos.Flow.object.includeClasses" was either excluded or is not loaded.', LOG_DEBUG);
+                $this->systemLogger->log('The package "' . $packageKey . '" specified in the setting "Neos.Flow.object.includeClasses" is not available.', LOG_DEBUG);
                 continue;
             }
             if (!is_array($filterExpressions)) {

--- a/Neos.Flow/Configuration/Settings.Object.yaml
+++ b/Neos.Flow/Configuration/Settings.Object.yaml
@@ -22,5 +22,4 @@ Neos:
       # reflected by default. You can however exclude specific (or all) classes from Flow packages
       # by specifying corresponding regular expressions that don't match classes to exclude.
       #
-      # Note: The previous setting "excludeClasses" has been deprecated with Flow 3.0
       includeClasses: []


### PR DESCRIPTION
The setting ``Neos.Flow.excludeClasses`` was deprecated since a while
but the code handling it was not removed until now.
