### PR TITLE
BUGFIX: Allow to delete "used" resources from a storage

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Package.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Package.php
@@ -15,6 +15,7 @@ use TYPO3\Flow\Package\Package as BasePackage;
 use TYPO3\Flow\Package\PackageInterface;
 use TYPO3\Flow\Package\PackageManagerInterface;
 use TYPO3\Flow\Resource\ResourceManager;
+use TYPO3\Flow\Resource\ResourceRepository;
 use TYPO3\Fluid\Core\Parser\TemplateParser;
 
 /**
@@ -130,5 +131,8 @@ class Package extends BasePackage
                 $bootstrap->getObjectManager()->get(\TYPO3\Flow\Cache\CacheManager::class)->flushCaches();
             });
         });
+
+        $dispatcher->connect(Persistence\Doctrine\PersistenceManager::class, 'allObjectsPersisted', ResourceRepository::class, 'resetAfterPersistingChanges');
+        $dispatcher->connect(Persistence\Generic\PersistenceManager::class, 'allObjectsPersisted', ResourceRepository::class, 'resetAfterPersistingChanges');
     }
 }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/ResourceManager.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/ResourceManager.php
@@ -319,7 +319,7 @@ class ResourceManager
 
         $collectionName = $resource->getCollectionName();
 
-        $result = $this->resourceRepository->findBySha1($resource->getSha1());
+        $result = $this->resourceRepository->findBySha1AndCollectionName($resource->getSha1(), $collectionName);
         if (count($result) > 1) {
             $this->systemLogger->log(sprintf('Not removing storage data of resource %s (%s) because it is still in use by %s other Resource object(s).', $resource->getFilename(), $resource->getSha1(), count($result) - 1), LOG_DEBUG);
         } else {

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/ResourceRepository.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/ResourceRepository.php
@@ -192,7 +192,7 @@ class ResourceRepository extends Repository
     }
 
     /**
-     * Finds other resources which are referring to the same resource data and filename
+     * Finds other resources which are referring to the same resource data, filename and collection
      *
      * @param PersistentResource $resource The resource used for finding similar resources
      * @return QueryResultInterface The result, including the given resource
@@ -203,7 +203,8 @@ class ResourceRepository extends Repository
         $query->matching(
             $query->logicalAnd(
                 $query->equals('sha1', $resource->getSha1()),
-                $query->equals('filename', $resource->getFilename())
+                $query->equals('filename', $resource->getFilename()),
+                $query->equals('collectionName', $resource->getCollectionName())
             )
         );
         return $query->execute();
@@ -222,6 +223,32 @@ class ResourceRepository extends Repository
         $resources = $query->execute()->toArray();
         foreach ($this->addedResources as $importedResource) {
             if ($importedResource->getSha1() === $sha1Hash) {
+                $resources[] = $importedResource;
+            }
+        }
+
+        return $resources;
+    }
+
+    /**
+     * Find all resources with the same SHA1 hash and collection
+     *
+     * @param string $sha1Hash
+     * @param string $collectionName
+     * @return array
+     */
+    public function findBySha1AndCollectionName($sha1Hash, $collectionName)
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->logicalAnd(
+                $query->equals('sha1', $sha1Hash),
+                $query->equals('collectionName', $collectionName)
+            )
+        );
+        $resources = $query->execute()->toArray();
+        foreach ($this->addedResources as $importedResource) {
+            if ($importedResource->getSha1() === $sha1Hash && $importedResource->getCollectionName() === $collectionName) {
                 $resources[] = $importedResource;
             }
         }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Resource/ResourceRepository.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Resource/ResourceRepository.php
@@ -50,12 +50,12 @@ class ResourceRepository extends Repository
     protected $persistenceManager;
 
     /**
-     * @var \SplObjectStorage
+     * @var \SplObjectStorage|PersistentResource[]
      */
     protected $removedResources;
 
     /**
-     * @var \SplObjectStorage
+     * @var \SplObjectStorage|PersistentResource[]
      */
     protected $addedResources;
 
@@ -99,6 +99,17 @@ class ResourceRepository extends Repository
             $this->removedResources->attach($object);
             parent::remove($object);
         }
