### PR TITLE
TASK: Speed up lookups in IdentityRoutePart

### DIFF
--- a/Neos.Flow/Classes/Mvc/Routing/ObjectPathMapping.php
+++ b/Neos.Flow/Classes/Mvc/Routing/ObjectPathMapping.php
@@ -19,6 +19,11 @@ use Neos\Flow\Annotations as Flow;
  * This contains the URI representation of an object (pathSegment)
  *
  * @Flow\Entity
+ * @ORM\Table(
+ *  indexes={
+ *      @ORM\Index(columns={"identifier", "uripattern", "pathsegment"})
+ *  }
+ * )
  */
 class ObjectPathMapping
 {

--- a/Neos.Flow/Migrations/Mysql/Version20180827132710.php
+++ b/Neos.Flow/Migrations/Mysql/Version20180827132710.php
@@ -2,7 +2,7 @@
 namespace Neos\Flow\Persistence\Doctrine\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\Migrations\AbstractMigration;
+use Doctrine\DBAL\Migrations\AbstractMigration;
 
 /**
  * Add additional index for neos_flow_mvc_routing_objectpathmapping query speedup
@@ -21,7 +21,6 @@ class Version20180827132710 extends AbstractMigration
     /**
      * @param Schema $schema
      * @return void
-     * @throws \Doctrine\DBAL\DBALException
      * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
      */
     public function up(Schema $schema)
@@ -34,7 +33,6 @@ class Version20180827132710 extends AbstractMigration
     /**
      * @param Schema $schema
      * @return void
-     * @throws \Doctrine\DBAL\DBALException
      * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
      */
     public function down(Schema $schema)

--- a/Neos.Flow/Migrations/Mysql/Version20180827132710.php
+++ b/Neos.Flow/Migrations/Mysql/Version20180827132710.php
@@ -1,0 +1,46 @@
+<?php
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add additional index for neos_flow_mvc_routing_objectpathmapping query speedup
+ */
+class Version20180827132710 extends AbstractMigration
+{
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return 'Add additional index for neos_flow_mvc_routing_objectpathmapping query speedup';
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     * @throws \Doctrine\DBAL\DBALException
+     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+
+        $this->addSql('CREATE INDEX IDX_535A651E772E836ADCCB5599802C8F9D ON neos_flow_mvc_routing_objectpathmapping (identifier, uripattern, pathsegment)');
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     * @throws \Doctrine\DBAL\DBALException
+     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+
+        $this->addSql('DROP INDEX IDX_535A651E772E836ADCCB5599802C8F9D ON neos_flow_mvc_routing_objectpathmapping');
+     }
+}

--- a/Neos.Flow/Migrations/Postgresql/Version20180827132221.php
+++ b/Neos.Flow/Migrations/Postgresql/Version20180827132221.php
@@ -1,0 +1,46 @@
+<?php
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add additional index for neos_flow_mvc_routing_objectpathmapping query speedup
+ */
+class Version20180827132221 extends AbstractMigration
+{
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return 'Add additional index for neos_flow_mvc_routing_objectpathmapping query speedup';
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     * @throws \Doctrine\DBAL\DBALException
+     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on "postgresql".');
+
+        $this->addSql('CREATE INDEX IDX_535A651E772E836ADCCB5599802C8F9D ON neos_flow_mvc_routing_objectpathmapping (identifier, uripattern, pathsegment)');
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     * @throws \Doctrine\DBAL\DBALException
+     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on "postgresql".');
+
+        $this->addSql('DROP INDEX IDX_535A651E772E836ADCCB5599802C8F9D');
+    }
+}

--- a/Neos.Flow/Migrations/Postgresql/Version20180827132221.php
+++ b/Neos.Flow/Migrations/Postgresql/Version20180827132221.php
@@ -2,7 +2,7 @@
 namespace Neos\Flow\Persistence\Doctrine\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\Migrations\AbstractMigration;
+use Doctrine\DBAL\Migrations\AbstractMigration;
 
 /**
  * Add additional index for neos_flow_mvc_routing_objectpathmapping query speedup
@@ -21,7 +21,6 @@ class Version20180827132221 extends AbstractMigration
     /**
      * @param Schema $schema
      * @return void
-     * @throws \Doctrine\DBAL\DBALException
      * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
      */
     public function up(Schema $schema)
@@ -34,7 +33,6 @@ class Version20180827132221 extends AbstractMigration
     /**
      * @param Schema $schema
      * @return void
-     * @throws \Doctrine\DBAL\DBALException
      * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
      */
     public function down(Schema $schema)


### PR DESCRIPTION
This adds a second index to the database table in which the
ObjectPathMapping instances are stored. It speeds up find operations
for which the existing primary key does not help.

With enough data (250k entries for ObjectPathMapping) this speeds up
page delivery by about 60%.