### PR TITLE
!!! TASK: Remove ``getTemplateVariableContainer`` method

### DIFF
--- a/Neos.FluidAdaptor/Classes/Core/Rendering/RenderingContext.php
+++ b/Neos.FluidAdaptor/Classes/Core/Rendering/RenderingContext.php
@@ -139,15 +139,6 @@ class RenderingContext extends FluidRenderingContext implements FlowAwareRenderi
     }
 
     /**
-     * @return \TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface
-     * @deprecated use "getVariableProvider"
-     */
-    public function getTemplateVariableContainer()
-    {
-        return $this->getVariableProvider();
-    }
-
-    /**
      * Build parser configuration
      *
      * @return Configuration


### PR DESCRIPTION
This method was deprecated with the switch to standalone Fluid in
Flow 4.0 to get closer to the ``RenderingContext`` in the base
package. It is therefore now removed.

Any calls to ``getTemplateVariableContainer`` can be replaced with calls to
``getVariableProvider``.
