### PR TITLE
!!! TASK: Deprecate PackageManagerInterface

### DIFF
--- a/Neos.Flow/Classes/Cli/RequestBuilder.php
+++ b/Neos.Flow/Classes/Cli/RequestBuilder.php
@@ -17,7 +17,7 @@ use Neos\Flow\Mvc\Exception\CommandException;
 use Neos\Flow\Mvc\Exception\InvalidArgumentMixingException;
 use Neos\Flow\Mvc\Exception\InvalidArgumentNameException;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Utility\Environment;
 
 /**
@@ -56,7 +56,7 @@ class RequestBuilder
     protected $objectManager;
 
     /**
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 
@@ -84,10 +84,10 @@ class RequestBuilder
     }
 
     /**
-     * @param PackageManagerInterface $packageManager
+     * @param PackageManager $packageManager
      * @return void
      */
-    public function injectPackageManager(PackageManagerInterface $packageManager)
+    public function injectPackageManager(PackageManager $packageManager)
     {
         $this->packageManager = $packageManager;
     }

--- a/Neos.Flow/Classes/Command/CacheCommandController.php
+++ b/Neos.Flow/Classes/Command/CacheCommandController.php
@@ -27,7 +27,7 @@ use Neos\Flow\Core\LockManager;
 use Neos\Flow\Mvc\Exception\StopActionException;
 use Neos\Flow\ObjectManagement\ObjectManager;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Utility\Environment;
 use Neos\Utility\TypeHandling;
 
@@ -51,7 +51,7 @@ class CacheCommandController extends CommandController
     protected $lockManager;
 
     /**
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 
@@ -89,10 +89,10 @@ class CacheCommandController extends CommandController
     }
 
     /**
-     * @param PackageManagerInterface $packageManager
+     * @param PackageManager $packageManager
      * @return void
      */
-    public function injectPackageManager(PackageManagerInterface $packageManager)
+    public function injectPackageManager(PackageManager $packageManager)
     {
         $this->packageManager =  $packageManager;
     }

--- a/Neos.Flow/Classes/Command/DoctrineCommandController.php
+++ b/Neos.Flow/Classes/Command/DoctrineCommandController.php
@@ -21,7 +21,7 @@ use Neos\Flow\Log\ThrowableStorageInterface;
 use Neos\Flow\Log\Utility\LogEnvironment;
 use Neos\Flow\Mvc\Exception\StopActionException;
 use Neos\Flow\Package;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Persistence\Doctrine\Service as DoctrineService;
 use Neos\Utility\Files;
 use Psr\Log\LoggerInterface;
