### PR TITLE
TASK: Make ContentStream easier to use

### DIFF
--- a/Neos.Flow/Classes/Http/ContentStream.php
+++ b/Neos.Flow/Classes/Http/ContentStream.php
@@ -39,13 +39,27 @@ class ContentStream implements StreamInterface
     protected $logger;
 
     /**
-     * @param string|resource $stream
+     * @param string|resource $stream a valid PHP resource or a filename supported by fopen (see http://php.net/manual/en/function.fopen.php)
      * @param string $mode Mode with which to open stream
      * @throws \InvalidArgumentException
      */
     public function __construct($stream, $mode = 'r')
     {
         $this->replace($stream, $mode);
+    }
+
+    /**
+     * Creates an instance representing the given $contents string
+     *
+     * @param string $contents
+     * @return self
+     */
+    public static function fromContents(string $contents): self
+    {
+        $handle = fopen('php://memory', 'r+');
+        fwrite($handle, $contents);
+        rewind($handle);
+        return new static($handle);
     }
 
     /**
@@ -88,7 +102,7 @@ class ContentStream implements StreamInterface
     {
         $this->close();
         if (!is_resource($stream)) {
-            $stream = $this->openStream($stream, $mode);
+            $stream = @fopen($stream, $mode);
         }
 
         if (!$this->isValidResource($stream)) {
@@ -335,19 +349,6 @@ class ContentStream implements StreamInterface
         }
 
         return $metadata[$key];
-    }
-
-    /**
-     * Set the internal stream resource.
-     *
-     * @param string $stream String stream target or stream resource.
-     * @param string $mode Resource mode for stream target.
-     * @return resource
-     */
-    protected function openStream($stream, $mode = 'r')
-    {
-        $resource = fopen($stream, $mode);
-        return $resource;
     }
 
     /**

--- a/Neos.Flow/Classes/Http/Helper/ArgumentsHelper.php
+++ b/Neos.Flow/Classes/Http/Helper/ArgumentsHelper.php
@@ -43,12 +43,10 @@ abstract class ArgumentsHelper
     /**
      * @param string $content
      * @return ContentStream
+     * @deprecated since Flow 5.2, use ContentStream::fromContents()
      */
     public static function createContentStreamFromString(string $content): ContentStream
     {
-        $handle = fopen('php://memory', 'r+');
-        fwrite($handle, $content);
-        rewind($handle);
-        return new ContentStream($handle);
+        return ContentStream::fromContents($content);
     }
 }

--- a/Neos.Flow/Tests/Unit/Http/ContentStreamTest.php
+++ b/Neos.Flow/Tests/Unit/Http/ContentStreamTest.php
@@ -1,0 +1,39 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Http;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Http\ContentStream;
+use Neos\Flow\Tests\UnitTestCase;
+
+/**
+ * Test case for the Http ContentStream class
+ */
+class ContentStreamTest extends UnitTestCase
+{
+
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function constructorThrowsExceptionWhenBeingPassedAnInvalidResource()
+    {
+        new ContentStream('invalid resource');
+    }
+
+    public function fromContentsCreatesValidContentStream()
+    {
+        $someContent = 'Lorem ipsum
+        dolor';
+        $contentStream = ContentStream::fromContents($someContent);
+        $this->assertSame($someContent, $contentStream->getContents());
+    }
+}


### PR DESCRIPTION
This adds a new named constructor `fromContents()` to the `ContentStream` class making
it easier to instantiate it from a given string.