### PR TITLE
TASK: Add typehint to allosCallOfMethod

### DIFF
--- a/Neos.Eel/Classes/FlowQuery/FlowQuery.php
+++ b/Neos.Eel/Classes/FlowQuery/FlowQuery.php
@@ -282,7 +282,7 @@ class FlowQuery implements ProtectedContextAwareInterface, \IteratorAggregate, \
      * @param string $methodName
      * @return boolean
      */
-    public function allowsCallOfMethod($methodName)
+    public function allowsCallOfMethod(string $methodName) : bool
     {
         return $this->operationResolver->hasOperation($methodName);
     }

--- a/Neos.Eel/Classes/Helper/ArrayHelper.php
+++ b/Neos.Eel/Classes/Helper/ArrayHelper.php
@@ -353,7 +353,7 @@ class ArrayHelper implements ProtectedContextAwareInterface
      * @param string $methodName
      * @return boolean
      */
-    public function allowsCallOfMethod($methodName)
+    public function allowsCallOfMethod(string $methodName) : bool
     {
         return true;
     }

--- a/Neos.Eel/Classes/Helper/ConfigurationHelper.php
+++ b/Neos.Eel/Classes/Helper/ConfigurationHelper.php
@@ -49,7 +49,7 @@ class ConfigurationHelper implements ProtectedContextAwareInterface
      * @param string $methodName
      * @return boolean
      */
-    public function allowsCallOfMethod($methodName)
+    public function allowsCallOfMethod(string $methodName) : bool
     {
         return true;
     }

--- a/Neos.Eel/Classes/Helper/DateHelper.php
+++ b/Neos.Eel/Classes/Helper/DateHelper.php
@@ -196,7 +196,7 @@ class DateHelper implements ProtectedContextAwareInterface
      * @param string $methodName
      * @return boolean
      */
-    public function allowsCallOfMethod($methodName)
+    public function allowsCallOfMethod(string $methodName) : bool
     {
         return true;
     }

--- a/Neos.Eel/Classes/Helper/JsonHelper.php
+++ b/Neos.Eel/Classes/Helper/JsonHelper.php
@@ -50,7 +50,7 @@ class JsonHelper implements ProtectedContextAwareInterface
      * @param string $methodName
      * @return boolean
      */
-    public function allowsCallOfMethod($methodName)
+    public function allowsCallOfMethod(string $methodName) : bool
     {
         return true;
     }

--- a/Neos.Eel/Classes/Helper/MathHelper.php
+++ b/Neos.Eel/Classes/Helper/MathHelper.php
@@ -508,7 +508,7 @@ class MathHelper implements ProtectedContextAwareInterface
      * @param string $methodName
      * @return boolean
      */
-    public function allowsCallOfMethod($methodName)
+    public function allowsCallOfMethod(string $methodName) : bool
     {
         return true;
     }

--- a/Neos.Eel/Classes/Helper/SecurityHelper.php
+++ b/Neos.Eel/Classes/Helper/SecurityHelper.php
@@ -68,7 +68,7 @@ class SecurityHelper implements ProtectedContextAwareInterface
      * @param string $methodName
      * @return boolean
      */
-    public function allowsCallOfMethod($methodName)
+    public function allowsCallOfMethod(string $methodName) : bool
     {
         return true;
     }

--- a/Neos.Eel/Classes/Helper/StringHelper.php
+++ b/Neos.Eel/Classes/Helper/StringHelper.php
@@ -576,7 +576,7 @@ class StringHelper implements ProtectedContextAwareInterface
      * @param string $methodName
      * @return boolean
      */
-    public function allowsCallOfMethod($methodName)
+    public function allowsCallOfMethod(string $methodName) : bool
     {
         return true;
     }

--- a/Neos.Eel/Classes/Helper/TypeHelper.php
+++ b/Neos.Eel/Classes/Helper/TypeHelper.php
@@ -163,7 +163,7 @@ class TypeHelper implements ProtectedContextAwareInterface
      * @param string $methodName
      * @return boolean
      */
-    public function allowsCallOfMethod($methodName)
+    public function allowsCallOfMethod(string $methodName) : bool
     {
         return true;
     }

--- a/Neos.Eel/Classes/ProtectedContextAwareInterface.php
+++ b/Neos.Eel/Classes/ProtectedContextAwareInterface.php
@@ -22,5 +22,5 @@ interface ProtectedContextAwareInterface
      * @param string $methodName
      * @return boolean
      */
-    public function allowsCallOfMethod($methodName);
+    public function allowsCallOfMethod(string $methodName) : bool;
 }

--- a/Neos.Eel/Tests/Unit/Fixtures/TestObject.php
+++ b/Neos.Eel/Tests/Unit/Fixtures/TestObject.php
@@ -78,7 +78,7 @@ class TestObject implements ProtectedContextAwareInterface
      * @param string $methodName
      * @return boolean
      */
-    public function allowsCallOfMethod($methodName)
+    public function allowsCallOfMethod(string $methodName) : bool
     {
         return $methodName === $this->dynamicMethodName;
     }

--- a/Neos.Flow/Classes/I18n/EelHelper/TranslationHelper.php
+++ b/Neos.Flow/Classes/I18n/EelHelper/TranslationHelper.php
@@ -85,7 +85,7 @@ class TranslationHelper implements ProtectedContextAwareInterface
      * @param string $methodName
      * @return boolean
      */
-    public function allowsCallOfMethod($methodName)
+    public function allowsCallOfMethod(string $methodName) : bool
     {
         return true;
     }

--- a/Neos.Flow/Classes/I18n/EelHelper/TranslationParameterToken.php
+++ b/Neos.Flow/Classes/I18n/EelHelper/TranslationParameterToken.php
@@ -199,7 +199,7 @@ class TranslationParameterToken implements ProtectedContextAwareInterface
      * @param string $methodName
      * @return boolean
      */
-    public function allowsCallOfMethod($methodName)
+    public function allowsCallOfMethod(string $methodName) : bool
     {
         return true;
     }


### PR DESCRIPTION
Since 3.3 is supporting PHP 5.5 I make this PR against 4.0. (PHP 5.5. doesn't support TypeHints.