### PR TITLE
FEATURE: Add methods `csrfToken`, `isAuthenticated` and `hasAccess` to `Security` EelHelper

### DIFF
--- a/Neos.Eel/Tests/Unit/Helper/SecurityHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/SecurityHelperTest.php
@@ -15,6 +15,150 @@ class SecurityHelperTest extends \Neos\Flow\Tests\UnitTestCase
     /**
      * @test
      */
+    public function csrfTokenIsReturnedFromTheSecurityContext()
+    {
+        $mockSecurityContext = $this->createMock(\Neos\Flow\Security\Context::class);
+        $mockSecurityContext->expects($this->any())->method('getCsrfProtectionToken')->willReturn('TheCsrfToken');
+
+        $helper = new SecurityHelper();
+        $this->inject($helper, 'securityContext', $mockSecurityContext);
+
+        $this->assertEquals('TheCsrfToken', $helper->csrfToken());
+    }
+
+    /**
+     * @test
+     */
+    public function isAuthenticatedReturnsTrueIfAnAuthenticatedTokenIsPresent()
+    {
+        $mockUnautenticatedAuthenticationToken = $this->createMock(\Neos\Flow\Security\Authentication\TokenInterface::class);
+        $mockUnautenticatedAuthenticationToken->expects($this->once())->method('isAuthenticated')->will($this->returnValue(false));
+
+        $mockAutenticatedAuthenticationToken = $this->createMock(\Neos\Flow\Security\Authentication\TokenInterface::class);
+        $mockAutenticatedAuthenticationToken->expects($this->once())->method('isAuthenticated')->will($this->returnValue(true));
+
+        $mockSecurityContext = $this->createMock(\Neos\Flow\Security\Context::class);
+
+        $mockSecurityContext->expects($this->once())->method('canBeInitialized')->will($this->returnValue(true));
+        $mockSecurityContext->expects($this->once())->method('getAuthenticationTokens')->will($this->returnValue([
+            $mockUnautenticatedAuthenticationToken,
+            $mockAutenticatedAuthenticationToken
+        ]));
+
+        $helper = new SecurityHelper();
+        $this->inject($helper, 'securityContext', $mockSecurityContext);
+
+        $this->assertTrue($helper->isAuthenticated());
+    }
+
+    /**
+     * @test
+     */
+    public function isAuthenticatedReturnsFalseIfNoAuthenticatedTokenIsPresent()
+    {
+        $mockUnautenticatedAuthenticationToken = $this->createMock(\Neos\Flow\Security\Authentication\TokenInterface::class);
+        $mockUnautenticatedAuthenticationToken->expects($this->once())->method('isAuthenticated')->will($this->returnValue(false));
+
+        $mockSecurityContext = $this->createMock(\Neos\Flow\Security\Context::class);
+
+        $mockSecurityContext->expects($this->once())->method('canBeInitialized')->will($this->returnValue(true));
+        $mockSecurityContext->expects($this->once())->method('getAuthenticationTokens')->will($this->returnValue([
+            $mockUnautenticatedAuthenticationToken
+        ]));
+
+        $helper = new SecurityHelper();
+        $this->inject($helper, 'securityContext', $mockSecurityContext);
+
+        $this->assertFalse($helper->isAuthenticated());
+    }
+
+    /**
+     * @test
+     */
+    public function isAuthenticatedReturnsFalseIfNoAuthenticatedTokensAre()
+    {
+        $mockSecurityContext = $this->createMock(\Neos\Flow\Security\Context::class);
+
+        $mockSecurityContext->expects($this->once())->method('canBeInitialized')->will($this->returnValue(true));
+        $mockSecurityContext->expects($this->once())->method('getAuthenticationTokens')->will($this->returnValue([]));
+
+        $helper = new SecurityHelper();
+        $this->inject($helper, 'securityContext', $mockSecurityContext);
+
+        $this->assertFalse($helper->isAuthenticated());
+    }
+
+    /**
+     * @test
+     */
+    public function isAuthenticatedReturnsFalseIfSecurityContextCannotBeInitialized()
+    {
+        $mockSecurityContext = $this->createMock(\Neos\Flow\Security\Context::class);
+
+        $mockSecurityContext->expects($this->once())->method('canBeInitialized')->will($this->returnValue(false));
+
+        $helper = new SecurityHelper();
+        $this->inject($helper, 'securityContext', $mockSecurityContext);
+
+        $this->assertFalse($helper->isAuthenticated());
+    }
+
+    /**
+     * @test
+     */
+    public function hasAccessToPrivilegeTargetReturnsTrueIfAccessIsAllowed()
+    {
+        $mockSecurityContext = $this->createMock(\Neos\Flow\Security\Context::class);
+        $mockPrivilegeManager = $this->createMock(\Neos\Flow\Security\Authorization\PrivilegeManagerInterface::class);
+
+        $mockSecurityContext->expects($this->once())->method('canBeInitialized')->will($this->returnValue(true));
+        $mockPrivilegeManager->expects($this->once())->method('isPrivilegeTargetGranted')->with('somePrivilegeTarget')->will($this->returnValue(true));
+
+        $helper = new SecurityHelper();
+        $this->inject($helper, 'securityContext', $mockSecurityContext);
+        $this->inject($helper, 'privilegeManager', $mockPrivilegeManager);
+
+        $this->assertTrue($helper->hasAccess('somePrivilegeTarget', []));
+    }
+
+    /**
+     * @test
+     */
+    public function hasAccessToPrivilegeTargetReturnsFalseIfAccessIsForbidden()
+    {
+        $mockSecurityContext = $this->createMock(\Neos\Flow\Security\Context::class);
+        $mockPrivilegeManager = $this->createMock(\Neos\Flow\Security\Authorization\PrivilegeManagerInterface::class);
+
+        $mockSecurityContext->expects($this->once())->method('canBeInitialized')->will($this->returnValue(true));
+        $mockPrivilegeManager->expects($this->once())->method('isPrivilegeTargetGranted')->with('somePrivilegeTarget')->will($this->returnValue(false));
+
+        $helper = new SecurityHelper();
+        $this->inject($helper, 'securityContext', $mockSecurityContext);
+        $this->inject($helper, 'privilegeManager', $mockPrivilegeManager);
+
+        $this->assertFalse($helper->hasAccess('somePrivilegeTarget', []));
+    }
+
+    /**
+     * @test
+     */
+    public function hasAccessToPrivilegeTargetReturnsFalseIfSecurityContextCannotBeInitialized()
+    {
+        $mockSecurityContext = $this->createMock(\Neos\Flow\Security\Context::class);
+        $mockPrivilegeManager = $this->createMock(\Neos\Flow\Security\Authorization\PrivilegeManagerInterface::class);
+
+        $mockSecurityContext->expects($this->once())->method('canBeInitialized')->will($this->returnValue(false));
+
+        $helper = new SecurityHelper();
+        $this->inject($helper, 'securityContext', $mockSecurityContext);
+        $this->inject($helper, 'privilegeManager', $mockPrivilegeManager);
+
+        $this->assertFalse($helper->hasAccess('somePrivilegeTarget', []));
+    }
+
+    /**
+     * @test
+     */
     public function getAccountReturnsNullIfSecurityContextCannotBeInitialized()
     {
         $mockSecurityContext = $this->createMock(\Neos\Flow\Security\Context::class);


### PR DESCRIPTION
- `csrfToken` returns CSRF token which is required for "unsafe" requests (e.g. POST, PUT, DELETE, ...)
- `isAuthenticated` returns true, if any account is currently authenticated
- `hasAccess` returns true, if access to the given privilege-target is granted

The new methods add features to eel that previously were available as viewHelpers so they can be used in Fusion directly.
