### PR TITLE
BUGFIX: Fix package:create and derived commands when private packagist is used

### DIFF
--- a/Neos.Flow/Classes/Package/PackageManager.php
+++ b/Neos.Flow/Classes/Package/PackageManager.php
@@ -345,7 +345,10 @@ class PackageManager implements PackageManagerInterface
             $composerManifestRepositories = ComposerUtility::getComposerManifest(FLOW_PATH_ROOT, 'repositories');
             if (is_array($composerManifestRepositories)) {
                 foreach ($composerManifestRepositories as $repository) {
-                    if ($repository['type'] == 'path' && substr($repository['url'], 0, 2) == './' && substr($repository['url'], -2) == '/*') {
+                    if (is_array($repository) &&
+                        isset($repository['type']) && $repository['type'] === 'path' &&
+                        isset($repository['url']) &&  substr($repository['url'], 0, 2) === './' && substr($repository['url'], -2) === '/*'
+                    ) {
                         $packagesPath = Files::getUnixStylePath(Files::concatenatePaths([FLOW_PATH_ROOT, substr($repository['url'], 0, -2)]));
                         $runComposerRequireForTheCreatedPackage = true;
                         break;


### PR DESCRIPTION
When private packagist is used the following setting isn added to the repositories section of the composer.json:

```
repositories: [
    {
        "packagist.org": false
    }
]
```

This caused an error because the package:create command tried to access the undefined `type` property of each defined repository.

This change simply checks for the existence of the type key before acessing it.

#fixes https://github.com/neos/neos-development-collection/issues/2448