### PR TITLE
BUGFIX: Wrong type hint on replacePlaceholders

### DIFF
--- a/Neos.Flow/Classes/Configuration/ConfigurationManager.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationManager.php
@@ -803,16 +803,16 @@ class ConfigurationManager
     /**
      * Replaces placeholders in the format <variableName> with the corresponding variable of the specified $variables collection.
      *
-     * @param string $string
+     * @param mixed $subject
      * @param array $variables
-     * @return string
+     * @return mixed
      */
-    protected function replacePlaceholders(string $string, array $variables): string
+    protected function replacePlaceholders($subject, array $variables)
     {
         foreach ($variables as $variableName => $variableValue) {
-            $string = str_replace('<' . $variableName . '>', $variableValue, $string);
+            $subject = str_replace('<' . $variableName . '>', $variableValue, $subject);
         }
-        return $string;
+        return $subject;
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -1400,7 +1400,14 @@ EOD;
                 'uriPattern' => '',
                 'defaults' => [
                     '@controller' => 'Standard',
-                    '@action' => 'redirect'
+                    '@action' => 'redirect',
+                    '--posts-paginator' => [
+                      '@package' => '',
+                      '@subpackage' => '',
+                      '@controller' => '',
+                      '@action' => 'index',
+                      'currentPage' => '1'
+                    ]
                 ],
             ]
         ];
@@ -1420,7 +1427,14 @@ EOD;
                 'defaults' => [
                     '@package' => 'Welcome',
                     '@controller' => 'Standard',
-                    '@action' => 'redirect'
+                    '@action' => 'redirect',
+                    '--posts-paginator' => [
+                        '@package' => '',
+                        '@subpackage' => '',
+                        '@controller' => '',
+                        '@action' => 'index',
+                        'currentPage' => '1'
+                    ]
                 ],
             ]
         ];


### PR DESCRIPTION
The configurationManager.replacePlaceholder() method must not use a
string type hint for the subject, since in fact that can be an array.