### PR TITLE
BUGFIX: if cached configuration does not contain all configuration types, ensure on next run the configuration is cached again

### DIFF
--- a/Neos.Flow/Classes/Configuration/ConfigurationManager.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationManager.php
@@ -604,7 +604,7 @@ class ConfigurationManager
     {
         // Make sure that all configuration types are loaded before writing configuration caches.
         foreach (array_keys($this->configurationTypes) as $configurationType) {
-            if (!isset($this->configurations[$configurationType]) || !is_array($this->configurations[$configurationType])) {
+            if (!isset($this->unprocessedConfiguration[$configurationType]) || !is_array($this->unprocessedConfiguration[$configurationType])) {
                 $this->loadConfiguration($configurationType, $this->packages);
             }
         }


### PR DESCRIPTION
## Problem Description

the following happens in Production context, if letting the CLI compile request run through, but abort the web request.

In this case:
- the cached Configurations.php object does *not* contain information for NodeTypes etc.
- thus, node types are loaded on every request
- this leads to a slow system which can only be fixed by removing the cached Configuration file.

To solve this issue, we now check whether the unprocessed configuration contains the right infos before serializing them.