### PR TITLE
!!! BUGFIX: Allow actually reconfiguring the ThrowableStorage

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -25,6 +25,7 @@ use Neos\Flow\Core\ProxyClassLoader;
 use Neos\Flow\Error\Debugger;
 use Neos\Flow\Error\ErrorHandler;
 use Neos\Flow\Error\ProductionExceptionHandler;
+use Neos\Flow\Http\HttpRequestHandlerInterface;
 use Neos\Flow\Log\Logger;
 use Neos\Flow\Log\LoggerBackendConfigurationHelper;
 use Neos\Flow\Log\LoggerFactory;
@@ -241,8 +242,7 @@ class Scripts
         $configurationManager = $bootstrap->getEarlyInstance(ConfigurationManager::class);
         $settings = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.Flow');
 
-        $throwableStorage = new FileStorage();
-        $throwableStorage->injectStoragePath(FLOW_PATH_DATA . 'Logs/Exceptions');
+        $throwableStorage = self::initializeExceptionStorage($bootstrap);
         $bootstrap->setEarlyInstance(ThrowableStorageInterface::class, $throwableStorage);
 
         /** @var PsrLoggerFactoryInterface $psrLoggerFactoryName */
@@ -255,7 +255,7 @@ class Scripts
         $psrLogFactory = $psrLoggerFactoryName::create($psrLogConfigurations);
 
         // This is all deprecated and can be removed with the removal of respective interfaces and classes.
-        $loggerFactory = new LoggerFactory($psrLogFactory);
+        $loggerFactory = new LoggerFactory($psrLogFactory, $throwableStorage);
         $bootstrap->setEarlyInstance($psrLoggerFactoryName, $psrLogFactory);
         $bootstrap->setEarlyInstance(PsrLoggerFactoryInterface::class, $psrLogFactory);
         $bootstrap->setEarlyInstance(LoggerFactory::class, $loggerFactory);
@@ -264,6 +264,62 @@ class Scripts
         $deprecatedLoggerBackendOptions = $settings['log']['systemLogger']['backendOptions'] ?? [];
         $systemLogger = $loggerFactory->create('SystemLogger', $deprecatedLogger, $deprecatedLoggerBackend, $deprecatedLoggerBackendOptions);
         $bootstrap->setEarlyInstance(SystemLoggerInterface::class, $systemLogger);
+    }
+
+    /**
+     * Initialize the exception storage
+     *
+     * @param Bootstrap $bootstrap
+     * @return ThrowableStorageInterface
+     * @throws FlowException
+     * @throws \Neos\Flow\Configuration\Exception\InvalidConfigurationTypeException
+     */
+    protected static function initializeExceptionStorage(Bootstrap $bootstrap)
+    {
+        $configurationManager = $bootstrap->getEarlyInstance(ConfigurationManager::class);
+        $settings = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.Flow');
+
+        $storageClasName = $settings['log']['throwables']['storageClass'] ?? FileStorage::class;
+        $storageOptions = $settings['log']['throwables']['optionsByImplementation'][$storageClasName] ?? [];
+
+
+        if (!in_array(ThrowableStorageInterface::class, class_implements($storageClasName, true))) {
+            throw new \Exception(
+                sprintf('The clas "%s" configured as throwable storage does not implement the ThrowableStorageInterface', $storageClasName),
+                1540583485
+            );
+        }
+
+        /** @var ThrowableStorageInterface $throwableStorage */
+        $throwableStorage = $storageClasName::createWithOptions($storageOptions);
+
+        $throwableStorage->setBacktraceRenderer(function ($backtrace) {
+            return Debugger::getBacktraceCode($backtrace, false, true);
+        });
+
+        $throwableStorage->setRequestInformationRenderer(function () {
+            $output = '';
+            if (!(Bootstrap::$staticObjectManager instanceof ObjectManagerInterface)) {
+                return $output;
+            }
+
+            $bootstrap = Bootstrap::$staticObjectManager->get(Bootstrap::class);
+            /* @var Bootstrap $bootstrap */
+            $requestHandler = $bootstrap->getActiveRequestHandler();
+            if (!$requestHandler instanceof HttpRequestHandlerInterface) {
+                return $output;
+            }
+
+            $request = $requestHandler->getHttpRequest();
+            $response = $requestHandler->getHttpResponse();
+            $output .= PHP_EOL . 'HTTP REQUEST:' . PHP_EOL . ($request == '' ? '[request was empty]' : $request) . PHP_EOL;
+            $output .= PHP_EOL . 'HTTP RESPONSE:' . PHP_EOL . ($response == '' ? '[response was empty]' : $response) . PHP_EOL;
+            $output .= PHP_EOL . 'PHP PROCESS:' . PHP_EOL . 'Inode: ' . getmyinode() . PHP_EOL . 'PID: ' . getmypid() . PHP_EOL . 'UID: ' . getmyuid() . PHP_EOL . 'GID: ' . getmygid() . PHP_EOL . 'User: ' . get_current_user() . PHP_EOL;
+
+            return $output;
+        });
+
+        return $throwableStorage;
     }
 
     /**

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -279,19 +279,19 @@ class Scripts
         $configurationManager = $bootstrap->getEarlyInstance(ConfigurationManager::class);
         $settings = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.Flow');
 
-        $storageClasName = $settings['log']['throwables']['storageClass'] ?? FileStorage::class;
-        $storageOptions = $settings['log']['throwables']['optionsByImplementation'][$storageClasName] ?? [];
+        $storageClassName = $settings['log']['throwables']['storageClass'] ?? FileStorage::class;
+        $storageOptions = $settings['log']['throwables']['optionsByImplementation'][$storageClassName] ?? [];
 
 
-        if (!in_array(ThrowableStorageInterface::class, class_implements($storageClasName, true))) {
+        if (!in_array(ThrowableStorageInterface::class, class_implements($storageClassName, true))) {
             throw new \Exception(
-                sprintf('The clas "%s" configured as throwable storage does not implement the ThrowableStorageInterface', $storageClasName),
+                sprintf('The class "%s" configured as throwable storage does not implement the ThrowableStorageInterface', $storageClassName),
                 1540583485
             );
         }
 
         /** @var ThrowableStorageInterface $throwableStorage */
