### PR TITLE
BUGFIX: Make session caches persistent by default

### DIFF
--- a/Neos.Flow/Classes/Command/CacheCommandController.php
+++ b/Neos.Flow/Classes/Command/CacheCommandController.php
@@ -128,7 +128,8 @@ class CacheCommandController extends CommandController
      * Flush all caches
      *
      * The flush command flushes all caches (including code caches) which have been
-     * registered with Flow's Cache Manager. It also removes any session data.
+     * registered with Flow's Cache Manager. It will NOT remove any session data, unless
+     * you specifically configure the session caches to not be persistent.
      *
      * If fatal errors caused by a package prevent the compile time bootstrap
      * from running, the removal of any temporary data can be forced by specifying

--- a/Neos.Flow/Classes/Command/SessionCommandController.php
+++ b/Neos.Flow/Classes/Command/SessionCommandController.php
@@ -1,0 +1,59 @@
+<?php
+namespace Neos\Flow\Command;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Cache\CacheManager;
+use Neos\Flow\Cli\CommandController;
+
+/**
+ * Command controller for managing sessions
+ *
+ * NOTE: This command controller will run in compile time (as defined in the package bootstrap)
+ *
+ * @Flow\Scope("singleton")
+ */
+class SessionCommandController extends CommandController
+{
+    /**
+     * @var CacheManager
+     */
+    protected $cacheManager;
+
+    /**
+     * @param CacheManager $cacheManager
+     * @return void
+     */
+    public function injectCacheManager(CacheManager $cacheManager)
+    {
+        $this->cacheManager = $cacheManager;
+    }
+
+    /**
+     * Destroys all sessions.
+     * This special command is needed, because sessions are kept in persistent storage and are not flushed
+     * with other caches by default.
+     *
+     * This is functionally equivalent to
+     * `./flow flow:cache:flushOne Flow_Session_Storage && ./flow flow:cache:flushOne Flow_Session_MetaData`
+     *
+     * @return void
+     * @since 5.2
+     */
+    public function destroyAllCommand()
+    {
+        $this->cacheManager->getCache('Flow_Session_Storage')->flush();
+        $this->cacheManager->getCache('Flow_Session_MetaData')->flush();
+        $this->outputLine('Destroyed all sessions.');
+        $this->sendAndExit(0);
+    }
+}

--- a/Neos.Flow/Configuration/Caches.yaml
+++ b/Neos.Flow/Configuration/Caches.yaml
@@ -124,8 +124,10 @@ Flow_Security_Cryptography_HashService:
 # Flow_Session_*
 Flow_Session_MetaData:
   backend: Neos\Cache\Backend\FileBackend
+  persistent: true
 Flow_Session_Storage:
   backend: Neos\Cache\Backend\FileBackend
+  persistent: true
 
 #  Aop filter expressions that need to be evaluated at runtime.
 Flow_Aop_RuntimeExpressions:

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
@@ -169,8 +169,8 @@ Persistent Cache
 Caches can be marked as being "persistent" which lets the Cache Manager skip the cache while flushing all other
 caches or flushing caches by tag. Persistent caches make for a versatile and easy to use low-level key-value-store.
 Simple data like tokens, preferences or the like which usually would be stored in the file system, can be stored in
-such a cache. Flow uses a persistent cache for storing an encryption key for the Hash Service. The configuration for
-this cache looks like this:
+such a cache. Flow uses a persistent cache for storing an encryption key for the Hash Service and Sessions. The
+configuration for this cache looks like this:
 
 *Example: Persistent cache settings* ::
 
@@ -427,7 +427,7 @@ to clean up hard disk space or memory.
 .. warning::
 
 	This backend is php-capable. Nevertheless it cannot be used to store the proxy-classes
-	from the ``FLOW_Object_Classes`` Cache. It can be used for other code-caches like
+	from the ``Flow_Object_Classes`` Cache. It can be used for other code-caches like
 	``Fluid_TemplateCache``, ``Eel_Expression_Code`` or ``Flow_Aop_RuntimeExpressions``.
 	This can be usefull in certain situations to avoid file operations on production
 	environments. If you want to use this backend for code-caching make sure that

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/SessionHandling.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/SessionHandling.rst
@@ -8,6 +8,7 @@ This chapter will explain:
 
 * ... how to store specific data in a session
 * ... how to store objects in the session
+* ... how to delete sessions
 
 Scope Session
 =============
@@ -118,3 +119,22 @@ The built-in session implementation provides a few more configuration options, r
 the session cookie and the automatic garbage collection. Please refer to the
 Settings.yaml file of the Flow package for a list of all possible options and
 their respective documentation.
+
+Session Storage
+===============
+
+.. note::
+
+	Since Flow 5.2 Sessions are no longer destroyed by default when caches are flushed. This is
+	due to the session caches being marked as "persistent". This previously lead to all sessions
+	being destroyed on each deployment, which was undesireable.
+
+If you deploy changes that change the structure of data that is stored in the session or the class
+of an `@Flow\scope("session")` object, you need to manually destroy sessions to avoid deserialization
+errors. You can do this by running `./flow flow:session:destroyAll` or manually deleting the folder
+where the sessions are stored.
+
+Also, sessions are shared among the application contexts, e.g. `Development` and `Production`, so if
+your use case requires to have sessions separated for different contexts, you need to configure the
+`cacheDirectory` backend option for the `Flow_Session_Storage` and `Flow_Session_MetaData` caches for
+each individual context. Please refer to the :doc:`Caching` section of this guide for further information.


### PR DESCRIPTION
Previously the sessions would be flushed whenever caches get flushed. This sometimes leads to unexpectedly logging out users, as happens for example in the neos setup in the last step.
This is only breaking in the sense, that you need to take care when deploying code that changes classes or data stored in the session. In those cases you need to flush the session caches manually via the new CLI command `./flow flow:session:destroyAll`. Also see the documentation https://flowframework.readthedocs.io/en/stable/TheDefinitiveGuide/PartIII/SessionHandling.html#session-storage

Resolves #1390
