### PR TITLE
TASK: Allow contains expression on entity properties

### DIFF
--- a/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/PropertyConditionGenerator.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/PropertyConditionGenerator.php
@@ -210,6 +210,24 @@ class PropertyConditionGenerator implements SqlGeneratorInterface
     }
 
     /**
+     * @param $operandDefinition
+     * @return $this
+     * @throws InvalidPolicyException
+     */
+    public function contains($operandDefinition)
+    {
+        if (strpos($this->path, '.') !== false) {
+            throw new InvalidPolicyException(sprintf('The "contains" operator does not work on nested property paths (contained a "."). Got: "%s"', $this->path), 1545212769);
+        }
+
+        $this->operator = 'contains';
+        $this->operandDefinition = $operandDefinition;
+        $this->operand = $this->getValueForOperand($operandDefinition);
+
+        return $this;
+    }
+
+    /**
      * @param DoctrineSqlFilter $sqlFilter
      * @param ClassMetadata $targetEntity
      * @param string $targetTableAlias
@@ -231,10 +249,68 @@ class PropertyConditionGenerator implements SqlGeneratorInterface
         } elseif ($targetEntity->isSingleValuedAssociation($targetEntityPropertyName) === true && $targetEntity->isAssociationInverseSide($targetEntityPropertyName) === true) {
             throw new InvalidQueryRewritingConstraintException('Single valued properties from the inverse side are not supported in a content security constraint path! Got: "' . $this->path . ' ' . $this->operator . ' ' . $this->operandDefinition . '"', 1416397754);
         } elseif ($targetEntity->isCollectionValuedAssociation($targetEntityPropertyName) === true) {
-            throw new InvalidQueryRewritingConstraintException('Multivalued properties are not supported in a content security constraint path! Got: "' . $this->path . ' ' . $this->operator . ' ' . $this->operandDefinition . '"', 1416397655);
+            return $this->getSqlForPropertyContains($sqlFilter, $quoteStrategy, $targetEntity, $targetTableAlias, $targetEntityPropertyName);
         }
 
         throw new InvalidQueryRewritingConstraintException('The configured operator of the entity constraint is not valid/supported. Got: ' . $this->operator, 1270483540);
+    }
+
+    /**
+     * @param DoctrineSqlFilter $sqlFilter
+     * @param QuoteStrategy $quoteStrategy
+     * @param ClassMetadata $targetEntity
+     * @param string $targetTableAlias
+     * @param string $targetEntityPropertyName
+     * @return string
+     * @throws InvalidQueryRewritingConstraintException
+     * @throws \Exception
+     */
+    protected function getSqlForPropertyContains(DoctrineSqlFilter $sqlFilter, QuoteStrategy $quoteStrategy, ClassMetadata $targetEntity, $targetTableAlias, $targetEntityPropertyName)
+    {
+        if ($this->operator !== 'contains') {
+            throw new InvalidQueryRewritingConstraintException('Multivalued properties are not supported in a content security constraint path unless the "contains" operation is used! Got: "' . $this->path . ' ' . $this->operator . ' ' . $this->operandDefinition . '"', 1416397655);
+        }
+
+        if (is_array($this->operandDefinition)) {
+            throw new InvalidQueryRewritingConstraintException('Multivalued properties with "contains" cannot have a multivalued operand! Got: "' . $this->path . ' ' . $this->operator . ' ' . $this->operandDefinition . '"', 1545145424);
+        }
+
+        $associationMapping = $targetEntity->getAssociationMapping($targetEntityPropertyName);
+        $identityColumnNames = $targetEntity->getIdentifierColumnNames();
+        if (count($identityColumnNames) > 1) {
+            throw new InvalidQueryRewritingConstraintException('Cannot apply constraints on multi-identity entities.', 1545219903);
+        }
+
+        $identityColumnName = reset($identityColumnNames);
+
+        $parameterValue = $this->operand;
+        if (is_object($parameterValue)) {
+            $parameterValue = $this->persistenceManager->getIdentifierByObject($parameterValue);
+        }
+        $parameterValue = $this->entityManager->getConnection()->quote($parameterValue);
+
+        if (isset($associationMapping['joinTable'])) {
+            // TODO: We take the first join column here, technically there could be multiple though.
+            if (!empty($associationMapping['mappedBy'])) {
+                $joinColumn = $associationMapping['joinTable']['joinColumns'][0]['name'];
+                $reverseColumn = $associationMapping['joinTable']['inverseJoinColumns'][0]['name'];
+            } else {
+                $joinColumn = $associationMapping['joinTable']['inverseJoinColumns'][0]['name'];
+                $reverseColumn = $associationMapping['joinTable']['joinColumns'][0]['name'];
+            }
+
+            $subQuerySql = 'SELECT ' . $reverseColumn . ' FROM ' . $associationMapping['joinTable']['name'] . ' WHERE ' . $joinColumn . ' = ' . $parameterValue;
+        } else {
+            $subselectQuery = new Query($targetEntity->getAssociationTargetClass($targetEntityPropertyName));
+            $rootAliases = $subselectQuery->getQueryBuilder()->getRootAliases();
+            $primaryRootAlias = reset($rootAliases);
+
+            $subselectQuery->getQueryBuilder()->where('' . $primaryRootAlias . ' = ' . $parameterValue);
+            $subselectQuery->getQueryBuilder()->select('IDENTITY(' . $primaryRootAlias . '.' . $associationMapping['mappedBy'] . ')');
+            $subQuerySql = $subselectQuery->getSql();
+        }
+
+        return $targetTableAlias . '.' . $identityColumnName . ' IN (' . $subQuerySql . ')';
     }
 
     /**

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/PropertyConditionGenerator.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/PropertyConditionGenerator.php
@@ -214,7 +214,7 @@ class PropertyConditionGenerator implements SqlGeneratorInterface
      * @return $this
      * @throws InvalidPolicyException
      */