-        $throwableStorage = $storageClasName::createWithOptions($storageOptions);
+        $throwableStorage = $storageClassName::createWithOptions($storageOptions);
 
         $throwableStorage->setBacktraceRenderer(function ($backtrace) {
             return Debugger::getBacktraceCode($backtrace, false, true);

--- a/Neos.Flow/Classes/Log/LoggerFactory.php
+++ b/Neos.Flow/Classes/Log/LoggerFactory.php
@@ -23,6 +23,7 @@ use Neos\Flow\ObjectManagement\ObjectManagerInterface;
  *
  * @api
  * @Flow\Scope("singleton")
+ * @Flow\Autowiring(false)
  */
 class LoggerFactory
 {
@@ -30,6 +31,11 @@ class LoggerFactory
      * @var PsrLoggerFactoryInterface
      */
     protected $psrLoggerFactory;
+
+    /**
+     * @var ThrowableStorageInterface
+     */
+    protected $throwableStorage;
 
     /**
      * @var array
@@ -45,10 +51,12 @@ class LoggerFactory
      * LoggerFactory constructor.
      *
      * @param PsrLoggerFactoryInterface $psrLoggerFactory
+     * @param ThrowableStorageInterface $throwableStorage
      */
-    public function __construct(PsrLoggerFactoryInterface $psrLoggerFactory)
+    public function __construct(PsrLoggerFactoryInterface $psrLoggerFactory, ThrowableStorageInterface $throwableStorage)
     {
         $this->psrLoggerFactory = $psrLoggerFactory;
+        $this->throwableStorage = $throwableStorage;
         $this->requestInfoCallback = function () {
             $output = '';
             if (!(Bootstrap::$staticObjectManager instanceof ObjectManagerInterface)) {
@@ -144,27 +152,9 @@ class LoggerFactory
     protected function injectAdditionalDependencies(LoggerInterface $logger): LoggerInterface
     {
         if ($logger instanceof Logger) {
-            $logger->injectThrowableStorage($this->instantiateThrowableStorage());
+            $logger->injectThrowableStorage($this->throwableStorage);
         }
 
         return $logger;
-    }
-
-    /**
-     * @return FileStorage|ThrowableStorageInterface
-     */
-    protected function instantiateThrowableStorage(): ThrowableStorageInterface
-    {
-        // Fallback early throwable storage
-        $throwableStorage = new FileStorage();
-        $throwableStorage->injectStoragePath(FLOW_PATH_DATA . 'Logs/Exceptions');
-        if (Bootstrap::$staticObjectManager instanceof ObjectManagerInterface) {
-            $throwableStorage = Bootstrap::$staticObjectManager->get(ThrowableStorageInterface::class);
-        }
-        $throwableStorage->setBacktraceRenderer(function ($backtrace) {
-            return Debugger::getBacktraceCode($backtrace, false, true);
-        });
-        $throwableStorage->setRequestInformationRenderer($this->requestInfoCallback);
-        return $throwableStorage;
     }
 }

--- a/Neos.Flow/Classes/Log/ThrowableStorage/FileStorage.php
+++ b/Neos.Flow/Classes/Log/ThrowableStorage/FileStorage.php
@@ -1,20 +1,23 @@
 <?php
 namespace Neos\Flow\Log\ThrowableStorage;
 
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\Error\Debugger;
+use Neos\Flow\Http\HttpRequestHandlerInterface;
 use Neos\Flow\Log\PlainTextFormatter;
 use Neos\Flow\Log\ThrowableStorageInterface;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Utility\Files;
 
 /**
  * Stores detailed information about throwables into files.
+ *
+ * @Flow\Proxy(false)
+ * @Flow\Autowiring(false)
  */
 class FileStorage implements ThrowableStorageInterface
 {
-    /**
-     * @var string
-     */
-    protected $storagePath;
-
     /**
      * @var \Closure
      */
@@ -26,13 +29,59 @@ class FileStorage implements ThrowableStorageInterface
     protected $backtraceRenderer;
 
     /**
-     * FileStorage path.
+     * @var string
+     */
+    protected $storagePath;
+
+    /**
+     * Factory method to get an instance.
+     *
+     * @param array $options
+     * @return ThrowableStorageInterface
+     */
+    public static function createWithOptions(array $options): ThrowableStorageInterface
+    {
+        $storagePath = $options['storagePath'] ?? (FLOW_PATH_DATA . 'Logs/Exceptions');
+        $storage = new static($storagePath);
+
+        return $storage;
+    }
+
+    /**
+     * Create new instance.
      *
      * @param string $storagePath
+     * @see createWithOptions
      */
-    public function injectStoragePath(string $storagePath)
+    public function __construct(string $storagePath)
     {
         $this->storagePath = $storagePath;
+
+        $this->requestInformationRenderer = function () {
+            $output = '';
+            if (!(Bootstrap::$staticObjectManager instanceof ObjectManagerInterface)) {
+                return $output;
+            }
+
+            $bootstrap = Bootstrap::$staticObjectManager->get(Bootstrap::class);
+            /* @var Bootstrap $bootstrap */
+            $requestHandler = $bootstrap->getActiveRequestHandler();
+            if (!$requestHandler instanceof HttpRequestHandlerInterface) {
+                return $output;
+            }
+
+            $request = $requestHandler->getHttpRequest();
+            $response = $requestHandler->getHttpResponse();
+            $output .= PHP_EOL . 'HTTP REQUEST:' . PHP_EOL . ($request == '' ? '[request was empty]' : $request) . PHP_EOL;
+            $output .= PHP_EOL . 'HTTP RESPONSE:' . PHP_EOL . ($response == '' ? '[response was empty]' : $response) . PHP_EOL;
+            $output .= PHP_EOL . 'PHP PROCESS:' . PHP_EOL . 'Inode: ' . getmyinode() . PHP_EOL . 'PID: ' . getmypid() . PHP_EOL . 'UID: ' . getmyuid() . PHP_EOL . 'GID: ' . getmygid() . PHP_EOL . 'User: ' . get_current_user() . PHP_EOL;
+
+            return $output;
+        };
+
+        $this->backtraceRenderer = function ($backtrace) {
+            return Debugger::getBacktraceCode($backtrace, false, true);
+        };
     }
 
     /**
@@ -42,6 +91,7 @@ class FileStorage implements ThrowableStorageInterface
     public function setRequestInformationRenderer(\Closure $requestInformationRenderer)
     {
         $this->requestInformationRenderer = $requestInformationRenderer;
+
         return $this;
     }
 
@@ -52,6 +102,7 @@ class FileStorage implements ThrowableStorageInterface
     public function setBacktraceRenderer(\Closure $backtraceRenderer)
     {
         $this->backtraceRenderer = $backtraceRenderer;
+
         return $this;
     }
 
@@ -62,22 +113,10 @@ class FileStorage implements ThrowableStorageInterface
      */
     public function logThrowable(\Throwable $throwable, array $additionalData = [])
     {
-        return $this->logError($throwable, $additionalData);
-    }
+        $message = $this->getErrorLogMessage($throwable);
 
-    /**
-     * Writes information about the given exception into the log.
-     *
-     * @param \Throwable $error \Exception or \Throwable
-     * @param array $additionalData Additional data to log
-     * @return string The exception message
-     */
-    protected function logError(\Throwable $error, array $additionalData = [])
-    {
-        $message = $this->getErrorLogMessage($error);
-
-        if ($error->getPrevious() !== null) {
-            $additionalData['previousException'] = $this->getErrorLogMessage($error->getPrevious());
+        if ($throwable->getPrevious() !== null) {
+            $additionalData['previousException'] = $this->getErrorLogMessage($throwable->getPrevious());
         }
 
         if (!file_exists($this->storagePath)) {
@@ -88,10 +127,13 @@ class FileStorage implements ThrowableStorageInterface
         }
 
         // FIXME: getReferenceCode should probably become an interface.
-        $referenceCode = (is_callable([$error, 'getReferenceCode']) ? $error->getReferenceCode() : $this->generateUniqueReferenceCode());
-        $errorDumpPathAndFilename = Files::concatenatePaths([$this->storagePath, $referenceCode . '.txt']);
-        file_put_contents($errorDumpPathAndFilename, $this->renderErrorInfo($error, $additionalData));
-        $message .= ' - See also: ' . basename($errorDumpPathAndFilename);
+        $referenceCode = (is_callable([
+            $throwable,
+            'getReferenceCode'
+        ]) ? $throwable->getReferenceCode() : $this->generateUniqueReferenceCode());
+        $throwableDumpPathAndFilename = Files::concatenatePaths([$this->storagePath, $referenceCode . '.txt']);
+        file_put_contents($throwableDumpPathAndFilename, $this->renderErrorInfo($throwable, $additionalData));
+        $message .= ' - See also: ' . basename($throwableDumpPathAndFilename);
 
         return $message;
     }
@@ -134,7 +176,7 @@ class FileStorage implements ThrowableStorageInterface
 
         $postMortemInfo .= PHP_EOL . $this->renderRequestInfo();
         $postMortemInfo .= PHP_EOL;
-        $postMortemInfo .= (new PlainTextFormatter($additionalData))->format();
+        $postMortemInfo .= empty($additionalData) ? '' : (new PlainTextFormatter($additionalData))->format();
 
         return $postMortemInfo;
     }

--- a/Neos.Flow/Classes/Log/ThrowableStorageInterface.php
+++ b/Neos.Flow/Classes/Log/ThrowableStorageInterface.php
@@ -8,6 +8,17 @@ namespace Neos\Flow\Log;
  */
 interface ThrowableStorageInterface
 {
+    /** TODO: Factory method to create an instance, should officially become part of the interface in next major.
+     *
+     * A factory method to create an instance of the throwable storage.
+     * Note that throwable storages must work without proxy so all dependencies need to be resolved manually or via options.
+     *
+     * @param array $options
+     * @return ThrowableStorageInterface
+     */
+//    public static function createWithOptions(array $options): ThrowableStorageInterface;
+
+
     /**
      * Writes information about the given exception into the log.
      *

--- a/Neos.Flow/Configuration/Objects.yaml
+++ b/Neos.Flow/Configuration/Objects.yaml
@@ -163,12 +163,8 @@ Neos\Flow\Log\SecurityLoggerInterface:
 
 Neos\Flow\Log\ThrowableStorageInterface:
   scope: singleton
+  # Note that this is a "fake" entry and doesn't get used. Please change the setting Neos.Flow.log.throwables.storageClass
   className: Neos\Flow\Log\ThrowableStorage\FileStorage
-
-Neos\Flow\Log\ThrowableStorage\FileStorage:
-  properties:
-    storagePath:
-      setting: Neos.Flow.log.throwables.fileStorage.path
 
 Neos\Flow\Log\PsrLoggerFactory:
   scope: singleton

--- a/Neos.Flow/Configuration/Settings.Log.yaml
+++ b/Neos.Flow/Configuration/Settings.Log.yaml
@@ -48,5 +48,7 @@ Neos:
           logFilesToKeep: 1
 
       throwables:
-        fileStorage:
-          path: '%FLOW_PATH_DATA%Logs/Exceptions'
+        storageClass: Neos\Flow\Log\ThrowableStorage\FileStorage
+        optionsByImplementation:
+          'Neos\Flow\Log\ThrowableStorage\FileStorage':
+            storagePath: '%FLOW_PATH_DATA%Logs/Exceptions'


### PR DESCRIPTION
This fixes the instantiation and configuration of ThrowableStorage
implementations and also fixes stack traces and HTTP request information
in stored throwables.

This change is not breaking but as pre notice that in the next major the
`ThrowableStorageInterface` will have an additional method that is currently
commented and already used to instantiate throwable storages.
If you implement the interface you must already implement that additional 
method despite it being not part of the interface. As the object configuration
for throwable storage doesn't work without this change there cannot be a
working alternative implementation yet, so this shouldn't break any project.