### PR TITLE
BUGFIX: Read currencyData from existing file

### DIFF
--- a/Neos.Flow/Classes/I18n/Cldr/Reader/CurrencyReader.php
+++ b/Neos.Flow/Classes/I18n/Cldr/Reader/CurrencyReader.php
@@ -98,7 +98,7 @@ class CurrencyReader
      */
     protected function generateFractions()
     {
-        $model = $this->cldrRepository->getModel('supplemental/currencyData');
+        $model = $this->cldrRepository->getModel('supplemental/supplementalData');
         $currencyData = $model->getRawArray('currencyData');
 
         foreach ($currencyData['fractions'] as $fractionString) {

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/CurrencyReaderTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/CurrencyReaderTest.php
@@ -43,7 +43,7 @@ class CurrencyReaderTest extends UnitTestCase
         $mockModel->expects($this->once())->method('getRawArray')->with('currencyData')->will($this->returnValue($sampleCurrencyFractionsData));
 
         $mockRepository = $this->createMock(I18n\Cldr\CldrRepository::class);
-        $mockRepository->expects($this->once())->method('getModel')->with('supplemental/currencyData')->will($this->returnValue($mockModel));
+        $mockRepository->expects($this->once())->method('getModel')->with('supplemental/supplementalData')->will($this->returnValue($mockModel));
 
         $mockCache = $this->getMockBuilder(VariableFrontend::class)->disableOriginalConstructor()->getMock();
         $mockCache->expects($this->at(0))->method('has')->with('fractions')->will($this->returnValue(false));


### PR DESCRIPTION
The feature worked and the test proved it. But both agreed on a filename
that does not exist for real.

Added with https://github.com/neos/flow-development-collection/pull/1241

Thanks to @mficzel for finding that.
