### PR TITLE
BUGFIX: Only add type hint if not already present

### DIFF
--- a/Neos.Flow/Migrations/Code/Version20180415105700.php
+++ b/Neos.Flow/Migrations/Code/Version20180415105700.php
@@ -29,6 +29,6 @@ class Version20180415105700 extends AbstractMigration
      */
     public function up()
     {
-        $this->searchAndReplaceRegex('~(CacheAwareInterface.*)(public function getCacheEntryIdentifier\\(\\))~s', '${1}public function getCacheEntryIdentifier(): string', ['php']);
+        $this->searchAndReplaceRegex('~(CacheAwareInterface.*public function getCacheEntryIdentifier\\(\\))([^{:]*{)~s', '${1}: string${2}', ['php']);
     }
 }


### PR DESCRIPTION
The code migration has to respect type hints already present. Otherwise there would be a illegal duplicate type hint.