### PR TITLE
TASK: Update Doctrine DBAL dependency to 2.8

### DIFF
--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -36,7 +36,7 @@
         "doctrine/orm": "~2.6.0",
         "doctrine/migrations": "~1.6.0",
         "doctrine/dbal": "~2.8.0",
-        "doctrine/common": ">=2.4,<2.8-dev",
+        "doctrine/common": "~2.4",
 
         "symfony/yaml": "~4.0.0",
         "symfony/dom-crawler": "~4.0.0",

--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -35,7 +35,7 @@
 
         "doctrine/orm": "~2.6.0",
         "doctrine/migrations": "~1.6.0",
-        "doctrine/dbal": "~2.7.0",
+        "doctrine/dbal": "~2.8.0",
         "doctrine/common": ">=2.4,<2.8-dev",
 
         "symfony/yaml": "~4.0.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ramsey/uuid": "^3.0.0",
         "doctrine/orm": "~2.6.0",
         "doctrine/migrations": "~1.8.1",
-        "doctrine/dbal": "~2.7.0",
+        "doctrine/dbal": "~2.8.0",
         "doctrine/common": ">=2.4,<2.8-dev",
         "symfony/yaml": "~4.1.0",
         "symfony/dom-crawler": "~4.1.5",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "doctrine/orm": "~2.6.0",
         "doctrine/migrations": "~1.8.1",
         "doctrine/dbal": "~2.8.0",
-        "doctrine/common": ">=2.4,<2.8-dev",
+        "doctrine/common": "~2.4",
         "symfony/yaml": "~4.1.0",
         "symfony/dom-crawler": "~4.1.5",
         "symfony/console": "~4.1.1",


### PR DESCRIPTION
Since DBAL 2.8 has no b/c breaks, it should be safe to update the version.

See https://github.com/doctrine/dbal/releases/tag/v2.8.0

In the longer term, we should also phase out the doctrine/common dependency.
See https://www.doctrine-project.org/2018/07/12/common-2-9-and-dbal-2-8-and-orm-2-6-2.html
AFAIS we only depend on `Doctrine\Common\Util\Debug` which we are suggested to replace with `symfony/var-dumper`.