### PR TITLE
BUGFIX: Remove usage of removed f:base viewhelper from kickstarter

### DIFF
--- a/Neos.Kickstarter/Resources/Private/Generator/View/DefaultLayout.html
+++ b/Neos.Kickstarter/Resources/Private/Generator/View/DefaultLayout.html
@@ -2,8 +2,7 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <title><![CDATA[<f:render section="Title" /></title>
-        <f:base />]]>
+        <title><![CDATA[<f:render section="Title" /></title>]]>
     </head>
     <body>
         <![CDATA[<f:flashMessages class="flashmessages" />]]>


### PR DESCRIPTION
Removes the f:base viewhelper from kickstarted Layout template file since the viewhelper does no longer exist.