### PR TITLE
BUGFIX: Prevent stability constraint issues with new packages

### DIFF
--- a/Neos.Flow/Classes/Package/PackageManager.php
+++ b/Neos.Flow/Classes/Package/PackageManager.php
@@ -17,6 +17,7 @@ use Neos\Flow\Composer\ComposerUtility as ComposerUtility;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\SignalSlot\Dispatcher;
+use Neos\Utility\Arrays;
 use Neos\Utility\Files;
 use Neos\Utility\OpcodeCacheHelper;
 use Neos\Flow\Package\Exception as PackageException;
@@ -380,7 +381,11 @@ class PackageManager implements PackageManagerInterface
         $manifest = ComposerUtility::writeComposerManifest($packagePath, $packageKey, $manifest);
 
         if ($runComposerRequireForTheCreatedPackage) {
-            exec('composer require ' . $manifest['name'] . ' @dev');
+            $rootManifestFilename = FLOW_PATH_ROOT . 'composer.json';
+            $rootManifestContent = json_decode(file_get_contents($rootManifestFilename));
+            $rootManifestContent = Arrays::arrayMergeRecursiveOverrule($rootManifestContent, ['require' => [$manifest['name'] => '@dev']]);
+            file_put_contents($rootManifestFilename, $rootManifestContent);
+            exec('cd ' . escapeshellarg(FLOW_PATH_ROOT) . ' && composer update');
         }
 
         $refreshedPackageStatesConfiguration = $this->rescanPackages();


### PR DESCRIPTION
By adding the new package directly to the root composer.json instead
of running ``composer require`` we can circumvent issues with the
defined ``minimum-stability`` in said root composer.json as in that
case it will be ignored.
