### PR TITLE
TASK: Allow to delete "used" resources from a storage

### DIFF
--- a/Neos.Flow/Classes/ResourceManagement/ResourceManager.php
+++ b/Neos.Flow/Classes/ResourceManagement/ResourceManager.php
@@ -317,7 +317,7 @@ class ResourceManager
 
         $collectionName = $resource->getCollectionName();
 
-        $result = $this->resourceRepository->findBySha1($resource->getSha1());
+        $result = $this->resourceRepository->findBySha1AndCollectionName($resource->getSha1(), $resource->getCollectionName());
         if (count($result) > 1) {
             $this->systemLogger->log(sprintf('Not removing storage data of resource %s (%s) because it is still in use by %s other PersistentResource object(s).', $resource->getFilename(), $resource->getSha1(), count($result) - 1), LOG_DEBUG);
         } else {

--- a/Neos.Flow/Classes/ResourceManagement/ResourceRepository.php
+++ b/Neos.Flow/Classes/ResourceManagement/ResourceRepository.php
@@ -180,7 +180,7 @@ class ResourceRepository extends Repository
     }
 
     /**
-     * Finds other resources which are referring to the same resource data and filename
+     * Finds other resources which are referring to the same resource data, filename and collection
      *
      * @param PersistentResource $resource The resource used for finding similar resources
      * @return QueryResultInterface The result, including the given resource
@@ -191,7 +191,8 @@ class ResourceRepository extends Repository
         $query->matching(
             $query->logicalAnd(
                 $query->equals('sha1', $resource->getSha1()),
-                $query->equals('filename', $resource->getFilename())
+                $query->equals('filename', $resource->getFilename()),
+                $query->equals('collectionName', $resource->getCollectionName())
             )
         );
         return $query->execute();
@@ -207,6 +208,32 @@ class ResourceRepository extends Repository
     {
         $query = $this->createQuery();
         $query->matching($query->equals('sha1', $sha1Hash));
+        $resources = $query->execute()->toArray();
+        foreach ($this->addedResources as $importedResource) {
+            if ($importedResource->getSha1() === $sha1Hash) {
+                $resources[] = $importedResource;
+            }
+        }
+
+        return $resources;
+    }
+
+    /**
+     * Find all resources with the same SHA1 hash and collection
+     *
+     * @param string $sha1Hash
+     * @param string $collectionName
+     * @return array
+     */
+    public function findBySha1AndCollectionName($sha1Hash, $collectionName)
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->logicalAnd(
+                $query->equals('sha1', $sha1Hash),
+                $query->equals('collectionName', $collectionName)
+            )
+        );
         $resources = $query->execute()->toArray();
         foreach ($this->addedResources as $importedResource) {
             if ($importedResource->getSha1() === $sha1Hash) {


### PR DESCRIPTION
This solves the following use-case…

Given these settings:

    resource:
      collections:
        readableFilenames:
          storage: 'readableFilenameResourcesStorage'
          target: 'readableFilenameResourcesTarget'
      storages:
        readableFilenameResourcesStorage:
          storage: 'Neos\Flow\ResourceManagement\Storage\WritableFileSystemStorage'
          storageOptions:
            path: '%FLOW_PATH_DATA%Persistent/ReadableResources/'
      targets:
        readableFilenameResourcesTarget:
          target: 'Acme\AcmeCom\FilenameFileSystemSymlinkTarget'
          targetOptions:
            path: '%FLOW_PATH_WEB%Files/'
            baseUri: 'Files/'

I want to "move" a resource from the `persistent` to the `readableFilenames` collection. To do this, I get an asset, fetch the resource and import it into the `readableFilenames` collection. After that the newly imported resource is published, assigned to the asset and then the old resource is deleted. Code would be something like this:

        $resource = $asset->getResource();

        $importedResource = $resourceCollection->importResource($resource->getStream());
        $importedResource->setFilename($resource->getFilename());
        $importedResource->setMediaType($resource->getMediaType());
        $resourceCollection->getTarget()->publishResource($resource, $resourceCollection);

        $asset->setResource($importedResource);
        $this->assetRepository->update($asset);

        $this->resourceManager->deleteResource($resource);

But this leads to log messages about the storage data not being deleted, because the resource is still being used. Which is not true, or at least not fully correct. The problem at this point: the same resource exists in two collections, but the check only looks at the SHA1 (and filename, partly).

So this change adjusts the checks involved to look at the collection a resource is in, too.