### PR TITLE
TASK: Avoid rendering of meta http-equiv if location headers are sent

### DIFF
--- a/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
@@ -323,11 +323,12 @@ abstract class AbstractController implements ControllerInterface
      */
     protected function redirectToUri($uri, $delay = 0, $statusCode = 303)
     {
-        $escapedUri = htmlentities($uri, ENT_QUOTES, 'utf-8');
-        $this->response->setContent('<html><head><meta http-equiv="refresh" content="' . intval($delay) . ';url=' . $escapedUri . '"/></head></html>');
         $this->response->setStatus($statusCode);
         if ($delay === 0) {
             $this->response->setHeader('Location', (string)$uri);
+        } else {
+            $escapedUri = htmlentities($uri, ENT_QUOTES, 'utf-8');
+            $this->response->setContent('<html><head><meta http-equiv="refresh" content="' . intval($delay) . ';url=' . $escapedUri . '"/></head></html>');
         }
         throw new StopActionException();
     }


### PR DESCRIPTION
Now meta http-equiv is only rendered if a delay is requested.
