### PR TITLE
TASK: Adjust to ActionResponse and ensure backward compatibility

### DIFF
--- a/Neos.Flow/Classes/Error/AbstractExceptionHandler.php
+++ b/Neos.Flow/Classes/Error/AbstractExceptionHandler.php
@@ -16,10 +16,10 @@ use Neos\Flow\Cli\Response as CliResponse;
 use Neos\Flow\Exception as FlowException;
 use Neos\Flow\Http\Helper\ResponseInformationHelper;
 use Neos\Flow\Http\Request;
-use Neos\Flow\Http\Response;
 use Neos\Flow\Log\SystemLoggerInterface;
 use Neos\Flow\Log\ThrowableStorageInterface;
 use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Mvc\ActionResponse;
 use Neos\Flow\Mvc\Controller\Arguments;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Flow\Mvc\Routing\UriBuilder;
@@ -173,7 +173,7 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
         $uriBuilder->setRequest($request);
         $view->setControllerContext(new ControllerContext(
             $request,
-            new Response(),
+            new ActionResponse(),
             new Arguments([]),
             $uriBuilder
         ));

--- a/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
@@ -331,11 +331,11 @@ abstract class AbstractController implements ControllerInterface
             if (!$uri instanceof UriInterface) {
                 $uri = new \Neos\Flow\Http\Uri($uri);
             }
-
-            $this->response->setRedirectUri($uri, $statusCode);
+            $this->response->setStatus($statusCode);
+            $this->response->setHeader('Location', (string)$uri);
         } else {
             $escapedUri = htmlentities($uri, ENT_QUOTES, 'utf-8');
-            $this->response->setStatusCode($statusCode);
+            $this->response->setStatus($statusCode);
             $this->response->setContent('<html><head><meta http-equiv="refresh" content="' . (int)$delay . ';url=' . $escapedUri . '"/></head></html>');
         }
         throw new StopActionException();

--- a/Neos.FluidAdaptor/Classes/View/StandaloneView.php
+++ b/Neos.FluidAdaptor/Classes/View/StandaloneView.php
@@ -15,8 +15,8 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Http\HttpRequestHandlerInterface;
 use Neos\Flow\Http\Request;
-use Neos\Flow\Http\Response;
 use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Mvc\ActionResponse;
 use Neos\Flow\Mvc\Controller\Arguments;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Flow\Mvc\Routing\UriBuilder;
@@ -125,7 +125,7 @@ class StandaloneView extends AbstractTemplateView
 
         $this->setControllerContext(new ControllerContext(
             $this->request,
-            new Response(),
+            new ActionResponse(),
             new Arguments([]),
             $uriBuilder
         ));


### PR DESCRIPTION
This adjusts two places to use the ``ActionResponse`` and ensures
backwards compatibility for userland code using the deprecated
``Response`` by not using the new methods just yet.
