### PR TITLE
FEATURE: Load configuration from paths including wildcards

### DIFF
--- a/Neos.Flow/Classes/Configuration/ConfigurationManager.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationManager.php
@@ -200,7 +200,7 @@ class ConfigurationManager
                 $contextNameParts = explode('/', (string)$currentContext);
                 $n = count($contextNameParts) - 1;
                 // traverse all permutations of a context
-                for ($i = 0; $i < 2**$n; $i++) {
+                for ($i = 0; $i < 2 ** $n; $i++) {
                     $pattern = sprintf('%0' . $n . 's', decbin($i));
                     $wildcardedParts = $contextNameParts;
                     for ($j = 0; $j < strlen($pattern); $j++) {
@@ -449,7 +449,7 @@ class ConfigurationManager
                     }
                     $this->configurations[$configurationType][$packageKey] = $configuration;
                 }
-            break;
+                break;
             case self::CONFIGURATION_PROCESSING_TYPE_POLICY:
                 if ($this->context->isTesting()) {
                     $testingPolicyPathAndFilename = $this->temporaryDirectoryPath . 'Policy';
@@ -472,7 +472,7 @@ class ConfigurationManager
                     }
                     $this->configurations[$configurationType] = $this->mergePolicyConfiguration($this->configurations[$configurationType], $this->configurationSource->load(FLOW_PATH_CONFIGURATION . $contextName . '/' . $configurationType, $allowSplitSource));
                 }
-            break;
+                break;
             case self::CONFIGURATION_PROCESSING_TYPE_DEFAULT:
                 foreach ($packages as $package) {
                     $this->configurations[$configurationType] = Arrays::arrayMergeRecursiveOverrule($this->configurations[$configurationType], $this->configurationSource->load($package->getConfigurationPath() . $configurationType, $allowSplitSource));
@@ -485,7 +485,7 @@ class ConfigurationManager
                     }
                     $this->configurations[$configurationType] = Arrays::arrayMergeRecursiveOverrule($this->configurations[$configurationType], $this->configurationSource->load(FLOW_PATH_CONFIGURATION . $contextName . '/' . $configurationType, $allowSplitSource));
                 }
-            break;
+                break;
             case self::CONFIGURATION_PROCESSING_TYPE_ROUTES:
                 // load main routes
                 foreach (array_reverse($this->orderedListOfContextNames) as $contextName) {
@@ -512,7 +512,7 @@ class ConfigurationManager
                     }
                     $this->configurations[$configurationType] = array_merge($this->configurations[$configurationType], $this->configurationSource->load(FLOW_PATH_CONFIGURATION . $contextName . '/' . $configurationType, $allowSplitSource));
                 }
-            break;
+                break;
             default:
                 throw new Exception\InvalidConfigurationTypeException('Configuration type "' . $configurationType . '" cannot be loaded with loadConfiguration().', 1251450613);
         }

--- a/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -349,8 +349,9 @@ class ConfigurationManagerTest extends UnitTestCase
             case FLOW_PATH_CONFIGURATION . 'Testing/Settings': return [];
             case FLOW_PATH_CONFIGURATION . 'Testing/System1/Settings': return [];
             default:
-                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0)
+                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0) {
                     throw new \Exception('Unexpected filename: ' . $filenameAndPath);
+                }
                 return [];
         }
     }
@@ -464,8 +465,9 @@ class ConfigurationManagerTest extends UnitTestCase
             case FLOW_PATH_CONFIGURATION . 'Testing/Objects': return $globalContextObjects;
             case FLOW_PATH_CONFIGURATION . 'Testing/System1/Objects': return $globalSubContextObjects;
             default:
-                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0)
+                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0) {
                     throw new \Exception('Unexpected filename: ' . $filenameAndPath);
+                }
                 return [];
         }
     }
@@ -574,8 +576,9 @@ class ConfigurationManagerTest extends UnitTestCase
             case FLOW_PATH_CONFIGURATION . 'Testing/Caches': return $globalContextCaches;
             case FLOW_PATH_CONFIGURATION . 'Testing/System1/Caches': return $globalSubContextCaches;
             default:
-                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0)
+                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0) {
                     throw new \Exception('Unexpected filename: ' . $filenameAndPath);
+                }
                 return [];
         }
     }
