### PR TITLE
FEATURE: Make recursion limit for the debugger configurable via Settings

### DIFF
--- a/Neos.Flow/Configuration/Settings.Error.yaml
+++ b/Neos.Flow/Configuration/Settings.Error.yaml
@@ -69,3 +69,7 @@ Neos:
           '.+Service$': true
           '.+Repository$': true
           'PHPUnit_Framework_MockObject_InvocationMocker': true
+
+        # Maximal recursion for the debugger
+        recursionLimit: 5
+

--- a/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.error.schema.yaml
+++ b/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.error.schema.yaml
@@ -42,3 +42,6 @@ properties:
         type: dictionary
         required: true
         patternProperties: { '/.*/': { type: boolean } }
+      'recursionLimit':
+        type: integer
+        required: true


### PR DESCRIPTION
With the default recursion Limit of 50 php often runs into memory-limits when debugging larger data structures. This change allows to define the recursionLimit via Settings. In addition the default recursionLimit is set to 5.