### PR TITLE
FEATURE: `MultiBackend` to ensure operation on cache failure

### DIFF
--- a/Neos.Cache/Classes/Backend/MultiBackend.php
+++ b/Neos.Cache/Classes/Backend/MultiBackend.php
@@ -1,0 +1,289 @@
+<?php
+namespace Neos\Cache\Backend;
+
+use Neos\Cache\BackendInstantiationTrait;
+use Neos\Cache\EnvironmentConfiguration;
+
+/**
+ * A multi backend, falling back to multiple backends if errors occur.
+ */
+class MultiBackend extends AbstractBackend implements BackendInterface
+{
+    use BackendInstantiationTrait;
+
+    /**
+     * Configuration for all sub backends (each with the keys "backend" and "backendOptions")
+     *
+     * @var array
+     */
+    protected $backendConfigurations = [];
+
+    /**
+     * @var BackendInterface[]
+     */
+    protected $backends = [];
+
+    /**
+     * @var bool
+     */
+    protected $setInAllBackends = true;
+
+    /**
+     * @var bool
+     */
+    protected $debug = false;
+
+    /**
+     * Are the backends initialized
+     *
+     * @var bool
+     */
+    protected $initialized = false;
+
+    /**
+     * Constructs this backend
+     *
+     * @param EnvironmentConfiguration $environmentConfiguration
+     * @param array $options Configuration options - depends on the actual backend
+     */
+    public function __construct(EnvironmentConfiguration $environmentConfiguration, array $options)
+    {
+        parent::__construct($environmentConfiguration, $options);
+    }
+
+    /**
+     * @return void
+     */
+    protected function prepareBackends()
+    {
+        if ($this->initialized === true) {
+            return;
+        }
+        foreach ($this->backendConfigurations as $backendConfiguration) {
+            $backendOptions = $backendConfiguration['backendOptions'] ?? [];
+             $backend = $this->buildSubBackend($backendConfiguration['backend'], $backendOptions);
+            if ($backend !== null) {
+                $this->backends[] = $backend;
+            }
+        }
+        $this->initialized = true;
+    }
+
+    /**
+     * @param string $backendClassName
+     * @param array $backendOptions
+     * @return BackendInterface
+     */
+    protected function buildSubBackend(string $backendClassName, array $backendOptions):? BackendInterface
+    {
+        $backend = null;
+        try {
+            $backend = $this->instantiateBackend($backendClassName, $backendOptions, $this->environmentConfiguration);
+            $backend->setCache($this->cache);
+        } catch (\Throwable $t) {
+            $this->handleError($t);
+            $backend = null;
+        }
+
+        return $backend;
+    }
+
+    /**
+     * @param string $entryIdentifier
+     * @param string $data
+     * @param array $tags
+     * @param int|null $lifetime
+     */
+    public function set(string $entryIdentifier, string $data, array $tags = [], int $lifetime = null)
+    {
+        $this->prepareBackends();
+        foreach ($this->backends as $backend) {
+            try {
+                $this->setInBackend($backend, $entryIdentifier, $data, $tags, $lifetime);
+            } catch (\Throwable $t) {
+                $this->handleError($t);
+                if (!$this->setInAllBackends) {
+                    return;
+                }
+            }
+        }
+
+    }
+
+    /**
+     * @param string $entryIdentifier
+     * @return bool|mixed
+     */
+    public function get(string $entryIdentifier)
+    {
+        $this->prepareBackends();
+        $result = false;
+        foreach ($this->backends as $backend) {
+            try {
+                $result = $this->getFromBackend($backend, $entryIdentifier);
+                return $result;
+            } catch (\Throwable $t) {
+                $this->handleError($t);
+                $result = false;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param string $entryIdentifier
+     * @return bool
+     */
+    public function has(string $entryIdentifier): bool
+    {
+        $this->prepareBackends();
+        $result = false;
+        foreach ($this->backends as $backend) {
+            try {
+                $result = $this->backendHas($backend, $entryIdentifier);
+                return $result;
+            } catch (\Throwable $t) {
+                $this->handleError($t);
+                $result = false;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param string $entryIdentifier
+     * @return bool
+     */
+    public function remove(string $entryIdentifier): bool
+    {
+        $this->prepareBackends();
+        $result = false;
+        foreach ($this->backends as $backend) {
+            try {
+                $result = $result || $this->removeFromBackend($backend, $entryIdentifier);
+            } catch (\Throwable $t) {
+                $this->handleError($t);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return void
+     */
+    public function flush()
+    {
+        $this->prepareBackends();
+        foreach ($this->backends as $backend) {
+            try {
+                $this->flushBackend($backend);
+            } catch (\Throwable $t) {
+                $this->handleError($t);
+            }
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function collectGarbage()
+    {
+        $this->prepareBackends();
+        foreach ($this->backends as $backend) {
+            try {
+                $backend->collectGarbage();
+            } catch (\Throwable $t) {
+                $this->handleError($t);
+            }
+        }
+    }
+
+    /**
+     * @param array $backendConfigurations
+     */
+    protected function setBackendConfigurations(array $backendConfigurations)
+    {
+        $this->backendConfigurations = $backendConfigurations;
+    }
+
+    /**
+     * @param bool $setInAllBackends
+     */
+    protected function setSetInAllBackends(bool $setInAllBackends)
+    {
+        $this->setInAllBackends = $setInAllBackends;
+    }
+
+    /**
+     * @param bool $debug
+     */
+    protected function setDebug(bool $debug)
+    {
+        $this->debug = $debug;
+    }
+
+    /**
+     * @param BackendInterface $backend
+     * @param string $entryIdentifier
+     * @param string $data
+     * @param array $tags
+     * @param int|null $lifetime
+     * @throws \Neos\Cache\Exception
+     */
+    protected function setInBackend(BackendInterface $backend, string $entryIdentifier, string $data, array $tags = [], int $lifetime = null)
+    {
+        $backend->set($entryIdentifier, $data, $tags, $lifetime);
+    }
+
+    /**
+     * @param BackendInterface $backend
+     * @param string $entryIdentifier
+     * @return mixed
+     */
+    protected function getFromBackend(BackendInterface $backend, string $entryIdentifier)
+    {
+        return $backend->get($entryIdentifier);
+    }
+
+    /**
+     * @param BackendInterface $backend
+     * @param string $entryIdentifier
+     * @return bool
+     */
+    protected function backendHas(BackendInterface $backend, string $entryIdentifier)
+    {
+        return $backend->has($entryIdentifier);
+    }
+
+    /**
+     * @param BackendInterface $backend
+     * @param string $entryIdentifier
+     * @return bool
+     */
+    protected function removeFromBackend(BackendInterface $backend, string $entryIdentifier)
+    {
+        return $backend->remove($entryIdentifier);
+    }
+
+    /**
+     * @param BackendInterface $backend
+     */
+    protected function flushBackend(BackendInterface $backend)
+    {
+        $backend->flush();
+    }
+
+    /**
+     * @param \Throwable $throwable
+     * @throws \Throwable
+     */
+    protected function handleError(\Throwable $throwable)
+    {
+        if ($this->debug) {
+            throw $throwable;
+        }
+    }
+}

--- a/Neos.Cache/Classes/Backend/TaggableMultiBackend.php
+++ b/Neos.Cache/Classes/Backend/TaggableMultiBackend.php
@@ -1,0 +1,75 @@
+<?php
+namespace Neos\Cache\Backend;
+
+/**
+ * A taggable multi backend, falling back to multiple backends if errors occur.
+ */
+class TaggableMultiBackend extends MultiBackend implements TaggableBackendInterface
+{
+    /**
+     * @var TaggableBackendInterface[]
+     */
+    protected $backends = [];
+
+    /**
+     * @param string $backendClassName
+     * @param array $backendOptions
+     * @return BackendInterface
+     */
+    protected function buildSubBackend(string $backendClassName, array $backendOptions):? BackendInterface
+    {
+        $backend = null;
+        if (!is_a($backendClassName, TaggableBackendInterface::class)) {
+            return $backend;
+        }
+
+        try {
+            $backend = $this->instantiateBackend($backendClassName, $backendOptions, $this->environmentConfiguration);
+            $backend->setCache($this->cache);
+        } catch (\Throwable $t) {
+            $this->handleError($t);
+            $backend = null;
+        }
+
+        return $backend;
+    }
+
+    /**
+     * @param string $tag
+     * @return int
+     */
+    public function flushByTag(string $tag): int
+    {
+        $count = 0;
+        /** @var TaggableBackendInterface $backend */
+        foreach ($this->backends as $backend) {
+            try {
+                $count = $count | $backend->flushByTag($tag);
+            } catch (\Throwable $t) {
+                $this->handleError($t);
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * @param string $tag
+     * @return array
+     */
+    public function findIdentifiersByTag(string $tag): array
+    {
+        $identifiers = [];
+        /** @var TaggableBackendInterface $backend */
+        foreach ($this->backends as $backend) {
+            try {
+                $localIdentifiers = $backend->findIdentifiersByTag($tag);
+                $identifiers = array_merge($identifiers, $localIdentifiers);
+            } catch (\Throwable $t) {
+            }
+        }
+
+        return array_values(array_unique($identifiers));
+    }
+
+}

--- a/Neos.Cache/Tests/Unit/Backend/MultiBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/MultiBackendTest.php
@@ -1,0 +1,115 @@
+<?php
+namespace Neos\Cache\Tests\Unit\Backend;
+
+include_once(__DIR__ . '/../../BaseTestCase.php');
+
+use Neos\Cache\Backend\MultiBackend;
+use Neos\Cache\Backend\NullBackend;
+use Neos\Cache\Backend\RedisBackend;
+use Neos\Cache\EnvironmentConfiguration;
+use Neos\Cache\Tests\BaseTestCase;
+
+/**
+ *
+ */
+class MultiBackendTest extends BaseTestCase
+{
+    /**
+     * @test
+     */
+    public function noExceptionIsThrownIfBackendFailsToBeCreated()
+    {
+        $backendOptions = [
+           'backendConfigurations' => [
+               [
+                   // Will fail as there shouldn't be a redis usually on that port
+                   'backend' => RedisBackend::class,
+                   'backendOptions' => [
+                        'port' => '60999'
+                    ]
+               ]
+           ]
+        ];
+
+        $multiBackend = new MultiBackend($this->getEnvironmentConfiguration(), $backendOptions);
+        // We need to trigger initialization.
+        $result = $multiBackend->get('foo');
+        self::assertFalse($result);
+    }
+
+    /**
+     * @test
+     * @expectedException Error
+     */
+    public function debugModeWillBubbleExceptions()
+    {
+        $backendOptions = [
+            'debug' => true,
+            'backendConfigurations' => [
+                [
+                    // Will fail as there shouldn't be a redis usually on that port
+                    'backend' => RedisBackend::class,
+                    'backendOptions' => [
+                        'port' => '60999'
+                    ]
+                ]
+            ]
+        ];
+
+        $multiBackend = new MultiBackend($this->getEnvironmentConfiguration(), $backendOptions);
+        // We need to trigger initialization.
+        $result = $multiBackend->get('foo');
+        self::assertFalse($result);
+    }
+
+    /**
+     * @test
+     */
+    public function writesToAllBackends()
+    {
+        $mockBuilder = $this->getMockBuilder(NullBackend::class);
+        $firstNullBackendMock = $mockBuilder->getMock();
+        $secondNullBackendMock = $mockBuilder->getMock();
+
+        $firstNullBackendMock->expects(self::once())->method('set')->withAnyParameters()->willReturn(null);
+        $secondNullBackendMock->expects(self::once())->method('set')->withAnyParameters()->willReturn(null);
+
+        $multiBackend = new MultiBackend($this->getEnvironmentConfiguration(), []);
+        $this->inject($multiBackend, 'backends', [$firstNullBackendMock, $secondNullBackendMock]);
+        $this->inject($multiBackend, 'initialized', true);
+
+        $multiBackend->set('foo', 1);
+    }
+
+    /**
+     * @test
+     */
+    public function fallsBackToSecondaryBackend()
+    {
+        $mockBuilder = $this->getMockBuilder(NullBackend::class);
+        $firstNullBackendMock = $mockBuilder->getMock();
+        $secondNullBackendMock = $mockBuilder->getMock();
+
+        $firstNullBackendMock->expects(self::once())->method('get')->with('foo')->willThrowException(new \Exception('Backend failure'));
+        $secondNullBackendMock->expects(self::once())->method('get')->with('foo')->willReturn(5);
+
+        $multiBackend = new MultiBackend($this->getEnvironmentConfiguration(), []);
+        $this->inject($multiBackend, 'backends', [$firstNullBackendMock, $secondNullBackendMock]);
+        $this->inject($multiBackend, 'initialized', true);
+
+        $result = $multiBackend->get('foo');
+        self::assertSame(5, $result);
+    }
+
+    /**
+     * @return EnvironmentConfiguration|\PHPUnit_Framework_MockObject_MockObject
+     */
+    public function getEnvironmentConfiguration()
+    {
+        return new EnvironmentConfiguration(
+            __DIR__ . '~Testing',
+            'vfs://Foo/',
+            255
+        );
+    }
+}

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
@@ -650,6 +650,61 @@ Options
 
 The null backend has no options.
 
+Neos\\Cache\\Backend\\MultiBackend
+----------------------------------
+
+This backend accepts several backend configurations
+to be used in order of appareance as a fallback mechanismn
+shoudln't one of them not be available.
+If `backendConfigurations` is an empty array this will act
+just like the NullBackend.
+
+.. warning::
+Due to the nature of this backend as fallback it will swallow all
+errors on creating and using the sub backends. So configuration
+errors won't show up. See `debug` option.
+
+Options
+~~~~~~~
+
+:title:`Multi cache backend options`
+
++-----------------------+------------------------------------------+-----------+---------+---------+
+| Option                | Description                              | Mandatory | Type    | Default |
++=======================+==========================================+===========+=========+=========+
+| setInAllBackends      | Should values given to the backend be    | No        | bool    | true    |
+|                       | replicated into all configured and       |           |         |         |
+|                       |  available backends?                     |           |         |         |
+|                       | Generally that is desireable for         |           |         |         |
+|                       | fallback purposes, but to avoid too much |           |         |         |
+|                       | duplication at the cost of performance on|           |         |         |
+|                       | fallbacks this can be disabled.          |           |         |         |
+|                       |                                          |           |         |         |
++-----------------------+------------------------------------------+-----------+---------+---------+
+| backendConfigurations | A list of backends to be used in order   | Yes       | array   | []      |
+|                       | of appearance. Each entry in that list   |           |         |         |
+|                       | should have the keys "backend" and       |           |         |         |
+|                       | "backendOptions" just as a top level     |           |         |         |
+|                       | backend configuration.                   |           |         |         |
+|                       |                                          |           |         |         |
++-----------------------+------------------------------------------+-----------+---------+---------+
+| debug                 | Switch on debug mode which will throw    | No        | bool    | false   |
+|                       | any errors happening in sub backends.    |           |         |         |
+|                       | Use this in development to make sure     |           |         |         |
+|                       | everything works as expected.            |           |         |         |
+|                       |                                          |           |         |         |
++-----------------------+------------------------------------------+-----------+---------+---------+
+
+
+Neos\\Cache\\Backend\\TaggableMultiBackend
+------------------------------------------
+
+Technically all the same as the MultiBackend above but implements the TaggableBackendInterface and
+so supports tagging.
+
+Options are the same as for the MultiBackend.
+
+
 How to Use the Caching Framework
 ================================
 


### PR DESCRIPTION
Introduces the `MultiBackend` and `TaggableMultiBackend` which
both can hold multiple backends to be used in order while catching
errors. This ensures operation of applications even if cache
backends are down or inaccessible. It will operate just like the
`NullBackend` in case no working backends are left.
