### PR TITLE
BUGFIX: Allow usage of multiple '%env:' replacements per Setting

### DIFF
--- a/Neos.Flow/Classes/Configuration/ConfigurationManager.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationManager.php
@@ -645,16 +645,16 @@ class ConfigurationManager
     protected function replaceVariablesInPhpString($phpString)
     {
         $phpString = preg_replace_callback('/
-            (?<startString>=>\s\'.*)?      # optionally assignment operator and starting a string
-            (?P<fullMatch>%                # an expression is indicated by %
+            (?<startString>=>\s\'.*?)?         # optionally assignment operator and starting a string
+            (?P<fullMatch>%                    # an expression is indicated by %
             (?P<expression>
-            (?:(?:\\\?[\d\w_\\\]+\:\:)     # either a class name followed by ::
-            |                              # or
-            (?:(?P<prefix>[a-z]+)\:)       # a prefix followed by : (like "env:")
+            (?:(?:\\\?[\d\w_\\\]+\:\:)         # either a class name followed by ::
+            |                                  # or
+            (?:(?P<prefix>[a-z]+)\:)           # a prefix followed by : (like "env:")
             )?
-            (?P<name>[A-Z_0-9]+))          # the actual variable name in all upper
-            %)                             # concluded by %
-            (?<endString>.*\',\n)?         # optionally concluding a string
+            (?P<name>[A-Z_0-9]+))              # the actual variable name in all upper
+            %)                                 # concluded by %
+            (?<endString>[^%]*?(?:\',\n)?)?    # optionally concluding a string
         /mx', function ($matchGroup) {
             $replacement = "";
             $constantDoesNotStartAsBeginning = false;

--- a/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -772,7 +772,8 @@ EOD;
 
         $settings = array(
             'foo' => 'bar',
-            'baz' => '%env:' . $envVarName . '%',
+            'bar' => '%env:' . $envVarName . '%',
+            'baz' => '%env:' . $envVarName . '% inspiring people %env:' . $envVarName . '% to share',
             'inspiring' => array(
                 'people' => array(
                     'to' => '%env:' . $envVarName . '%',
@@ -786,7 +787,8 @@ EOD;
         $processedPhpString = $configurationManager->_call('replaceVariablesInPhpString', $settingsPhpString);
         $settings = eval('return ' . $processedPhpString . ';');
 
-        $this->assertSame($envVarValue, $settings['baz']);
+        $this->assertSame($envVarValue, $settings['bar']);
+        $this->assertSame($envVarValue . ' inspiring people ' . $envVarValue . ' to share', $settings['baz']);
         $this->assertSame($envVarValue, $settings['inspiring']['people']['to']);
         $this->assertSame('foo ' . $envVarValue . ' bar', $settings['inspiring']['people']['share']);
 


### PR DESCRIPTION
**What I did**
Allowed usage of multiple '%env:NAME%' per Settings. In Flow versions below 4.0, this used to work fine. Since 4.0 the ConfigurationManager uses a different regular expression which
only matches the last environment variable used in a Setting.
**How I did it**
Modified the regex used to parse the Configuration of Environment Variables.
**How to verify it**
Run tests or add Setting that has two Environment Variables in it (`something: '%env:VAR1% something else %env:VAR2%'`).

**Checklist**

- [X] Code follows the PSR-2 coding style
- [X] Tests have been created, run and adjusted as needed
- [X] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
