### PR TITLE
TASK: Add support for DateTimeImmutable classes mapping with doctrine

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -732,6 +732,9 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
                         case 'DateTime':
                             $mapping['type'] = 'datetime';
                             break;
+                        case 'DateTimeImmutable':
+                            $mapping['type'] = 'datetime_immutable';
+                            break;
                         case 'string':
                         case 'integer':
                         case 'boolean':

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/ExtendedTypesEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/ExtendedTypesEntity.php
@@ -72,6 +72,12 @@ class ExtendedTypesEntity
     protected $time;
 
     /**
+     * @var \DateTimeImmutable
+     * @ORM\Column(nullable=true)
+     */
+    protected $dateTimeImmutable;
+
+    /**
      * @param \DateTime $time
      * @return $this
      */
@@ -141,6 +147,24 @@ class ExtendedTypesEntity
     public function getDateTime()
     {
         return $this->dateTime;
+    }
+
+    /**
+     * @param \DateTimeImmutable $dateTime
+     * @return $this
+     */
+    public function setDateTimeImmutable(\DateTimeImmutable $dateTime = null)
+    {
+        $this->dateTimeImmutable = $dateTime;
+        return $this;
+    }
+
+    /**
+     * @return \DateTimeImmutable
+     */
+    public function getDateTimeImmutable()
+    {
+        return $this->dateTimeImmutable;
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
@@ -538,6 +538,26 @@ class PersistenceTest extends FunctionalTestCase
 
     /**
      * @test
+     */
+    public function immutableDateTimeIsPersistedAndIsReconstituted()
+    {
+        $dateTimeTz = new \DateTimeImmutable('2008-11-16 19:03:30', new \DateTimeZone(ini_get('date.timezone')));
+        $extendedTypesEntity = new Fixtures\ExtendedTypesEntity();
+        $extendedTypesEntity->setDateTimeImmutable($dateTimeTz);
+        $this->persistenceManager->add($extendedTypesEntity);
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        /**  @var Fixtures\ExtendedTypesEntity $persistedExtendedTypesEntity */
+        $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
+        $this->assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        $this->assertInstanceOf('DateTimeImmutable', $persistedExtendedTypesEntity->getDateTimeImmutable());
+        $this->assertEquals($dateTimeTz->getTimestamp(), $persistedExtendedTypesEntity->getDateTimeImmutable()->getTimestamp());
+        $this->assertEquals(ini_get('date.timezone'), $persistedExtendedTypesEntity->getDateTimeImmutable()->getTimezone()->getName());
+    }
+
+    /**
+     * @test
      * @todo We need different tests at least for two types of database.
      * * 1. mysql without timezone support.
      * * 2. a db with timezone support.


### PR DESCRIPTION
This change correctly maps `DateTimeImmutable` property types with doctrine.

Depends on #1442