@@ -658,8 +661,9 @@ class ConfigurationManagerTest extends UnitTestCase
             case FLOW_PATH_CONFIGURATION . 'Settings': return $settingsGlobal;
             case FLOW_PATH_CONFIGURATION . ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD . '/Package/Settings': return $settingsGlobalAnySub;
             default:
-                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0)
+                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0) {
                     throw new \Exception('Unexpected filename: ' . $filenameAndPath);
+                }
                 return [];
         }
     }
@@ -1023,8 +1027,9 @@ EOD;
             case FLOW_PATH_CONFIGURATION . 'Testing/Routes': return $globalContextRoutes;
             case FLOW_PATH_CONFIGURATION . 'Testing/System1/Routes': return $globalSubContextRoutes;
             default:
-                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0)
+                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0) {
                     throw new \Exception('Unexpected filename: ' . $filenameAndPath);
+                }
                 return [];
         }
     }
@@ -1262,8 +1267,9 @@ EOD;
             case FLOW_PATH_CONFIGURATION . 'Settings': return $globalSettings;
             case FLOW_PATH_CONFIGURATION . 'Testing/Settings': return [];
             default:
-                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0)
+                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0) {
                     throw new \Exception('Unexpected filename: ' . $filenameAndPath);
+                }
                 return [];
         }
     }
@@ -1612,8 +1618,9 @@ EOD;
             case FLOW_PATH_CONFIGURATION . 'Testing/Views': return $globalContextViewConfigurations;
             case FLOW_PATH_CONFIGURATION . 'Testing/System1/Views': return $globalSubContextViewConfigurations;
             default:
-                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0)
+                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0) {
                     throw new \Exception('Unexpected filename: ' . $filenameAndPath);
+                }
                 return [];
         }
     }

--- a/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -349,7 +349,9 @@ class ConfigurationManagerTest extends UnitTestCase
             case FLOW_PATH_CONFIGURATION . 'Testing/Settings': return [];
             case FLOW_PATH_CONFIGURATION . 'Testing/System1/Settings': return [];
             default:
-                throw new \Exception('Unexpected filename: ' . $filenameAndPath);
+                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0)
+                    throw new \Exception('Unexpected filename: ' . $filenameAndPath);
+                return [];
         }
     }
 
@@ -462,7 +464,9 @@ class ConfigurationManagerTest extends UnitTestCase
             case FLOW_PATH_CONFIGURATION . 'Testing/Objects': return $globalContextObjects;
             case FLOW_PATH_CONFIGURATION . 'Testing/System1/Objects': return $globalSubContextObjects;
             default:
-                throw new \Exception('Unexpected filename: ' . $filenameAndPath);
+                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0)
+                    throw new \Exception('Unexpected filename: ' . $filenameAndPath);
+                return [];
         }
     }
 
@@ -570,7 +574,93 @@ class ConfigurationManagerTest extends UnitTestCase
             case FLOW_PATH_CONFIGURATION . 'Testing/Caches': return $globalContextCaches;
             case FLOW_PATH_CONFIGURATION . 'Testing/System1/Caches': return $globalSubContextCaches;
             default:
