### PR TITLE
TASK: Support converting from json_serialized DateTime

### DIFF
--- a/Neos.Flow/Classes/Property/TypeConverter/DateTimeConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/DateTimeConverter.php
@@ -159,6 +159,10 @@ class DateTimeConverter extends AbstractTypeConverter
             } catch (\Exception $exception) {
                 throw new TypeConverterException('The specified timezone "' . $source['timezone'] . '" is invalid.', 1308240974);
             }
+            if (isset($source['timezone_type'])) {
+                // DateTime internal format when being serialized with json_encode
+                $dateFormat = "Y-m-d\TH:i:s.v";
+            }
             $date = $targetType::createFromFormat($dateFormat, $dateAsString, $timezone);
         } else {
             $date = $targetType::createFromFormat($dateFormat, $dateAsString);


### PR DESCRIPTION
This change adds support for converting values that are received from serializing a DateTimeInterface object with `json_serialize`.
If the source array contains a property 'timezone_type' the source date string is assumed to be in the internal serialization format, which is "Y-m-d\TH:i:s.v" without timezone information, since the timezone is provided in the additional 'timezone' property.

Related to https://github.com/neos/Neos.EventSourcing/issues/181

TODO: Add tests