### PR TITLE
BUGFIX: Fix exit code for unresolved CLI commands

### DIFF
--- a/Neos.Flow/Classes/Command/HelpCommandController.php
+++ b/Neos.Flow/Classes/Command/HelpCommandController.php
@@ -18,6 +18,7 @@ use Neos\Flow\Cli\CommandController;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Mvc\Exception\AmbiguousCommandIdentifierException;
 use Neos\Flow\Mvc\Exception\CommandException;
+use Neos\Flow\Mvc\Exception\StopActionException;
 use Neos\Flow\Package\PackageManagerInterface;
 
 /**
@@ -79,6 +80,7 @@ class HelpCommandController extends CommandController
      *
      * @param string $commandIdentifier Identifier of a command for more details
      * @return void
+     * @throws StopActionException
      */
     public function helpCommand($commandIdentifier = null)
     {
@@ -93,10 +95,12 @@ class HelpCommandController extends CommandController
             $matchingCommands = $this->commandManager->getCommandsByIdentifier($commandIdentifier);
             $numberOfMatchingCommands = count($matchingCommands);
             if ($numberOfMatchingCommands === 0) {
-                $this->outputLine('No command could be found that matches the command identifier "%s".', [$commandIdentifier]);
+                $this->outputLine('<error>No command could be found that matches the command identifier "%s".</error>', [$commandIdentifier]);
+                $this->quit(1);
             } elseif ($numberOfMatchingCommands > 1) {
-                $this->outputLine('%d commands match the command identifier "%s":', [$numberOfMatchingCommands, $commandIdentifier]);
+                $this->outputLine('<error>%d commands match the command identifier "%s":</error>', [$numberOfMatchingCommands, $commandIdentifier]);
                 $this->displayShortHelpForCommands($matchingCommands);
+                $this->quit(1);
             } else {
                 $this->displayHelpForCommand(array_shift($matchingCommands));
             }
@@ -245,10 +249,11 @@ class HelpCommandController extends CommandController
      * @Flow\Internal
      * @param CommandException $exception
      * @return void
+     * @throws StopActionException
      */
     public function errorCommand(CommandException $exception)
     {
-        $this->outputLine($exception->getMessage());
+        $this->outputLine('<error>%s</error>', [$exception->getMessage()]);
         if ($exception instanceof AmbiguousCommandIdentifierException) {
             $this->outputLine('Please specify the complete command identifier. Matched commands:');
             $this->displayShortHelpForCommands($exception->getMatchingCommands());
@@ -256,6 +261,7 @@ class HelpCommandController extends CommandController
         $this->outputLine();
         $this->outputLine('Enter "%s help" for an overview of all available commands', [$this->getFlowInvocationString()]);
         $this->outputLine('or "%s help <commandIdentifier>" for a detailed description of the corresponding command.', [$this->getFlowInvocationString()]);
+        $this->quit(1);
     }
 
     /**


### PR DESCRIPTION
Fixes the exit code of

    ./flow non:existing:command

to be 1 instead of 0.

Fixes: #1504