### PR TITLE
BUGFIX: Allow nullable constructor arguments

### DIFF
--- a/Neos.Flow/Classes/Property/PropertyMapper.php
+++ b/Neos.Flow/Classes/Property/PropertyMapper.php
@@ -155,7 +155,8 @@ class PropertyMapper
     protected function doMapping($source, $targetType, PropertyMappingConfigurationInterface $configuration, &$currentPropertyPath)
     {
         $targetTypeWithoutNull = TypeHandling::stripNullableType($targetType);
-        if ($source === null && $targetType !== $targetTypeWithoutNull) {
+        $isNullableType = $targetType !== $targetTypeWithoutNull;
+        if ($source === null && $isNullableType) {
             return null;
         }
         $targetType = $targetTypeWithoutNull;

--- a/Neos.Flow/Classes/Property/PropertyMapper.php
+++ b/Neos.Flow/Classes/Property/PropertyMapper.php
@@ -154,6 +154,12 @@ class PropertyMapper
      */
     protected function doMapping($source, $targetType, PropertyMappingConfigurationInterface $configuration, &$currentPropertyPath)
     {
+        $targetTypeWithoutNull = TypeHandling::stripNullableType($targetType);
+        if ($source === null && $targetType !== $targetTypeWithoutNull) {
+            return null;
+        }
+        $targetType = $targetTypeWithoutNull;
+        
         if (is_object($source)) {
             $targetClass = TypeHandling::truncateElementType($targetType);
             if ($source instanceof $targetClass) {

--- a/Neos.Flow/Classes/Property/PropertyMapper.php
+++ b/Neos.Flow/Classes/Property/PropertyMapper.php
@@ -159,7 +159,7 @@ class PropertyMapper
             return null;
         }
         $targetType = $targetTypeWithoutNull;
-        
+
         if (is_object($source)) {
             $targetClass = TypeHandling::truncateElementType($targetType);
             if ($source instanceof $targetClass) {

--- a/Neos.Flow/Classes/Property/TypeConverter/ObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ObjectConverter.php
@@ -131,12 +131,7 @@ class ObjectConverter extends AbstractTypeConverter
 
         $methodParameters = $this->reflectionService->getMethodParameters($targetType, '__construct');
         if (isset($methodParameters[$propertyName]) && isset($methodParameters[$propertyName]['type'])) {
-            $typeWithoutNull = TypeHandling::stripNullableType($methodParameters[$propertyName]['type']);
-            if ($typeWithoutNull != $methodParameters[$propertyName]['type']) {
-                return $methodParameters[$propertyName]['class'] . '|null';
-            } else {
-                return $methodParameters[$propertyName]['type'];
-            }
+            return $methodParameters[$propertyName]['type'];
         } elseif ($this->reflectionService->hasMethod($targetType, ObjectAccess::buildSetterMethodName($propertyName))) {
             $methodParameters = $this->reflectionService->getMethodParameters($targetType, ObjectAccess::buildSetterMethodName($propertyName));
             $methodParameter = current($methodParameters);

--- a/Neos.Flow/Classes/Property/TypeConverter/ObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ObjectConverter.php
@@ -131,7 +131,12 @@ class ObjectConverter extends AbstractTypeConverter
 
         $methodParameters = $this->reflectionService->getMethodParameters($targetType, '__construct');
         if (isset($methodParameters[$propertyName]) && isset($methodParameters[$propertyName]['type'])) {
-            return $methodParameters[$propertyName]['type'];
+            $typeWithoutNull = TypeHandling::stripNullableType($methodParameters[$propertyName]['type']);
+            if ($typeWithoutNull != $methodParameters[$propertyName]['type']) {
+                return $methodParameters[$propertyName]['class'] . '|null';
+            } else {
+                return $methodParameters[$propertyName]['type'];
+            }
         } elseif ($this->reflectionService->hasMethod($targetType, ObjectAccess::buildSetterMethodName($propertyName))) {
             $methodParameters = $this->reflectionService->getMethodParameters($targetType, ObjectAccess::buildSetterMethodName($propertyName));
             $methodParameter = current($methodParameters);

--- a/Neos.Flow/Tests/Functional/Reflection/Fixtures/AnnotatedClass.php
+++ b/Neos.Flow/Tests/Functional/Reflection/Fixtures/AnnotatedClass.php
@@ -63,4 +63,32 @@ class AnnotatedClass
     public function intAndIntegerParameters($int, $integer)
     {
     }
+
+    /**
+     * @param AnnotatedClass $nullable
+     */
+    public function nativeNullableParameter($nullable = null)
+    {
+    }
+
+    /**
+     * @param AnnotatedClass|null $nullable
+     */
+    public function annotatedNullableParameter($nullable)
+    {
+    }
+
+    /**
+     * @param null|AnnotatedClass $nullable
+     */
+    public function reverseAnnotatedNullableParameter($nullable)
+    {
+    }
+
+    /**
+     * @param AnnotatedClass|null $nullable
+     */
+    public function annotatedAndNativeNullableParameter($nullable = null)
+    {
+    }
 }

--- a/Neos.Flow/Tests/Functional/Reflection/Fixtures/Model/EntityWithUseStatements.php
+++ b/Neos.Flow/Tests/Functional/Reflection/Fixtures/Model/EntityWithUseStatements.php
@@ -60,6 +60,14 @@ class EntityWithUseStatements
     }
 
     /**
+     * @param SubEntity|null $parameter
+     * @return void
+     */
+    public function nullableClassName(SubEntity $parameter)
+    {
+    }
+
+    /**
      * @param float $parameter
      * @return void
      */

--- a/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
@@ -190,6 +190,18 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function methodParameterTypeExpansionWorksWithNullable()
+    {
+        $methodParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\Model\EntityWithUseStatements::class, 'nullableClassName');
+
+        $expectedType = Reflection\Fixtures\Model\SubEntity::class . '|null';
+        $actualType = $methodParameters['parameter']['type'];
+        $this->assertSame($expectedType, $actualType);
+    }
+
+    /**
+     * @test
+     */
     public function methodParameterTypeExpansionDoesNotModifySimpleTypes()
     {
         $methodParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\Model\EntityWithUseStatements::class, 'simpleType');
@@ -241,5 +253,26 @@ class ReflectionServiceTest extends FunctionalTestCase
         foreach ($methodParameters as $methodParameter) {
             $this->assertEquals('integer', $methodParameter['type']);
         }
+    }
+
+    /**
+     * @test
+     */
+    public function nullableMethodParametersWorkCorrectly()
+    {
+        $nativeNullableMethodParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\AnnotatedClass::class, 'nativeNullableParameter');
+        $annotatedNullableMethodParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\AnnotatedClass::class, 'annotatedNullableParameter');
+        $reverseAnnotatedNullableMethodParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\AnnotatedClass::class, 'reverseAnnotatedNullableParameter');
+        $annotatedAndNativeNullableMethodParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\AnnotatedClass::class, 'annotatedAndNativeNullableParameter');
+
+        $this->assertTrue($nativeNullableMethodParameters['nullable']['allowsNull']);
+        $this->assertTrue($annotatedNullableMethodParameters['nullable']['allowsNull']);
+        $this->assertTrue($reverseAnnotatedNullableMethodParameters['nullable']['allowsNull']);
+        $this->assertTrue($annotatedAndNativeNullableMethodParameters['nullable']['allowsNull']);
+
+        $this->assertEquals(Reflection\Fixtures\AnnotatedClass::class, $nativeNullableMethodParameters['nullable']['type']);
+        $this->assertEquals(Reflection\Fixtures\AnnotatedClass::class . '|null', $annotatedNullableMethodParameters['nullable']['type']);
+        $this->assertEquals(Reflection\Fixtures\AnnotatedClass::class . '|null', $reverseAnnotatedNullableMethodParameters['nullable']['type']);
+        $this->assertEquals(Reflection\Fixtures\AnnotatedClass::class . '|null', $annotatedAndNativeNullableMethodParameters['nullable']['type']);
     }
 }

