### PR TITLE
TASK: Make HTTP Request getClientIpAddress() use the request attribute value

### DIFF
--- a/Neos.Flow/Classes/Http/Request.php
+++ b/Neos.Flow/Classes/Http/Request.php
@@ -421,18 +421,7 @@ class Request extends BaseRequest implements ServerRequestInterface
      */
     public function getClientIpAddress()
     {
-        $serverFields = array('HTTP_CLIENT_IP', 'HTTP_X_FORWARDED_FOR', 'HTTP_X_FORWARDED', 'HTTP_X_CLUSTER_CLIENT_IP', 'HTTP_FORWARDED_FOR', 'HTTP_FORWARDED');
-        foreach ($serverFields as $field) {
-            if (empty($this->server[$field])) {
-                continue;
-            }
-            $length = strpos($this->server[$field], ',');
-            $ipAddress = trim(($length === false) ? $this->server[$field] : substr($this->server[$field], 0, $length));
-            if (filter_var($ipAddress, FILTER_VALIDATE_IP, FILTER_FLAG_NO_RES_RANGE | FILTER_FLAG_NO_PRIV_RANGE) !== false) {
-                return $ipAddress;
-            }
-        }
-        return (isset($this->server['REMOTE_ADDR']) ? $this->server['REMOTE_ADDR'] : null);
+        return $this->getAttribute(self::ATTRIBUTE_CLIENT_IP);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Http/Component/TrustedProxiesComponentTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Component/TrustedProxiesComponentTest.php
@@ -128,7 +128,6 @@ class TrustedProxiesComponentTest extends UnitTestCase
             array(array('HTTP_X_FORWARDED_FOR' => '123.123.123.123, 209.85.148.101, 209.85.148.102'), '123.123.123.123'),
             array(array('HTTP_X_CLUSTER_CLIENT_IP' => '209.85.148.101, 209.85.148.102'), '209.85.148.101'),
             array(array('HTTP_FORWARDED_FOR' => '209.85.148.101'), '209.85.148.101'),
-            array(array('HTTP_FORWARDED' => '209.85.148.101'), '209.85.148.101'),
             array(array('REMOTE_ADDR' => '127.0.0.1'), '127.0.0.1'),
         );
     }


### PR DESCRIPTION
This in turn will actually make the method take the trusted proxy settings into account instead
of a hardcoded list of headers.
Also, this change removes the test for the `Forwarded` header, because the test had wrong expectations
on the actual formatting of the header value. See #1060