### PR TITLE
TASK: Generate doctrine migrations with new abstractclass

### DIFF
--- a/Neos.Flow/Classes/Command/DoctrineCommandController.php
+++ b/Neos.Flow/Classes/Command/DoctrineCommandController.php
@@ -104,6 +104,7 @@ class DoctrineCommandController extends CommandController
      *
      * @return void
      * @see neos.flow:doctrine:entitystatus
+     * @throws StopActionException
      */
     public function validateCommand()
     {
@@ -135,6 +136,7 @@ class DoctrineCommandController extends CommandController
      * @return void
      * @see neos.flow:doctrine:update
      * @see neos.flow:doctrine:migrate
+     * @throws StopActionException
      */
     public function createCommand(string $output = null)
     {
@@ -163,6 +165,7 @@ class DoctrineCommandController extends CommandController
      * @return void
      * @see neos.flow:doctrine:create
      * @see neos.flow:doctrine:migrate
+     * @throws StopActionException
      */
     public function updateCommand(bool $unsafeMode = false, string $output = null)
     {
@@ -246,6 +249,7 @@ class DoctrineCommandController extends CommandController
      * @param integer $limit Limit the result to this number
      * @return void
      * @throws \InvalidArgumentException
+     * @throws StopActionException
      */
     public function dqlCommand(int $depth = 3, string $hydrationMode = 'array', int $offset = null, int $limit = null)
     {
@@ -279,6 +283,7 @@ class DoctrineCommandController extends CommandController
      * @see neos.flow:doctrine:migrationexecute
      * @see neos.flow:doctrine:migrationgenerate
      * @see neos.flow:doctrine:migrationversion
+     * @throws StopActionException
      */
     public function migrationStatusCommand(bool $showMigrations = false, bool $showDescriptions = false)
     {
@@ -309,6 +314,7 @@ class DoctrineCommandController extends CommandController
      * @see neos.flow:doctrine:migrationexecute
      * @see neos.flow:doctrine:migrationgenerate
      * @see neos.flow:doctrine:migrationversion
+     * @throws StopActionException
      */
     public function migrateCommand(string $version = null, string $output = null, bool $dryRun = false, bool $quiet = false)
     {
@@ -359,6 +365,7 @@ class DoctrineCommandController extends CommandController
      * @see neos.flow:doctrine:migrationstatus
      * @see neos.flow:doctrine:migrationgenerate
      * @see neos.flow:doctrine:migrationversion
+     * @throws StopActionException
      */
     public function migrationExecuteCommand(string $version, string $direction = 'up', string $output = null, bool $dryRun = false)
     {
@@ -385,6 +392,7 @@ class DoctrineCommandController extends CommandController
      * @param boolean $delete The migration to mark as not migrated
      * @return void
      * @throws \InvalidArgumentException
+     * @throws StopActionException
      * @see neos.flow:doctrine:migrate
      * @see neos.flow:doctrine:migrationstatus
      * @see neos.flow:doctrine:migrationexecute
@@ -431,6 +439,8 @@ class DoctrineCommandController extends CommandController
      * @param string $filterExpression Only include tables/sequences matching the filter expression regexp
      * @param boolean $force Generate migrations even if there are migrations left to execute
      * @return void
+     * @throws StopActionException
+     * @throws \Neos\Utility\Exception\FilesException
      * @see neos.flow:doctrine:migrate
      * @see neos.flow:doctrine:migrationstatus
      * @see neos.flow:doctrine:migrationexecute

--- a/Neos.Flow/Classes/Persistence/Doctrine/Service.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Service.php
@@ -606,7 +606,7 @@ class Service
 <?php
 namespace $namespace;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
 /**

--- a/Neos.Flow/Classes/Persistence/Doctrine/Service.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Service.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Persistence\Doctrine;
  * source code.
  */
 
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\Migration;
 use Doctrine\DBAL\Migrations\MigrationException;
@@ -23,9 +24,11 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\ORM\Tools\SchemaValidator;
+use Doctrine\ORM\Tools\ToolsException;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Package\PackageInterface;
 use Neos\Flow\Reflection\DocCommentParser;
+use Neos\Utility\Exception\FilesException;
 use Neos\Utility\ObjectAccess;
 use Neos\Flow\Utility\Exception;
 use Neos\Utility\Files;
@@ -84,6 +87,7 @@ class Service
      *
      * @param string $outputPathAndFilename A file to write SQL to, instead of executing it
      * @return string
+     * @throws ToolsException
      */
     public function createSchema($outputPathAndFilename = null)
     {
@@ -121,6 +125,7 @@ class Service
      * Compiles the Doctrine proxy class code using the Doctrine ProxyFactory.
      *
      * @return void
+     * @throws FilesException
      */
     public function compileProxies()
     {
@@ -135,6 +140,7 @@ class Service
      * mapping information contains errors or not.
      *
      * @return array
+     * @throws \Doctrine\ORM\ORMException
      */
     public function getEntityStatus()
     {
@@ -178,6 +184,7 @@ class Service
      * Return the configuration needed for Migrations.
      *
      * @return Configuration
+     * @throws DBALException
      */
     protected function getMigrationConfiguration()
     {
@@ -223,6 +230,7 @@ class Service
      * Returns the current migration status as an array.
      *
      * @return array
+     * @throws DBALException
      */
     public function getMigrationStatus()
     {
@@ -261,6 +269,8 @@ class Service
      * @param boolean $showMigrations
      * @param boolean $showDescriptions
      * @return string
+     * @throws \ReflectionException
+     * @throws DBALException
      */
     public function getFormattedMigrationStatus($showMigrations = false, $showDescriptions = false)
     {
@@ -325,6 +335,7 @@ class Service
      *
      * @param Version $version
      * @return string
+     * @throws \ReflectionException
      */
     protected function getPackageKeyFromMigrationVersion(Version $version)
     {
@@ -382,6 +393,7 @@ class Service
      * @param Version $version
      * @param DocCommentParser $parser
      * @return string
+     * @throws \ReflectionException
      */
     protected function getMigrationDescription(Version $version, DocCommentParser $parser)
     {
@@ -404,6 +416,8 @@ class Service
      * @param boolean $dryRun Whether to do a dry run or not
      * @param boolean $quiet Whether to do a quiet run or not
      * @return string
+     * @throws MigrationException
+     * @throws DBALException
      */
     public function executeMigrations($version = null, $outputPathAndFilename = null, $dryRun = false, $quiet = false)
     {
@@ -439,6 +453,8 @@ class Service
      * @param string $outputPathAndFilename A file to write SQL to, instead of executing it
      * @param boolean $dryRun Whether to do a dry run or not
      * @return string
+     * @throws MigrationException
+     * @throws DBALException
      */
     public function executeMigration($version, $direction = 'up', $outputPathAndFilename = null, $dryRun = false)
     {
@@ -463,6 +479,7 @@ class Service
      * @return void
      * @throws MigrationException
      * @throws \LogicException
+     * @throws DBALException
      */
     public function markAsMigrated($version, $markAsMigrated)
     {
@@ -510,7 +527,10 @@ class Service
      *
      * @param boolean $diffAgainstCurrent
      * @param string $filterExpression
-     * @return string Path to the new file
+     * @return array Path to the new file
+     * @throws DBALException
+     * @throws \Doctrine\ORM\ORMException
+     * @throws FilesException
      */
     public function generateMigration($diffAgainstCurrent = true, $filterExpression = null)
     {
@@ -574,7 +594,7 @@ class Service
      * @param string $name
      * @return string
      */
-    private function resolveTableName($name)
+    private function resolveTableName(string $name): string
     {
         $pos = strpos($name, '.');
 
@@ -587,8 +607,9 @@ class Service
      * @param string $down
      * @return string
      * @throws \RuntimeException
+     * @throws FilesException
      */
-    protected function writeMigrationClassToFile(Configuration $configuration, $up, $down)
+    protected function writeMigrationClassToFile(Configuration $configuration, ?string $up, ?string $down): string
     {
         $namespace = $configuration->getMigrationsNamespace();
         $className = 'Version' . date('YmdHis');
@@ -654,8 +675,9 @@ EOT;
      * @param Configuration $configuration
      * @param array $sql
      * @return string
+     * @throws DBALException
      */
-    protected function buildCodeFromSql(Configuration $configuration, array $sql)
+    protected function buildCodeFromSql(Configuration $configuration, array $sql): string
     {
         $currentPlatform = $configuration->getConnection()->getDatabasePlatform()->getName();
         $code = [];
@@ -685,6 +707,7 @@ EOT;
      * Get name of current database platform
      *
      * @return string
+     * @throws DBALException
      */
     public function getDatabasePlatformName()
     {


### PR DESCRIPTION
The abstract doctrine migration class changed, the generated classes
used the deprecated abstract class.

Actual change in: https://github.com/neos/flow-development-collection/commit/572d63a38198d35ef68a9e6e0a2473e55bd5006d

Code cleanup in: https://github.com/neos/flow-development-collection/commit/32420b7fe34d1801178f4e7a2722842b040b50bf