### PR TITLE
BUGFIX: Continue in switch means break

### DIFF
--- a/Neos.Flow/Classes/Persistence/Generic/DataMapper.php
+++ b/Neos.Flow/Classes/Persistence/Generic/DataMapper.php
@@ -202,7 +202,7 @@ class DataMapper
             } else {
                 switch ($propertyData['type']) {
                     case 'NULL':
-                        continue;
+                    break;
                     case 'array':
                         $propertyValue = $this->mapArray(null);
                     break;


### PR DESCRIPTION
The same as in https://github.com/neos/neos-development-collection/pull/2309. But here we actually want a `break`.
```
Exception #1355480641 in line 406 of .../Packages/Framework/Neos.Flow/Classes/Core/Booting/Scripts.php: Warning: "continue" targeting switch is equivalent to "break".
Did you mean to use "continue 2"? in
.../Packages/Framework/Neos.Flow/Classes/Persistence/Generic/DataMapper.php
line 205

  Type: Neos\Flow\Error\Exception
  Code: 1
  File: Packages/Framework/Neos.Flow/Classes/Error/ErrorHandler.php
  Line: 81

Open Data/Logs/Exceptions/20181207120347fca3ef.txt for a full stack trace.

12 Neos\Flow\Core\Booting\Scripts::executeCommand("neos.flow:core:compile", array|16|)
11 Neos\Flow\Core\Booting\Scripts::initializeProxyClasses(Neos\Flow\Core\Bootstrap)
10 call_user_func(array|2|, Neos\Flow\Core\Bootstrap)
9 Neos\Flow\Core\Booting\Step::__invoke(Neos\Flow\Core\Bootstrap)
8 Neos\Flow\Core\Booting\Sequence::invokeStep(Neos\Flow\Core\Booting\Step, Neos\Flow\Core\Bootstrap)
7 Neos\Flow\Core\Booting\Sequence::invokeStep(Neos\Flow\Core\Booting\Step, Neos\Flow\Core\Bootstrap)
6 Neos\Flow\Core\Booting\Sequence::invokeStep(Neos\Flow\Core\Booting\Step, Neos\Flow\Core\Bootstrap)
5 Neos\Flow\Core\Booting\Sequence::invokeStep(Neos\Flow\Core\Booting\Step, Neos\Flow\Core\Bootstrap)
4 Neos\Flow\Core\Booting\Sequence::invoke(Neos\Flow\Core\Bootstrap)
3 Neos\Flow\Http\RequestHandler::boot()
2 Neos\Flow\Http\RequestHandler::handleRequest()
1 Neos\Flow\Core\Bootstrap::run()
```