### PR TITLE
FEATURE: Make cache application identifier configurable

### DIFF
--- a/Neos.Flow/Classes/Cache/CacheFactory.php
+++ b/Neos.Flow/Classes/Cache/CacheFactory.php
@@ -81,15 +81,16 @@ class CacheFactory extends \Neos\Cache\CacheFactory implements CacheFactoryInter
      *
      * @param ApplicationContext $context The current Flow context
      * @param Environment $environment
+     * @param string $applicationIdentifier
      * @Flow\Autowiring(enabled=false)
      */
-    public function __construct(ApplicationContext $context, Environment $environment)
+    public function __construct(ApplicationContext $context, Environment $environment, string $applicationIdentifier)
     {
         $this->context = $context;
         $this->environment = $environment;
 
         $environmentConfiguration = new EnvironmentConfiguration(
-            FLOW_PATH_ROOT . '~' . (string)$environment->getContext(),
+            $applicationIdentifier,
             $environment->getPathToTemporaryDirectory()
         );
 

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -366,7 +366,7 @@ class Scripts
         $cacheFactoryClass = isset($cacheFactoryObjectConfiguration['className']) ? $cacheFactoryObjectConfiguration['className'] : CacheFactory::class;
 
         /** @var CacheFactory $cacheFactory */
-        $cacheFactory = new $cacheFactoryClass($bootstrap->getContext(), $environment, $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS , 'Neos.Flow.cache.applicationIdentifier'));
+        $cacheFactory = new $cacheFactoryClass($bootstrap->getContext(), $environment, $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.Flow.cache.applicationIdentifier'));
 
         $cacheManager = new CacheManager();
         $cacheManager->setCacheConfigurations($configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_CACHES));

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -366,7 +366,7 @@ class Scripts
         $cacheFactoryClass = isset($cacheFactoryObjectConfiguration['className']) ? $cacheFactoryObjectConfiguration['className'] : CacheFactory::class;
 
         /** @var CacheFactory $cacheFactory */
-        $cacheFactory = new $cacheFactoryClass($bootstrap->getContext(), $environment);
+        $cacheFactory = new $cacheFactoryClass($bootstrap->getContext(), $environment, $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS , 'Neos.Flow.cache.applicationIdentifier'));
 
         $cacheManager = new CacheManager();
         $cacheManager->setCacheConfigurations($configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_CACHES));

--- a/Neos.Flow/Classes/Core/Bootstrap.php
+++ b/Neos.Flow/Classes/Core/Bootstrap.php
@@ -549,6 +549,8 @@ class Bootstrap
         define('FLOW_ONLY_COMPOSER_LOADER', $onlyUseComposerAutoLoaderForPackageClasses);
 
         define('FLOW_VERSION_BRANCH', '5.1');
+
+        define('FLOW_APPLICATION_CONTEXT', (string)$this->context);
     }
 
     /**

--- a/Neos.Flow/Configuration/Objects.yaml
+++ b/Neos.Flow/Configuration/Objects.yaml
@@ -22,11 +22,6 @@ Composer\Autoload\ClassLoader:
 Neos\Cache\CacheFactoryInterface:
   className: Neos\Flow\Cache\CacheFactory
 
-Neos\Flow\Cache\CacheFactory:
-  arguments:
-    1:
-      setting: Neos.Flow.context
-
 Neos\Flow\Cache\CacheManager:
   properties:
     logger:

--- a/Neos.Flow/Configuration/Settings.Cache.yaml
+++ b/Neos.Flow/Configuration/Settings.Cache.yaml
@@ -1,0 +1,12 @@
+Neos:
+  Flow:
+    cache:
+      # The application identifier can be used by cache backends to differentiate cache entries
+      # with the same cache identifier in the same storage from each other. For example memcache is global,
+      # so if you use it for multiple installations or possibly just for different Flow contexts you need to
+      # find a way to separate entries from each other. This setting will do that.
+      # The default is just for backwards compatibility and might change for the next major. It is not well suited
+      # for installations in which the FLOW_PATH_ROOT changes after each deployment, so in such cases you might
+      # want to exchange it for some hardcoded value identifying this specific installation.
+      # Note that changing it will make cache entries generated with the old identifier useless.
+      applicationIdentifier: '%FLOW_PATH_ROOT%~%FLOW_APPLICATION_CONTEXT%'

--- a/Neos.Flow/Tests/Unit/Cache/CacheFactoryTest.php
+++ b/Neos.Flow/Tests/Unit/Cache/CacheFactoryTest.php
@@ -75,7 +75,7 @@ class CacheFactoryTest extends UnitTestCase
      */
     public function createReturnsInstanceOfTheSpecifiedCacheFrontend()
     {
-        $factory = new CacheFactory(new ApplicationContext('Testing'), $this->mockEnvironment);
+        $factory = new CacheFactory(new ApplicationContext('Testing'), $this->mockEnvironment, 'UnitTesting');
         $factory->injectEnvironmentConfiguration($this->mockEnvironmentConfiguration);
 
         $cache = $factory->create('TYPO3_Flow_Cache_FactoryTest_Cache', VariableFrontend::class, NullBackend::class);
@@ -87,7 +87,7 @@ class CacheFactoryTest extends UnitTestCase
      */
     public function createInjectsAnInstanceOfTheSpecifiedBackendIntoTheCacheFrontend()
     {
-        $factory = new CacheFactory(new ApplicationContext('Testing'), $this->mockEnvironment);
+        $factory = new CacheFactory(new ApplicationContext('Testing'), $this->mockEnvironment, 'UnitTesting');
         $factory->injectEnvironmentConfiguration($this->mockEnvironmentConfiguration);
 
         $cache = $factory->create('TYPO3_Flow_Cache_FactoryTest_Cache', VariableFrontend::class, FileBackend::class);
@@ -100,7 +100,7 @@ class CacheFactoryTest extends UnitTestCase
     public function aDifferentDefaultCacheDirectoryIsUsedForPersistentFileCaches()
     {
         $cacheManager = new CacheManager();
-        $factory = new CacheFactory(new ApplicationContext('Testing'), $this->mockEnvironment);
+        $factory = new CacheFactory(new ApplicationContext('Testing'), $this->mockEnvironment, 'UnitTesting');
         $factory->injectCacheManager($cacheManager);
         $factory->injectEnvironmentConfiguration($this->mockEnvironmentConfiguration);
 


### PR DESCRIPTION
In multiple permutations we tried to fix problems with cache identifier
uniqueness in cache backends that are shared like apcu or memcache.
In earlier days it included the PHP_SAPI and then in more recent times
the context and root path. With the refactoring of caches these two
became the hardcoded `applicationIdentifier` which can be used by
any backend to add more specificity to cache identifiers.
It turns out that the root path doesn't work well for some environments
and can result in bugs when used with eg. the PdoBackend and a
deployment that changes the root path (typical Surf or Deployer).
The only backwards compatible way to fix this was to make the
applicationIdentifier configurable with a default that matches the
previously hardcoded values. That way nothing changes in existing
installations but if the bug appears it can be easily fixed.