-    public function contains($operandDefinition)
+    public function contains($operandDefinition): PropertyConditionGenerator
     {
         if (strpos($this->path, '.') !== false) {
             throw new InvalidPolicyException(sprintf('The "contains" operator does not work on nested property paths (contained a "."). Got: "%s"', $this->path), 1545212769);

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/PropertyConditionGenerator.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/PropertyConditionGenerator.php
@@ -265,7 +265,7 @@ class PropertyConditionGenerator implements SqlGeneratorInterface
      * @throws InvalidQueryRewritingConstraintException
      * @throws \Exception
      */
-    protected function getSqlForPropertyContains(DoctrineSqlFilter $sqlFilter, QuoteStrategy $quoteStrategy, ClassMetadata $targetEntity, $targetTableAlias, $targetEntityPropertyName)
+    protected function getSqlForPropertyContains(DoctrineSqlFilter $sqlFilter, QuoteStrategy $quoteStrategy, ClassMetadata $targetEntity, string $targetTableAlias, string $targetEntityPropertyName): string
     {
         if ($this->operator !== 'contains') {
             throw new InvalidQueryRewritingConstraintException('Multivalued properties are not supported in a content security constraint path unless the "contains" operation is used! Got: "' . $this->path . ' ' . $this->operator . ' ' . $this->operandDefinition . '"', 1416397655);

--- a/Neos.Flow/Configuration/Testing/Policy.yaml
+++ b/Neos.Flow/Configuration/Testing/Policy.yaml
@@ -49,6 +49,12 @@ privilegeTargets:
     'Neos.Flow:inOperatorWithObjectsTestResource':
       matcher: 'isType("Neos\Flow\Tests\Functional\Security\Fixtures\TestEntityC") && property("relatedEntityD").in("context.testContext.securityFixturesEntityDCollection")'
 
+    'Neos.Flow:containsOperatorWithOneToMany':
+      matcher: 'isType("Neos\Flow\Tests\Functional\Security\Fixtures\TestEntityC") && property("oneToManyToRelatedEntityD").contains("context.testContext.securityFixturesEntityD")'
+
+    'Neos.Flow:containsOperatorWithManyToMany':
+      matcher: 'isType("Neos\Flow\Tests\Functional\Security\Fixtures\TestEntityC") && property("manyToManyToRelatedEntityD").contains("context.testContext.securityFixturesEntityD")'
+
 
 roles:
 
@@ -64,6 +70,14 @@ roles:
 
       -
         privilegeTarget: 'Neos.Flow:Tests.Functional.Security.Fixtures.RestrictableEntity.AllEntities'
+        permission: GRANT
+
+      -
+        privilegeTarget: 'Neos.Flow:containsOperatorWithOneToMany'
+        permission: GRANT
+
+      -
+        privilegeTarget: 'Neos.Flow:containsOperatorWithManyToMany'
         permission: GRANT
 
   'Neos.Flow:Administrator':

--- a/Neos.Flow/Tests/Functional/Security/Authorization/Privilege/Entity/Doctrine/EntityPrivilegeExpressionEvaluatorTest.php
+++ b/Neos.Flow/Tests/Functional/Security/Authorization/Privilege/Entity/Doctrine/EntityPrivilegeExpressionEvaluatorTest.php
@@ -16,6 +16,7 @@ use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Security\Authorization\Privilege\Entity\Doctrine\ConditionGenerator;
 use Neos\Flow\Security\Authorization\Privilege\Entity\Doctrine\EntityPrivilegeExpressionEvaluator;
 use Neos\Flow\Security\Authorization\Privilege\Entity\Doctrine\SqlFilter;
+use Neos\Flow\Tests\Functional\Security\Fixtures\TestEntityC;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Eel;
 use Neos\Flow\Tests\Functional\Security\Fixtures;
@@ -76,5 +77,43 @@ class EntityPrivilegeExpressionEvaluatorTest extends FunctionalTestCase
 
         $this->assertEquals(Fixtures\RestrictableEntity::class, $result['entityType']);
         $this->assertEquals($expectedSqlCode, $result['conditionGenerator']->getSql($sqlFilter, $entityManager->getClassMetadata(Fixtures\RestrictableEntity::class), 't0'));
+    }
+
+    /**
+     * @test
+     */
+    public function propertyContainsExpressionGeneratesExpectedSqlFilterForOneToMany()
+    {
+        $context = new Eel\Context(new ConditionGenerator());
+
+        $evaluator = new EntityPrivilegeExpressionEvaluator();
+        $result = $evaluator->evaluate('isType("Neos\Flow\Tests\Functional\Security\Fixtures\TestEntityC") && property("oneToManyToRelatedEntityD").contains("c1ed7ad7-3618-4e0d-bcf8-c849a505dfe1")', $context);
+
+        $entityManager = $this->objectManager->get(EntityManagerInterface::class);
+        $sqlFilter = new SqlFilter($entityManager);
+
+        $this->assertEquals(TestEntityC::class, $result['entityType']);
+        $this->assertEquals('(t0.persistence_object_identifier IN (SELECT n0_.manytoonetorelatedentityc AS sclr_0 FROM neos_flow_tests_functional_security_fixtures_testentityd n0_ WHERE n0_.persistence_object_identifier = \'c1ed7ad7-3618-4e0d-bcf8-c849a505dfe1\'))',
+            $result['conditionGenerator']->getSql($sqlFilter, $entityManager->getClassMetadata(TestEntityC::class), 't0')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function propertyContainsExpressionGeneratesExpectedSqlFilterForManyToMany()
+    {
+        $context = new Eel\Context(new ConditionGenerator());
+
+        $evaluator = new EntityPrivilegeExpressionEvaluator();
+        $result = $evaluator->evaluate('isType("Neos\Flow\Tests\Functional\Security\Fixtures\TestEntityC") && property("manyToManyToRelatedEntityD").contains("c1ed7ad7-3618-4e0d-bcf8-c849a505dfe1")', $context);
+
+        $entityManager = $this->objectManager->get(EntityManagerInterface::class);
+        $sqlFilter = new SqlFilter($entityManager);
+
+        $this->assertEquals(TestEntityC::class, $result['entityType']);
+        $this->assertEquals('(t0.persistence_object_identifier IN (SELECT flow_fixtures_testentityc FROM neos_flow_tests_functiona_09cce_manytomanytorelatedentityd_join WHERE flow_fixtures_testentityd = \'c1ed7ad7-3618-4e0d-bcf8-c849a505dfe1\'))',
+            $result['conditionGenerator']->getSql($sqlFilter, $entityManager->getClassMetadata(TestEntityC::class), 't0')
+        );
     }
 }

--- a/Neos.Flow/Tests/Functional/Security/Fixtures/TestEntityD.php
+++ b/Neos.Flow/Tests/Functional/Security/Fixtures/TestEntityD.php
@@ -23,7 +23,7 @@ class TestEntityD
 {
     /**
      * @var TestEntityC
-     * @ORM\OneToMany(mappedBy="relatedEntityD")
+     * @ORM\OneToOne(mappedBy="relatedEntityD")
      */
     protected $relatedEntityC;
 
@@ -36,17 +36,17 @@ class TestEntityD
     /**
      * @param TestEntityC $oneToManyToRelatedEntityC
      */
-    public function setOneToManyToRelatedEntityC($oneToManyToRelatedEntityC)
+    public function setManyToOneToRelatedEntityC($oneToManyToRelatedEntityC)
     {
-        $this->oneToManyToRelatedEntityC = $oneToManyToRelatedEntityC;
+        $this->manyToOneToRelatedEntityC = $oneToManyToRelatedEntityC;
     }
 
     /**
      * @return TestEntityC
      */
-    public function getOneToManyToRelatedEntityC()
+    public function getManyToOneToRelatedEntityC()
     {
-        return $this->oneToManyToRelatedEntityC;
+        return $this->manyToOneToRelatedEntityC;
     }
 
     /**


### PR DESCRIPTION
This is very limited on purpose but allows to write policies like this:

`'isType("Whatever\Domain\Model\Party") && (!property("accounts").contains("context.securityContext.account"))'`