### PR TITLE
BUGFIX: Make $referenceCode nullable in ProductionExceptionHandler

### DIFF
--- a/Neos.Flow/Classes/Error/ProductionExceptionHandler.php
+++ b/Neos.Flow/Classes/Error/ProductionExceptionHandler.php
@@ -66,7 +66,7 @@ class ProductionExceptionHandler extends AbstractExceptionHandler
      * @param string $referenceCode
      * @return string
      */
-    protected function renderStatically(int $statusCode, string $referenceCode): string
+    protected function renderStatically(int $statusCode, ?string $referenceCode): string
     {
         $statusMessage = Response::getStatusMessageByCode($statusCode);
         $referenceCodeMessage = ($referenceCode !== null) ? '<p>When contacting the maintainer of this application please mention the following reference code:<br /><br />' . $referenceCode . '</p>' : '';


### PR DESCRIPTION
Just a few lines above the reference code may be set to null, and two lines
down the file a check against null is made. So, null is to be tolerated!