### PR TITLE
BUGFIX: Verify the existence of the `repositories` section in the composer manifest before searching for local packages path

### DIFF
--- a/Neos.Flow/Classes/Package/PackageManager.php
+++ b/Neos.Flow/Classes/Package/PackageManager.php
@@ -343,11 +343,13 @@ class PackageManager implements PackageManagerInterface
         $runComposerRequireForTheCreatedPackage = false;
         if ($packagesPath === null) {
             $composerManifestRepositories = ComposerUtility::getComposerManifest(FLOW_PATH_ROOT, 'repositories');
-            foreach ($composerManifestRepositories as $repository) {
-                if ($repository['type'] == 'path' && substr($repository['url'], 0, 2) == './' && substr($repository['url'], -2) == '/*') {
-                    $packagesPath = Files::getUnixStylePath(Files::concatenatePaths([FLOW_PATH_ROOT, substr($repository['url'], 0, -2)]));
-                    $runComposerRequireForTheCreatedPackage = true;
-                    break;
+            if (is_array($composerManifestRepositories)) {
+                foreach ($composerManifestRepositories as $repository) {
+                    if ($repository['type'] == 'path' && substr($repository['url'], 0, 2) == './' && substr($repository['url'], -2) == '/*') {
+                        $packagesPath = Files::getUnixStylePath(Files::concatenatePaths([FLOW_PATH_ROOT, substr($repository['url'], 0, -2)]));
+                        $runComposerRequireForTheCreatedPackage = true;
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
In older setups that did not have a `repositories` section in the composer-maifest `package:create` tried to foreach over a null-value which lead to an php-error. This change checks that the `repositories` is actually an array before iterating.