### PR TITLE
BUGFIX: Avoid "wrong" error if Redis is unavailable

### DIFF
--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -498,9 +498,17 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
             $this->port = null;
         }
         $redis = new \Redis();
-        if (!$redis->connect($this->hostname, $this->port)) {
-            throw new CacheException('Could not connect to Redis.', 1391972021);
+
+        try {
+            $connected = false;
+            // keep the above! the line below leave the variable undefined if an error occurs.
+            $connected = $redis->connect($this->hostname, $this->port);
+        } finally {
+            if ($connected === false) {
+                throw new CacheException('Could not connect to Redis.', 1391972021);
+            }
         }
+
         if ($this->password !== '') {
             if (!$redis->auth($this->password)) {
                 throw new CacheException('Redis authentication failed.', 1502366200);


### PR DESCRIPTION
At least when running unit tests for the `MultiBackend` the `connect()`
call raises an error that circumvents exception handling and breaks
correct execution.
