### PR TITLE
BUGFIX: Avoid strlen call on null value

### DIFF
--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Format/CropViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Format/CropViewHelper.php
@@ -77,7 +77,7 @@ class CropViewHelper extends AbstractViewHelper
     {
         $value = $arguments['value'];
         if ($value === null) {
-            $value = $renderChildrenClosure();
+            $value = (string)$renderChildrenClosure();
         }
 
         if (UnicodeUtilityFunctions::strlen($value) > $arguments['maxCharacters']) {


### PR DESCRIPTION
The `CropViewHelper` should gracefully handle `null` values
internally. Otherwise you get `Argument 1 passed to
Neos\Utility\Unicode\Functions::strlen() must be of the type string,
null given` errors.