### PR TITLE
BUGFIX: Accessing non existing array keys can cause a PHP Notice.

### DIFF
--- a/Neos.Flow/Classes/I18n/Cldr/Reader/PluralsReader.php
+++ b/Neos.Flow/Classes/I18n/Cldr/Reader/PluralsReader.php
@@ -150,7 +150,7 @@ class PluralsReader
             return self::RULE_OTHER;
         }
 
-        $ruleset = $this->rulesets[$locale->getLanguage()][$this->rulesetsIndices[$locale->getLanguage()]];
+        $ruleset = $this->rulesets[$locale->getLanguage()][$this->rulesetsIndices[$locale->getLanguage()]] ?? null;
 
         if ($ruleset === null) {
             return self::RULE_OTHER;
@@ -226,7 +226,13 @@ class PluralsReader
             return [self::RULE_OTHER];
         }
 
-        return array_merge(array_keys($this->rulesets[$locale->getLanguage()][$this->rulesetsIndices[$locale->getLanguage()]]), [self::RULE_OTHER]);
+        $ruleset = $this->rulesets[$locale->getLanguage()][$this->rulesetsIndices[$locale->getLanguage()]] ?? null;
+
+        if ($ruleset === null) {
+            return [self::RULE_OTHER];
+        }
+
+        return array_merge(array_keys($ruleset), [self::RULE_OTHER]);
     }
 
     /**


### PR DESCRIPTION
Would be better to check the array keys before using them.

INFO: For some langauges like "zh" (china), the property "$this->rulesets" is
not filled properly. So accessing for example "$this->rulesets['zh']" will cause
a PHP Notice: "Undefined index".

**What I did**

In my fluidtemplate, i want to translate a language ID from "zh/Main.xlf" with this code:

```
{f:translate(
  id: 'lang.id.with.plurals.definition',
  package: 'Some.Package',
  source: 'Main.xlf',
  locale: 'zh',
  quantity: 2
)}
```

The definition of this language ID in my "zh/Main.xlf" is this:

```
<group id="lang.id.with.plurals.definition" restype="x-gettext-plurals">
		<trans-unit id="lang.id.with.plurals.definition[0]">
			<source>Acme default Foo</source>
			<target>Acme ZH Foo</target>
		</trans-unit>
		<trans-unit id="lang.id.with.plurals.definition[1]">
			<source>Acme default Foos</source>
			<target>"Acme ZH Foos</target>
		</trans-unit>
</group>
```

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
