### PR TITLE
 BUGFIX: doctrine:migrationgenerate won't move file to selected package 

### DIFF
--- a/Neos.Flow/Classes/Cli/ConsoleOutput.php
+++ b/Neos.Flow/Classes/Cli/ConsoleOutput.php
@@ -154,13 +154,13 @@ class ConsoleOutput
      *
      * @param string|array $question The question to ask. If an array each array item is turned into one line of a multi-line question
      * @param array $choices List of choices to pick from
-     * @param boolean $default The default answer if the user enters nothing
+     * @param mixed|null $default The default answer if the user enters nothing
      * @param boolean $multiSelect If true the result will be an array with the selected options. Multiple options can be given separated by commas
-     * @param boolean|null $attempts Max number of times to ask before giving up (null by default, which means infinite)
+     * @param integer|null $attempts Max number of times to ask before giving up (null by default, which means infinite)
      * @return integer|string|array The selected value or values (the key of the choices array)
      * @throws \InvalidArgumentException
      */
-    public function select($question, array $choices, bool $default = null, bool $multiSelect = false, $attempts = null)
+    public function select($question, array $choices, $default = null, bool $multiSelect = false, int $attempts = null)
     {
         $question = new ChoiceQuestion($this->combineQuestion($question), $choices, $default);
         $question

--- a/Neos.Flow/Classes/Command/DoctrineCommandController.php
+++ b/Neos.Flow/Classes/Command/DoctrineCommandController.php
@@ -463,7 +463,7 @@ class DoctrineCommandController extends CommandController
         $this->outputLine();
         if ($migrationClassPathAndFilename) {
             $choices = ['Don\'t Move'];
-            $packages = [null];
+            $packages = [];
 
             /** @var Package $package */
             foreach ($this->packageManager->getAvailablePackages() as $package) {
@@ -472,14 +472,15 @@ class DoctrineCommandController extends CommandController
                     continue;
                 }
                 $choices[] = $package->getPackageKey();
-                $packages[] = $package;
+                $packages[$package->getPackageKey()] = $package;
             }
-            $selectedPackageIndex = (integer)$this->output->select('Do you want to move the migration to one of these packages?', $choices, 0);
+
+            $selectedPackage = $this->output->select('Do you want to move the migration to one of these packages?', $choices, $choices[0]);
             $this->outputLine();
 
-            if ($selectedPackageIndex !== 0) {
+            if ($selectedPackage !== $choices[0]) {
                 /** @var Package $selectedPackage */
-                $selectedPackage = $packages[$selectedPackageIndex];
+                $selectedPackage = $packages[$selectedPackage];
                 $targetPathAndFilename = Files::concatenatePaths([$selectedPackage->getPackagePath(), 'Migrations', $this->doctrineService->getDatabasePlatformName(), basename($migrationClassPathAndFilename)]);
                 Files::createDirectoryRecursively(dirname($targetPathAndFilename));
                 rename($migrationClassPathAndFilename, $targetPathAndFilename);

--- a/Neos.Flow/Tests/Unit/Cli/ConsoleOutputTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/ConsoleOutputTest.php
@@ -11,7 +11,6 @@ namespace Neos\Flow\Tests\Unit\Cli;
  * source code.
  */
 
-use Neos\Flow\Cli;
 use Neos\Flow\Cli\ConsoleOutput;
 use Neos\Flow\Tests\UnitTestCase;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -23,7 +22,7 @@ use Symfony\Component\Console\Output\StreamOutput;
 class ConsoleOutputTest extends UnitTestCase
 {
     /**
-     * @var Cli\ConsoleOutput
+     * @var ConsoleOutput
      */
     private $consoleOutput;
 
@@ -196,38 +195,63 @@ class ConsoleOutputTest extends UnitTestCase
     /**
      * @test
      */
-    public function selectAnChoosableeAnswer()
+    public function selectWithStringTypeChoiceKeys()
     {
-        $this->answerCustom('no');
+        $this->answerCustom('y');
         $choices = [
-            'yes' => 'No',
-            'no' => 'Yes'
+            'n' => 'No',
+            'y' => 'Yes'
         ];
-        $userAnswer = $this->consoleOutput->select('Is this a good test?', $choices, 'no', true);
+        $userAnswer = $this->consoleOutput->select('Is this a good test?', $choices, 'yes', true);
 
-        $this->assertSame(['no'], $userAnswer);
+        $this->assertEquals(
+            'Is this a good test?' . PHP_EOL .
+            '  [n] No' . PHP_EOL .
+            '  [y] Yes' . PHP_EOL .
+            ' > y',
+            $this->getActualConsoleOutput()
+        );
+
+        $this->assertSame(['y'], $userAnswer, 'The answer is the key, NOT the value from the choices');
     }
 
     /**
      * @test
      */
-    public function selectAnswerIsDisplayed()
+    public function selectWithIntegerTypeChoiceKeys()
     {
-        $userAnswer = 1;
-        $this->answerCustom($userAnswer);
+        $givenAnswer = 2;
+        $this->answerCustom($givenAnswer);
         $choices = [
             1 => 'No',
             2 => 'Yes'
         ];
-        $this->consoleOutput->select('Is this a good test?', $choices, 1, true);
+        $userAnswer = $this->consoleOutput->select('Is this a good test?', $choices, 1, true);
 
-        $this->assertSame(
+        $this->assertEquals(
             'Is this a good test?' . PHP_EOL .
             '  [1] No' . PHP_EOL .
             '  [2] Yes' . PHP_EOL .
-            ' > ' . $userAnswer,
+            ' > ' . $givenAnswer,
             $this->getActualConsoleOutput()
         );
+
+        $this->assertSame(['Yes'], $userAnswer, 'The answer is the value, NOT the key from the choices');
+    }
+
+    /**
+     * @test
+     */
+    public function selectTheDefaultWhenAnswerIsNothing()
+    {
+        $this->answerNothing();
+        $choices = [
+            'yes' => 'Yes',
+            'no' => 'No'
+        ];
+        $userAnswer = $this->consoleOutput->select('Is this a good test?', $choices, 'yes', true);
+
+        $this->assertSame(['yes'], $userAnswer, 'The default value is returned');
     }
 
     /**
@@ -276,7 +300,7 @@ class ConsoleOutputTest extends UnitTestCase
 
         // remove control characters for cursor manipulation
         if ($removeControlCharacters === true) {
-            $cursorCommandCharacters = ["\u{001b}[K", "\u{001b}[1P", "\u{001b}[1X", "\u{001b}[1@", "\u{001b}[1L",  "\u{001b}[1M"];
+            $cursorCommandCharacters = ["\u{001b}[K", "\u{001b}[1P", "\u{001b}[1X", "\u{001b}[1@", "\u{001b}[1L", "\u{001b}[1M", "\u{001b}7", "\u{001b}8"];
             $streamContent = str_replace($cursorCommandCharacters, '', $streamContent);
         }
 


### PR DESCRIPTION
Fixes an issue where running doctrine:migrationgenerate would never move the migration-file to the selected package. After doctrine:migrationgenerate has generated a migration, it asks whether the migration-file should be moved to a specific package. No matter what you choose, it would assume you chose "Don't Move".

Also fixes two related issues in the ConsoleOutput's select method:
- Wrong typehint on $default, breaking the default answer functionality
- Wrong phpdoc typehint on $attempts, as it is an integer, not a boolean.

I added a testcase and modified a couple of other testcases for the ConsoleOutput as well.