### PR TITLE
BUGFIX: Flow CLI command warns of mismatching php version

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -701,7 +701,6 @@ class Scripts
     /**
      * @param array $settings The Neos.Flow settings
      * @return string A command line command for PHP, which can be extended and then exec()uted
-     *
      * @throws Exception
      */
     public static function buildPhpCommand(array $settings)

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -792,19 +792,19 @@ class Scripts
             return;
         }
 
-        exec($phpCommand . ' -r "echo phpversion();"', $output, $result);
+        exec($phpCommand . ' -r "echo PHP_VERSION;"', $output, $result);
 
         if ($result !== 0) {
             return;
         }
-        $runningPHPVersion = phpversion();
+
         $configuredPHPVersion = $output[0];
-        if ($runningPHPVersion !== $configuredPHPVersion) {
+        if (array_slice(explode('.', $configuredPHPVersion), 0, 2) !== array_slice(explode('.', PHP_VERSION), 0, 2);) {
             throw new Exception(sprintf('You are executing Neos/Flow with a PHP version different from the one Flow is configured to use internally. ' .
                 'Flow is running with with PHP "%s", while the PHP version Flow is configured to use for subrequests is "%s". Make sure to configure Flow to ' .
                 'use the same PHP version by setting the "Neos.Flow.core.phpBinaryPathAndFilename" configuration option to a PHP-CLI binary of the version ' .
                 '%s. Flush the caches by removing the folder Data/Temporary before executing Flow/Neos again.',
-                $runningPHPVersion, $configuredPHPVersion, $runningPHPVersion), 1536563428);
+                PHP_VERSION, $configuredPHPVersion, PHP_VERSION), 1536563428);
         }
     }
 

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -799,7 +799,7 @@ class Scripts
         }
 
         $configuredPHPVersion = $output[0];
-        if (array_slice(explode('.', $configuredPHPVersion), 0, 2) !== array_slice(explode('.', PHP_VERSION), 0, 2);) {
+        if (array_slice(explode('.', $configuredPHPVersion), 0, 2) !== array_slice(explode('.', PHP_VERSION), 0, 2)) {
             throw new Exception(sprintf('You are executing Neos/Flow with a PHP version different from the one Flow is configured to use internally. ' .
                 'Flow is running with with PHP "%s", while the PHP version Flow is configured to use for subrequests is "%s". Make sure to configure Flow to ' .
                 'use the same PHP version by setting the "Neos.Flow.core.phpBinaryPathAndFilename" configuration option to a PHP-CLI binary of the version ' .

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -764,7 +764,7 @@ class Scripts
         $configuredPhpBinaryPathAndFilename = realpath($phpBinaryPathAndFilename);
 
         // if the configured PHP binary is empty here, the file does not exist. We ignore that here because it is checked later in the script.
-        if (strlen($configuredPhpBinaryPathAndFilename) === 0) {
+        if ($configuredPhpBinaryPathAndFilename === false || strlen($configuredPhpBinaryPathAndFilename) === 0) {
             return;
         }
 


### PR DESCRIPTION
If Flow builds a PHP command for a subrequest, it uses the system default if nothing else is configured. With this change, we avoid Flow executing that request if it isn't explicitly configured to use that same PHP version internally too. This should avoid some errors especially in shared hosting scenarios for less experienced users.