### PR TITLE
TASK: Separate security context and authentication manager

### DIFF
--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -17,6 +17,8 @@ use Neos\Flow\Package\Package as BasePackage;
 use Neos\Flow\Package\PackageManager;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Flow\ResourceManagement\ResourceRepository;
+use Neos\Flow\Security\Authentication\AuthenticationProviderManager;
+use Neos\Flow\Security\Context;
 
 /**
  * The Flow Package
@@ -132,5 +134,8 @@ class Package extends BasePackage
 
         $dispatcher->connect(Persistence\Doctrine\PersistenceManager::class, 'allObjectsPersisted', ResourceRepository::class, 'resetAfterPersistingChanges');
         $dispatcher->connect(Persistence\Generic\PersistenceManager::class, 'allObjectsPersisted', ResourceRepository::class, 'resetAfterPersistingChanges');
+
+        $dispatcher->connect(AuthenticationProviderManager::class, 'successfullyAuthenticated', Context::class, 'refreshRoles');
+        $dispatcher->connect(AuthenticationProviderManager::class, 'loggedOut', Context::class, 'refreshTokens');
     }
 }

--- a/Neos.Flow/Classes/Security/Authentication/AuthenticationManagerInterface.php
+++ b/Neos.Flow/Classes/Security/Authentication/AuthenticationManagerInterface.php
@@ -12,6 +12,8 @@ namespace Neos\Flow\Security\Authentication;
  */
 
 use Neos\Flow\Security\Context as SecurityContext;
+use Neos\Flow\Security\Exception\AuthenticationRequiredException;
+use Neos\Flow\Security\Exception\NoTokensAuthenticatedException;
 
 /**
  * Contract for an authentication manager.
@@ -26,6 +28,8 @@ interface AuthenticationManagerInterface
      * Note: The order of the tokens in the array is important, as the tokens will be authenticated in the given order.
      *
      * @return array<TokenInterface> An array of tokens this manager is responsible for
+     * @deprecated Use the TokenAndProviderFactory
+     * @see TokenAndProviderFactoryInterface
      */
     public function getTokens();
 
@@ -33,6 +37,8 @@ interface AuthenticationManagerInterface
      * Returns all configured authentication providers
      *
      * @return array Array of \Neos\Flow\Security\Authentication\AuthenticationProviderInterface
+     * @deprecated Use the TokenAndProviderFactory
+     * @see TokenAndProviderFactoryInterface
      */
     public function getProviders();
 
@@ -41,6 +47,7 @@ interface AuthenticationManagerInterface
      *
      * @param SecurityContext $securityContext The security context of the current request
      * @return void
+     * @deprecated Just get it injected
      */
     public function setSecurityContext(SecurityContext $securityContext);
 
@@ -56,6 +63,8 @@ interface AuthenticationManagerInterface
      * (Have a look at the Authentication\TokenManager for an implementation example)
      *
      * @return void
+     * @throws AuthenticationRequiredException
+     * @throws NoTokensAuthenticatedException
      */
     public function authenticate();
 

--- a/Neos.Flow/Classes/Security/Authentication/AuthenticationProviderManager.php
+++ b/Neos.Flow/Classes/Security/Authentication/AuthenticationProviderManager.php
@@ -12,14 +12,11 @@ namespace Neos\Flow\Security\Authentication;
  */
 
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Log\PsrSecurityLoggerInterface;
 use Neos\Flow\Security\Authentication\Token\SessionlessTokenInterface;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Security\Exception\NoTokensAuthenticatedException;
 use Neos\Flow\Security\Exception\AuthenticationRequiredException;
 use Neos\Flow\Security\Exception;
-use Neos\Flow\Security\RequestPatternInterface;
-use Neos\Flow\Security\RequestPatternResolver;
 use Neos\Flow\Session\SessionManagerInterface;
 
 /**
@@ -37,26 +34,17 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
     protected $sessionManager;
 
     /**
-     * The provider resolver
-     *
-     * @var AuthenticationProviderResolver
+     * @var TokenAndProviderFactoryInterface
      */
-    protected $providerResolver;
+    protected $tokenAndProviderFactory;
 
     /**
      * The security context of the current request
      *
+     * @Flow\Inject
      * @var Context
      */
     protected $securityContext;
-
-    /**
-     * The request pattern resolver
-     *
-     * @var RequestPatternResolver
-     */
-    protected $requestPatternResolver;
-
     /**
      * Injected configuration for providers.
      * Will be null'd again after building the object instances.
@@ -64,16 +52,6 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
      * @var array|null
      */
     protected $providerConfigurations;
-
-    /**
-     * @var array
-     */
-    protected $providers = [];
-
-    /**
-     * @var array
-     */
-    protected $tokens = [];
 
     /**
      * @var boolean
@@ -86,13 +64,16 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
     protected $isInitialized = false;
 
     /**
-     * @param AuthenticationProviderResolver $providerResolver The provider resolver
-     * @param RequestPatternResolver $requestPatternResolver The request pattern resolver
+     * @var string
      */