--- a/Neos.Flow/Tests/Unit/Property/PropertyMapperTest.php
+++ b/Neos.Flow/Tests/Unit/Property/PropertyMapperTest.php
@@ -556,4 +556,18 @@ class PropertyMapperTest extends UnitTestCase
         $mockConfiguration = $this->getMockBuilder(PropertyMappingConfiguration::class)->disableOriginalConstructor()->getMock();
         $propertyMapper->convert($source, $fullTargetType, $mockConfiguration);
     }
+
+    /**
+     * @test
+     */
+    public function convertCallsConvertToNullWithNullableTargetType()
+    {
+        $source = null;
+        $fullTargetType = 'SplObjectStorage|null';
+
+        $propertyMapper = $this->getAccessibleMock(PropertyMapper::class, ['dummy']);
+
+        $mockConfiguration = $this->getMockBuilder(PropertyMappingConfiguration::class)->disableOriginalConstructor()->getMock();
+        $this->assertEquals(null, $propertyMapper->convert($source, $fullTargetType, $mockConfiguration));
+    }
 }


### PR DESCRIPTION
In PropertyMapper checks if the $targetType is nullable and the given source, too. If this is true, return null. Also, in ReflectionService, the annotated type is properly expanded when annotated with '|null' or 'null|'.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)

Alternative push for #1353

Fixes #1361