### PR TITLE
TASK: Remove empty documentation parts

### DIFF
--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/FileMonitoring.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/FileMonitoring.rst
@@ -1,2 +1,0 @@
-File Monitoring (to be written)
-===============================

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/LoggingAndDebugging.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/LoggingAndDebugging.rst
@@ -1,2 +1,0 @@
-Logging and Debugging (to be written)
-=====================================

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Testing.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Testing.rst
@@ -1,2 +1,0 @@
-Testing (to be written)
-=======================

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/index.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/index.rst
@@ -24,10 +24,7 @@ Part III: Manual
 	Security
 	Internationalization
 	ErrorAndExceptionHandling
-	LoggingAndDebugging
 	SignalsAndSlots
 	Reflection
 	Eel
-	FileMonitoring
-	Testing
 	UtilityFunctions

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIV/index.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIV/index.rst
@@ -1,3 +1,0 @@
-Part IV: Deployment and Administration (to be written)
-======================================================
-

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/index.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/index.rst
@@ -7,6 +7,5 @@ The Definitive Guide
 	PartI/index
 	PartII/index
 	PartIII/index
-	PartIV/index
 	PartV/index
 	Contributors

--- a/Neos.Flow/Documentation/index.rst
+++ b/Neos.Flow/Documentation/index.rst
@@ -7,7 +7,7 @@ This version of the documentation covering Flow |release| has been rendered at: 
 
 .. note::
 
-	We'd love to get your feedback on this documentation! Please share 
+	We'd love to get your feedback on this documentation! Please share
 	your thoughts in our `forum <https://discuss.neos.io>`_, or the #flow-general channel
 	in the `Neos Project's Slack <https://slack.neos.io>`_.
 
@@ -33,7 +33,6 @@ This version of the documentation covering Flow |release| has been rendered at: 
 	  - :doc:`TheDefinitiveGuide/PartI/index`
 	  - :doc:`TheDefinitiveGuide/PartII/index`
 	  - :doc:`TheDefinitiveGuide/PartIII/index`
-	  - :doc:`TheDefinitiveGuide/PartIV/index`
 	  - :doc:`TheDefinitiveGuide/PartV/index`
 	  - :doc:`TheDefinitiveGuide/Contributors`
 


### PR DESCRIPTION
This removes empty parts of the documentation, they are to be written
following their respective tickets:

- File Monitoring, https://github.com/neos/documentation/issues/20
- Logging and Debugging, https://github.com/neos/documentation/issues/18
- Testing, https://github.com/neos/documentation/issues/17
- Deployment and Administration, https://github.com/neos/documentation/issues/15

The part numbering was kept as is, to not break links. The "Deployment
and Administration" part can be put back as "Part IV" when actually
being written.

Resolves https://github.com/neos/documentation/issues/1