### PR TITLE
TASK: Remove checks for old (pre 3.0) Policy configuration

### DIFF
--- a/Neos.Flow/Classes/Configuration/ConfigurationManager.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationManager.php
@@ -490,7 +490,6 @@ class ConfigurationManager
                 /** @var $package PackageInterface */
                 foreach ($packages as $package) {
                     $packagePolicyConfiguration = $this->configurationSource->load($package->getConfigurationPath() . $configurationType, $allowSplitSource);
-                    $this->validatePolicyConfiguration($packagePolicyConfiguration, $package);
                     $this->configurations[$configurationType] = $this->mergePolicyConfiguration($this->configurations[$configurationType], $packagePolicyConfiguration);
                 }
                 $this->configurations[$configurationType] = $this->mergePolicyConfiguration($this->configurations[$configurationType], $this->configurationSource->load(FLOW_PATH_CONFIGURATION . $configurationType, $allowSplitSource));
@@ -499,7 +498,6 @@ class ConfigurationManager
                     /** @var $package PackageInterface */
                     foreach ($packages as $package) {
                         $packagePolicyConfiguration = $this->configurationSource->load($package->getConfigurationPath() . $contextName . '/' . $configurationType, $allowSplitSource);
-                        $this->validatePolicyConfiguration($packagePolicyConfiguration, $package);
                         $this->configurations[$configurationType] = $this->mergePolicyConfiguration($this->configurations[$configurationType], $packagePolicyConfiguration);
                     }
                     $this->configurations[$configurationType] = $this->mergePolicyConfiguration($this->configurations[$configurationType], $this->configurationSource->load(FLOW_PATH_CONFIGURATION . $contextName . '/' . $configurationType, $allowSplitSource));
@@ -847,28 +845,6 @@ class ConfigurationManager
             $result['roles'][$roleIdentifier]['privileges'] = array_merge($firstConfigurationArray['roles'][$roleIdentifier]['privileges'], $secondConfigurationArray['roles'][$roleIdentifier]['privileges']);
         }
         return $result;
-    }
-
-    /**
-     * Validates the given $policyConfiguration and throws an exception if its not valid
-     *
-     * @param array $policyConfiguration
-     * @param PackageInterface $package
-     * @return void
-     * @throws Exception
-     */
-    protected function validatePolicyConfiguration(array $policyConfiguration, PackageInterface $package)
-    {
-        $errors = [];
-        if (isset($policyConfiguration['resources'])) {
-            $errors[] = 'deprecated "resources" options';
-        }
-        if (isset($policyConfiguration['acls'])) {
-            $errors[] = 'deprecated "acls" options';
-        }
-        if ($errors !== []) {
-            throw new Exception(sprintf('The policy configuration for package "%s" is not valid.%sIt contains following error(s):%s Make sure to run all code migrations.', $package->getPackageKey(), chr(10), chr(10) . '  * ' . implode(chr(10) . '  * ', $errors) . chr(10)), 1415717875);
-        }
     }
 
     /**


### PR DESCRIPTION
Unless someone upgrades straight to 5.0 from versions <3.0 this
configuration shouldn't be in anything anymore. Therefore we
should be able to safely remove the check and safe some resources
in the ``ConfigurationManager``.
