### PR TITLE
BUGFIX: Throw MappingException in loadMetaDataForClass

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -178,9 +178,13 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
          * @var ORM\ClassMetadata $metadata
          */
 
-        $class = $metadata->getReflectionClass();
-        $classSchema = $this->getClassSchema($class->getName());
-        $classAnnotations = $this->reader->getClassAnnotations($class);
+        try {
+            $class = $metadata->getReflectionClass();
+            $classSchema = $this->getClassSchema($class->getName());
+            $classAnnotations = $this->reader->getClassAnnotations($class);
+        } catch (ClassSchemaNotFoundException $exception) {
+            throw new ORM\MappingException(sprintf('Failure while fetching class schema class "%s": %s', $metadata->getName(), $exception->getMessage()), 1542792708, $exception);
+        }
 
         // Evaluate Entity annotation
         if (isset($classAnnotations[ORM\MappedSuperclass::class])) {


### PR DESCRIPTION
When no class schema can be found in `loadMetaDataForClass`, a Doctrine
`MappingException` is now thrown. This makes our code work nicely with the
change in https://github.com/doctrine/doctrine2/pull/7471/ that otherwise
leads to errors like this as of ORM 2.6.3:

```
FlowAnnotationDriver.php: No class schema found for "some-non-mapped-class".

89 …\FlowAnnotationDriver_Original::getClassSchema("some-non-mapped-class")
88 …\FlowAnnotationDriver_Original::loadMetadataForClass("some-non-mapped-class", Neos\Flow\Persistence\Doctrine\Mapping\ClassMetadata)
```

Fixes #1453