@@ -46,7 +46,7 @@ class DoctrineCommandController extends CommandController
 
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Neos.Flow/Classes/Command/HelpCommandController.php
+++ b/Neos.Flow/Classes/Command/HelpCommandController.php
@@ -18,7 +18,7 @@ use Neos\Flow\Cli\CommandController;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Mvc\Exception\AmbiguousCommandIdentifierException;
 use Neos\Flow\Mvc\Exception\CommandException;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 
 /**
  * A Command Controller which provides help for available commands
@@ -29,7 +29,7 @@ class HelpCommandController extends CommandController
 {
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Neos.Flow/Classes/Command/ResourceCommandController.php
+++ b/Neos.Flow/Classes/Command/ResourceCommandController.php
@@ -16,7 +16,7 @@ use Neos\Flow\Cli\CommandController;
 use Neos\Error\Messages\Message;
 use Neos\Flow\Exception;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\ResourceManagement\CollectionInterface;
 use Neos\Flow\ResourceManagement\Publishing\MessageCollector;
@@ -54,7 +54,7 @@ class ResourceCommandController extends CommandController
 
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Neos.Flow/Classes/Command/SchemaCommandController.php
+++ b/Neos.Flow/Classes/Command/SchemaCommandController.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Command;
 
 use Neos\Error\Messages\Result;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Cli\CommandController;
 use Neos\Error\Messages\Error;
 use Neos\Error\Messages\Notice;
@@ -37,7 +37,7 @@ class SchemaCommandController extends CommandController
 
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -38,7 +38,6 @@ use Neos\Flow\ObjectManagement\CompileTimeObjectManager;
 use Neos\Flow\ObjectManagement\ObjectManager;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Package\FlowPackageInterface;
-use Neos\Flow\Package\Package;
 use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Package\PackageManagerInterface;
 use Neos\Flow\Reflection\ReflectionService;

--- a/Neos.Flow/Classes/Http/RequestHandler.php
+++ b/Neos.Flow/Classes/Http/RequestHandler.php
@@ -17,7 +17,7 @@ use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Http\Component\ComponentChain;
 use Neos\Flow\Http\Component\ComponentContext;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -228,7 +228,7 @@ class RequestHandler implements HttpRequestHandlerInterface
             return 'Flow' . ($applicationIsNotFlow ? ' ' . $applicationName : '');
         }
 
-        $packageManager = $objectManager->get(PackageManagerInterface::class);
+        $packageManager = $objectManager->get(PackageManager::class);
         $flowPackage = $packageManager->getPackage('Neos.Flow');
         $applicationPackage = $applicationIsNotFlow ? $packageManager->getPackage($applicationPackageKey) : null;
 

--- a/Neos.Flow/Classes/Log/Utility/LogEnvironment.php
+++ b/Neos.Flow/Classes/Log/Utility/LogEnvironment.php
@@ -16,7 +16,6 @@ use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Package\PackageInterface;
 use Neos\Flow\Package\PackageKeyAwareInterface;
 use Neos\Flow\Package\PackageManager;
-use Neos\Flow\Package\PackageManagerInterface;
 use Neos\Flow\Annotations as Flow;
 
 abstract class LogEnvironment
@@ -84,7 +83,7 @@ abstract class LogEnvironment
                 return [];
             }
 
-            /** @var PackageManagerInterface $packageManager */
+            /** @var PackageManager $packageManager */
             $packageManager = Bootstrap::$staticObjectManager->get(PackageManager::class);
 
             /** @var PackageInterface $package */

--- a/Neos.Flow/Classes/Mvc/ActionRequest.php
+++ b/Neos.Flow/Classes/Mvc/ActionRequest.php
@@ -15,7 +15,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\Request as HttpRequest;
 use Neos\Flow\ObjectManagement\Exception\UnknownObjectException;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Security\Cryptography\HashService;
 use Neos\Flow\SignalSlot\Dispatcher as SignalSlotDispatcher;
 use Neos\Utility\Arrays;
