### PR TITLE
BUGFIX: Skip names of "numeric" arguments

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -687,9 +687,13 @@ class Scripts
         }
 
         $escapedArguments = '';
-        foreach ($commandArguments as $argument => $argumentValue) {
+        foreach ($commandArguments as $argumentName => $argumentValue) {
             $argumentValue = trim($argumentValue);
-            $escapedArguments .= ' ' . escapeshellarg('--' . trim($argument)) . ($argumentValue !== '' ? '=' . escapeshellarg($argumentValue) : '');
+            if (is_numeric($argumentName)) {
+                $escapedArguments .= ' ' . escapeshellarg($argumentValue);
+            } else {
+                $escapedArguments .= ' ' . escapeshellarg('--' . trim($argumentName)) . ($argumentValue !== '' ? '=' . escapeshellarg($argumentValue) : '');
+            }
         }
 
         $command .= sprintf(' %s %s %s', escapeshellarg(FLOW_PATH_FLOW . 'Scripts/flow.php'), escapeshellarg($commandIdentifier), trim($escapedArguments));


### PR DESCRIPTION
When building the list of arguments for a sub-command, the following
does not work:

    $ '/Users/karsten/…/flow.php' 'flowpack.jobqueue.common:job:execute' \
    '--0=dummy' '--1=4959aa81b9aa43f79b7b8d81b2e6f388fa94db47'

and leads to

    Please specify the required argument "queue": ^C

This change skips the names, if they are numeric:

    $ '/Users/karsten/…/flow.php' 'flowpack.jobqueue.common:job:execute' \
    'dummy' '4959aa81b9aa43f79b7b8d81b2e6f388fa94db47'

Fixes #1382
