### PR TITLE
BUGFIX: Use same instance for injecting Doctrine ObjectManager and EntityManagerInterface

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
@@ -191,6 +191,11 @@ class ObjectManager implements ObjectManagerInterface
      */
     public function get($objectName)
     {
+        // XXX: This is a b/c fix for the deprecation of doctrine ObjectManager. Remove this with Flow 6.0
+        if ($objectName === \Doctrine\Common\Persistence\ObjectManager::class) {
+            $objectName = \Doctrine\ORM\EntityManagerInterface::class;
+        }
+
         if (func_num_args() > 1 && isset($this->objects[$objectName]) && $this->objects[$objectName]['s'] !== ObjectConfiguration::SCOPE_PROTOTYPE) {
             throw new \InvalidArgumentException('You cannot provide constructor arguments for singleton objects via get(). If you need to pass arguments to the constructor, define them in the Objects.yaml configuration.', 1298049934);
         }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassWithDoctrineInjections.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassWithDoctrineInjections.php
@@ -1,0 +1,34 @@
+<?php
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A class which has doctrine ObjectManager / EntityManagerInterface injections
+ */
+class ClassWithDoctrineInjections
+{
+    /**
+     * @Flow\Inject(lazy = FALSE)
+     * @var ObjectManager
+     */
+    public $objectManager;
+
+    /**
+     * @Flow\Inject(lazy = FALSE)
+     * @var EntityManagerInterface
+     */
+    public $entityManager;
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ObjectManagerTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ObjectManagerTest.php
@@ -68,4 +68,15 @@ class ObjectManagerTest extends FunctionalTestCase
 
         $this->assertTrue($entity->isDestructed());
     }
+
+    /**
+     * XXX: Remove this with Flow 6.0
+     * @test
+     */
+    public function deprecatedDoctrineObjectManagerInjectsSameInstanceAsEntityManagerInterface()
+    {
+        $classWithInjections = $this->objectManager->get(Fixtures\ClassWithDoctrineInjections::class);
+
+        $this->assertSame($classWithInjections->entityManager, $classWithInjections->objectManager);
+    }
 }


### PR DESCRIPTION
This fixes the b/c break introduced with the deprecation of the ObjectManager. The fix can be removed with Flow 6.0

Fixes #1345