### PR TITLE
BUGFIX: Fix usage of SubContexts in ProxyClassLoader

### DIFF
--- a/Neos.Flow/Classes/Core/Bootstrap.php
+++ b/Neos.Flow/Classes/Core/Bootstrap.php
@@ -18,6 +18,7 @@ use Neos\Flow\Core\Booting\Scripts;
 use Neos\Flow\Exception as FlowException;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\SignalSlot\Dispatcher;
+use Neos\Flow\Utility\Environment;
 use Neos\Utility\Files;
 
 /**
@@ -535,7 +536,7 @@ class Bootstrap
 
         if (!defined('FLOW_PATH_TEMPORARY_BASE')) {
             define('FLOW_PATH_TEMPORARY_BASE', self::getEnvironmentConfigurationSetting('FLOW_PATH_TEMPORARY_BASE') ?: FLOW_PATH_DATA . '/Temporary');
-            $temporaryDirectoryPath = Files::concatenatePaths([FLOW_PATH_TEMPORARY_BASE, str_replace('/', '/SubContext', (string)$this->context)]) . '/';
+            $temporaryDirectoryPath = Environment::composeTemporaryDirectoryName(FLOW_PATH_TEMPORARY_BASE, $this->context);
             define('FLOW_PATH_TEMPORARY', $temporaryDirectoryPath);
         }
 

--- a/Neos.Flow/Classes/Core/ProxyClassLoader.php
+++ b/Neos.Flow/Classes/Core/ProxyClassLoader.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Core;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Cache\Frontend\PhpFrontend;
+use Neos\Flow\Utility\Environment;
 
 /**
  * Class loader for Flow proxy classes.
@@ -111,7 +112,9 @@ class ProxyClassLoader
             return;
         }
 
-        $proxyClasses = @include(FLOW_PATH_TEMPORARY_BASE . '/' . (string)$context . '/AvailableProxyClasses.php');
+        $temporaryDirectoryPath = Environment::composeTemporaryDirectoryName(FLOW_PATH_TEMPORARY_BASE, $context);
+
+        $proxyClasses = @include($temporaryDirectoryPath . 'AvailableProxyClasses.php');
         if ($proxyClasses !== false) {
             $this->availableProxyClasses = $proxyClasses;
         }

--- a/Neos.Flow/Classes/Utility/Environment.php
+++ b/Neos.Flow/Classes/Utility/Environment.php
@@ -108,12 +108,29 @@ class Environment
     }
 
     /**
+     * Compose path name for the temporary directory respecting supplied context.
+     *
+     * For nested contexts, the folders are prefixed with "SubContext" to
+     * avoid ambiguity, and look like: Data/Temporary/Production/SubContextLive
+     *
+     * @param string $temporaryDirectoryBase Full path to the base for the temporary directory
+     * @param ApplicationContext $context
+     * @return string The full path to the temporary directory, with trailing slash
+     */
+    public static function composeTemporaryDirectoryName($temporaryDirectoryBase, ApplicationContext $context)
+    {
+        $temporaryDirectoryBase = Files::getUnixStylePath($temporaryDirectoryBase);
+        if (substr($temporaryDirectoryBase, -1, 1) !== '/') {
+            $temporaryDirectoryBase .= '/';
+        }
+        return $temporaryDirectoryBase . str_replace('/', '/SubContext', (string)$context) . '/';
+    }
+
+    /**
      * Creates Flow's temporary directory - or at least asserts that it exists and is
      * writable.
      *
-     * For each Flow Application Context, we create an extra temporary folder,
-     * and for nested contexts, the folders are prefixed with "SubContext" to
-     * avoid ambiguity, and look like: Data/Temporary/Production/SubContextLive
+     * For each Flow Application Context, we create an extra temporary folder.
      *
      * @param string $temporaryDirectoryBase Full path to the base for the temporary directory
      * @return string The full path to the temporary directory
@@ -121,11 +138,7 @@ class Environment
      */
     protected function createTemporaryDirectory($temporaryDirectoryBase)
     {
-        $temporaryDirectoryBase = Files::getUnixStylePath($temporaryDirectoryBase);
-        if (substr($temporaryDirectoryBase, -1, 1) !== '/') {
-            $temporaryDirectoryBase .= '/';
-        }
-        $temporaryDirectory = $temporaryDirectoryBase . str_replace('/', '/SubContext', (string)$this->context) . '/';
+        $temporaryDirectory = self::composeTemporaryDirectoryName($temporaryDirectoryBase, $this->context);
 
         if (!is_dir($temporaryDirectory) && !is_link($temporaryDirectory)) {
             try {


### PR DESCRIPTION
Previously there were three different implementations of the composition of a temporary directory path name. The one in ProxyClassLoader didn't use SubContexts correctly.
This change unifies all implementations to a central static method `composeTemporaryDirectoryName()`.

Previous error message:
```
include(): Failed opening '/var/www/myproject/Data//Temporary/Development/Local/AvailableProxyClasses.php' for inclusion (include_path='.:/usr/share/php')
```