### PR TITLE
BUGFIX: Fix log environment in logging aspects

### DIFF
--- a/Neos.Flow/Classes/Session/Aspect/LoggingAspect.php
+++ b/Neos.Flow/Classes/Session/Aspect/LoggingAspect.php
@@ -133,7 +133,6 @@ class LoggingAspect
      */
     public function logCollectGarbage(JoinPointInterface $joinPoint)
     {
-
         $logEnvironment = [
             'FLOW_LOG_ENVIRONMENT' => [
                 'packageKey' => 'Neos.Flow',

--- a/Neos.Flow/Classes/Session/Aspect/LoggingAspect.php
+++ b/Neos.Flow/Classes/Session/Aspect/LoggingAspect.php
@@ -115,11 +115,11 @@ class LoggingAspect
         $oldId = $session->getId();
         $newId = $joinPoint->getAdviceChain()->proceed($joinPoint);
         if ($session->isStarted()) {
-            $this->logger->info(sprintf('%s: Changed session id from %s to %s', $this->getClassName($joinPoint), $oldId, $newId), [
+            $this->logger->info(sprintf('%s: Changed session id from %s to %s', $this->getClassName($joinPoint), $oldId, $newId), ['FLOW_LOG_ENVIRONMENT' => [
                 'packageKey' => 'Neos.Flow',
                 'className' => $joinPoint->getClassName(),
                 'methodName' => $joinPoint->getMethodName()
-            ]);
+            ]]);
         }
         return $newId;
     }
@@ -133,25 +133,22 @@ class LoggingAspect
      */
     public function logCollectGarbage(JoinPointInterface $joinPoint)
     {
+
+        $logEnvironment = [
+            'FLOW_LOG_ENVIRONMENT' => [
+                'packageKey' => 'Neos.Flow',
+                'className' => $joinPoint->getClassName(),
+                'methodName' => $joinPoint->getMethodName()
+            ]
+        ];
+
         $sessionRemovalCount = $joinPoint->getResult();
         if ($sessionRemovalCount > 0) {
-            $this->logger->info(sprintf('%s: Triggered garbage collection and removed %s expired sessions.', $this->getClassName($joinPoint), $sessionRemovalCount), [
-                'packageKey' => 'Neos.Flow',
-                'className' => $joinPoint->getClassName(),
-                'methodName' => $joinPoint->getMethodName()
-            ]);
+            $this->logger->info(sprintf('%s: Triggered garbage collection and removed %s expired sessions.', $this->getClassName($joinPoint), $sessionRemovalCount), $logEnvironment);
         } elseif ($sessionRemovalCount === 0) {
-            $this->logger->info(sprintf('%s: Triggered garbage collection but no sessions needed to be removed.', $this->getClassName($joinPoint)), [
-                'packageKey' => 'Neos.Flow',
-                'className' => $joinPoint->getClassName(),
-                'methodName' => $joinPoint->getMethodName()
-            ]);
+            $this->logger->info(sprintf('%s: Triggered garbage collection but no sessions needed to be removed.', $this->getClassName($joinPoint)), $logEnvironment);
         } elseif ($sessionRemovalCount === false) {
-            $this->logger->warning(sprintf('%s: Ommitting garbage collection because another process is already running. Consider lowering the GC propability if these messages appear a lot.', $this->getClassName($joinPoint)), [
-                'packageKey' => 'Neos.Flow',
-                'className' => $joinPoint->getClassName(),
-                'methodName' => $joinPoint->getMethodName()
-            ]);
+            $this->logger->warning(sprintf('%s: Ommitting garbage collection because another process is already running. Consider lowering the GC propability if these messages appear a lot.', $this->getClassName($joinPoint)), $logEnvironment);
         }
     }
 


### PR DESCRIPTION
As the `'FLOW_LOG_ENVIRONMENT' => []` level was missing in the log data, the log environment data was not set correctly and written to the log by the file writer. 