### PR TITLE
BUGFIX: Use source as target if target-language is empty in XLIFF

### DIFF
--- a/Neos.Flow/Classes/I18n/Xliff/Model/FileAdapter.php
+++ b/Neos.Flow/Classes/I18n/Xliff/Model/FileAdapter.php
@@ -124,16 +124,14 @@ class FileAdapter
             return false;
         }
 
-        if ($this->fileData['translationUnits'][$transUnitId][$pluralFormIndex]['target']) {
-            return $this->fileData['translationUnits'][$transUnitId][$pluralFormIndex]['target'];
-        } elseif ($this->requestedLocale->getLanguage() === $this->fileData['sourceLocale']->getLanguage()) {
-            return $this->fileData['translationUnits'][$transUnitId][$pluralFormIndex]['source'] ?: false;
-        } else {
-            $this->i18nLogger->log('The target translation was empty and the source translation language (' . $this->fileData['sourceLocale']->getLanguage() . ') does not match the current locale (' . $this->requestedLocale->getLanguage() . ') for the trans-unit element with the id "' . $transUnitId . '" in ' . $this->fileData['fileIdentifier'],
+        if (!isset($this->fileData['translationUnits'][$transUnitId][$pluralFormIndex]['target'])) {
+            $this->i18nLogger->log('The target translation was empty for the trans-unit element with the id "' . $transUnitId . '" and the plural form index "' . $pluralFormIndex . '" in ' . $this->fileData['fileIdentifier'],
                 LOG_DEBUG);
 
             return false;
         }
+
+        return $this->fileData['translationUnits'][$transUnitId][$pluralFormIndex]['target'];
     }
 
     /**

--- a/Neos.Flow/Classes/I18n/Xliff/V12/XliffParser.php
+++ b/Neos.Flow/Classes/I18n/Xliff/V12/XliffParser.php
@@ -59,6 +59,22 @@ class XliffParser extends AbstractXmlParser
      */
     protected function getFileData(\SimpleXMLElement $file): array
     {
+        /**
+         * If an XLIFF file has no target-language set the source element of a trans-unit is
+         * used to fill the target element, if the target element is left out (as is common
+         * for "source" XLIFF files.)
+         *
+         * @param \SimpleXMLElement $element
+         * @return string
+         */
+        $getTarget = function (\SimpleXMLElement $element) use ($file): string {
+            $hasTargetLanguage = ((string)$file['target-language']) !== '';
+            if ($hasTargetLanguage) {
+                return (string)$element->target;
+            }
+            return (string)($element->target ?? $element->source);
+        };
+
         $parsedFile = [
             'sourceLocale' => new Locale((string)$file['source-language'])
         ];
@@ -72,7 +88,7 @@ class XliffParser extends AbstractXmlParser
                         }
                         $parsedFile['translationUnits'][(string)$translationElement['id']][0] = array(
                             'source' => (string)$translationElement->source,
-                            'target' => (string)$translationElement->target,
+                            'target' => $getTarget($translationElement),
                         );
                     }
                     break;
@@ -86,7 +102,7 @@ class XliffParser extends AbstractXmlParser
 
                                 $parsedTranslationElement[(int)$formIndex] = array(
                                     'source' => (string)$translationPluralForm->source,
-                                    'target' => (string)$translationPluralForm->target,
+                                    'target' => $getTarget($translationPluralForm),
                                 );
                             }
                         }

--- a/Neos.Flow/Tests/Unit/I18n/Fixtures/MockParsedXliffData.php
+++ b/Neos.Flow/Tests/Unit/I18n/Fixtures/MockParsedXliffData.php
@@ -26,7 +26,7 @@ return [
             'key3' => [
                 0 => [
                     'source' => 'No target',
-                    'target' => '',
+                    'target' => 'No target',
                 ],
             ],
         ]


### PR DESCRIPTION
The target element in XLIFF is optional, and even though we recommend
in the documentation to set it, most people omit the target for
"source" XLIFF files (i.e. having english content and target-language
being unset).

For these cases the XliffParser now reads the source element content
into the target element. This makes the fallback rules work for
individual translations and not only full XLIFF files.

In other words: when a new string is added to a source catalog, it
will be used as is even when no translation is available – instead of
simply the id being output.