### PR TITLE
TASK: Remove dummy assertions from tests

### DIFF
--- a/Neos.Flow/Configuration/Settings.Reflection.yaml
+++ b/Neos.Flow/Configuration/Settings.Reflection.yaml
@@ -40,6 +40,7 @@ Neos:
         'AfterStep': TRUE
         'WithoutSecurityChecks': TRUE
         'covers': TRUE
+        'doesNotPerformAssertions': TRUE
 
       # If enabled, the Reflection Service notes all incorrect or inconsistent usage
       # of @param annotations in the default log.

--- a/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
@@ -329,6 +329,7 @@ class PersistenceTest extends FunctionalTestCase
 
     /**
      * @test
+     * @doesNotPerformAssertions
      */
     public function validationIsOnlyDoneForPropertiesWhichAreInTheDefaultOrPersistencePropertyGroup()
     {
@@ -342,9 +343,6 @@ class PersistenceTest extends FunctionalTestCase
         $testEntity->setDescription('');
         $this->testEntityRepository->update($testEntity);
         $this->persistenceManager->persistAll();
-
-        // dummy assertion to suppress PHPUnit warning
-        $this->assertTrue(true);
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
@@ -47,13 +47,11 @@ class ReflectionServiceTest extends FunctionalTestCase
      * Test for https://jira.neos.io/browse/FLOW-316
      *
      * @test
+     * @doesNotPerformAssertions
      */
     public function classSchemaCanBeBuiltForAggregateRootsWithPlainOldPhpBaseClasses()
     {
         $this->reflectionService->getClassSchema(Reflection\Fixtures\Model\EntityExtendingPlainObject::class);
-
-        // dummy assertion to suppress PHPUnit warning
-        $this->assertTrue(true);
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/Session/SessionManagementTest.php
+++ b/Neos.Flow/Tests/Functional/Session/SessionManagementTest.php
@@ -83,13 +83,12 @@ class SessionManagementTest extends FunctionalTestCase
      * See bug #43590
      *
      * @test
+     * @doesNotPerformAssertions
      */
     public function aSessionCanBeStartedInAFunctionalTest()
     {
         $session = $this->objectManager->get(Session\SessionInterface::class);
         $session->start();
-        // dummy assertion to avoid PHPUnit warning
-        $this->assertTrue(true);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Error/DebuggerTest.php
+++ b/Neos.Flow/Tests/Unit/Error/DebuggerTest.php
@@ -27,13 +27,12 @@ class DebuggerTest extends UnitTestCase
 
     /**
      * @test
+     * @doesNotPerformAssertions
      */
     public function renderingClosuresWorksWithoutThrowingException()
     {
         Debugger::renderDump(function () {
         }, 0);
-        // dummy assertion to avoid PHPUnit warning
-        $this->assertTrue(true);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Http/Component/ComponentChainTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Component/ComponentChainTest.php
@@ -36,15 +36,13 @@ class ComponentChainTest extends UnitTestCase
 
     /**
      * @test
+     * @doesNotPerformAssertions
      */
     public function handleReturnsIfNoComponentsAreConfigured()
     {
         $options = [];
         $this->componentChain = new Http\Component\ComponentChain($options);
         $this->componentChain->handle($this->mockComponentContext);
-
-        // dummy assertion to silence PHPUnit warning
-        $this->assertTrue(true);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Http/HeadersTest.php
+++ b/Neos.Flow/Tests/Unit/Http/HeadersTest.php
@@ -322,6 +322,7 @@ class HeadersTest extends UnitTestCase
 
     /**
      * @test
+     * @doesNotPerformAssertions
      *
      * Note: This is a fix for https://jira.neos.io/browse/FLOW-324 (see https://code.google.com/p/chromium/issues/detail?id=501095)
      */
@@ -329,9 +330,6 @@ class HeadersTest extends UnitTestCase
     {
         $headers = new Headers();
         $headers->set('HTTPS', 1);
-
-        // dummy assertion to suppress PHPUnit warning
-        $this->assertTrue(true);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Http/RequestTest.php
+++ b/Neos.Flow/Tests/Unit/Http/RequestTest.php
@@ -1031,6 +1031,7 @@ class RequestTest extends UnitTestCase
 
     /**
      * @test
+     * @doesNotPerformAssertions
      *
      * Note: This is a fix for https://jira.neos.io/browse/FLOW-324 (see https://code.google.com/p/chromium/issues/detail?id=501095)
      */
@@ -1040,8 +1041,5 @@ class RequestTest extends UnitTestCase
             'HTTP_HTTPS' => '1',
         ];
         new Request([], [], [], $server);
-
-        // dummy assertion to avoid PHPUnit warning
-        $this->assertTrue(true);
     }
 }

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/MvcPropertyMappingConfigurationServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/MvcPropertyMappingConfigurationServiceTest.php
@@ -157,6 +157,7 @@ class MvcPropertyMappingConfigurationServiceTest extends UnitTestCase
 
     /**
      * @test
+     * @doesNotPerformAssertions
      */
     public function initializePropertyMappingConfigurationDoesNothingIfTrustedPropertiesAreNotSet()
     {
@@ -166,9 +167,6 @@ class MvcPropertyMappingConfigurationServiceTest extends UnitTestCase
 
         $requestHashService = new Mvc\Controller\MvcPropertyMappingConfigurationService();
         $requestHashService->initializePropertyMappingConfigurationFromRequest($request, $arguments);
-
-        // dummy assertion to avoid PHPUnit warning
-        $this->assertTrue(true);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Property/PropertyMapperTest.php
+++ b/Neos.Flow/Tests/Unit/Property/PropertyMapperTest.php
@@ -434,6 +434,7 @@ class PropertyMapperTest extends UnitTestCase
 
     /**
      * @test
+     * @doesNotPerformAssertions
      */
     public function convertSkipsPropertiesIfConfiguredTo()
     {
@@ -452,13 +453,11 @@ class PropertyMapperTest extends UnitTestCase
         $propertyMapper->_set('typeConverters', $typeConverters);
 
         $propertyMapper->convert($source, 'stdClass', $configuration->allowProperties('firstProperty')->skipProperties('secondProperty'));
-
-        // dummy assertion to avoid PHPUnit warning
-        $this->assertTrue(true);
     }
 
     /**
      * @test
+     * @doesNotPerformAssertions
      */
     public function convertSkipsUnknownPropertiesIfConfiguredTo()
     {
@@ -477,9 +476,6 @@ class PropertyMapperTest extends UnitTestCase
         $propertyMapper->_set('typeConverters', $typeConverters);
 
         $propertyMapper->convert($source, 'stdClass', $configuration->allowProperties('firstProperty')->skipUnknownProperties());
-
-        // dummy assertion to avoid PHPUnit warning
-        $this->assertTrue(true);
     }
 
     /**
@@ -498,6 +494,7 @@ class PropertyMapperTest extends UnitTestCase
 
     /**
      * @test
+     * @doesNotPerformAssertions
      * @dataProvider convertCallsCanConvertFromWithTheFullNormalizedTargetTypeDataProvider
      */
     public function convertCallsCanConvertFromWithTheFullNormalizedTargetType($source, $fullTargetType)
@@ -515,8 +512,5 @@ class PropertyMapperTest extends UnitTestCase
 
         $mockConfiguration = $this->getMockBuilder(PropertyMappingConfiguration::class)->disableOriginalConstructor()->getMock();
         $propertyMapper->convert($source, $fullTargetType, $mockConfiguration);
-
-        // dummy assertion to avoid PHPUnit warning
-        $this->assertTrue(true);
     }
 }

--- a/Neos.Flow/Tests/Unit/Reflection/ClassSchemaTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/ClassSchemaTest.php
@@ -146,13 +146,12 @@ class ClassSchemaTest extends UnitTestCase
     /**
      * @dataProvider validPropertyTypes()
      * @test
+     * @doesNotPerformAssertions
      */
     public function addPropertyAcceptsValidPropertyTypes($propertyType)
     {
         $classSchema = new ClassSchema('SomeClass');
         $classSchema->addProperty('a', $propertyType);
-        // dummy assertion to avoid incomplete  test detection
-        $this->assertNull(null);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/ResourceManagement/Storage/WritableFileSystemStorageTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/Storage/WritableFileSystemStorageTest.php
@@ -51,6 +51,7 @@ class WritableFileSystemStorageTest extends UnitTestCase
 
     /**
      * @test
+     * @doesNotPerformAssertions
      */
     public function importTemporaryFileFixesPermissionsForTemporaryFile()
     {
@@ -58,9 +59,6 @@ class WritableFileSystemStorageTest extends UnitTestCase
             ->withContent('fixture')
             ->at($this->mockDirectory);
         $this->writableFileSystemStorage->_call('importTemporaryFile', $mockTempFile->url(), 'default');
-
-        // dummy assertion to suppress PHPUnit warning
-        $this->assertTrue(true);
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/AbstractFormFieldViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/AbstractFormFieldViewHelperTest.php
@@ -714,6 +714,7 @@ class AbstractFormFieldViewHelperTest extends FormFieldViewHelperBaseTestcase
 
     /**
      * @test
+     * @doesNotPerformAssertions
      */
     public function renderHiddenFieldForEmptyValueRemovesEmptySquareBracketsFromHiddenFieldName()
     {
@@ -728,13 +729,11 @@ class AbstractFormFieldViewHelperTest extends FormFieldViewHelperBaseTestcase
         );
 
         $formViewHelper->_call('renderHiddenFieldForEmptyValue');
-
-        // dummy assertion to avoid "risky test" warning
-        $this->assertTrue(true);
     }
 
     /**
      * @test
+     * @doesNotPerformAssertions
      */
     public function renderHiddenFieldForEmptyValueDoesNotRemoveNonEmptySquareBracketsFromHiddenFieldName()
     {
@@ -749,9 +748,6 @@ class AbstractFormFieldViewHelperTest extends FormFieldViewHelperBaseTestcase
         );
 
         $formViewHelper->_call('renderHiddenFieldForEmptyValue');
-
-        // dummy assertion to avoid "risky test" warning
-        $this->assertTrue(true);
     }
 
     /**


### PR DESCRIPTION
This replaces dummy assertions used to silence PHPUnit warnings with the
use of the `@doesNotPerformAssertions` annotation.