### PR TITLE
BUGFIX: Do not remove leading slashes from base path

### DIFF
--- a/Neos.Utility.Files/Classes/TYPO3/Flow/Utility/Files.php
+++ b/Neos.Utility.Files/Classes/TYPO3/Flow/Utility/Files.php
@@ -180,7 +180,7 @@ abstract class Files
     public static function removeEmptyDirectoriesOnPath($path, $basePath = null)
     {
         if ($basePath !== null) {
-            $basePath = trim($basePath, '/');
+            $basePath = rtrim($basePath, '/');
             if (strpos($path, $basePath) !== 0) {
                 throw new Exception(sprintf('Could not remove empty directories on path because the given base path "%s" is not a parent path of "%s".', $basePath, $path), 1323962907);
             }


### PR DESCRIPTION
Passing a path with a leading slash as base path always fails on unix, as all absolute paths begin with a slash there. the tests do not cover this because they use vfs, whose paths start with `vfs://`.