### PR TITLE
BUGFIX: Fix distinction between PSR and legacy loggers in the LoggerFactory

### DIFF
--- a/Neos.Flow/Classes/Log/LoggerFactory.php
+++ b/Neos.Flow/Classes/Log/LoggerFactory.php
@@ -86,9 +86,9 @@ class LoggerFactory
     {
         if (!isset($this->logInstanceCache[$identifier])) {
             if (is_a($loggerObjectName, DefaultLogger::class, true)) {
-                $logger = $this->createPsrBasedLogger($identifier, $loggerObjectName);
-            } else {
                 $logger = $this->instantiateLogger($loggerObjectName, $backendObjectNames, $backendOptions);
+            } else {
+                $logger = $this->createPsrBasedLogger($identifier, $loggerObjectName);
             }
 
             $this->logInstanceCache[$identifier] = $logger;

--- a/Neos.Flow/Classes/Log/LoggerFactory.php
+++ b/Neos.Flow/Classes/Log/LoggerFactory.php
@@ -85,7 +85,7 @@ class LoggerFactory
     public function create($identifier, $loggerObjectName, $backendObjectNames, array $backendOptions = [])
     {
         if (!isset($this->logInstanceCache[$identifier])) {
-            if (is_a($loggerObjectName, DefaultLogger::class)) {
+            if (is_a($loggerObjectName, DefaultLogger::class, true)) {
                 $logger = $this->createPsrBasedLogger($identifier, $loggerObjectName);
             } else {
                 $logger = $this->instantiateLogger($loggerObjectName, $backendObjectNames, $backendOptions);


### PR DESCRIPTION
As discussed[1] - set third parameter to "true" to do the correct comparison.
If this parameter is set to true, a class name string as "object" is allowed.

[1] https://neos-project.slack.com/archives/C04PYL8H3/p1526288487000147