### PR TITLE
BUGFIX: Set recursion limit for debugger to 5

### DIFF
--- a/Neos.Flow/Classes/Error/Debugger.php
+++ b/Neos.Flow/Classes/Error/Debugger.php
@@ -118,7 +118,7 @@ class Debugger
      */
     public static function renderDump($variable, $level, $plaintext = false, $ansiColors = false)
     {
-        if ($level > 50) {
+        if ($level > 5) {
             return 'RECURSION ... ' . chr(10);
         }
         if (is_string($variable)) {

--- a/Neos.Flow/Tests/Functional/Error/DebuggerTest.php
+++ b/Neos.Flow/Tests/Functional/Error/DebuggerTest.php
@@ -43,7 +43,7 @@ class DebuggerTest extends FunctionalTestCase
     public function ignoredClassesCanBeOverwrittenBySettings()
     {
         $object = new ApplicationContext('Development');
-        $this->assertEquals(sprintf('%s prototype object', ApplicationContext::class), Debugger::renderDump($object, 10, true));
+        $this->assertEquals(sprintf('%s prototype object', ApplicationContext::class), Debugger::renderDump($object, 0, true));
         Debugger::clearState();
 
         $currentConfiguration = ObjectAccess::getProperty($this->configurationManager, 'configurations', true);
@@ -51,6 +51,6 @@ class DebuggerTest extends FunctionalTestCase
         $newConfiguration = Arrays::arrayMergeRecursiveOverrule($currentConfiguration, $configurationOverwrite);
         ObjectAccess::setProperty($this->configurationManager, 'configurations', $newConfiguration, true);
 
-        $this->assertContains('rootContextString', Debugger::renderDump($object, 10, true));
+        $this->assertContains('rootContextString', Debugger::renderDump($object, 0, true));
     }
 }

--- a/Neos.Flow/Tests/Unit/Error/DebuggerTest.php
+++ b/Neos.Flow/Tests/Unit/Error/DebuggerTest.php
@@ -61,6 +61,6 @@ class DebuggerTest extends UnitTestCase
     public function ignoredClassesAreNotRendered()
     {
         $object = new ApplicationContext('Development');
-        $this->assertEquals('Neos\Flow\Core\ApplicationContext object', Debugger::renderDump($object, 10, true));
+        $this->assertEquals('Neos\Flow\Core\ApplicationContext object', Debugger::renderDump($object, 0, true));
     }
 }


### PR DESCRIPTION
With the previous recursion limit of 50 php often ran into memory-limits when debugging larger data structures.