### PR TITLE
!!!BUGFIX: Cyclic validator calls don't lose previous results

### DIFF
--- a/Neos.Flow/Classes/Validation/Validator/AbstractValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/AbstractValidator.php
@@ -51,9 +51,15 @@ abstract class AbstractValidator implements ValidatorInterface
     protected $options = [];
 
     /**
+     * @deprecated since Flow 5.1. Don't overwrite this and instead use pushResult/popResult
      * @var ErrorResult
      */
     protected $result;
+
+    /**
+     * @var array<ErrorResult>
+     */
+    protected $resultStack;
 
     /**
      * Constructs the validator and sets validation options
@@ -90,6 +96,34 @@ abstract class AbstractValidator implements ValidatorInterface
             ),
             $options
         );
+
+        $this->resultStack = [];
+    }
+
+    /**
+     * Push a new Result onto the Result stack and return it in order to fix cyclic calls to a single validator.
+     * @since Flow 5.1
+     * @see https://github.com/neos/flow-development-collection/pull/1275#issuecomment-414052031
+     * @return ErrorResult
+     */
+    protected function pushResult()
+    {
+        if ($this->result !== null) {
+            \array_push($this->resultStack, $this->result);
+        }
+        $this->result = new ErrorResult();
+        return $this->result;
+    }
+
+    /**
+     * Pop and return the current Result from the stack and make $this->result point to the last Result again.
+     * @return ErrorResult
+     */
+    protected function popResult()
+    {
+        $result = $this->result;
+        $this->result = array_pop($this->resultStack);
+        return $result;
     }
 
     /**
@@ -102,11 +136,11 @@ abstract class AbstractValidator implements ValidatorInterface
      */
     public function validate($value)
     {
-        $this->result = new ErrorResult();
+        $this->pushResult();
         if ($this->acceptsEmptyValues === false || $this->isEmpty($value) === false) {
             $this->isValid($value);
         }
-        return $this->result;
+        return $this->popResult();
     }
 
     /**

--- a/Neos.Flow/Classes/Validation/Validator/AbstractValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/AbstractValidator.php
@@ -51,7 +51,7 @@ abstract class AbstractValidator implements ValidatorInterface
     protected $options = [];
 
     /**
-     * @deprecated since Flow 5.1. Don't overwrite this and instead use pushResult/popResult
+     * @deprecated since Flow 4.3. Don't overwrite this and instead use pushResult/popResult
      * @var ErrorResult
      */
     protected $result;
@@ -102,14 +102,14 @@ abstract class AbstractValidator implements ValidatorInterface
 
     /**
      * Push a new Result onto the Result stack and return it in order to fix cyclic calls to a single validator.
-     * @since Flow 5.1
+     * @since Flow 4.3
      * @see https://github.com/neos/flow-development-collection/pull/1275#issuecomment-414052031
      * @return ErrorResult
      */
     protected function pushResult()
     {
         if ($this->result !== null) {
-            \array_push($this->resultStack, $this->result);
+            array_push($this->resultStack, $this->result);
         }
         $this->result = new ErrorResult();
         return $this->result;
@@ -117,6 +117,7 @@ abstract class AbstractValidator implements ValidatorInterface
 
     /**
      * Pop and return the current Result from the stack and make $this->result point to the last Result again.
+     * @since Flow 4.3
      * @return ErrorResult
      */
     protected function popResult()

--- a/Neos.Flow/Classes/Validation/Validator/AggregateBoundaryValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/AggregateBoundaryValidator.php
@@ -32,7 +32,6 @@ class AggregateBoundaryValidator extends GenericObjectValidator
      */
     public function validate($value)
     {
-        $this->result = new Result();
         /**
          * The idea is that Aggregates form a consistency boundary, and an Aggregate only needs to be
          * validated if it changed state. Also since all entity relations are lazy loaded by default,
@@ -42,7 +41,7 @@ class AggregateBoundaryValidator extends GenericObjectValidator
          * relations. Therefore proper Aggregate Design becomes a performance optimization.
          */
         if ($value instanceof \Doctrine\ORM\Proxy\Proxy && !$value->__isInitialized()) {
-            return $this->result;
+            return new Result();
         }
         return parent::validate($value);
     }

--- a/Neos.Flow/Classes/Validation/Validator/AggregateBoundaryValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/AggregateBoundaryValidator.php
@@ -27,10 +27,10 @@ class AggregateBoundaryValidator extends GenericObjectValidator
      * an uninitialized lazy loading proxy.
      *
      * @param mixed $value The value that should be validated
-     * @return \Neos\Error\Messages\Result
+     * @return void
      * @api
      */
-    public function validate($value)
+    public function isValid($value)
     {
         /**
          * The idea is that Aggregates form a consistency boundary, and an Aggregate only needs to be
@@ -41,8 +41,8 @@ class AggregateBoundaryValidator extends GenericObjectValidator
          * relations. Therefore proper Aggregate Design becomes a performance optimization.
          */
         if ($value instanceof \Doctrine\ORM\Proxy\Proxy && !$value->__isInitialized()) {
-            return new Result();
+            return;
         }
-        return parent::validate($value);
+        parent::isValid($value);
     }
 }

