### PR TITLE
BUGFIX: Correctly build sub process command arguments

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -689,7 +689,7 @@ class Scripts
         $escapedArguments = '';
         foreach ($commandArguments as $argument => $argumentValue) {
             $argumentValue = trim($argumentValue);
-            $escapedArguments .= ' --' . trim($argument) . ($argumentValue !== '' ? '=' . escapeshellarg($argumentValue) : '');
+            $escapedArguments .= ' ' . escapeshellarg('--' . trim($argument)) . ($argumentValue !== '' ? '=' . escapeshellarg($argumentValue) : '');
         }
 
         $command .= sprintf(' %s %s %s', escapeshellarg(FLOW_PATH_FLOW . 'Scripts/flow.php'), escapeshellarg($commandIdentifier), trim($escapedArguments));

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -687,13 +687,9 @@ class Scripts
         }
 
         $escapedArguments = '';
-        if ($commandArguments !== []) {
-            foreach ($commandArguments as $argument => $argumentValue) {
-                $escapedArguments .= ' ' . escapeshellarg('--' . trim($argument));
-                if (trim($argumentValue) !== '') {
-                    $escapedArguments .= ' ' . escapeshellarg(trim($argumentValue));
-                }
-            }
+        foreach ($commandArguments as $argument => $argumentValue) {
+            $argumentValue = trim($argumentValue);
+            $escapedArguments .= ' --' . trim($argument) . ($argumentValue !== '' ? '=' . escapeshellarg($argumentValue) : '');
         }
 
         $command .= sprintf(' %s %s %s', escapeshellarg(FLOW_PATH_FLOW . 'Scripts/flow.php'), escapeshellarg($commandIdentifier), trim($escapedArguments));


### PR DESCRIPTION
While building sub commands via ``Scripts::buildSubprocessCommand``
the arguments are not build in a syntax that is sensible for parsing
by Flow later. Specifically an argument is build like this:

    '--argumentName' 'argumentValue'

The missing equals sign (=) makes this problematic to parse if the
value contains an equal sign itself as that will then be identified
as separator between argument name and value. With this change those
arguments are now build like this:

    '--argumentName'='argumentValue'
