### PR TITLE
TASK: Avoid code migration error if source file does not exist

### DIFF
--- a/Neos.Flow/Scripts/Migrations/AbstractMigration.php
+++ b/Neos.Flow/Scripts/Migrations/AbstractMigration.php
@@ -448,6 +448,9 @@ abstract class AbstractMigration
                 }
             } else {
                 $oldPath = Files::concatenatePaths(array($this->targetPackageData['path'] . '/' . $operation[0]));
+                if (!file_exists($oldPath)) {
+                    continue;
+                }
                 $newPath = Files::concatenatePaths(array($this->targetPackageData['path'] . '/' . $operation[1]));
                 Git::move($oldPath, $newPath);
             }


### PR DESCRIPTION
This avoids errors like `fatal: bad source, source=Packages/Sites/Acme.AcmeCom/Resources/Private/Fusion/Root.ts2, destination=Packages/Sites/Acme.AcmeCom/Resources/Private/Fusion/Root.fusion` during `core:migrate`.