--- a/Neos.Flow/Classes/Validation/Validator/CollectionValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/CollectionValidator.php
@@ -39,33 +39,6 @@ class CollectionValidator extends GenericObjectValidator
     protected $validatorResolver;
 
     /**
-     * Checks if the given value is valid according to the validator, and returns
-     * the Error Messages object which occurred.
-     *
-     * @param mixed $value The value that should be validated
-     * @return ErrorResult
-     * @api
-     */
-    public function validate($value)
-    {
-        $this->pushResult();
-
-        if ($this->acceptsEmptyValues === false || $this->isEmpty($value) === false) {
-            if ($value instanceof \Doctrine\ORM\PersistentCollection && !$value->isInitialized()) {
-                return $this->popResult();
-            } elseif ((is_object($value) && !TypeHandling::isCollectionType(get_class($value))) && !is_array($value)) {
-                $this->addError('The given subject was not a collection.', 1317204797);
-                return $this->popResult();
-            } elseif (is_object($value) && $this->isValidatedAlready($value)) {
-                return $this->popResult();
-            } else {
-                $this->isValid($value);
-            }
-        }
-        return $this->popResult();
-    }
-
-    /**
      * Checks for a collection and if needed validates the items in the collection.
      * This is done with the specified element validator or a validator based on
      * the given element type and validation group.
@@ -78,6 +51,15 @@ class CollectionValidator extends GenericObjectValidator
      */
     protected function isValid($value)
     {
+        if ($value instanceof \Doctrine\ORM\PersistentCollection && !$value->isInitialized()) {
+            return;
+        } elseif ((is_object($value) && !TypeHandling::isCollectionType(get_class($value))) && !is_array($value)) {
+            $this->addError('The given subject was not a collection.', 1317204797);
+            return;
+        } elseif (is_object($value) && $this->isValidatedAlready($value)) {
+            return;
+        }
+
         foreach ($value as $index => $collectionElement) {
             if (isset($this->options['elementValidator'])) {
                 $collectionElementValidator = $this->validatorResolver->createValidator($this->options['elementValidator'], $this->options['elementValidatorOptions']);

--- a/Neos.Flow/Classes/Validation/Validator/CollectionValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/CollectionValidator.php
@@ -48,21 +48,21 @@ class CollectionValidator extends GenericObjectValidator
      */
     public function validate($value)
     {
-        $this->result = new ErrorResult();
+        $this->pushResult();
 
         if ($this->acceptsEmptyValues === false || $this->isEmpty($value) === false) {
             if ($value instanceof \Doctrine\ORM\PersistentCollection && !$value->isInitialized()) {
-                return $this->result;
+                return $this->popResult();
             } elseif ((is_object($value) && !TypeHandling::isCollectionType(get_class($value))) && !is_array($value)) {
                 $this->addError('The given subject was not a collection.', 1317204797);
-                return $this->result;
+                return $this->popResult();
             } elseif (is_object($value) && $this->isValidatedAlready($value)) {
-                return $this->result;
+                return $this->popResult();
             } else {
                 $this->isValid($value);
             }
         }
-        return $this->result;
+        return $this->popResult();
     }
 
     /**
@@ -93,6 +93,7 @@ class CollectionValidator extends GenericObjectValidator
             if ($collectionElementValidator instanceof ObjectValidatorInterface) {
                 $collectionElementValidator->setValidatedInstancesContainer($this->validatedInstancesContainer);
             }
+
             $this->result->forProperty($index)->merge($collectionElementValidator->validate($collectionElement));
         }
     }

--- a/Neos.Flow/Classes/Validation/Validator/GenericObjectValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/GenericObjectValidator.php
@@ -44,28 +44,6 @@ class GenericObjectValidator extends AbstractValidator implements ObjectValidato
     }
 
     /**
-     * Checks if the given value is valid according to the validator, and returns
-     * the Error Messages object which occurred.
-     *
-     * @param mixed $value The value that should be validated
-     * @return ErrorResult
-     * @api
-     */
-    public function validate($value)
-    {
-        $this->pushResult();
-        if ($this->acceptsEmptyValues === false || $this->isEmpty($value) === false) {
-            if (!is_object($value)) {
-                $this->addError('Object expected, %1$s given.', 1241099149, [gettype($value)]);
-            } elseif ($this->isValidatedAlready($value) === false) {
-                $this->isValid($value);
-            }
-        }
-
-        return $this->popResult();
-    }
-
-    /**
      * Checks if the given value is valid according to the property validators.
      *
      * @param mixed $object The value that should be validated
@@ -74,6 +52,12 @@ class GenericObjectValidator extends AbstractValidator implements ObjectValidato
      */
     protected function isValid($object)
     {
+        if (!is_object($object)) {
+            $this->addError('Object expected, %1$s given.', 1241099149, [gettype($value)]);
+            return;
+        } elseif ($this->isValidatedAlready($object) === true) {
+            return;
+        }
         foreach ($this->propertyValidators as $propertyName => $validators) {
             $propertyValue = $this->getPropertyValue($object, $propertyName);
             $result = $this->checkProperty($propertyValue, $validators);

--- a/Neos.Flow/Classes/Validation/Validator/GenericObjectValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/GenericObjectValidator.php
@@ -53,7 +53,7 @@ class GenericObjectValidator extends AbstractValidator implements ObjectValidato
     protected function isValid($object)
     {
         if (!is_object($object)) {
-            $this->addError('Object expected, %1$s given.', 1241099149, [gettype($value)]);
+            $this->addError('Object expected, %1$s given.', 1241099149, [gettype($object)]);
             return;
         } elseif ($this->isValidatedAlready($object) === true) {
             return;
@@ -100,11 +100,7 @@ class GenericObjectValidator extends AbstractValidator implements ObjectValidato
             $object->__load();
         }
 
-        if (ObjectAccess::isPropertyGettable($object, $propertyName)) {
-            return ObjectAccess::getProperty($object, $propertyName);
-        } else {
-            return ObjectAccess::getProperty($object, $propertyName, true);
-        }
+        return ObjectAccess::getProperty($object, $propertyName, !ObjectAccess::isPropertyGettable($object, $propertyName));
     }
 
     /**
@@ -160,8 +156,7 @@ class GenericObjectValidator extends AbstractValidator implements ObjectValidato
     {
         if ($propertyName !== null) {
             return $this->propertyValidators[$propertyName] ?? [];
-        } else {
-            return $this->propertyValidators;
         }
+        return $this->propertyValidators;
     }
 }

--- a/Neos.Flow/Classes/Validation/Validator/GenericObjectValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/GenericObjectValidator.php
@@ -53,7 +53,7 @@ class GenericObjectValidator extends AbstractValidator implements ObjectValidato
      */
     public function validate($value)
     {
-        $this->result = new ErrorResult();
+        $this->pushResult();
         if ($this->acceptsEmptyValues === false || $this->isEmpty($value) === false) {
             if (!is_object($value)) {
                 $this->addError('Object expected, %1$s given.', 1241099149, [gettype($value)]);
@@ -62,7 +62,7 @@ class GenericObjectValidator extends AbstractValidator implements ObjectValidato
             }
         }
 
-        return $this->result;
+        return $this->popResult();
     }
 
     /**
@@ -74,15 +74,13 @@ class GenericObjectValidator extends AbstractValidator implements ObjectValidato
      */
     protected function isValid($object)
     {
-        $messages = new ErrorResult();
         foreach ($this->propertyValidators as $propertyName => $validators) {
             $propertyValue = $this->getPropertyValue($object, $propertyName);
             $result = $this->checkProperty($propertyValue, $validators);
             if ($result !== null) {
-                $messages->forProperty($propertyName)->merge($result);
+                $this->result->forProperty($propertyName)->merge($result);
             }
         }
-        $this->result = $messages;
     }
 
     /**
@@ -177,7 +175,7 @@ class GenericObjectValidator extends AbstractValidator implements ObjectValidato
     public function getPropertyValidators($propertyName = null)
     {
         if ($propertyName !== null) {
-            return (isset($this->propertyValidators[$propertyName])) ? $this->propertyValidators[$propertyName] : [];
+            return $this->propertyValidators[$propertyName] ?? [];
         } else {
             return $this->propertyValidators;
         }

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Validation.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Validation.rst
@@ -332,7 +332,7 @@ against it. See ``AbstractCompositeValidator`` and ``isValidatedAlready`` in the
 for examples of how to do this.
 
 Writing Validators
-======================
+==================
 
 Usually, when writing your own validator, you will not directly implement ``ValidatorInterface``, but
 rather subclass ``AbstractValidator``. You only need to specify any options your validator might use and
@@ -372,6 +372,10 @@ implement the ``isValid()`` method then::
 
 In the above example, the ``isValid()`` method has been implemented, and the parameter ``$value`` is the
 data we want to check for validity. In case the data is valid, nothing needs to be done.
+
+.. warning:: You should avoid overwriting ``validate()`` and if you do, you should never overwrite ``$this->result``
+			 instance variable of the validator. Instead, use ``pushResult()`` to create a new result object and at
+			 the end of your validator, return ``popResult()``.
 
 In case the data is invalid, ``$this->addError()`` should be used to add an error message, an error code
 (which should be the unix timestamp of the current time) and optional arguments which are inserted into

--- a/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
@@ -287,6 +287,28 @@ class ActionControllerTest extends FunctionalTestCase
     }
 
     /**
+     * @test
+     */
+    public function cyclicCollectionsAreValidated()
+    {
+        $arguments = [
+            'argument' => [
+                'name' => 'Foo',
+                'collection' => [
+                    [
+                        'name' => 'Bar',
+                        'emailAddress' => '-invalid-'
+                    ]
+                ]
+            ]
+        ];
+        $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertestb/validatedcollectionobject', 'POST', $arguments);
+
+        $expectedResult = 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->validatedCollectionObjectAction().' . PHP_EOL;
+        $this->assertEquals($expectedResult, $response->getContent());
+    }
+
+    /**
      * Data provider for argumentTests()
      *
      * @TODO Using 'optional float - default value'    => array('optionalFloat', NULL, 12.34),

--- a/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/ActionControllerTestBController.php
+++ b/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/ActionControllerTestBController.php
@@ -23,7 +23,11 @@ class ActionControllerTestBController extends ActionController
 {
     public function initializeAction()
     {
-        $this->arguments['argument']->getPropertyMappingConfiguration()->allowAllProperties();
+        /* @var $propertyMappingConfiguration \Neos\Flow\Property\PropertyMappingConfiguration */
+        $propertyMappingConfiguration = $this->arguments['argument']->getPropertyMappingConfiguration();
+        $propertyMappingConfiguration->allowAllProperties();
+        $propertyMappingConfiguration->forProperty('collection')->allowAllProperties();
+        $propertyMappingConfiguration->forProperty('collection.*')->allowAllProperties();
     }
 
     /**
@@ -87,6 +91,16 @@ class ActionControllerTestBController extends ActionController
     public function validatedGroupObjectAction(TestObjectArgument $argument)
     {
         return $argument->getEmailAddress();
+    }
+
+    /**
+     * @param TestObjectArgument $argument
+     * @Flow\ValidationGroups({"validatedGroup"})
+     * @return string
+     */
+    public function validatedCollectionObjectAction(TestObjectArgument $argument)
+    {
+        return $argument->getCollection()->get(0)->getEmailAddress();
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/TestObjectArgument.php
+++ b/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/TestObjectArgument.php
@@ -11,6 +11,8 @@ namespace Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller;
  * source code.
  */
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Neos\Flow\Annotations as Flow;
 
 /**
@@ -31,6 +33,16 @@ class TestObjectArgument
     protected $emailAddress;
 
     /**
+     * @var Collection<TestObjectArgument>
+     */
+    protected $collection;
+
+    public function __construct()
+    {
+        $this->collection = new ArrayCollection();
+    }
+
+    /**
      * @return string
      */
     public function getName()
@@ -44,6 +56,22 @@ class TestObjectArgument
     public function setName($name)
     {
         $this->name = $name;
+    }
+
+    /**
+     * @param Collection<TestObjectArgument> $collection
+     */
+    public function setCollection(Collection $collection)
+    {
+        $this->collection = $collection;
+    }
+
+    /**
+     * @return Collection<TestObjectArgument>
+     */
+    public function getCollection()
+    {
+        return clone $this->collection;
     }
 
     /**


### PR DESCRIPTION
This changes uses a stack inside Validators to store results of previous
calls, so that results are not lost when a validator is called in a cycle.
This may happen for any Object or Collection validators, since the Validator
instances chain is built per class and hence cyclic relations (A -> * -> A)
may lead to incorrect validation results otherwise.

Note: This bugfix is only breaking if you implemented your own Validator, extending `GenericObjectValidator` or `CollectionValidator`, overriding the `validate()` method and setting `$this->result` inside. In that case you are required to change the code to make use of `pushResult()`/`popResult()` like it is done inside `AbstractValidator::validate()`.
This is an exception to the otherwise semantic versioning we strive for. It was decided because the breaking only happens in cases that would otherwise potentially be affected by the buggy behaviour of validation that could lead to invalid data entering the system.

In general, you are advised to create own Validators only by implementing the `isValid()` method instead of overriding the `validate()` method.