### PR TITLE
BUGIFX: Correctly check for TaggableBackendInterface

### DIFF
--- a/Neos.Cache/Classes/Backend/TaggableMultiBackend.php
+++ b/Neos.Cache/Classes/Backend/TaggableMultiBackend.php
@@ -30,7 +30,7 @@ class TaggableMultiBackend extends MultiBackend implements TaggableBackendInterf
     protected function buildSubBackend(string $backendClassName, array $backendOptions): ?BackendInterface
     {
         $backend = null;
-        if (!is_a($backendClassName, TaggableBackendInterface::class)) {
+        if (!is_sublcass_of($backendClassName, TaggableBackendInterface::class)) {
             return $backend;
         }
 


### PR DESCRIPTION
The `is_a` only checks for parents but not for implemented interfaces. `is_sublcass_of` should be used instead to check if the `$backendClassName` implements the interface
