### PR TITLE
BUGFIX: Properly parse `DateTimeImmutable` types

### DIFF
--- a/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
+++ b/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
@@ -24,7 +24,7 @@ abstract class TypeHandling
     /**
      * A property type parse pattern.
      */
-    const PARSE_TYPE_PATTERN = '/^\\\\?(?P<type>integer|int|float|double|boolean|bool|string|DateTime|[a-zA-Z0-9\\\\_]+|object|array|ArrayObject|SplObjectStorage|Doctrine\\\\Common\\\\Collections\\\\Collection|Doctrine\\\\Common\\\\Collections\\\\ArrayCollection)(?:<\\\\?(?P<elementType>[a-zA-Z0-9\\\\_]+)>)?/';
+    const PARSE_TYPE_PATTERN = '/^\\\\?(?P<type>integer|int|float|double|boolean|bool|string|DateTime(?:Immutable)?|[a-zA-Z0-9\\\\_]+|object|array|ArrayObject|SplObjectStorage|Doctrine\\\\Common\\\\Collections\\\\Collection|Doctrine\\\\Common\\\\Collections\\\\ArrayCollection)(?:<\\\\?(?P<elementType>[a-zA-Z0-9\\\\_]+)>)?/';
 
     /**
      * A type pattern to detect literal types.

--- a/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
@@ -45,6 +45,7 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
             ['int', ['type' => 'integer', 'elementType' => null]],
             ['string', ['type' => 'string', 'elementType' => null]],
             ['DateTime', ['type' => 'DateTime', 'elementType' => null]],
+            ['DateTimeImmutable', ['type' => 'DateTimeImmutable', 'elementType' => null]],
             ['TYPO3\Foo\Bar', ['type' => 'TYPO3\Foo\Bar', 'elementType' => null]],
             ['\TYPO3\Foo\Bar', ['type' => 'TYPO3\Foo\Bar', 'elementType' => null]],
             ['\stdClass', ['type' => 'stdClass', 'elementType' => null]],


### PR DESCRIPTION
Currently, a type string of `DateTimeImmutable` will be parsed as `DateTime`. This for example leads to any entity properties annotated as `@var DateTimeImmutable` to be hydrated into a `DateTime` class instead.

Note that this is a hotfix at most, because the real issue is, that the regex does not check for a type ending character, like whitespace, line end or other non-word character. Therefore, it eagerly parses `DateTimeImmutable` by matching the `DateTime` prefix and taking that as the parsed type, which is wrong.

I'd rather change the regex to end with `(?:\b|$)`, but I'm unsure how breaking that would be.