### PR TITLE
TASK: De-clutter logging

### DIFF
--- a/Neos.Flow/Classes/Security/Aspect/LoggingAspect.php
+++ b/Neos.Flow/Classes/Security/Aspect/LoggingAspect.php
@@ -126,26 +126,14 @@ class LoggingAspect
 
         switch ($token->getAuthenticationStatus()) {
             case TokenInterface::AUTHENTICATION_SUCCESSFUL:
-                $this->securityLogger->notice(sprintf('Successfully authenticated token: %s', $token), [
-                    'packageKey' => 'Neos.Flow',
-                    'className' => $joinPoint->getClassName(),
-                    'methodName' => $joinPoint->getMethodName()
-                ]);
+                $this->securityLogger->notice(sprintf('Successfully authenticated token: %s (in Neos.Flow:%s->%s)', $token, $joinPoint->getClassName(), $joinPoint->getMethodName()));
                 $this->alreadyLoggedAuthenticateCall = true;
             break;
             case TokenInterface::WRONG_CREDENTIALS:
-                $this->securityLogger->warning(sprintf('Wrong credentials given for token: %s', $token), [
-                    'packageKey' => 'Neos.Flow',
-                    'className' => $joinPoint->getClassName(),
-                    'methodName' => $joinPoint->getMethodName()
-                ]);
+                $this->securityLogger->warning(sprintf('Wrong credentials given for token: %s (in Neos.Flow:%s->%s)', $token, $joinPoint->getClassName(), $joinPoint->getMethodName()));
             break;
             case TokenInterface::NO_CREDENTIALS_GIVEN:
-                $this->securityLogger->warning(sprintf('No credentials given or no account found for token: %s', $token), [
-                    'packageKey' => 'Neos.Flow',
-                    'className' => $joinPoint->getClassName(),
-                    'methodName' => $joinPoint->getMethodName()
-                ]);
+                $this->securityLogger->warning(sprintf('No credentials given or no account found for token: %s (in Neos.Flow:%s->%s)', $token, $joinPoint->getClassName(), $joinPoint->getMethodName()));
             break;
         }
     }

--- a/Neos.Flow/Classes/Session/Aspect/LoggingAspect.php
+++ b/Neos.Flow/Classes/Session/Aspect/LoggingAspect.php
@@ -51,11 +51,7 @@ class LoggingAspect
     {
         $session = $joinPoint->getProxy();
         if ($session->isStarted()) {
-            $this->logger->info(sprintf('%s: Started session with id %s.', $this->getClassName($joinPoint), $session->getId()), [
-                'packageKey' => 'Neos.Flow',
-                'className' => $joinPoint->getClassName(),
-                'methodName' => $joinPoint->getMethodName()
-            ]);
+            $this->logger->info(sprintf('%s: Started session with id %s in %s.', $this->getClassName($joinPoint), $session->getId(), $joinPoint->getMethodName()));
         }
     }
 
@@ -115,11 +111,7 @@ class LoggingAspect
         $oldId = $session->getId();
         $newId = $joinPoint->getAdviceChain()->proceed($joinPoint);
         if ($session->isStarted()) {
-            $this->logger->info(sprintf('%s: Changed session id from %s to %s', $this->getClassName($joinPoint), $oldId, $newId), [
-                'packageKey' => 'Neos.Flow',
-                'className' => $joinPoint->getClassName(),
-                'methodName' => $joinPoint->getMethodName()
-            ]);
+            $this->logger->info(sprintf('%s: Changed session id from %s to %s in %s', $this->getClassName($joinPoint), $oldId, $newId, $joinPoint->getMethodName()));
         }
         return $newId;
     }
@@ -135,23 +127,11 @@ class LoggingAspect
     {
         $sessionRemovalCount = $joinPoint->getResult();
         if ($sessionRemovalCount > 0) {
-            $this->logger->info(sprintf('%s: Triggered garbage collection and removed %s expired sessions.', $this->getClassName($joinPoint), $sessionRemovalCount), [
-                'packageKey' => 'Neos.Flow',
-                'className' => $joinPoint->getClassName(),
-                'methodName' => $joinPoint->getMethodName()
-            ]);
+            $this->logger->info(sprintf('%s: Triggered garbage collection and removed %s expired sessions in %s.', $this->getClassName($joinPoint), $sessionRemovalCount, $joinPoint->getMethodName()));
         } elseif ($sessionRemovalCount === 0) {
-            $this->logger->info(sprintf('%s: Triggered garbage collection but no sessions needed to be removed.', $this->getClassName($joinPoint)), [
-                'packageKey' => 'Neos.Flow',
-                'className' => $joinPoint->getClassName(),
-                'methodName' => $joinPoint->getMethodName()
-            ]);
+            $this->logger->info(sprintf('%s: Triggered garbage collection but no sessions needed to be removed in %s.', $this->getClassName($joinPoint), $joinPoint->getMethodName()));
         } elseif ($sessionRemovalCount === false) {
-            $this->logger->warning(sprintf('%s: Ommitting garbage collection because another process is already running. Consider lowering the GC propability if these messages appear a lot.', $this->getClassName($joinPoint)), [
-                'packageKey' => 'Neos.Flow',
-                'className' => $joinPoint->getClassName(),
-                'methodName' => $joinPoint->getMethodName()
-            ]);
+            $this->logger->warning(sprintf('%s: Ommitting garbage collection because another process is already running. Consider lowering the GC propability if these messages appear a lot in %s', $this->getClassName($joinPoint), $joinPoint->getMethodName()));
         }
     }
 


### PR DESCRIPTION
The logging of session activity and authentication became cluttered
and hard to filter with 5.2 without any added benefit.

This change reduces that clutter and restores "filterability."