### PR TITLE
[BUGFIX] Interface used is not imported

### DIFF
--- a/Neos.Kickstarter/Classes/Service/GeneratorService.php
+++ b/Neos.Kickstarter/Classes/Service/GeneratorService.php
@@ -12,10 +12,11 @@ namespace Neos\Kickstarter\Service;
  */
 
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\I18n\Xliff\XliffParser;
+use Neos\Flow\I18n\Xliff\V12\XliffParser;
 use Neos\FluidAdaptor\View\StandaloneView;
 use Neos\Flow\Core\ClassLoader;
 use Neos\Flow\Package\PackageInterface;
+use Neos\Flow\Package\FlowPackageInterface;
 use Neos\Utility\Files;
 
 /**


### PR DESCRIPTION
This fixes fatal error when running kickstart:model command

<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->


When running ./flow kickstart:model Test.Me Event "title:string" found fatal error 
Class 'Neos\Kickstarter\Service\FlowPackageInterface' not found

Imported missing interface to fix this

To verify run kickstart:model and it should work without errors!

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
