### PR TITLE
FEATURE: Support HTML5 dialog method

### DIFF
--- a/Neos.FluidAdaptor/Classes/ViewHelpers/FormViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/FormViewHelper.php
@@ -144,7 +144,7 @@ class FormViewHelper extends AbstractFormViewHelper
 
         if (strtolower($this->arguments['method']) === 'get') {
             $this->tag->addAttribute('method', 'get');
-        } else if($this->arguments['method']) === 'dialog') {
+        } elseif(strtolower($this->arguments['method']) === 'dialog') {
              $this->tag->addAttribute('method', 'dialog');
         } else {
             $this->tag->addAttribute('method', 'post');

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/FormViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/FormViewHelper.php
@@ -103,7 +103,7 @@ class FormViewHelper extends AbstractFormViewHelper
     public function initializeArguments()
     {
         $this->registerTagAttribute('enctype', 'string', 'MIME type with which the form is submitted');
-        $this->registerTagAttribute('method', 'string', 'Transfer type (GET or POST)');
+        $this->registerTagAttribute('method', 'string', 'Transfer type (GET or POST or dialog)');
         $this->registerTagAttribute('name', 'string', 'Name of form');
         $this->registerTagAttribute('onreset', 'string', 'JavaScript: On reset of the form');
         $this->registerTagAttribute('onsubmit', 'string', 'JavaScript: On submit of the form');
@@ -144,6 +144,8 @@ class FormViewHelper extends AbstractFormViewHelper
 
         if (strtolower($this->arguments['method']) === 'get') {
             $this->tag->addAttribute('method', 'get');
+        } else if($this->arguments['method']) === 'dialog'){
+             $this->tag->addAttribute('method', 'dialog');
         } else {
             $this->tag->addAttribute('method', 'post');
         }

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/FormViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/FormViewHelper.php
@@ -145,7 +145,7 @@ class FormViewHelper extends AbstractFormViewHelper
         if (strtolower($this->arguments['method']) === 'get') {
             $this->tag->addAttribute('method', 'get');
         } elseif (strtolower($this->arguments['method']) === 'dialog') {
-             $this->tag->addAttribute('method', 'dialog');
+            $this->tag->addAttribute('method', 'dialog');
         } else {
             $this->tag->addAttribute('method', 'post');
         }

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/FormViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/FormViewHelper.php
@@ -144,7 +144,7 @@ class FormViewHelper extends AbstractFormViewHelper
 
         if (strtolower($this->arguments['method']) === 'get') {
             $this->tag->addAttribute('method', 'get');
-        } elseif(strtolower($this->arguments['method']) === 'dialog') {
+        } elseif (strtolower($this->arguments['method']) === 'dialog') {
              $this->tag->addAttribute('method', 'dialog');
         } else {
             $this->tag->addAttribute('method', 'post');

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/FormViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/FormViewHelper.php
@@ -144,7 +144,7 @@ class FormViewHelper extends AbstractFormViewHelper
 
         if (strtolower($this->arguments['method']) === 'get') {
             $this->tag->addAttribute('method', 'get');
-        } else if($this->arguments['method']) === 'dialog'){
+        } else if($this->arguments['method']) === 'dialog') {
              $this->tag->addAttribute('method', 'dialog');
         } else {
             $this->tag->addAttribute('method', 'post');


### PR DESCRIPTION
Update to support 'dialog' method used in HTML5 <dialog> element
eg. `<form method="dialog" ...>`
See form submission point 20.
https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-2 

(note I am not sure if any change required  for` protected function renderCsrfTokenField()`

<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->


**What I did**

**How I did it**

**How to verify it**

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