@@ -41,7 +41,7 @@ class ActionRequest implements RequestInterface
 
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -72,7 +72,7 @@ class Package extends BasePackage
                 if ($step->getIdentifier() === 'neos.flow:resources') {
                     $publicResourcesFileMonitor = Monitor\FileMonitor::createFileMonitorAtBoot('Flow_PublicResourcesFiles', $bootstrap);
                     /** @var PackageManager $packageManager */
-                    $packageManager = $bootstrap->getEarlyInstance(Package\PackageManagerInterface::class);
+                    $packageManager = $bootstrap->getEarlyInstance(Package\PackageManager::class);
                     foreach ($packageManager->getFlowPackages() as $packageKey => $package) {
                         if ($packageManager->isPackageFrozen($packageKey)) {
                             continue;

--- a/Neos.Flow/Classes/Package/PackageManagerInterface.php
+++ b/Neos.Flow/Classes/Package/PackageManagerInterface.php
@@ -16,6 +16,8 @@ use Neos\Flow\Core\Bootstrap;
  * Interface for the Flow Package Manager
  *
  * @api
+ * @deprecated Directly use the PackageManager
+ * @see PackageManager
  */
 interface PackageManagerInterface
 {

--- a/Neos.Flow/Classes/Persistence/Doctrine/Service.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Service.php
@@ -27,6 +27,7 @@ use Doctrine\ORM\Tools\SchemaValidator;
 use Doctrine\ORM\Tools\ToolsException;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Package\PackageInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Reflection\DocCommentParser;
 use Neos\Utility\Exception\FilesException;
 use Neos\Utility\ObjectAccess;
@@ -55,7 +56,7 @@ class Service
 
     /**
      * @Flow\Inject
-     * @var \Neos\Flow\Package\PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -21,7 +21,7 @@ use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Core\ApplicationContext;
 use Neos\Flow\ObjectManagement\Proxy\ProxyInterface;
 use Neos\Flow\Package;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Persistence\RepositoryInterface;
 use Neos\Flow\Reflection\Exception\ClassSchemaConstraintViolationException;
 use Neos\Flow\Reflection\Exception\InvalidPropertyTypeException;
@@ -136,7 +136,7 @@ class ReflectionService
     protected $logger;
 
     /**
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 
@@ -297,10 +297,10 @@ class ReflectionService
     }
 
     /**
-     * @param PackageManagerInterface $packageManager
+     * @param PackageManager $packageManager
      * @return void
      */
-    public function injectPackageManager(PackageManagerInterface $packageManager)
+    public function injectPackageManager(PackageManager $packageManager)
     {
         $this->packageManager = $packageManager;
     }

--- a/Neos.Flow/Classes/Reflection/ReflectionServiceFactory.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionServiceFactory.php
@@ -16,7 +16,7 @@ use Neos\Flow\Cache\CacheManager;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Log\PsrLoggerFactoryInterface;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Utility\Environment;
 
 /**
@@ -64,7 +64,7 @@ class ReflectionServiceFactory
         $reflectionService = new ReflectionService();
         $reflectionService->injectLogger($this->bootstrap->getEarlyInstance(PsrLoggerFactoryInterface::class)->get('systemLogger'));
         $reflectionService->injectSettings($settings);
-        $reflectionService->injectPackageManager($this->bootstrap->getEarlyInstance(PackageManagerInterface::class));
+        $reflectionService->injectPackageManager($this->bootstrap->getEarlyInstance(PackageManager::class));
         $reflectionService->setStatusCache($cacheManager->getCache('Flow_Reflection_Status'));
         $reflectionService->setReflectionDataCompiletimeCache($cacheManager->getCache('Flow_Reflection_CompiletimeData'));
         $reflectionService->setReflectionDataRuntimeCache($cacheManager->getCache('Flow_Reflection_RuntimeData'));

--- a/Neos.Flow/Classes/ResourceManagement/Streams/ResourceStreamWrapper.php
+++ b/Neos.Flow/Classes/ResourceManagement/Streams/ResourceStreamWrapper.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\ResourceManagement\Streams;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\Uri;
 use Neos\Flow\Package\FlowPackageInterface;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\ResourceManagement\Exception as ResourceException;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Utility\Files;
@@ -47,7 +47,7 @@ class ResourceStreamWrapper implements StreamWrapperInterface
 
     /**
      * @Flow\Inject(lazy = false)
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Neos.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
+++ b/Neos.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
@@ -14,7 +14,6 @@ namespace Neos\Flow\Tests\Functional\Configuration;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Configuration\ConfigurationSchemaValidator;
-use Neos\Flow\Package\PackageManagerInterface;
 use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Core\ApplicationContext;
 use Neos\Error\Messages\Error;
@@ -79,7 +78,7 @@ class ConfigurationValidationTest extends FunctionalTestCase
         $configurationPackages = [];
 
         // get all packages and select the ones we want to test
-        $temporaryPackageManager = $this->objectManager->get(PackageManagerInterface::class);
+        $temporaryPackageManager = $this->objectManager->get(PackageManager::class);
         foreach ($temporaryPackageManager->getAvailablePackages() as $package) {
             if (in_array($package->getPackageKey(), $this->getSchemaPackageKeys())) {
                 $schemaPackages[$package->getPackageKey()] = $package;

--- a/Neos.Flow/Tests/Functional/Configuration/SchemaValidationTest.php
+++ b/Neos.Flow/Tests/Functional/Configuration/SchemaValidationTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Functional\Configuration;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Tests\FunctionalTestCase;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Utility\SchemaValidator;
 use Neos\Utility\Files;
 use Symfony\Component\Yaml\Yaml;
@@ -64,7 +64,7 @@ class SchemaValidationTest extends FunctionalTestCase
     {
         $bootstrap = Bootstrap::$staticObjectManager->get(Bootstrap::class);
         $objectManager = $bootstrap->getObjectManager();
-        $packageManager = $objectManager->get(PackageManagerInterface::class);
+        $packageManager = $objectManager->get(PackageManager::class);
 
         $activePackages = $packageManager->getAvailablePackages();
         foreach ($activePackages as $package) {

--- a/Neos.Flow/Tests/Functional/Mvc/ViewsConfiguration/ViewsConfigurationTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/ViewsConfiguration/ViewsConfigurationTest.php
@@ -10,8 +10,8 @@ namespace Neos\Flow\Tests\Functional\Mvc\ViewsConfiguration;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-use Neos\Flow\Package\PackageManagerInterface;
 
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Tests\FunctionalTestCase;
 
 /**
@@ -90,7 +90,7 @@ class ViewsConfigurationTest extends FunctionalTestCase
      */
     public function changeTemplatePathAndFilenameForWidget()
     {
-        if ($this->objectManager->get(PackageManagerInterface::class)->isPackageAvailable('Neos.FluidAdaptor') === false) {
+        if ($this->objectManager->get(PackageManager::class)->isPackageAvailable('Neos.FluidAdaptor') === false) {
             $this->markTestSkipped('No Fluid adaptor installed');
         }
 

--- a/Neos.Flow/Tests/Unit/Mvc/ActionRequestTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/ActionRequestTest.php
@@ -15,7 +15,6 @@ use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Http;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Package\PackageManager;
-use Neos\Flow\Package\PackageManagerInterface;
 use Neos\Flow\Security\Cryptography\HashService;
 use Neos\Flow\Security\Exception\InvalidHashException;
 use Neos\Flow\SignalSlot\Dispatcher;
@@ -285,8 +284,8 @@ class ActionRequestTest extends UnitTestCase
         $actionRequest = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->setMethods(['getControllerObjectName'])->getMock();
         $actionRequest->expects($this->once())->method('getControllerObjectName')->will($this->returnValue('Neos\MyPackage\Some\SubPackage\Controller\Foo\BarController'));
 
-        /** @var PackageManagerInterface|\PHPUnit_Framework_MockObject_MockObject $mockPackageManager */
-        $mockPackageManager = $this->createMock(PackageManagerInterface::class);
+        /** @var PackageManager|\PHPUnit_Framework_MockObject_MockObject $mockPackageManager */
+        $mockPackageManager = $this->createMock(PackageManager::class);
         $mockPackageManager->expects($this->any())->method('getCaseSensitivePackageKey')->with('neos.mypackage')->will($this->returnValue('Neos.MyPackage'));
         $this->inject($actionRequest, 'packageManager', $mockPackageManager);
 
@@ -304,8 +303,8 @@ class ActionRequestTest extends UnitTestCase
         $actionRequest = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->setMethods(['getControllerObjectName'])->getMock();
         $actionRequest->expects($this->any())->method('getControllerObjectName')->will($this->returnValue('Neos\MyPackage\Controller\Foo\BarController'));
 
-        /** @var PackageManagerInterface|\PHPUnit_Framework_MockObject_MockObject $mockPackageManager */
-        $mockPackageManager = $this->createMock(PackageManagerInterface::class);
+        /** @var PackageManager|\PHPUnit_Framework_MockObject_MockObject $mockPackageManager */
+        $mockPackageManager = $this->createMock(PackageManager::class);
         $mockPackageManager->expects($this->any())->method('getCaseSensitivePackageKey')->with('neos.mypackage')->will($this->returnValue('Neos.MyPackage'));
         $this->inject($actionRequest, 'packageManager', $mockPackageManager);
 
@@ -322,8 +321,8 @@ class ActionRequestTest extends UnitTestCase
         $actionRequest = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->setMethods(['getControllerObjectName'])->getMock();
         $actionRequest->expects($this->once())->method('getControllerObjectName')->will($this->returnValue(''));
 
-        /** @var PackageManagerInterface|\PHPUnit_Framework_MockObject_MockObject $mockPackageManager */
-        $mockPackageManager = $this->createMock(PackageManagerInterface::class);
+        /** @var PackageManager|\PHPUnit_Framework_MockObject_MockObject $mockPackageManager */
+        $mockPackageManager = $this->createMock(PackageManager::class);
         $mockPackageManager->expects($this->any())->method('getCaseSensitivePackageKey')->with('neos.mypackage')->will($this->returnValue(false));
         $this->inject($actionRequest, 'packageManager', $mockPackageManager);
 

--- a/Neos.Flow/Tests/Unit/ResourceManagement/Streams/ResourceStreamWrapperTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/Streams/ResourceStreamWrapperTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\ResourceManagement\Streams;
 
 use Neos\Flow\Package\FlowPackageInterface;
 use org\bovigo\vfs\vfsStream;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Flow\ResourceManagement\Streams\ResourceStreamWrapper;
@@ -30,7 +30,7 @@ class ResourceStreamWrapperTest extends UnitTestCase
     protected $resourceStreamWrapper;
 
     /**
-     * @var PackageManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var PackageManager|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $mockPackageManager;
 
@@ -45,7 +45,7 @@ class ResourceStreamWrapperTest extends UnitTestCase
 
         $this->resourceStreamWrapper = new ResourceStreamWrapper();
 
-        $this->mockPackageManager = $this->createMock(PackageManagerInterface::class);
+        $this->mockPackageManager = $this->createMock(PackageManager::class);
         $this->inject($this->resourceStreamWrapper, 'packageManager', $this->mockPackageManager);
 
         $this->mockResourceManager = $this->getMockBuilder(ResourceManager::class)->disableOriginalConstructor()->getMock();

--- a/Neos.FluidAdaptor/Classes/Core/ViewHelper/ViewHelperResolver.php
+++ b/Neos.FluidAdaptor/Classes/Core/ViewHelper/ViewHelperResolver.php
@@ -14,7 +14,7 @@ namespace Neos\FluidAdaptor\Core\ViewHelper;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Package\Package;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 
 /**
  * Class ViewHelperResolver
@@ -40,7 +40,7 @@ class ViewHelperResolver extends \TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperRes
 
     /**
      * @Flow\Inject
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Neos.FluidAdaptor/Classes/Package.php
+++ b/Neos.FluidAdaptor/Classes/Package.php
@@ -18,7 +18,6 @@ use Neos\Flow\Monitor\FileMonitor;
 use Neos\Flow\Package\FlowPackageInterface;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\Flow\Package\PackageManager;
-use Neos\Flow\Package\PackageManagerInterface;
 
 /**
  * The Fluid Package
@@ -46,11 +45,8 @@ class Package extends BasePackage
             $dispatcher->connect(Sequence::class, 'afterInvokeStep', function ($step) use ($bootstrap, $dispatcher) {
                 if ($step->getIdentifier() === 'neos.flow:systemfilemonitor') {
                     $templateFileMonitor = FileMonitor::createFileMonitorAtBoot('Fluid_TemplateFiles', $bootstrap);
-                    $packageManager = $bootstrap->getEarlyInstance(PackageManagerInterface::class);
-                    /**
-                     * @var PackageManager $packageKey
-                     * @var FlowPackageInterface $package
-                     */
+                    $packageManager = $bootstrap->getEarlyInstance(PackageManager::class);
+                    /** @var FlowPackageInterface $package */
                     foreach ($packageManager->getFlowPackages() as $packageKey => $package) {
                         if ($packageManager->isPackageFrozen($packageKey)) {
                             continue;

--- a/Neos.FluidAdaptor/Classes/View/TemplatePaths.php
+++ b/Neos.FluidAdaptor/Classes/View/TemplatePaths.php
@@ -12,7 +12,7 @@ namespace Neos\FluidAdaptor\View;
  */
 
 use Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException;
-use Neos\Flow\Package\PackageManagerInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Utility\ObjectAccess;
 use Neos\Utility\Files;
 
@@ -55,7 +55,7 @@ class TemplatePaths extends \TYPO3Fluid\Fluid\View\TemplatePaths
     protected $options = [];
 
     /**
-     * @var PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 
@@ -67,9 +67,9 @@ class TemplatePaths extends \TYPO3Fluid\Fluid\View\TemplatePaths
     }
 
     /**
-     * @param PackageManagerInterface $packageManager
+     * @param PackageManager $packageManager
      */
-    public function injectPackageManager(PackageManagerInterface $packageManager)
+    public function injectPackageManager(PackageManager $packageManager)
     {
         $this->packageManager = $packageManager;
     }

--- a/Neos.Kickstarter/Classes/Command/KickstartCommandController.php
+++ b/Neos.Kickstarter/Classes/Command/KickstartCommandController.php
@@ -13,6 +13,7 @@ namespace Neos\Kickstarter\Command;
 
 use Neos\Flow\Composer\ComposerUtility;
 use Neos\Flow\Package\PackageInterface;
+use Neos\Flow\Package\PackageManager;
 use Neos\Utility\Arrays;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
@@ -26,7 +27,7 @@ class KickstartCommandController extends CommandController
 {
     /**
      * @Flow\Inject
-     * @var \Neos\Flow\Package\PackageManagerInterface
+     * @var PackageManager
      */
     protected $packageManager;
 

--- a/Neos.Kickstarter/Classes/Service/GeneratorService.php
+++ b/Neos.Kickstarter/Classes/Service/GeneratorService.php
@@ -13,6 +13,7 @@ namespace Neos\Kickstarter\Service;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\I18n\Xliff\V12\XliffParser;
+use Neos\Flow\Package\PackageManager;
 use Neos\FluidAdaptor\View\StandaloneView;
 use Neos\Flow\Core\ClassLoader;
 use Neos\Flow\Package\PackageInterface;
@@ -32,7 +33,7 @@ class GeneratorService
     protected $objectManager;
 
     /**
-     * @var \Neos\Flow\Package\PackageManagerInterface
+     * @var PackageManager
      * @Flow\Inject
      */
     protected $packageManager;

--- a/Neos.Utility.Schema/Tests/Unit/SchemaValidatorTest.php
+++ b/Neos.Utility.Schema/Tests/Unit/SchemaValidatorTest.php
@@ -11,7 +11,6 @@ namespace Neos\Flow\Tests\Unit\Utility;
  * source code.
  */
 
-use Neos\Flow\Package\PackageManager;
 use Neos\Utility\SchemaValidator;
 use Neos\Error\Messages as Error;
 
@@ -671,7 +670,7 @@ class SchemaValidatorTest extends \PHPUnit\Framework\TestCase
     public function validateHandlesStringTypePropertyWithFormatClassNameConstraintDataProvider()
     {
         return [
-            [PackageManager::class, true],
+            [SchemaValidator::class, true],
             ['Neos\Flow\UnknownClass', false],
             ['foobar', false],
             ['foo bar', false],
@@ -700,7 +699,7 @@ class SchemaValidatorTest extends \PHPUnit\Framework\TestCase
     public function validateHandlesStringTypePropertyWithFormatInterfaceNameConstraintDataProvider()
     {
         return [
-            [PackageManager::class, true],
+            [\Iterator::class, true],
             ['\Neos\Flow\UnknownClass', false],
             ['foobar', false],
             ['foo bar', false],

--- a/Neos.Utility.Schema/Tests/Unit/SchemaValidatorTest.php
+++ b/Neos.Utility.Schema/Tests/Unit/SchemaValidatorTest.php
@@ -12,7 +12,6 @@ namespace Neos\Flow\Tests\Unit\Utility;
  */
 
 use Neos\Flow\Package\PackageManager;
-use Neos\Flow\Package\PackageManagerInterface;
 use Neos\Utility\SchemaValidator;
 use Neos\Error\Messages as Error;
 
@@ -701,7 +700,7 @@ class SchemaValidatorTest extends \PHPUnit\Framework\TestCase
     public function validateHandlesStringTypePropertyWithFormatInterfaceNameConstraintDataProvider()
     {
         return [
-            [PackageManagerInterface::class, true],
+            [PackageManager::class, true],
             ['\Neos\Flow\UnknownClass', false],
             ['foobar', false],
             ['foo bar', false],


### PR DESCRIPTION
As the package manager cannot be overwritten the interface is purely
cosmetic and IF you actually use the package manager (which you
probably should not in the first place) you can just inject the
``PackageManager`` directly instead of the interface.
