### PR TITLE
TASK: PHP 7.3 - Use break instead of continue within a switch case

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
@@ -315,7 +315,7 @@ return ' . var_export($this->storedProxyClasses, true) . ';';
                     break;
                 default:
                     if ($optionValue === $optionDefault) {
-                        continue;
+                        break;
                     }
                     $optionsAsStrings[] = $optionName . '=' . $optionValueAsString;
             }

--- a/Neos.Flow/Classes/Persistence/Generic/DataMapper.php
+++ b/Neos.Flow/Classes/Persistence/Generic/DataMapper.php
@@ -202,7 +202,7 @@ class DataMapper
             } else {
                 switch ($propertyData['type']) {
                     case 'NULL':
-                        continue;
+                        break;
                     case 'array':
                         $propertyValue = $this->mapArray(null);
                     break;


### PR DESCRIPTION
Starting in PHP 7.3, PHP will throw a warning when using `continue`
within a `switch` to confirm intent. In PHP, within `switch`, `break`
and `continue` do the same thing.