### PR TITLE
BUGFIX: Adjust has() to phpredis >= 4.0.0

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Cache/Backend/RedisBackend.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Cache/Backend/RedisBackend.php
@@ -147,7 +147,9 @@ class RedisBackend extends AbstractBackend implements TaggableBackendInterface, 
      */
     public function has($entryIdentifier)
     {
-        return $this->redis->exists($this->buildKey('entry:' . $entryIdentifier));
+        // exists returned TRUE or FALSE in phpredis versions < 4.0.0, now it returns the number of keys
+        $existsResult = $this->redis->exists($this->buildKey('entry:' . $entryIdentifier));
+        return $existsResult === true || $existsResult > 0;
     }
 
     /**


### PR DESCRIPTION
The `exists()` method returned TRUE or FALSE in phpredis versions < 4.0.0, now it
returns the number of keys tested that do exist.
