### PR TITLE
TASK: Deprecate LoggerFactory and ThrowableLoggerInterface

### DIFF
--- a/Neos.Flow/Classes/Log/LoggerFactory.php
+++ b/Neos.Flow/Classes/Log/LoggerFactory.php
@@ -23,6 +23,7 @@ use Neos\Flow\ObjectManagement\ObjectManagerInterface;
  *
  * @api
  * @Flow\Scope("singleton")
+ * @deprecated Instead a \Neos\Flow\Log\PsrLoggerFactoryInterface should be used.
  */
 class LoggerFactory
 {

--- a/Neos.Flow/Classes/Log/ThrowableLoggerInterface.php
+++ b/Neos.Flow/Classes/Log/ThrowableLoggerInterface.php
@@ -24,6 +24,7 @@ namespace Neos\Flow\Log;
  *   LOG_INFO    # Informational: informational messages
  *   LOG_DEBUG   # Debug: debug-level messages
  *
+ * @deprecated Use a \Neos\Flow\Log\ThrowableStorageInterface instead.
  */
 interface ThrowableLoggerInterface extends LoggerInterface
 {


### PR DESCRIPTION
Both are just consequences of already existing deprecations and were
overseen when the rest was deprecated. They should be removed with the
rest of the legacy logging in the next major.
