### PR TITLE
FEATURE: Add ``set`` method to ``Array`` Eel-helper

### DIFF
--- a/Neos.Eel/Classes/Helper/ArrayHelper.php
+++ b/Neos.Eel/Classes/Helper/ArrayHelper.php
@@ -367,6 +367,20 @@ class ArrayHelper implements ProtectedContextAwareInterface
     }
 
     /**
+     * Set the specified key in the the array
+     *
+     * @param array $array
+     * @param string|integer $key the Key that will be set
+     * @param mixed $value the value to assign to the key
+     * @return array The modified array.
+     */
+    public function set(array $array, $key, $value)
+    {
+        $array[$key] = $value;
+        return $array;
+    }
+
+    /**
      * All methods are considered safe
      *
      * @param string $methodName

--- a/Neos.Eel/Tests/Unit/Helper/ArrayHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/ArrayHelperTest.php
@@ -473,4 +473,34 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $result = call_user_func_array([$helper, 'range'], $arguments);
         $this->assertEquals($expected, $result);
     }
+
+
+    public function setExamples()
+    {
+        return [
+            'add key in empty array' => [
+                [[], 'foo', 'bar'],
+                ['foo' => 'bar']
+            ],
+            'add key to array' => [
+                [['bar' => 'baz'], 'foo', 'bar'],
+                ['bar' => 'baz', 'foo' => 'bar']
+            ],
+            'override value in array' => [
+                [['foo' => 'bar'], 'foo', 'baz'],
+                ['foo' => 'baz']
+            ]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider setExamples
+     */
+    public function setWorks($arguments, $expected)
+    {
+        $helper = new ArrayHelper();
+        $result = call_user_func_array([$helper, 'set'], $arguments);
+        $this->assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
This allows to set keys which are calculated at runtime in Eel. A possible use case for this
is the ``Neos.Fusion:Reduce`` prototype that can be used for grouping with ``set``.