### PR TITLE
TASK: Remove doesNotPerformAssertions from a test

### DIFF
--- a/Neos.Flow/Tests/Unit/Property/PropertyMapperTest.php
+++ b/Neos.Flow/Tests/Unit/Property/PropertyMapperTest.php
@@ -494,7 +494,6 @@ class PropertyMapperTest extends UnitTestCase
 
     /**
      * @test
-     * @doesNotPerformAssertions
      * @dataProvider convertCallsCanConvertFromWithTheFullNormalizedTargetTypeDataProvider
      */
     public function convertCallsCanConvertFromWithTheFullNormalizedTargetType($source, $fullTargetType)


### PR DESCRIPTION
… because the test does in fact assert something. So PhpUnit complained:

`This test is annotated with "@doesNotPerformAssertions" but performed 1 assertions`
