### PR TITLE
TASK: Fix duplicate FLOW_VERSION_BRANCH declaration after upmerge

### DIFF
--- a/Neos.Flow/Classes/Core/Bootstrap.php
+++ b/Neos.Flow/Classes/Core/Bootstrap.php
@@ -546,8 +546,6 @@ class Bootstrap
         }
 
         define('FLOW_ONLY_COMPOSER_LOADER', $onlyUseComposerAutoLoaderForPackageClasses);
-        define('FLOW_VERSION_BRANCH', '4.3');
-
         define('FLOW_VERSION_BRANCH', '5.0');
         define('FLOW_APPLICATION_CONTEXT', (string)$this->context);
     }


### PR DESCRIPTION
A duplicate declaration of FLOW_VERSION_BRANCH slipped in while upmerging from 4.3