-                throw new \Exception('Unexpected filename: ' . $filenameAndPath);
+                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0)
+                    throw new \Exception('Unexpected filename: ' . $filenameAndPath);
+                return [];
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function loadConfigurationFromWildcardedContexts()
+    {
+        $configurationManager = $this->getConfigurationManagerWithFlowPackage('wildCardedConfigurationsCallback', 'Testing/Package');
+        $mockPackages = $this->getMockPackages();
+
+        $configurationManager->_call('loadConfiguration', ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, $mockPackages);
+
+        $actualConfigurations = $configurationManager->_get('configurations');
+        $expectedSettings = [
+            'Neos' => [
+                'Flow' => [
+                    'core' => [
+                        'context' => 'Testing/Package',
+                    ],
+                ],
+            ],
+            'Package' => [
+                'foo' => 'global',
+                'testing' => true,
+                'bar' => 'local testing',
+                'baz' => 'local wildcard',
+                'fubar' => 'global wildcard',
+            ],
+        ];
+
+        $this->assertSame($expectedSettings, $actualConfigurations[ConfigurationManager::CONFIGURATION_TYPE_SETTINGS]);
+    }
+
+    /**
+     * Callback for the above test.
+     */
+    public function wildCardedConfigurationsCallback()
+    {
+        $filenameAndPath = func_get_arg(0);
+
+        $settingsPackage = [
+            'Package' => [
+                'foo' => 'local',
+            ],
+        ];
+        $settingsGlobal = [
+            'Package' => [
+                'foo' => 'global',
+            ],
+        ];
+        $settingsPackageTesting = [
+            'Package' => [
+                'testing' => true,
+            ],
+        ];
+        $settingsPackageAnySub = [
+            'Package' => [
+                'bar' => 'local wildcard',
+                'baz' => 'local wildcard',
+            ],
+        ];
+        $settingsGlobalAnySub = [
+            'Package' => [
+                'fubar' => 'global wildcard',
+            ],
+        ];
+        $settingsPackageTestingSub = [
+            'Package' => [
+                'bar' => 'local testing',
+            ],
+        ];
+
+        switch ($filenameAndPath) {
+            case 'Flow/Configuration/Settings': return $settingsPackage;
+            case 'Flow/Configuration/Testing/Settings': return $settingsPackageTesting;
+            case 'Flow/Configuration/Testing/Package/Settings': return $settingsPackageTestingSub;
+            case 'Flow/Configuration/' . ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD . '/Package/Settings': return $settingsPackageAnySub;
+            case FLOW_PATH_CONFIGURATION . 'Settings': return $settingsGlobal;
+            case FLOW_PATH_CONFIGURATION . ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD . '/Package/Settings': return $settingsGlobalAnySub;
+            default:
+                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0)
+                    throw new \Exception('Unexpected filename: ' . $filenameAndPath);
+                return [];
         }
     }
 
@@ -933,7 +1023,9 @@ EOD;
             case FLOW_PATH_CONFIGURATION . 'Testing/Routes': return $globalContextRoutes;
             case FLOW_PATH_CONFIGURATION . 'Testing/System1/Routes': return $globalSubContextRoutes;
             default:
-                throw new \Exception('Unexpected filename: ' . $filenameAndPath);
+                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0)
+                    throw new \Exception('Unexpected filename: ' . $filenameAndPath);
+                return [];
         }
     }
 
@@ -1170,7 +1262,9 @@ EOD;
             case FLOW_PATH_CONFIGURATION . 'Settings': return $globalSettings;
             case FLOW_PATH_CONFIGURATION . 'Testing/Settings': return [];
             default:
-                throw new \Exception('Unexpected filename: ' . $filenameAndPath);
+                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0)
+                    throw new \Exception('Unexpected filename: ' . $filenameAndPath);
+                return [];
         }
     }
 
@@ -1518,7 +1612,9 @@ EOD;
             case FLOW_PATH_CONFIGURATION . 'Testing/Views': return $globalContextViewConfigurations;
             case FLOW_PATH_CONFIGURATION . 'Testing/System1/Views': return $globalSubContextViewConfigurations;
             default:
-                throw new \Exception('Unexpected filename: ' . $filenameAndPath);
+                if (strpos($filenameAndPath, ConfigurationManager::CONFIGURATION_CONTEXT_WILDCARD) < 0)
+                    throw new \Exception('Unexpected filename: ' . $filenameAndPath);
+                return [];
         }
     }
 


### PR DESCRIPTION
**What I did**
The ConfigurationManager loads paths based on permutations of the FLOW_CONTEXT and a wildcard, e.g. it is possible to have settings shared within a sub-context to be loaded from `Configuration/Any/SubContext` instead of duplicating the necessary configuration in e.g. `Development/SubContext` and `Production/SubContext`.
The loading-order is `/` < `Any/` < `ConcreteContext/`.
The name of the wildcard is a constant within the ConfigurationManager (currently "Any").

The existing unit-tests are adapted to not throw exceptions on non-configured paths containing the wildcard, as the actual system gracefully handles non-existing paths as well.

**How I did it**
When constructing the ConfigurationManager, it creates the list of context names including the wildcard in every possible "Slot", e.g. for context `Production/SubContext/SubSubContext` it will generate `Any/Any/SubSubContext`,`Any/SubContext/SubSubcontext`,  `Production/Any/SubContext`, `Production/SubContext/SubSubContext` in appropriate order.

**How to verify it**
Add Settings-files and change the FLOW_CONTEXT environment variable when looking at the configuration cli-tool.