### PR TITLE
BUGFIX: Make  dev collection and neos/flow dependencies match

### DIFF
--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -34,13 +34,13 @@
         "ramsey/uuid": "^3.0.0",
 
         "doctrine/orm": "~2.6.0",
-        "doctrine/migrations": "~1.6.0",
+        "doctrine/migrations": "~1.8.1",
         "doctrine/dbal": "~2.7.0",
         "doctrine/common": ">=2.4,<2.8-dev",
 
-        "symfony/yaml": "~4.0.0",
-        "symfony/dom-crawler": "~4.0.0",
-        "symfony/console": "~4.0.0",
+        "symfony/yaml": "~4.1.0",
+        "symfony/dom-crawler": "~4.1.5",
+        "symfony/console": "~4.1.1",
 
         "neos/composer-plugin": "^2.0.0",
         "neos/utility-pdo": "~5.2.0"


### PR DESCRIPTION
The dependabot changes done to the dev collections are not good. Why? Because dependabot only changes the top-level `composer.json` bit leaves the manifests in Neos.Flow untouched.

This makes sure the dependencies in `neos/flow` match the collection dependencies again.

Fixes neos/neos-development-collection#2310