### PR TITLE
TASK: Fix risky unit test

### DIFF
--- a/Neos.Flow/Tests/Unit/Property/PropertyMapperTest.php
+++ b/Neos.Flow/Tests/Unit/Property/PropertyMapperTest.php
@@ -536,7 +536,6 @@ class PropertyMapperTest extends UnitTestCase
 
     /**
      * @test
-     * @doesNotPerformAssertions
      * @dataProvider convertCallsCanConvertFromWithNullableTargetTypeDataProvider
      */
     public function convertCallsCanConvertFromWithNullableTargetType($source, $fullTargetType)


### PR DESCRIPTION
The changed test does contain an `expects` but did advertise it
`@doesNotPerformAssertions`, leading PhpUnit to consider the
test as risky.