-    public function __construct(AuthenticationProviderResolver $providerResolver, RequestPatternResolver $requestPatternResolver)
+    protected $authenticationStrategy;
+
+    /**
+     * @param TokenAndProviderFactoryInterface $tokenAndProviderFacory
+     */
+    public function __construct(TokenAndProviderFactoryInterface $tokenAndProviderFacory)
     {
-        $this->providerResolver = $providerResolver;
-        $this->requestPatternResolver = $requestPatternResolver;
+        $this->tokenAndProviderFactory = $tokenAndProviderFacory;
     }
 
     /**
@@ -100,14 +81,29 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
      *
      * @param array $settings The settings
      * @return void
+     * @throws Exception
      */
     public function injectSettings(array $settings)
     {
-        if (!isset($settings['security']['authentication']['providers']) || !is_array($settings['security']['authentication']['providers'])) {
-            return;
+        if (isset($settings['security']['authentication']['authenticationStrategy'])) {
+            $authenticationStrategyName = $settings['security']['authentication']['authenticationStrategy'];
+            switch ($authenticationStrategyName) {
+                case 'allTokens':
+                    $this->authenticationStrategy = Context::AUTHENTICATE_ALL_TOKENS;
+                    break;
+                case 'oneToken':
+                    $this->authenticationStrategy = Context::AUTHENTICATE_ONE_TOKEN;
+                    break;
+                case 'atLeastOneToken':
+                    $this->authenticationStrategy = Context::AUTHENTICATE_AT_LEAST_ONE_TOKEN;
+                    break;
+                case 'anyToken':
+                    $this->authenticationStrategy = Context::AUTHENTICATE_ANY_TOKEN;
+                    break;
+                default:
+                    throw new Exception('Invalid setting "' . $authenticationStrategyName . '" for security.authentication.authenticationStrategy', 1291043022);
+            }
         }
-
-        $this->providerConfigurations = $settings['security']['authentication']['providers'];
     }
 
     /**
@@ -115,6 +111,7 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
      *
      * @param Context $securityContext The security context of the current request
      * @return void
+     * @deprecated Just get it injected
      */
     public function setSecurityContext(Context $securityContext)
     {
@@ -136,22 +133,24 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
      * Note: The order of the tokens in the array is important, as the tokens will be authenticated in the given order.
      *
      * @return array Array of TokenInterface this manager is responsible for
+     * @deprecated Use TokenAndProviderFactory
+     * @see TokenAndProviderFactoryInterface::getTokens()
      */
     public function getTokens()
     {
-        $this->buildProvidersAndTokensFromConfiguration();
-        return $this->tokens;
+        return $this->tokenAndProviderFactory->getTokens();
     }
 
     /**
      * Returns all configured authentication providers
      *
      * @return array Array of \Neos\Flow\Security\Authentication\AuthenticationProviderInterface
+     * @deprecated Use TokenAndProviderFactory
+     * @see TokenAndProviderFactoryInterface::getProviders()
      */
     public function getProviders()
     {
-        $this->buildProvidersAndTokensFromConfiguration();
-        return $this->providers;
+        return $this->tokenAndProviderFactory->getProviders();
     }
 
     /**
@@ -165,6 +164,7 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
      * @return void
      * @throws Exception
      * @throws AuthenticationRequiredException
+     * @throws NoTokensAuthenticatedException
      */
     public function authenticate()
     {
@@ -180,13 +180,12 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
             throw new NoTokensAuthenticatedException('The security context contained no tokens which could be authenticated.', 1258721059);
         }
 
-        $this->buildProvidersAndTokensFromConfiguration();
         $session = $this->sessionManager->getCurrentSession();
 
         /** @var $token TokenInterface */
         foreach ($tokens as $token) {
             /** @var $provider AuthenticationProviderInterface */
-            foreach ($this->providers as $provider) {
+            foreach ($this->tokenAndProviderFactory->getProviders() as $provider) {
                 if ($provider->canAuthenticate($token) && $token->getAuthenticationStatus() === TokenInterface::AUTHENTICATION_NEEDED) {
                     $provider->authenticate($token);
                     if ($token->isAuthenticated()) {
@@ -207,25 +206,25 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
                         });
                     }
                 }
-                if ($this->securityContext->getAuthenticationStrategy() === Context::AUTHENTICATE_ONE_TOKEN) {
+                if ($this->authenticationStrategy === Context::AUTHENTICATE_ONE_TOKEN) {
                     $this->isAuthenticated = true;
-                    $this->securityContext->refreshRoles();
+                    $this->emitSuccessfullyAuthenticated();
                     return;
                 }
                 $anyTokenAuthenticated = true;
             } else {
-                if ($this->securityContext->getAuthenticationStrategy() === Context::AUTHENTICATE_ALL_TOKENS) {
+                if ($this->authenticationStrategy === Context::AUTHENTICATE_ALL_TOKENS) {
                     throw new AuthenticationRequiredException('Could not authenticate all tokens, but authenticationStrategy was set to "all".', 1222203912);
                 }
             }
         }
 
-        if (!$anyTokenAuthenticated && $this->securityContext->getAuthenticationStrategy() !== Context::AUTHENTICATE_ANY_TOKEN) {
+        if (!$anyTokenAuthenticated && $this->authenticationStrategy !== Context::AUTHENTICATE_ANY_TOKEN) {
             throw new NoTokensAuthenticatedException('Could not authenticate any token. Might be missing or wrong credentials or no authentication provider matched.', 1222204027);
         }
 
         $this->isAuthenticated = $anyTokenAuthenticated;
-        $this->securityContext->refreshRoles();
+        $this->emitSuccessfullyAuthenticated();
     }
 
     /**
@@ -234,6 +233,7 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
      * Will call authenticate() if not done before.
      *
      * @return boolean
+     * @throws Exception
      */
     public function isAuthenticated()
     {
@@ -267,7 +267,6 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
         if ($session->isStarted()) {
             $session->destroy('Logout through AuthenticationProviderManager');
         }
-        $this->securityContext->refreshTokens();
     }
 
     /**
@@ -293,99 +292,12 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
     }
 
     /**
-     * Builds the provider and token objects based on the given configuration
+     * Signals that authentication commenced and at least one token was authenticated.
      *
      * @return void
-     * @throws Exception\InvalidAuthenticationProviderException
-     * @throws Exception\NoEntryPointFoundException
+     * @Flow\Signal
      */
-    protected function buildProvidersAndTokensFromConfiguration()
+    protected function emitSuccessfullyAuthenticated()
     {
-        if ($this->isInitialized) {
-            return;
-        }
-
-        $this->tokens = [];
-        $this->providers = [];
-
-        foreach ($this->providerConfigurations as $providerName => $providerConfiguration) {
-            if (!is_array($providerConfiguration) || !isset($providerConfiguration['provider'])) {
-                throw new Exception\InvalidAuthenticationProviderException('The configured authentication provider "' . $providerName . '" needs a "provider" option!', 1248209521);
-            }
-
-            $providerObjectName = $this->providerResolver->resolveProviderClass((string)$providerConfiguration['provider']);
-            if ($providerObjectName === null) {
-                throw new Exception\InvalidAuthenticationProviderException('The configured authentication provider "' . $providerConfiguration['provider'] . '" could not be found!', 1237330453);
-            }
-            $providerOptions = [];
-            if (isset($providerConfiguration['providerOptions']) && is_array($providerConfiguration['providerOptions'])) {
-                $providerOptions = $providerConfiguration['providerOptions'];
-            }
-
-            /** @var $providerInstance AuthenticationProviderInterface */
-            $providerInstance = $providerObjectName::create($providerName, $providerOptions);
-            $this->providers[$providerName] = $providerInstance;
-
-            /** @var $tokenInstance TokenInterface */
-            $tokenInstance = null;
-            foreach ($providerInstance->getTokenClassNames() as $tokenClassName) {
-                if (isset($providerConfiguration['token']) && $providerConfiguration['token'] !== $tokenClassName) {
-                    continue;
-                }
-
-                $tokenInstance = new $tokenClassName();
-                $tokenInstance->setAuthenticationProviderName($providerName);
-                $this->tokens[] = $tokenInstance;
-                break;
-            }
-
-            if (isset($providerConfiguration['requestPatterns']) && is_array($providerConfiguration['requestPatterns'])) {
-                $requestPatterns = [];
-                foreach ($providerConfiguration['requestPatterns'] as $patternName => $patternConfiguration) {
-                    // skip request patterns that are set to NULL (i.e. `somePattern: ~` in a YAML file)
-                    if ($patternConfiguration === null) {
-                        continue;
-                    }
-
-                    $patternType = $patternConfiguration['pattern'];
-                    $patternOptions = isset($patternConfiguration['patternOptions']) ? $patternConfiguration['patternOptions'] : [];
-                    $patternClassName = $this->requestPatternResolver->resolveRequestPatternClass($patternType);
-                    $requestPattern = new $patternClassName($patternOptions);
-                    if (!$requestPattern instanceof RequestPatternInterface) {
-                        throw new Exception\InvalidRequestPatternException(sprintf('Invalid request pattern configuration in setting "Neos:Flow:security:authentication:providers:%s": Class "%s" does not implement RequestPatternInterface', $providerName, $patternClassName), 1446222774);
-                    }
-
-                    $requestPatterns[] = $requestPattern;
-                }
-                if ($tokenInstance !== null) {
-                    $tokenInstance->setRequestPatterns($requestPatterns);
-                }
-            }
-
-            if (isset($providerConfiguration['entryPoint'])) {
-                if (is_array($providerConfiguration['entryPoint'])) {
-                    $message = 'Invalid entry point configuration in setting "Neos:Flow:security:authentication:providers:' . $providerName . '. Check your settings and make sure to specify only one entry point for each provider.';
-                    throw new Exception\InvalidAuthenticationProviderException($message, 1327671458);
-                }
-                $entryPointName = $providerConfiguration['entryPoint'];
-                $entryPointClassName = $entryPointName;
-                if (!class_exists($entryPointClassName)) {
-                    $entryPointClassName = 'Neos\Flow\Security\Authentication\EntryPoint\\' . $entryPointClassName;
-                }
-                if (!class_exists($entryPointClassName)) {
-                    throw new Exception\NoEntryPointFoundException('An entry point with the name: "' . $entryPointName . '" could not be resolved. Make sure it is a valid class name, either fully qualified or relative to Neos\Flow\Security\Authentication\EntryPoint!', 1236767282);
-                }
-
-                /** @var $entryPoint EntryPointInterface */
-                $entryPoint = new $entryPointClassName();
-                if (isset($providerConfiguration['entryPointOptions'])) {
-                    $entryPoint->setOptions($providerConfiguration['entryPointOptions']);
-                }
-
-                $tokenInstance->setAuthenticationEntryPoint($entryPoint);
-            }
-        }
-
-        $this->isInitialized = true;
     }
 }

--- a/Neos.Flow/Classes/Security/Authentication/TokenAndProviderFactory.php
+++ b/Neos.Flow/Classes/Security/Authentication/TokenAndProviderFactory.php
@@ -1,0 +1,212 @@
+<?php
+namespace Neos\Flow\Security\Authentication;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Security\Exception;
+use Neos\Flow\Security\RequestPatternInterface;
+use Neos\Flow\Security\RequestPatternResolver;
+
+/**
+ * @Flow\Scope("singleton")
+ */
+class TokenAndProviderFactory implements TokenAndProviderFactoryInterface
+{
+    /**
+     * @var bool
+     */
+    protected $isInitialized = false;
+
+    /**
+     * @var AuthenticationProviderInterface[]
+     */
+    protected $providers = [];
+
+    /**
+     * @var TokenInterface[]
+     */
+    protected $tokens = [];
+
+    /**
+     * @var array
+     */
+    protected $providerConfigurations = [];
+
+    /**
+     * @var AuthenticationProviderResolver
+     */
+    protected $providerResolver;
+
+    /**
+     * @var RequestPatternResolver
+     */
+    protected $requestPatternResolver;
+
+    /**
+     * @param AuthenticationProviderResolver $providerResolver The provider resolver
+     * @param RequestPatternResolver $requestPatternResolver The request pattern resolver
+     */
+    public function __construct(AuthenticationProviderResolver $providerResolver, RequestPatternResolver $requestPatternResolver)
+    {
+        $this->providerResolver = $providerResolver;
+        $this->requestPatternResolver = $requestPatternResolver;
+    }
+
+    /**
+     * Returns clean tokens this manager is responsible for.
+     * Note: The order of the tokens in the array is important, as the tokens will be authenticated in the given order.
+     *
+     * @return TokenInterface[]
+     * @throws Exception\InvalidAuthenticationProviderException
+     * @throws Exception\InvalidRequestPatternException
+     * @throws Exception\NoAuthenticationProviderFoundException
+     * @throws Exception\NoEntryPointFoundException
+     * @throws Exception\NoRequestPatternFoundException
+     */
+    public function getTokens(): array
+    {
+        $this->buildProvidersAndTokensFromConfiguration();
+        return $this->tokens;
+    }
+
+    /**
+     * Returns all configured authentication providers
+     *
+     * @return AuthenticationProviderInterface[]
+     * @throws Exception\InvalidAuthenticationProviderException
+     * @throws Exception\InvalidRequestPatternException
+     * @throws Exception\NoAuthenticationProviderFoundException
+     * @throws Exception\NoEntryPointFoundException
+     * @throws Exception\NoRequestPatternFoundException
+     */
+    public function getProviders(): array
+    {
+        $this->buildProvidersAndTokensFromConfiguration();
+        return $this->providers;
+    }
+
+    /**
+     * Inject the settings and does a fresh build of tokens based on the injected settings
+     *
+     * @param array $settings The settings
+     * @return void
+     * @throws Exception
+     */
+    public function injectSettings(array $settings)
+    {
+        if (!isset($settings['security']['authentication']['providers']) || !is_array($settings['security']['authentication']['providers'])) {
+            return;
+        }
+
+        $this->providerConfigurations = $settings['security']['authentication']['providers'];
+    }
+
+    /**
+     * Builds the provider and token objects based on the given configuration
+     *
+     * @return void
+     * @throws Exception\InvalidAuthenticationProviderException
+     * @throws Exception\InvalidRequestPatternException
+     * @throws Exception\NoAuthenticationProviderFoundException
+     * @throws Exception\NoEntryPointFoundException
+     * @throws Exception\NoRequestPatternFoundException
+     */
+    protected function buildProvidersAndTokensFromConfiguration()
+    {
+        if ($this->isInitialized) {
+            return;
+        }
+
+        $this->tokens = [];
+        $this->providers = [];
+
+        foreach ($this->providerConfigurations as $providerName => $providerConfiguration) {
+            if (!is_array($providerConfiguration) || !isset($providerConfiguration['provider'])) {
+                throw new Exception\InvalidAuthenticationProviderException('The configured authentication provider "' . $providerName . '" needs a "provider" option!', 1248209521);
+            }
+
+            $providerObjectName = $this->providerResolver->resolveProviderClass((string)$providerConfiguration['provider']);
+            if ($providerObjectName === null) {
+                throw new Exception\InvalidAuthenticationProviderException('The configured authentication provider "' . $providerConfiguration['provider'] . '" could not be found!', 1237330453);
+            }
+            $providerOptions = [];
+            if (isset($providerConfiguration['providerOptions']) && is_array($providerConfiguration['providerOptions'])) {
+                $providerOptions = $providerConfiguration['providerOptions'];
+            }
+
+            /** @var $providerInstance AuthenticationProviderInterface */
+            $providerInstance = $providerObjectName::create($providerName, $providerOptions);
+            $this->providers[$providerName] = $providerInstance;
+
+            /** @var $tokenInstance TokenInterface */
+            $tokenInstance = null;
+            foreach ($providerInstance->getTokenClassNames() as $tokenClassName) {
+                if (isset($providerConfiguration['token']) && $providerConfiguration['token'] !== $tokenClassName) {
+                    continue;
+                }
+
+                $tokenInstance = new $tokenClassName();
+                $tokenInstance->setAuthenticationProviderName($providerName);
+                $this->tokens[] = $tokenInstance;
+                break;
+            }
+
+            if (isset($providerConfiguration['requestPatterns']) && is_array($providerConfiguration['requestPatterns'])) {
+                $requestPatterns = [];
+                foreach ($providerConfiguration['requestPatterns'] as $patternName => $patternConfiguration) {
+                    // skip request patterns that are set to NULL (i.e. `somePattern: ~` in a YAML file)
+                    if ($patternConfiguration === null) {
+                        continue;
+                    }
+
+                    $patternType = $patternConfiguration['pattern'];
+                    $patternOptions = isset($patternConfiguration['patternOptions']) ? $patternConfiguration['patternOptions'] : [];
+                    $patternClassName = $this->requestPatternResolver->resolveRequestPatternClass($patternType);
+                    $requestPattern = new $patternClassName($patternOptions);
+                    if (!$requestPattern instanceof RequestPatternInterface) {
+                        throw new Exception\InvalidRequestPatternException(sprintf('Invalid request pattern configuration in setting "Neos:Flow:security:authentication:providers:%s": Class "%s" does not implement RequestPatternInterface', $providerName, $patternClassName), 1446222774);
+                    }
+
+                    $requestPatterns[] = $requestPattern;
+                }
+                if ($tokenInstance !== null) {
+                    $tokenInstance->setRequestPatterns($requestPatterns);
+                }
+            }
+
+            if (isset($providerConfiguration['entryPoint'])) {
+                if (is_array($providerConfiguration['entryPoint'])) {
+                    $message = 'Invalid entry point configuration in setting "Neos:Flow:security:authentication:providers:' . $providerName . '. Check your settings and make sure to specify only one entry point for each provider.';
+                    throw new Exception\InvalidAuthenticationProviderException($message, 1327671458);
+                }
+                $entryPointName = $providerConfiguration['entryPoint'];
+                $entryPointClassName = $entryPointName;
+                if (!class_exists($entryPointClassName)) {
+                    $entryPointClassName = 'Neos\Flow\Security\Authentication\EntryPoint\\' . $entryPointClassName;
+                }
+                if (!class_exists($entryPointClassName)) {
+                    throw new Exception\NoEntryPointFoundException('An entry point with the name: "' . $entryPointName . '" could not be resolved. Make sure it is a valid class name, either fully qualified or relative to Neos\Flow\Security\Authentication\EntryPoint!', 1236767282);
+                }
+
+                /** @var $entryPoint EntryPointInterface */
+                $entryPoint = new $entryPointClassName();
+                if (isset($providerConfiguration['entryPointOptions'])) {
+                    $entryPoint->setOptions($providerConfiguration['entryPointOptions']);
+                }
+
+                $tokenInstance->setAuthenticationEntryPoint($entryPoint);
+            }
+        }
+
+        $this->isInitialized = true;
+    }
+}

--- a/Neos.Flow/Classes/Security/Authentication/TokenAndProviderFactoryInterface.php
+++ b/Neos.Flow/Classes/Security/Authentication/TokenAndProviderFactoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+namespace Neos\Flow\Security\Authentication;
+
+interface TokenAndProviderFactoryInterface
+{
+    /**
+     * @return TokenInterface[]
+     */
+    public function getTokens(): array;
+
+    /**
+     * @return AuthenticationProviderInterface[]
+     */
+    public function getProviders(): array;
+}

--- a/Neos.Flow/Classes/Security/Context.php
+++ b/Neos.Flow/Classes/Security/Context.php
@@ -14,8 +14,8 @@ namespace Neos\Flow\Security;
 use Neos\Flow\Annotations as Flow;
 use Neos\Cache\CacheAwareInterface;
 use Neos\Flow\Log\PsrSecurityLoggerInterface;
-use Neos\Flow\Mvc\RequestInterface;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Flow\Security\Authentication\TokenAndProviderFactoryInterface;
 use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\Policy\Role;
 use Neos\Flow\Mvc\ActionRequest;
@@ -27,7 +27,7 @@ use Neos\Utility\TypeHandling;
  * This is the default implementation of a security context, which holds current
  * security information like roles oder details of authenticated users.
  *
- * @Flow\Scope("session")
+ * @Flow\Scope("singleton")
  */
 class Context
 {
@@ -78,18 +78,18 @@ class Context
     const CONTEXT_HASH_UNINITIALIZED = '__uninitialized__';
 
     /**
-     * true if the context is initialized in the current request, false or NULL otherwise.
+     * One of the AUTHENTICATE_* constants to set the authentication strategy.
      *
-     * @var boolean
-     * @Flow\Transient
+     * @var integer
      */
-    protected $initialized = false;
+    protected $authenticationStrategy = self::AUTHENTICATE_ANY_TOKEN;
 
     /**
-     * Array of configured tokens (might have request patterns)
-     * @var array
+     * One of the CSRF_* constants to set the csrf protection strategy
+     *
+     * @var integer
      */
-    protected $tokens = [];
+    protected $csrfProtectionStrategy = self::CSRF_ONE_PER_SESSION;
 
     /**
      * @var array
@@ -102,35 +102,65 @@ class Context
     ];
 
     /**
+     * true if the context is initialized in the current request, false or NULL otherwise.
+     *
+     * @var boolean
+     */
+    protected $initialized = false;
+
+    /**
      * Array of tokens currently active
      * @var TokenInterface[]
-     * @Flow\Transient
      */
     protected $activeTokens = [];
 
     /**
      * Array of tokens currently inactive
-     * @var array
-     * @Flow\Transient
+     * @var TokenInterface[]
      */
     protected $inactiveTokens = [];
 
     /**
-     * One of the AUTHENTICATE_* constants to set the authentication strategy.
-     * @var integer
-     */
-    protected $authenticationStrategy = self::AUTHENTICATE_ANY_TOKEN;
-
-    /**
      * @var ActionRequest
-     * @Flow\Transient
      */
     protected $request;
 
     /**
-     * @var Authentication\AuthenticationManagerInterface
+     * @var Role[]
      */
-    protected $authenticationManager;
+    protected $roles = null;
+
+    /**
+     * Whether authorization is disabled @see areAuthorizationChecksDisabled()
+     *
+     * @var boolean
+     */
+    protected $authorizationChecksDisabled = false;
+
+    /**
+     * A hash for this security context that is unique to the currently authenticated roles. @see getContextHash()
+     *
+     * @var string
+     */
+    protected $contextHash = null;
+
+    /**
+     * CSRF tokens that are valid during this request but will be gone after.
+     * @var array
+     */
+    protected $csrfTokensRemovedAfterCurrentRequest = [];
+
+    /**
+     * CSRF token created in the current request.
+     * @var string
+     */
+    protected $requestCsrfToken = '';
+
+    /**
+     * @Flow\Inject
+     * @var TokenAndProviderFactoryInterface
+     */
+    protected $tokenAndProviderFactory;
 
     /**
      * @Flow\Inject
@@ -152,50 +182,6 @@ class Context
 
     /**
      * @Flow\Inject
-     * @var Cryptography\HashService
-     */
-    protected $hashService;
-
-    /**
-     * One of the CSRF_* constants to set the csrf protection strategy
-     * @var integer
-     */
-    protected $csrfProtectionStrategy = self::CSRF_ONE_PER_SESSION;
-
-    /**
-     * @var array
-     */
-    protected $csrfProtectionTokens = [];
-
-    /**
-     * @var RequestInterface
-     */
-    protected $interceptedRequest;
-
-    /**
-     * @Flow\Transient
-     * @var Role[]
-     */
-    protected $roles = null;
-
-    /**
-     * Whether authorization is disabled @see areAuthorizationChecksDisabled()
-     *
-     * @Flow\Transient
-     * @var boolean
-     */
-    protected $authorizationChecksDisabled = false;
-
-    /**
-     * A hash for this security context that is unique to the currently authenticated roles. @see getContextHash()
-     *
-     * @Flow\Transient
-     * @var string
-     */
-    protected $contextHash = null;
-
-    /**
-     * @Flow\Inject
      * @var ObjectManagerInterface
      */
     protected $objectManager;
@@ -208,17 +194,6 @@ class Context
      */
     protected $globalObjects = [];
 
-    /**
-     * Inject the authentication manager
-     *
-     * @param Authentication\AuthenticationManagerInterface $authenticationManager The authentication manager
-     * @return void
-     */
-    public function injectAuthenticationManager(Authentication\AuthenticationManagerInterface $authenticationManager)
-    {
-        $this->authenticationManager = $authenticationManager;
-        $this->authenticationManager->setSecurityContext($this);
-    }
 
     /**
      * Lets you switch off authorization checks (CSRF token, policies, content security, ...) for the runtime of $callback
@@ -338,15 +313,14 @@ class Context
             throw new Exception('The security Context cannot be initialized yet. Please check if it can be initialized with $securityContext->canBeInitialized() before trying to do so.', 1358513802);
         }
 
-        if ($this->csrfProtectionStrategy !== self::CSRF_ONE_PER_SESSION) {
-            $this->csrfProtectionTokens = [];
-        }
-
-        $this->tokens = $this->mergeTokens($this->authenticationManager->getTokens(), $this->tokens);
-        $this->separateActiveAndInactiveTokens();
+        $sessionDataContainer = $this->objectManager->get(SessionDataContainer::class);
+        $factoryTokens = $this->tokenAndProviderFactory->getTokens();
+        $tokens = $this->mergeTokens($factoryTokens, $sessionDataContainer->getSecurityTokens());
+        $this->separateActiveAndInactiveTokens($tokens);
         $this->updateTokens($this->activeTokens);
 
         $this->initialized = true;
+        return $tokens;
     }
 
     /**
@@ -419,6 +393,8 @@ class Context
      * The "Neos.Flow:Everybody" roles is always returned.
      *
      * @return Role[]
+     * @throws Exception
+     * @throws Exception\NoSuchRoleException
      */
     public function getRoles()
     {
@@ -426,39 +402,31 @@ class Context
             $this->initialize();
         }
 
-        if ($this->roles === null) {
-            $this->roles = ['Neos.Flow:Everybody' => $this->policyService->getRole('Neos.Flow:Everybody')];
+        if ($this->roles !== null) {
+            return $this->roles;
+        }
 
-            if ($this->authenticationManager->isAuthenticated() === false) {
-                $this->roles['Neos.Flow:Anonymous'] = $this->policyService->getRole('Neos.Flow:Anonymous');
-            } else {
-                $this->roles['Neos.Flow:AuthenticatedUser'] = $this->policyService->getRole('Neos.Flow:AuthenticatedUser');
-                /** @var $token TokenInterface */
-                foreach ($this->getAuthenticationTokens() as $token) {
-                    if ($token->isAuthenticated() !== true) {
-                        continue;
-                    }
-                    $account = $token->getAccount();
-                    if ($account === null) {
-                        continue;
-                    }
-                    if ($account !== null) {
-                        $accountRoles = $account->getRoles();
-                        /** @var $currentRole Role */
-                        foreach ($accountRoles as $currentRole) {
-                            if (!in_array($currentRole, $this->roles)) {
-                                $this->roles[$currentRole->getIdentifier()] = $currentRole;
-                            }
-                            /** @var $currentParentRole Role */
-                            foreach ($currentRole->getAllParentRoles() as $currentParentRole) {
-                                if (!in_array($currentParentRole, $this->roles)) {
-                                    $this->roles[$currentParentRole->getIdentifier()] = $currentParentRole;
-                                }
-                            }
-                        }
-                    }
-                }
+        $this->roles = ['Neos.Flow:Everybody' => $this->policyService->getRole('Neos.Flow:Everybody')];
+
+        $authenticatedTokens = array_filter($this->getAuthenticationTokens(), function (TokenInterface $token) {
+            return $token->isAuthenticated();
+        });
+
+        if (empty($authenticatedTokens)) {
+            $this->roles['Neos.Flow:Anonymous'] = $this->policyService->getRole('Neos.Flow:Anonymous');
+            return $this->roles;
+        }
+
+        $this->roles['Neos.Flow:AuthenticatedUser'] = $this->policyService->getRole('Neos.Flow:AuthenticatedUser');
+
+        /** @var $token TokenInterface */
+        foreach ($authenticatedTokens as $token) {
+            $account = $token->getAccount();
+            if ($account === null) {
+                continue;
             }
+
+            $this->roles = array_merge($this->roles, $this->collectRolesAndParentRolesFromAccount($account));
         }
 
         return $this->roles;
@@ -470,17 +438,13 @@ class Context
      *
      * @param string $roleIdentifier The string representation of the role to search for
      * @return boolean true, if a role with the given string representation was found
+     * @throws Exception
+     * @throws Exception\NoSuchRoleException
      */
     public function hasRole($roleIdentifier)
     {
         if ($roleIdentifier === 'Neos.Flow:Everybody') {
             return true;
-        }
-        if ($roleIdentifier === 'Neos.Flow:Anonymous') {
-            return (!$this->authenticationManager->isAuthenticated());
-        }
-        if ($roleIdentifier === 'Neos.Flow:AuthenticatedUser') {
-            return ($this->authenticationManager->isAuthenticated());
         }
 
         $roles = $this->getRoles();
@@ -541,16 +505,26 @@ class Context
      */
     public function getCsrfProtectionToken()
     {
-        if ($this->initialized === false) {
-            $this->initialize();
+        $sessionDataContainer = $this->objectManager->get(SessionDataContainer::class);
+        $csrfProtectionTokens = $sessionDataContainer->getCsrfProtectionTokens();
+        if ($this->csrfProtectionStrategy === self::CSRF_ONE_PER_SESSION && count($csrfProtectionTokens) === 1) {
+            reset($csrfProtectionTokens);
+            return key($csrfProtectionTokens);
         }
 
-        if (count($this->csrfProtectionTokens) === 1 && $this->csrfProtectionStrategy !== self::CSRF_ONE_PER_URI) {
-            reset($this->csrfProtectionTokens);
-            return key($this->csrfProtectionTokens);
+        if ($this->csrfProtectionStrategy === self::CSRF_ONE_PER_REQUEST) {
+            if (empty($this->requestCsrfToken)) {
+                $this->requestCsrfToken = Algorithms::generateRandomToken(16);
+                $csrfProtectionTokens[$this->requestCsrfToken] = true;
+                $sessionDataContainer->setCsrfProtectionTokens($csrfProtectionTokens);
+            }
+
+            return $this->requestCsrfToken;
         }
+
         $newToken = Algorithms::generateRandomToken(16);
-        $this->csrfProtectionTokens[$newToken] = true;
+        $csrfProtectionTokens[$newToken] = true;
+        $sessionDataContainer->setCsrfProtectionTokens($csrfProtectionTokens);
 
         return $newToken;
     }
@@ -562,7 +536,9 @@ class Context
      */
     public function hasCsrfProtectionTokens()
     {
-        return count($this->csrfProtectionTokens) > 0;
+        $sessionDataContainer = $this->objectManager->get(SessionDataContainer::class);
+        $csrfProtectionTokens = $sessionDataContainer->getCsrfProtectionTokens();
+        return count($csrfProtectionTokens) > 0;
     }
 
     /**
@@ -571,20 +547,28 @@ class Context
      *
      * @param string $csrfToken The token string to be validated
      * @return boolean true, if the token is valid. false otherwise.
+     * @throws Exception
      */
     public function isCsrfProtectionTokenValid($csrfToken)
     {
-        if ($this->initialized === false) {
-            $this->initialize();
+        $sessionDataContainer = $this->objectManager->get(SessionDataContainer::class);
+        $csrfProtectionTokens = $sessionDataContainer->getCsrfProtectionTokens();
+
+        if (!isset($csrfProtectionTokens[$csrfToken]) && !isset($this->csrfTokensRemovedAfterCurrentRequest[$csrfToken])) {
+            return false;
         }
 
-        if (isset($this->csrfProtectionTokens[$csrfToken])) {
-            if ($this->csrfProtectionStrategy === self::CSRF_ONE_PER_URI) {
-                unset($this->csrfProtectionTokens[$csrfToken]);
-            }
-            return true;
+        if ($this->csrfProtectionStrategy === self::CSRF_ONE_PER_URI) {
+            unset($csrfProtectionTokens[$csrfToken]);
         }
-        return false;
+
+        if ($this->csrfProtectionStrategy === self::CSRF_ONE_PER_REQUEST) {
+            $this->csrfTokensRemovedAfterCurrentRequest[$csrfToken] = true;
+            unset($csrfProtectionTokens[$csrfToken]);
+        }
+
+        $sessionDataContainer->setCsrfProtectionTokens($csrfProtectionTokens);
+        return true;
     }
 
     /**
@@ -597,18 +581,29 @@ class Context
      */
     public function setInterceptedRequest(ActionRequest $interceptedRequest = null)
     {
-        $this->interceptedRequest = $interceptedRequest;
+        if ($this->initialized === false) {
+            $this->initialize();
+        }
+
+        $sessionDataContainer = $this->objectManager->get(SessionDataContainer::class);
+        $sessionDataContainer->setInterceptedRequest($interceptedRequest);
     }
 
     /**
      * Returns the request, that has been stored for later resuming after it
      * has been intercepted by a security exception, NULL if there is none.
      *
-     * @return ActionRequest
+     * @return ActionRequest|null
+     * TODO: Revisit type (ActionRequest / HTTP request)
      */
     public function getInterceptedRequest()
     {
-        return $this->interceptedRequest;
+        if ($this->initialized === false) {
+            $this->initialize();
+        }
+
+        $sessionDataContainer = $this->objectManager->get(SessionDataContainer::class);
+        return $sessionDataContainer->getInterceptedRequest();
     }
 
     /**
@@ -618,31 +613,64 @@ class Context
      */
     public function clearContext()
     {
+        $sessionDataContainer = $this->objectManager->get(SessionDataContainer::class);
+        $sessionDataContainer->setSecurityTokens([]);
+        $sessionDataContainer->setCsrfProtectionTokens([]);
+        $sessionDataContainer->setInterceptedRequest(null);
+
         $this->roles = null;
         $this->contextHash = null;
-        $this->tokens = [];
         $this->activeTokens = [];
         $this->inactiveTokens = [];
         $this->request = null;
-        $this->csrfProtectionTokens = [];
-        $this->interceptedRequest = null;
         $this->authorizationChecksDisabled = false;
         $this->initialized = false;
     }
 
     /**
+     * @param Account $account
+     * @return array
+     */
+    protected function collectRolesAndParentRolesFromAccount(Account $account): array
+    {
+        $reducer = function (array $roles, $currentRole) {
+            $roles[$currentRole->getIdentifier()] = $currentRole;
+            $roles = array_merge($roles, $this->collectParentRoles($currentRole));
+
+            return $roles;
+        };
+
+        return array_reduce($account->getRoles(), $reducer, []);
+    }
+
+    /**
+     * @param Role $role
+     * @return array
+     */
+    protected function collectParentRoles(Role $role): array
+    {
+        $reducer = function (array $roles, Role $parentRole) {
+            $roles[$parentRole->getIdentifier()] = $parentRole;
+            return $roles;
+        };
+
+        return array_reduce($role->getAllParentRoles(), $reducer, []);
+    }
+
+    /**
      * Stores all active tokens in $this->activeTokens, all others in $this->inactiveTokens
      *
+     * @param TokenInterface[] $tokens
      * @return void
      */
-    protected function separateActiveAndInactiveTokens()
+    protected function separateActiveAndInactiveTokens(array $tokens)
     {
         if ($this->request === null) {
             return;
         }
 
         /** @var $token TokenInterface */
-        foreach ($this->tokens as $token) {
+        foreach ($tokens as $token) {
             if ($this->isTokenActive($token)) {
                 $this->activeTokens[$token->getAuthenticationProviderName()] = $token;
             } else {
@@ -693,39 +721,48 @@ class Context
             return $resultTokens;
         }
 
+        $sessionTokens = $sessionTokens ?? [];
+
         /** @var $managerToken TokenInterface */
         foreach ($managerTokens as $managerToken) {
-            $noCorrespondingSessionTokenFound = true;
-
-            if (!is_array($sessionTokens)) {
-                continue;
-            }
-
-            /** @var $sessionToken TokenInterface */
-            foreach ($sessionTokens as $sessionToken) {
-                if ($sessionToken->getAuthenticationProviderName() === $managerToken->getAuthenticationProviderName()) {
-                    $session = $this->sessionManager->getCurrentSession();
-                    $this->securityLogger->info(
-                        sprintf(
-                            'Session %s contains auth token %s for provider %s. Status: %s',
-                            $session->getId(),
-                            get_class($sessionToken),
-                            $sessionToken->getAuthenticationProviderName(),
-                            $this->tokenStatusLabels[$sessionToken->getAuthenticationStatus()]
-                        )
-                    );
-
-                    $resultTokens[$sessionToken->getAuthenticationProviderName()] = $sessionToken;
-                    $noCorrespondingSessionTokenFound = false;
-                }
-            }
-
-            if ($noCorrespondingSessionTokenFound) {
-                $resultTokens[$managerToken->getAuthenticationProviderName()] = $managerToken;
-            }
+            $resultTokens[$managerToken->getAuthenticationProviderName()] = $this->findBestMatchingToken($managerToken, $sessionTokens);
         }
 
         return $resultTokens;
+    }
+
+    /**
+     * Tries to find a token matchting the given manager token in the session tokens, will return that or the manager token.
+     *
+     * @param TokenInterface $managerToken
+     * @param TokenInterface[] $sessionTokens
+     * @return TokenInterface
+     * @throws \Neos\Flow\Session\Exception\SessionNotStartedException
+     */
+    protected function findBestMatchingToken(TokenInterface $managerToken, array $sessionTokens): TokenInterface
+    {
+        $matchingSessionTokens = array_filter($sessionTokens, function (TokenInterface $sessionToken) use ($managerToken) {
+            return ($sessionToken->getAuthenticationProviderName() === $managerToken->getAuthenticationProviderName());
+        });
+
+        if (empty($matchingSessionTokens)) {
+            return $managerToken;
+        }
+
+        $matchingSessionToken = reset($matchingSessionTokens);
+
+        $session = $this->sessionManager->getCurrentSession();
+        $this->securityLogger->debug(
+            sprintf(
+                'Session %s contains auth token %s for provider %s. Status: %s',
+                $session->getId(),
+                get_class($matchingSessionToken),
+                $matchingSessionToken->getAuthenticationProviderName(),
+                $this->tokenStatusLabels[$matchingSessionToken->getAuthenticationStatus()]
+            )
+        );
+
+        return $matchingSessionToken;
     }
 
     /**
@@ -736,15 +773,20 @@ class Context
      */
     protected function updateTokens(array $tokens)
     {
-        if ($this->request !== null) {
-            /** @var $token TokenInterface */
-            foreach ($tokens as $token) {
-                $token->updateCredentials($this->request);
-            }
-        }
-
         $this->roles = null;
         $this->contextHash = null;
+
+        if ($this->request === null) {
+            return;
+        }
+
+        /** @var $token TokenInterface */
+        foreach ($tokens as $token) {
+            $token->updateCredentials($this->request);
+        }
+
+        $sessionDataContainer = $this->objectManager->get(SessionDataContainer::class);
+        $sessionDataContainer->setSecurityTokens(array_merge($this->inactiveTokens, $this->activeTokens));
     }
 
     /**
@@ -773,17 +815,6 @@ class Context
         $this->roles = null;
         $this->contextHash = null;
         $this->getRoles();
-    }
-
-    /**
-     * Shut the object down
-     *
-     * @return void
-     */
-    public function shutdownObject()
-    {
-        $this->tokens = array_merge($this->inactiveTokens, $this->activeTokens);
-        $this->initialized = false;
     }
 
     /**
@@ -818,20 +849,24 @@ class Context
             }
             $this->initialize();
         }
-        if ($this->contextHash === null) {
-            $contextHashSoFar = implode('|', array_keys($this->getRoles()));
 
-            $this->withoutAuthorizationChecks(function () use (&$contextHashSoFar) {
-                foreach ($this->globalObjects as $globalObjectsRegisteredClassName) {
-                    if (is_subclass_of($globalObjectsRegisteredClassName, CacheAwareInterface::class)) {
-                        $globalObject = $this->objectManager->get($globalObjectsRegisteredClassName);
-                        $contextHashSoFar .= '<' . $globalObject->getCacheEntryIdentifier();
-                    }
-                }
-            });
-
-            $this->contextHash = md5($contextHashSoFar);
+        if ($this->contextHash !== null) {
+            return $this->contextHash;
         }
+
+        $contextHashSoFar = implode('|', array_keys($this->getRoles()));
+
+        $this->withoutAuthorizationChecks(function () use (&$contextHashSoFar) {
+            foreach ($this->globalObjects as $globalObjectsRegisteredClassName) {
+                if (is_subclass_of($globalObjectsRegisteredClassName, CacheAwareInterface::class)) {
+                    $globalObject = $this->objectManager->get($globalObjectsRegisteredClassName);
+                    $contextHashSoFar .= '<' . $globalObject->getCacheEntryIdentifier();
+                }
+            }
+        });
+
+        $this->contextHash = md5($contextHashSoFar);
+
         return $this->contextHash;
     }
 }

--- a/Neos.Flow/Classes/Security/SessionDataContainer.php
+++ b/Neos.Flow/Classes/Security/SessionDataContainer.php
@@ -1,0 +1,75 @@
+<?php
+namespace Neos\Flow\Security;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\RequestInterface;
+
+/**
+ * @Flow\Scope("session")
+ * @internal
+ */
+class SessionDataContainer
+{
+    /**
+     * @var array
+     */
+    protected $securityTokens = [];
+
+    /**
+     * @var array
+     */
+    protected $csrfProtectionTokens = [];
+
+    /**
+     * @var RequestInterface|null
+     */
+    protected $interceptedRequest;
+
+    /**
+     * @return array
+     */
+    public function getSecurityTokens(): array
+    {
+        return $this->securityTokens;
+    }
+
+    /**
+     * @param array $securityTokens
+     */
+    public function setSecurityTokens(array $securityTokens)
+    {
+        $this->securityTokens = $securityTokens;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCsrfProtectionTokens(): array
+    {
+        return $this->csrfProtectionTokens;
+    }
+
+    /**
+     * @param array $csrfProtectionTokens
+     */
+    public function setCsrfProtectionTokens(array $csrfProtectionTokens)
+    {
+        $this->csrfProtectionTokens = $csrfProtectionTokens;
+    }
+
+    /**
+     * @return RequestInterface
+     */
+    public function getInterceptedRequest():? RequestInterface
+    {
+        return $this->interceptedRequest;
+    }
+
+    /**
+     * @param RequestInterface $interceptedRequest
+     */
+    public function setInterceptedRequest(RequestInterface $interceptedRequest = null)
+    {
+        $this->interceptedRequest = $interceptedRequest;
+    }
+}

--- a/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderManagerTest.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Tests\Unit\Security\Authentication;
 
 use Neos\Flow\Security\Authentication\AuthenticationProviderInterface;
 use Neos\Flow\Security\Authentication\AuthenticationProviderResolver;
+use Neos\Flow\Security\Authentication\TokenAndProviderFactoryInterface;
 use Neos\Flow\Security\RequestPatternResolver;
 use Neos\Flow\Session\SessionManager;
 use Neos\Flow\Tests\UnitTestCase;
@@ -21,6 +22,7 @@ use Neos\Flow\Security\Authentication\AuthenticationProviderManager;
 use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Session\SessionInterface;
+use phpDocumentor\Reflection\Types\Self_;
 
 /**
  * Test case for authentication provider manager
@@ -31,6 +33,11 @@ class AuthenticationProviderManagerTest extends UnitTestCase
      * @var AuthenticationProviderManager
      */
     protected $authenticationProviderManager;
+
+    /**
+     * @var TokenAndProviderFactoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $tokenAndProviderFactory;
 
     /**
      * @var SessionInterface|\PHPUnit_Framework_MockObject_MockObject
@@ -52,7 +59,8 @@ class AuthenticationProviderManagerTest extends UnitTestCase
      */
     public function setUp()
     {
-        $this->authenticationProviderManager = $this->getAccessibleMock(AuthenticationProviderManager::class, ['dummy'], [], '', false);
+        $this->tokenAndProviderFactory = $this->getMockBuilder(TokenAndProviderFactoryInterface::class)->getMock();
+        $this->authenticationProviderManager = $this->getAccessibleMock(AuthenticationProviderManager::class, ['dummy'], [$this->tokenAndProviderFactory], '', true);
         $this->mockSession = $this->getMockBuilder(SessionInterface::class)->getMock();
         $this->mockSecurityContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
 
@@ -85,10 +93,14 @@ class AuthenticationProviderManagerTest extends UnitTestCase
         $mockProvider1->expects($this->once())->method('authenticate')->with($mockToken1);
         $mockProvider2->expects($this->once())->method('authenticate')->with($mockToken2);
 
-        $this->mockSecurityContext->expects($this->atLeastOnce())->method('getAuthenticationStrategy')->will($this->returnValue(Context::AUTHENTICATE_ALL_TOKENS));
         $this->mockSecurityContext->expects($this->atLeastOnce())->method('getAuthenticationTokens')->will($this->returnValue([$mockToken1, $mockToken2]));
 
-        $this->inject($this->authenticationProviderManager, 'providers', [$mockProvider1, $mockProvider2]);
+        $this->tokenAndProviderFactory->expects(self::any())->method('getProviders')->willReturn([
+            $mockProvider1,
+            $mockProvider2
+        ]);
+
+        $this->inject($this->authenticationProviderManager, 'authenticationStrategy', Context::AUTHENTICATE_ALL_TOKENS);
 
         $this->authenticationProviderManager->authenticate();
     }
@@ -111,7 +123,6 @@ class AuthenticationProviderManagerTest extends UnitTestCase
 
         $this->mockSession->expects($this->once())->method('addTag')->with('Neos-Flow-Security-Account-21232f297a57a5a743894a0e4a801fc3');
 
-        $this->inject($this->authenticationProviderManager, 'providers', []);
         $this->inject($this->authenticationProviderManager, 'securityContext', $securityContext);
 
         $this->authenticationProviderManager->authenticate();
@@ -138,10 +149,13 @@ class AuthenticationProviderManagerTest extends UnitTestCase
         $mockProvider->expects($this->any())->method('canAuthenticate')->will($this->returnValue(true));
         $mockProvider->expects($this->once())->method('authenticate')->with($mockToken3);
 
-        $this->mockSecurityContext->expects($this->atLeastOnce())->method('getAuthenticationStrategy')->will($this->returnValue(Context::AUTHENTICATE_ONE_TOKEN));
         $this->mockSecurityContext->expects($this->atLeastOnce())->method('getAuthenticationTokens')->will($this->returnValue([$mockToken1, $mockToken2, $mockToken3]));
 
-        $this->inject($this->authenticationProviderManager, 'providers', [$mockProvider]);
+        $this->tokenAndProviderFactory->expects(self::any())->method('getProviders')->willReturn([
+            $mockProvider
+        ]);
+
+        $this->inject($this->authenticationProviderManager, 'authenticationStrategy', Context::AUTHENTICATE_ONE_TOKEN);
 
         $this->authenticationProviderManager->authenticate();
     }
@@ -160,8 +174,6 @@ class AuthenticationProviderManagerTest extends UnitTestCase
 
         $this->mockSecurityContext->expects($this->atLeastOnce())->method('getAuthenticationTokens')->will($this->returnValue([$token1, $token2]));
 
-        $this->inject($this->authenticationProviderManager, 'providers', []);
-
         $this->authenticationProviderManager->authenticate();
     }
 
@@ -178,10 +190,8 @@ class AuthenticationProviderManagerTest extends UnitTestCase
         $token2->expects($this->atLeastOnce())->method('isAuthenticated')->will($this->returnValue(false));
 
         $this->mockSecurityContext->expects($this->atLeastOnce())->method('getAuthenticationTokens')->will($this->returnValue([$token1, $token2]));
-        $this->mockSecurityContext->expects($this->atLeastOnce())->method('getAuthenticationStrategy')->will($this->returnValue(Context::AUTHENTICATE_ALL_TOKENS));
 
-        $this->inject($this->authenticationProviderManager, 'providers', []);
-
+        $this->inject($this->authenticationProviderManager, 'authenticationStrategy', Context::AUTHENTICATE_ALL_TOKENS);
         $this->authenticationProviderManager->authenticate();
     }
 
@@ -303,7 +313,7 @@ class AuthenticationProviderManagerTest extends UnitTestCase
      */
     public function logoutDestroysSessionIfStarted()
     {
-        $this->authenticationProviderManager = $this->getAccessibleMock(AuthenticationProviderManager::class, ['emitLoggedOut'], [], '', false);
+        $this->authenticationProviderManager = $this->getAccessibleMock(AuthenticationProviderManager::class, ['emitLoggedOut'], [$this->tokenAndProviderFactory], '', true);
         $this->inject($this->authenticationProviderManager, 'securityContext', $this->mockSecurityContext);
         $this->inject($this->authenticationProviderManager, 'sessionManager', $this->mockSessionManager);
         $this->inject($this->authenticationProviderManager, 'isInitialized', true);
@@ -326,7 +336,7 @@ class AuthenticationProviderManagerTest extends UnitTestCase
      */
     public function logoutDoesNotDestroySessionIfNotStarted()
     {
-        $this->authenticationProviderManager = $this->getAccessibleMock(AuthenticationProviderManager::class, ['emitLoggedOut'], [], '', false);
+        $this->authenticationProviderManager = $this->getAccessibleMock(AuthenticationProviderManager::class, ['emitLoggedOut'], [$this->tokenAndProviderFactory], '', true);
         $this->inject($this->authenticationProviderManager, 'securityContext', $this->mockSecurityContext);
         $this->inject($this->authenticationProviderManager, 'sessionManager', $this->mockSessionManager);
         $this->inject($this->authenticationProviderManager, 'isInitialized', true);
@@ -346,7 +356,7 @@ class AuthenticationProviderManagerTest extends UnitTestCase
      */
     public function logoutEmitsLoggedOutSignalBeforeDestroyingSession()
     {
-        $this->authenticationProviderManager = $this->getAccessibleMock(AuthenticationProviderManager::class, ['emitLoggedOut'], [], '', false);
+        $this->authenticationProviderManager = $this->getAccessibleMock(AuthenticationProviderManager::class, ['emitLoggedOut'], [$this->tokenAndProviderFactory], '', true);
         $this->inject($this->authenticationProviderManager, 'securityContext', $this->mockSecurityContext);
         $this->inject($this->authenticationProviderManager, 'sessionManager', $this->mockSessionManager);
         $this->inject($this->authenticationProviderManager, 'isInitialized', true);
@@ -377,7 +387,7 @@ class AuthenticationProviderManagerTest extends UnitTestCase
      */
     public function logoutRefreshesTokensInSecurityContext()
     {
-        $this->authenticationProviderManager = $this->getAccessibleMock(AuthenticationProviderManager::class, ['emitLoggedOut'], [], '', false);
+        $this->authenticationProviderManager = $this->getAccessibleMock(AuthenticationProviderManager::class, ['emitLoggedOut'], [$this->tokenAndProviderFactory], '', true);
         $this->inject($this->authenticationProviderManager, 'securityContext', $this->mockSecurityContext);
         $this->inject($this->authenticationProviderManager, 'sessionManager', $this->mockSessionManager);
         $this->inject($this->authenticationProviderManager, 'isInitialized', true);
@@ -390,42 +400,8 @@ class AuthenticationProviderManagerTest extends UnitTestCase
 
         $this->mockSecurityContext->expects($this->any())->method('getAuthenticationTokens')->will($this->returnValue([$token]));
 
-        $this->mockSecurityContext->expects($this->once())->method('refreshTokens');
+        $this->authenticationProviderManager->expects(self::once())->method('emitLoggedOut');
 
         $this->authenticationProviderManager->logout();
-    }
-
-    /**
-     * @test
-     */
-    public function noTokensAndProvidersAreBuiltIfTheConfigurationArrayIsEmpty()
-    {
-        $this->authenticationProviderManager->_call('buildProvidersAndTokensFromConfiguration', []);
-
-        $providers = $this->authenticationProviderManager->_get('providers');
-        $tokens = $this->authenticationProviderManager->_get('tokens');
-
-        $this->assertEquals([], $providers, 'The array of providers should be empty.');
-        $this->assertEquals([], $tokens, 'The array of tokens should be empty.');
-    }
-
-    /**
-     * @test
-     * @expectedException \Neos\Flow\Security\Exception\InvalidAuthenticationProviderException
-     */
-    public function anExceptionIsThrownIfTheConfiguredProviderDoesNotExist()
-    {
-        $providerConfiguration = [
-            'NotExistingProvider' => [
-                'providerClass' => 'NotExistingProviderClass'
-            ],
-        ];
-
-        $mockProviderResolver = $this->getMockBuilder(AuthenticationProviderResolver::class)->disableOriginalConstructor()->getMock();
-        $mockRequestPatternResolver = $this->getMockBuilder(RequestPatternResolver::class)->disableOriginalConstructor()->getMock();
-
-        $this->authenticationProviderManager = $this->getAccessibleMock(AuthenticationProviderManager::class, ['authenticate'], [$mockProviderResolver, $mockRequestPatternResolver]);
-        $this->authenticationProviderManager->injectSettings(['security' => ['authentication' => ['providers' => $providerConfiguration]]]);
-        $this->authenticationProviderManager->_call('buildProvidersAndTokensFromConfiguration', $providerConfiguration);
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/Authentication/TokenAndProviderFactoryTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/TokenAndProviderFactoryTest.php
@@ -1,0 +1,58 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Security\Authentication;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Security\Authentication\AuthenticationProviderResolver;
+use Neos\Flow\Security\Authentication\TokenAndProviderFactory;
+use Neos\Flow\Security\RequestPatternResolver;
+use Neos\Flow\Tests\UnitTestCase;
+
+/**
+ * Test for the default token and provider factory
+ */
+class TokenAndProviderFactoryTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function noTokensAndProvidersAreBuiltIfTheConfigurationArrayIsEmpty()
+    {
+        $mockProviderResolver = $this->getMockBuilder(AuthenticationProviderResolver::class)->disableOriginalConstructor()->getMock();
+        $mockRequestPatternResolver = $this->getMockBuilder(RequestPatternResolver::class)->disableOriginalConstructor()->getMock();
+
+        $tokenAndProviderFactory = new TokenAndProviderFactory($mockProviderResolver, $mockRequestPatternResolver);
+
+        $this->assertEquals([], $tokenAndProviderFactory->getProviders(), 'The array of providers should be empty.');
+        $this->assertEquals([], $tokenAndProviderFactory->getTokens(), 'The array of tokens should be empty.');
+    }
+
+    /**
+     * @test
+     * @expectedException \Neos\Flow\Security\Exception\InvalidAuthenticationProviderException
+     */
+    public function anExceptionIsThrownIfTheConfiguredProviderDoesNotExist()
+    {
+        $providerConfiguration = [
+            'NotExistingProvider' => [
+                'providerClass' => 'NotExistingProviderClass'
+            ],
+        ];
+
+        $mockProviderResolver = $this->getMockBuilder(AuthenticationProviderResolver::class)->disableOriginalConstructor()->getMock();
+        $mockRequestPatternResolver = $this->getMockBuilder(RequestPatternResolver::class)->disableOriginalConstructor()->getMock();
+
+        $tokenAndProviderFactory = new TokenAndProviderFactory($mockProviderResolver, $mockRequestPatternResolver);
+        $tokenAndProviderFactory->injectSettings(['security' => ['authentication' => ['providers' => $providerConfiguration]]]);
+
+        $tokenAndProviderFactory->getProviders();
+    }
+}


### PR DESCRIPTION
This contains a break up of the cross dependency between
AuthenticationProviderManager and Security context.

First a new TokenAndProviderFactory (with interface) is
introduced to serve both the constructed tokens and providers
from the configuration. Additionally the session persistent
data was moved from the Context to the new SessionDataContainer
(marked internal). This makes the context a simple singleton to
the outside, avoiding duplication (security context injected
before the session was started would create a duplicate instance
without the session data (most notably some SQL security could
have that).

Additionally it fixes ONE_PER_REQUEST CSRF protection tokens
which wouldn't correctly behave.
