### PR TITLE
BUGFIX: correctly handle 410 redirect exceptions

### DIFF
--- a/Neos.Flow/Configuration/Settings.yaml
+++ b/Neos.Flow/Configuration/Settings.yaml
@@ -75,7 +75,7 @@ Neos:
         renderingGroups:
 
           notFoundExceptions:
-            matchingStatusCodes: [404]
+            matchingStatusCodes: [404, 410]
             options:
               logException: FALSE
               templatePathAndFilename: 'resource://Neos.Flow/Private/Templates/Error/Default.html'
@@ -271,7 +271,7 @@ Neos:
         # You can list any paths that you want to include in scanning for locales relative to the "Resources"
         # directory of each package. Setting a path to FALSE will skip scanning this folder.
         # Additionally, you can define patterns that you want to further skip inside the scanned paths.
-        #
+        #/
         # Example:
         #   includePaths:
         #     '/Public/': TRUE


### PR DESCRIPTION
The redirect package throws exceptions on 410, but currently they are not caught, the way 404 exceptions are handled.

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
