### PR TITLE
BUGFIX: Fix format for json_encoded DateTime conversion

### DIFF
--- a/Neos.Flow/Classes/Property/TypeConverter/DateTimeConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/DateTimeConverter.php
@@ -161,7 +161,7 @@ class DateTimeConverter extends AbstractTypeConverter
             }
             if (isset($source['timezone_type'])) {
                 // DateTime internal format when being serialized with json_encode
-                $dateFormat = "Y-m-d\TH:i:s.v";
+                $dateFormat = "Y-m-d H:i:s.u";
             }
             $date = $targetType::createFromFormat($dateFormat, $dateAsString, $timezone);
         } else {

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/DateTimeConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/DateTimeConverterTest.php
@@ -531,4 +531,17 @@ class DateTimeConverterTest extends UnitTestCase
         $this->assertInstanceOf($className, $date);
         $this->assertSame('Bar', $date->foo());
     }
+
+    /**
+     * @test
+     */
+    public function canConvertFromJsonSerializedDateTime()
+    {
+        $sourceDate = new \DateTime('2005-08-15T15:52:01+00:00');
+        // Serialize to an array with json_decode from an json_encoded string
+        $source = json_decode(json_encode($sourceDate), true);
+        $convertedDate = $this->converter->convertFrom($source, 'DateTime');
+        $this->assertInstanceOf('DateTime', $convertedDate);
+        $this->assertSame($sourceDate->getTimestamp(), $convertedDate->getTimestamp());
+    }
 }


### PR DESCRIPTION
The format for converting from json_encode'd DateTime was wrong. The format doesn't use the `\T` separator, but a whitespace and as it seems, `v` is not a valid format specifier for `DateTime::createFromFormat` while it is for `date()`.

http://php.net/manual/en/datetime.createfromformat.php
"In **most cases**, the same letters as for the [date()](http://php.net/manual/en/function.date.php) can be used." [emphasis by me]

Also, this provides a test to actually verify the functionality.
Related to #1415