### PR TITLE
TASK: Translator uses locale chain

### DIFF
--- a/Neos.Flow/Classes/I18n/Translator.php
+++ b/Neos.Flow/Classes/I18n/Translator.php
@@ -148,7 +148,10 @@ class Translator
             }
         }
 
-        return $originalLabel;
+        return $arguments === []
+            ? $originalLabel
+            : $this->formatResolver->resolvePlaceholders($originalLabel, $arguments, $locale)
+        ;
     }
 
     /**

--- a/Neos.Flow/Classes/I18n/Translator.php
+++ b/Neos.Flow/Classes/I18n/Translator.php
@@ -126,19 +126,29 @@ class Translator
         if ($locale === null) {
             $locale = $this->localizationService->getConfiguration()->getCurrentLocale();
         }
-        $pluralForm = $this->getPluralForm($quantity, $locale);
 
-        $translatedMessage = $this->translationProvider->getTranslationByOriginalLabel($originalLabel, $locale, $pluralForm, $sourceName, $packageKey);
+        foreach ($this->localizationService->getLocaleChain($locale) as $localeInChain) {
+            $translatedMessage = $this->translationProvider->getTranslationByOriginalLabel(
+                $originalLabel,
+                $localeInChain,
+                $this->getPluralForm($quantity, $localeInChain),
+                $sourceName,
+                $packageKey
+            );
 
-        if ($translatedMessage === false) {
-            $translatedMessage = $originalLabel;
+            if ($translatedMessage !== false) {
+                return $arguments === []
+                    ? $translatedMessage
+                    : $this->formatResolver->resolvePlaceholders(
+                        $translatedMessage,
+                        $arguments,
+                        $localeInChain
+                    )
+                ;
+            }
         }
 
-        if (!empty($arguments)) {
-            $translatedMessage = $this->formatResolver->resolvePlaceholders($translatedMessage, $arguments, $locale);
-        }
-
-        return $translatedMessage;
+        return $originalLabel;
     }
 
     /**
@@ -169,17 +179,29 @@ class Translator
         if ($locale === null) {
             $locale = $this->localizationService->getConfiguration()->getCurrentLocale();
         }
-        $pluralForm = $this->getPluralForm($quantity, $locale);
 
-        $translatedMessage = $this->translationProvider->getTranslationById($labelId, $locale, $pluralForm, $sourceName, $packageKey);
-        if ($translatedMessage === false) {
-            return null;
+        foreach ($this->localizationService->getLocaleChain($locale) as $localeInChain) {
+            $translatedMessage = $this->translationProvider->getTranslationById(
+                $labelId,
+                $localeInChain,
+                $this->getPluralForm($quantity, $localeInChain),
+                $sourceName,
+                $packageKey
+            );
+
+            if ($translatedMessage !== false) {
+                return $arguments === []
+                    ? $translatedMessage
+                    : $this->formatResolver->resolvePlaceholders(
+                        $translatedMessage,
+                        $arguments,
+                        $localeInChain
+                    )
+                ;
+            }
         }
 
-        if (!empty($arguments)) {
-            return $this->formatResolver->resolvePlaceholders($translatedMessage, $arguments, $locale);
-        }
-        return $translatedMessage;
+        return null;
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/I18n/TranslatorTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/TranslatorTest.php
@@ -114,7 +114,11 @@ class TranslatorTest extends UnitTestCase
             ->will($this->returnValue(false))
         ;
 
+        $mockFormatResolver = $this->createMock(I18n\FormatResolver::class);
+        $mockFormatResolver->expects($this->once())->method('resolvePlaceholders')->with('original {0}', ['label'], $this->defaultLocale)->willReturn('original label');
+
         $this->translator->injectTranslationProvider($mockTranslationProvider);
+        $this->translator->injectFormatResolver($mockFormatResolver);
 
         $result = $this->translator->translateByOriginalLabel('original {0}', ['label'], null, null, 'source', 'packageKey');
         $this->assertEquals('original label', $result);

--- a/Neos.Flow/Tests/Unit/I18n/TranslatorTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/TranslatorTest.php
@@ -104,6 +104,25 @@ class TranslatorTest extends UnitTestCase
     /**
      * @test
      */
+    public function translateByOriginalLabelInterpolatesArgumentsIntoOriginalLabelWhenTranslationNotAvailable()
+    {
+        $mockTranslationProvider = $this->createMock(XliffTranslationProvider::class);
+        $mockTranslationProvider
+            ->expects($this->exactly(\count($this->defaultLocaleChain)))
+            ->method('getTranslationByOriginalLabel')
+            ->with('original {0}', $this->isInstanceOf(I18n\Locale::class), null, 'source', 'packageKey')
+            ->will($this->returnValue(false))
+        ;
+
+        $this->translator->injectTranslationProvider($mockTranslationProvider);
+
+        $result = $this->translator->translateByOriginalLabel('original {0}', ['label'], null, null, 'source', 'packageKey');
+        $this->assertEquals('original label', $result);
+    }
+
+    /**
+     * @test
+     */
     public function translateByOriginalLabelUsesLocaleChain()
     {
         $mockTranslationProvider = $this->createMock(XliffTranslationProvider::class);


### PR DESCRIPTION
This change makes getTranslationById and getTranslationByOriginalLabel use the configured
locale chain.

This is an updated version of #327 and #328. Please see the discussions there. May be retargeted on master.