### PR TITLE
TASK: Respect type hinting in reflection / support "@param Type[]" array syntax

### DIFF
--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1454,7 +1454,7 @@ class ReflectionService
         }
 
         // expand SomeElementType[]" to "array<\ElementTypeNamespace\SomeElementType>"
-        if (strpos($typeWithoutNull, '[]') === strlen($typeWithoutNull) - 2) {
+        if (substr_compare($typeWithoutNull, '[]', -2, 2) === 0) {
             $elementType = substr($typeWithoutNull, 0, -2);
             return 'array<' . $this->expandType($class, $elementType) . '>' . ($isNullable ? '|null' : '');
         }

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1453,6 +1453,12 @@ class ReflectionService
             return $this->expandType($class, $type) . '<' . $this->expandType($class, $elementType) . '>' . ($isNullable ? '|null' : '');
         }
 
+        // expand SomeElementType[]" to "array<\ElementTypeNamespace\SomeElementType>"
+        if (strpos($typeWithoutNull, '[]') === strlen($typeWithoutNull) - 2) {
+            $elementType = substr($typeWithoutNull, 0, -2);
+            return 'array<' . $this->expandType($class, $elementType) . '>' . ($isNullable ? '|null' : '');
+        }
+
         // skip simple types and types with fully qualified namespaces
         if ($type === 'mixed' || $type[0] === '\\' || TypeHandling::isSimpleType($type)) {
             return TypeHandling::normalizeType($type) . ($isNullable ? '|null' : '');
@@ -1824,7 +1830,7 @@ class ReflectionService
         if (!isset($parameterInformation[self::DATA_PARAMETER_TYPE]) && $parameterClass !== null) {
             $parameterInformation[self::DATA_PARAMETER_TYPE] = $this->cleanClassName($parameterClass->getName());
         } elseif (!isset($parameterInformation[self::DATA_PARAMETER_TYPE])) {
-            $parameterInformation[self::DATA_PARAMETER_TYPE] = 'mixed';
+            $parameterInformation[self::DATA_PARAMETER_TYPE] = $parameter->isArray() ? 'array' : 'mixed';
         }
 
         return $parameterInformation;

--- a/Neos.Flow/Tests/Functional/Reflection/Fixtures/DummyClassWithTypeHints.php
+++ b/Neos.Flow/Tests/Functional/Reflection/Fixtures/DummyClassWithTypeHints.php
@@ -17,10 +17,12 @@ namespace Neos\Flow\Tests\Functional\Reflection\Fixtures;
  */
 class DummyClassWithTypeHints
 {
-    public function methodWithScalarTypeHints(int $integer, string $string) {
+    public function methodWithScalarTypeHints(int $integer, string $string)
+    {
     }
 
-    public function methodWithArrayTypeHint(array $array) {
+    public function methodWithArrayTypeHint(array $array)
+    {
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/Reflection/Fixtures/DummyClassWithTypeHints.php
+++ b/Neos.Flow/Tests/Functional/Reflection/Fixtures/DummyClassWithTypeHints.php
@@ -1,0 +1,32 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Reflection\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Dummy class for the Reflection tests
+ *
+ */
+class DummyClassWithTypeHints
+{
+    public function methodWithScalarTypeHints(int $integer, string $string) {
+    }
+
+    public function methodWithArrayTypeHint(array $array) {
+    }
+
+    /**
+     * @param string[] $array
+     */
+    public function methodWithArrayTypeHintAndAnnotation(array $array)
+    {
+    }
+}

--- a/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
@@ -273,4 +273,33 @@ class ReflectionServiceTest extends FunctionalTestCase
         $this->assertEquals(Reflection\Fixtures\AnnotatedClass::class . '|null', $reverseAnnotatedNullableMethodParameters['nullable']['type']);
         $this->assertEquals(Reflection\Fixtures\AnnotatedClass::class . '|null', $annotatedAndNativeNullableMethodParameters['nullable']['type']);
     }
+
+    /**
+     * @test
+     */
+    public function scalarTypeHintsWorkCorrectly()
+    {
+        $methodWithTypeHintsParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\DummyClassWithTypeHints::class, 'methodWithScalarTypeHints');
+
+        $this->assertEquals('int', $methodWithTypeHintsParameters['integer']['type']);
+        $this->assertEquals('string', $methodWithTypeHintsParameters['string']['type']);
+    }
+
+    /**
+     * @test
+     */
+    public function arrayTypeHintsWorkCorrectly()
+    {
+        $methodWithTypeHintsParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\DummyClassWithTypeHints::class, 'methodWithArrayTypeHint');
+        $this->assertEquals('array', $methodWithTypeHintsParameters['array']['type']);
+    }
+
+    /**
+     * @test
+     */
+    public function annotatedArrayTypeHintsWorkCorrectly()
+    {
+        $methodWithTypeHintsParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\DummyClassWithTypeHints::class, 'methodWithArrayTypeHintAndAnnotation');
+        $this->assertEquals('array<string>', $methodWithTypeHintsParameters['array']['type']);
+    }
 }


### PR DESCRIPTION
Currently the Reflection Service does not work well with the `@param Type[]` array syntax. Also `array` type hints without a `@param` annotation result in a `mixed` type. 

Through this PR the Reflection Service resolves `Type[]` to `array<Type>`. And `array` stays `array` even without annotation.