### PR TITLE
!!! TASK: Remove ``getValue`` from ``AbstractFormFieldViewHelper``

### DIFF
--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Form/AbstractFormFieldViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Form/AbstractFormFieldViewHelper.php
@@ -97,38 +97,6 @@ abstract class AbstractFormFieldViewHelper extends AbstractFormViewHelper
     }
 
     /**
-     * Get the value of this form element.
-     * Either returns arguments['value'], or the correct value for Object Access.
-     *
-     * @param boolean $convertObjects whether or not to convert objects to identifiers
-     * @return mixed Value
-     * @deprecated since Flow 3.0. Use getValueAttribute() and (if applicable) addAdditionalIdentityPropertiesIfNeeded()
-     */
-    protected function getValue($convertObjects = true)
-    {
-        $value = null;
-
-        if ($this->hasArgument('value')) {
-            $value = $this->arguments['value'];
-        } elseif ($this->isObjectAccessorMode()) {
-            if ($this->hasMappingErrorOccurred()) {
-                $value = $this->getLastSubmittedFormData();
-            } else {
-                $value = $this->getPropertyValue();
-            }
-            $this->addAdditionalIdentityPropertiesIfNeeded();
-        }
-
-        if ($convertObjects && is_object($value)) {
-            $identifier = $this->persistenceManager->getIdentifierByObject($value);
-            if ($identifier !== null) {
-                $value = $identifier;
-            }
-        }
-        return $value;
-    }
-
-    /**
      * Returns the current value of this Form ViewHelper and converts it to an identifier string in case it's an object
      * The value is determined as follows:
      * * If property mapping errors occurred and the form is re-displayed, the *last submitted* value is returned


### PR DESCRIPTION
The ``getValue`` method was deprecated since Flow 3.0 and should be
replaced with calls to ``getValueAttribute()`` and if applicable
to ``addAdditionalIdentityPropertiesIfNeeded()``.
