### PR TITLE
!!! TASK: Remove deprecated ``getClassNameByObject``

### DIFF
--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -495,19 +495,6 @@ class ReflectionService
     }
 
     /**
-     * Returns the class name of the given object. This is a convenience
-     * method that returns the expected class names even for proxy classes.
-     *
-     * @param object $object
-     * @return string The class name of the given object
-     * @deprecated since 3.0 use \Neos\Utility\TypeHandling::getTypeForValue() instead
-     */
-    public function getClassNameByObject($object)
-    {
-        return TypeHandling::getTypeForValue($object);
-    }
-
-    /**
      * Searches for and returns all names of classes which are tagged by the specified
      * annotation. If no classes were found, an empty array is returned.
      *

--- a/Neos.Flow/Tests/Unit/Package/PackageManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Package/PackageManagerTest.php
@@ -68,12 +68,6 @@ class PackageManagerTest extends UnitTestCase
         $mockObjectManager = $this->createMock(ObjectManagerInterface::class);
         $this->mockBootstrap->expects($this->any())->method('getObjectManager')->will($this->returnValue($mockObjectManager));
         $mockReflectionService = $this->createMock(ReflectionService::class);
-        $mockReflectionService->expects($this->any())->method('getClassNameByObject')->will($this->returnCallback(function ($object) {
-            if ($object instanceof \Doctrine\ORM\Proxy\Proxy) {
-                return get_parent_class($object);
-            }
-            return get_class($object);
-        }));
         $mockObjectManager->expects($this->any())->method('get')->with(ReflectionService::class)->will($this->returnValue($mockReflectionService));
 
         mkdir('vfs://Test/Packages/Application', 0700, true);


### PR DESCRIPTION
Use static ``TypeHandling::getTypeForValue`` as immediate replacement.