+    }
+
+    /**
+     * Reset internal state after changes have been persisted
+     *
+     * @return void
+     */
+    public function resetAfterPersistingChanges()
+    {
+        $this->removedResources = new \SplObjectStorage();
+        $this->addedResources = new \SplObjectStorage();
     }
 
     /**

--- a/TYPO3.Flow/Configuration/Testing/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Testing/Settings.yaml
@@ -66,7 +66,13 @@ TYPO3:
         defaultPersistentResourcesStorage:
           storage: 'TYPO3\Flow\Resource\Storage\WritableFileSystemStorage'
           storageOptions:
-            path: '%FLOW_PATH_DATA%Persistent/TestResources/'
+            path: '%FLOW_PATH_DATA%Persistent/Test/Resources/'
+
+        #
+        customPersistentResourcesStorage:
+          storage: 'TYPO3\Flow\Resource\Storage\WritableFileSystemStorage'
+          storageOptions:
+            path: '%FLOW_PATH_DATA%Persistent/Test/CustomResources/'
 
         #
         defaultStaticResourcesStorage:
@@ -89,6 +95,11 @@ TYPO3:
           storage: 'defaultPersistentResourcesStorage'
           target: 'localWebDirectoryPersistentResourcesTarget'
 
+        # Custom collection for persistent resources
+        custom:
+          storage: 'customPersistentResourcesStorage'
+          target: 'customWebDirectoryPersistentResourcesTarget'
+
       # Definition of the basic resource publication targets.
       targets:
         # Target for publishing static resources to the local web directory
@@ -104,6 +115,15 @@ TYPO3:
           targetOptions:
             path: '%FLOW_PATH_WEB%_Resources/Testing/Persistent/'
             baseUri: '_Resources/Testing/Persistent/'
+            # If the generated URI path segment containing the sha1 should be divided into multiple segments (recommended if you expect many resources):
+            subdivideHashPathSegment: false
+
+        # Custom target for publishing persistent resources to the local web directory
+        customWebDirectoryPersistentResourcesTarget:
+          target: 'TYPO3\Flow\Resource\Target\FileSystemSymlinkTarget'
+          targetOptions:
+            path: '%FLOW_PATH_WEB%_Resources/Testing/Custom/'
+            baseUri: '_Resources/Testing/Custom/'
             # If the generated URI path segment containing the sha1 should be divided into multiple segments (recommended if you expect many resources):
             subdivideHashPathSegment: false
 

--- a/TYPO3.Flow/Tests/Functional/Resource/ResourceManagerTest.php
+++ b/TYPO3.Flow/Tests/Functional/Resource/ResourceManagerTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace TYPO3\Flow\Tests\Functional\ResourceManagement;
+namespace TYPO3\Flow\Tests\Functional\Resource;
 
 /*
  * This file is part of the TYPO3.Flow package.

--- a/TYPO3.Flow/Tests/Functional/Resource/ResourceManagerTest.php
+++ b/TYPO3.Flow/Tests/Functional/Resource/ResourceManagerTest.php
@@ -1,0 +1,93 @@
+<?php
+namespace TYPO3\Flow\Tests\Functional\ResourceManagement;
+
+/*
+ * This file is part of the TYPO3.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Persistence\Doctrine\PersistenceManager;
+use TYPO3\Flow\Resource\ResourceManager;
+use TYPO3\Flow\Resource\ResourceRepository;
+use TYPO3\Flow\Tests\FunctionalTestCase;
+
+/**
+ * Functional tests for the ResourceManager
+ */
+class ResourceManagerTest extends FunctionalTestCase
+{
+    /**
+     * @var ResourceManager
+     */
+    protected $resourceManager;
+
+    /**
+     * @var ResourceRepository
+     */
+    protected $resourceRepository;
+
+    /**
+     * @var boolean
+     */
+    protected static $testablePersistenceEnabled = true;
+
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        if (!$this->persistenceManager instanceof PersistenceManager) {
+            $this->markTestSkipped('Doctrine persistence is not enabled');
+        }
+        $this->resourceManager = $this->objectManager->get(ResourceManager::class);
+        $this->resourceRepository = $this->objectManager->get(ResourceRepository::class);
+    }
+
+    /**
+     * @test
+     */
+    public function deleteResourceKeepsDataIfStillInUse()
+    {
+        $this->resourceManager->importResourceFromContent('fixture', 'fixture.txt');
+        $otherResource = $this->resourceManager->importResourceFromContent('fixture', 'other-fixture.txt');
+
+        $this->resourceManager->deleteResource($otherResource);
+
+        self::assertStringEqualsFile(FLOW_PATH_DATA . 'Persistent/Test/Resources/5/1/c/f/51cff3c1f0bc59f6187e7040cc12a4e9b1eca7aa', 'fixture');
+    }
+
+    /**
+     * @test
+     */
+    public function deleteResourceRemovesDataIfStillInUseButCollectionDiffersWithoutPersistAll()
+    {
+        $this->resourceManager->importResourceFromContent('fixture', 'fixture.txt');
+        $otherResource = $this->resourceManager->importResourceFromContent('fixture', 'fixture.txt', 'custom');
+
+        $this->resourceManager->deleteResource($otherResource);
+
+        self::assertStringEqualsFile(FLOW_PATH_DATA . 'Persistent/Test/Resources/5/1/c/f/51cff3c1f0bc59f6187e7040cc12a4e9b1eca7aa', 'fixture');
+        self::assertFileNotExists(FLOW_PATH_DATA . 'Persistent/Test/CustomResources/5/1/c/f/51cff3c1f0bc59f6187e7040cc12a4e9b1eca7aa');
+    }
+
+    /**
+     * @test
+     */
+    public function deleteResourceRemovesDataIfStillInUseButCollectionDiffersWithPersistAll()
+    {
+        $this->resourceManager->importResourceFromContent('fixture', 'fixture.txt');
+        $otherResource = $this->resourceManager->importResourceFromContent('fixture', 'fixture.txt', 'custom');
+
+        $this->persistenceManager->persistAll();
+        $this->resourceManager->deleteResource($otherResource);
+
+        self::assertStringEqualsFile(FLOW_PATH_DATA . 'Persistent/Test/Resources/5/1/c/f/51cff3c1f0bc59f6187e7040cc12a4e9b1eca7aa', 'fixture');
+        self::assertFileNotExists(FLOW_PATH_DATA . 'Persistent/Test/CustomResources/5/1/c/f/51cff3c1f0bc59f6187e7040cc12a4e9b1eca7aa');
+    }
+}

