### PR TITLE
FEATURE: Add Forwarded Header support

### DIFF
--- a/Neos.Flow/Classes/Http/Component/TrustedProxiesComponent.php
+++ b/Neos.Flow/Classes/Http/Component/TrustedProxiesComponent.php
@@ -82,7 +82,9 @@ class TrustedProxiesComponent implements ComponentInterface
      */
     protected function unquoteArray($array)
     {
-        return array_map(function($value) { return trim($value, '"'); }, array_values(array_filter($array)));
+        return array_map(function ($value) {
+            return trim($value, '"');
+        }, array_values(array_filter($array)));
     }
 
     /**

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
@@ -332,7 +332,9 @@ and which headers specifically are accepted for overriding those request informa
 	          proto: 'X-Forwarded-Proto'
 
 This would mean that only the ``X-Forwarded-*`` headers are accepted and only as long as those come from one of the
-IP ranges ``216.246.40.0-255`` or ``216.246.100.0-255``.
+IP ranges ``216.246.40.0-255`` or ``216.246.100.0-255``. If you are using the standardized `Forwarded Header`__, you
+can also simply set ``trustedProxies.headers`` to ``'Forwarded'``, which is the same as setting all four properties to
+this value.
 By default, all proxies are trusted (``trustedProxies.proxies`` set to ``'*'``) and only the ``X-Forwarded-*`` headers
 are accepted. Also, for backwards compatibility the following headers are trusted for providing the client IP address:
 
@@ -563,3 +565,4 @@ other application parts which are accessible via HTTP. This browser has the ``In
 .. _REST: http://en.wikipedia.org/wiki/Representational_state_transfer
 .. _Coordinated Universal Time: http://en.wikipedia.org/wiki/Coordinated_Universal_Time
 .. _Greenwich Mean Time: http://en.wikipedia.org/wiki/Greenwich_Mean_Time
+.. _Forwarded Header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded

--- a/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.http.schema.yaml
+++ b/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.http.schema.yaml
@@ -47,7 +47,7 @@ properties:
              additionalProperties:
                type: string
       'headers':
-        type: dictionary
+        type: [string, dictionary]
         required: true
         additionalProperties: false
         properties:

--- a/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.http.schema.yaml
+++ b/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.http.schema.yaml
@@ -47,11 +47,15 @@ properties:
              additionalProperties:
                type: string
       'headers':
-        type: [string, dictionary]
         required: true
-        additionalProperties: false
-        properties:
-          'clientIp': { type: string, required: true }
-          'host': { type: string, required: true }
-          'port': { type: string, required: true }
-          'proto': { type: string, required: true }
+        type:
+          -
+            type: 'string'
+          -
+            type: dictionary
+            additionalProperties: false
+            properties:
+              'clientIp': { type: string, required: true }
+              'host': { type: string, required: true }
+              'port': { type: string, required: true }
+              'proto': { type: string, required: true }

--- a/Neos.Flow/Tests/Unit/Http/Component/TrustedProxiesComponentTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Component/TrustedProxiesComponentTest.php
@@ -129,8 +129,6 @@ class TrustedProxiesComponentTest extends UnitTestCase
             array(array('HTTP_X_CLUSTER_CLIENT_IP' => '209.85.148.101, 209.85.148.102'), '209.85.148.101'),
             array(array('HTTP_FORWARDED_FOR' => '209.85.148.101'), '209.85.148.101'),
             array(array('HTTP_FORWARDED' => '209.85.148.101'), '209.85.148.101'),
-            array(array('HTTP_FORWARDED' => 'for=209.85.148.101'), '209.85.148.101'),
-            array(array('HTTP_FORWARDED' => 'for=123.123.123.123, for=209.85.148.101'), '123.123.123.123'),
             array(array('REMOTE_ADDR' => '127.0.0.1'), '127.0.0.1'),
         );
     }

--- a/Neos.Flow/Tests/Unit/Http/Component/TrustedProxiesComponentTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Component/TrustedProxiesComponentTest.php
@@ -129,6 +129,8 @@ class TrustedProxiesComponentTest extends UnitTestCase
             array(array('HTTP_X_CLUSTER_CLIENT_IP' => '209.85.148.101, 209.85.148.102'), '209.85.148.101'),
             array(array('HTTP_FORWARDED_FOR' => '209.85.148.101'), '209.85.148.101'),
             array(array('HTTP_FORWARDED' => '209.85.148.101'), '209.85.148.101'),
+            array(array('HTTP_FORWARDED' => 'for=209.85.148.101'), '209.85.148.101'),
+            array(array('HTTP_FORWARDED' => 'for=123.123.123.123, for=209.85.148.101'), '123.123.123.123'),
             array(array('REMOTE_ADDR' => '127.0.0.1'), '127.0.0.1'),
         );
     }
@@ -155,6 +157,47 @@ class TrustedProxiesComponentTest extends UnitTestCase
         $request = Request::create(new Uri('http://flow.neos.io'), 'GET', array(), array(), array_replace($defaultServerEnvironment, $serverEnvironment));
         $trustedRequest = $this->callWithRequest($request);
         $this->assertSame($expectedIpAddress, $trustedRequest->getClientIpAddress());
+    }
+
+    /**
+     * Data Provider
+     */
+    public function serverEnvironmentsForForwardedHeader()
+    {
+        return array(
+            array(array('HTTP_FORWARDED' => 'for=209.85.148.101; proto=https; host=www.acme.org'), '209.85.148.101', 'https', 'www.acme.org', 443),
+            array(array('HTTP_FORWARDED' => 'For=123.123.123.123, for=209.85.148.101'), '123.123.123.123', 'http', 'flow.neos.io', 80),
+            array(array('HTTP_FORWARDED' => 'FOR=192.0.2.60, for=209.85.148.101; proto=https; HOST="123.123.123.123:4711", host=www.acme.org:8080; by=203.0.113.43'), '192.0.2.60', 'https', '123.123.123.123', 4711),
+            array(array('HTTP_FORWARDED' => 'for=192.0.2.60; proto=https; host=www.acme.org:8080; by=203.0.113.43'), '192.0.2.60', 'https', 'www.acme.org', 8080),
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider serverEnvironmentsForForwardedHeader
+     */
+    public function trustedProxyCorrectlyParsesForwardedHeaders(array $serverEnvironment, $expectedIpAddress, $expectedProto, $expectedHost, $expectedPort)
+    {
+        $defaultServerEnvironment = array(
+            'HTTP_USER_AGENT' => 'Flow/' . FLOW_VERSION_BRANCH . '.x',
+            'HTTP_HOST' => 'flow.neos.io',
+            'SERVER_NAME' => 'neos.io',
+            'SERVER_ADDR' => '217.29.36.55',
+            'SERVER_PORT' => 80,
+            'REMOTE_ADDR' => '17.172.224.47',
+            'SCRIPT_FILENAME' => FLOW_PATH_WEB . 'index.php',
+            'SERVER_PROTOCOL' => 'HTTP/1.1',
+            'SCRIPT_NAME' => '/index.php',
+            'PHP_SELF' => '/index.php',
+        );
+
+        $this->withTrustedProxiesSettings(['proxies' => '*', 'headers' => 'Forwarded']);
+        $request = Request::create(new Uri('http://flow.neos.io'), 'GET', array(), array(), array_replace($defaultServerEnvironment, $serverEnvironment));
+        $trustedRequest = $this->callWithRequest($request);
+        $this->assertSame($expectedIpAddress, $trustedRequest->getAttribute(Request::ATTRIBUTE_CLIENT_IP));
+        $this->assertSame($expectedProto, $trustedRequest->getUri()->getScheme());
+        $this->assertSame($expectedHost, $trustedRequest->getUri()->getHost());
+        $this->assertSame($expectedPort, $trustedRequest->getUri()->getPort());
     }
 
     /**


### PR DESCRIPTION
This adds support for setting the standardized `Forwarded` Header as described in RFC 7239 Section 4 (https://tools.ietf.org/html/rfc7239#section-4), as the `headers` trusted proxy setting.
Also, this change allows to set a single header value for the `headers`, so that working with the single `Forwarded` header is more convenient:

```
Neos:
  Flow:
    http:
      trustedProxies:
        headers: 'Forwarded'
```

Resolves: #1060