### PR TITLE
BUGFIX: Extend the expected exceptions for missing templates and sections

### DIFF
--- a/Neos.FluidAdaptor/Classes/View/Exception/InvalidSectionException.php
+++ b/Neos.FluidAdaptor/Classes/View/Exception/InvalidSectionException.php
@@ -11,13 +11,11 @@ namespace Neos\FluidAdaptor\View\Exception;
  * source code.
  */
 
-use Neos\FluidAdaptor\View;
-
 /**
  * An "Invalid Section" exception
  *
  * @api
  */
-class InvalidSectionException extends View\Exception
+class InvalidSectionException extends \TYPO3Fluid\Fluid\View\Exception\InvalidSectionException
 {
 }

--- a/Neos.FluidAdaptor/Classes/View/Exception/InvalidTemplateResourceException.php
+++ b/Neos.FluidAdaptor/Classes/View/Exception/InvalidTemplateResourceException.php
@@ -11,13 +11,11 @@ namespace Neos\FluidAdaptor\View\Exception;
  * source code.
  */
 
-use Neos\FluidAdaptor\View;
-
 /**
  * An "Invalid Template Resource" exception
  *
  * @api
  */
-class InvalidTemplateResourceException extends View\Exception
+class InvalidTemplateResourceException extends \TYPO3Fluid\Fluid\View\Exception\InvalidTemplateResourceException
 {
 }


### PR DESCRIPTION
typo3fluid/fluid expects specific exceptions to be thrown to implement
the feature of optional sections and partials. Neos.FluidAdaptor has to
throw these exceptions or derivates of them. Otherwise the exceptions won't
be catched and displayed to the user.

fixes: #1347

**What I did**

I implemented solution 1 from the issue

**How I did it**

I made the exceptions shipped with FluidAdaptor inherit from the expected ones from typo3fluid/fluid

**How to verify it**

Try to reproduce the issue after applying the patch

**Checklist**

- [X] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [X] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
