### PR TITLE
FEATURE: Add `createFromEnvironment` factory method to ControllerContext

### DIFF
--- a/Neos.Flow/Classes/Mvc/Controller/ControllerContext.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ControllerContext.php
@@ -12,7 +12,9 @@ namespace Neos\Flow\Mvc\Controller;
  */
 
 
+use Neos\Flow\Http\Request;
 use Neos\Flow\Http\Response;
+use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\FlashMessageContainer;
 use Neos\Flow\Mvc\RequestInterface;
 use Neos\Flow\Mvc\ResponseInterface;
@@ -69,6 +71,26 @@ class ControllerContext
         $this->response = $response;
         $this->arguments = $arguments;
         $this->uriBuilder = $uriBuilder;
+    }
+
+    /**
+     * Creates a blind controller context from the current request environment.
+     * @see \Neos\Flow\Http\Request::createFromEnvironment()
+     *
+     * @return ControllerContext
+     */
+    public static function createFromEnvironment(): ControllerContext
+    {
+        $httpRequest = Request::createFromEnvironment();
+        $actionRequest = new ActionRequest($httpRequest);
+        $uriBuilder = new UriBuilder();
+        $uriBuilder->setRequest($actionRequest);
+        $response = new Response();
+        $arguments = new Arguments([]);
+
+        $controllerContext = new static($actionRequest, $response, $arguments, $uriBuilder);
+
+        return $controllerContext;
     }
 
     /**


### PR DESCRIPTION
This introduces a factory method to
\Neos\Flow\Mvc\Controller\ControllerContext that has a similar purpose
as and works similarly to
\Neos\Flow\Http\Request::createFromEnvironment().

It allows to quickly create an ad-hoc controller context outside of the
usual http process chain.

Oftentimes, especially when doing extensive work with Fusion, it is necessary to spin up objects that require a `ControllerContext`. I've seen workarounds written for those ad-hoc contexts all over the place and have been in the situation of awkwardly writing them myself quite a few times. So I figured it might be worth providing a standard short-hand way of creating them.

Yet, I'm not entirely sure, whether this is a good idea, since it still feels like a workaround. Creating a FusionRuntime outside the MVC framework and providing it with an otherwise meaningless ControllerContext feels like I'm doing something I'm not supposed to be doing.

On the other hand, this pattern is quite common and currently it is pretty tedious to create a ControllerContext out of the blue.

So, let's discuss this. Maybe it is sufficient to provide the method and simply denying it an `@api` annotation. Maybe there's a good reason for not having anything like this, that I'm not seeing here.