--- a/TYPO3.Flow/Tests/FunctionalTestCase.php
+++ b/TYPO3.Flow/Tests/FunctionalTestCase.php
@@ -435,13 +435,22 @@ abstract class FunctionalTestCase extends \TYPO3\Flow\Tests\BaseTestCase
      */
     protected function cleanupPersistentResourcesDirectory()
     {
-        $settings = self::$bootstrap->getObjectManager()->get(\TYPO3\Flow\Configuration\ConfigurationManager::class)->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS);
-        $resourcesStoragePath = $settings['TYPO3']['Flow']['resource']['storages']['defaultPersistentResourcesStorage']['storageOptions']['path'];
-        if (strpos($resourcesStoragePath, FLOW_PATH_DATA) === false) {
-            throw new \Exception(sprintf('The storage path for persistent resources for the Testing context is "%s" but it must point to a directory below "%s". Please check the Flow settings for the Testing context.', $resourcesStoragePath, FLOW_PATH_DATA), 1382018388);
-        }
-        if (file_exists($resourcesStoragePath)) {
-            Files::removeDirectoryRecursively($resourcesStoragePath);
+        $settings = self::$bootstrap->getObjectManager()->get(ConfigurationManager::class)->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS);
+        foreach ($settings['TYPO3']['Flow']['resource']['storages'] as $storageName => $storageSettings) {
+            if (!isset($storageSettings['storageOptions']['path'])) {
+                continue;
+            }
+
+            $resourcesStoragePath = $storageSettings['storageOptions']['path'];
+            if (strpos($resourcesStoragePath, FLOW_PATH_DATA) === false) {
+                throw new \Exception(sprintf('The storage path for persistent resources for the Testing context is "%s" for the "%s" storage, but it must point to a directory below "%s". Please check the Flow settings for the Testing context.', $resourcesStoragePath, $storageName, FLOW_PATH_DATA), 1382018388);
+            }
+            if (strpos($resourcesStoragePath, '/Test/') === false) {
+                throw new \Exception(sprintf('The storage path for persistent resources for the Testing context is "%s" for the "%s" storage, but it must contain "/Test/". Please check the Flow settings for the Testing context.', $resourcesStoragePath, $storageName), 1382018388);
+            }
+            if (file_exists($resourcesStoragePath)) {
+                Files::removeDirectoryRecursively($resourcesStoragePath);
+            }
         }
     }
 


### PR DESCRIPTION
This solves the following case…

Given these settings:

    resource:
      collections:
        readableFilenames:
          storage: 'readableFilenameResourcesStorage'
          target: 'readableFilenameResourcesTarget'
      storages:
        readableFilenameResourcesStorage:
          storage: 'TYPO3\Flow\Resource\Storage\WritableFileSystemStorage'
          storageOptions:
            path: '%FLOW_PATH_DATA%Persistent/ReadableResources/'
      targets:
        readableFilenameResourcesTarget:
          target: 'Acme\AcmeCom\FilenameFileSystemSymlinkTarget'
          targetOptions:
            path: '%FLOW_PATH_WEB%Files/'
            baseUri: 'Files/'

I want to "move" a resource from the `persistent` to the `readableFilenames` collection. To do this, I get an asset, fetch the resource and import it into the `readableFilenames` collection. After that the newly imported resource is published, assigned to the asset and then the old resource is deleted. Code would be something like this:

        $resource = $asset->getResource();

        $importedResource = $resourceCollection->importResource($resource->getStream());
        $importedResource->setFilename($resource->getFilename());
        $importedResource->setMediaType($resource->getMediaType());
        $resourceCollection->getTarget()->publishResource($resource, $resourceCollection);

        $asset->setResource($importedResource);
        $this->assetRepository->update($asset);

        $this->resourceManager->deleteResource($resource);

But this leads to log messages about the storage data not being deleted, because the resource is still being used. Which is not true, or at least not fully correct. The problem at this point: the same resource exists in two collections, but the check only looks at the SHA1 (and filename, partly).

So this change adjusts the checks involved to look at the collection a resource is in, too.