### PR TITLE
BUGFIX: Allow testing provider everywhere

### DIFF
--- a/Neos.Flow/Configuration/Testing/Settings.yaml
+++ b/Neos.Flow/Configuration/Testing/Settings.yaml
@@ -140,11 +140,6 @@ Neos:
             entryPoint: 'WebRedirect'
             entryPointOptions:
               uri: 'flow/authentication'
-            requestPatterns:
-              'TestsPattern':
-                pattern: 'ControllerObjectName'
-                patternOptions:
-                  controllerObjectNamePattern: 'Neos\Flow\Tests\.*'
           HttpBasicTestingProvider:
             provider: 'Neos\Flow\Security\Authentication\Provider\PersistedUsernamePasswordProvider'
             token: 'Neos\Flow\Security\Authentication\Token\UsernamePasswordHttpBasic'


### PR DESCRIPTION
The TestingProvider should be available for all controllers/routes not only for Flow testing controllers otherwise the generic possibility to authenticateRoles in the FunctionalTestCase makes no sense for any other package. In the respective case a Neos test tried to authenticate roles but these would never have an effect due to the patterns.
