### PR TITLE
BUGFIX: Render debugger-styles directly with first debug-output

### DIFF
--- a/Neos.Flow/Classes/Error/Debugger.php
+++ b/Neos.Flow/Classes/Error/Debugger.php
@@ -582,15 +582,15 @@ function var_dump($variable, $title = null, $return = false, $plaintext = null)
     }
     Debugger::clearState();
 
-    if (!$plaintext && Debugger::$stylesheetEchoed === false) {
-        echo '<style type="text/css">' . file_get_contents('resource://Neos.Flow/Public/Error/Debugger.css') . '</style>';
-        Debugger::$stylesheetEchoed = true;
-    }
-
     if ($plaintext) {
         $output = $title . chr(10) . Debugger::renderDump($variable, 0, true, $ansiColors) . chr(10) . chr(10);
     } else {
-        $output = '
+        $output = '';
+        if (Debugger::$stylesheetEchoed === false) {
+            $output .= '<style type="text/css">' . file_get_contents('resource://Neos.Flow/Public/Error/Debugger.css') . '</style>';
+            Debugger::$stylesheetEchoed = true;
+        }
+        $output .= '
 			<div class="Flow-Error-Debugger-VarDump ' . ($return ? 'Flow-Error-Debugger-VarDump-Inline' : 'Flow-Error-Debugger-VarDump-Floating') . '">
 				<div class="Flow-Error-Debugger-VarDump-Top">
 					' . htmlspecialchars($title) . '


### PR DESCRIPTION
The styles for rendering the debug-output are now rendered with the
first output itself instead of being echoed.

The direct echo solution caused trouble whenever non html-data like
json was rendered because the styles were rendered outside the json-structure 
and thus caused invalid json.