### PR TITLE
BUGFIX: Make  dev collection and neos/flow dependencies match

### DIFF
--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -12,6 +12,7 @@
         "ext-SPL": "*",
         "ext-json": ">=1.2.0",
         "ext-reflection": "*",
+        "ext-xml": "*",
 
         "neos/cache": "~5.2.0",
         "neos/eel": "~5.2.0",

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,12 @@
         "ext-SPL": "*",
         "ext-json": ">=1.2.0",
         "ext-reflection": "*",
+        "ext-xml": "*",
         "psr/http-message": "~1.0.0",
         "psr/container": "~1.0.0",
         "ramsey/uuid": "^3.0.0",
         "doctrine/orm": "~2.6.0",
-        "doctrine/migrations": "~1.6.0",
+        "doctrine/migrations": "~1.8.1",
         "doctrine/dbal": "~2.7.0",
         "doctrine/common": ">=2.4,<2.8-dev",
         "symfony/yaml": "~4.1.0",
@@ -26,8 +27,7 @@
         "symfony/console": "~4.1.1",
         "neos/composer-plugin": "^2.0.0",
         "typo3fluid/fluid": "~2.5.3",
-        "ext-mbstring": "*",
-        "ext-xml": "*"
+        "ext-mbstring": "*"
     },
     "replace": {
         "typo3/eel": "self.version",


### PR DESCRIPTION
Fixes the doctrine/migrations dependency (again) and adds ext-xml to
the neos/flow dependencies so updating the collection manifest picks
it up correctly.

Fixes neos/neos-development-collection#2310
Related #1356
