### PR TITLE
BUGFIX: Avoid type error when a non taggable cache backend gets flushed by tag

### DIFF
--- a/Neos.Cache/Classes/Frontend/AbstractFrontend.php
+++ b/Neos.Cache/Classes/Frontend/AbstractFrontend.php
@@ -135,7 +135,7 @@ abstract class AbstractFrontend implements FrontendInterface
      * Removes all cache entries of this cache which are tagged by the specified tag.
      *
      * @param string $tag The tag the entries must have
-     * @return integer The number of entries which have been affected by this flush or NULL if the number is unknown
+     * @return integer The number of entries which have been affected by this flush
      * @throws \InvalidArgumentException
      * @api
      */
@@ -147,6 +147,7 @@ abstract class AbstractFrontend implements FrontendInterface
         if ($this->backend instanceof TaggableBackendInterface) {
             return $this->backend->flushByTag($tag);
         }
+        return 0;
     }
 
     /**


### PR DESCRIPTION
The typehint of the `flushByTag` method expected an `int` return type, but the method inside the `AbstractFrontend` returned void when a non taggable backend was flushed. This was the case for a `SimpleFileBackend` for example and led to an error.