### PR TITLE
FEATURE: Extends Eel DateHelper with machine-readable formats

### DIFF
--- a/Neos.Eel/Classes/Helper/DateHelper.php
+++ b/Neos.Eel/Classes/Helper/DateHelper.php
@@ -250,6 +250,39 @@ class DateHelper implements ProtectedContextAwareInterface
     }
 
     /**
+     * Format a given datetime in a machine-readable way to use it in a <time> tag
+     *
+     * @param \DateTimeInterface $dateTime
+     * @return string
+     */
+    public function htmlDateTime(\DateTimeInterface $dateTime)
+    {
+        return $dateTime->format(\DateTime::W3C);
+    }
+
+    /**
+     * Format a given date in a machine-readable way to use it in a <time> tag
+     *
+     * @param \DateTimeInterface $dateTime
+     * @return string
+     */
+    public function htmlDate(\DateTimeInterface $date)
+    {
+        return $date->format('Y-m-d');
+    }
+
+    /**
+     * Format a given time in a machine-readable way to use it in a <time> tag
+     *
+     * @param \DateTimeInterface $dateTime
+     * @return string
+     */
+    public function htmlTime(\DateTimeInterface $time)
+    {
+        return $time->format('H:i:sP');
+    }
+
+    /**
      * All methods are considered safe
      *
      * @param string $methodName


### PR DESCRIPTION
Adds methods which format a DateTime into machine-readable formats to use it e.g. in the `datetime` attribute of a `<time>` tag.

* htmlDateTime formats a DateTime into the W3C format "Y-m-d\TH:i:sP"
* htmlDate formats the date part of a DateTime into "Y-m-D"
* htmlTime formats the time part of a DateTime into "H:i:sP"

