### PR TITLE
FEATURE: Utility Function to detect Eel expressions

### DIFF
--- a/Neos.Eel/Classes/Utility.php
+++ b/Neos.Eel/Classes/Utility.php
@@ -21,8 +21,7 @@ class Utility
      * Return the expression if it is an valid EEL expression, otherwise return null.
      *
      * @param string $expression
-     *
-     * @return bool
+     * @return string|null
      */
     public static function parseEelExpression($expression)
     {

--- a/Neos.Eel/Classes/Utility.php
+++ b/Neos.Eel/Classes/Utility.php
@@ -21,13 +21,12 @@ class Utility
      * Check if expression is an Eel expression.
      *
      * @param string $expression
-     * @param array $matches
      *
      * @return bool
      */
-    public static function isEelExpression($expression, &$matches = null)
+    public static function isEelExpression($expression)
     {
-        return preg_match(Package::EelExpressionRecognizer, $expression, $matches);
+        return preg_match(Package::EelExpressionRecognizer, $expression) === 1;
     }
 
     /**
@@ -67,10 +66,11 @@ class Utility
      */
     public static function evaluateEelExpression($expression, EelEvaluatorInterface $eelEvaluator, array $contextVariables, array $defaultContextConfiguration = [])
     {
-        $matches = null;
-        if (!self::isEelExpression($expression, $matches)) {
+        if (!self::isEelExpression($expression)) {
             throw new Exception('The EEL expression "' . $expression . '" was not a valid EEL expression. Perhaps you forgot to wrap it in ${...}?', 1410441849);
         }
+
+        preg_match(Package::EelExpressionRecognizer, $expression, $matches);
 
         $defaultContextVariables = self::getDefaultContextVariables($defaultContextConfiguration);
         $contextVariables = array_merge($defaultContextVariables, $contextVariables);

--- a/Neos.Eel/Classes/Utility.php
+++ b/Neos.Eel/Classes/Utility.php
@@ -24,9 +24,9 @@ class Utility
      *
      * @return bool
      */
-    public static function isEelExpression($expression)
+    public static function parseEelExpression($expression)
     {
-        return preg_match(Package::EelExpressionRecognizer, $expression) === 1;
+        return preg_match(Package::EelExpressionRecognizer, $expression, $matches) === 1 ? $matches : null;
     }
 
     /**
@@ -66,7 +66,8 @@ class Utility
      */
     public static function evaluateEelExpression($expression, EelEvaluatorInterface $eelEvaluator, array $contextVariables, array $defaultContextConfiguration = [])
     {
-        if (!self::isEelExpression($expression)) {
+        $eelExpression = self::parseEelExpression($expression);
+        if ($eelExpression === null) {
             throw new Exception('The EEL expression "' . $expression . '" was not a valid EEL expression. Perhaps you forgot to wrap it in ${...}?', 1410441849);
         }
 

--- a/Neos.Eel/Classes/Utility.php
+++ b/Neos.Eel/Classes/Utility.php
@@ -18,7 +18,7 @@ namespace Neos\Eel;
 class Utility
 {
     /**
-     * Check if expression is an Eel expression.
+     * Return the expression if it is an valid EEL expression, otherwise return null.
      *
      * @param string $expression
      *
@@ -26,7 +26,7 @@ class Utility
      */
     public static function parseEelExpression($expression)
     {
-        return preg_match(Package::EelExpressionRecognizer, $expression, $matches) === 1 ? $matches : null;
+        return preg_match(Package::EelExpressionRecognizer, $expression, $matches) === 1 ? $matches['exp'] : null;
     }
 
     /**
@@ -71,8 +71,6 @@ class Utility
             throw new Exception('The EEL expression "' . $expression . '" was not a valid EEL expression. Perhaps you forgot to wrap it in ${...}?', 1410441849);
         }
 
-        preg_match(Package::EelExpressionRecognizer, $expression, $matches);
-
         $defaultContextVariables = self::getDefaultContextVariables($defaultContextConfiguration);
         $contextVariables = array_merge($defaultContextVariables, $contextVariables);
 
@@ -87,6 +85,6 @@ class Utility
         $context = new ProtectedContext($contextVariables);
         $context->whitelist('q');
 
-        return $eelEvaluator->evaluate($matches['exp'], $context);
+        return $eelEvaluator->evaluate($eelExpression, $context);
     }
 }

--- a/Neos.Eel/Classes/Utility.php
+++ b/Neos.Eel/Classes/Utility.php
@@ -18,6 +18,19 @@ namespace Neos\Eel;
 class Utility
 {
     /**
+     * Check if expression is an Eel expression.
+     *
+     * @param string $expression
+     * @param array $matches
+     *
+     * @return bool
+     */
+    public static function isEelExpression($expression, &$matches = null)
+    {
+        return preg_match(Package::EelExpressionRecognizer, $expression, $matches);
+    }
+
+    /**
      * Get variables from configuration that should be set in the context by default.
      * For example Eel helpers are made available by this.
      *
@@ -55,7 +68,7 @@ class Utility
     public static function evaluateEelExpression($expression, EelEvaluatorInterface $eelEvaluator, array $contextVariables, array $defaultContextConfiguration = [])
     {
         $matches = null;
-        if (!preg_match(Package::EelExpressionRecognizer, $expression, $matches)) {
+        if (!self::isEelExpression($expression, $matches)) {
             throw new Exception('The EEL expression "' . $expression . '" was not a valid EEL expression. Perhaps you forgot to wrap it in ${...}?', 1410441849);
         }
 


### PR DESCRIPTION
The function was added to provide a function for validity checks without any need to duplicate the code which was previously used in the first if-condition of the function evaluateEelExpression.

As @kitsunet mentioned in https://github.com/neos/eel/pull/2 the variable `matches` is not necessary, but I've used it to avoid calling `preg_match(Package::EelExpressionRecognizer, $expression, $matches)` inside the existing function `evaluateEelExpression` and `preg_match(Package::EelExpressionRecognizer, $expression)` inside the new function `isEelExpression`, because to me this seems like duplicated code.
I'm happy with both solutions, so feel free to change it if you decide to remove the variable.
