### PR TITLE
TASK: Require composer autoloader in entry scripts

### DIFF
--- a/Neos.Flow/Classes/Core/Bootstrap.php
+++ b/Neos.Flow/Classes/Core/Bootstrap.php
@@ -79,11 +79,12 @@ class Bootstrap
      * Constructor
      *
      * @param string $context The application context, for example "Production" or "Development"
+     * @param \Composer\Autoload\ClassLoader $composerAutoloader Composer autoloader
      */
-    public function __construct(string $context)
+    public function __construct(string $context, \Composer\Autoload\ClassLoader $composerAutoloader = null)
     {
-        // Load the composer autoloader first
-        $composerAutoloader = require(__DIR__ . '/../../../../Libraries/autoload.php');
+        // Load the composer autoloader first if not provided
+        $composerAutoloader = $composerAutoloader ?? require(__DIR__ . '/../../../../Libraries/autoload.php');
 
         $this->context = new ApplicationContext($context);
         $this->earlyInstances[__CLASS__] = $this;

--- a/Neos.Flow/Resources/Private/Installer/Distribution/Defaults/Web/index.php
+++ b/Neos.Flow/Resources/Private/Installer/Distribution/Defaults/Web/index.php
@@ -20,8 +20,8 @@ if ($rootPath === false) {
     $rootPath .= '/';
 }
 
-require($rootPath . 'Packages/Framework/Neos.Flow/Classes/Core/Bootstrap.php');
+$composerAutoloader = require($rootPath . 'Packages/Libraries/autoload.php');
 
 $context = \Neos\Flow\Core\Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT') ?: 'Development';
-$bootstrap = new \Neos\Flow\Core\Bootstrap($context);
+$bootstrap = new \Neos\Flow\Core\Bootstrap($context, $composerAutoloader);
 $bootstrap->run();

--- a/Neos.Flow/Scripts/flow.php
+++ b/Neos.Flow/Scripts/flow.php
@@ -39,7 +39,7 @@ if (isset($argv[1]) && ($argv[1] === 'neos.flow:core:setfilepermissions' || $arg
     array_shift($argv);
     require(__DIR__ . '/migrate.php');
 } else {
-    require(__DIR__ . '/../Classes/Core/Bootstrap.php');
+    $composerAutoloader = require(__DIR__ . '/../../../Libraries/autoload.php');
 
     if (DIRECTORY_SEPARATOR !== '/' && trim(getenv('FLOW_ROOTPATH'), '"\' ') === '') {
         $absoluteRootpath = dirname(realpath(__DIR__ . '/../../../'));
@@ -57,6 +57,6 @@ if (isset($argv[1]) && ($argv[1] === 'neos.flow:core:setfilepermissions' || $arg
 
     $context = trim(\Neos\Flow\Core\Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT'), '"\' ') ?: 'Development';
 
-    $bootstrap = new \Neos\Flow\Core\Bootstrap($context);
+    $bootstrap = new \Neos\Flow\Core\Bootstrap($context, $composerAutoloader);
     $bootstrap->run();
 }


### PR DESCRIPTION
Instead of requiring the bootstrap class file and
then requiring Composer autoloader in the Bootstrap constructor,
we can require the autoloader early in the two entry scripts.

This makes it possible to set FLOW_CONTEXT through .env files
e.g with packages like helhum/dotenv-connector