### PR TITLE
TASK: Use proper dummy hash in PersistedUsernamePasswordProvider

### DIFF
--- a/Neos.Flow/Classes/Security/Authentication/Provider/PersistedUsernamePasswordProvider.php
+++ b/Neos.Flow/Classes/Security/Authentication/Provider/PersistedUsernamePasswordProvider.php
@@ -97,7 +97,7 @@ class PersistedUsernamePasswordProvider extends AbstractProvider
         $authenticationToken->setAuthenticationStatus(TokenInterface::WRONG_CREDENTIALS);
 
         if ($account === null) {
-            $this->hashService->validatePassword($credentials['password'], 'bcrypt=>$2a$14$DummySaltToPreventTim,.ingAttacksOnThisProvider');
+            $this->hashService->validatePassword($credentials['password'], 'bcrypt=>$2a$16$RW.NZM/uP3mC8rsXKJGuN.2pG52thRp5w39NFO.ShmYWV7mJQp0rC');
             return;
         }
 

--- a/Neos.Flow/Classes/Security/Authentication/Provider/PersistedUsernamePasswordProvider.php
+++ b/Neos.Flow/Classes/Security/Authentication/Provider/PersistedUsernamePasswordProvider.php
@@ -97,6 +97,7 @@ class PersistedUsernamePasswordProvider extends AbstractProvider
         $authenticationToken->setAuthenticationStatus(TokenInterface::WRONG_CREDENTIALS);
 
         if ($account === null) {
+            // validate the account anyways (with a dummy salt) in order to prevent timing attacks on this provider
             $this->hashService->validatePassword($credentials['password'], 'bcrypt=>$2a$16$RW.NZM/uP3mC8rsXKJGuN.2pG52thRp5w39NFO.ShmYWV7mJQp0rC');
             return;
         }


### PR DESCRIPTION
This replaces the dummy hash used to prevent timing based attacks by
a valid hash for a random password that was never actually stored
somewhere.

This avoids problems with PHP's encryption methods. With the
previous hash, the hashing was sometimes not applied properly
and the method returns early so that the time-based information
disclosure vulnerability still exists.
