### PR TITLE
BUGFIX: Do not join select property paths to embedded objects

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/Query.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Query.php
@@ -644,7 +644,9 @@ class Query implements QueryInterface
     {
         $aliases = $this->queryBuilder->getRootAliases();
         $previousJoinAlias = $aliases[0];
-        if (strpos($propertyPath, '.') === false) {
+        if (strpos($propertyPath, '.') === false
+            || $this->entityManager->getClassMetadata($this->entityClassName)->hasField($propertyPath)
+        ) {
             return $previousJoinAlias . '.' . $propertyPath;
         }
 

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/QueryTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/QueryTest.php
@@ -314,7 +314,7 @@ class QueryTest extends FunctionalTestCase
         $this->persistenceManager->persistAll();
 
         $query = new Query(Fixtures\TestEntity::class);
-        $entities = $query->matching($query->equals('embeddedValueObject.value', 'vo'))->setLimit(1)->execute()->toArray();
+        $entities = $query->matching($query->equals('embeddedValueObject.value', 'vo'))->execute()->toArray();
 
         $this->assertEquals(2, count($entities));
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/QueryTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/QueryTest.php
@@ -291,6 +291,37 @@ class QueryTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function embeddedValueObjectQueryingWorks()
+    {
+        $testEntityRepository = new Fixtures\TestEntityRepository();
+        $testEntityRepository->removeAll();
+
+        $testEntity = new Fixtures\TestEntity();
+        $testEntity->setName('Flow1');
+
+        $valueObject1 = new Fixtures\TestEmbeddedValueObject('vo');
+        $testEntity->setEmbeddedValueObject($valueObject1);
+        $testEntityRepository->add($testEntity);
+
+        $testEntity2 = new Fixtures\TestEntity();
+        $testEntity2->setName('Flow2');
+
+        $valueObject2 = new Fixtures\TestEmbeddedValueObject('vo');
+        $testEntity2->setEmbeddedValueObject($valueObject2);
+
+        $testEntityRepository->add($testEntity2);
+
+        $this->persistenceManager->persistAll();
+
+        $query = new Query(Fixtures\TestEntity::class);
+        $entities = $query->matching($query->equals('embeddedValueObject.value', 'vo'))->setLimit(1)->execute()->toArray();
+
+        $this->assertEquals(2, count($entities));
+    }
+
+    /**
+     * @test
+     */
     public function comlexQueryWithJoinsCanBeExecutedAfterDeserialization()
     {
         $postEntityRepository = new Fixtures\PostRepository();


### PR DESCRIPTION
Instead of assuming that every property path with a dot is a path
to an other entity check if the property path is a mapped field which
is also true for embedded object properties.

Resolves #989

**What I did**
We'll i suppose i fixed it :sweat_smile: 

**How I did it**
I searched the existing class schema for hints about embedded properties and found it in the entityManager. When the path exists in the fieldMappings it is a field embedded in the object's table. Since we're using doctrine in this kind of query anyway i think we're safe to go whit this solution.

**How to verify it**
The description of the original bug should be suffice.

**Checklist**

- [X] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
