### PR TITLE
Add setArguments function

### DIFF
--- a/Neos.Flow/Classes/Http/Uri.php
+++ b/Neos.Flow/Classes/Http/Uri.php
@@ -337,6 +337,19 @@ class Uri implements UriInterface
     {
         return $this->arguments;
     }
+    
+    /**
+     * Sets the URI's arguments. Updates (= overwrites) the query accordingly!
+     *
+     * @param array $arguments The query arguments.
+     * @return void
+     * @api
+     */
+    public function setArguments($arguments)
+    {
+        $this->arguments = $arguments;
+        $this->query = http_build_query($arguments);
+    }
 
     /**
      * Returns the fragment / anchor, if any


### PR DESCRIPTION
Right now, it's only possible to update the URI query with a string, through setQuery. This change does the respective changes to the query and arguments by setting the arguments instead.

<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->


**What I did**
Added a setter for the Uri arguments property

**How I did it**
In the same manner as the setQuery method

**How to verify it**
Use setArguments instead of setQuery, the result will be the same

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
