### PR TITLE
FEATURE: Introduce an utility to add log environment from method name

### DIFF
--- a/Neos.Flow.Log/Tests/Unit/Psr/LoggerTest.php
+++ b/Neos.Flow.Log/Tests/Unit/Psr/LoggerTest.php
@@ -1,6 +1,16 @@
 <?php
 namespace Neos\Flow\Log\Tests\Unit\Psr;
 
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
 use Neos\Flow\Log\Backend\BackendInterface;
 use Neos\Flow\Log\Psr\Logger;
 use Neos\Flow\Tests\UnitTestCase;

--- a/Neos.Flow/Classes/Log/Utility/LogEnvironment.php
+++ b/Neos.Flow/Classes/Log/Utility/LogEnvironment.php
@@ -12,11 +12,12 @@ namespace Neos\Flow\Log\Utility;
  */
 
 use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Package\PackageInterface;
 use Neos\Flow\Package\PackageKeyAwareInterface;
 use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Package\PackageManagerInterface;
-use Neos\Utility\Arrays;
+use Neos\Flow\Annotations as Flow;
 
 abstract class LogEnvironment
 {
@@ -53,7 +54,7 @@ abstract class LogEnvironment
      */
     protected static function getPackageKeyFromClassName(string $className): string
     {
-        $packageKeys = self::getPackageKeys();
+        $packageKeys = static::getPackageKeys();
         $classPathArray = explode('\\', $className);
 
         $determinedPackageKey = array_shift($classPathArray);
@@ -74,10 +75,15 @@ abstract class LogEnvironment
 
     /**
      * @return array
+     * @Flow\CompileStatic
      */
     protected static function getPackageKeys(): array
     {
         if (self::$packageKeys === null) {
+            if (!Bootstrap::$staticObjectManager instanceof ObjectManagerInterface) {
+                return [];
+            }
+
             /** @var PackageManagerInterface $packageManager */
             $packageManager = Bootstrap::$staticObjectManager->get(PackageManager::class);
 

--- a/Neos.Flow/Classes/Log/Utility/LogEnvironment.php
+++ b/Neos.Flow/Classes/Log/Utility/LogEnvironment.php
@@ -1,0 +1,94 @@
+<?php
+namespace Neos\Flow\Log\Utility;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\Package\PackageInterface;
+use Neos\Flow\Package\PackageKeyAwareInterface;
+use Neos\Flow\Package\PackageManager;
+use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Utility\Arrays;
+
+abstract class LogEnvironment
+{
+
+    /**
+     * @var array
+     */
+    protected static $packageKeys = null;
+
+    /**
+     * Returns an array containing the log environment variables
+     * under the key FLOW_LOG_ENVIRONMENT to be set as part of the additional data
+     * in an log method call.
+     *
+     * @param string $methodName
+     * @return array
+     */
+    public static function fromMethodName(string $methodName): array
+    {
+        list($className, $functionName) = explode('::', $methodName);
+
+        return [
+            'FLOW_LOG_ENVIRONMENT' => [
+                'packageKey' => self::getPackageKeyFromClassName($className),
+                'className' => $className,
+                'methodName' => $functionName
+            ]
+        ];
+    }
+
+    /**
+     * @param string $className
+     * @return string
+     */
+    protected static function getPackageKeyFromClassName(string $className): string
+    {
+        $packageKeys = self::getPackageKeys();
+        $classPathArray = explode('\\', $className);
+
+        $determinedPackageKey = array_shift($classPathArray);
+        $packageKeyCandidate = $determinedPackageKey;
+
+        foreach ($classPathArray as $classPathSegment) {
+            $packageKeyCandidate = $packageKeyCandidate . '.' . $classPathSegment;
+
+            if (!isset($packageKeys[$packageKeyCandidate])) {
+                continue;
+            }
+
+            $determinedPackageKey = $packageKeyCandidate;
+        }
+
+        return $determinedPackageKey;
+    }
+
+    /**
+     * @return array
+     */
+    protected static function getPackageKeys(): array
+    {
+        if (self::$packageKeys === null) {
+            /** @var PackageManagerInterface $packageManager */
+            $packageManager = Bootstrap::$staticObjectManager->get(PackageManager::class);
+
+            /** @var PackageInterface $package */
+            foreach ($packageManager->getAvailablePackages() as $package) {
+                if ($package instanceof PackageKeyAwareInterface) {
+                    self::$packageKeys[$package->getPackageKey()] = true;
+                }
+            }
+        }
+
+        return self::$packageKeys;
+    }
+}

--- a/Neos.Flow/Classes/Monitor/FileMonitor.php
+++ b/Neos.Flow/Classes/Monitor/FileMonitor.php
@@ -15,6 +15,7 @@ use Neos\Flow\Cache\CacheManager;
 use Neos\Cache\Frontend\StringFrontend;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Log\PsrLoggerFactoryInterface;
+use Neos\Flow\Log\Utility\LogEnvironment;
 use Neos\Flow\Monitor\ChangeDetectionStrategy\ChangeDetectionStrategyInterface;
 use Neos\Flow\Monitor\ChangeDetectionStrategy\StrategyWithMarkDeletedInterface;
 use Neos\Flow\SignalSlot\Dispatcher;
@@ -275,7 +276,7 @@ class FileMonitor
             $this->emitDirectoriesHaveChanged($this->identifier, $this->changedPaths);
         }
         if ($changedFileCount > 0 || $changedPathCount) {
-            $this->logger->info(sprintf('File Monitor "%s" detected %s changed files and %s changed directories.', $this->identifier, $changedFileCount, $changedPathCount));
+            $this->logger->info(sprintf('File Monitor "%s" detected %s changed files and %s changed directories.', $this->identifier, $changedFileCount, $changedPathCount), LogEnvironment::fromMethodName(__METHOD__));
         }
     }
 

--- a/Neos.Flow/Tests/Functional/Log/Utility/LogEnvironmentTest.php
+++ b/Neos.Flow/Tests/Functional/Log/Utility/LogEnvironmentTest.php
@@ -1,0 +1,63 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Log\Utility;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Log\Utility\LogEnvironment;
+use Neos\Flow\Tests\FunctionalTestCase;
+
+class LogEnvironmentTest extends FunctionalTestCase
+{
+
+    /**
+     * @return array
+     */
+    public function fromMethodNameDataProvider(): array
+    {
+        return [
+            'packageKeyCanBeDetermined' => [
+                'method' => __METHOD__,
+                'expected' => [
+                    'FLOW_LOG_ENVIRONMENT' => [
+                        'packageKey' => 'Neos.Flow',
+                        'className' => 'Neos\Flow\Tests\Functional\Log\Utility\LogEnvironmentTest',
+                        'methodName' => 'fromMethodNameDataProvider'
+                    ]
+                ]
+            ],
+            'unknownPackageKeyReturnsFirstPart' => [
+                'method' => 'Some\Unknown\CLass\Path::methodName',
+                'expected' => [
+                    'FLOW_LOG_ENVIRONMENT' => [
+                        'packageKey' => 'Some',
+                        'className' => 'Some\Unknown\CLass\Path',
+                        'methodName' => 'methodName'
+                    ]
+                ]
+            ]
+        ];
+    }
+
+
+    /**
+     * @test
+     *
+     * @param $method
+     * @param $expected
+     *
+     * @dataProvider fromMethodNameDataProvider
+     */
+    public function fromMethodName($method, $expected)
+    {
+        $actual = LogEnvironment::fromMethodName($method);
+        $this->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
This utility can be used to easily add the log environment to log
messages using the PSR compatible logger.

Example:

```
$logger->debug('Running sub process loop.', LogEnvironment::fromMethodName(__METHOD__));
```