### PR TITLE
BUGFIX: Add nullable parameter detection

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethod.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethod.php
@@ -250,6 +250,7 @@ class ProxyMethod
     {
         $methodParametersCode = '';
         $methodParameterTypeName = '';
+        $nullableSign = '';
         $defaultValue = '';
         $byReferenceSign = '';
 
@@ -266,11 +267,16 @@ class ProxyMethod
                         $methodParameterTypeName = 'array';
                     } elseif ($methodParameterInfo['scalarDeclaration']) {
                         $methodParameterTypeName = $methodParameterInfo['type'];
+                    } elseif ($methodParameterInfo['class'] !== null) {
+                        $methodParameterTypeName = '\\' . $methodParameterInfo['class'];
                     } else {
-                        $methodParameterTypeName = ($methodParameterInfo['class'] === null) ? '' : '\\' . $methodParameterInfo['class'];
+                        $methodParameterTypeName = '';
+                    }
+                    if (\PHP_MAJOR_VERSION >= 7 && \PHP_MINOR_VERSION >= 1) {
+                        $nullableSign = $methodParameterInfo['allowsNull'] ? '?' : '';
                     }
                     if ($methodParameterInfo['optional'] === true) {
-                        $rawDefaultValue = (isset($methodParameterInfo['defaultValue']) ? $methodParameterInfo['defaultValue'] : null);
+                        $rawDefaultValue = $methodParameterInfo['defaultValue'] ?? null;
                         if ($rawDefaultValue === null) {
                             $defaultValue = ' = NULL';
                         } elseif (is_bool($rawDefaultValue)) {
@@ -286,7 +292,13 @@ class ProxyMethod
                     $byReferenceSign = ($methodParameterInfo['byReference'] ? '&' : '');
                 }
 
-                $methodParametersCode .= ($methodParametersCount > 0 ? ', ' : '') . ($methodParameterTypeName ? $methodParameterTypeName . ' ' : '') . $byReferenceSign . '$' . $methodParameterName . $defaultValue;
+                $methodParametersCode .= ($methodParametersCount > 0 ? ', ' : '')
+                    . ($methodParameterTypeName ? $nullableSign . $methodParameterTypeName . ' ' : '')
+                    . $byReferenceSign
+                    . '$'
+                    . $methodParameterName
+                    . $defaultValue
+                ;
                 $methodParametersCount++;
             }
         }

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyMethodTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyMethodTest.php
@@ -80,7 +80,7 @@ class ProxyMethodTest extends \Neos\Flow\Tests\UnitTestCase
                 'byReference' => false,
                 'array' => true,
                 'optional' => false,
-                'allowsNull' => true,
+                'allowsNull' => false,
                 'class' => null,
                 'scalarDeclaration' => false
             ],
@@ -89,7 +89,7 @@ class ProxyMethodTest extends \Neos\Flow\Tests\UnitTestCase
                 'byReference' => false,
                 'array' => false,
                 'optional' => false,
-                'allowsNull' => true,
+                'allowsNull' => false,
                 'class' => 'ArrayObject',
                 'scalarDeclaration' => false
             ],
@@ -118,7 +118,7 @@ class ProxyMethodTest extends \Neos\Flow\Tests\UnitTestCase
                 'byReference' => false,
                 'array' => true,
                 'optional' => true,
-                'allowsNull' => true,
+                'allowsNull' => false,
                 'class' => null,
                 'defaultValue' => [0 => true, 'foo' => 'bar', 1 => null, 3 => 1, 4 => 2.3],
                 'scalarDeclaration' => false


### PR DESCRIPTION
Nullable paramters (type prepended with `?`) were introduced with PHP 7.1
see https://secure.php.net/manual/en/migration71.new-features.php#migration71.new-features.nullable-types

We need to support a syntax like `functionName(?string $param)`. Without this fix, this function will get extended as `functionName(string $param)`, which is incompatible.

Starting with PHP 7.1 `functionName(string $param = null)` can also be written as `functionName(?string $param = null)` (but not as ~~`functionName(?string $param)`~~).

For the upmerge with Flow >= 5.0, the PHP version check in line 275 can be removed since at least PHP 7.1 is required there.