### PR TITLE
!!! FEATURE: Raise phpunit to v8.1

### DIFF
--- a/Neos.Cache/Tests/Functional/Backend/RedisBackendTest.php
+++ b/Neos.Cache/Tests/Functional/Backend/RedisBackendTest.php
@@ -46,7 +46,7 @@ class RedisBackendTest extends BaseTestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $phpredisVersion = phpversion('redis');
         if (version_compare($phpredisVersion, '1.2.0', '<')) {
@@ -73,7 +73,7 @@ class RedisBackendTest extends BaseTestCase
      *
      * @return void
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         if ($this->backend instanceof RedisBackend) {
             $this->backend->flush();

--- a/Neos.Cache/Tests/Unit/Backend/AbstractBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/AbstractBackendTest.php
@@ -31,7 +31,7 @@ class AbstractBackendTest extends BaseTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         class_exists(AbstractBackend::class);
         $className = 'ConcreteBackend_' . md5(uniqid(mt_rand(), true));

--- a/Neos.Cache/Tests/Unit/Backend/ApcuBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/ApcuBackendTest.php
@@ -15,6 +15,7 @@ include_once(__DIR__ . '/../../BaseTestCase.php');
 
 use Neos\Cache\Backend\ApcuBackend;
 use Neos\Cache\EnvironmentConfiguration;
+use Neos\Cache\Exception;
 use Neos\Cache\Tests\BaseTestCase;
 use Neos\Cache\Frontend\FrontendInterface;
 use Neos\Cache\Frontend\VariableFrontend;
@@ -43,10 +44,10 @@ class ApcuBackendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Exception
      */
     public function setThrowsExceptionIfNoFrontEndHasBeenSet()
     {
+        $this->expectException(Exception::class);
         $backend = new ApcuBackend($this->getEnvironmentConfiguration(), []);
         $data = 'Some data';
         $identifier = 'MyIdentifier' . md5(uniqid(mt_rand(), true));

--- a/Neos.Cache/Tests/Unit/Backend/ApcuBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/ApcuBackendTest.php
@@ -31,7 +31,7 @@ class ApcuBackendTest extends BaseTestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         if (ini_get('apc.enabled') == 0 || ini_get('apc.enable_cli') == 0) {
             $this->markTestSkipped('APCu is disabled (for CLI).');

--- a/Neos.Cache/Tests/Unit/Backend/FileBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/FileBackendTest.php
@@ -28,7 +28,7 @@ class FileBackendTest extends BaseTestCase
 {
     /**
      */
-    public function setUp()
+    protected function setUp(): void
     {
         vfsStream::setup('Foo');
     }

--- a/Neos.Cache/Tests/Unit/Backend/FileBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/FileBackendTest.php
@@ -15,11 +15,14 @@ include_once(__DIR__ . '/../../BaseTestCase.php');
 
 use Neos\Cache\Backend\FileBackend;
 use Neos\Cache\EnvironmentConfiguration;
+use Neos\Cache\Exception;
 use Neos\Cache\Tests\BaseTestCase;
 use org\bovigo\vfs\vfsStream;
 use Neos\Cache\Frontend\AbstractFrontend;
 use Neos\Cache\Frontend\PhpFrontend;
 use Neos\Cache\Frontend\VariableFrontend;
+use PHPUnit\Framework\Error\Notice;
+use PHPUnit\Framework\Error\Warning;
 
 /**
  * Test case for the cache to file backend
@@ -35,10 +38,10 @@ class FileBackendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Exception
      */
     public function setCacheThrowsExceptionOnNonWritableDirectory()
     {
+        $this->expectException(Exception::class);
         $mockCache = $this->createMock(AbstractFrontend::class);
 
         $mockEnvironmentConfiguration = $this->createEnvironmentConfigurationMock([__DIR__ . '~Testing', 'http://localhost/', PHP_MAXPATHLEN]);
@@ -183,11 +186,11 @@ class FileBackendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Exception
-     * @expectedExceptionCode 1248710426
      */
     public function setThrowsExceptionIfCachePathLengthExceedsMaximumPathLength()
     {
+        $this->expectExceptionCode(1248710426);
+        $this->expectException(Exception::class);
         $cachePath = 'vfs://Foo';
 
         $mockEnvironmentConfiguration = $this->createEnvironmentConfigurationMock([
@@ -427,10 +430,10 @@ class FileBackendTest extends BaseTestCase
     /**
      * @test
      * @dataProvider invalidEntryIdentifiers
-     * @expectedException \InvalidArgumentException
      */
     public function setThrowsExceptionForInvalidIdentifier($identifier)
     {
+        $this->expectException(\InvalidArgumentException::class);
         $mockCache = $this->createMock(AbstractFrontend::class);
         $mockCache->expects($this->atLeastOnce())->method('getIdentifier')->will($this->returnValue('UnitTestCache'));
         $backend = $this->prepareDefaultBackend();
@@ -442,10 +445,10 @@ class FileBackendTest extends BaseTestCase
     /**
      * @test
      * @dataProvider invalidEntryIdentifiers
-     * @expectedException \InvalidArgumentException
      */
     public function getThrowsExceptionForInvalidIdentifier($identifier)
     {
+        $this->expectException(\InvalidArgumentException::class);
         $mockCache = $this->createMock(AbstractFrontend::class);
         $mockCache->expects($this->atLeastOnce())->method('getIdentifier')->will($this->returnValue('UnitTestCache'));
 
@@ -458,10 +461,10 @@ class FileBackendTest extends BaseTestCase
     /**
      * @test
      * @dataProvider invalidEntryIdentifiers
-     * @expectedException \InvalidArgumentException
      */
     public function hasThrowsExceptionForInvalidIdentifier($identifier)
     {
+        $this->expectException(\InvalidArgumentException::class);
         $backend = $this->prepareDefaultBackend(['dummy']);
 
         $backend->has($identifier);
@@ -470,10 +473,10 @@ class FileBackendTest extends BaseTestCase
     /**
      * @test
      * @dataProvider invalidEntryIdentifiers
-     * @expectedException \InvalidArgumentException
      */
     public function removeThrowsExceptionForInvalidIdentifier($identifier)
     {
+        $this->expectException(\InvalidArgumentException::class);
         $mockCache = $this->createMock(AbstractFrontend::class);
         $mockCache->expects($this->atLeastOnce())->method('getIdentifier')->will($this->returnValue('UnitTestCache'));
 
@@ -486,10 +489,10 @@ class FileBackendTest extends BaseTestCase
     /**
      * @test
      * @dataProvider invalidEntryIdentifiers
-     * @expectedException \InvalidArgumentException
      */
     public function requireOnceThrowsExceptionForInvalidIdentifier($identifier)
     {
+        $this->expectException(\InvalidArgumentException::class);
         $mockCache = $this->createMock(AbstractFrontend::class);
         $mockCache->expects($this->atLeastOnce())->method('getIdentifier')->will($this->returnValue('UnitTestCache'));
 
@@ -543,10 +546,10 @@ class FileBackendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Exception
      */
     public function requireOnceDoesNotSwallowExceptionsOfTheIncludedFile()
     {
+        $this->expectException(\Exception::class);
         $mockCache = $this->createMock(AbstractFrontend::class);
         $mockCache->expects($this->atLeastOnce())->method('getIdentifier')->will($this->returnValue('UnitTestCache'));
 
@@ -560,10 +563,10 @@ class FileBackendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \PHPUnit\Framework\Error\Warning
      */
     public function requireOnceDoesNotSwallowPhpWarningsOfTheIncludedFile()
     {
+        $this->expectException(Warning::class);
         $mockCache = $this->createMock(AbstractFrontend::class);
         $mockCache->expects($this->atLeastOnce())->method('getIdentifier')->will($this->returnValue('UnitTestCache'));
 
@@ -577,10 +580,10 @@ class FileBackendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \PHPUnit\Framework\Error\Notice
      */
     public function requireOnceDoesNotSwallowPhpNoticesOfTheIncludedFile()
     {
+        $this->expectException(Notice::class);
         $mockCache = $this->createMock(AbstractFrontend::class);
         $mockCache->expects($this->atLeastOnce())->method('getIdentifier')->will($this->returnValue('UnitTestCache'));
 

--- a/Neos.Cache/Tests/Unit/Backend/FileBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/FileBackendTest.php
@@ -614,7 +614,7 @@ class FileBackendTest extends BaseTestCase
         $expectedEntry = 'BackendFileTest2';
 
         $actualEntries = $backend->findIdentifiersByTag('UnitTestTag%special');
-        $this->assertInternalType('array', $actualEntries);
+        $this->assertIsArray($actualEntries);
 
         $this->assertEquals($expectedEntry, array_pop($actualEntries));
     }

--- a/Neos.Cache/Tests/Unit/Backend/MemcachedBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/MemcachedBackendTest.php
@@ -31,7 +31,7 @@ class MemcachedBackendTest extends BaseTestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         try {
             if (!@fsockopen('localhost', 11211)) {

--- a/Neos.Cache/Tests/Unit/Backend/MemcachedBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/MemcachedBackendTest.php
@@ -15,6 +15,7 @@ include_once(__DIR__ . '/../../BaseTestCase.php');
 
 use Neos\Cache\Backend\MemcachedBackend;
 use Neos\Cache\EnvironmentConfiguration;
+use Neos\Cache\Exception;
 use Neos\Cache\Tests\BaseTestCase;
 use Neos\Cache\Frontend\AbstractFrontend;
 use Neos\Cache\Frontend\FrontendInterface;
@@ -44,10 +45,10 @@ class MemcachedBackendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Exception
      */
     public function setThrowsExceptionIfNoFrontEndHasBeenSet()
     {
+        $this->expectException(Exception::class);
         $backendOptions = ['servers' => ['localhost:11211']];
         $backend = new MemcachedBackend($this->getEnvironmentConfiguration(), $backendOptions);
         $data = 'Some data';
@@ -57,19 +58,19 @@ class MemcachedBackendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Exception
      */
     public function initializeObjectThrowsExceptionIfNoMemcacheServerIsConfigured()
     {
+        $this->expectException(Exception::class);
         $backend = new MemcachedBackend($this->getEnvironmentConfiguration(), []);
     }
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Exception
      */
     public function setThrowsExceptionIfConfiguredServersAreUnreachable()
     {
+        $this->expectException(Exception::class);
         $backend = $this->setUpBackend(['servers' => ['localhost:11212']]);
         $data = 'Somedata';
         $identifier = 'MyIdentifier' . md5(uniqid(mt_rand(), true));

--- a/Neos.Cache/Tests/Unit/Backend/MultiBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/MultiBackendTest.php
@@ -39,10 +39,10 @@ class MultiBackendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Throwable
      */
     public function debugModeWillBubbleExceptions()
     {
+        $this->expectException(\Throwable::class);
         $backendOptions = [
             'debug' => true,
             'backendConfigurations' => [

--- a/Neos.Cache/Tests/Unit/Backend/PdoBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/PdoBackendTest.php
@@ -15,6 +15,7 @@ include_once(__DIR__ . '/../../BaseTestCase.php');
 
 use Neos\Cache\Backend\PdoBackend;
 use Neos\Cache\EnvironmentConfiguration;
+use Neos\Cache\Exception;
 use Neos\Cache\Frontend\FrontendInterface;
 use Neos\Cache\Tests\BaseTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -38,10 +39,10 @@ class PdoBackendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Exception
      */
     public function setThrowsExceptionIfNoFrontEndHasBeenSet()
     {
+        $this->expectException(Exception::class);
         $backend = new PdoBackend(new EnvironmentConfiguration('SomeApplication Testing', '/some/path', PHP_MAXPATHLEN));
         $data = 'Some data';
         $identifier = 'MyIdentifier';

--- a/Neos.Cache/Tests/Unit/Backend/RedisBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/RedisBackendTest.php
@@ -45,7 +45,7 @@ class RedisBackendTest extends BaseTestCase
      * Set up test case
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $phpredisVersion = phpversion('redis');
         if (version_compare($phpredisVersion, '1.2.0', '<')) {

--- a/Neos.Cache/Tests/Unit/Backend/RedisBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/RedisBackendTest.php
@@ -194,11 +194,11 @@ class RedisBackendTest extends BaseTestCase
     /**
      * @test
      * @dataProvider writingOperationsProvider
-     * @expectedException \RuntimeException
      * @param string $method
      */
     public function writingOperationsThrowAnExceptionIfCacheIsFrozen($method)
     {
+        $this->expectException(\RuntimeException::class);
         $this->inject($this->backend, 'frozen', null);
         $this->redis->expects($this->once())
             ->method('exists')

--- a/Neos.Cache/Tests/Unit/Backend/SimpleFileBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/SimpleFileBackendTest.php
@@ -38,7 +38,7 @@ class SimpleFileBackendTest extends BaseTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         vfsStream::setup('Temporary/Directory/');
 

--- a/Neos.Cache/Tests/Unit/Backend/SimpleFileBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/SimpleFileBackendTest.php
@@ -15,10 +15,13 @@ include_once(__DIR__ . '/../../BaseTestCase.php');
 
 use Neos\Cache\Backend\SimpleFileBackend;
 use Neos\Cache\EnvironmentConfiguration;
+use Neos\Cache\Exception;
 use Neos\Cache\Tests\BaseTestCase;
 use org\bovigo\vfs\vfsStream;
 use Neos\Cache\Frontend\FrontendInterface;
 use Neos\Cache\Frontend\PhpFrontend;
+use PHPUnit\Framework\Error\Notice;
+use PHPUnit\Framework\Error\Warning;
 
 /**
  * Test case for the SimpleFileBackend
@@ -75,10 +78,10 @@ class SimpleFileBackendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Exception
      */
     public function setCacheThrowsExceptionOnNonWritableDirectory()
     {
+        $this->expectException(Exception::class);
         $mockEnvironmentConfiguration = $this->getMockBuilder(EnvironmentConfiguration::class)
             ->setMethods(null)
             ->setConstructorArgs([
@@ -95,11 +98,11 @@ class SimpleFileBackendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Exception
-     * @expectedExceptionCode 1248710426
      */
     public function setThrowsExceptionIfCachePathLengthExceedsMaximumPathLength()
     {
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(1248710426);
         $mockEnvironmentConfiguration = new EnvironmentConfiguration(
             __DIR__ . '~Testing',
             'vfs://Temporary/Directory/',
@@ -310,10 +313,10 @@ class SimpleFileBackendTest extends BaseTestCase
      * @test
      * @param string $identifier
      * @dataProvider invalidEntryIdentifiers
-     * @expectedException \InvalidArgumentException
      */
     public function setThrowsExceptionForInvalidIdentifier($identifier)
     {
+        $this->expectException(\InvalidArgumentException::class);
         $simpleFileBackend = $this->getSimpleFileBackend();
         $simpleFileBackend->set($identifier, 'some data');
     }
@@ -322,10 +325,10 @@ class SimpleFileBackendTest extends BaseTestCase
      * @test
      * @param string $identifier
      * @dataProvider invalidEntryIdentifiers
-     * @expectedException \InvalidArgumentException
      */
     public function getThrowsExceptionForInvalidIdentifier($identifier)
     {
+        $this->expectException(\InvalidArgumentException::class);
         $simpleFileBackend = $this->getSimpleFileBackend();
         $simpleFileBackend->get($identifier);
     }
@@ -334,10 +337,10 @@ class SimpleFileBackendTest extends BaseTestCase
      * @test
      * @param string $identifier
      * @dataProvider invalidEntryIdentifiers
-     * @expectedException \InvalidArgumentException
      */
     public function hasThrowsExceptionForInvalidIdentifier($identifier)
     {
+        $this->expectException(\InvalidArgumentException::class);
         $simpleFileBackend = $this->getSimpleFileBackend();
         $simpleFileBackend->has($identifier);
     }
@@ -346,10 +349,10 @@ class SimpleFileBackendTest extends BaseTestCase
      * @test
      * @param string $identifier
      * @dataProvider invalidEntryIdentifiers
-     * @expectedException \InvalidArgumentException
      */
     public function removeThrowsExceptionForInvalidIdentifier($identifier)
     {
+        $this->expectException(\InvalidArgumentException::class);
         $simpleFileBackend = $this->getSimpleFileBackend();
         $simpleFileBackend->remove($identifier);
     }
@@ -358,10 +361,10 @@ class SimpleFileBackendTest extends BaseTestCase
      * @test
      * @param string $identifier
      * @dataProvider invalidEntryIdentifiers
-     * @expectedException \InvalidArgumentException
      */
     public function requireOnceThrowsExceptionForInvalidIdentifier($identifier)
     {
+        $this->expectException(\InvalidArgumentException::class);
         $simpleFileBackend = $this->getSimpleFileBackend();
         $simpleFileBackend->requireOnce($identifier);
     }
@@ -384,10 +387,10 @@ class SimpleFileBackendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Exception
      */
     public function requireOnceDoesNotSwallowExceptionsOfTheIncludedFile()
     {
+        $this->expectException(\Exception::class);
         $entryIdentifier = 'SomePhpEntryWithException';
 
         $simpleFileBackend = $this->getSimpleFileBackend();
@@ -397,10 +400,10 @@ class SimpleFileBackendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \PHPUnit\Framework\Error\Warning
      */
     public function requireOnceDoesNotSwallowPhpWarningsOfTheIncludedFile()
     {
+        $this->expectException(Warning::class);
         $entryIdentifier = 'SomePhpEntryWithPhpWarning';
 
         $simpleFileBackend = $this->getSimpleFileBackend();
@@ -410,10 +413,10 @@ class SimpleFileBackendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \PHPUnit\Framework\Error\Notice
      */
     public function requireOnceDoesNotSwallowPhpNoticesOfTheIncludedFile()
     {
+        $this->expectException(Notice::class);
         $entryIdentifier = 'SomePhpEntryWithPhpNotice';
 
         $simpleFileBackend = $this->getSimpleFileBackend();

--- a/Neos.Cache/Tests/Unit/Backend/TransientMemoryBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/TransientMemoryBackendTest.php
@@ -15,6 +15,7 @@ include_once(__DIR__ . '/../../BaseTestCase.php');
 
 use Neos\Cache\Backend\TransientMemoryBackend;
 use Neos\Cache\EnvironmentConfiguration;
+use Neos\Cache\Exception;
 use Neos\Cache\Tests\BaseTestCase;
 use Neos\Cache\Frontend\FrontendInterface;
 
@@ -25,11 +26,11 @@ use Neos\Cache\Frontend\FrontendInterface;
 class TransientMemoryBackendTest extends BaseTestCase
 {
     /**
-     * @expectedException \Neos\Cache\Exception
      * @test
      */
     public function setThrowsExceptionIfNoFrontEndHasBeenSet()
     {
+        $this->expectException(Exception::class);
         $backend = new TransientMemoryBackend($this->getEnvironmentConfiguration());
 
         $data = 'Some data';

--- a/Neos.Cache/Tests/Unit/Frontend/AbstractFrontendTest.php
+++ b/Neos.Cache/Tests/Unit/Frontend/AbstractFrontendTest.php
@@ -77,10 +77,10 @@ class AbstractFrontendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function flushByTagRejectsInvalidTags()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $identifier = 'someCacheIdentifier';
         $backend = $this->createMock(TaggableBackendInterface::class);
         $backend->expects($this->never())->method('flushByTag');

--- a/Neos.Cache/Tests/Unit/Frontend/AbstractFrontendTest.php
+++ b/Neos.Cache/Tests/Unit/Frontend/AbstractFrontendTest.php
@@ -26,7 +26,7 @@ class AbstractFrontendTest extends BaseTestCase
     /** @var  AbstractBackend */
     protected $mockBackend;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->mockBackend = $this->getMockBuilder(AbstractBackend::class)->setMethods(['get', 'set', 'has', 'remove', 'findIdentifiersByTag', 'flush', 'flushByTag', 'collectGarbage'])->disableOriginalConstructor()->getMock();

--- a/Neos.Cache/Tests/Unit/Frontend/PhpFrontendTest.php
+++ b/Neos.Cache/Tests/Unit/Frontend/PhpFrontendTest.php
@@ -12,6 +12,8 @@ include_once(__DIR__ . '/../../BaseTestCase.php');
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+
+use Neos\Cache\Exception\InvalidDataException;
 use Neos\Cache\Tests\BaseTestCase;
 use Neos\Cache\Backend\PhpCapableBackendInterface;
 use Neos\Cache\Frontend\PhpFrontend;
@@ -24,11 +26,11 @@ use Neos\Cache\Frontend\StringFrontend;
 class PhpFrontendTest extends BaseTestCase
 {
     /**
-     * @expectedException \InvalidArgumentException
      * @test
      */
     public function setChecksIfTheIdentifierIsValid()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $cache = $this->getMockBuilder(StringFrontend::class)
             ->setMethods(['isValidEntryIdentifier'])
             ->disableOriginalConstructor()
@@ -58,10 +60,10 @@ class PhpFrontendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Exception\InvalidDataException
      */
     public function setThrowsInvalidDataExceptionOnNonStringValues()
     {
+        $this->expectException(InvalidDataException::class);
         $cache = $this->getMockBuilder(PhpFrontend::class)
             ->setMethods(null)
             ->disableOriginalConstructor()

--- a/Neos.Cache/Tests/Unit/Frontend/StringFrontendTest.php
+++ b/Neos.Cache/Tests/Unit/Frontend/StringFrontendTest.php
@@ -15,6 +15,8 @@ include_once(__DIR__ . '/../../BaseTestCase.php');
 use Neos\Cache\Backend\AbstractBackend;
 use Neos\Cache\Backend\NullBackend;
 use Neos\Cache\Backend\TaggableBackendInterface;
+use Neos\Cache\Exception\InvalidDataException;
+use Neos\Cache\Exception\NotSupportedByBackendException;
 use Neos\Cache\Frontend\StringFrontend;
 use Neos\Cache\Tests\BaseTestCase;
 
@@ -25,11 +27,11 @@ use Neos\Cache\Tests\BaseTestCase;
 class StringFrontendTest extends BaseTestCase
 {
     /**
-     * @expectedException \InvalidArgumentException
      * @test
      */
     public function setChecksIfTheIdentifierIsValid()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $cache = $this->getMockBuilder(StringFrontend::class)
             ->setMethods(['isValidEntryIdentifier'])
             ->disableOriginalConstructor()
@@ -68,10 +70,10 @@ class StringFrontendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Exception\InvalidDataException
      */
     public function setThrowsInvalidDataExceptionOnNonStringValues()
     {
+        $this->expectException(InvalidDataException::class);
         $backend = $this->prepareDefaultBackend();
 
         $cache = new StringFrontend('StringFrontend', $backend);
@@ -119,10 +121,10 @@ class StringFrontendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function getByTagRejectsInvalidTags()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $backend = $this->createMock(TaggableBackendInterface::class);
         $backend->expects($this->never())->method('findIdentifiersByTag');
 
@@ -132,10 +134,10 @@ class StringFrontendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Exception\NotSupportedByBackendException
      */
     public function getByTagThrowAnExceptionWithoutTaggableBackend()
     {
+        $this->expectException(NotSupportedByBackendException::class);
         $backend = $this->prepareDefaultBackend();
         $cache = new StringFrontend('VariableFrontend', $backend);
         $cache->getByTag('foo');

--- a/Neos.Cache/Tests/Unit/Frontend/VariableFrontendTest.php
+++ b/Neos.Cache/Tests/Unit/Frontend/VariableFrontendTest.php
@@ -14,6 +14,7 @@ include_once(__DIR__ . '/../../BaseTestCase.php');
  */
 use Neos\Cache\Backend\AbstractBackend;
 use Neos\Cache\Backend\NullBackend;
+use Neos\Cache\Exception\NotSupportedByBackendException;
 use Neos\Cache\Tests\BaseTestCase;
 use Neos\Cache\Backend\TaggableBackendInterface;
 use Neos\Cache\Frontend\StringFrontend;
@@ -26,11 +27,11 @@ use Neos\Cache\Frontend\VariableFrontend;
 class VariableFrontendTest extends BaseTestCase
 {
     /**
-     * @expectedException \InvalidArgumentException
      * @test
      */
     public function setChecksIfTheIdentifierIsValid()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $cache = $this->getMockBuilder(StringFrontend::class)
             ->setMethods(['isValidEntryIdentifier'])
             ->disableOriginalConstructor()
@@ -175,10 +176,10 @@ class VariableFrontendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function getByTagRejectsInvalidTags()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $backend = $this->createMock(TaggableBackendInterface::class);
         $backend->expects($this->never())->method('findIdentifiersByTag');
 
@@ -188,10 +189,10 @@ class VariableFrontendTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Exception\NotSupportedByBackendException
      */
     public function getByTagThrowAnExceptionWithoutTaggableBackend()
     {
+        $this->expectException(NotSupportedByBackendException::class);
         $backend = $this->prepareDefaultBackend();
         $cache = new VariableFrontend('VariableFrontend', $backend);
         $cache->getByTag('foo');

--- a/Neos.Cache/Tests/Unit/Psr/Cache/CachePoolTest.php
+++ b/Neos.Cache/Tests/Unit/Psr/Cache/CachePoolTest.php
@@ -14,6 +14,7 @@ namespace Neos\Cache\Tests\Unit\Psr\Cache;
 use Neos\Cache\Backend\AbstractBackend;
 use Neos\Cache\Psr\Cache\CachePool;
 use Neos\Cache\Psr\Cache\CacheItem;
+use Neos\Cache\Psr\InvalidArgumentException;
 use Neos\Cache\Tests\BaseTestCase;
 
 /**
@@ -23,11 +24,11 @@ use Neos\Cache\Tests\BaseTestCase;
 class CachePoolTest extends BaseTestCase
 {
     /**
-     * @expectedException \Neos\Cache\Psr\InvalidArgumentException
      * @test
      */
     public function getItemChecksIfTheIdentifierIsValid()
     {
+        $this->expectException(InvalidArgumentException::class);
         /** @var PsrFrontend|\PHPUnit_Framework_MockObject_MockObject $cache */
         $cache = $this->getMockBuilder(CachePool::class)
             ->setMethods(['isValidEntryIdentifier'])

--- a/Neos.Cache/Tests/Unit/Psr/SimpleCache/SimpleCacheFactoryTest.php
+++ b/Neos.Cache/Tests/Unit/Psr/SimpleCache/SimpleCacheFactoryTest.php
@@ -21,7 +21,7 @@ class SimpleCacheFactoryTest extends BaseTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         vfsStream::setup('Temporary/Directory/');
 

--- a/Neos.Cache/Tests/Unit/Psr/SimpleCache/SimpleCacheTest.php
+++ b/Neos.Cache/Tests/Unit/Psr/SimpleCache/SimpleCacheTest.php
@@ -19,7 +19,7 @@ class SimpleCacheTest extends BaseTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockBackend = $this->getMockBuilder(BackendInterface::class)->getMock();
     }

--- a/Neos.Cache/Tests/Unit/Psr/SimpleCache/SimpleCacheTest.php
+++ b/Neos.Cache/Tests/Unit/Psr/SimpleCache/SimpleCacheTest.php
@@ -3,6 +3,7 @@ namespace Neos\Cache\Tests\Unit\Psr\SimpleCache;
 
 use Neos\Cache\Backend\BackendInterface;
 use Neos\Cache\Exception;
+use Neos\Cache\Psr\InvalidArgumentException;
 use Neos\Cache\Psr\SimpleCache\SimpleCache;
 use Neos\Cache\Tests\BaseTestCase;
 
@@ -35,29 +36,29 @@ class SimpleCacheTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Psr\InvalidArgumentException
      */
     public function constructingWithInvalidIdentifierThrowsPsrInvalidArgumentException()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->createSimpleCache('Invalid #*<>/()=?!');
     }
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Psr\InvalidArgumentException
      */
     public function setThrowsInvalidArgumentExceptionOnInvalidIdentifier()
     {
+        $this->expectException(InvalidArgumentException::class);
         $simpleCache = $this->createSimpleCache();
         $simpleCache->set('Invalid #*<>/()=?!', 'does not matter');
     }
 
     /**
      * @test
-     * @expectedException Exception
      */
     public function setThrowsExceptionOnBackendError()
     {
+        $this->expectException(Exception::class);
         $this->mockBackend->expects(self::any())->method('set')->willThrowException(new Exception\InvalidDataException('Some other exception', 1234));
         $simpleCache = $this->createSimpleCache();
         $simpleCache->set('validkey', 'valid data');
@@ -76,20 +77,20 @@ class SimpleCacheTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Psr\InvalidArgumentException
      */
     public function getThrowsInvalidArgumentExceptionOnInvalidIdentifier()
     {
+        $this->expectException(InvalidArgumentException::class);
         $simpleCache = $this->createSimpleCache();
         $simpleCache->get('Invalid #*<>/()=?!', false);
     }
 
     /**
      * @test
-     * @expectedException Exception
      */
     public function getThrowsExceptionOnBackendError()
     {
+        $this->expectException(Exception::class);
         $this->mockBackend->expects(self::any())->method('get')->willThrowException(new Exception\InvalidDataException('Some other exception', 1234));
         $simpleCache = $this->createSimpleCache();
         $simpleCache->get('validkey', false);
@@ -122,20 +123,20 @@ class SimpleCacheTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Psr\InvalidArgumentException
      */
     public function deleteThrowsInvalidArgumentExceptionOnInvalidIdentifier()
     {
+        $this->expectException(InvalidArgumentException::class);
         $simpleCache = $this->createSimpleCache();
         $simpleCache->delete('Invalid #*<>/()=?!');
     }
 
     /**
      * @test
-     * @expectedException Exception
      */
     public function deleteThrowsExceptionOnBackendError()
     {
+        $this->expectException(Exception::class);
         $this->mockBackend->expects(self::any())->method('remove')->willThrowException(new Exception\InvalidDataException('Some other exception', 1234));
         $simpleCache = $this->createSimpleCache();
         $simpleCache->delete('validkey');
@@ -143,10 +144,10 @@ class SimpleCacheTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Psr\InvalidArgumentException
      */
     public function getMultipleThrowsInvalidArgumentExceptionOnInvalidIdentifier()
     {
+        $this->expectException(InvalidArgumentException::class);
         $simpleCache = $this->createSimpleCache();
         $simpleCache->getMultiple(['validKey', 'Invalid #*<>/()=?!']);
     }
@@ -181,10 +182,10 @@ class SimpleCacheTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Psr\InvalidArgumentException
      */
     public function setMultipleThrowsInvalidArgumentExceptionOnInvalidIdentifier()
     {
+        $this->expectException(InvalidArgumentException::class);
         $simpleCache = $this->createSimpleCache();
         $simpleCache->setMultiple(['validKey' => 'value', 'Invalid #*<>/()=?!' => 'value']);
     }
@@ -208,20 +209,20 @@ class SimpleCacheTest extends BaseTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Psr\InvalidArgumentException
      */
     public function deleteMultipleThrowsInvalidArgumentExceptionOnInvalidIdentifier()
     {
+        $this->expectException(InvalidArgumentException::class);
         $simpleCache = $this->createSimpleCache();
         $simpleCache->deleteMultiple(['validKey', 'Invalid #*<>/()=?!']);
     }
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Psr\InvalidArgumentException
      */
     public function hasThrowsInvalidArgumentExceptionOnInvalidIdentifier()
     {
+        $this->expectException(InvalidArgumentException::class);
         $simpleCache = $this->createSimpleCache();
         $simpleCache->has('Invalid #*<>/()=?!');
     }

--- a/Neos.Cache/composer.json
+++ b/Neos.Cache/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "mikey179/vfsstream": "~1.6",
-        "phpunit/phpunit": "~8.1.3"
+        "phpunit/phpunit": "~8.1"
     },
     "autoload": {
         "psr-4": {

--- a/Neos.Cache/composer.json
+++ b/Neos.Cache/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "mikey179/vfsstream": "~1.6",
-        "phpunit/phpunit": "~7.1"
+        "phpunit/phpunit": "~8.1.3"
     },
     "autoload": {
         "psr-4": {

--- a/Neos.Eel/Tests/Functional/FlowQuery/OperationResolverTest.php
+++ b/Neos.Eel/Tests/Functional/FlowQuery/OperationResolverTest.php
@@ -16,7 +16,7 @@ class OperationResolverTest extends FunctionalTestCase
     protected $operationResolver;
 
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->operationResolver = $this->objectManager->get(OperationResolver::class);

--- a/Neos.Eel/Tests/Unit/AbstractEvaluatorTest.php
+++ b/Neos.Eel/Tests/Unit/AbstractEvaluatorTest.php
@@ -13,6 +13,8 @@ namespace Neos\Eel\Tests\Unit;
 
 use Neos\Eel\Context;
 use Neos\Eel\EelEvaluatorInterface;
+use Neos\Eel\EvaluationException;
+use Neos\Eel\ParserException;
 use Neos\Flow\Tests\UnitTestCase;
 
 /**
@@ -570,10 +572,10 @@ abstract class AbstractEvaluatorTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Eel\EvaluationException
      */
     public function methodCallOfUndefinedFunctionThrowsException()
     {
+        $this->expectException(EvaluationException::class);
         $c = new Context([
             'arr' => [
                 'func' => function ($arg) {
@@ -586,10 +588,10 @@ abstract class AbstractEvaluatorTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Eel\EvaluationException
      */
     public function methodCallOfUnknownMethodThrowsException()
     {
+        $this->expectException(EvaluationException::class);
         $o = new \Neos\Eel\Tests\Unit\Fixtures\TestObject();
 
         $c = new Context([
@@ -671,10 +673,10 @@ abstract class AbstractEvaluatorTest extends UnitTestCase
     /**
      * @test
      * @dataProvider invalidExpressions
-     * @expectedException \Neos\Eel\ParserException
      */
     public function invalidExpressionsThrowExceptions($expression)
     {
+        $this->expectException(ParserException::class);
         $this->assertEvaluated(false, $expression, new Context());
     }
 

--- a/Neos.Eel/Tests/Unit/FlowQuery/FlowQueryTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/FlowQueryTest.php
@@ -11,6 +11,7 @@ namespace Neos\Eel\Tests\Unit\FlowQuery;
  * source code.
  */
 
+use Neos\Eel\FlowQuery\FizzleException;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Eel\FlowQuery\OperationResolver;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
@@ -578,10 +579,11 @@ class FlowQueryTest extends UnitTestCase
     /**
      * @dataProvider dataProviderForErrorQueries
      * @test
-     * @expectedException \Neos\Eel\FlowQuery\FizzleException
      */
     public function errorQueriesThrowError($expression)
     {
+        $this->expectException(FizzleException::class);
+
         $x = new \stdClass();
         $x->foo = new \stdClass();
         $x->foo->foo = 'asdf';

--- a/Neos.Eel/Tests/Unit/Helper/DateHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/DateHelperTest.php
@@ -41,7 +41,7 @@ class DateHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new DateHelper();
         $result = $helper->parse($string, $format);
         $this->assertInstanceOf(\DateTime::class, $result);
-        $this->assertEquals((float)$expected->format('U'), (float)$result->format('U'), 'Timestamps should match', 60);
+        $this->assertEqualsWithDelta((float)$expected->format('U'), (float)$result->format('U'), 60, 'Timestamps should match');
     }
 
     /**
@@ -132,7 +132,7 @@ class DateHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new DateHelper();
         $result = $helper->now();
         $this->assertInstanceOf(\DateTime::class, $result);
-        $this->assertEquals(time(), (integer)$result->format('U'), 'Now should be now', 1);
+        $this->assertEqualsWithDelta(time(), (integer)$result->format('U'), 1, 'Now should be now');
     }
 
     /**
@@ -144,7 +144,7 @@ class DateHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $result = $helper->create('yesterday noon');
         $expected = new \DateTime('yesterday noon');
         $this->assertInstanceOf(\DateTime::class, $result);
-        $this->assertEquals($expected->getTimestamp(), $result->getTimestamp(), 'Created DateTime object should match expected', 1);
+        $this->assertEqualsWithDelta($expected->getTimestamp(), $result->getTimestamp(), 1, 'Created DateTime object should match expected');
     }
 
     /**
@@ -156,7 +156,7 @@ class DateHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $result = $helper->today();
         $this->assertInstanceOf(\DateTime::class, $result);
         $today = new \DateTime('today');
-        $this->assertEquals($today->getTimestamp(), $result->getTimestamp(), 'Today should be today', 1);
+        $this->assertEqualsWithDelta($today->getTimestamp(), $result->getTimestamp(), 1, 'Today should be today');
     }
 
     /**

--- a/Neos.Eel/Tests/Unit/Helper/FileHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/FileHelperTest.php
@@ -20,7 +20,7 @@ use org\bovigo\vfs\vfsStream;
  */
 class FileHelperTest extends UnitTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         vfsStream::setup('Foo');
     }

--- a/Neos.Eel/Tests/Unit/Helper/MathHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/MathHelperTest.php
@@ -46,7 +46,7 @@ class MathHelperTest extends \Neos\Flow\Tests\UnitTestCase
         if ($expected === static::NAN) {
             $this->assertTrue(is_nan($result), 'Expected NAN');
         } else {
-            $this->assertEquals($expected, $result, 'Rounded value did not match', 0.0001);
+            $this->assertEqualsWithDelta($expected, $result, 0.0001, 'Rounded value did not match');
         }
     }
 
@@ -76,7 +76,7 @@ class MathHelperTest extends \Neos\Flow\Tests\UnitTestCase
             'Math' => $helper
         ]);
         $result = $evaluator->evaluate($method, $context);
-        $this->assertEquals($expected, $result, 'Rounded value did not match', 0.001);
+        $this->assertEqualsWithDelta($expected, $result, 0.001, 'Rounded value did not match');
     }
 
     public function trigonometricExamples()
@@ -110,7 +110,7 @@ class MathHelperTest extends \Neos\Flow\Tests\UnitTestCase
             'Math' => $helper
         ]);
         $result = $evaluator->evaluate($method, $context);
-        $this->assertEquals($expected, $result, 'Rounded value did not match', 0.001);
+        $this->assertEqualsWithDelta($expected, $result, 0.001, 'Rounded value did not match');
     }
 
     public function variousExamples()
@@ -213,7 +213,7 @@ class MathHelperTest extends \Neos\Flow\Tests\UnitTestCase
         if ($expected === static::NAN) {
             $this->assertTrue(is_nan($result), 'Expected NAN, got value "' . $result . '"');
         } else {
-            $this->assertEquals($expected, $result, 'Rounded value did not match', 0.001);
+            $this->assertEqualsWithDelta($expected, $result, 0.001, 'Rounded value did not match');
         }
     }
 

--- a/Neos.Eel/Tests/Unit/ProtectedContextTest.php
+++ b/Neos.Eel/Tests/Unit/ProtectedContextTest.php
@@ -13,6 +13,7 @@ namespace Neos\Eel\Tests\Unit;
 
 use Neos\Cache\Frontend\StringFrontend;
 use Neos\Eel\CompilingEvaluator;
+use Neos\Eel\NotAllowedException;
 use Neos\Eel\ProtectedContext;
 use Neos\Eel\Tests\Unit\Fixtures\TestObject;
 use Neos\Flow\Tests\UnitTestCase;
@@ -24,10 +25,10 @@ class ProtectedContextTest extends UnitTestCase
 {
     /**
      * @test
-     * @expectedException \Neos\Eel\NotAllowedException
      */
     public function methodCallToAnyValueIsNotAllowed()
     {
+        $this->expectException(NotAllowedException::class);
         $securedObject = new TestObject();
 
         $context = new ProtectedContext([
@@ -40,10 +41,10 @@ class ProtectedContextTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Eel\NotAllowedException
      */
     public function arrayAccessResultIsStillUntrusted()
     {
+        $this->expectException(NotAllowedException::class);
         $securedObject = new TestObject();
 
         $context = new ProtectedContext([
@@ -92,10 +93,10 @@ class ProtectedContextTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Eel\NotAllowedException
      */
     public function firstLevelFunctionsHaveToBeWhitelisted()
     {
+        $this->expectException(NotAllowedException::class);
         $context = new ProtectedContext([
             'ident' => function ($value) {
                 return $value;
@@ -109,10 +110,10 @@ class ProtectedContextTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Eel\NotAllowedException
      */
     public function resultOfFirstLevelMethodCallIsProtected()
     {
+        $this->expectException(NotAllowedException::class);
         $securedObject = new TestObject();
 
         $context = new ProtectedContext([
@@ -133,10 +134,10 @@ class ProtectedContextTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Eel\NotAllowedException
      */
     public function resultOfWhitelistedMethodCallIsProtected()
     {
+        $this->expectException(NotAllowedException::class);
         $securedObject = new TestObject();
 
         $context = new ProtectedContext([

--- a/Neos.Error.Messages/Tests/Unit/ResultTest.php
+++ b/Neos.Error.Messages/Tests/Unit/ResultTest.php
@@ -24,7 +24,7 @@ class ResultTest extends \PHPUnit\Framework\TestCase
      */
     protected $result;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->result = new Result();
     }

--- a/Neos.Error.Messages/composer.json
+++ b/Neos.Error.Messages/composer.json
@@ -8,7 +8,7 @@
         "php": "~7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.1"
+        "phpunit/phpunit": "~8.1.3"
     },
     "autoload": {
         "psr-4": {

--- a/Neos.Error.Messages/composer.json
+++ b/Neos.Error.Messages/composer.json
@@ -8,7 +8,7 @@
         "php": "~7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~8.1.3"
+        "phpunit/phpunit": "~8.1"
     },
     "autoload": {
         "psr-4": {

--- a/Neos.Flow.Log/Tests/Unit/Backend/AbstractBackendTest.php
+++ b/Neos.Flow.Log/Tests/Unit/Backend/AbstractBackendTest.php
@@ -27,7 +27,7 @@ class AbstractBackendTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->backendClassName = 'ConcreteBackend_' . md5(uniqid(mt_rand(), true));
         eval('

--- a/Neos.Flow.Log/Tests/Unit/Backend/FileBackendTest.php
+++ b/Neos.Flow.Log/Tests/Unit/Backend/FileBackendTest.php
@@ -23,7 +23,7 @@ class FileBackendTest extends UnitTestCase
 {
     /**
      */
-    public function setUp()
+    protected function setUp(): void
     {
         vfsStream::setup('testDirectory');
     }

--- a/Neos.Flow.Log/Tests/Unit/Backend/FileBackendTest.php
+++ b/Neos.Flow.Log/Tests/Unit/Backend/FileBackendTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Log\Tests\Unit\Backend;
  * source code.
  */
 
+use Neos\Flow\Log\Exception\CouldNotOpenResourceException;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamWrapper;
 use Neos\Flow\Log\Backend\FileBackend;
@@ -41,10 +42,10 @@ class FileBackendTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Log\Exception\CouldNotOpenResourceException
      */
     public function openDoesNotCreateParentDirectoriesByDefault()
     {
+        $this->expectException(CouldNotOpenResourceException::class);
         $logFileUrl = vfsStream::url('testDirectory') . '/foo/test.log';
         $backend = new FileBackend(['logFileUrl' => $logFileUrl]);
         $backend->open();

--- a/Neos.Flow.Log/Tests/Unit/Backend/JsonFileBackendTest.php
+++ b/Neos.Flow.Log/Tests/Unit/Backend/JsonFileBackendTest.php
@@ -23,7 +23,7 @@ class JsonFileBackendTest extends UnitTestCase
 {
     /**
      */
-    public function setUp()
+    protected function setUp(): void
     {
         vfsStream::setup('testDirectory');
     }

--- a/Neos.Flow.Log/Tests/Unit/LoggerTest.php
+++ b/Neos.Flow.Log/Tests/Unit/LoggerTest.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Log\Tests\Unit;
 
 use Neos\Flow\Log\Backend\BackendInterface;
 use Neos\Flow\Log\DefaultLogger;
+use Neos\Flow\Log\Exception\NoSuchBackendException;
 use Neos\Flow\Tests\UnitTestCase;
 
 /**
@@ -69,10 +70,10 @@ class LoggerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Log\Exception\NoSuchBackendException
      */
     public function removeThrowsAnExceptionOnTryingToRemoveABackendNotPreviouslyAdded()
     {
+        $this->expectException(NoSuchBackendException::class);
         $mockBackend = $this->getMockBuilder(BackendInterface::class)->setMethods(['open', 'append', 'close'])->getMock();
 
         $logger = new DefaultLogger();

--- a/Neos.Flow.Log/composer.json
+++ b/Neos.Flow.Log/composer.json
@@ -12,7 +12,7 @@
         "psr/log": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.0.0"
+        "phpunit/phpunit": "~8.1.3"
     },
     "autoload": {
         "psr-4": {

--- a/Neos.Flow.Log/composer.json
+++ b/Neos.Flow.Log/composer.json
@@ -12,7 +12,7 @@
         "psr/log": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~8.1.3"
+        "phpunit/phpunit": "~8.1"
     },
     "autoload": {
         "psr-4": {

--- a/Neos.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
+++ b/Neos.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
@@ -66,7 +66,7 @@ class ConfigurationValidationTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -112,7 +112,7 @@ class ConfigurationValidationTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         $this->objectManager->setInstance(ConfigurationManager::class, $this->originalConfigurationManager);
         $this->injectApplicationContextIntoConfigurationManager($this->objectManager->getContext());

--- a/Neos.Flow/Tests/Functional/Configuration/SchemaValidationTest.php
+++ b/Neos.Flow/Tests/Functional/Configuration/SchemaValidationTest.php
@@ -50,7 +50,7 @@ class SchemaValidationTest extends FunctionalTestCase
      */
     protected $schemaValidator;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->schemaValidator = new SchemaValidator();

--- a/Neos.Flow/Tests/Functional/Error/DebuggerTest.php
+++ b/Neos.Flow/Tests/Functional/Error/DebuggerTest.php
@@ -51,6 +51,6 @@ class DebuggerTest extends FunctionalTestCase
         $newConfiguration = Arrays::arrayMergeRecursiveOverrule($currentConfiguration, $configurationOverwrite);
         ObjectAccess::setProperty($this->configurationManager, 'configurations', $newConfiguration, true);
 
-        $this->assertContains('rootContextString', Debugger::renderDump($object, 0, true));
+        $this->assertStringContainsString('rootContextString', Debugger::renderDump($object, 0, true));
     }
 }

--- a/Neos.Flow/Tests/Functional/Error/DebuggerTest.php
+++ b/Neos.Flow/Tests/Functional/Error/DebuggerTest.php
@@ -29,7 +29,7 @@ class DebuggerTest extends FunctionalTestCase
     protected $configurationManager;
 
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->configurationManager = $this->objectManager->get(ConfigurationManager::class);

--- a/Neos.Flow/Tests/Functional/Http/Client/BrowserTest.php
+++ b/Neos.Flow/Tests/Functional/Http/Client/BrowserTest.php
@@ -62,7 +62,7 @@ class BrowserTest extends FunctionalTestCase
     {
         $this->browser->setFollowRedirects(false);
         $response = $this->browser->request('http://localhost/test/http/redirecting');
-        $this->assertNotContains('arrived.', $response->getContent());
+        $this->assertStringNotContainsString('arrived.', $response->getContent());
         $this->assertEquals(303, $response->getStatusCode());
         $this->assertEquals('http://localhost/test/http/redirecting/tohere', $response->getHeader('Location'));
     }

--- a/Neos.Flow/Tests/Functional/Http/Client/BrowserTest.php
+++ b/Neos.Flow/Tests/Functional/Http/Client/BrowserTest.php
@@ -26,7 +26,7 @@ class BrowserTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->registerRoute(

--- a/Neos.Flow/Tests/Functional/Http/Client/CurlEngineTest.php
+++ b/Neos.Flow/Tests/Functional/Http/Client/CurlEngineTest.php
@@ -29,7 +29,7 @@ class CurlEngineTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $curlEngine = $this->objectManager->get(CurlEngine::class);

--- a/Neos.Flow/Tests/Functional/Http/Client/CurlEngineTest.php
+++ b/Neos.Flow/Tests/Functional/Http/Client/CurlEngineTest.php
@@ -57,6 +57,6 @@ class CurlEngineTest extends FunctionalTestCase
     public function getRequestReturnsResponse()
     {
         $response = $this->browser->request('http://www.neos.io');
-        $this->assertContains('This website is powered by Neos', $response->getContent());
+        $this->assertStringContainsString('This website is powered by Neos', $response->getContent());
     }
 }

--- a/Neos.Flow/Tests/Functional/Http/Client/InternalRequestEngineTest.php
+++ b/Neos.Flow/Tests/Functional/Http/Client/InternalRequestEngineTest.php
@@ -27,7 +27,7 @@ class InternalRequestEngineTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Neos.Flow/Tests/Functional/I18n/Cldr/CldrRepositoryTest.php
+++ b/Neos.Flow/Tests/Functional/I18n/Cldr/CldrRepositoryTest.php
@@ -35,7 +35,7 @@ class CldrRepositoryTest extends FunctionalTestCase
     /**
      * Initialize dependencies
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->cldrRepository = $this->objectManager->get(CldrRepository::class);

--- a/Neos.Flow/Tests/Functional/I18n/FormatResolverTest.php
+++ b/Neos.Flow/Tests/Functional/I18n/FormatResolverTest.php
@@ -29,7 +29,7 @@ class FormatResolverTest extends FunctionalTestCase
     /**
      * Initialize dependencies
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->formatResolver = $this->objectManager->get(FormatResolver::class);

--- a/Neos.Flow/Tests/Functional/I18n/TranslatorTest.php
+++ b/Neos.Flow/Tests/Functional/I18n/TranslatorTest.php
@@ -28,7 +28,7 @@ class TranslatorTest extends FunctionalTestCase
     /**
      * Initialize dependencies
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->translator = $this->objectManager->get(I18n\Translator::class);

--- a/Neos.Flow/Tests/Functional/I18n/Xliff/Service/XliffFileProviderTest.php
+++ b/Neos.Flow/Tests/Functional/I18n/Xliff/Service/XliffFileProviderTest.php
@@ -34,7 +34,7 @@ class XliffFileProviderTest extends FunctionalTestCase
     /**
      * Initialize dependencies
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $cacheManager = $this->objectManager->get(CacheManager::class);

--- a/Neos.Flow/Tests/Functional/Mvc/AbstractControllerTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/AbstractControllerTest.php
@@ -24,7 +24,7 @@ class AbstractControllerTest extends FunctionalTestCase
     /**
      * Additional setup: Routes
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
@@ -27,7 +27,7 @@ class ActionControllerTest extends FunctionalTestCase
     /**
      * Additional setup: Routes
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
@@ -35,7 +35,7 @@ class RoutingTest extends FunctionalTestCase
     /**
      * Validate that test routes are loaded
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Neos.Flow/Tests/Functional/Mvc/ViewsConfiguration/ViewsConfigurationTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/ViewsConfiguration/ViewsConfigurationTest.php
@@ -32,7 +32,7 @@ class ViewsConfigurationTest extends FunctionalTestCase
     /**
      * Additional setup: Routes
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
@@ -28,7 +28,7 @@ class DependencyInjectionTest extends FunctionalTestCase
      */
     protected $configurationManager;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Neos.Flow/Tests/Functional/Persistence/Aspect/PersistenceMagicAspectTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Aspect/PersistenceMagicAspectTest.php
@@ -28,7 +28,7 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/AggregateTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/AggregateTest.php
@@ -38,7 +38,7 @@ class AggregateTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/IndexedCollectionTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/IndexedCollectionTest.php
@@ -27,7 +27,7 @@ class IndexedCollectionTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/LazyLoadingTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/LazyLoadingTest.php
@@ -38,7 +38,7 @@ class LazyLoadingTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriverTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriverTest.php
@@ -30,7 +30,7 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/PersistClonedRelatedEntitiesTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/PersistClonedRelatedEntitiesTest.php
@@ -33,7 +33,7 @@ class PersistClonedRelatedEntitiesTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/QueryTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/QueryTest.php
@@ -30,7 +30,7 @@ class QueryTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/RepositoryTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/RepositoryTest.php
@@ -45,7 +45,7 @@ class RepositoryTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/RepositoryTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/RepositoryTest.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Tests\Functional\Persistence\Doctrine;
 
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Persistence\Doctrine\Repository;
+use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Flow\Persistence\QueryResultInterface;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures;
 use Neos\Flow\Tests\FunctionalTestCase;
@@ -274,10 +275,10 @@ class RepositoryTest extends FunctionalTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Persistence\Exception\IllegalObjectTypeException
      */
     public function addingASuperTypeToAMoreSpecificRepositoryThrowsAnException()
     {
+        $this->expectException(IllegalObjectTypeException::class);
         $this->subSubEntityRepository = $this->objectManager->get(Fixtures\SubSubEntityRepository::class);
 
         $subEntity = new Fixtures\SubEntity();

--- a/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
@@ -42,7 +42,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {

--- a/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
@@ -16,6 +16,8 @@ use Doctrine\ORM\Tools\SchemaTool;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Persistence\Doctrine\QueryResult;
+use Neos\Flow\Persistence\Exception;
+use Neos\Flow\Persistence\Exception\ObjectValidationFailedException;
 use Neos\Flow\Tests\FunctionalTestCase;
 
 /**
@@ -275,10 +277,10 @@ class PersistenceTest extends FunctionalTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Persistence\Exception\ObjectValidationFailedException
      */
     public function validationIsDoneForNewEntities()
     {
+        $this->expectException(ObjectValidationFailedException::class);
         $this->removeExampleEntities();
         $this->insertExampleEntity('A');
 
@@ -287,10 +289,10 @@ class PersistenceTest extends FunctionalTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Persistence\Exception\ObjectValidationFailedException
      */
     public function validationIsDoneForReconstitutedEntities()
     {
+        $this->expectException(ObjectValidationFailedException::class);
         $this->removeExampleEntities();
         $this->insertExampleEntity();
         $this->persistenceManager->persistAll();
@@ -305,10 +307,10 @@ class PersistenceTest extends FunctionalTestCase
      * Testcase for issue #32830 - Validation on persist breaks with Doctrine Lazy Loading Proxies
      *
      * @test
-     * @expectedException \Neos\Flow\Persistence\Exception\ObjectValidationFailedException
      */
     public function validationIsDoneForReconstitutedEntitiesWhichAreLazyLoadingProxies()
     {
+        $this->expectException(ObjectValidationFailedException::class);
         $this->removeExampleEntities();
         $this->insertExampleEntity();
         $this->persistenceManager->persistAll();
@@ -373,11 +375,11 @@ class PersistenceTest extends FunctionalTestCase
     }
 
     /**
-     * @expectedException \Neos\Flow\Persistence\Exception
      * @test
      */
     public function persistAllThrowsExceptionIfNonWhitelistedObjectsAreDirtyAndFlagIsSet()
     {
+        $this->expectException(Exception::class);
         $testEntity = new Fixtures\TestEntity();
         $testEntity->setName('Surfer girl');
         $this->testEntityRepository->add($testEntity);
@@ -385,11 +387,11 @@ class PersistenceTest extends FunctionalTestCase
     }
 
     /**
-     * @expectedException \Neos\Flow\Persistence\Exception
      * @test
      */
     public function persistAllThrowsExceptionIfNonWhitelistedObjectsAreUpdatedAndFlagIsSet()
     {
+        $this->expectException(Exception::class);
         $this->removeExampleEntities();
         $this->insertExampleEntity();
         $this->persistenceManager->persistAll();

--- a/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
@@ -79,7 +79,7 @@ class PersistenceTest extends FunctionalTestCase
         $this->assertAttributeInternalType('null', 'rows', $allResults, 'Query Result did not load the result collection lazily.');
 
         $allResultsArray = $allResults->toArray();
-        $this->assertEquals('Flow', $allResultsArray[0]->getName());
+        $this->assertStringContainsString('Flow', $allResultsArray[0]->getName());
         $this->assertAttributeInternalType('array', 'rows', $allResults);
     }
 

--- a/Neos.Flow/Tests/Functional/Property/PropertyMapperTest.php
+++ b/Neos.Flow/Tests/Functional/Property/PropertyMapperTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Tests\Functional\Property;
  * source code.
  */
 
+use Neos\Flow\Property\Exception;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
@@ -159,10 +160,10 @@ class PropertyMapperTest extends FunctionalTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Property\Exception
      */
     public function overriddenTargetTypeForEntityMustBeASubclass()
     {
+        $this->expectException(Exception::class);
         $source = [
             '__type' => Fixtures\TestClass::class,
             'name' => 'A horse'
@@ -193,10 +194,10 @@ class PropertyMapperTest extends FunctionalTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Property\Exception
      */
     public function overriddenTargetTypeForSimpleObjectMustBeASubclass()
     {
+        $this->expectException(Exception::class);
         $source = [
             '__type' => Fixtures\TestEntity::class,
             'name' => 'A horse'
@@ -350,10 +351,10 @@ class PropertyMapperTest extends FunctionalTestCase
     /**
      * @test
      * @dataProvider invalidTypeConverterConfigurationsForOverridingTargetTypes
-     * @expectedException \Neos\Flow\Property\Exception
      */
     public function mappingToFieldsFromSubclassThrowsExceptionIfTypeConverterOptionIsInvalidOrNotSet(PropertyMappingConfigurationInterface $configuration = null)
     {
+        $this->expectException(Exception::class);
         $source = [
             '__type' => Fixtures\TestEntitySubclassWithNewField::class,
             'testField' => 'A horse'
@@ -383,10 +384,10 @@ class PropertyMapperTest extends FunctionalTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Property\Exception
      */
     public function convertFromShouldThrowExceptionIfGivenSourceTypeIsNotATargetType()
     {
+        $this->expectException(Exception::class);
         $source = [
             '__type' => Fixtures\TestClass::class,
             'testField' => 'A horse'

--- a/Neos.Flow/Tests/Functional/Property/PropertyMapperTest.php
+++ b/Neos.Flow/Tests/Functional/Property/PropertyMapperTest.php
@@ -35,7 +35,7 @@ class PropertyMapperTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->propertyMapper = $this->objectManager->get(PropertyMapper::class);

--- a/Neos.Flow/Tests/Functional/Property/TypeConverter/FloatConverterTest.php
+++ b/Neos.Flow/Tests/Functional/Property/TypeConverter/FloatConverterTest.php
@@ -28,7 +28,7 @@ class FloatConverterTest extends FunctionalTestCase
      */
     protected $converter;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->converter = $this->objectManager->get(\Neos\Flow\Property\TypeConverter\FloatConverter::class);

--- a/Neos.Flow/Tests/Functional/Property/TypeConverter/FloatConverterTest.php
+++ b/Neos.Flow/Tests/Functional/Property/TypeConverter/FloatConverterTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Tests\Functional\Property\TypeConverter;
  * source code.
  */
 
+use Neos\Flow\I18n\Exception\InvalidLocaleIdentifierException;
 use Neos\Flow\I18n\Locale;
 use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\Property\TypeConverter\FloatConverter;
@@ -83,10 +84,10 @@ class FloatConverterTest extends FunctionalTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\I18n\Exception\InvalidLocaleIdentifierException
      */
     public function convertFromThrowsExceptionIfLocaleIsInvalid()
     {
+        $this->expectException(InvalidLocaleIdentifierException::class);
         $configuration = new PropertyMappingConfiguration();
         $configuration->setTypeConverterOption(FloatConverter::class, 'locale', 'some-non-existent-locale-identifier');
 

--- a/Neos.Flow/Tests/Functional/Property/TypeConverter/ObjectConverterTest.php
+++ b/Neos.Flow/Tests/Functional/Property/TypeConverter/ObjectConverterTest.php
@@ -26,7 +26,7 @@ class ObjectConverterTest extends FunctionalTestCase
      */
     protected $converter;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->converter = $this->objectManager->get(ObjectConverter::class);

--- a/Neos.Flow/Tests/Functional/Property/TypeConverter/ObjectConverterTest.php
+++ b/Neos.Flow/Tests/Functional/Property/TypeConverter/ObjectConverterTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Tests\Functional\Property\TypeConverter;
  * source code.
  */
 
+use Neos\Flow\Property\Exception\InvalidTargetException;
 use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\Property\TypeConverter\ObjectConverter;
 use Neos\Utility\ObjectAccess;
@@ -79,11 +80,11 @@ class ObjectConverterTest extends FunctionalTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Property\Exception\InvalidTargetException
-     * @expectedExceptionCode 1406821818
      */
     public function getTypeOfChildPropertyThrowsExceptionIfThatPropertyIsPubliclyPresentButHasNoProperTypeAnnotation()
     {
+        $this->expectExceptionCode(1406821818);
+        $this->expectException(InvalidTargetException::class);
         $this->converter->getTypeOfChildProperty(
             Fixtures\TestClass::class,
             'somePublicPropertyWithoutVarAnnotation',
@@ -172,10 +173,10 @@ class ObjectConverterTest extends FunctionalTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Property\Exception\InvalidTargetException
      */
     public function convertFromThrowsMeaningfulExceptionWhenTheTargetExpectsAnUnknownDependencyThatIsNotSpecifiedInTheSource()
     {
+        $this->expectException(InvalidTargetException::class);
         $this->converter->convertFrom(
             'irrelevant',
             \Neos\Flow\Tests\Functional\Property\Fixtures\TestClassWithThirdPartyClassConstructorInjection::class

--- a/Neos.Flow/Tests/Functional/Property/TypeConverter/PersistentObjectConverterTest.php
+++ b/Neos.Flow/Tests/Functional/Property/TypeConverter/PersistentObjectConverterTest.php
@@ -34,7 +34,7 @@ class PersistentObjectConverterTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->propertyMapper = $this->objectManager->get(PropertyMapper::class);

--- a/Neos.Flow/Tests/Functional/Property/TypeConverter/PersistentObjectConverterTest.php
+++ b/Neos.Flow/Tests/Functional/Property/TypeConverter/PersistentObjectConverterTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Tests\Functional\Property\TypeConverter;
  * source code.
  */
 
+use Neos\Flow\Property\Exception;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Flow\Tests\Functional\Property\Fixtures;
@@ -97,10 +98,10 @@ class PersistentObjectConverterTest extends FunctionalTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Property\Exception
      */
     public function entityWithImmutablePropertyCanNotBeUpdatedWhenImmutablePropertyChanged()
     {
+        $this->expectException(Exception::class);
         $result = $this->propertyMapper->convert($this->sourceProperties, Fixtures\TestEntityWithImmutableProperty::class);
         $identifier = $this->persistenceManager->getIdentifierByObject($result);
         $this->persistenceManager->add($result);

--- a/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
@@ -26,7 +26,7 @@ class ReflectionServiceTest extends FunctionalTestCase
      */
     protected $reflectionService;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->reflectionService = $this->objectManager->get(ReflectionService::class);

--- a/Neos.Flow/Tests/Functional/ResourceManagement/PersistentResourceTest.php
+++ b/Neos.Flow/Tests/Functional/ResourceManagement/PersistentResourceTest.php
@@ -33,7 +33,7 @@ class PersistentResourceTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {

--- a/Neos.Flow/Tests/Functional/ResourceManagement/ResourceManagerTest.php
+++ b/Neos.Flow/Tests/Functional/ResourceManagement/ResourceManagerTest.php
@@ -39,7 +39,7 @@ class ResourceManagerTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {

--- a/Neos.Flow/Tests/Functional/Security/AccountTest.php
+++ b/Neos.Flow/Tests/Functional/Security/AccountTest.php
@@ -31,7 +31,7 @@ class AccountTest extends FunctionalTestCase
      */
     protected $account;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Neos.Flow/Tests/Functional/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
+++ b/Neos.Flow/Tests/Functional/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
@@ -45,7 +45,7 @@ class PersistedUsernamePasswordProviderTest extends FunctionalTestCase
 
 
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Neos.Flow/Tests/Functional/Security/AuthenticationTest.php
+++ b/Neos.Flow/Tests/Functional/Security/AuthenticationTest.php
@@ -163,7 +163,7 @@ class AuthenticationTest extends FunctionalTestCase
     public function failedAuthenticationCallsOnAuthenticationFailureMethod()
     {
         $response = $this->browser->request('http://localhost/test/security/authentication');
-        $this->assertContains('Uncaught Exception in Flow #42: Failure Method Exception', $response->getContent());
+        $this->assertStringContainsString('Uncaught Exception in Flow #42: Failure Method Exception', $response->getContent());
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/Security/AuthenticationTest.php
+++ b/Neos.Flow/Tests/Functional/Security/AuthenticationTest.php
@@ -36,7 +36,7 @@ class AuthenticationTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Neos.Flow/Tests/Functional/Security/Authorization/Privilege/Entity/Doctrine/ContentSecurityTest.php
+++ b/Neos.Flow/Tests/Functional/Security/Authorization/Privilege/Entity/Doctrine/ContentSecurityTest.php
@@ -63,7 +63,7 @@ class ContentSecurityTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {

--- a/Neos.Flow/Tests/Functional/Security/Authorization/Privilege/Entity/Doctrine/EntityPrivilegeExpressionEvaluatorTest.php
+++ b/Neos.Flow/Tests/Functional/Security/Authorization/Privilege/Entity/Doctrine/EntityPrivilegeExpressionEvaluatorTest.php
@@ -31,7 +31,7 @@ class EntityPrivilegeExpressionEvaluatorTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {

--- a/Neos.Flow/Tests/Functional/Security/CsrfProtectionTest.php
+++ b/Neos.Flow/Tests/Functional/Security/CsrfProtectionTest.php
@@ -37,7 +37,7 @@ class CsrfProtectionTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Neos.Flow/Tests/Functional/Session/SessionManagementTest.php
+++ b/Neos.Flow/Tests/Functional/Session/SessionManagementTest.php
@@ -20,7 +20,7 @@ class SessionManagementTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Neos.Flow/Tests/Functional/Session/SessionManagementTest.php
+++ b/Neos.Flow/Tests/Functional/Session/SessionManagementTest.php
@@ -101,10 +101,10 @@ class SessionManagementTest extends FunctionalTestCase
     {
         $response = $this->browser->request('http://localhost/test/session');
         $this->assertTrue($response->hasHeader('Set-Cookie'), 'Available Cookies are: ' . implode(', ', array_keys($response->getHeader('Set-Cookie'))));
-        $this->assertContains('Flow_Testing_Session', implode(',', $response->getHeader('Set-Cookie')));
+        $this->assertStringContainsString('Flow_Testing_Session', implode(',', $response->getHeader('Set-Cookie')));
 
         $response = $this->browser->request('http://localhost/test/session');
         $this->assertTrue($response->hasHeader('Set-Cookie'), 'Available Cookies are: ' . implode(', ', array_keys($response->getHeader('Set-Cookie'))));
-        $this->assertContains('Flow_Testing_Session', implode(',', $response->getHeader('Set-Cookie')));
+        $this->assertStringContainsString('Flow_Testing_Session', implode(',', $response->getHeader('Set-Cookie')));
     }
 }

--- a/Neos.Flow/Tests/Functional/Validation/ValidationTest.php
+++ b/Neos.Flow/Tests/Functional/Validation/ValidationTest.php
@@ -36,7 +36,7 @@ class ValidationTest extends FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {

--- a/Neos.Flow/Tests/Functional/Validation/Validator/UniqueEntityValidatorTest.php
+++ b/Neos.Flow/Tests/Functional/Validation/Validator/UniqueEntityValidatorTest.php
@@ -33,7 +33,7 @@ class UniqueEntityValidatorTest extends \Neos\Flow\Tests\FunctionalTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof \Neos\Flow\Persistence\Doctrine\PersistenceManager) {

--- a/Neos.Flow/Tests/FunctionalTestCase.php
+++ b/Neos.Flow/Tests/FunctionalTestCase.php
@@ -119,7 +119,7 @@ abstract class FunctionalTestCase extends \Neos\Flow\Tests\BaseTestCase
      *
      * @return void
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$bootstrap = \Neos\Flow\Core\Bootstrap::$staticObjectManager->get(\Neos\Flow\Core\Bootstrap::class);
         self::setupSuperGlobals();
@@ -133,7 +133,7 @@ abstract class FunctionalTestCase extends \Neos\Flow\Tests\BaseTestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->objectManager = self::$bootstrap->getObjectManager();
 
@@ -234,7 +234,7 @@ abstract class FunctionalTestCase extends \Neos\Flow\Tests\BaseTestCase
      *
      * @return void
      */
-    public function tearDown()
+    protected function tearDown(): void
     {
         $this->tearDownSecurity();
 

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutExpressionParserTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutExpressionParserTest.php
@@ -49,20 +49,20 @@ class PointcutExpressionParserTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Aop\Exception\InvalidPointcutExpressionException
      */
     public function parseThrowsExceptionIfPointcutExpressionIsNotAString()
     {
+        $this->expectException(Aop\Exception\InvalidPointcutExpressionException::class);
         $parser = new PointcutExpressionParser();
         $parser->parse(false, 'Unit Test');
     }
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Aop\Exception\InvalidPointcutExpressionException
      */
     public function parseThrowsExceptionIfThePointcutExpressionContainsNoDesignator()
     {
+        $this->expectException(Aop\Exception\InvalidPointcutExpressionException::class);
         $parser = new PointcutExpressionParser();
         $parser->injectObjectManager($this->mockObjectManager);
         $parser->parse('()', 'Unit Test');
@@ -183,10 +183,10 @@ class PointcutExpressionParserTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Aop\Exception\InvalidPointcutExpressionException
      */
     public function parseDesignatorMethodThrowsAnExceptionIfTheExpressionLacksTheClassMethodArrow()
     {
+        $this->expectException(Aop\Exception\InvalidPointcutExpressionException::class);
         $mockComposite = $this->getMockBuilder(PointcutFilterComposite::class)->disableOriginalConstructor()->getMock();
         $parser = $this->getAccessibleMock(PointcutExpressionParser::class, ['dummy'], [], '', false);
         $parser->_call('parseDesignatorMethod', '&&', 'Foo bar', $mockComposite);
@@ -271,10 +271,10 @@ class PointcutExpressionParserTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Aop\Exception\InvalidPointcutExpressionException
      */
     public function parseDesignatorPointcutThrowsAnExceptionIfTheExpressionLacksTheAspectClassMethodArrow()
     {
+        $this->expectException(Aop\Exception\InvalidPointcutExpressionException::class);
         $mockComposite = $this->getMockBuilder(PointcutFilterComposite::class)->disableOriginalConstructor()->getMock();
         $parser = $this->getAccessibleMock(PointcutExpressionParser::class, ['dummy'], [], '', false);
         $parser->_call('parseDesignatorPointcut', '&&', '\Foo\Bar', $mockComposite);
@@ -299,10 +299,10 @@ class PointcutExpressionParserTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Aop\Exception\InvalidPointcutExpressionException
      */
     public function parseDesignatorFilterThrowsAnExceptionIfACustomFilterDoesNotImplementThePointcutFilterInterface()
     {
+        $this->expectException(Aop\Exception\InvalidPointcutExpressionException::class);
         $mockFilter = new \ArrayObject();
         $mockPointcutFilterComposite = $this->getMockBuilder(PointcutFilterComposite::class)->disableOriginalConstructor()->getMock();
 

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutExpressionParserTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutExpressionParserTest.php
@@ -42,7 +42,8 @@ class PointcutExpressionParserTest extends UnitTestCase
      *
      * @return void
      */
-    protected function setUp(): void    {
+    protected function setUp(): void
+    {
         $this->mockObjectManager = $this->createMock(ObjectManagerInterface::class);
         $this->mockReflectionService = $this->getMockBuilder(ReflectionService::class)->disableOriginalConstructor()->getMock();
     }

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutExpressionParserTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutExpressionParserTest.php
@@ -42,8 +42,7 @@ class PointcutExpressionParserTest extends UnitTestCase
      *
      * @return void
      */
-    public function setup()
-    {
+    protected function setUp(): void    {
         $this->mockObjectManager = $this->createMock(ObjectManagerInterface::class);
         $this->mockReflectionService = $this->getMockBuilder(ReflectionService::class)->disableOriginalConstructor()->getMock();
     }

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutFilterTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutFilterTest.php
@@ -21,10 +21,10 @@ class PointcutFilterTest extends UnitTestCase
 {
     /**
      * @test
-     * @expectedException \Neos\Flow\Aop\Exception\UnknownPointcutException
      */
     public function matchesThrowsAnExceptionIfTheSpecifiedPointcutDoesNotExist()
     {
+        $this->expectException(Aop\Exception\UnknownPointcutException::class);
         $className = 'Foo';
         $methodName = 'bar';
         $methodDeclaringClassName = 'Baz';

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutSettingFilterTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutSettingFilterTest.php
@@ -52,10 +52,10 @@ class PointcutSettingFilterTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Aop\Exception\InvalidPointcutExpressionException
      */
     public function filterThrowsAnExceptionForNotExistingConfigurationSetting()
     {
+        $this->expectException(Aop\Exception\InvalidPointcutExpressionException::class);
         $mockConfigurationManager = $this->getMockBuilder(ConfigurationManager::class)->disableOriginalConstructor()->getMock();
 
         $settings['foo']['bar']['baz']['value'] = true;
@@ -142,10 +142,11 @@ class PointcutSettingFilterTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Aop\Exception\InvalidPointcutExpressionException
+     *
      */
     public function filterThrowsAnExceptionForAnIncorectCondition()
     {
+        $this->expectException(Aop\Exception\InvalidPointcutExpressionException::class);
         $mockConfigurationManager = $this->getMockBuilder(ConfigurationManager::class)->disableOriginalConstructor()->getMock();
 
         $settings['foo']['bar']['baz']['value'] = 'option value';

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutTest.php
@@ -39,10 +39,10 @@ class PointcutTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Aop\Exception\CircularPointcutReferenceException
      */
     public function matchesDetectsCircularMatchesAndThrowsAndException()
     {
+        $this->expectException(Aop\Exception\CircularPointcutReferenceException::class);
         $pointcutExpression = 'ThePointcutExpression';
         $aspectClassName = 'TheAspect';
         $className = 'TheClass';

--- a/Neos.Flow/Tests/Unit/Cache/CacheFactoryTest.php
+++ b/Neos.Flow/Tests/Unit/Cache/CacheFactoryTest.php
@@ -45,7 +45,7 @@ class CacheFactoryTest extends UnitTestCase
     /**
      * Creates the mocked filesystem used in the tests
      */
-    public function setUp()
+    protected function setUp(): void
     {
         vfsStream::setup('Foo');
 

--- a/Neos.Flow/Tests/Unit/Cache/CacheManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Cache/CacheManagerTest.php
@@ -45,7 +45,7 @@ class CacheManagerTest extends UnitTestCase
      */
     protected $mockEnvironment;
 
-    public function setUp()
+    protected function setUp(): void
     {
         vfsStream::setup('Foo');
         $this->cacheManager = new CacheManager();

--- a/Neos.Flow/Tests/Unit/Cache/CacheManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Cache/CacheManagerTest.php
@@ -77,10 +77,10 @@ class CacheManagerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Exception\DuplicateIdentifierException
      */
     public function managerThrowsExceptionOnCacheRegistrationWithAlreadyExistingIdentifier()
     {
+        $this->expectException(Cache\Exception\DuplicateIdentifierException::class);
         $cache1 = $this->getMockBuilder(Cache\Frontend\AbstractFrontend::class)->disableOriginalConstructor()->getMock();
         $cache1->expects($this->atLeastOnce())->method('getIdentifier')->will($this->returnValue('test'));
 
@@ -110,10 +110,10 @@ class CacheManagerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Cache\Exception\NoSuchCacheException
      */
     public function getCacheThrowsExceptionForNonExistingIdentifier()
     {
+        $this->expectException(Cache\Exception\NoSuchCacheException::class);
         $cache = $this->getMockBuilder(Cache\Frontend\AbstractFrontend::class)->disableOriginalConstructor()->getMock();
         $cache->expects($this->atLeastOnce())->method('getIdentifier')->will($this->returnValue('someidentifier'));
 

--- a/Neos.Flow/Tests/Unit/Cli/CommandManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/CommandManagerTest.php
@@ -14,6 +14,8 @@ namespace Neos\Flow\Tests\Unit\Cli;
 use Neos\Flow\Cli\CommandManager;
 use Neos\Flow\Cli;
 use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\Mvc\Exception\AmbiguousCommandIdentifierException;
+use Neos\Flow\Mvc\Exception\NoSuchCommandException;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Tests\UnitTestCase;
@@ -110,10 +112,10 @@ class CommandManagerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\NoSuchCommandException
      */
     public function getCommandByIdentifierThrowsExceptionIfNoMatchingCommandWasFound()
     {
+        $this->expectException(NoSuchCommandException::class);
         $mockCommand = $this->getMockBuilder(Cli\Command::class)->disableOriginalConstructor()->getMock();
         $mockCommand->expects($this->once())->method('getCommandIdentifier')->will($this->returnValue('package.key:controller:command'));
         $mockCommands = [$mockCommand];
@@ -124,10 +126,10 @@ class CommandManagerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\AmbiguousCommandIdentifierException
      */
     public function getCommandByIdentifierThrowsExceptionIfMoreThanOneMatchingCommandWasFound()
     {
+        $this->expectException(AmbiguousCommandIdentifierException::class);
         $mockCommand1 = $this->getMockBuilder(Cli\Command::class)->disableOriginalConstructor()->getMock();
         $mockCommand1->expects($this->once())->method('getCommandIdentifier')->will($this->returnValue('package.key:controller:command'));
         $mockCommand2 = $this->getMockBuilder(Cli\Command::class)->disableOriginalConstructor()->getMock();
@@ -140,10 +142,10 @@ class CommandManagerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\AmbiguousCommandIdentifierException
      */
     public function getCommandByIdentifierThrowsExceptionIfOnlyPackageKeyIsSpecifiedAndContainsMoreThanOneCommand()
     {
+        $this->expectException(AmbiguousCommandIdentifierException::class);
         $mockCommand1 = $this->getMockBuilder(Cli\Command::class)->disableOriginalConstructor()->getMock();
         $mockCommand1->expects($this->atLeastOnce())->method('getCommandIdentifier')->will($this->returnValue('package.key:controller:command'));
         $mockCommand2 = $this->getMockBuilder(Cli\Command::class)->disableOriginalConstructor()->getMock();

--- a/Neos.Flow/Tests/Unit/Cli/CommandManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/CommandManagerTest.php
@@ -40,7 +40,7 @@ class CommandManagerTest extends UnitTestCase
      */
     protected $commandManager;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockReflectionService = $this->createMock(ReflectionService::class);
         $this->commandManager = $this->getMockBuilder(Cli\CommandManager::class)->setMethods(['getAvailableCommands'])->getMock();

--- a/Neos.Flow/Tests/Unit/Cli/CommandTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/CommandTest.php
@@ -36,7 +36,7 @@ class CommandTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->command = $this->getAccessibleMock(Cli\Command::class, ['getCommandMethodReflection'], [], '', false);
         $this->methodReflection = $this->createMock(MethodReflection::class, [], [__CLASS__, 'dummyMethod']);

--- a/Neos.Flow/Tests/Unit/Cli/ConsoleOutputTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/ConsoleOutputTest.php
@@ -40,7 +40,7 @@ class ConsoleOutputTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->input = new ArrayInput([]);
         $this->answerNothing();

--- a/Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php
@@ -52,7 +52,7 @@ class RequestBuilderTest extends UnitTestCase
      * Sets up this test case
      *
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockObjectManager = $this->createMock(ObjectManagerInterface::class);
         $this->mockObjectManager->expects($this->any())->method('getObjectNameByClassName')->with('Acme\Test\Command\DefaultCommandController')->will($this->returnValue('Acme\Test\Command\DefaultCommandController'));

--- a/Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\Tests\Unit\Cli;
  */
 
 use Neos\Flow\Command\HelpCommandController;
+use Neos\Flow\Mvc\Exception\InvalidArgumentMixingException;
 use Neos\Flow\Mvc\Exception\NoSuchCommandException;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Reflection\ReflectionService;
@@ -299,10 +300,10 @@ class RequestBuilderTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\InvalidArgumentMixingException
      */
     public function ifNamedArgumentsAreUsedAllRequiredArgumentsMustBeNamed()
     {
+        $this->expectException(InvalidArgumentMixingException::class);
         $methodParameters = [
             'testArgument1' => ['optional' => false, 'type' => 'string'],
             'testArgument2' => ['optional' => false, 'type' => 'string'],
@@ -314,10 +315,10 @@ class RequestBuilderTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\InvalidArgumentMixingException
      */
     public function ifUnnamedArgumentsAreUsedAllRequiredArgumentsMustBeUnnamed()
     {
+        $this->expectException(InvalidArgumentMixingException::class);
         $methodParameters = [
             'requiredArgument1' => ['optional' => false, 'type' => 'string'],
             'requiredArgument2' => ['optional' => false, 'type' => 'string'],

--- a/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -689,8 +689,8 @@ EOD;
         $settingsPhpString = var_export($settings, true);
         $configurationManager = $this->getAccessibleMock(ConfigurationManager::class, ['dummy'], [], '', false);
         $processedPhpString = $configurationManager->_call('replaceVariablesInPhpString', $settingsPhpString);
-        $this->assertContains("'baz' => (defined('PHP_VERSION') ? constant('PHP_VERSION') : null)", $processedPhpString);
-        $this->assertContains("'to' => (defined('FLOW_PATH_ROOT') ? constant('FLOW_PATH_ROOT') : null)", $processedPhpString);
+        $this->assertStringContainsString("'baz' => (defined('PHP_VERSION') ? constant('PHP_VERSION') : null)", $processedPhpString);
+        $this->assertStringContainsString("'to' => (defined('FLOW_PATH_ROOT') ? constant('FLOW_PATH_ROOT') : null)", $processedPhpString);
     }
 
     /**
@@ -712,10 +712,10 @@ EOD;
         $configurationManager = $this->getAccessibleMock(ConfigurationManager::class, ['dummy'], [], '', false);
         $processedPhpString = $configurationManager->_call('replaceVariablesInPhpString', $settingsPhpString);
         $settings = eval('return ' . $processedPhpString . ';');
-        $this->assertInternalType('integer', $settings['anIntegerConstant']);
+        $this->assertIsInt($settings['anIntegerConstant']);
         $this->assertSame(PHP_VERSION_ID, $settings['anIntegerConstant']);
 
-        $this->assertInternalType('string', $settings['casted']['to']['string']);
+        $this->assertIsString($settings['casted']['to']['string']);
         $this->assertSame('Version id is ' . PHP_VERSION_ID, $settings['casted']['to']['string']);
     }
 

--- a/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -11,7 +11,6 @@ namespace Neos\Flow\Tests\Unit\Configuration;
  * source code.
  */
 
-use Neos\Flow\Composer\Exception\InvalidConfigurationException;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Configuration\Exception\InvalidConfigurationTypeException;
 use Neos\Flow\Configuration\Exception\ParseErrorException;

--- a/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -11,7 +11,11 @@ namespace Neos\Flow\Tests\Unit\Configuration;
  * source code.
  */
 
+use Neos\Flow\Composer\Exception\InvalidConfigurationException;
 use Neos\Flow\Configuration\ConfigurationManager;
+use Neos\Flow\Configuration\Exception\InvalidConfigurationTypeException;
+use Neos\Flow\Configuration\Exception\ParseErrorException;
+use Neos\Flow\Configuration\Exception\RecursionException;
 use Neos\Flow\Configuration\RouteConfigurationProcessor;
 use Neos\Flow\Configuration\Source\YamlSource;
 use Neos\Flow\Core\ApplicationContext;
@@ -146,10 +150,10 @@ class ConfigurationManagerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Configuration\Exception\InvalidConfigurationTypeException
      */
     public function gettingUnregisteredConfigurationTypeFails()
     {
+        $this->expectException(InvalidConfigurationTypeException::class);
         $configurationManager = new ConfigurationManager(new ApplicationContext('Testing'));
         $configurationManager->getConfiguration('Custom');
     }
@@ -178,11 +182,11 @@ class ConfigurationManagerTest extends UnitTestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
      * @test
      */
     public function registerConfigurationTypeThrowsExceptionOnInvalidConfigurationProcessingType()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $configurationManager = $this->getAccessibleMock(ConfigurationManager::class, ['loadConfiguration'], [], '', false);
         $configurationManager->registerConfigurationType('MyCustomType', 'Nonsense');
     }
@@ -1176,10 +1180,10 @@ EOD;
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Configuration\Exception\RecursionException
      */
     public function loadConfigurationForRoutesThrowsExceptionIfSubRoutesContainCircularReferences()
     {
+        $this->expectException(RecursionException::class);
         $mockSubRouteConfiguration =
             [
                 'name' => 'SomeRouteOrSubRoute',
@@ -1203,10 +1207,10 @@ EOD;
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Configuration\Exception\ParseErrorException
      */
     public function mergeRoutesWithSubRoutesThrowsExceptionIfRouteRefersToNonExistingOrInactivePackages()
     {
+        $this->expectException(ParseErrorException::class);
         $routesConfiguration = [
             [
                 'name' => 'Welcome',

--- a/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -31,7 +31,7 @@ class ConfigurationManagerTest extends UnitTestCase
      */
     protected $mockContext;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockContext = $this->getMockBuilder(ApplicationContext::class)->disableOriginalConstructor()->getMock();
     }

--- a/Neos.Flow/Tests/Unit/Configuration/Source/YamlSourceTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/Source/YamlSourceTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Tests\Unit\Configuration\Source;
  * source code.
  */
 
+use Neos\Flow\Configuration\Exception;
 use org\bovigo\vfs\vfsStream;
 use Neos\Flow\Configuration\Source\YamlSource;
 use Neos\Flow\Tests\UnitTestCase;
@@ -153,10 +154,10 @@ class YamlSourceTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Configuration\Exception
      */
     public function configurationFileWithYmlExtensionResultsInException()
     {
+        $this->expectException(Exception::class);
         $pathAndFilename = __DIR__ . '/../Fixture/YmlThrowsException';
         $configurationSource = new YamlSource();
         $configurationSource->load($pathAndFilename, true);

--- a/Neos.Flow/Tests/Unit/Configuration/Source/YamlSourceTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/Source/YamlSourceTest.php
@@ -25,7 +25,7 @@ class YamlSourceTest extends UnitTestCase
      * Sets up this test case
      *
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         vfsStream::setup('testDirectory');
     }

--- a/Neos.Flow/Tests/Unit/Configuration/Source/YamlSourceTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/Source/YamlSourceTest.php
@@ -68,7 +68,7 @@ class YamlSourceTest extends UnitTestCase
         $configurationSource->save($pathAndFilename, $mockConfiguration);
 
         $yaml = 'configurationFileHasBeenLoaded: true' . chr(10) . 'foo:' . chr(10) . '  bar: Baz' . chr(10);
-        $this->assertContains($yaml, file_get_contents($pathAndFilename . '.yaml'), 'Configuration was not written to the file as expected.');
+        $this->assertStringContainsString($yaml, file_get_contents($pathAndFilename . '.yaml'), 'Configuration was not written to the file as expected.');
     }
 
     /**
@@ -87,7 +87,7 @@ class YamlSourceTest extends UnitTestCase
         $configurationSource->save($pathAndFilename, $mockConfiguration);
 
         $yaml = 'configurationFileHasBeenLoaded: true' . chr(10) . 'foo:' . chr(10) . '  \'Foo.Bar:Baz\': \'a quoted key\'' . chr(10);
-        $this->assertContains($yaml, file_get_contents($pathAndFilename . '.yaml'), 'Configuration was not written to the file as expected.');
+        $this->assertStringContainsString($yaml, file_get_contents($pathAndFilename . '.yaml'), 'Configuration was not written to the file as expected.');
     }
 
     /**
@@ -103,8 +103,8 @@ class YamlSourceTest extends UnitTestCase
         $configurationSource->save($pathAndFilename, ['configurationFileHasBeenLoaded' => true]);
 
         $yaml = file_get_contents($pathAndFilename . '.yaml');
-        $this->assertContains('# This comment should stay' . chr(10) . chr(10), $yaml, 'Header comment was removed from file.');
-        $this->assertNotContains('Test: foo', $yaml);
+        $this->assertStringContainsString('# This comment should stay' . chr(10) . chr(10), $yaml, 'Header comment was removed from file.');
+        $this->assertStringNotContainsString('Test: foo', $yaml);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Core/ApplicationContextTest.php
+++ b/Neos.Flow/Tests/Unit/Core/ApplicationContextTest.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\Tests\Unit\Core;
  */
 
 use Neos\Flow\Core\ApplicationContext;
+use Neos\Flow\Exception;
 use Neos\Flow\Tests\UnitTestCase;
 
 /**
@@ -65,10 +66,10 @@ class ApplicationContextTest extends UnitTestCase
     /**
      * @test
      * @dataProvider forbiddenContexts
-     * @expectedException \Neos\Flow\Exception
      */
     public function constructorThrowsExceptionIfMainContextIsForbidden($forbiddenContext)
     {
+        $this->expectException(Exception::class);
         new ApplicationContext($forbiddenContext);
     }
 

--- a/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
+++ b/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
@@ -26,7 +26,7 @@ class ScriptsTest extends UnitTestCase
 
     /**
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->scriptsMock = $this->getAccessibleMock(Scripts::class, ['dummy']);

--- a/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
+++ b/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
@@ -44,22 +44,22 @@ class ScriptsTest extends UnitTestCase
 
         $message = 'The command must contain the current ini because it is not explicitly set in settings.';
         $actual = $this->scriptsMock->_call('buildSubprocessCommand', 'flow:foo:identifier', $settings);
-        $this->assertContains(sprintf(' -c %s ', escapeshellarg(php_ini_loaded_file())), $actual, $message);
+        $this->assertStringContainsString(sprintf(' -c %s ', escapeshellarg(php_ini_loaded_file())), $actual, $message);
 
         $settings['core']['subRequestPhpIniPathAndFilename'] = null;
         $message = 'The command must contain the current ini because it is explicitly set, but NULL, in settings.';
         $actual = $this->scriptsMock->_call('buildSubprocessCommand', 'flow:foo:identifier', $settings);
-        $this->assertContains(sprintf(' -c %s ', escapeshellarg(php_ini_loaded_file())), $actual, $message);
+        $this->assertStringContainsString(sprintf(' -c %s ', escapeshellarg(php_ini_loaded_file())), $actual, $message);
 
         $settings['core']['subRequestPhpIniPathAndFilename'] = '/foo/ini/path';
         $message = 'The command must contain a specified ini file path because it is set in settings.';
         $actual = $this->scriptsMock->_call('buildSubprocessCommand', 'flow:foo:identifier', $settings);
-        $this->assertContains(sprintf(' -c %s ', escapeshellarg('/foo/ini/path')), $actual, $message);
+        $this->assertStringContainsString(sprintf(' -c %s ', escapeshellarg('/foo/ini/path')), $actual, $message);
 
         $settings['core']['subRequestPhpIniPathAndFilename'] = false;
         $message = 'The command must not contain an ini file path because it is set to false in settings.';
         $actual = $this->scriptsMock->_call('buildSubprocessCommand', 'flow:foo:identifier', $settings);
-        $this->assertNotContains(' -c ', $actual, $message);
+        $this->assertStringNotContainsString(' -c ', $actual, $message);
     }
 
     /**
@@ -74,7 +74,7 @@ class ScriptsTest extends UnitTestCase
         ]];
         $actual = $this->scriptsMock->_call('buildSubprocessCommand', 'flow:foo:identifier', $settings);
 
-        $this->assertContains(sprintf(' -d %s=%s ', escapeshellarg('someSetting'), escapeshellarg('withValue')), $actual);
-        $this->assertContains(sprintf(' -d %s ', escapeshellarg('someFlagSettingWithoutValue')), $actual);
+        $this->assertStringContainsString(sprintf(' -d %s=%s ', escapeshellarg('someSetting'), escapeshellarg('withValue')), $actual);
+        $this->assertStringContainsString(sprintf(' -d %s ', escapeshellarg('someFlagSettingWithoutValue')), $actual);
     }
 }

--- a/Neos.Flow/Tests/Unit/Core/BootstrapTest.php
+++ b/Neos.Flow/Tests/Unit/Core/BootstrapTest.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\Tests\Unit\Core;
  */
 
 use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\Exception;
 use Neos\Flow\Tests\UnitTestCase;
 
 /**
@@ -53,10 +54,10 @@ class BootstrapTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Exception
      */
     public function resolveRequestHandlerThrowsUsefulExceptionIfNoRequestHandlerFound()
     {
+        $this->expectException(Exception::class);
         $bootstrap = $this->getAccessibleMock(Bootstrap::class, ['dummy'], [], '', false);
         $bootstrap->_call('resolveRequestHandler');
     }

--- a/Neos.Flow/Tests/Unit/Core/ClassLoaderTest.php
+++ b/Neos.Flow/Tests/Unit/Core/ClassLoaderTest.php
@@ -58,7 +58,7 @@ class ClassLoaderTest extends UnitTestCase
 
     /**
      */
-    public function setUp()
+    protected function setUp(): void
     {
         if (FLOW_ONLY_COMPOSER_LOADER) {
             $this->markTestSkipped('Not testing if composer-only loading is requested.');

--- a/Neos.Flow/Tests/Unit/Core/LockManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Core/LockManagerTest.php
@@ -43,7 +43,7 @@ class LockManagerTest extends UnitTestCase
     protected $mockLockFlagFile;
 
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockLockDirectory = vfsStream::setup('LockPath');
         $this->mockLockFile = vfsStream::newFile(md5(FLOW_PATH_ROOT) . '_Flow.lock')->at($this->mockLockDirectory);

--- a/Neos.Flow/Tests/Unit/Error/DebuggerTest.php
+++ b/Neos.Flow/Tests/Unit/Error/DebuggerTest.php
@@ -20,7 +20,7 @@ use Neos\Flow\Tests\UnitTestCase;
  */
 class DebuggerTest extends UnitTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         Debugger::clearState();
     }

--- a/Neos.Flow/Tests/Unit/Error/DebuggerTest.php
+++ b/Neos.Flow/Tests/Unit/Error/DebuggerTest.php
@@ -51,7 +51,7 @@ class DebuggerTest extends UnitTestCase
     public function ignoredClassesRegexContainsFallback()
     {
         $ignoredClassesRegex = Debugger::getIgnoredClassesRegex();
-        $this->assertContains('Neos\\\\Flow\\\\Core\\\\.*', $ignoredClassesRegex);
+        $this->assertStringContainsString('Neos\\\\Flow\\\\Core\\\\.*', $ignoredClassesRegex);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Http/BrowserTest.php
+++ b/Neos.Flow/Tests/Unit/Http/BrowserTest.php
@@ -143,10 +143,10 @@ class BrowserTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Http\Client\InfiniteRedirectionException
      */
     public function browserHaltsOnAttemptedInfiniteRedirectionLoop()
     {
+        $this->expectException(Client\InfiniteRedirectionException::class);
         $wildResponses = [];
         $wildResponses[0] = new Http\Response();
         $wildResponses[0]->setStatus(301);
@@ -175,10 +175,10 @@ class BrowserTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Http\Client\InfiniteRedirectionException
      */
     public function browserHaltsOnExceedingMaximumRedirections()
     {
+        $this->expectException(Client\InfiniteRedirectionException::class);
         $requestEngine = $this->createMock(Client\RequestEngineInterface::class);
         for ($i=0; $i<=10; $i++) {
             $response = new Http\Response();

--- a/Neos.Flow/Tests/Unit/Http/BrowserTest.php
+++ b/Neos.Flow/Tests/Unit/Http/BrowserTest.php
@@ -29,7 +29,7 @@ class BrowserTest extends UnitTestCase
     /**
      *
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->browser = new Client\Browser();

--- a/Neos.Flow/Tests/Unit/Http/BrowserTest.php
+++ b/Neos.Flow/Tests/Unit/Http/BrowserTest.php
@@ -68,7 +68,7 @@ class BrowserTest extends UnitTestCase
 
         $this->assertTrue($this->browser->getLastRequest()->hasHeader('X-Test-Header'));
         $this->assertSame('Acme', $this->browser->getLastRequest()->getHeader('X-Test-Header'));
-        $this->assertContains('text/plain', $this->browser->getLastRequest()->getHeader('Content-Type'));
+        $this->assertStringContainsString('text/plain', $this->browser->getLastRequest()->getHeader('Content-Type'));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Http/Component/ComponentChainFactoryTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Component/ComponentChainFactoryTest.php
@@ -73,10 +73,10 @@ class ComponentChainFactoryTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Http\Component\Exception
      */
     public function createThrowsExceptionIfComponentClassNameIsNotConfigured()
     {
+        $this->expectException(Http\Component\Exception::class);
         $chainConfiguration = [
             'foo' => [
                 'position' => 'start',
@@ -88,10 +88,10 @@ class ComponentChainFactoryTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Http\Component\Exception
      */
     public function createThrowsExceptionIfComponentClassNameDoesNotImplementComponentInterface()
     {
+        $this->expectException(Http\Component\Exception::class);
         $chainConfiguration = [
             'foo' => [
                 'component' => 'Foo\Component\ClassName',

--- a/Neos.Flow/Tests/Unit/Http/Component/ComponentChainFactoryTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Component/ComponentChainFactoryTest.php
@@ -35,7 +35,7 @@ class ComponentChainFactoryTest extends UnitTestCase
      */
     protected $mockComponent;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->componentChainFactory = new Http\Component\ComponentChainFactory();
 

--- a/Neos.Flow/Tests/Unit/Http/Component/ComponentChainTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Component/ComponentChainTest.php
@@ -29,7 +29,7 @@ class ComponentChainTest extends UnitTestCase
      */
     protected $mockComponentContext;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockComponentContext = $this->getMockBuilder(Http\Component\ComponentContext::class)->disableOriginalConstructor()->getMock();
     }

--- a/Neos.Flow/Tests/Unit/Http/Component/ComponentContextTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Component/ComponentContextTest.php
@@ -34,7 +34,7 @@ class ComponentContextTest extends UnitTestCase
      */
     protected $mockHttpResponse;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockHttpRequest = $this->getMockBuilder(Http\Request::class)->disableOriginalConstructor()->getMock();
         $this->mockHttpResponse = $this->getMockBuilder(Http\Response::class)->disableOriginalConstructor()->getMock();

--- a/Neos.Flow/Tests/Unit/Http/Component/StandardsComplianceComponentTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Component/StandardsComplianceComponentTest.php
@@ -39,7 +39,7 @@ class StandardsComplianceComponentTest extends UnitTestCase
      */
     protected $mockHttpResponse;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockHttpRequest = $this->getMockBuilder(Http\Request::class)->disableOriginalConstructor()->getMock();
         $this->response = new Http\Response();

--- a/Neos.Flow/Tests/Unit/Http/Component/TrustedProxiesComponentTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Component/TrustedProxiesComponentTest.php
@@ -48,7 +48,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
      */
     protected $mockHttpResponse;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockHttpRequest = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
         $this->mockHttpResponse = $this->getMockBuilder(Response::class)->disableOriginalConstructor()->getMock();

--- a/Neos.Flow/Tests/Unit/Http/ContentStreamTest.php
+++ b/Neos.Flow/Tests/Unit/Http/ContentStreamTest.php
@@ -22,10 +22,10 @@ class ContentStreamTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function constructorThrowsExceptionWhenBeingPassedAnInvalidResource()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new ContentStream('invalid resource');
     }
 

--- a/Neos.Flow/Tests/Unit/Http/CookieTest.php
+++ b/Neos.Flow/Tests/Unit/Http/CookieTest.php
@@ -62,10 +62,10 @@ class CookieTest extends UnitTestCase
      * @param string  $cookieName
      * @test
      * @dataProvider invalidCookieNames
-     * @expectedException \InvalidArgumentException
      */
     public function constructorThrowsExceptionOnInvalidCookieNames($cookieName)
     {
+        $this->expectException(\InvalidArgumentException::class);
         new Cookie($cookieName);
     }
 
@@ -117,10 +117,10 @@ class CookieTest extends UnitTestCase
      * @param mixed $parameter
      * @test
      * @dataProvider invalidExpiresParameters
-     * @expectedException \InvalidArgumentException
      */
     public function constructorThrowsExceptionOnInvalidExpiresParameter($parameter)
     {
+        $this->expectException(\InvalidArgumentException::class);
         new Cookie('foo', 'bar', $parameter);
     }
 
@@ -141,10 +141,10 @@ class CookieTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function constructorThrowsExceptionOnInvalidMaximumAgeParameter()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new Cookie('foo', 'bar', 0, 'urks');
     }
 
@@ -179,10 +179,10 @@ class CookieTest extends UnitTestCase
      * @param mixed $domain
      * @test
      * @dataProvider invalidDomains
-     * @expectedException \InvalidArgumentException
      */
     public function constructorThrowsExceptionOnInvalidDomain($domain)
     {
+        $this->expectException(\InvalidArgumentException::class);
         new Cookie('foo', 'bar', 0, null, $domain);
     }
 
@@ -212,10 +212,10 @@ class CookieTest extends UnitTestCase
      * @param mixed $path
      * @test
      * @dataProvider invalidPaths
-     * @expectedException \InvalidArgumentException
      */
     public function constructorThrowsExceptionOnInvalidPath($path)
     {
+        $this->expectException(\InvalidArgumentException::class);
         new Cookie('foo', 'bar', 0, null, null, $path);
     }
 

--- a/Neos.Flow/Tests/Unit/Http/RequestTest.php
+++ b/Neos.Flow/Tests/Unit/Http/RequestTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Tests\Unit\Http;
  * source code.
  */
 
+use Neos\Flow\Http\Exception;
 use Neos\Flow\Http\Helper\UploadedFilesHelper;
 use Neos\Flow\Http\Request;
 use Neos\Flow\Http\Uri;
@@ -342,10 +343,10 @@ class RequestTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Http\Exception
      */
     public function getContentThrowsAnExceptionOnTryingToRetrieveContentAsResourceAlthoughItHasBeenRetrievedPreviously()
     {
+        $this->expectException(Exception::class);
         vfsStream::setup('Foo');
 
         file_put_contents('vfs://Foo/content.txt', 'xy');

--- a/Neos.Flow/Tests/Unit/Http/ResponseTest.php
+++ b/Neos.Flow/Tests/Unit/Http/ResponseTest.php
@@ -126,10 +126,10 @@ class ResponseTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function createFromRawThrowsExceptionOnFirstLine()
     {
+        $this->expectException(\InvalidArgumentException::class);
         Response::createFromRaw('No valid response');
     }
 
@@ -177,10 +177,10 @@ class ResponseTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function setStatusThrowsExceptionOnNonNumericCode()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $response = new Response();
         $response->setStatus('400');
     }

--- a/Neos.Flow/Tests/Unit/Http/UriTest.php
+++ b/Neos.Flow/Tests/Unit/Http/UriTest.php
@@ -153,10 +153,10 @@ class UriTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function settingInvalidHostThrowsException()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $uri = new Uri('');
         $uri->setHost('an#invalid.host');
     }
@@ -182,19 +182,19 @@ class UriTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function constructingWithNotAStringThrowsException()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new Uri(42);
     }
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function unparsableUriStringThrowsException()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new Uri('http:////localhost');
     }
 }

--- a/Neos.Flow/Tests/Unit/I18n/AbstractXmlParserTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/AbstractXmlParserTest.php
@@ -33,10 +33,10 @@ class AbstractXmlParserTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\I18n\Exception\InvalidXmlFileException
      */
     public function throwsExceptionWhenBadFilenameGiven()
     {
+        $this->expectException(I18n\Exception\InvalidXmlFileException::class);
         $mockFilenamePath = 'foo';
 
         $parser = $this->getAccessibleMock(I18n\AbstractXmlParser::class, ['doParsingFromRoot']);

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/CldrModelTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/CldrModelTest.php
@@ -28,7 +28,7 @@ class CldrModelTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $samplePaths = ['foo', 'bar', 'baz'];
         $sampleParsedFile1 = require(__DIR__ . '/../Fixtures/MockParsedCldrFile1.php');

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/CldrRepositoryTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/CldrRepositoryTest.php
@@ -33,7 +33,7 @@ class CldrRepositoryTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         vfsStream::setup('Foo');
 

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/CurrencyReaderTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/CurrencyReaderTest.php
@@ -29,7 +29,7 @@ class CurrencyReaderTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $sampleCurrencyFractionsData = [
             'fractions' => [

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/DatesReaderTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/DatesReaderTest.php
@@ -14,6 +14,7 @@ namespace Neos\Flow\Tests\Unit\I18n\Cldr\Reader;
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\I18n;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Testcase for the DatesReader
@@ -39,10 +40,10 @@ class DatesReaderTest extends UnitTestCase
      * Setting cache expectations is partially same for many tests, so it's been
      * extracted to this method.
      *
-     * @param \PHPUnit_Framework_MockObject_MockObject $mockCache
+     * @param MockObject $mockCache
      * @return array
      */
-    public function createCacheExpectations(\PHPUnit_Framework_MockObject_MockObject $mockCache)
+    public function createCacheExpectations(MockObject $mockCache)
     {
         $mockCache->expects($this->at(0))->method('has')->with('parsedFormats')->will($this->returnValue(true));
         $mockCache->expects($this->at(1))->method('has')->with('parsedFormatsIndices')->will($this->returnValue(true));

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/DatesReaderTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/DatesReaderTest.php
@@ -30,7 +30,7 @@ class DatesReaderTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->sampleLocale = new I18n\Locale('en');
     }

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/NumbersReaderTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/NumbersReaderTest.php
@@ -140,10 +140,10 @@ class NumbersReaderTest extends UnitTestCase
     /**
      * @test
      * @dataProvider unsupportedFormats
-     * @expectedException \Neos\Flow\I18n\Cldr\Reader\Exception\UnsupportedNumberFormatException
      */
     public function throwsExceptionWhenUnsupportedFormatsEncountered($format)
     {
+        $this->expectException(I18n\Cldr\Reader\Exception\UnsupportedNumberFormatException::class);
         $reader = $this->getAccessibleMock(I18n\Cldr\Reader\NumbersReader::class, ['dummy']);
 
         $reader->_call('parseFormat', $format);

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/NumbersReaderTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/NumbersReaderTest.php
@@ -55,7 +55,7 @@ class NumbersReaderTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->sampleLocale = new I18n\Locale('en');
     }

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/PluralsReaderTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/PluralsReaderTest.php
@@ -29,7 +29,7 @@ class PluralsReaderTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $samplePluralRulesData = [
             'pluralRules[@locales="ro mo"]' => [

--- a/Neos.Flow/Tests/Unit/I18n/DetectorTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/DetectorTest.php
@@ -27,7 +27,7 @@ class DetectorTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $findBestMatchingLocaleCallback = function () {
             $args = func_get_args();

--- a/Neos.Flow/Tests/Unit/I18n/FormatResolverTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/FormatResolverTest.php
@@ -29,7 +29,7 @@ class FormatResolverTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->sampleLocale = new I18n\Locale('en_GB');
     }

--- a/Neos.Flow/Tests/Unit/I18n/FormatResolverTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/FormatResolverTest.php
@@ -65,30 +65,30 @@ class FormatResolverTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\I18n\Exception\InvalidFormatPlaceholderException
      */
     public function throwsExceptionWhenInvalidPlaceholderEncountered()
     {
+        $this->expectException(I18n\Exception\InvalidFormatPlaceholderException::class);
         $formatResolver = new I18n\FormatResolver();
         $formatResolver->resolvePlaceholders('{0,damaged {1}', [], $this->sampleLocale);
     }
 
     /**
      * @test
-     * @expectedException \Neos\Flow\I18n\Exception\IndexOutOfBoundsException
      */
     public function throwsExceptionWhenInsufficientNumberOfArgumentsProvided()
     {
+        $this->expectException(I18n\Exception\IndexOutOfBoundsException::class);
         $formatResolver = new I18n\FormatResolver();
         $formatResolver->resolvePlaceholders('{0}', [], $this->sampleLocale);
     }
 
     /**
      * @test
-     * @expectedException \Neos\Flow\I18n\Exception\UnknownFormatterException
      */
     public function throwsExceptionWhenFormatterDoesNotExist()
     {
+        $this->expectException(I18n\Exception\UnknownFormatterException::class);
         $mockObjectManager = $this->createMock(ObjectManagerInterface::class);
         $mockObjectManager
             ->expects($this->at(0))
@@ -109,10 +109,10 @@ class FormatResolverTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\I18n\Exception\InvalidFormatterException
      */
     public function throwsExceptionWhenFormatterDoesNotImplementFormatterInterface()
     {
+        $this->expectException(I18n\Exception\InvalidFormatterException::class);
         $mockObjectManager = $this->createMock(ObjectManagerInterface::class);
         $mockObjectManager
             ->expects($this->once())

--- a/Neos.Flow/Tests/Unit/I18n/Formatter/DatetimeFormatterTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Formatter/DatetimeFormatterTest.php
@@ -46,7 +46,7 @@ class DatetimeFormatterTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->sampleLocale = new I18n\Locale('en');
         $this->sampleLocalizedLiterals = require(__DIR__ . '/../Fixtures/MockLocalizedLiteralsArray.php');

--- a/Neos.Flow/Tests/Unit/I18n/Formatter/NumberFormatterTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Formatter/NumberFormatterTest.php
@@ -79,7 +79,7 @@ class NumberFormatterTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->sampleLocale = new I18n\Locale('en');
     }

--- a/Neos.Flow/Tests/Unit/I18n/LocaleCollectionTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/LocaleCollectionTest.php
@@ -32,7 +32,7 @@ class LocaleCollectionTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->locales = [
             new I18n\Locale('en'),

--- a/Neos.Flow/Tests/Unit/I18n/LocaleTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/LocaleTest.php
@@ -36,10 +36,10 @@ class LocaleTest extends UnitTestCase
     /**
      * @test
      * @dataProvider invalidLocaleIdentifiers
-     * @expectedException \Neos\Flow\I18n\Exception\InvalidLocaleIdentifierException
      */
     public function theConstructorThrowsAnExceptionOnPassingAInvalidLocaleIdentifiers($invalidIdentifier)
     {
+        $this->expectException(I18n\Exception\InvalidLocaleIdentifierException::class);
         new I18n\Locale($invalidIdentifier);
     }
 

--- a/Neos.Flow/Tests/Unit/I18n/LocaleTypeConverterTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/LocaleTypeConverterTest.php
@@ -28,7 +28,7 @@ class LocaleTypeConverterTest extends UnitTestCase
      */
     protected $converter;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->converter = new LocaleTypeConverter();
     }

--- a/Neos.Flow/Tests/Unit/I18n/Parser/DatetimeParserTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Parser/DatetimeParserTest.php
@@ -48,7 +48,7 @@ class DatetimeParserTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->sampleLocale = new I18n\Locale('en_GB');
         $this->sampleLocalizedLiterals = require(__DIR__ . '/../Fixtures/MockLocalizedLiteralsArray.php');

--- a/Neos.Flow/Tests/Unit/I18n/Parser/NumberParserTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Parser/NumberParserTest.php
@@ -67,7 +67,7 @@ class NumberParserTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->sampleLocale = new I18n\Locale('en_GB');
     }

--- a/Neos.Flow/Tests/Unit/I18n/ServiceTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/ServiceTest.php
@@ -26,7 +26,7 @@ class ServiceTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         vfsStream::setup('Foo');
     }

--- a/Neos.Flow/Tests/Unit/I18n/TranslationProvider/XliffTranslationProviderTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/TranslationProvider/XliffTranslationProviderTest.php
@@ -113,10 +113,10 @@ class XliffTranslationProviderTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\I18n\TranslationProvider\Exception\InvalidPluralFormException
      */
     public function getTranslationByOriginalLabelThrowsExceptionWhenInvalidPluralFormProvided()
     {
+        $this->expectException(I18n\TranslationProvider\Exception\InvalidPluralFormException::class);
         $this->mockPluralsReader->expects($this->any())
             ->method('getPluralForms')
             ->with($this->sampleLocale)
@@ -130,10 +130,10 @@ class XliffTranslationProviderTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\I18n\TranslationProvider\Exception\InvalidPluralFormException
      */
     public function getTranslationByIdThrowsExceptionWhenInvalidPluralFormProvided()
     {
+        $this->expectException(I18n\TranslationProvider\Exception\InvalidPluralFormException::class);
         $this->mockPluralsReader->expects($this->any())
             ->method('getPluralForms')
             ->with($this->sampleLocale)

--- a/Neos.Flow/Tests/Unit/I18n/TranslationProvider/XliffTranslationProviderTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/TranslationProvider/XliffTranslationProviderTest.php
@@ -52,7 +52,7 @@ class XliffTranslationProviderTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->samplePackageKey = 'Neos.Flow';
         $this->sampleSourceName = 'Foo';

--- a/Neos.Flow/Tests/Unit/I18n/TranslatorTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/TranslatorTest.php
@@ -34,7 +34,7 @@ class TranslatorTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->defaultLocale = new I18n\Locale('en_GB');
 

--- a/Neos.Flow/Tests/Unit/I18n/Xliff/Model/FileAdapterTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Xliff/Model/FileAdapterTest.php
@@ -28,7 +28,7 @@ class FileAdapterTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $mockParsedXliffData = require(__DIR__ . '/../../Fixtures/MockParsedXliffData.php');
         $this->mockParsedXliffFile = $mockParsedXliffData[0];

--- a/Neos.Flow/Tests/Unit/I18n/Xliff/V12/XliffParserTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Xliff/V12/XliffParserTest.php
@@ -34,10 +34,10 @@ class XliffParserTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\I18n\Xliff\Exception\InvalidXliffDataException
      */
     public function missingIdInSingularTransUnitCausesException()
     {
+        $this->expectException(I18n\Xliff\Exception\InvalidXliffDataException::class);
         $mockFilenamePath = __DIR__ . '/../../Fixtures/MockInvalidXliffData.xlf';
 
         $parser = new I18n\Xliff\V12\XliffParser();
@@ -46,10 +46,10 @@ class XliffParserTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\I18n\Xliff\Exception\InvalidXliffDataException
      */
     public function missingIdInPluralTransUnitCausesException()
     {
+        $this->expectException(I18n\Xliff\Exception\InvalidXliffDataException::class);
         $mockFilenamePath = __DIR__ . '/../../Fixtures/MockInvalidPluralXliffData.xlf';
 
         $parser = new I18n\Xliff\V12\XliffParser();

--- a/Neos.Flow/Tests/Unit/Monitor/ChangeDetectionStrategy/ModificationTimeStrategyTest.php
+++ b/Neos.Flow/Tests/Unit/Monitor/ChangeDetectionStrategy/ModificationTimeStrategyTest.php
@@ -32,7 +32,7 @@ class ModificationTimeStrategyTest extends \Neos\Flow\Tests\UnitTestCase
 
     /**
      */
-    public function setUp()
+    protected function setUp(): void
     {
         vfsStream::setup('testDirectory');
 

--- a/Neos.Flow/Tests/Unit/Monitor/FileMonitorTest.php
+++ b/Neos.Flow/Tests/Unit/Monitor/FileMonitorTest.php
@@ -39,7 +39,7 @@ class FileMonitorTest extends UnitTestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->unixStylePath = Files::getUnixStylePath(__DIR__);
         $this->unixStylePathAndFilename = Files::getUnixStylePath(__FILE__);

--- a/Neos.Flow/Tests/Unit/Mvc/ActionRequestTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/ActionRequestTest.php
@@ -35,7 +35,7 @@ class ActionRequestTest extends UnitTestCase
      */
     protected $mockHttpRequest;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockHttpRequest = $this->getMockBuilder(Http\Request::class)->disableOriginalConstructor()->getMock();
         $this->actionRequest = new ActionRequest($this->mockHttpRequest);

--- a/Neos.Flow/Tests/Unit/Mvc/ActionRequestTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/ActionRequestTest.php
@@ -13,6 +13,11 @@ namespace Neos\Flow\Tests\Unit\Mvc;
 
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Http;
+use Neos\Flow\Mvc\Exception\InvalidActionNameException;
+use Neos\Flow\Mvc\Exception\InvalidArgumentNameException;
+use Neos\Flow\Mvc\Exception\InvalidArgumentTypeException;
+use Neos\Flow\Mvc\Exception\InvalidControllerNameException;
+use Neos\Flow\ObjectManagement\Exception\UnknownObjectException;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Security\Cryptography\HashService;
@@ -57,11 +62,11 @@ class ActionRequestTest extends UnitTestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
      * @test
      */
     public function constructorThrowsAnExceptionIfNoValidRequestIsPassed()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new ActionRequest(new \stdClass());
     }
 
@@ -237,10 +242,10 @@ class ActionRequestTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\ObjectManagement\Exception\UnknownObjectException
      */
     public function setControllerObjectNameThrowsExceptionOnUnknownObjectName()
     {
+        $this->expectException(UnknownObjectException::class);
         $mockObjectManager = $this->createMock(ObjectManagerInterface::class);
         $mockObjectManager->expects($this->any())->method('getCaseSensitiveObjectName')->will($this->returnValue(false));
 
@@ -347,10 +352,10 @@ class ActionRequestTest extends UnitTestCase
      * @test
      * @param mixed $invalidControllerName
      * @dataProvider invalidControllerNames
-     * @expectedException \Neos\Flow\Mvc\Exception\InvalidControllerNameException
      */
     public function setControllerNameThrowsExceptionOnInvalidControllerNames($invalidControllerName)
     {
+        $this->expectException(InvalidControllerNameException::class);
         $this->actionRequest->setControllerName($invalidControllerName);
     }
 
@@ -383,10 +388,10 @@ class ActionRequestTest extends UnitTestCase
      * @test
      * @param mixed $invalidActionName
      * @dataProvider invalidActionNames
-     * @expectedException \Neos\Flow\Mvc\Exception\InvalidActionNameException
      */
     public function setControllerActionNameThrowsExceptionOnInvalidActionNames($invalidActionName)
     {
+        $this->expectException(InvalidActionNameException::class);
         $this->actionRequest->setControllerActionName($invalidActionName);
     }
 
@@ -429,19 +434,19 @@ class ActionRequestTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\InvalidArgumentNameException
      */
     public function setArgumentThrowsAnExceptionOnInvalidArgumentNames()
     {
+        $this->expectException(InvalidArgumentNameException::class);
         $this->actionRequest->setArgument('', 'theValue');
     }
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\InvalidArgumentTypeException
      */
     public function setArgumentDoesNotAllowObjectValuesForRegularArguments()
     {
+        $this->expectException(InvalidArgumentTypeException::class);
         $this->actionRequest->setArgument('foo', new \stdClass());
     }
 
@@ -533,10 +538,10 @@ class ActionRequestTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\InvalidHashException
      */
     public function getReferringRequestThrowsAnExceptionIfTheHmacOfTheArgumentsCouldNotBeValid()
     {
+        $this->expectException(InvalidHashException::class);
         $serializedArguments = base64_encode('some manipulated arguments string without valid HMAC');
         $referrer = [
             '@controller' => 'Foo',

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
@@ -48,7 +48,7 @@ class AbstractControllerTest extends UnitTestCase
      */
     protected $mockActionRequest;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockHttpRequest = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
         $this->mockHttpRequest->expects($this->any())->method('getNegotiatedMediaType')->will($this->returnValue('text/html'));

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
@@ -19,7 +19,9 @@ use Neos\Flow\Http\Request;
 use Neos\Flow\Http\Response;
 use Neos\Flow\Http\Uri;
 use Neos\Flow\Mvc\Exception\ForwardException;
+use Neos\Flow\Mvc\Exception\RequiredArgumentMissingException;
 use Neos\Flow\Mvc\Exception\StopActionException;
+use Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException;
 use Neos\Flow\Mvc\FlashMessageContainer;
 use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
@@ -61,10 +63,10 @@ class AbstractControllerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException
      */
     public function initializeControllerWillThrowAnExceptionIfTheGivenRequestIsNotSupported()
     {
+        $this->expectException(UnsupportedRequestTypeException::class);
         $request = new Cli\Request();
         $response = new Cli\Response();
 
@@ -136,10 +138,10 @@ class AbstractControllerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function addFlashMessageThrowsExceptionOnInvalidMessageBody()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $flashMessageContainer = new FlashMessageContainer();
         $controller = $this->getAccessibleMock(AbstractController::class, ['processRequest']);
         $this->inject($controller, 'flashMessageContainer', $flashMessageContainer);
@@ -316,10 +318,10 @@ class AbstractControllerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\StopActionException
      */
     public function redirectToUriThrowsStopActionException()
     {
+        $this->expectException(StopActionException::class);
         $controller = $this->getAccessibleMock(AbstractController::class, ['processRequest']);
         $controller->_call('initializeController', $this->mockActionRequest, $this->actionResponse);
 
@@ -381,10 +383,10 @@ class AbstractControllerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\StopActionException
      */
     public function throwStatusSetsThrowsStopActionException()
     {
+        $this->expectException(StopActionException::class);
         $controller = $this->getAccessibleMock(AbstractController::class, ['processRequest']);
         $controller->_call('initializeController', $this->mockActionRequest, $this->actionResponse);
 
@@ -461,10 +463,10 @@ class AbstractControllerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\RequiredArgumentMissingException
      */
     public function mapRequestArgumentsToControllerArgumentsThrowsExceptionIfRequiredArgumentWasNotSet()
     {
+        $this->expectException(RequiredArgumentMissingException::class);
         $mockPropertyMapper = $this->getMockBuilder(PropertyMapper::class)->disableOriginalConstructor()->setMethods(['convert'])->getMock();
         $mockPropertyMapper->expects($this->atLeastOnce())->method('convert')->will($this->returnArgument(0));
 

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/ActionControllerTest.php
@@ -128,10 +128,10 @@ class ActionControllerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException  \Neos\Flow\Mvc\Exception\NoSuchActionException
      */
     public function processRequestThrowsExceptionIfRequestedActionIsNotCallable()
     {
+        $this->expectException(Mvc\Exception\NoSuchActionException::class);
         $this->actionController = new ActionController();
 
         $this->inject($this->actionController, 'objectManager', $this->mockObjectManager);
@@ -153,10 +153,10 @@ class ActionControllerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException  \Neos\Flow\Mvc\Exception\InvalidActionVisibilityException
      */
     public function processRequestThrowsExceptionIfRequestedActionIsNotPublic()
     {
+        $this->expectException(Mvc\Exception\InvalidActionVisibilityException::class);
         $this->actionController = new ActionController();
 
         $this->inject($this->actionController, 'objectManager', $this->mockObjectManager);
@@ -252,10 +252,10 @@ class ActionControllerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\ViewNotFoundException
      */
     public function resolveViewThrowsExceptionIfResolvedViewDoesNotImplementViewInterface()
     {
+        $this->expectException(Mvc\Exception\ViewNotFoundException::class);
         $this->mockObjectManager->expects($this->any())->method('getCaseSensitiveObjectName')->will($this->returnValue(false));
         $this->actionController->_set('defaultViewObjectName', 'ViewDefaultObjectName');
         $this->actionController->_call('resolveView');

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/ActionControllerTest.php
@@ -52,7 +52,7 @@ class ActionControllerTest extends UnitTestCase
      */
     protected $mockControllerContext;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->actionController = $this->getAccessibleMock(ActionController::class, ['dummy']);
 

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/ArgumentTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/ArgumentTest.php
@@ -56,19 +56,19 @@ class ArgumentTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function constructingArgumentWithoutNameThrowsException()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new Mvc\Controller\Argument('', 'Text');
     }
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function constructingArgumentWithInvalidNameThrowsException()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new Mvc\Controller\Argument(new \ArrayObject(), 'Text');
     }
 

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/ArgumentTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/ArgumentTest.php
@@ -39,7 +39,7 @@ class ArgumentTest extends UnitTestCase
 
     /**
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->simpleValueArgument = new Mvc\Controller\Argument('someName', 'string');
         $this->objectArgument = new Mvc\Controller\Argument('someName', 'DateTime');

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/ArgumentsTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/ArgumentsTest.php
@@ -149,10 +149,10 @@ class ArgumentsTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \LogicException
      */
     public function callingInvalidMethodThrowsException()
     {
+        $this->expectException(\LogicException::class);
         $arguments = new Arguments();
         $arguments->nonExistingMethod();
     }

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/CommandControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/CommandControllerTest.php
@@ -60,10 +60,10 @@ class CommandControllerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException
      */
     public function processRequestThrowsExceptionIfGivenRequestIsNoCliRequest()
     {
+        $this->expectException(Mvc\Exception\UnsupportedRequestTypeException::class);
         $mockRequest = $this->createMock(Mvc\RequestInterface::class);
         $mockResponse = $this->createMock(Mvc\ResponseInterface::class);
 

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/CommandControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/CommandControllerTest.php
@@ -45,7 +45,7 @@ class CommandControllerTest extends UnitTestCase
      */
     protected $mockConsoleOutput;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->commandController = $this->getAccessibleMock(CommandController::class, ['resolveCommandMethodName', 'callCommandMethod']);
 

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/FlashMessageContainerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/FlashMessageContainerTest.php
@@ -25,7 +25,7 @@ class FlashMessageContainerTest extends UnitTestCase
      */
     protected $flashMessageContainer;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->flashMessageContainer = new Mvc\FlashMessageContainer();
     }

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/MvcPropertyMappingConfigurationServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/MvcPropertyMappingConfigurationServiceTest.php
@@ -14,6 +14,7 @@ namespace Neos\Flow\Tests\Unit\Mvc\Controller;
 use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
 use Neos\Flow\Security\Cryptography\HashService;
+use Neos\Flow\Security\Exception\InvalidArgumentForHashGenerationException;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\Mvc;
 
@@ -123,10 +124,10 @@ class MvcPropertyMappingConfigurationServiceTest extends UnitTestCase
     /**
      * @test
      * @dataProvider dataProviderForgenerateTrustedPropertiesTokenWithUnallowedValues
-     * @expectedException \Neos\Flow\Security\Exception\InvalidArgumentForHashGenerationException
      */
     public function generateTrustedPropertiesTokenThrowsExceptionInWrongCases($input)
     {
+        $this->expectException(InvalidArgumentForHashGenerationException::class);
         $requestHashService = $this->getMockBuilder(Mvc\Controller\MvcPropertyMappingConfigurationService::class)->setMethods(['serializeAndHashFormFieldArray'])->getMock();
         $requestHashService->generateTrustedPropertiesToken($input);
     }

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/MvcPropertyMappingConfigurationTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/MvcPropertyMappingConfigurationTest.php
@@ -27,7 +27,7 @@ class MvcPropertyMappingConfigurationTest extends UnitTestCase
     /**
      *
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mvcPropertyMappingConfiguration = new MvcPropertyMappingConfiguration();
     }

--- a/Neos.Flow/Tests/Unit/Mvc/DispatchComponentTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/DispatchComponentTest.php
@@ -79,7 +79,7 @@ class DispatchComponentTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->dispatchComponent = new DispatchComponent();
 

--- a/Neos.Flow/Tests/Unit/Mvc/DispatcherTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/DispatcherTest.php
@@ -93,7 +93,7 @@ class DispatcherTest extends UnitTestCase
     /**
      * Sets up this test case
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->dispatcher = $this->getMockBuilder(Dispatcher::class)->disableOriginalConstructor()->setMethods(['resolveController'])->getMock();
 

--- a/Neos.Flow/Tests/Unit/Mvc/DispatcherTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/DispatcherTest.php
@@ -17,8 +17,10 @@ use Neos\Flow\Http\Request as HttpRequest;
 use Neos\Flow\Log\PsrLoggerFactoryInterface;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\Controller\ControllerInterface;
+use Neos\Flow\Mvc\Controller\Exception\InvalidControllerException;
 use Neos\Flow\Mvc\Dispatcher;
 use Neos\Flow\Mvc\Exception\ForwardException;
+use Neos\Flow\Mvc\Exception\InfiniteLoopException;
 use Neos\Flow\Mvc\Exception\StopActionException;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Security\Authentication\EntryPointInterface;
@@ -199,10 +201,10 @@ class DispatcherTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\InfiniteLoopException
      */
     public function dispatchThrowsAnInfiniteLoopExceptionIfTheRequestCouldNotBeDispachedAfter99Iterations()
     {
+        $this->expectException(InfiniteLoopException::class);
         $requestCallCounter = 0;
         $requestCallBack = function () use (&$requestCallCounter) {
             return ($requestCallCounter++ < 101) ? false : true;
@@ -254,10 +256,10 @@ class DispatcherTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\AuthenticationRequiredException
      */
     public function dispatchRethrowsAuthenticationRequiredExceptionIfSecurityContextDoesNotContainAnyAuthenticationToken()
     {
+        $this->expectException(AuthenticationRequiredException::class);
         $this->mockActionRequest->expects($this->any())->method('isDispatched')->will($this->returnValue(true));
 
         $this->mockSecurityContext->expects($this->atLeastOnce())->method('getAuthenticationTokens')->will($this->returnValue([]));
@@ -341,10 +343,10 @@ class DispatcherTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\AccessDeniedException
      */
     public function dispatchRethrowsAccessDeniedException()
     {
+        $this->expectException(AccessDeniedException::class);
         $this->mockActionRequest->expects($this->any())->method('isDispatched')->will($this->returnValue(true));
 
         $this->mockFirewall->expects($this->once())->method('blockIllegalRequests')->will($this->throwException(new AccessDeniedException()));
@@ -375,10 +377,10 @@ class DispatcherTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Controller\Exception\InvalidControllerException
      */
     public function resolveControllerThrowsAnInvalidControllerExceptionIfTheResolvedControllerDoesNotImplementTheControllerInterface()
     {
+        $this->expectException(InvalidControllerException::class);
         $mockController = $this->createMock('stdClass');
 
         /** @var ObjectManagerInterface|\PHPUnit_Framework_MockObject_MockObject $mockObjectManager */
@@ -397,10 +399,10 @@ class DispatcherTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Controller\Exception\InvalidControllerException
      */
     public function resolveControllerThrowsAnInvalidControllerExceptionIfTheResolvedControllerDoesNotExist()
     {
+        $this->expectException(InvalidControllerException::class);
         $mockHttpRequest = $this->getMockBuilder(HttpRequest::class)->disableOriginalConstructor()->getMock();
         $mockRequest = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->setMethods(['getControllerObjectName', 'getHttpRequest'])->getMock();
         $mockRequest->expects($this->any())->method('getControllerObjectName')->will($this->returnValue(''));

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/RouteContextTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/RouteContextTest.php
@@ -42,7 +42,7 @@ class RouteContextTest extends UnitTestCase
      */
     private $mockUri2;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockHttpRequest1 = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
 

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/RouteParametersTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/RouteParametersTest.php
@@ -33,10 +33,10 @@ class RouteParametersTest extends UnitTestCase
     /**
      * @test
      * @dataProvider withParameterThrowsExceptionForInvalidParameterValuesDataProvider
-     * @expectedException \InvalidArgumentException
      */
     public function withParameterThrowsExceptionForInvalidParameterValues($parameterValue)
     {
+        $this->expectException(\InvalidArgumentException::class);
         RouteParameters::createEmpty()->withParameter('someParameter', $parameterValue);
     }
 

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/RouteTagsTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/RouteTagsTest.php
@@ -30,11 +30,11 @@ class RouteTagsTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      * @dataProvider createFromTagThrowsExceptionForInvalidTagsDataProvider
      */
     public function createFromTagThrowsExceptionForInvalidTags($tag)
     {
+        $this->expectException(\InvalidArgumentException::class);
         RouteTags::createFromTag($tag);
     }
 
@@ -58,19 +58,19 @@ class RouteTagsTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function createFromArrayDoesNotAcceptIntegerValues()
     {
+        $this->expectException(\InvalidArgumentException::class);
         RouteTags::createFromArray([123]);
     }
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function createFromArrayDoesNotAcceptObjectValues()
     {
+        $this->expectException(\InvalidArgumentException::class);
         RouteTags::createFromArray([new \stdClass()]);
     }
 

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/DynamicRoutePartTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/DynamicRoutePartTest.php
@@ -31,7 +31,7 @@ class DynamicRoutePartTest extends UnitTestCase
      */
     protected $mockPersistenceManager;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->dynamicRoutPart = $this->getAccessibleMock(DynamicRoutePart::class, ['dummy']);
 

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/IdentityRoutePartTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/IdentityRoutePartTest.php
@@ -51,7 +51,7 @@ class IdentityRoutePartTest extends UnitTestCase
     /**
      * Sets up this test case
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->identityRoutePart = $this->getAccessibleMock(IdentityRoutePart::class, ['createPathSegmentForObject']);
 

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/IdentityRoutePartTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/IdentityRoutePartTest.php
@@ -10,6 +10,9 @@ namespace Neos\Flow\Tests\Unit\Mvc\Routing;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+
+use Neos\Flow\Mvc\Exception\InfiniteLoopException;
+use Neos\Flow\Mvc\Exception\InvalidUriPatternException;
 use Neos\Flow\Mvc\Routing\IdentityRoutePart;
 use Neos\Flow\Mvc\Routing\ObjectPathMapping;
 use Neos\Flow\Mvc\Routing\ObjectPathMappingRepository;
@@ -470,10 +473,10 @@ class IdentityRoutePartTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\InfiniteLoopException
      */
     public function resolveValueThrowsInfiniteLoopExceptionIfNoUniquePathSegmentCantBeFound()
     {
+        $this->expectException(InfiniteLoopException::class);
         $object = new \stdClass();
         $this->mockPersistenceManager->expects($this->atLeastOnce())->method('getIdentifierByObject')->with($object)->will($this->returnValue('TheIdentifier'));
         $this->mockPersistenceManager->expects($this->atLeastOnce())->method('getObjectByIdentifier')->with('TheIdentifier')->will($this->returnValue($object));
@@ -538,10 +541,10 @@ class IdentityRoutePartTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\InvalidUriPatternException
      */
     public function createPathSegmentForObjectThrowsInvalidUriPatterExceptionIfItSpecifiedPropertiesContainObjects()
     {
+        $this->expectException(InvalidUriPatternException::class);
         $identityRoutePart = $this->getAccessibleMock(IdentityRoutePart::class, ['dummy']);
         $object = new \stdClass();
         $object->objectProperty = new \stdClass();

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/RouteTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/RouteTest.php
@@ -13,7 +13,10 @@ namespace Neos\Flow\Tests\Unit\Mvc\Routing;
 
 use Neos\Flow\Http;
 use Neos\Flow\Http\Request;
+use Neos\Flow\Mvc\Exception\InvalidRoutePartHandlerException;
 use Neos\Flow\Mvc\Exception\InvalidRoutePartValueException;
+use Neos\Flow\Mvc\Exception\InvalidRouteSetupException;
+use Neos\Flow\Mvc\Exception\InvalidUriPatternException;
 use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
 use Neos\Flow\Mvc\Routing\Dto\RouteContext;
 use Neos\Flow\Mvc\Routing\Fixtures\MockRoutePartHandler;
@@ -144,10 +147,10 @@ class RouteTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\InvalidRoutePartHandlerException
      */
     public function settingInvalidRoutePartHandlerThrowsException()
     {
+        $this->expectException(InvalidRoutePartHandlerException::class);
         $this->route->setUriPattern('{key1}/{key2}');
         $this->route->setRoutePartsConfiguration(
             [
@@ -204,60 +207,60 @@ class RouteTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\InvalidUriPatternException
      */
     public function uriPatternWithTrailingSlashThrowsException()
     {
+        $this->expectException(InvalidUriPatternException::class);
         $this->route->setUriPattern('some/uri/pattern/');
         $this->route->parse();
     }
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\InvalidUriPatternException
      */
     public function uriPatternWithLeadingSlashThrowsException()
     {
+        $this->expectException(InvalidUriPatternException::class);
         $this->route->setUriPattern('/some/uri/pattern');
         $this->route->parse();
     }
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\InvalidUriPatternException
      */
     public function uriPatternWithSuccessiveDynamicRoutepartsThrowsException()
     {
+        $this->expectException(InvalidUriPatternException::class);
         $this->route->setUriPattern('{key1}{key2}');
         $this->route->parse();
     }
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\InvalidUriPatternException
      */
     public function uriPatternWithSuccessiveOptionalSectionsThrowsException()
     {
+        $this->expectException(InvalidUriPatternException::class);
         $this->route->setUriPattern('(foo/bar)(/bar/foo)');
         $this->route->parse();
     }
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\InvalidUriPatternException
      */
     public function uriPatternWithUnterminatedOptionalSectionsThrowsException()
     {
+        $this->expectException(InvalidUriPatternException::class);
         $this->route->setUriPattern('foo/(bar');
         $this->route->parse();
     }
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\InvalidUriPatternException
      */
     public function uriPatternWithUnopenedOptionalSectionsThrowsException()
     {
+        $this->expectException(InvalidUriPatternException::class);
         $this->route->setUriPattern('foo)/bar');
         $this->route->parse();
     }
@@ -567,10 +570,10 @@ class RouteTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\InvalidRouteSetupException
      */
     public function routeThrowsExceptionIfUriPatternContainsOneOptionalDynamicRoutePartWithoutDefaultValue()
     {
+        $this->expectException(InvalidRouteSetupException::class);
         $this->route->setUriPattern('({optional})');
 
         $this->assertFalse($this->routeMatchesPath(''));
@@ -1053,10 +1056,10 @@ class RouteTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\InvalidRoutePartValueException
      */
     public function resolvesThrowsExceptionIfRoutePartValueIsNoString()
     {
+        $this->expectException(InvalidRoutePartValueException::class);
         $mockRoutePart = $this->createMock(Routing\RoutePartInterface::class);
         $mockRoutePart->expects($this->any())->method('resolve')->will($this->returnValue(true));
         $mockRoutePart->expects($this->any())->method('hasValue')->will($this->returnValue(true));
@@ -1070,10 +1073,10 @@ class RouteTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\InvalidRoutePartValueException
      */
     public function resolvesThrowsExceptionIfRoutePartDefaultValueIsNoString()
     {
+        $this->expectException(InvalidRoutePartValueException::class);
         $mockRoutePart = $this->createMock(Routing\RoutePartInterface::class);
         $mockRoutePart->expects($this->any())->method('resolve')->will($this->returnValue(true));
         $mockRoutePart->expects($this->any())->method('hasValue')->will($this->returnValue(false));

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/RouteTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/RouteTest.php
@@ -54,7 +54,7 @@ class RouteTest extends UnitTestCase
      * Sets up this test case
      *
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockObjectManager = $this->createMock(ObjectManagerInterface::class);
         $this->route = $this->getAccessibleMock(Routing\Route::class, ['dummy']);

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/RouterCachingServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/RouterCachingServiceTest.php
@@ -81,7 +81,7 @@ class RouterCachingServiceTest extends UnitTestCase
     /**
      * Sets up this test case
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->routerCachingService = $this->getAccessibleMock(RouterCachingService::class, ['dummy']);
 

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/RouterTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/RouterTest.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Tests\Unit\Mvc\Routing;
 
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Http\Request;
+use Neos\Flow\Mvc\Exception\InvalidRouteSetupException;
 use Neos\Flow\Mvc\Exception\NoMatchingRouteException;
 use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
 use Neos\Flow\Mvc\Routing\Dto\ResolveContext;
@@ -150,10 +151,10 @@ class RouterTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\InvalidRouteSetupException
      */
     public function createRoutesFromConfigurationThrowsExceptionIfOnlySomeRoutesWithTheSameUriPatternHaveHttpMethodConstraints()
     {
+        $this->expectException(InvalidRouteSetupException::class);
         $routesConfiguration = [
             [
                 'uriPattern' => 'somePattern'
@@ -200,10 +201,10 @@ class RouterTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Exception\NoMatchingRouteException
      */
     public function resolveThrowsExceptionIfNoMatchingRouteWasFound()
     {
+        $this->expectException(NoMatchingRouteException::class);
         /** @var Router|\PHPUnit_Framework_MockObject_MockObject $router */
         $router = $this->getAccessibleMock(Router::class, ['createRoutesFromConfiguration']);
         $this->inject($router, 'routerCachingService', $this->mockRouterCachingService);

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/RouterTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/RouterTest.php
@@ -65,7 +65,7 @@ class RouterTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->router = $this->getAccessibleMock(Router::class, ['dummy']);
 

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/RoutingComponentTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/RoutingComponentTest.php
@@ -60,7 +60,7 @@ class RoutingComponentTest extends UnitTestCase
      * Sets up this test case
      *
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->routingComponent = new RoutingComponent([]);
 

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/UriBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/UriBuilderTest.php
@@ -63,7 +63,7 @@ class UriBuilderTest extends UnitTestCase
      * Sets up the test case
      *
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockHttpRequest = $this->getMockBuilder(Http\Request::class)->disableOriginalConstructor()->getMock();
 

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/UriBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/UriBuilderTest.php
@@ -139,10 +139,10 @@ class UriBuilderTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Mvc\Routing\Exception\MissingActionNameException
      */
     public function uriForThrowsExceptionIfActionNameIsNotSpecified()
     {
+        $this->expectException(Mvc\Routing\Exception\MissingActionNameException::class);
         $this->uriBuilder->uriFor(null, [], 'SomeController', 'SomePackage');
     }
 

--- a/Neos.Flow/Tests/Unit/Mvc/View/JsonViewTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/View/JsonViewTest.php
@@ -40,7 +40,7 @@ class JsonViewTest extends UnitTestCase
      * Sets up this test case
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->view = $this->getMockBuilder(Mvc\View\JsonView::class)->setMethods(['loadConfigurationFromYamlFile'])->getMock();
         $this->controllerContext = $this->getMockBuilder(Mvc\Controller\ControllerContext::class)->disableOriginalConstructor()->getMock();

--- a/Neos.Flow/Tests/Unit/Mvc/ViewConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/ViewConfigurationManagerTest.php
@@ -46,7 +46,7 @@ class ViewConfigurationManagerTest extends \Neos\Flow\Tests\UnitTestCase
     protected $mockCache;
 
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->viewConfigurationManager = new ViewConfigurationManager();
 

--- a/Neos.Flow/Tests/Unit/ObjectManagement/CompileTimeObjectManagerTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/CompileTimeObjectManagerTest.php
@@ -30,7 +30,7 @@ class CompileTimeObjectManagerTest extends UnitTestCase
      */
     protected $compileTimeObjectManager;
 
-    public function setUp()
+    protected function setUp(): void
     {
         vfsStream::setup('Packages');
         $this->mockPackageManager = $this->getMockBuilder(PackageManager::class)->disableOriginalConstructor()->getMock();

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationBuilderTest.php
@@ -16,6 +16,8 @@ use Neos\Flow\ObjectManagement\Configuration\Configuration;
 use Neos\Flow\ObjectManagement\Configuration\ConfigurationArgument;
 use Neos\Flow\ObjectManagement\Configuration\ConfigurationBuilder;
 use Neos\Flow\ObjectManagement\Configuration\ConfigurationProperty;
+use Neos\Flow\ObjectManagement\Exception;
+use Neos\Flow\ObjectManagement\Exception\InvalidObjectConfigurationException;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\Annotations as Flow;
@@ -117,10 +119,10 @@ class ConfigurationBuilderTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\ObjectManagement\Exception\InvalidObjectConfigurationException
      */
     public function invalidOptionResultsInException()
     {
+        $this->expectException(InvalidObjectConfigurationException::class);
         $configurationArray = ['scoopy' => 'prototype'];
         $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy']);
         $configurationBuilder->_call('parseConfigurationArray', 'TestObject', $configurationArray, __CLASS__);
@@ -128,10 +130,10 @@ class ConfigurationBuilderTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\ObjectManagement\Exception
      */
     public function privatePropertyAnnotatedForInjectionThrowsException()
     {
+        $this->expectException(Exception::class);
         $configurationArray = [];
         $configurationArray['arguments'][1]['setting'] = 'Neos.Foo.Bar';
         $configurationArray['properties']['someProperty']['setting'] = 'Neos.Bar.Baz';
@@ -158,10 +160,10 @@ class ConfigurationBuilderTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\ObjectManagement\Exception\UnknownClassException
      */
     public function errorOnGetClassMethodsThrowsException()
     {
+        $this->expectException(Exception\UnknownClassException::class);
         $configurationArray = [];
         $configurationArray['properties']['someProperty']['object']['name'] = 'Foo';
         $configurationArray['properties']['someProperty']['object']['className'] = 'foobar';

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Tests\Unit\ObjectManagement\Configuration;
  * source code.
  */
 
+use Neos\Flow\Configuration\Exception\InvalidConfigurationException;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\ObjectManagement\Configuration;
 
@@ -37,10 +38,10 @@ class ConfigurationTest extends UnitTestCase
      * Checks if setProperties accepts only valid values
      *
      * @test
-     * @expectedException \Neos\Flow\Configuration\Exception\InvalidConfigurationException
      */
     public function setPropertiesOnlyAcceptsValidValues()
     {
+        $this->expectException(InvalidConfigurationException::class);
         $invalidProperties = [
             'validProperty' => new Configuration\ConfigurationProperty('validProperty', 'simple string'),
             'invalidProperty' => 'foo'
@@ -69,10 +70,10 @@ class ConfigurationTest extends UnitTestCase
      * Checks if setArguments accepts only valid values
      *
      * @test
-     * @expectedException \Neos\Flow\Configuration\Exception\InvalidConfigurationException
      */
     public function setArgumentsOnlyAcceptsValidValues()
     {
+        $this->expectException(InvalidConfigurationException::class);
         $invalidArguments = [
             1 => new Configuration\ConfigurationArgument(1, 'simple string'),
             2 => 'foo'
@@ -117,10 +118,10 @@ class ConfigurationTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function setFactoryMethodNameRejectsAnythingElseThanAString()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->objectConfiguration->setFactoryMethodName([]);
     }
 

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationTest.php
@@ -28,7 +28,7 @@ class ConfigurationTest extends UnitTestCase
      * Prepares everything for a test
      *
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->objectConfiguration = new Configuration\Configuration('Neos\Foo\Bar');
     }

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/CompilerTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/CompilerTest.php
@@ -31,7 +31,7 @@ class CompilerTest extends UnitTestCase
      */
     protected $compiler;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->compiler = $this->getAccessibleMock(Compiler::class, null);
     }

--- a/Neos.Flow/Tests/Unit/Package/PackageFactoryTest.php
+++ b/Neos.Flow/Tests/Unit/Package/PackageFactoryTest.php
@@ -11,6 +11,8 @@ namespace Neos\Flow\Tests\Unit\Package;
  * source code.
  */
 
+use Neos\Flow\Package\Exception\CorruptPackageException;
+use Neos\Flow\Package\Exception\InvalidPackagePathException;
 use org\bovigo\vfs\vfsStream;
 use Neos\Flow\Composer\ComposerUtility;
 use Neos\Flow\Package\Package;
@@ -48,19 +50,19 @@ class PackageFactoryTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Package\Exception\InvalidPackagePathException
      */
     public function createThrowsExceptionWhenSpecifyingANonExistingPackagePath()
     {
+        $this->expectException(InvalidPackagePathException::class);
         $this->packageFactory->create('vfs://Packages/', 'Some/Non/Existing/Path/Some.Package/', 'Some.Package', 'some/package');
     }
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Package\Exception\CorruptPackageException
      */
     public function createThrowsExceptionIfCustomPackageFileCantBeAnalyzed()
     {
+        $this->expectException(CorruptPackageException::class);
         $packagePath = 'vfs://Packages/Some/Path/Some.Package/';
         $packageFilePath = $packagePath . 'Classes/Some/Package/Package.php';
         mkdir(dirname($packageFilePath), 0777, true);
@@ -72,10 +74,10 @@ class PackageFactoryTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Package\Exception\CorruptPackageException
      */
     public function createThrowsExceptionIfCustomPackageDoesNotImplementPackageInterface()
     {
+        $this->expectException(CorruptPackageException::class);
         $packagePath = 'vfs://Packages/Some/Path/Some.Package/';
         $packageFilePath = $packagePath . 'Classes/Some/Package/Package.php';
         mkdir(dirname($packageFilePath), 0777, true);

--- a/Neos.Flow/Tests/Unit/Package/PackageFactoryTest.php
+++ b/Neos.Flow/Tests/Unit/Package/PackageFactoryTest.php
@@ -36,7 +36,7 @@ class PackageFactoryTest extends UnitTestCase
 
     /**
      */
-    public function setUp()
+    protected function setUp(): void
     {
         ComposerUtility::flushCaches();
         vfsStream::setup('Packages');

--- a/Neos.Flow/Tests/Unit/Package/PackageManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Package/PackageManagerTest.php
@@ -56,7 +56,7 @@ class PackageManagerTest extends UnitTestCase
      * Sets up this test case
      *
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         ComposerUtility::flushCaches();
         vfsStream::setup('Test');

--- a/Neos.Flow/Tests/Unit/Package/PackageManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Package/PackageManagerTest.php
@@ -16,6 +16,8 @@ use Neos\Flow\Core\ApplicationContext;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Package\Exception\InvalidPackageKeyException;
+use Neos\Flow\Package\Exception\PackageKeyAlreadyExistsException;
+use Neos\Flow\Package\Exception\UnknownPackageException;
 use Neos\Flow\Package\FlowPackageInterface;
 use Neos\Flow\Package\PackageFactory;
 use Neos\Flow\Package\PackageInterface;
@@ -101,10 +103,10 @@ class PackageManagerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Package\Exception\UnknownPackageException
      */
     public function getPackageThrowsExceptionOnUnknownPackage()
     {
+        $this->expectException(UnknownPackageException::class);
         $this->packageManager->getPackage('PrettyUnlikelyThatThisPackageExists');
     }
 
@@ -343,10 +345,10 @@ class PackageManagerTest extends UnitTestCase
      * Makes sure that duplicate package keys are detected.
      *
      * @test
-     * @expectedException \Neos\Flow\Package\Exception\PackageKeyAlreadyExistsException
      */
     public function createPackageThrowsExceptionForExistingPackageKey()
     {
+        $this->expectException(PackageKeyAlreadyExistsException::class);
         $this->packageManager->createPackage('Acme.YetAnotherTestPackage', [], 'vfs://Test/Packages/Application');
         $this->packageManager->createPackage('Acme.YetAnotherTestPackage', [], 'vfs://Test/Packages/Application');
     }
@@ -400,10 +402,10 @@ class PackageManagerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Package\Exception\PackageKeyAlreadyExistsException
      */
     public function registeringTheSamePackageKeyWithDifferentCaseShouldThrowException()
     {
+        $this->expectException(PackageKeyAlreadyExistsException::class);
         $this->packageManager->createPackage('doctrine.instantiator', [], 'vfs://Test/Packages/Application');
         $this->packageManager->createPackage('doctrine.Instantiator', [], 'vfs://Test/Packages/Application');
     }

--- a/Neos.Flow/Tests/Unit/Package/PackageTest.php
+++ b/Neos.Flow/Tests/Unit/Package/PackageTest.php
@@ -31,7 +31,7 @@ class PackageTest extends UnitTestCase
 
     /**
      */
-    public function setUp()
+    protected function setUp(): void
     {
         ComposerUtility::flushCaches();
         vfsStream::setup('Packages');

--- a/Neos.Flow/Tests/Unit/Package/PackageTest.php
+++ b/Neos.Flow/Tests/Unit/Package/PackageTest.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\Tests\Unit\Package;
  */
 
 use Neos\Flow\Composer\ComposerUtility;
+use Neos\Flow\Composer\Exception\MissingPackageManifestException;
 use Neos\Flow\Package\Package;
 use org\bovigo\vfs\vfsStream;
 use Neos\Flow\Package\PackageManager;
@@ -87,10 +88,10 @@ class PackageTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Composer\Exception\MissingPackageManifestException
      */
     public function throwExceptionWhenSpecifyingAPathWithMissingComposerManifest()
     {
+        $this->expectException(MissingPackageManifestException::class);
         $packagePath = 'vfs://Packages/Some/Path/Some.Package/';
         mkdir($packagePath, 0777, true);
         $package = new Package('Some.Package', 'some/package', 'vfs://Packages/Some/Path/Some.Package/', []);

--- a/Neos.Flow/Tests/Unit/Persistence/AbstractPersistenceManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/AbstractPersistenceManagerTest.php
@@ -24,7 +24,7 @@ class AbstractPersistenceManagerTest extends UnitTestCase
      */
     protected $abstractPersistenceManager;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->abstractPersistenceManager = $this->getMockBuilder(AbstractPersistenceManager::class)->setMethods(['initialize', 'persistAll', 'isNewObject', 'getObjectByIdentifier', 'createQueryForType', 'add', 'remove', 'update', 'getIdentifierByObject', 'clearState', 'isConnected'])->getMock();
     }

--- a/Neos.Flow/Tests/Unit/Persistence/AbstractPersistenceManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/AbstractPersistenceManagerTest.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\Tests\Unit\Persistence;
  */
 
 use Neos\Flow\Persistence\AbstractPersistenceManager;
+use Neos\Flow\Persistence\Exception\UnknownObjectException;
 use Neos\Flow\Tests\UnitTestCase;
 
 /**
@@ -44,10 +45,10 @@ class AbstractPersistenceManagerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Persistence\Exception\UnknownObjectException
      */
     public function convertObjectToIdentityArrayThrowsExceptionIfIdentityForTheGivenObjectCantBeDetermined()
     {
+        $this->expectException(UnknownObjectException::class);
         $someObject = new \stdClass();
         $this->abstractPersistenceManager->expects($this->once())->method('getIdentifierByObject')->with($someObject)->will($this->returnValue(null));
 

--- a/Neos.Flow/Tests/Unit/Persistence/Aspect/PersistenceMagicAspectTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Aspect/PersistenceMagicAspectTest.php
@@ -39,7 +39,7 @@ class PersistenceMagicAspectTest extends UnitTestCase
     /**
      * Sets up this test case
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->persistenceMagicAspect = $this->getAccessibleMock(PersistenceMagicAspect::class, ['dummy'], []);
 

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/DataTypes/JsonArrayTypeTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/DataTypes/JsonArrayTypeTest.php
@@ -29,7 +29,7 @@ class JsonArrayTypeTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->jsonArrayTypeMock = $this->getMockBuilder(JsonArrayType::class)
             ->setMethods(['initializeDependencies'])

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/PersistenceManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/PersistenceManagerTest.php
@@ -12,11 +12,13 @@ namespace Neos\Flow\Tests\Unit\Persistence\Doctrine;
  */
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\UnitOfWork;
 use Neos\Flow\Log\ThrowableStorageInterface;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
+use Neos\Flow\Persistence\Exception;
 use Neos\Flow\Tests\UnitTestCase;
 use Psr\Log\LoggerInterface;
 
@@ -94,11 +96,11 @@ class PersistenceManagerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Persistence\Exception
-     * @expectedExceptionMessageRegExp /^Detected modified or new objects/
      */
     public function persistAllThrowsExceptionIfTryingToPersistNonWhitelistedObjectsAndOnlyWhitelistedObjectsFlagIsTrue()
     {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageRegExp('/^Detected modified or new objects/');
         $mockObject = new \stdClass();
         $scheduledEntityUpdates = [spl_object_hash($mockObject) => $mockObject];
         $scheduledEntityDeletes = [];
@@ -171,10 +173,10 @@ class PersistenceManagerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Doctrine\DBAL\DBALException
      */
     public function persistAllThrowsOriginalExceptionWhenEntityManagerGotClosed()
     {
+        $this->expectException(DBALException::class);
         $this->mockEntityManager->expects($this->exactly(1))->method('flush')->willThrowException(new \Doctrine\DBAL\DBALException('Dummy error that closed the entity manager'));
 
         $this->mockConnection->expects($this->never())->method('close');

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/PersistenceManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/PersistenceManagerTest.php
@@ -55,7 +55,7 @@ class PersistenceManagerTest extends UnitTestCase
      */
     protected $mockPing;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->persistenceManager = $this->getMockBuilder(\Neos\Flow\Persistence\Doctrine\PersistenceManager::class)->setMethods(['emitAllObjectsPersisted'])->getMock();
 

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/QueryResultTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/QueryResultTest.php
@@ -35,7 +35,7 @@ class QueryResultTest extends UnitTestCase
      * Sets up this test case
      *
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->query = $this->getMockBuilder(Query::class)->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $this->query->expects($this->any())->method('getResult')->will($this->returnValue(['First result', 'second result', 'third result']));

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/RepositoryTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/RepositoryTest.php
@@ -34,7 +34,7 @@ class RepositoryTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockEntityManager = $this->getMockBuilder(EntityManagerInterface::class)->disableOriginalConstructor()->getMock();
 

--- a/Neos.Flow/Tests/Unit/Persistence/Generic/DataMapperTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Generic/DataMapperTest.php
@@ -24,10 +24,10 @@ class DataMapperTest extends UnitTestCase
 {
     /**
      * @test
-     * @expectedException \Neos\Flow\Persistence\Generic\Exception\InvalidObjectDataException
      */
     public function mapToObjectThrowsExceptionOnEmptyInput()
     {
+        $this->expectException(Persistence\Generic\Exception\InvalidObjectDataException::class);
         $objectData = [];
 
         $dataMapper = $this->getAccessibleMock(Persistence\Generic\DataMapper::class, ['dummy']);

--- a/Neos.Flow/Tests/Unit/Persistence/Generic/QueryResultTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Generic/QueryResultTest.php
@@ -52,7 +52,7 @@ class QueryResultTest extends UnitTestCase
      * Sets up this test case
      *
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->persistenceManager = $this->getMockBuilder(PersistenceManager::class)->disableOriginalConstructor()->getMock();
         $this->persistenceManager->expects($this->any())->method('getObjectDataByQuery')->will($this->returnValue(['one', 'two']));

--- a/Neos.Flow/Tests/Unit/Persistence/Generic/QueryTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Generic/QueryTest.php
@@ -59,37 +59,37 @@ class QueryTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function setLimitAcceptsOnlyIntegers()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->query->setLimit(1.5);
     }
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function setLimitRejectsIntegersLessThanOne()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->query->setLimit(0);
     }
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function setOffsetAcceptsOnlyIntegers()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->query->setOffset(1.5);
     }
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function setOffsetRejectsIntegersLessThanZero()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $this->query->setOffset(-1);
     }
 }

--- a/Neos.Flow/Tests/Unit/Persistence/Generic/QueryTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Generic/QueryTest.php
@@ -40,7 +40,7 @@ class QueryTest extends UnitTestCase
      * Sets up this test case
      *
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->reflectionService = $this->createMock(ReflectionService::class);
         $this->objectManager = $this->createMock(ObjectManagerInterface::class);

--- a/Neos.Flow/Tests/Unit/Persistence/RepositoryTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/RepositoryTest.php
@@ -14,6 +14,7 @@ namespace Neos\Flow\Tests\Unit\Persistence;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\Persistence;
 use Neos\Flow\Tests\Persistence\Fixture;
+use PHPUnit\Framework\Error\Error;
 
 require_once('Fixture/Repository/NonstandardEntityRepository.php');
 
@@ -237,20 +238,20 @@ class RepositoryTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \PHPUnit\Framework\Error\Error
      */
     public function magicCallMethodTriggersAnErrorIfUnknownMethodsAreCalled()
     {
+        $this->expectException(Error::class);
         $repository = $this->getMockBuilder(Persistence\Repository::class)->setMethods(['createQuery'])->getMock();
         $repository->__call('foo', []);
     }
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Persistence\Exception\IllegalObjectTypeException
      */
     public function addChecksObjectType()
     {
+        $this->expectException(Persistence\Exception\IllegalObjectTypeException::class);
         $repository = $this->getAccessibleMock(Persistence\Repository::class, ['dummy']);
         $repository->_set('entityClassName', 'ExpectedObjectType');
 
@@ -259,10 +260,10 @@ class RepositoryTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Persistence\Exception\IllegalObjectTypeException
      */
     public function removeChecksObjectType()
     {
+        $this->expectException(Persistence\Exception\IllegalObjectTypeException::class);
         $repository = $this->getAccessibleMock(Persistence\Repository::class, ['dummy']);
         $repository->_set('entityClassName', 'ExpectedObjectType');
 
@@ -270,10 +271,10 @@ class RepositoryTest extends UnitTestCase
     }
     /**
      * @test
-     * @expectedException \Neos\Flow\Persistence\Exception\IllegalObjectTypeException
      */
     public function updateChecksObjectType()
     {
+        $this->expectException(Persistence\Exception\IllegalObjectTypeException::class);
         $repository = $this->getAccessibleMock(Persistence\Repository::class, ['dummy']);
         $repository->_set('entityClassName', 'ExpectedObjectType');
 

--- a/Neos.Flow/Tests/Unit/Property/PropertyMapperTest.php
+++ b/Neos.Flow/Tests/Unit/Property/PropertyMapperTest.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Tests\Unit\Property;
 
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Property\Exception\DuplicateTypeConverterException;
+use Neos\Flow\Property\Exception\InvalidSourceException;
 use Neos\Flow\Property\Exception\InvalidTargetException;
 use Neos\Flow\Property\Exception\TypeConverterException;
 use Neos\Flow\Property\PropertyMapper;
@@ -80,10 +81,10 @@ class PropertyMapperTest extends UnitTestCase
     /**
      * @test
      * @dataProvider invalidSourceTypes
-     * @expectedException \Neos\Flow\Property\Exception\InvalidSourceException
      */
     public function sourceWhichIsNoSimpleTypeOrObjectThrowsException($source)
     {
+        $this->expectException(InvalidSourceException::class);
         $propertyMapper = $this->getAccessibleMock(PropertyMapper::class, ['dummy']);
         $propertyMapper->_call('determineSourceTypes', $source);
     }
@@ -194,10 +195,10 @@ class PropertyMapperTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Property\Exception\TypeConverterException
      */
     public function findTypeConverterThrowsExceptionIfAllMatchingConvertersHaveNegativePriorities()
     {
+        $this->expectException(TypeConverterException::class);
         $internalTypeConverter1 = $this->getMockTypeConverter('string2string,prio-1');
         $internalTypeConverter1->expects($this->atLeastOnce())->method('getPriority')->will($this->returnValue(-1));
 
@@ -389,10 +390,10 @@ class PropertyMapperTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException Exception
      */
     public function convertDoesNotCatchSecurityExceptions()
     {
+        $this->expectException(Exception::class);
         $propertyMapper = $this->getAccessibleMock(PropertyMapper::class, ['doMapping']);
         $propertyMapper->expects($this->once())->method('doMapping')->with('sourceType', 'targetType', $this->mockConfiguration)->will($this->throwException(new Exception()));
 

--- a/Neos.Flow/Tests/Unit/Property/PropertyMapperTest.php
+++ b/Neos.Flow/Tests/Unit/Property/PropertyMapperTest.php
@@ -37,7 +37,7 @@ class PropertyMapperTest extends UnitTestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockConfiguration = $this->createMock(PropertyMappingConfigurationInterface::class);
     }

--- a/Neos.Flow/Tests/Unit/Property/PropertyMappingConfigurationTest.php
+++ b/Neos.Flow/Tests/Unit/Property/PropertyMappingConfigurationTest.php
@@ -32,7 +32,7 @@ class PropertyMappingConfigurationTest extends UnitTestCase
     /**
      * Initialization
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->propertyMappingConfiguration = new PropertyMappingConfiguration();
     }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/ArrayConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/ArrayConverterTest.php
@@ -26,7 +26,7 @@ class ArrayConverterTest extends UnitTestCase
      */
     protected $converter;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->converter = new ArrayConverter();
     }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/ArrayFromObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/ArrayFromObjectConverterTest.php
@@ -25,7 +25,7 @@ class ArrayFromObjectConverterTest extends UnitTestCase
      */
     protected $converter;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->converter = new ArrayFromObjectConverter();
     }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/BooleanConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/BooleanConverterTest.php
@@ -24,7 +24,7 @@ class BooleanConverterTest extends UnitTestCase
      */
     protected $converter;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->converter = new BooleanConverter();
     }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/CollectionConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/CollectionConverterTest.php
@@ -25,7 +25,7 @@ class CollectionConverterTest extends UnitTestCase
      */
     protected $converter;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->converter = new CollectionConverter();
     }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/DateTimeConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/DateTimeConverterTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
  * source code.
  */
 
+use Neos\Flow\Property\Exception\TypeConverterException;
 use Neos\Flow\Property\TypeConverter\DateTimeConverter;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\Property\PropertyMappingConfiguration;
@@ -276,10 +277,10 @@ class DateTimeConverterTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Property\Exception\TypeConverterException
      */
     public function convertFromThrowsExceptionIfGivenArrayDoesNotSpecifyTheDate()
     {
+        $this->expectException(TypeConverterException::class);
         $this->converter->convertFrom(['hour' => '12', 'minute' => '30'], 'DateTime');
     }
 
@@ -312,11 +313,11 @@ class DateTimeConverterTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Property\Exception\TypeConverterException
      * @dataProvider invalidDatePartKeyValuesDataProvider
      */
     public function convertFromThrowsExceptionIfDatePartKeysHaveInvalidValuesSpecified($source)
     {
+        $this->expectException(TypeConverterException::class);
         $this->converter->convertFrom($source, 'DateTime');
     }
 
@@ -414,10 +415,10 @@ class DateTimeConverterTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Property\Exception\TypeConverterException
      */
     public function convertFromThrowsExceptionIfSpecifiedTimezoneIsInvalid()
     {
+        $this->expectException(TypeConverterException::class);
         $source = [
             'date' => '2011-06-16',
             'dateFormat' => 'Y-m-d',
@@ -428,10 +429,10 @@ class DateTimeConverterTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Property\Exception\TypeConverterException
      */
     public function convertFromArrayThrowsExceptionForEmptyArray()
     {
+        $this->expectException(TypeConverterException::class);
         $this->converter->convertFrom([], 'DateTime', [], null);
     }
 

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/DateTimeConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/DateTimeConverterTest.php
@@ -29,7 +29,7 @@ class DateTimeConverterTest extends UnitTestCase
      */
     protected $converter;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->converter = new DateTimeConverter();
     }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/FloatConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/FloatConverterTest.php
@@ -28,7 +28,7 @@ class FloatConverterTest extends UnitTestCase
      */
     protected $converter;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->converter = new FloatConverter();
     }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/IntegerConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/IntegerConverterTest.php
@@ -28,7 +28,7 @@ class IntegerConverterTest extends UnitTestCase
      */
     protected $converter;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->converter = new IntegerConverter();
     }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/MediaTypeConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/MediaTypeConverterTest.php
@@ -34,7 +34,7 @@ class MediaTypeConverterTest extends UnitTestCase
     /**
      * Set up this test case
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mediaTypeConverter = new MediaTypeConverter();
 

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/ObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/ObjectConverterTest.php
@@ -40,7 +40,7 @@ class ObjectConverterTest extends UnitTestCase
      */
     protected $mockObjectManager;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockReflectionService = $this->createMock(ReflectionService::class);
         $this->mockObjectManager = $this->createMock(ObjectManagerInterface::class);

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/PersistentObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/PersistentObjectConverterTest.php
@@ -15,6 +15,10 @@ use Neos\Flow\Fixtures\ClassWithSetters;
 use Neos\Flow\Fixtures\ClassWithSettersAndConstructor;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Persistence;
+use Neos\Flow\Property\Exception\DuplicateObjectException;
+use Neos\Flow\Property\Exception\InvalidPropertyMappingConfigurationException;
+use Neos\Flow\Property\Exception\InvalidSourceException;
+use Neos\Flow\Property\Exception\InvalidTargetException;
 use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\Property\TypeConverter\Error\TargetNotFoundError;
 use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
@@ -244,10 +248,10 @@ class PersistentObjectConverterTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Property\Exception\InvalidPropertyMappingConfigurationException
      */
     public function convertFromShouldThrowExceptionIfObjectNeedsToBeModifiedButConfigurationIsNotSet()
     {
+        $this->expectException(InvalidPropertyMappingConfigurationException::class);
         $identifier = '550e8400-e29b-11d4-a716-446655440000';
         $object = new \stdClass();
         $object->someProperty = 'asdf';
@@ -347,10 +351,10 @@ class PersistentObjectConverterTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Property\Exception\InvalidSourceException
      */
     public function convertFromShouldThrowExceptionIfIdentityIsOfInvalidType()
     {
+        $this->expectException(InvalidSourceException::class);
         $source = [
             '__identity' => new \stdClass(),
         ];
@@ -359,10 +363,10 @@ class PersistentObjectConverterTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Property\Exception\DuplicateObjectException
      */
     public function convertFromShouldThrowExceptionIfMoreThanOneObjectWasFound()
     {
+        $this->expectException(DuplicateObjectException::class);
         $this->setupMockQuery(2, $this->never());
 
         $source = [
@@ -373,10 +377,10 @@ class PersistentObjectConverterTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Property\Exception\InvalidPropertyMappingConfigurationException
      */
     public function convertFromShouldThrowExceptionIfObjectNeedsToBeCreatedButConfigurationIsNotSet()
     {
+        $this->expectException(InvalidPropertyMappingConfigurationException::class);
         $source = [
             'foo' => 'bar'
         ];
@@ -406,10 +410,10 @@ class PersistentObjectConverterTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Property\Exception\InvalidTargetException
      */
     public function convertFromShouldThrowExceptionIfPropertyOnTargetObjectCouldNotBeSet()
     {
+        $this->expectException(InvalidTargetException::class);
         $source = [
             'propertyX' => 'bar'
         ];
@@ -473,10 +477,10 @@ class PersistentObjectConverterTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Property\Exception\InvalidTargetException
      */
     public function convertFromShouldThrowExceptionIfRequiredConstructorParameterWasNotFound()
     {
+        $this->expectException(InvalidTargetException::class);
         $source = [
             'propertyX' => 'bar'
         ];

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/PersistentObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/PersistentObjectConverterTest.php
@@ -52,7 +52,7 @@ class PersistentObjectConverterTest extends UnitTestCase
      */
     protected $mockObjectManager;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->converter = new PersistentObjectConverter();
         $this->mockReflectionService = $this->createMock(ReflectionService::class);
@@ -295,7 +295,7 @@ class PersistentObjectConverterTest extends UnitTestCase
      * @param \PHPUnit_Framework_MockObject_Matcher_Invocation $howOftenIsGetFirstCalled
      * @return \stdClass
      */
-    public function setupMockQuery($numberOfResults, $howOftenIsGetFirstCalled)
+    protected function setUpMockQuery($numberOfResults, $howOftenIsGetFirstCalled)
     {
         $mockClassSchema = $this->createMock(ClassSchema::class, [], ['Dummy']);
         $mockClassSchema->expects($this->once())->method('getIdentityProperties')->will($this->returnValue(['key1' => 'someType']));

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/ScalarTypeToObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/ScalarTypeToObjectConverterTest.php
@@ -35,7 +35,7 @@ class ScalarTypeToObjectConverterTest extends UnitTestCase
      */
     protected $reflectionMock;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/StringConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/StringConverterTest.php
@@ -27,7 +27,7 @@ class StringConverterTest extends UnitTestCase
      */
     protected $converter;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->converter = new StringConverter();
     }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/TypedArrayConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/TypedArrayConverterTest.php
@@ -25,7 +25,7 @@ class TypedArrayConverterTest extends UnitTestCase
      */
     protected $converter;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->converter = new TypedArrayConverter();
     }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/UriTypeConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/UriTypeConverterTest.php
@@ -28,7 +28,7 @@ class UriTypeConverterTest extends UnitTestCase
 
     /**
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->typeConverter = new UriTypeConverter();

--- a/Neos.Flow/Tests/Unit/Reflection/ClassReflectionTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/ClassReflectionTest.php
@@ -77,7 +77,7 @@ class ClassReflectionTest extends UnitTestCase implements Fixture\DummyInterface
         $class = new ClassReflection(__CLASS__);
         $methods = $class->getMethods();
         foreach (array_keys($methods) as $key) {
-            $this->assertInternalType('integer', $key, 'The index was not an integer.');
+            $this->assertIsInt($key, 'The index was not an integer.');
         }
     }
 

--- a/Neos.Flow/Tests/Unit/Reflection/ClassSchemaTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/ClassSchemaTest.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\Tests\Unit\Reflection;
  */
 
 use Neos\Flow\Reflection\ClassSchema;
+use Neos\Flow\Reflection\Exception\ClassSchemaConstraintViolationException;
 use Neos\Flow\Tests\UnitTestCase;
 
 /**
@@ -83,10 +84,10 @@ class ClassSchemaTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function markAsIdentityPropertyRejectsUnknownProperties()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $classSchema = new ClassSchema('SomeClass');
 
         $classSchema->markAsIdentityProperty('unknownProperty');
@@ -94,10 +95,10 @@ class ClassSchemaTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function markAsIdentityPropertyRejectsLazyLoadedProperties()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $classSchema = new ClassSchema('SomeClass');
         $classSchema->addProperty('lazyProperty', 'Neos\Flow\SomeObject', true);
 
@@ -168,10 +169,10 @@ class ClassSchemaTest extends UnitTestCase
     /**
      * @dataProvider invalidPropertyTypes()
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function addPropertyRejectsInvalidPropertyTypes($propertyType)
     {
+        $this->expectException(\InvalidArgumentException::class);
         $classSchema = new ClassSchema('SomeClass');
         $classSchema->addProperty('a', $propertyType);
     }
@@ -193,10 +194,10 @@ class ClassSchemaTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Reflection\Exception\ClassSchemaConstraintViolationException
      */
     public function markAsIdentityPropertyThrowsExceptionForValueObjects()
     {
+        $this->expectException(ClassSchemaConstraintViolationException::class);
         $classSchema = new ClassSchema('SomeClass');
         $classSchema->setModelType(ClassSchema::MODELTYPE_VALUEOBJECT);
         $classSchema->markAsIdentityProperty('foo');

--- a/Neos.Flow/Tests/Unit/Reflection/PropertyReflectionTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/PropertyReflectionTest.php
@@ -36,10 +36,10 @@ class PropertyReflectionTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Reflection\Exception
      */
     public function getValueThrowsAnExceptionOnReflectingANonObject()
     {
+        $this->expectException(Reflection\Exception::class);
         $reflectionProperty = new Reflection\PropertyReflection(__CLASS__, 'protectedProperty');
         $reflectionProperty->getValue(__CLASS__);
     }

--- a/Neos.Flow/Tests/Unit/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/ReflectionServiceTest.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\Tests\Unit\Reflection;
  */
 
 use Doctrine\Common\Annotations\Reader;
+use Neos\Flow\Reflection\Exception\ClassLoadingForReflectionFailedException;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Tests\UnitTestCase;
 
@@ -42,28 +43,28 @@ class ReflectionServiceTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Reflection\Exception\ClassLoadingForReflectionFailedException
      */
     public function reflectClassThrowsExceptionForNonExistingClasses()
     {
+        $this->expectException(ClassLoadingForReflectionFailedException::class);
         $this->reflectionService->_call('reflectClass', 'Non\Existing\Class');
     }
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Reflection\Exception\ClassLoadingForReflectionFailedException
      */
     public function reflectClassThrowsExceptionForFilesWithNoClass()
     {
+        $this->expectException(ClassLoadingForReflectionFailedException::class);
         $this->reflectionService->_call('reflectClass', Fixture\FileWithNoClass::class);
     }
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Reflection\Exception\ClassLoadingForReflectionFailedException
      */
     public function reflectClassThrowsExceptionForClassesWithNoMatchingFilename()
     {
+        $this->expectException(ClassLoadingForReflectionFailedException::class);
         $this->reflectionService->_call('reflectClass', Fixture\ClassWithDifferentNameDifferent::class);
     }
 

--- a/Neos.Flow/Tests/Unit/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/ReflectionServiceTest.php
@@ -31,7 +31,7 @@ class ReflectionServiceTest extends UnitTestCase
      */
     protected $mockAnnotationReader;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->reflectionService = $this->getAccessibleMock(ReflectionService::class, null);
 

--- a/Neos.Flow/Tests/Unit/ResourceManagement/PersistentResourceTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/PersistentResourceTest.php
@@ -93,10 +93,10 @@ class PersistentResourceTest extends UnitTestCase
     /**
      * @test
      * @dataProvider invalidSha1Values
-     * @expectedException \InvalidArgumentException
      */
     public function setSha1RejectsInvalidValues($invalidValue)
     {
+        $this->expectException(\InvalidArgumentException::class);
         $resource = new PersistentResource();
         $resource->setSha1($invalidValue);
         $this->assertSame('d0be2dc421be4fcd0172e5afceea3970e2f3d940', $resource->getSha1());

--- a/Neos.Flow/Tests/Unit/ResourceManagement/ResourceTypeConverterTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/ResourceTypeConverterTest.php
@@ -41,7 +41,7 @@ class ResourceTypeConverterTest extends UnitTestCase
      */
     protected $mockResourceManager;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->resourceTypeConverter = $this->getAccessibleMock(ResourceTypeConverter::class, ['dummy']);
 

--- a/Neos.Flow/Tests/Unit/ResourceManagement/Storage/WritableFileSystemStorageTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/Storage/WritableFileSystemStorageTest.php
@@ -38,7 +38,7 @@ class WritableFileSystemStorageTest extends UnitTestCase
      */
     protected $mockEnvironment;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockDirectory = vfsStream::setup('WritableFileSystemStorageTest');
 

--- a/Neos.Flow/Tests/Unit/ResourceManagement/Streams/ResourceStreamWrapperTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/Streams/ResourceStreamWrapperTest.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\Tests\Unit\ResourceManagement\Streams;
  */
 
 use Neos\Flow\Package\FlowPackageInterface;
+use Neos\Flow\ResourceManagement\Exception;
 use org\bovigo\vfs\vfsStream;
 use Neos\Flow\Package\PackageManager;
 use Neos\Flow\ResourceManagement\PersistentResource;
@@ -54,10 +55,10 @@ class ResourceStreamWrapperTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function openThrowsExceptionForInvalidScheme()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $openedPathAndFilename = '';
         $this->resourceStreamWrapper->open('invalid-scheme://foo/bar', 'r', 0, $openedPathAndFilename);
     }
@@ -100,10 +101,10 @@ class ResourceStreamWrapperTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\ResourceManagement\Exception
      */
     public function openThrowsExceptionForNonExistingPackages()
     {
+        $this->expectException(Exception::class);
         $packageKey = 'Non.Existing.Package';
         $this->mockPackageManager->expects(self::once())->method('getPackage')->willThrowException(new \Neos\Flow\Package\Exception\UnknownPackageException('Test exception'));
 

--- a/Neos.Flow/Tests/Unit/ResourceManagement/Streams/ResourceStreamWrapperTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/Streams/ResourceStreamWrapperTest.php
@@ -39,7 +39,7 @@ class ResourceStreamWrapperTest extends UnitTestCase
      */
     protected $mockResourceManager;
 
-    public function setUp()
+    protected function setUp(): void
     {
         vfsStream::setup('Foo');
 

--- a/Neos.Flow/Tests/Unit/ResourceManagement/Streams/StreamWrapperAdapterTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/Streams/StreamWrapperAdapterTest.php
@@ -31,7 +31,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
     protected $mockStreamWrapper;
 
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->streamWrapperAdapter = $this->getAccessibleMock(StreamWrapperAdapter::class, ['createStreamWrapper']);
         $this->mockStreamWrapper = $this->createMock(StreamWrapperInterface::class);

--- a/Neos.Flow/Tests/Unit/ResourceManagement/Target/FileSystemTargetTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/Target/FileSystemTargetTest.php
@@ -51,7 +51,7 @@ class FileSystemTargetTest extends UnitTestCase
      */
     protected $mockHttpRequest;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->fileSystemTarget = new FileSystemTarget('test');
 

--- a/Neos.Flow/Tests/Unit/ResourceManagement/Target/FileSystemTargetTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/Target/FileSystemTargetTest.php
@@ -21,6 +21,7 @@ use Neos\Flow\Package\PackageManager;
 use Neos\Flow\ResourceManagement\Collection;
 use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\Flow\ResourceManagement\Storage\PackageStorage;
+use Neos\Flow\ResourceManagement\Target\Exception;
 use Neos\Flow\ResourceManagement\Target\FileSystemTarget;
 use Neos\Flow\Tests\UnitTestCase;
 use org\bovigo\vfs\vfsStream;
@@ -118,10 +119,10 @@ class FileSystemTargetTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\ResourceManagement\Target\Exception
      */
     public function getPublicStaticResourceUriThrowsExceptionIfBaseUriCantBeResolved()
     {
+        $this->expectException(Exception::class);
         $mockBootstrap = $this->getMockBuilder(Bootstrap::class)->disableOriginalConstructor()->getMock();
         $mockCommandRequestHandler = $this->getMockBuilder(CommandRequestHandler::class)->disableOriginalConstructor()->getMock();
         $mockBootstrap->expects($this->any())->method('getActiveRequestHandler')->will($this->returnValue($mockCommandRequestHandler));
@@ -186,10 +187,10 @@ class FileSystemTargetTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\ResourceManagement\Target\Exception
      */
     public function getPublicPersistentResourceUriThrowsExceptionIfBaseUriCantBeResolved()
     {
+        $this->expectException(Exception::class);
         $mockBootstrap = $this->getMockBuilder(Bootstrap::class)->disableOriginalConstructor()->getMock();
         $mockCommandRequestHandler = $this->getMockBuilder(CommandRequestHandler::class)->disableOriginalConstructor()->getMock();
         $mockBootstrap->expects($this->any())->method('getActiveRequestHandler')->will($this->returnValue($mockCommandRequestHandler));

--- a/Neos.Flow/Tests/Unit/Security/AccountTest.php
+++ b/Neos.Flow/Tests/Unit/Security/AccountTest.php
@@ -40,7 +40,7 @@ class AccountTest extends UnitTestCase
     /**
      * Setup function for the test case
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $administratorRole = new Role('Neos.Flow:Administrator');
         $this->administratorRole = $administratorRole;

--- a/Neos.Flow/Tests/Unit/Security/Aspect/PolicyEnforcementAspectTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Aspect/PolicyEnforcementAspectTest.php
@@ -47,7 +47,7 @@ class PolicyEnforcementAspectTest extends UnitTestCase
      */
     protected $policyEnforcementAspect;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockJoinPoint = $this->getMockBuilder(JoinPointInterface::class)->disableOriginalConstructor()->getMock();
         $this->mockAdviceChain = $this->getMockBuilder(AdviceChain::class)->disableOriginalConstructor()->getMock();

--- a/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderManagerTest.php
@@ -54,7 +54,7 @@ class AuthenticationProviderManagerTest extends UnitTestCase
     /**
      * Sets up this test case
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->tokenAndProviderFactory = $this->getMockBuilder(TokenAndProviderFactoryInterface::class)->getMock();
         $this->authenticationProviderManager = $this->getAccessibleMock(AuthenticationProviderManager::class, ['dummy'], [$this->tokenAndProviderFactory], '', true);

--- a/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderManagerTest.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Tests\Unit\Security\Authentication;
 
 use Neos\Flow\Security\Authentication\AuthenticationProviderInterface;
 use Neos\Flow\Security\Authentication\TokenAndProviderFactoryInterface;
+use Neos\Flow\Security\Exception\AuthenticationRequiredException;
 use Neos\Flow\Session\SessionManager;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\Security\Account;
@@ -159,10 +160,10 @@ class AuthenticationProviderManagerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\AuthenticationRequiredException
      */
     public function authenticateThrowsAnExceptionIfNoTokenCouldBeAuthenticated()
     {
+        $this->expectException(AuthenticationRequiredException::class);
         $token1 = $this->createMock(TokenInterface::class);
         $token2 = $this->createMock(TokenInterface::class);
 
@@ -176,10 +177,10 @@ class AuthenticationProviderManagerTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\AuthenticationRequiredException
      */
     public function authenticateThrowsAnExceptionIfAuthenticateAllTokensIsTrueButATokenCouldNotBeAuthenticated()
     {
+        $this->expectException(AuthenticationRequiredException::class);
         $token1 = $this->createMock(TokenInterface::class);
         $token2 = $this->createMock(TokenInterface::class);
 

--- a/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderResolverTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderResolverTest.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Tests\Unit\Security\Authentication;
 
 use Neos\Flow\ObjectManagement\ObjectManager;
 use Neos\Flow\Security\Authentication\AuthenticationProviderResolver;
+use Neos\Flow\Security\Exception\NoAuthenticationProviderFoundException;
 use Neos\Flow\Tests\UnitTestCase;
 
 /**
@@ -22,10 +23,10 @@ class AuthenticationProviderResolverTest extends UnitTestCase
 {
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\NoAuthenticationProviderFoundException
      */
     public function resolveProviderObjectNameThrowsAnExceptionIfNoProviderIsAvailable()
     {
+        $this->expectException(NoAuthenticationProviderFoundException::class);
         $mockObjectManager = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->getMock();
         $mockObjectManager->expects($this->any())->method('getClassNameByObjectName')->will($this->returnValue(false));
 

--- a/Neos.Flow/Tests/Unit/Security/Authentication/EntryPoint/WebRedirectTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/EntryPoint/WebRedirectTest.php
@@ -16,6 +16,7 @@ use Neos\Flow\Http\Response;
 use Neos\Flow\Http\Uri;
 use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\Flow\Security\Authentication\EntryPoint\WebRedirect;
+use Neos\Flow\Security\Exception\MissingConfigurationException;
 use Neos\Flow\Tests\UnitTestCase;
 
 /**
@@ -25,10 +26,10 @@ class WebRedirectTest extends UnitTestCase
 {
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\MissingConfigurationException
      */
     public function startAuthenticationThrowsAnExceptionIfTheConfigurationOptionsAreMissing()
     {
+        $this->expectException(MissingConfigurationException::class);
         $request = Request::create(new Uri('http://robertlemke.com/admin'));
         $response = new Response();
 
@@ -73,10 +74,10 @@ class WebRedirectTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\MissingConfigurationException
      */
     public function startAuthenticationThrowsAnExceptionIfTheConfiguredRoutePartsAreInvalid()
     {
+        $this->expectException(MissingConfigurationException::class);
         $request = Request::create(new Uri('http://robertlemke.com/admin'));
         $response = new Response();
 

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Provider/FileBasedSimpleKeyProviderTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Provider/FileBasedSimpleKeyProviderTest.php
@@ -16,6 +16,7 @@ use Neos\Flow\Security\Authentication\Token\PasswordToken;
 use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\Cryptography\FileBasedSimpleKeyService;
 use Neos\Flow\Security\Cryptography\HashService;
+use Neos\Flow\Security\Exception\UnsupportedAuthenticationTokenException;
 use Neos\Flow\Security\Policy\PolicyService;
 use Neos\Flow\Security\Policy\Role;
 use Neos\Flow\Tests\UnitTestCase;
@@ -161,10 +162,10 @@ class FileBasedSimpleKeyProviderTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\UnsupportedAuthenticationTokenException
      */
     public function authenticatingAnUnsupportedTokenThrowsAnException()
     {
+        $this->expectException(UnsupportedAuthenticationTokenException::class);
         $someInvalidToken = $this->createMock(TokenInterface::class);
 
         $authenticationProvider = FileBasedSimpleKeyProvider::create('myProvider', []);

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Provider/FileBasedSimpleKeyProviderTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Provider/FileBasedSimpleKeyProviderTest.php
@@ -61,7 +61,7 @@ class FileBasedSimpleKeyProviderTest extends UnitTestCase
      */
     protected $mockToken;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockRole = $this->getMockBuilder(Role::class)->disableOriginalConstructor()->getMock();
         $this->mockRole->expects($this->any())->method('getIdentifier')->will($this->returnValue('Neos.Flow:TestRoleIdentifier'));

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
@@ -128,10 +128,10 @@ class PersistedUsernamePasswordProviderTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\UnsupportedAuthenticationTokenException
      */
     public function authenticatingAnUnsupportedTokenThrowsAnException()
     {
+        $this->expectException(Security\Exception\UnsupportedAuthenticationTokenException::class);
         $someNiceToken = $this->createMock(Security\Authentication\TokenInterface::class);
 
         $usernamePasswordProvider = Security\Authentication\Provider\PersistedUsernamePasswordProvider::create('myProvider', []);

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
@@ -56,7 +56,7 @@ class PersistedUsernamePasswordProviderTest extends UnitTestCase
     protected $persistedUsernamePasswordProvider;
 
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockHashService = $this->createMock(Security\Cryptography\HashService::class);
         $this->mockAccount = $this->getMockBuilder(Security\Account::class)->disableOriginalConstructor()->getMock();

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Token/AbstractTokenTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Token/AbstractTokenTest.php
@@ -28,7 +28,7 @@ class AbstractTokenTest extends UnitTestCase
      */
     protected $token;
 
-    public function setup()
+    protected function setUp(): void
     {
         $this->token = $this->getMockForAbstractClass(AbstractToken::class);
     }

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Token/AbstractTokenTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Token/AbstractTokenTest.php
@@ -14,6 +14,7 @@ namespace Neos\Flow\Tests\Unit\Security\Authentication\Token;
 use Neos\Flow\Security\Authentication\EntryPoint\WebRedirect;
 use Neos\Flow\Security\Authentication\Token\AbstractToken;
 use Neos\Flow\Security\Authentication\TokenInterface;
+use Neos\Flow\Security\Exception\InvalidAuthenticationStatusException;
 use Neos\Flow\Security\RequestPattern\Uri as UriRequestPattern;
 use Neos\Flow\Tests\UnitTestCase;
 
@@ -91,10 +92,10 @@ class AbstractTokenTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\InvalidAuthenticationStatusException
      */
     public function setAuthenticationStatusThrowsAnExceptionForAnInvalidStatus()
     {
+        $this->expectException(InvalidAuthenticationStatusException::class);
         $this->token->setAuthenticationStatus(-1);
     }
 
@@ -114,10 +115,10 @@ class AbstractTokenTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function setRequestPatternsOnlyAcceptsRequestPatterns()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $uriRequestPattern = new UriRequestPattern(['uriPattern' => 'http://mydomain.com/some/path/pattern']);
         $this->token->setRequestPatterns([$uriRequestPattern, 'no valid pattern']);
     }

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Token/PasswordTokenTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Token/PasswordTokenTest.php
@@ -40,7 +40,7 @@ class PasswordTokenTest extends UnitTestCase
     /**
      * Set up this test case
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->token = new PasswordToken();
 

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Token/UsernamePasswordHttpBasicTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Token/UsernamePasswordHttpBasicTest.php
@@ -32,7 +32,7 @@ class UsernamePasswordHttpBasicTest extends UnitTestCase
     /**
      * Sets up this test case
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->token = new UsernamePasswordHttpBasic();
     }

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Token/UsernamePasswordTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Token/UsernamePasswordTest.php
@@ -41,7 +41,7 @@ class UsernamePasswordTest extends UnitTestCase
     /**
      * Set up this test case
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->token = new UsernamePassword();
 

--- a/Neos.Flow/Tests/Unit/Security/Authentication/TokenAndProviderFactoryTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/TokenAndProviderFactoryTest.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Tests\Unit\Security\Authentication;
 
 use Neos\Flow\Security\Authentication\AuthenticationProviderResolver;
 use Neos\Flow\Security\Authentication\TokenAndProviderFactory;
+use Neos\Flow\Security\Exception\InvalidAuthenticationProviderException;
 use Neos\Flow\Security\RequestPatternResolver;
 use Neos\Flow\Tests\UnitTestCase;
 
@@ -37,10 +38,10 @@ class TokenAndProviderFactoryTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\InvalidAuthenticationProviderException
      */
     public function anExceptionIsThrownIfTheConfiguredProviderDoesNotExist()
     {
+        $this->expectException(InvalidAuthenticationProviderException::class);
         $providerConfiguration = [
             'NotExistingProvider' => [
                 'providerClass' => 'NotExistingProviderClass'

--- a/Neos.Flow/Tests/Unit/Security/Authorization/FilterFirewallTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authorization/FilterFirewallTest.php
@@ -18,6 +18,7 @@ use Neos\Flow\Security\Authorization\Interceptor\AccessGrant;
 use Neos\Flow\Security\Authorization\InterceptorInterface;
 use Neos\Flow\Security\Authorization\InterceptorResolver;
 use Neos\Flow\Security\Authorization\RequestFilter;
+use Neos\Flow\Security\Exception\AccessDeniedException;
 use Neos\Flow\Security\RequestPattern\Uri;
 use Neos\Flow\Security\RequestPatternResolver;
 use Neos\Flow\Tests\UnitTestCase;
@@ -144,10 +145,10 @@ class FilterFirewallTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\AccessDeniedException
      */
     public function ifRejectAllIsSetAndNoFilterExplicitlyAllowsTheRequestAPermissionDeniedExceptionIsThrown()
     {
+        $this->expectException(AccessDeniedException::class);
         $mockActionRequest = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->getMock();
 
         $mockFilter1 = $this->getMockBuilder(RequestFilter::class)->disableOriginalConstructor()->getMock();

--- a/Neos.Flow/Tests/Unit/Security/Authorization/InterceptorResolverTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authorization/InterceptorResolverTest.php
@@ -22,10 +22,10 @@ class InterceptorResolverTest extends UnitTestCase
 {
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\NoInterceptorFoundException
      */
     public function resolveInterceptorClassThrowsAnExceptionIfNoInterceptorIsAvailable()
     {
+        $this->expectException(Security\Exception\NoInterceptorFoundException::class);
         $mockObjectManager = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->getMock();
         $mockObjectManager->expects($this->any())->method('getClassNameByObjectName')->will($this->returnValue(false));
 

--- a/Neos.Flow/Tests/Unit/Security/Authorization/PrivilegeManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authorization/PrivilegeManagerTest.php
@@ -67,7 +67,7 @@ class PrivilegeManagerTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockSecurityContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
         $this->mockObjectManager = $this->getMockBuilder(ObjectManagerInterface::class)->getMock();

--- a/Neos.Flow/Tests/Unit/Security/ContextTest.php
+++ b/Neos.Flow/Tests/Unit/Security/ContextTest.php
@@ -61,7 +61,7 @@ class ContextTest extends UnitTestCase
     /**
      * Sets up this test case
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockSessionDataContainer = $this->createMock(SessionDataContainer::class);
 

--- a/Neos.Flow/Tests/Unit/Security/ContextTest.php
+++ b/Neos.Flow/Tests/Unit/Security/ContextTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Tests\Unit\Security;
  * source code.
  */
 
+use Neos\Flow\Exception;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Security\Authentication\AuthenticationManagerInterface;
@@ -437,11 +438,11 @@ class ContextTest extends UnitTestCase
     }
 
     /**
-     * @expectedException \Neos\Flow\Exception
      * @test
      */
     public function invalidAuthenticationStrategyFromConfigurationThrowsException()
     {
+        $this->expectException(Exception::class);
         $settings = [];
         $settings['security']['authentication']['authenticationStrategy'] = 'fizzleGoesHere';
 
@@ -482,11 +483,11 @@ class ContextTest extends UnitTestCase
     }
 
     /**
-     * @expectedException \Neos\Flow\Exception
      * @test
      */
     public function invalidCsrfProtectionStrategyFromConfigurationThrowsException()
     {
+        $this->expectException(Exception::class);
         $settings = [];
         $settings['security']['csrf']['csrfStrategy'] = 'fizzleGoesHere';
 

--- a/Neos.Flow/Tests/Unit/Security/Cryptography/HashServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Cryptography/HashServiceTest.php
@@ -59,7 +59,7 @@ class HashServiceTest extends UnitTestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->cache = new StringFrontend('TestCache', new TransientMemoryBackend(new EnvironmentConfiguration('Hash Testing', '/some/path', PHP_MAXPATHLEN)));
         $this->cache->initializeObject();

--- a/Neos.Flow/Tests/Unit/Security/Cryptography/HashServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Cryptography/HashServiceTest.php
@@ -17,6 +17,9 @@ use Neos\Cache\Frontend\StringFrontend;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Security\Cryptography\HashService;
 use Neos\Flow\Security\Cryptography\PasswordHashingStrategyInterface;
+use Neos\Flow\Security\Exception\InvalidArgumentForHashGenerationException;
+use Neos\Flow\Security\Exception\InvalidHashException;
+use Neos\Flow\Security\Exception\MissingConfigurationException;
 use Neos\Flow\Tests\Unit\Cryptography\Fixture\TestHashingStrategy;
 use Neos\Flow\Tests\UnitTestCase;
 
@@ -102,10 +105,10 @@ class HashServiceTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\InvalidArgumentForHashGenerationException
      */
     public function generateHmacThrowsExceptionIfNoStringGiven()
     {
+        $this->expectException(InvalidArgumentForHashGenerationException::class);
         $this->hashService->generateHmac(null);
     }
 
@@ -170,20 +173,20 @@ class HashServiceTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\MissingConfigurationException
      */
     public function hashPasswordThrowsExceptionIfTheGivenHashingStrategyIsNotConfigured()
     {
+        $this->expectException(MissingConfigurationException::class);
         $this->hashService->hashPassword('myTestPassword', 'nonExistingHashingStrategy');
     }
 
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\MissingConfigurationException
      */
     public function hashPasswordThrowsExceptionIfNoDefaultHashingStrategyIsConfigured()
     {
+        $this->expectException(MissingConfigurationException::class);
         $mockSettings = [
             'security' => [
                 'cryptography' => [
@@ -222,10 +225,10 @@ class HashServiceTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\InvalidArgumentForHashGenerationException
      */
     public function appendHmacThrowsExceptionIfNoStringGiven()
     {
+        $this->expectException(InvalidArgumentForHashGenerationException::class);
         $this->hashService->appendHmac(null);
     }
 
@@ -241,37 +244,37 @@ class HashServiceTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\InvalidArgumentForHashGenerationException
      */
     public function validateAndStripHmacThrowsExceptionIfNoStringGiven()
     {
+        $this->expectException(InvalidArgumentForHashGenerationException::class);
         $this->hashService->validateAndStripHmac(null);
     }
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\InvalidArgumentForHashGenerationException
      */
     public function validateAndStripHmacThrowsExceptionIfGivenStringIsTooShort()
     {
+        $this->expectException(InvalidArgumentForHashGenerationException::class);
         $this->hashService->validateAndStripHmac('string with less than 40 characters');
     }
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\InvalidHashException
      */
     public function validateAndStripHmacThrowsExceptionIfGivenStringHasNoHashAppended()
     {
+        $this->expectException(InvalidHashException::class);
         $this->hashService->validateAndStripHmac('string with exactly a length 40 of chars');
     }
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\InvalidHashException
      */
     public function validateAndStripHmacThrowsExceptionIfTheAppendedHashIsInvalid()
     {
+        $this->expectException(InvalidHashException::class);
         $this->hashService->validateAndStripHmac('some Stringac43682075d36592d4cb320e69ff0aa515886eab');
     }
 

--- a/Neos.Flow/Tests/Unit/Security/Cryptography/RsaWalletServicePhpTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Cryptography/RsaWalletServicePhpTest.php
@@ -38,7 +38,7 @@ class RsaWalletServicePhpTest extends UnitTestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         vfsStream::setup('Foo');
         $settings['security']['cryptography']['RSAWalletServicePHP']['keystorePath'] = 'vfs://Foo/EncryptionKey';

--- a/Neos.Flow/Tests/Unit/Security/Cryptography/RsaWalletServicePhpTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Cryptography/RsaWalletServicePhpTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Tests\Unit\Security\Cryptography;
  * source code.
  */
 
+use Neos\Flow\Security\Exception\DecryptionNotAllowedException;
 use org\bovigo\vfs\vfsStream;
 use Neos\Flow\Security\Cryptography\RsaWalletServicePhp;
 use Neos\Flow\Tests\UnitTestCase;
@@ -104,10 +105,10 @@ class RsaWalletServicePhpTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\DecryptionNotAllowedException
      */
     public function decryptingWithAKeypairUUIDMarkedForPasswordUsageThrowsAnException()
     {
+        $this->expectException(DecryptionNotAllowedException::class);
         $this->keyPairUuid = $this->rsaWalletService->generateNewKeypair(true);
         $this->rsaWalletService->decrypt('some cipher', $this->keyPairUuid);
     }

--- a/Neos.Flow/Tests/Unit/Security/Policy/PolicyExpressionParserTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Policy/PolicyExpressionParserTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Tests\Unit\Security\Policy;
  * source code.
  */
 
+use Neos\Flow\Aop\Exception\InvalidPointcutExpressionException;
 use Neos\Flow\Security\Authorization\Privilege\Method\MethodTargetExpressionParser;
 use Neos\Flow\Tests\UnitTestCase;
 
@@ -21,10 +22,10 @@ class PolicyExpressionParserTest extends UnitTestCase
 {
     /**
      * @test
-     * @expectedException \Neos\Flow\Aop\Exception\InvalidPointcutExpressionException
      */
     public function parseMethodThrowsAnExceptionIfAnotherPrivilegeTargetIsReferencedInAnExpression()
     {
+        $this->expectException(InvalidPointcutExpressionException::class);
         $parser = $this->getMockBuilder(MethodTargetExpressionParser::class)->setMethods(['parseDesignatorMethod'])->getMock();
         $parser->parse('method(TYPO3\TestPackage\BasicClass->setSomeProperty()) || privilegeTarget2', 'FunctionTests');
     }

--- a/Neos.Flow/Tests/Unit/Security/Policy/PolicyServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Policy/PolicyServiceTest.php
@@ -15,6 +15,7 @@ use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\ObjectManagement\ObjectManager;
 use Neos\Flow\Security\Authorization\Privilege\AbstractPrivilege;
 use Neos\Flow\Security\Authorization\Privilege\PrivilegeTarget;
+use Neos\Flow\Security\Exception\NoSuchRoleException;
 use Neos\Flow\Security\Policy\PolicyService;
 use Neos\Flow\Security\Policy\Role;
 use Neos\Flow\Tests\UnitTestCase;
@@ -88,10 +89,10 @@ class PolicyServiceTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\NoSuchRoleException
      */
     public function getRoleThrowsExceptionIfTheSpecifiedRoleIsNotConfigured()
     {
+        $this->expectException(NoSuchRoleException::class);
         $this->policyService->getRole('Non.Existing:Role');
     }
 

--- a/Neos.Flow/Tests/Unit/Security/Policy/PolicyServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Policy/PolicyServiceTest.php
@@ -49,7 +49,7 @@ class PolicyServiceTest extends UnitTestCase
      */
     protected $mockPrivilege;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->policyService = new PolicyService();
 

--- a/Neos.Flow/Tests/Unit/Security/RequestPattern/CsrfProtectionTest.php
+++ b/Neos.Flow/Tests/Unit/Security/RequestPattern/CsrfProtectionTest.php
@@ -41,7 +41,7 @@ class CsrfProtectionTest extends UnitTestCase
      */
     protected $mockSystemLogger;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Neos.Flow/Tests/Unit/Security/RequestPatternResolverTest.php
+++ b/Neos.Flow/Tests/Unit/Security/RequestPatternResolverTest.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\Tests\Unit\Security;
  */
 
 use Neos\Flow\ObjectManagement\ObjectManager;
+use Neos\Flow\Security\Exception\NoRequestPatternFoundException;
 use Neos\Flow\Security\RequestPatternResolver;
 use Neos\Flow\Tests\UnitTestCase;
 
@@ -22,10 +23,10 @@ class RequestPatternResolverTest extends UnitTestCase
 {
     /**
      * @test
-     * @expectedException \Neos\Flow\Security\Exception\NoRequestPatternFoundException
      */
     public function resolveRequestPatternClassThrowsAnExceptionIfNoRequestPatternIsAvailable()
     {
+        $this->expectException(NoRequestPatternFoundException::class);
         $mockObjectManager = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->getMock();
         $mockObjectManager->expects($this->any())->method('getClassNameByObjectName')->will($this->returnValue(false));
 

--- a/Neos.Flow/Tests/Unit/Session/SessionTest.php
+++ b/Neos.Flow/Tests/Unit/Session/SessionTest.php
@@ -82,7 +82,7 @@ class SessionTest extends UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setup();
 

--- a/Neos.Flow/Tests/Unit/Session/SessionTest.php
+++ b/Neos.Flow/Tests/Unit/Session/SessionTest.php
@@ -11,6 +11,8 @@ namespace Neos\Flow\Tests\Unit\Session;
  * source code.
  */
 
+use Neos\Flow\Session\Exception\DataNotSerializableException;
+use Neos\Flow\Session\Exception\OperationNotSupportedException;
 use org\bovigo\vfs\vfsStream;
 use Neos\Cache\Backend\FileBackend;
 use Neos\Cache\EnvironmentConfiguration;
@@ -119,10 +121,10 @@ class SessionTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function constructRequiresAStorageIdentifierIfASessionIdentifierWasGiven()
     {
+        $this->expectException(\InvalidArgumentException::class);
         new Session('ZPjPj3A0Opd7JeDoe7rzUQYCoDMcxscb');
     }
 
@@ -325,10 +327,10 @@ class SessionTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Session\Exception\SessionNotStartedException
      */
     public function renewIdThrowsExceptionIfCalledOnNonStartedSession()
     {
+        $this->expectException(SessionNotStartedException::class);
         $session = new Session();
         $this->inject($session, 'settings', $this->settings);
         $this->inject($session, 'metaDataCache', $this->createCache('Meta'));
@@ -339,10 +341,10 @@ class SessionTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Session\Exception\OperationNotSupportedException
      */
     public function renewIdThrowsExceptionIfCalledOnRemoteSession()
     {
+        $this->expectException(OperationNotSupportedException::class);
         $storageIdentifier = '6e988eaa-7010-4ee8-bfb8-96ea4b40ec16';
         $session = new Session('ZPjPj3A0Opd7JeDoe7rzUQYCoDMcxscb', $storageIdentifier, 1354293259, []);
         $this->inject($session, 'settings', $this->settings);
@@ -388,30 +390,30 @@ class SessionTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Session\Exception\SessionNotStartedException
      */
     public function getDataThrowsExceptionIfSessionIsNotStarted()
     {
+        $this->expectException(SessionNotStartedException::class);
         $session = new Session();
         $session->getData('some key');
     }
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Session\Exception\SessionNotStartedException
      */
     public function putDataThrowsExceptionIfSessionIsNotStarted()
     {
+        $this->expectException(SessionNotStartedException::class);
         $session = new Session();
         $session->putData('some key', 'some value');
     }
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Session\Exception\DataNotSerializableException
      */
     public function putDataThrowsExceptionIfTryingToPersistAResource()
     {
+        $this->expectException(DataNotSerializableException::class);
         $session = new Session();
         $this->inject($session, 'settings', $this->settings);
         $this->inject($session, 'metaDataCache', $this->createCache('Meta'));
@@ -444,10 +446,10 @@ class SessionTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Session\Exception\SessionNotStartedException
      */
     public function hasKeyThrowsExceptionIfCalledOnNonStartedSession()
     {
+        $this->expectException(SessionNotStartedException::class);
         $session = new Session();
         $session->hasKey('foo');
     }
@@ -483,10 +485,10 @@ class SessionTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Session\Exception\SessionNotStartedException
      */
     public function getLastActivityTimestampThrowsExceptionIfCalledOnNonStartedSession()
     {
+        $this->expectException(SessionNotStartedException::class);
         $session = new Session();
         $session->getLastActivityTimestamp();
     }
@@ -521,20 +523,20 @@ class SessionTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Session\Exception\SessionNotStartedException
      */
     public function addTagThrowsExceptionIfCalledOnNonStartedSession()
     {
+        $this->expectException(SessionNotStartedException::class);
         $session = new Session();
         $session->addTag('MyTag');
     }
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function addTagThrowsExceptionIfTagIsNotValid()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $taggedSession = new Session();
         $this->inject($taggedSession, 'settings', $this->settings);
         $this->inject($taggedSession, 'metaDataCache', $this->createCache('Meta'));
@@ -662,20 +664,20 @@ class SessionTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Session\Exception\SessionNotStartedException
      */
     public function getTagsThrowsExceptionIfCalledOnNonStartedSession()
     {
+        $this->expectException(SessionNotStartedException::class);
         $session = new Session();
         $session->getTags();
     }
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Session\Exception\SessionNotStartedException
      */
     public function removeTagThrowsExceptionIfCalledOnNonStartedSession()
     {
+        $this->expectException(SessionNotStartedException::class);
         $session = new Session();
         $session->removeTag('MyTag');
     }
@@ -706,10 +708,10 @@ class SessionTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Session\Exception\SessionNotStartedException
      */
     public function touchThrowsExceptionIfCalledOnNonStartedSession()
     {
+        $this->expectException(SessionNotStartedException::class);
         $session = new Session();
         $session->touch();
     }
@@ -856,10 +858,10 @@ class SessionTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Session\Exception\SessionNotStartedException
      */
     public function destroyThrowsExceptionIfSessionIsNotStarted()
     {
+        $this->expectException(SessionNotStartedException::class);
         $session = new Session();
         $session->destroy();
     }

--- a/Neos.Flow/Tests/Unit/Session/TransientSessionTest.php
+++ b/Neos.Flow/Tests/Unit/Session/TransientSessionTest.php
@@ -40,10 +40,10 @@ class TransientSessionTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Session\Exception\SessionNotStartedException
      */
     public function tryingToGetTheSessionIdWithoutStartingTheSessionThrowsAnException()
     {
+        $this->expectException(Session\Exception\SessionNotStartedException::class);
         $session = new Session\TransientSession();
         $session->getId();
     }

--- a/Neos.Flow/Tests/Unit/SignalSlot/DispatcherTest.php
+++ b/Neos.Flow/Tests/Unit/SignalSlot/DispatcherTest.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Tests\Unit\SignalSlot;
 
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\SignalSlot\Dispatcher;
+use Neos\Flow\SignalSlot\Exception\InvalidSlotException;
 use Neos\Flow\Tests\UnitTestCase;
 
 /**
@@ -159,10 +160,10 @@ class DispatcherTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\SignalSlot\Exception\InvalidSlotException
      */
     public function dispatchThrowsAnExceptionIfTheSpecifiedClassOfASlotIsUnknown()
     {
+        $this->expectException(InvalidSlotException::class);
         $mockObjectManager = $this->createMock(ObjectManagerInterface::class);
         $mockObjectManager->expects($this->once())->method('isRegistered')->with('NonExistingClassName')->will($this->returnValue(false));
 
@@ -174,10 +175,10 @@ class DispatcherTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\SignalSlot\Exception\InvalidSlotException
      */
     public function dispatchThrowsAnExceptionIfTheSpecifiedSlotMethodDoesNotExist()
     {
+        $this->expectException(InvalidSlotException::class);
         $slotClassName = 'Mock_' . md5(uniqid(mt_rand(), true));
         eval('class ' . $slotClassName . ' { function slot($foo, $baz) { $this->arguments = array($foo, $baz); } }');
         $mockSlot = new $slotClassName();
@@ -216,10 +217,10 @@ class DispatcherTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function connectWithSignalNameStartingWithEmitShouldNotBeAllowed()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $mockSignal = $this->getMockBuilder('stdClass')->setMethods(['emitSomeSignal'])->getMock();
         $mockSlot = $this->getMockBuilder('stdClass')->setMethods(['someSlotMethod'])->getMock();
 

--- a/Neos.Flow/Tests/Unit/Validation/Validator/AbstractValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/AbstractValidatorTest.php
@@ -21,7 +21,7 @@ class AbstractValidatorTest extends UnitTestCase
 {
     protected $validator;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->validator = $this->getAccessibleMockForAbstractClass(AbstractValidator::class, [], '', false);
         $this->validator->_set('supportedOptions', [

--- a/Neos.Flow/Tests/Unit/Validation/Validator/AbstractValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/AbstractValidatorTest.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\Tests\Unit\Validation\Validator;
  */
 
 use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Validation\Exception\InvalidValidationOptionsException;
 use Neos\Flow\Validation\Validator\AbstractValidator;
 
 /**
@@ -43,10 +44,10 @@ class AbstractValidatorTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Validation\Exception\InvalidValidationOptionsException
      */
     public function abstractValidatorConstructWithoutRequiredOptionShouldFail()
     {
+        $this->expectException(InvalidValidationOptionsException::class);
         $this->validator->__construct([]);
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/AbstractValidatorTestcase.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/AbstractValidatorTestcase.php
@@ -27,7 +27,7 @@ abstract class AbstractValidatorTestcase extends UnitTestCase
      */
     protected $validator;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->validator = $this->getValidator();
     }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/CollectionValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/CollectionValidatorTest.php
@@ -30,7 +30,7 @@ class CollectionValidatorTest extends AbstractValidatorTestcase
 
     protected $mockValidatorResolver;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->mockValidatorResolver = $this->getMockBuilder(ValidatorResolver::class)->setMethods(['createValidator', 'buildBaseValidatorConjunction'])->getMock();

--- a/Neos.Flow/Tests/Unit/Validation/Validator/ConjunctionValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/ConjunctionValidatorTest.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\Tests\Unit\Validation\Validator;
  */
 
 use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Validation\Exception\NoSuchValidatorException;
 use Neos\Flow\Validation\Validator\ConjunctionValidator;
 use Neos\Flow\Validation\Validator\ValidatorInterface;
 use Neos\Error\Messages as Error;
@@ -115,10 +116,10 @@ class ConjunctionValidatorTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Validation\Exception\NoSuchValidatorException
      */
     public function removingANotExistingValidatorIndexThrowsException()
     {
+        $this->expectException(NoSuchValidatorException::class);
         $validatorConjunction = new ConjunctionValidator([]);
         $validator = $this->createMock(ValidatorInterface::class);
         $validatorConjunction->removeValidator($validator);

--- a/Neos.Flow/Tests/Unit/Validation/Validator/DateTimeRangeValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/DateTimeRangeValidatorTest.php
@@ -34,7 +34,7 @@ class DateTimeRangeValidatorTest extends AbstractValidatorTestcase
     /**
      * Sets up this test case
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->accessibleValidator = $this->getAccessibleMock(DateTimeRangeValidator::class, ['dummy']);
     }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/DateTimeValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/DateTimeValidatorTest.php
@@ -34,7 +34,7 @@ class DateTimeValidatorTest extends AbstractValidatorTestcase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->sampleLocale = new Locale('en_GB');

--- a/Neos.Flow/Tests/Unit/Validation/Validator/NumberValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/NumberValidatorTest.php
@@ -35,7 +35,7 @@ class NumberValidatorTest extends AbstractValidatorTestcase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->sampleLocale = new Locale('en_GB');

--- a/Neos.Flow/Tests/Unit/Validation/Validator/RegularExpressionValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/RegularExpressionValidatorTest.php
@@ -33,10 +33,10 @@ class RegularExpressionValidatorTest extends AbstractValidatorTestcase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Validation\Exception\InvalidValidationOptionsException
      */
     public function validateThrowsExceptionIfExpressionIsEmpty()
     {
+        $this->expectException(Validation\Exception\InvalidValidationOptionsException::class);
         $this->validatorOptions([]);
         $this->validator->validate('foo');
     }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/RegularExpressionValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/RegularExpressionValidatorTest.php
@@ -27,7 +27,7 @@ class RegularExpressionValidatorTest extends AbstractValidatorTestcase
     /**
      * Looks empty - and that's the purpose: do not run the parent's setUp().
      */
-    public function setUp()
+    protected function setUp(): void
     {
     }
 

--- a/Neos.Flow/Tests/Unit/Validation/Validator/StringLengthValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/StringLengthValidatorTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Tests\Unit\Validation\Validator;
  * source code.
  */
 
+use Neos\Flow\Validation\Exception\InvalidValidationOptionsException;
 use Neos\Flow\Validation\Validator\StringLengthValidator;
 
 require_once('AbstractValidatorTestcase.php');
@@ -136,10 +137,10 @@ class StringLengthValidatorTest extends AbstractValidatorTestcase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Validation\Exception\InvalidValidationOptionsException
      */
     public function stringLengthValidatorThrowsAnExceptionIfMinLengthIsGreaterThanMaxLength()
     {
+        $this->expectException(InvalidValidationOptionsException::class);
         $this->validator = $this->getMockBuilder(StringLengthValidator::class)->disableOriginalConstructor()->setMethods(['addError'])->getMock();
         $this->validatorOptions(['minimum' => 101, 'maximum' => 100]);
         $this->validator->validate('1234567890');

--- a/Neos.Flow/Tests/Unit/Validation/Validator/UniqueEntityValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/UniqueEntityValidatorTest.php
@@ -36,7 +36,7 @@ class UniqueEntityValidatorTest extends AbstractValidatorTestcase
 
     /**
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->classSchema = $this->getMockBuilder(ClassSchema::class)->disableOriginalConstructor()->getMock();

--- a/Neos.Flow/Tests/Unit/Validation/Validator/UniqueEntityValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/UniqueEntityValidatorTest.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Tests\Unit\Validation\Validator;
 
 use Neos\Flow\Reflection\ClassSchema;
 use Neos\Flow\Reflection\ReflectionService;
+use Neos\Flow\Validation\Exception\InvalidValidationOptionsException;
 use Neos\Flow\Validation\Validator\UniqueEntityValidator;
 
 /**
@@ -48,21 +49,21 @@ class UniqueEntityValidatorTest extends AbstractValidatorTestcase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Validation\Exception\InvalidValidationOptionsException
-     * @expectedExceptionCode 1358454270
      */
     public function validatorThrowsExceptionIfValueIsNotAnObject()
     {
+        $this->expectException(InvalidValidationOptionsException::class);
+        $this->expectExceptionCode(1358454270);
         $this->validator->validate('a string');
     }
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Validation\Exception\InvalidValidationOptionsException
-     * @expectedExceptionCode 1358454284
      */
     public function validatorThrowsExceptionIfValueIsNotReflectedAtAll()
     {
+        $this->expectException(InvalidValidationOptionsException::class);
+        $this->expectExceptionCode(1358454284);
         $this->classSchema->expects($this->once())->method('getModelType')->will($this->returnValue(null));
 
         $this->validator->validate(new \stdClass());
@@ -70,11 +71,11 @@ class UniqueEntityValidatorTest extends AbstractValidatorTestcase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Validation\Exception\InvalidValidationOptionsException
-     * @expectedExceptionCode 1358454284
      */
     public function validatorThrowsExceptionIfValueIsNotAFlowEntity()
     {
+        $this->expectException(InvalidValidationOptionsException::class);
+        $this->expectExceptionCode(1358454284);
         $this->classSchema->expects($this->once())->method('getModelType')->will($this->returnValue(ClassSchema::MODELTYPE_VALUEOBJECT));
 
         $this->validator->validate(new \stdClass());
@@ -82,11 +83,11 @@ class UniqueEntityValidatorTest extends AbstractValidatorTestcase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Validation\Exception\InvalidValidationOptionsException
-     * @expectedExceptionCode 1358960500
      */
     public function validatorThrowsExceptionIfSetupPropertiesAreNotPresentInActualClass()
     {
+        $this->expectException(InvalidValidationOptionsException::class);
+        $this->expectExceptionCode(1358960500);
         $this->prepareMockExpectations();
         $this->inject($this->validator, 'options', ['identityProperties' => ['propertyWhichDoesntExist']]);
         $this->classSchema
@@ -100,11 +101,11 @@ class UniqueEntityValidatorTest extends AbstractValidatorTestcase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Validation\Exception\InvalidValidationOptionsException
-     * @expectedExceptionCode 1358459831
      */
     public function validatorThrowsExceptionIfThereIsNoIdentityProperty()
     {
+        $this->expectException(InvalidValidationOptionsException::class);
+        $this->expectExceptionCode(1358459831);
         $this->prepareMockExpectations();
         $this->classSchema
             ->expects($this->once())
@@ -116,11 +117,11 @@ class UniqueEntityValidatorTest extends AbstractValidatorTestcase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Validation\Exception\InvalidValidationOptionsException
-     * @expectedExceptionCode 1358501745
      */
     public function validatorThrowsExceptionOnMultipleOrmIdAnnotations()
     {
+        $this->expectException(InvalidValidationOptionsException::class);
+        $this->expectExceptionCode(1358501745);
         $this->prepareMockExpectations();
         $this->classSchema
             ->expects($this->once())

--- a/Neos.Flow/Tests/Unit/Validation/ValidatorResolverTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/ValidatorResolverTest.php
@@ -16,6 +16,7 @@ use Neos\Flow\ObjectManagement\Configuration\Configuration;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Validation\Exception\InvalidValidationConfigurationException;
 use Neos\Flow\Validation\Validator\CollectionValidator;
 use Neos\Flow\Validation\Validator\ConjunctionValidator;
 use Neos\Flow\Validation\Validator\DateTimeValidator;
@@ -215,10 +216,10 @@ class ValidatorResolverTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Validation\Exception\InvalidValidationConfigurationException
      */
     public function createValidatorThrowsExceptionForSingletonValidatorsWithOptions()
     {
+        $this->expectException(InvalidValidationConfigurationException::class);
         $mockObjectManager = $this->createMock(ObjectManagerInterface::class);
         $mockObjectManager->expects($this->once())->method('getScope')->with('FooType')->will($this->returnValue(Configuration::SCOPE_SINGLETON));
 
@@ -361,10 +362,10 @@ class ValidatorResolverTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Validation\Exception\InvalidValidationConfigurationException
      */
     public function buildMethodArgumentsValidatorConjunctionsThrowsExceptionIfValidationAnnotationForNonExistingArgumentExists()
     {
+        $this->expectException(InvalidValidationConfigurationException::class);
         $mockObject = new \stdClass();
 
         $methodParameters = [

--- a/Neos.Flow/Tests/Unit/Validation/ValidatorResolverTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/ValidatorResolverTest.php
@@ -47,7 +47,7 @@ class ValidatorResolverTest extends UnitTestCase
      */
     protected $mockReflectionService;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockObjectManager = $this->createMock(ObjectManagerInterface::class);
         $this->mockReflectionService = $this->createMock(ReflectionService::class);

--- a/Neos.FluidAdaptor/Tests/Functional/Core/WidgetTest.php
+++ b/Neos.FluidAdaptor/Tests/Functional/Core/WidgetTest.php
@@ -21,7 +21,7 @@ class WidgetTest extends \Neos\Flow\Tests\FunctionalTestCase
     /**
      * Additional setup: Routes
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Neos.FluidAdaptor/Tests/Functional/Form/FormObjectsTest.php
+++ b/Neos.FluidAdaptor/Tests/Functional/Form/FormObjectsTest.php
@@ -31,7 +31,7 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
     /**
      * Initializer
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Neos.FluidAdaptor/Tests/Functional/View/StandaloneViewTest.php
+++ b/Neos.FluidAdaptor/Tests/Functional/View/StandaloneViewTest.php
@@ -16,7 +16,10 @@ use Neos\Flow\Http\Request;
 use Neos\Flow\Http\Uri;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\FluidAdaptor\Core\ViewHelper\Exception\WrongEnctypeException;
 use Neos\FluidAdaptor\Tests\Functional\View\Fixtures\View\StandaloneView;
+use Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException;
+use TYPO3Fluid\Fluid\Core\Parser\UnknownNamespaceException;
 
 /**
  * Testcase for Standalone View
@@ -79,10 +82,10 @@ class StandaloneViewTest extends FunctionalTestCase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException
      */
     public function renderThrowsExceptionIfNeitherTemplateSourceNorTemplatePathAndFilenameAreSpecified()
     {
+        $this->expectException(InvalidTemplateResourceException::class);
         $httpRequest = Request::create(new Uri('http://localhost'));
         $actionRequest = new ActionRequest($httpRequest);
 
@@ -92,10 +95,10 @@ class StandaloneViewTest extends FunctionalTestCase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException
      */
     public function renderThrowsExceptionSpecifiedTemplatePathAndFilenameDoesNotExist()
     {
+        $this->expectException(InvalidTemplateResourceException::class);
         $httpRequest = Request::create(new Uri('http://localhost'));
         $actionRequest = new ActionRequest($httpRequest);
 
@@ -106,10 +109,10 @@ class StandaloneViewTest extends FunctionalTestCase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception\WrongEnctypeException
      */
     public function renderThrowsExceptionIfWrongEnctypeIsSetForFormUpload()
     {
+        $this->expectException(WrongEnctypeException::class);
         $httpRequest = Request::create(new Uri('http://localhost'));
         $actionRequest = new ActionRequest($httpRequest);
 
@@ -120,10 +123,10 @@ class StandaloneViewTest extends FunctionalTestCase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException
      */
     public function renderThrowsExceptionIfSpecifiedTemplatePathAndFilenamePointsToADirectory()
     {
+        $this->expectException(InvalidTemplateResourceException::class);
         $request = Request::create(new Uri('http://localhost'));
         $actionRequest = new ActionRequest($request);
 
@@ -249,10 +252,10 @@ class StandaloneViewTest extends FunctionalTestCase
 
     /**
      * @test
-     * @expectedException \TYPO3Fluid\Fluid\Core\Parser\UnknownNamespaceException
      */
     public function viewThrowsExceptionWhenUnknownViewHelperIsCalled()
     {
+        $this->expectException(UnknownNamespaceException::class);
         $httpRequest = Request::create(new Uri('http://localhost'));
         $actionRequest = new ActionRequest($httpRequest);
         $actionRequest->setFormat('txt');

--- a/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
@@ -29,7 +29,7 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(AbstractConditionViewHelper::class, ['getRenderingContext', 'renderChildren', 'hasArgument']);

--- a/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
@@ -17,7 +17,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
  */
 class AbstractTagBasedViewHelperTest extends \Neos\Flow\Tests\UnitTestCase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         $this->viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\Core\ViewHelper\AbstractTagBasedViewHelper::class, ['dummy'], [], '', false);
     }

--- a/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -12,6 +12,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\Core\ViewHelper;
  */
 
 use Neos\Flow\Mvc\Controller\ControllerContext;
+use Neos\FluidAdaptor\Core\ViewHelper\Exception;
 use Neos\FluidAdaptor\Core\ViewHelper\TemplateVariableContainer;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 use Neos\FluidAdaptor\View\TemplateView;
@@ -103,10 +104,10 @@ class AbstractViewHelperTest extends \Neos\Flow\Tests\UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function registeringTheSameArgumentNameAgainThrowsException()
     {
+        $this->expectException(Exception::class);
         $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, ['render'], [], '', false);
 
         $name = 'shortName';
@@ -143,10 +144,10 @@ class AbstractViewHelperTest extends \Neos\Flow\Tests\UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function overrideArgumentThrowsExceptionWhenTryingToOverwriteAnNonexistingArgument()
     {
+        $this->expectException(Exception::class);
         $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, ['render'], [], '', false);
         $viewHelper->injectObjectManager($this->mockObjectManager);
 
@@ -260,10 +261,10 @@ class AbstractViewHelperTest extends \Neos\Flow\Tests\UnitTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function validateArgumentsCallsTheRightValidatorsAndThrowsExceptionIfValidationIsWrong()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $viewHelper = $this->getAccessibleMock(AbstractViewHelper::class, ['render', 'prepareArguments'], [], '', false);
         $viewHelper->injectObjectManager($this->mockObjectManager);
 

--- a/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -74,7 +74,7 @@ class AbstractViewHelperTest extends \Neos\Flow\Tests\UnitTestCase
         ]
     ];
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockReflectionService = $this->getMockBuilder(\Neos\Flow\Reflection\ReflectionService::class)->disableOriginalConstructor()->getMock();
         $this->mockObjectManager = $this->createMock(\Neos\Flow\ObjectManagement\ObjectManagerInterface::class);

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetControllerTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetControllerTest.php
@@ -14,6 +14,7 @@ use Neos\Flow\Http\Request;
 use Neos\Flow\Http\Response;
 use Neos\Flow\Http\Uri;
 use Neos\Flow\Tests\UnitTestCase;
+use Neos\FluidAdaptor\Core\Widget\Exception\WidgetContextNotFoundException;
 use Neos\FluidAdaptor\Core\Widget\WidgetContext;
 
 /**
@@ -23,10 +24,10 @@ class AbstractWidgetControllerTest extends UnitTestCase
 {
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\Widget\Exception\WidgetContextNotFoundException
      */
     public function processRequestShouldThrowExceptionIfWidgetContextNotFound()
     {
+        $this->expectException(WidgetContextNotFoundException::class);
         /** @var \Neos\Flow\Mvc\ActionRequest $mockActionRequest */
         $mockActionRequest = $this->createMock(\Neos\Flow\Mvc\ActionRequest::class);
         $mockActionRequest->expects($this->atLeastOnce())->method('getInternalArgument')->with('__widgetContext')->will($this->returnValue(null));

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetViewHelperTest.php
@@ -53,7 +53,7 @@ class AbstractWidgetViewHelperTest extends \Neos\Flow\Tests\UnitTestCase
 
     /**
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\Core\Widget\AbstractWidgetViewHelper::class, ['validateArguments', 'initialize', 'callRenderMethod', 'getWidgetConfiguration', 'getRenderingContext']);
 

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetViewHelperTest.php
@@ -11,6 +11,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\Core\Widget;
  * source code.
  */
 
+use Neos\FluidAdaptor\Core\Widget\Exception\MissingControllerException;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\AbstractNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\TextNode;
@@ -152,10 +153,10 @@ class AbstractWidgetViewHelperTest extends \Neos\Flow\Tests\UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\Widget\Exception\MissingControllerException
      */
     public function initiateSubRequestThrowsExceptionIfControllerIsNoWidgetController()
     {
+        $this->expectException(MissingControllerException::class);
         $controller = $this->createMock(\Neos\Flow\Mvc\Controller\ControllerInterface::class);
         $this->viewHelper->_set('controller', $controller);
 

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AjaxWidgetComponentTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AjaxWidgetComponentTest.php
@@ -87,7 +87,7 @@ class AjaxWidgetComponentTest extends UnitTestCase
 
     /**
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->ajaxWidgetComponent = new AjaxWidgetComponent();
 

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AjaxWidgetContextHolderTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AjaxWidgetContextHolderTest.php
@@ -11,6 +11,8 @@ namespace Neos\FluidAdaptor\Tests\Unit\Core\Widget;
  * source code.
  */
 
+use Neos\FluidAdaptor\Core\Widget\Exception\WidgetContextNotFoundException;
+
 /**
  * Testcase for AjaxWidgetContextHolder
  *
@@ -48,10 +50,10 @@ class AjaxWidgetContextHolderTest extends \Neos\Flow\Tests\UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\Widget\Exception\WidgetContextNotFoundException
      */
     public function getThrowsExceptionIfWidgetContextIsNotFound()
     {
+        $this->expectException(WidgetContextNotFoundException::class);
         $ajaxWidgetContextHolder = new \Neos\FluidAdaptor\Core\Widget\AjaxWidgetContextHolder();
         $ajaxWidgetContextHolder->get(42);
     }

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/WidgetContextTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/WidgetContextTest.php
@@ -26,7 +26,7 @@ class WidgetContextTest extends \Neos\Flow\Tests\UnitTestCase
 
     /**
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->widgetContext = new \Neos\FluidAdaptor\Core\Widget\WidgetContext();
     }

--- a/Neos.FluidAdaptor/Tests/Unit/View/AbstractTemplateViewTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/View/AbstractTemplateViewTest.php
@@ -45,7 +45,7 @@ class AbstractTemplateViewTest extends \Neos\Flow\Tests\UnitTestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->templateVariableContainer = $this->getMockBuilder(TemplateVariableContainer::class)->setMethods(['exists', 'remove', 'add'])->getMock();
         $this->viewHelperVariableContainer = $this->getMockBuilder(ViewHelperVariableContainer::class)->setMethods(['setView'])->getMock();

--- a/Neos.FluidAdaptor/Tests/Unit/View/StandaloneViewTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/View/StandaloneViewTest.php
@@ -38,7 +38,7 @@ class StandaloneViewTest extends UnitTestCase
      */
     protected $mockRequest;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->standaloneView = $this->getAccessibleMock(\Neos\FluidAdaptor\View\StandaloneView::class, ['dummy']);
 

--- a/Neos.FluidAdaptor/Tests/Unit/View/StandaloneViewTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/View/StandaloneViewTest.php
@@ -12,6 +12,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\View;
  */
 
 
+use Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException;
 use org\bovigo\vfs\vfsStreamWrapper;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\Controller\ControllerContext;
@@ -50,10 +51,10 @@ class StandaloneViewTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException
      */
     public function getLayoutPathAndFilenameThrowsExceptionIfSpecifiedLayoutRootPathIsNoDirectory()
     {
+        $this->expectException(InvalidTemplateResourceException::class);
         vfsStreamWrapper::register();
         mkdir('vfs://MyLayouts');
         \file_put_contents('vfs://MyLayouts/NotAFolder', 'foo');
@@ -63,10 +64,10 @@ class StandaloneViewTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException
      */
     public function getLayoutPathAndFilenameThrowsExceptionIfLayoutFileIsADirectory()
     {
+        $this->expectException(InvalidTemplateResourceException::class);
         vfsStreamWrapper::register();
         mkdir('vfs://MyLayouts/NotAFile');
         $this->standaloneView->setLayoutRootPath('vfs://MyLayouts');
@@ -75,10 +76,10 @@ class StandaloneViewTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException
      */
     public function getPartialPathAndFilenameThrowsExceptionIfSpecifiedPartialRootPathIsNoDirectory()
     {
+        $this->expectException(InvalidTemplateResourceException::class);
         vfsStreamWrapper::register();
         mkdir('vfs://MyPartials');
         \file_put_contents('vfs://MyPartials/NotAFolder', 'foo');
@@ -88,10 +89,10 @@ class StandaloneViewTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException
      */
     public function getPartialPathAndFilenameThrowsExceptionIfPartialFileIsADirectory()
     {
+        $this->expectException(InvalidTemplateResourceException::class);
         vfsStreamWrapper::register();
         mkdir('vfs://MyPartials/NotAFile');
         $this->standaloneView->setPartialRootPath('vfs://MyPartials');

--- a/Neos.FluidAdaptor/Tests/Unit/View/TemplatePathsTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/View/TemplatePathsTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Neos\FluidAdaptor\Tests\Unit\View;
 
+use Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException;
 use org\bovigo\vfs\vfsStreamWrapper;
 use Neos\Flow\Http\Request;
 use Neos\Flow\Http\Uri;
@@ -642,10 +643,10 @@ class TemplatePathsTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException
      */
     public function getTemplatePathAndFilenameThrowsExceptionIfNoPathCanBeResolved()
     {
+        $this->expectException(InvalidTemplateResourceException::class);
         vfsStreamWrapper::register();
         $paths = [
             'vfs://NonExistentDir/UnknownFile.html',
@@ -669,10 +670,10 @@ class TemplatePathsTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException
      */
     public function getTemplatePathAndFilenameThrowsExceptionIfResolvedPathPointsToADirectory()
     {
+        $this->expectException(InvalidTemplateResourceException::class);
         vfsStreamWrapper::register();
         mkdir('vfs://MyTemplates/NotAFile');
         $paths = [
@@ -711,10 +712,10 @@ class TemplatePathsTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException
      */
     public function getLayoutPathAndFilenameThrowsExceptionIfNoPathCanBeResolved()
     {
+        $this->expectException(InvalidTemplateResourceException::class);
         vfsStreamWrapper::register();
         $paths = [
             'vfs://NonExistentDir/UnknownFile.html',
@@ -738,10 +739,10 @@ class TemplatePathsTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException
      */
     public function getLayoutPathAndFilenameThrowsExceptionIfResolvedPathPointsToADirectory()
     {
+        $this->expectException(InvalidTemplateResourceException::class);
         vfsStreamWrapper::register();
         mkdir('vfs://MyTemplates/NotAFile');
         $paths = [
@@ -766,10 +767,10 @@ class TemplatePathsTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException
      */
     public function getPartialPathAndFilenameThrowsExceptionIfNoPathCanBeResolved()
     {
+        $this->expectException(InvalidTemplateResourceException::class);
         vfsStreamWrapper::register();
         $paths = [
             'vfs://NonExistentDir/UnknownFile.html',
@@ -793,10 +794,10 @@ class TemplatePathsTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException
      */
     public function getPartialPathAndFilenameThrowsExceptionIfResolvedPathPointsToADirectory()
     {
+        $this->expectException(InvalidTemplateResourceException::class);
         vfsStreamWrapper::register();
         mkdir('vfs://MyTemplates/NotAFile');
         $paths = [

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/FlashMessagesViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/FlashMessagesViewHelperTest.php
@@ -40,7 +40,7 @@ class FlashMessagesViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelp
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockFlashMessageContainer = $this->createMock(\Neos\Flow\Mvc\FlashMessageContainer::class);
         $mockControllerContext = $this->getMockBuilder(\Neos\Flow\Mvc\Controller\ControllerContext::class)->disableOriginalConstructor()->getMock();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/ButtonViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/ButtonViewHelperTest.php
@@ -25,7 +25,7 @@ class ButtonViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\For
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\ViewHelpers\Form\ButtonViewHelper::class, ['renderChildren','registerRenderMethodArguments']);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/CheckboxViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/CheckboxViewHelperTest.php
@@ -36,7 +36,7 @@ class CheckboxViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\F
      */
     protected $mockTagBuilder;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(CheckboxViewHelper::class, ['setErrorClassAttribute', 'getName', 'getValueAttribute', 'isObjectAccessorMode', 'getPropertyValue', 'registerFieldNameForFormTokenGeneration', 'registerRenderMethodArguments']);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/HiddenViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/HiddenViewHelperTest.php
@@ -25,7 +25,7 @@ class HiddenViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\For
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\ViewHelpers\Form\HiddenViewHelper::class, ['setErrorClassAttribute', 'getName', 'getValueAttribute', 'registerFieldNameForFormTokenGeneration']);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/PasswordViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/PasswordViewHelperTest.php
@@ -27,7 +27,7 @@ class PasswordViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\F
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\ViewHelpers\Form\PasswordViewHelper::class, ['setErrorClassAttribute', 'registerFieldNameForFormTokenGeneration', 'registerRenderMethodArguments']);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/RadioViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/RadioViewHelperTest.php
@@ -23,7 +23,7 @@ class RadioViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Form
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\ViewHelpers\Form\RadioViewHelper::class, ['setErrorClassAttribute', 'getName', 'getValueAttribute', 'isObjectAccessorMode', 'getPropertyValue', 'registerFieldNameForFormTokenGeneration', 'registerRenderMethodArguments']);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/SelectViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/SelectViewHelperTest.php
@@ -28,7 +28,7 @@ class SelectViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\For
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->arguments['name'] = '';

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/SelectViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/SelectViewHelperTest.php
@@ -12,6 +12,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Form;
  */
 
 use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\FluidAdaptor\Core\ViewHelper\Exception;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 
 require_once(__DIR__ . '/Fixtures/EmptySyntaxTreeNode.php');
@@ -378,10 +379,10 @@ class SelectViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\For
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function selectOnDomainObjectsThrowsExceptionIfNoValueCanBeFound()
     {
+        $this->expectException(Exception::class);
         $mockPersistenceManager = $this->createMock(\Neos\Flow\Persistence\PersistenceManagerInterface::class);
         $mockPersistenceManager->expects($this->any())->method('getIdentifierByObject')->will($this->returnValue(null));
         $this->viewHelper->injectPersistenceManager($mockPersistenceManager);
@@ -542,10 +543,10 @@ class SelectViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\For
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function getTranslatedLabelThrowsExceptionForInvalidLocales()
     {
+        $this->expectException(Exception::class);
         $this->arguments['translate'] = ['locale' => 'invalid-locale'];
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
 
@@ -554,10 +555,10 @@ class SelectViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\For
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function getTranslatedLabelThrowsExceptionForUnknownTranslateBy()
     {
+        $this->expectException(Exception::class);
         $this->arguments['translate'] = ['by' => 'foo'];
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
 

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/SubmitViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/SubmitViewHelperTest.php
@@ -23,7 +23,7 @@ class SubmitViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\For
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = new \Neos\FluidAdaptor\ViewHelpers\Form\SubmitViewHelper();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/TextareaViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/TextareaViewHelperTest.php
@@ -27,7 +27,7 @@ class TextareaViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\F
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\ViewHelpers\Form\TextareaViewHelper::class, ['setErrorClassAttribute', 'registerFieldNameForFormTokenGeneration']);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/TextfieldViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/TextfieldViewHelperTest.php
@@ -27,7 +27,7 @@ class TextfieldViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\ViewHelpers\Form\TextfieldViewHelper::class, ['setErrorClassAttribute', 'registerFieldNameForFormTokenGeneration']);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/UploadViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/UploadViewHelperTest.php
@@ -44,7 +44,7 @@ class UploadViewHelperTest extends FormFieldViewHelperBaseTestcase
      */
     protected $mockMappingResult;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(UploadViewHelper::class, ['setErrorClassAttribute', 'registerFieldNameForFormTokenGeneration', 'getMappingResultsForProperty']);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/FormViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/FormViewHelperTest.php
@@ -46,7 +46,7 @@ class FormViewHelperTest extends ViewHelperBaseTestcase
     /**
      * Set up test dependencies
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->arguments['action'] = '';

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/FormViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/FormViewHelperTest.php
@@ -16,6 +16,7 @@ use Neos\Flow\Security\Authentication\AuthenticationManagerInterface;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Security\Cryptography\HashService;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
+use Neos\FluidAdaptor\Core\ViewHelper\Exception;
 use Neos\FluidAdaptor\ViewHelpers\FormViewHelper;
 
 /**
@@ -530,10 +531,10 @@ class FormViewHelperTest extends ViewHelperBaseTestcase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function renderThrowsExceptionIfNeitherActionNorActionUriArgumentIsSpecified()
     {
+        $this->expectException(Exception::class);
         $viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\ViewHelpers\FormViewHelper::class, ['renderChildren', 'registerRenderMethodArguments'], [], '', false);
         $this->injectDependenciesIntoViewHelper($viewHelper);
         $viewHelper = $this->prepareArguments($viewHelper, []);
@@ -542,11 +543,11 @@ class FormViewHelperTest extends ViewHelperBaseTestcase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception
-     * @expectedExceptionCode 1361354942
      */
     public function renderThrowsExceptionIfUseParentRequestIsSetAndTheCurrentRequestHasNoParentRequest()
     {
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(1361354942);
         $viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\ViewHelpers\FormViewHelper::class, ['renderChildren', 'registerRenderMethodArguments'], [], '', false);
         $this->arguments['useParentRequest'] = true;
         $this->arguments['action'] = 'index';

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/BytesViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/BytesViewHelperTest.php
@@ -25,7 +25,7 @@ class BytesViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getMockBuilder(\Neos\FluidAdaptor\ViewHelpers\Format\BytesViewHelper::class)->setMethods(['renderChildren', 'registerRenderMethodArguments'])->getMock();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CaseViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CaseViewHelperTest.php
@@ -38,7 +38,7 @@ class CaseViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $originalMbEncodingValue;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->renderingContext = $this->getMockBuilder(RenderingContext::class)->disableOriginalConstructor()->getMock();
@@ -50,7 +50,7 @@ class CaseViewHelperTest extends ViewHelperBaseTestcase
 
     /**
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         mb_internal_encoding($this->originalMbEncodingValue);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CaseViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CaseViewHelperTest.php
@@ -14,6 +14,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Format;
 require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 
 use Neos\FluidAdaptor\Core\Rendering\RenderingContext;
+use Neos\FluidAdaptor\Core\ViewHelper\Exception\InvalidVariableException;
 use Neos\FluidAdaptor\ViewHelpers\Format\CaseViewHelper;
 use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
@@ -95,10 +96,10 @@ class CaseViewHelperTest extends ViewHelperBaseTestcase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception\InvalidVariableException
      */
     public function viewHelperThrowsExceptionIfIncorrectModeIsGiven()
     {
+        $this->expectException(InvalidVariableException::class);
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => 'Foo', 'mode' => 'incorrectMode']);
         $this->viewHelper->render('Foo', 'incorrectMode');
     }
@@ -116,10 +117,10 @@ class CaseViewHelperTest extends ViewHelperBaseTestcase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception\InvalidVariableException
      */
     public function viewHelperRestoresMbInternalEncodingAfterExceptionOccurred()
     {
+        $this->expectException(InvalidVariableException::class);
         mb_internal_encoding('ASCII');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => 'dummy', 'mode' => 'incorrectModeResultingInException']);
         $this->viewHelper->render();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CropViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CropViewHelperTest.php
@@ -25,7 +25,7 @@ class CropViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getMockBuilder(\Neos\FluidAdaptor\ViewHelpers\Format\CropViewHelper::class)->setMethods(['renderChildren', 'registerRenderMethodArguments'])->getMock();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CurrencyViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CurrencyViewHelperTest.php
@@ -21,7 +21,7 @@ use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
  */
 class CurrencyViewHelperTest extends ViewHelperBaseTestcase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getMockBuilder(\Neos\FluidAdaptor\ViewHelpers\Format\CurrencyViewHelper::class)->setMethods(['renderChildren', 'registerRenderMethodArguments'])->getMock();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CurrencyViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CurrencyViewHelperTest.php
@@ -14,6 +14,8 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Format;
 
 require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 
+use Neos\FluidAdaptor\Core\ViewHelper\Exception;
+use Neos\FluidAdaptor\Core\ViewHelper\Exception\InvalidVariableException;
 use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
 /**
@@ -129,10 +131,10 @@ class CurrencyViewHelperTest extends ViewHelperBaseTestcase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception\InvalidVariableException
      */
     public function viewHelperThrowsExceptionIfLocaleIsUsedWithoutExplicitCurrencySign()
     {
+        $this->expectException(InvalidVariableException::class);
         $localizationConfiguration = new \Neos\Flow\I18n\Configuration('de_DE');
 
         $mockLocalizationService = $this->getMockBuilder(\Neos\Flow\I18n\Service::class)->setMethods(['getConfiguration'])->getMock();
@@ -146,10 +148,10 @@ class CurrencyViewHelperTest extends ViewHelperBaseTestcase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function viewHelperConvertsI18nExceptionsIntoViewHelperExceptions()
     {
+        $this->expectException(Exception::class);
         $localizationConfiguration = new \Neos\Flow\I18n\Configuration('de_DE');
 
         $mockLocalizationService = $this->getMockBuilder(\Neos\Flow\I18n\Service::class)->setMethods(['getConfiguration'])->getMock();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/DateViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/DateViewHelperTest.php
@@ -11,6 +11,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Format;
  * source code.
  */
 
+use Neos\FluidAdaptor\Core\ViewHelper\Exception;
 use Neos\FluidAdaptor\ViewHelpers\Format;
 use Neos\Flow\I18n;
 
@@ -72,10 +73,10 @@ class DateViewHelperTest extends ViewHelperBaseTestcase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function viewHelperThrowsExceptionIfDateStringCantBeParsed()
     {
+        $this->expectException(Exception::class);
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['date' => 'foo']);
         $actualResult = $this->viewHelper->render();
     }
@@ -104,10 +105,10 @@ class DateViewHelperTest extends ViewHelperBaseTestcase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception\InvalidVariableException
      */
     public function viewHelperThrowsExceptionIfInvalidLocaleIdentifierIsGiven()
     {
+        $this->expectException(Exception\InvalidVariableException::class);
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['date' => new \DateTime(), 'forceLocale' => '123-not-existing-locale']);
         $this->viewHelper->render();
     }
@@ -154,10 +155,10 @@ class DateViewHelperTest extends ViewHelperBaseTestcase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function viewHelperConvertsI18nExceptionsIntoViewHelperExceptions()
     {
+        $this->expectException(Exception::class);
         $localizationConfiguration = new I18n\Configuration('de_DE');
 
         $mockLocalizationService = $this->getMockBuilder(\Neos\Flow\I18n\Service::class)->setMethods(['getConfiguration'])->getMock();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/DateViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/DateViewHelperTest.php
@@ -23,7 +23,7 @@ use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
  */
 class DateViewHelperTest extends ViewHelperBaseTestcase
 {
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getMockBuilder(\Neos\FluidAdaptor\ViewHelpers\Format\DateViewHelper::class)->setMethods(['renderChildren', 'registerRenderMethodArguments'])->getMock();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/HtmlentitiesDecodeViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/HtmlentitiesDecodeViewHelperTest.php
@@ -138,10 +138,10 @@ class HtmlentitiesDecodeViewHelperTest extends ViewHelperBaseTestcase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function renderDoesNotModifySourceIfItIsAnObjectThatCantBeConvertedToAString()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $user = new UserWithoutToString('Xaver <b>Cross-Site</b>');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $user]);
         $this->viewHelper->render();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/HtmlentitiesDecodeViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/HtmlentitiesDecodeViewHelperTest.php
@@ -29,7 +29,7 @@ class HtmlentitiesDecodeViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getMockBuilder(\Neos\FluidAdaptor\ViewHelpers\Format\HtmlentitiesDecodeViewHelper::class)->setMethods(['renderChildren', 'registerRenderMethodArguments'])->getMock();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/HtmlentitiesViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/HtmlentitiesViewHelperTest.php
@@ -162,10 +162,10 @@ class HtmlentitiesViewHelperTest extends ViewHelperBaseTestcase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function renderDoesNotModifySourceIfItIsAnObjectThatCantBeConvertedToAString()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $user = new UserWithoutToString('Xaver <b>Cross-Site</b>');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $user]);
         $this->viewHelper->render();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/HtmlentitiesViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/HtmlentitiesViewHelperTest.php
@@ -29,7 +29,7 @@ class HtmlentitiesViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getMockBuilder(\Neos\FluidAdaptor\ViewHelpers\Format\HtmlentitiesViewHelper::class)->setMethods(['renderChildren', 'registerRenderMethodArguments'])->getMock();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/IdentifierViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/IdentifierViewHelperTest.php
@@ -99,10 +99,10 @@ class IdentifierViewHelperTest extends ViewHelperBaseTestcase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function renderThrowsExceptionIfGivenValueIsNoObject()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $notAnObject = [];
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $notAnObject]);
         $this->viewHelper->render();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/IdentifierViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/IdentifierViewHelperTest.php
@@ -33,7 +33,7 @@ class IdentifierViewHelperTest extends ViewHelperBaseTestcase
     /**
      * Sets up this test case
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\ViewHelpers\Format\IdentifierViewHelper::class, ['renderChildren', 'registerRenderMethodArguments']);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/JsonViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/JsonViewHelperTest.php
@@ -25,7 +25,7 @@ class JsonViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getMockBuilder(\Neos\FluidAdaptor\ViewHelpers\Format\JsonViewHelper::class)->setMethods(['renderChildren', 'registerRenderMethodArguments'])->getMock();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/Nl2brViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/Nl2brViewHelperTest.php
@@ -25,7 +25,7 @@ class Nl2brViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getMockBuilder(\Neos\FluidAdaptor\ViewHelpers\Format\Nl2brViewHelper::class)->setMethods(['renderChildren', 'registerRenderMethodArguments'])->getMock();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/NumberViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/NumberViewHelperTest.php
@@ -11,6 +11,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Format;
  * source code.
  */
 
+use Neos\FluidAdaptor\Core\ViewHelper\Exception;
 use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
 
 /**
@@ -87,10 +88,10 @@ class NumberViewHelperTest extends ViewHelperBaseTestcase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function viewHelperConvertsI18nExceptionsIntoViewHelperExceptions()
     {
+        $this->expectException(Exception::class);
         $localizationConfiguration = new \Neos\Flow\I18n\Configuration('de_DE');
 
         $mockLocalizationService = $this->getMockBuilder(\Neos\Flow\I18n\Service::class)->setMethods(['getConfiguration'])->getMock();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/NumberViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/NumberViewHelperTest.php
@@ -24,7 +24,7 @@ class NumberViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->viewHelper = $this->getMockBuilder(\Neos\FluidAdaptor\ViewHelpers\Format\NumberViewHelper::class)->setMethods(['renderChildren', 'registerRenderMethodArguments'])->getMock();
     }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/PaddingViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/PaddingViewHelperTest.php
@@ -25,7 +25,7 @@ class PaddingViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getMockBuilder(\Neos\FluidAdaptor\ViewHelpers\Format\PaddingViewHelper::class)->setMethods(['renderChildren', 'registerRenderMethodArguments'])->getMock();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/StripTagsViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/StripTagsViewHelperTest.php
@@ -129,10 +129,10 @@ class StripTagsViewHelperTest extends ViewHelperBaseTestcase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function renderDoesNotModifySourceIfItIsAnObjectThatCantBeConvertedToAString()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $user = new UserWithoutToString('Xaver <b>Cross-Site</b>');
         $this->viewHelper->expects(self::any())->method('buildRenderChildrenClosure')->willReturn(function () {
             throw new \Exception('renderChildrenClosure was invoked but should not have been');

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/StripTagsViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/StripTagsViewHelperTest.php
@@ -29,7 +29,7 @@ class StripTagsViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getMockBuilder(\Neos\FluidAdaptor\ViewHelpers\Format\StripTagsViewHelper::class)->setMethods(['buildRenderChildrenClosure', 'renderChildren', 'registerRenderMethodArguments'])->getMock();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/UrlencodeViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/UrlencodeViewHelperTest.php
@@ -89,10 +89,10 @@ class UrlencodeViewHelperTest extends ViewHelperBaseTestcase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function renderThrowsExceptionIfItIsNoStringAndHasNoToStringMethod()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $source = new \stdClass();
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $source]);
         $this->viewHelper->render();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/UrlencodeViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/UrlencodeViewHelperTest.php
@@ -27,7 +27,7 @@ class UrlencodeViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getMockBuilder(UrlencodeViewHelper::class)->setMethods(['renderChildren', 'registerRenderMethodArguments'])->getMock();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/ActionViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/ActionViewHelperTest.php
@@ -11,6 +11,8 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Link;
  * source code.
  */
 
+use Neos\FluidAdaptor\Core\ViewHelper\Exception;
+
 require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 
 /**
@@ -96,10 +98,10 @@ class ActionViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Vie
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function renderThrowsExceptionIfUseParentRequestIsSetAndTheCurrentRequestHasNoParentRequest()
     {
+        $this->expectException(Exception::class);
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['action' => 'someAction', 'arguments' => [], 'controller' => null, 'package' => null, 'subpackage' => null, 'section' => '', 'format' => '', 'additionalParams' => [], 'addQueryString' => false, 'argumentsToBeExcludedFromQueryString' => [], 'useParentRequest' => true]);
         $this->viewHelper->render();
     }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/ActionViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/ActionViewHelperTest.php
@@ -22,7 +22,7 @@ class ActionViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Vie
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\ViewHelpers\Link\ActionViewHelper::class, ['renderChildren', 'registerRenderMethodArguments']);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/EmailViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/EmailViewHelperTest.php
@@ -22,7 +22,7 @@ class EmailViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\View
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\ViewHelpers\Link\EmailViewHelper::class, ['renderChildren', 'registerRenderMethodArguments']);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/ExternalViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/ExternalViewHelperTest.php
@@ -25,7 +25,7 @@ class ExternalViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\V
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\ViewHelpers\Link\ExternalViewHelper::class, ['renderChildren', 'registerRenderMethodArguments']);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/RenderChildrenViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/RenderChildrenViewHelperTest.php
@@ -29,7 +29,7 @@ class RenderChildrenViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHel
 
     /**
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getMockBuilder(\Neos\FluidAdaptor\ViewHelpers\RenderChildrenViewHelper::class)->setMethods(['renderChildren'])->getMock();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/RenderChildrenViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/RenderChildrenViewHelperTest.php
@@ -11,6 +11,8 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers;
  * source code.
  */
 
+use Neos\FluidAdaptor\Core\Widget\Exception\RenderingContextNotFoundException;
+use Neos\FluidAdaptor\Core\Widget\Exception\WidgetContextNotFoundException;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
@@ -67,10 +69,10 @@ class RenderChildrenViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHel
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\Widget\Exception\WidgetContextNotFoundException
      */
     public function renderThrowsExceptionIfTheRequestIsNotAWidgetRequest()
     {
+        $this->expectException(WidgetContextNotFoundException::class);
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
         $this->viewHelper->initializeArguments();
 
@@ -79,10 +81,10 @@ class RenderChildrenViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHel
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\Widget\Exception\RenderingContextNotFoundException
      */
     public function renderThrowsExceptionIfTheChildNodeRenderingContextIsNotThere()
     {
+        $this->expectException(RenderingContextNotFoundException::class);
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
         $this->viewHelper->initializeArguments();
 

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Security/CsrfTokenViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Security/CsrfTokenViewHelperTest.php
@@ -33,7 +33,7 @@ class CsrfTokenViewHelperTest extends ViewHelperBaseTestcase
     /**
      *
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getMockBuilder(CsrfTokenViewHelper::class)->setMethods(['buildRenderChildrenClosure'])->getMock();

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Security/IfAccessViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Security/IfAccessViewHelperTest.php
@@ -33,7 +33,7 @@ class IfAccessViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $mockPrivilegeManager;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->mockPrivilegeManager = $this->getMockBuilder(\Neos\Flow\Security\Authorization\PrivilegeManagerInterface::class)->disableOriginalConstructor()->getMock();
 

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Security/IfHasRoleViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Security/IfHasRoleViewHelperTest.php
@@ -43,7 +43,7 @@ class IfHasRoleViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $mockPolicyService;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->mockViewHelper = $this->getMockBuilder(\Neos\FluidAdaptor\ViewHelpers\Security\IfHasRoleViewHelper::class)->setMethods([

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/TranslateViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/TranslateViewHelperTest.php
@@ -13,6 +13,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers;
 
 use Neos\Flow\I18n\Locale;
 use Neos\Flow\I18n\Translator;
+use Neos\FluidAdaptor\Core\ViewHelper\Exception;
 use Neos\FluidAdaptor\ViewHelpers\TranslateViewHelper;
 
 require_once(__DIR__ . '/ViewHelperBaseTestcase.php');
@@ -118,20 +119,20 @@ class TranslateViewHelperTest extends ViewHelperBaseTestcase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function renderThrowsExceptionIfGivenLocaleIdentifierIsInvalid()
     {
+        $this->expectException(Exception::class);
         $this->translateViewHelper = $this->prepareArguments($this->translateViewHelper, ['id' => 'some.label', 'value' => null, 'arguments' => [], 'source' => 'Main', 'package' => null, 'quantity' => null, 'locale' => 'INVALIDLOCALE']);
         $this->translateViewHelper->render();
     }
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function renderThrowsExceptionIfNoPackageCouldBeResolved()
     {
+        $this->expectException(Exception::class);
         $mockRequest = $this->getMockBuilder(\Neos\Flow\Mvc\ActionRequest::class)->disableOriginalConstructor()->getMock();
         $mockRequest->expects($this->any())->method('getControllerPackageKey')->will($this->returnValue(null));
 

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/TranslateViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/TranslateViewHelperTest.php
@@ -37,7 +37,7 @@ class TranslateViewHelperTest extends ViewHelperBaseTestcase
      */
     protected $mockTranslator;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ActionViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ActionViewHelperTest.php
@@ -11,6 +11,8 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Uri;
  * source code.
  */
 
+use Neos\FluidAdaptor\Core\ViewHelper\Exception;
+
 require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 
 /**
@@ -95,10 +97,10 @@ class ActionViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Vie
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function renderThrowsExceptionIfUseParentRequestIsSetAndTheCurrentRequestHasNoParentRequest()
     {
+        $this->expectException(Exception::class);
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['action' => 'someAction', 'arguments' => [], 'controller' => null, 'package' => null, 'subpackage' => null, 'section' => '', 'format' => '', 'additionalParams' => [], 'absolute' => false, 'addQueryString' => false, 'argumentsToBeExcludedFromQueryString' => [], 'useParentRequest' => true]);
         $this->viewHelper->render();
     }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ActionViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ActionViewHelperTest.php
@@ -24,7 +24,7 @@ class ActionViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Vie
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\ViewHelpers\Uri\ActionViewHelper::class, ['renderChildren', 'registerRenderMethodArguments']);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/EmailViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/EmailViewHelperTest.php
@@ -23,7 +23,7 @@ class EmailViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\View
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\ViewHelpers\Uri\EmailViewHelper::class, ['renderChildren', 'registerRenderMethodArguments']);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ExternalViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ExternalViewHelperTest.php
@@ -24,7 +24,7 @@ class ExternalViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\V
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\ViewHelpers\Uri\ExternalViewHelper::class, ['renderChildren', 'registerRenderMethodArguments']);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ResourceViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ResourceViewHelperTest.php
@@ -46,7 +46,7 @@ class ResourceViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\V
      */
     protected $mockResourceManager;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->mockI18nService = $this->createMock(Service::class);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ResourceViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ResourceViewHelperTest.php
@@ -17,6 +17,7 @@ use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\ResourceManagement\Exception;
 use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\Flow\ResourceManagement\ResourceManager;
+use Neos\FluidAdaptor\Core\ViewHelper\Exception\InvalidVariableException;
 use Neos\FluidAdaptor\ViewHelpers\Uri\ResourceViewHelper;
 
 require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
@@ -201,10 +202,10 @@ class ResourceViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\V
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception\InvalidVariableException
      */
     public function renderThrowsExceptionIfNeitherResourceNorPathWereGiven()
     {
+        $this->expectException(InvalidVariableException::class);
         $this->viewHelper = $this->prepareArguments($this->viewHelper, [
             'path' => null,
             'package' => 'SomePackage',
@@ -215,10 +216,10 @@ class ResourceViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\V
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception\InvalidVariableException
      */
     public function renderThrowsExceptionIfResourceUriNotPointingToPublicWasGivenAsPath()
     {
+        $this->expectException(InvalidVariableException::class);
         $this->mockResourceManager
             ->expects($this->once())
             ->method('getPackageAndPathByPublicPath')

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Validation/IfHasErrorsViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Validation/IfHasErrorsViewHelperTest.php
@@ -29,7 +29,7 @@ class IfHasErrorsViewHelperTest extends ViewHelperBaseTestcase
 
     /**
      */
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\ViewHelpers\Validation\IfHasErrorsViewHelper::class, ['renderThenChild', 'renderElseChild']);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Validation/ResultsViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Validation/ResultsViewHelperTest.php
@@ -24,7 +24,7 @@ class ResultsViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Vi
      */
     protected $viewHelper;
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->viewHelper = $this->getMockBuilder(\Neos\FluidAdaptor\ViewHelpers\Validation\ResultsViewHelper::class)

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php
@@ -75,7 +75,7 @@ abstract class ViewHelperBaseTestcase extends \Neos\Flow\Tests\UnitTestCase
     /**
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->viewHelperVariableContainer = $this->createMock(\TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer::class);
         $this->viewHelperVariableContainer->expects($this->any())->method('exists')->will($this->returnCallback([$this, 'viewHelperVariableContainerExistsCallback']));

--- a/Neos.Utility.Arrays/Tests/Unit/ArraysTest.php
+++ b/Neos.Utility.Arrays/Tests/Unit/ArraysTest.php
@@ -82,10 +82,10 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function getValueByPathThrowsExceptionIfPathIsNoArrayOrString()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $array = ['Foo' => ['Bar' => ['Baz' => [2 => 'the value']]]];
         Arrays::getValueByPath($array, null);
     }
@@ -174,30 +174,30 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function setValueByPathThrowsExceptionIfPathIsNoArrayOrString()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $array = ['Foo' => ['Bar' => ['Baz' => [2 => 'the value']]]];
         Arrays::setValueByPath($array, null, 'Some Value');
     }
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function setValueByPathThrowsExceptionIfSubjectIsNoArray()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $subject = 'foobar';
         Arrays::setValueByPath($subject, 'foo', 'bar');
     }
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function setValueByPathThrowsExceptionIfSubjectIsNoArrayAccess()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $subject = new \stdClass();
         Arrays::setValueByPath($subject, 'foo', 'bar');
     }
@@ -265,10 +265,10 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function unsetValueByPathThrowsExceptionIfPathIsNoArrayOrString()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $array = ['Foo' => ['Bar' => ['Baz' => [2 => 'the value']]]];
         Arrays::unsetValueByPath($array, null);
     }

--- a/Neos.Utility.Arrays/Tests/Unit/PositionalArraySorterTest.php
+++ b/Neos.Utility.Arrays/Tests/Unit/PositionalArraySorterTest.php
@@ -11,6 +11,7 @@ namespace Neos\Utility\Arrays\Tests\Unit;
  * source code.
  */
 
+use Neos\Utility\Exception\InvalidPositionException;
 use Neos\Utility\PositionalArraySorter;
 
 /**
@@ -49,10 +50,10 @@ class PositionalArraySorterTest extends \PHPUnit\Framework\TestCase
      * @dataProvider invalidPositions
      *
      * @param array $subject
-     * @expectedException \Neos\Utility\Exception\InvalidPositionException
      */
     public function toArrayThrowsExceptionForInvalidPositions(array $subject)
     {
+        $this->expectException(InvalidPositionException::class);
         $positionalArraySorter = new PositionalArraySorter($subject);
         $positionalArraySorter->toArray();
     }

--- a/Neos.Utility.Arrays/composer.json
+++ b/Neos.Utility.Arrays/composer.json
@@ -10,7 +10,7 @@
   },
   "require-dev": {
     "mikey179/vfsstream": "~1.6",
-    "phpunit/phpunit": "~7.1"
+    "phpunit/phpunit": "~8.1.3"
   },
   "autoload": {
     "psr-4": {

--- a/Neos.Utility.Arrays/composer.json
+++ b/Neos.Utility.Arrays/composer.json
@@ -10,7 +10,7 @@
   },
   "require-dev": {
     "mikey179/vfsstream": "~1.6",
-    "phpunit/phpunit": "~8.1.3"
+    "phpunit/phpunit": "~8.1"
   },
   "autoload": {
     "psr-4": {

--- a/Neos.Utility.Files/Tests/Unit/FilesTest.php
+++ b/Neos.Utility.Files/Tests/Unit/FilesTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Tests\Unit\Utility;
  * source code.
  */
 
+use Neos\Utility\Exception\FilesException;
 use org\bovigo\vfs\vfsStream;
 use Neos\Utility\Files;
 
@@ -266,19 +267,19 @@ class FilesTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \Neos\Utility\Exception\FilesException
      */
     public function emptyDirectoryRecursivelyThrowsExceptionIfSpecifiedPathDoesNotExist()
     {
+        $this->expectException(FilesException::class);
         Files::emptyDirectoryRecursively('NonExistingPath');
     }
 
     /**
      * @test
-     * @expectedException \Neos\Utility\Exception\FilesException
      */
     public function removeDirectoryRecursivelyThrowsExceptionIfSpecifiedPathDoesNotExist()
     {
+        $this->expectException(FilesException::class);
         Files::removeDirectoryRecursively('NonExistingPath');
     }
 
@@ -346,10 +347,10 @@ class FilesTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \Neos\Utility\Exception\FilesException
      */
     public function removeEmptyDirectoriesOnPathThrowsExceptionIfBasePathIsNotParentOfPath()
     {
+        $this->expectException(FilesException::class);
         Files::createDirectoryRecursively('vfs://Foo/Bar/Baz/Quux');
         Files::removeEmptyDirectoriesOnPath('vfs://Foo/Bar/Baz/Quux', 'vfs://Other/Bar');
     }
@@ -654,10 +655,10 @@ class FilesTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \Neos\Utility\Exception\FilesException
      */
     public function sizeStringThrowsExceptionIfTheSpecifiedUnitIsUnknown()
     {
+        $this->expectException(FilesException::class);
         Files::sizeStringToBytes('123 UnknownUnit');
     }
 }

--- a/Neos.Utility.Files/Tests/Unit/FilesTest.php
+++ b/Neos.Utility.Files/Tests/Unit/FilesTest.php
@@ -24,7 +24,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
      */
     protected $temporaryDirectory;
 
-    public function setUp()
+    protected function setUp(): void
     {
         vfsStream::setup('Foo');
 
@@ -35,7 +35,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
         $this->temporaryDirectory = realpath($intendedTemporaryDirectory);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         Files::removeDirectoryRecursively($this->temporaryDirectory);
     }

--- a/Neos.Utility.Files/composer.json
+++ b/Neos.Utility.Files/composer.json
@@ -10,7 +10,7 @@
   },
   "require-dev": {
     "mikey179/vfsstream": "~1.6",
-    "phpunit/phpunit": "~7.1"
+    "phpunit/phpunit": "~8.1.3"
   },
   "autoload": {
     "psr-4": {

--- a/Neos.Utility.Files/composer.json
+++ b/Neos.Utility.Files/composer.json
@@ -10,7 +10,7 @@
   },
   "require-dev": {
     "mikey179/vfsstream": "~1.6",
-    "phpunit/phpunit": "~8.1.3"
+    "phpunit/phpunit": "~8.1"
   },
   "autoload": {
     "psr-4": {

--- a/Neos.Utility.Lock/Tests/Unit/LockTest.php
+++ b/Neos.Utility.Lock/Tests/Unit/LockTest.php
@@ -27,7 +27,7 @@ class LockTest extends \PHPUnit\Framework\TestCase
      */
     protected $lockFileName;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         vfsStream::setup('Lock');
 
@@ -37,14 +37,14 @@ class LockTest extends \PHPUnit\Framework\TestCase
         Lock::setLockManager($lockManager);
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         $lock = new Lock('testLock');
         $this->lockFileName = $lock->getLockStrategy()->getLockFileName();
         $lock->release();
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         Lock::setLockManager(null);
     }

--- a/Neos.Utility.Lock/composer.json
+++ b/Neos.Utility.Lock/composer.json
@@ -11,7 +11,7 @@
   },
   "require-dev": {
     "mikey179/vfsstream": "~1.6",
-    "phpunit/phpunit": "~8.1.3"
+    "phpunit/phpunit": "~8.1"
   },
   "autoload": {
     "psr-4": {

--- a/Neos.Utility.Lock/composer.json
+++ b/Neos.Utility.Lock/composer.json
@@ -11,7 +11,7 @@
   },
   "require-dev": {
     "mikey179/vfsstream": "~1.6",
-    "phpunit/phpunit": "~7.1"
+    "phpunit/phpunit": "~8.1.3"
   },
   "autoload": {
     "psr-4": {

--- a/Neos.Utility.MediaTypes/composer.json
+++ b/Neos.Utility.MediaTypes/composer.json
@@ -9,7 +9,7 @@
   },
   "require-dev": {
     "mikey179/vfsstream": "~1.6",
-    "phpunit/phpunit": "~8.1.3",
+    "phpunit/phpunit": "~8.1",
     "neos/flow": "*"
   },
   "autoload": {

--- a/Neos.Utility.MediaTypes/composer.json
+++ b/Neos.Utility.MediaTypes/composer.json
@@ -9,7 +9,7 @@
   },
   "require-dev": {
     "mikey179/vfsstream": "~1.6",
-    "phpunit/phpunit": "~7.1",
+    "phpunit/phpunit": "~8.1.3",
     "neos/flow": "*"
   },
   "autoload": {

--- a/Neos.Utility.ObjectHandling/Tests/Unit/ObjectAccessTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/ObjectAccessTest.php
@@ -33,7 +33,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
 
     /**
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->dummyObject = new DummyClassWithGettersAndSetters();
         $this->dummyObject->setProperty('string1');

--- a/Neos.Utility.ObjectHandling/Tests/Unit/ObjectAccessTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/ObjectAccessTest.php
@@ -11,6 +11,7 @@ namespace Neos\Utility\ObjectHandling\Tests\Unit;
  * source code.
  */
 
+use Neos\Utility\Exception\PropertyNotAccessibleException;
 use Neos\Utility\ObjectHandling\Tests\Unit\Fixture\DummyClassWithGettersAndSetters;
 use Neos\Utility\ObjectHandling\Tests\Unit\Fixture\Model\EntityWithDoctrineProxy;
 use Neos\Utility\ObjectHandling\Tests\Unit\Fixture\ArrayAccessClass;
@@ -80,28 +81,28 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \Neos\Utility\Exception\PropertyNotAccessibleException
      */
     public function getPropertyReturnsPropertyNotAccessibleExceptionForNotExistingPropertyIfForceDirectAccessIsTrue()
     {
+        $this->expectException(PropertyNotAccessibleException::class);
         ObjectAccess::getProperty($this->dummyObject, 'notExistingProperty', true);
     }
 
     /**
      * @test
-     * @expectedException \Neos\Utility\Exception\PropertyNotAccessibleException
      */
     public function getPropertyReturnsThrowsExceptionIfPropertyDoesNotExist()
     {
+        $this->expectException(PropertyNotAccessibleException::class);
         ObjectAccess::getProperty($this->dummyObject, 'notExistingProperty');
     }
 
     /**
      * @test
-     * @expectedException \Neos\Utility\Exception\PropertyNotAccessibleException
      */
     public function getPropertyReturnsThrowsExceptionIfArrayKeyDoesNotExist()
     {
+        $this->expectException(PropertyNotAccessibleException::class);
         ObjectAccess::getProperty([], 'notExistingProperty');
     }
 
@@ -129,19 +130,19 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function getPropertyThrowsExceptionIfThePropertyNameIsNotAString()
     {
+        $this->expectException(\InvalidArgumentException::class);
         ObjectAccess::getProperty($this->dummyObject, new \ArrayObject());
     }
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function setPropertyThrowsExceptionIfThePropertyNameIsNotAString()
     {
+        $this->expectException(\InvalidArgumentException::class);
         ObjectAccess::setProperty($this->dummyObject, new \ArrayObject(), 42);
     }
 
@@ -249,20 +250,20 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \Neos\Utility\Exception\PropertyNotAccessibleException
      */
     public function getPropertyThrowsExceptionIfArrayObjectDoesNotContainMatchingKeyNorGetter()
     {
+        $this->expectException(PropertyNotAccessibleException::class);
         $arrayObject = new \ArrayObject();
         ObjectAccess::getProperty($arrayObject, 'nonExistingProperty');
     }
 
     /**
      * @test
-     * @expectedException \Neos\Utility\Exception\PropertyNotAccessibleException
      */
     public function getPropertyDoesNotTryArrayAccessOnSplObjectStorageSubject()
     {
+        $this->expectException(PropertyNotAccessibleException::class);
         $splObjectStorage = new \SplObjectStorage();
         ObjectAccess::getProperty($splObjectStorage, 'something');
     }
@@ -523,10 +524,10 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @expectedException \Neos\Utility\Exception\PropertyNotAccessibleException
      */
     public function accessorCacheIsNotUsedForStdClass()
     {
+        $this->expectException(PropertyNotAccessibleException::class);
         $object1 = new \stdClass();
         $object1->property = 'booh!';
         $object2 = new \stdClass();

--- a/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
@@ -11,6 +11,7 @@ namespace Neos\Utility\ObjectHandling\Tests\Unit;
  * source code.
  */
 
+use Neos\Utility\Exception\InvalidTypeException;
 use Neos\Utility\TypeHandling;
 
 /**
@@ -20,19 +21,19 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @test
-     * @expectedException \Neos\Utility\Exception\InvalidTypeException
      */
     public function parseTypeThrowsExceptionOnInvalidType()
     {
+        $this->expectException(InvalidTypeException::class);
         TypeHandling::parseType('$something');
     }
 
     /**
      * @test
-     * @expectedException \Neos\Utility\Exception\InvalidTypeException
      */
     public function parseTypeThrowsExceptionOnInvalidElementTypeHint()
     {
+        $this->expectException(InvalidTypeException::class);
         TypeHandling::parseType('string<integer>');
     }
 

--- a/Neos.Utility.ObjectHandling/composer.json
+++ b/Neos.Utility.ObjectHandling/composer.json
@@ -8,7 +8,7 @@
     "php": "~7.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "~7.1",
+    "phpunit/phpunit": "~8.1.3",
     "doctrine/orm": "~2.6.0",
     "doctrine/common": ">=2.4,<2.8-dev"
   },

--- a/Neos.Utility.ObjectHandling/composer.json
+++ b/Neos.Utility.ObjectHandling/composer.json
@@ -8,7 +8,7 @@
     "php": "~7.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "~8.1.3",
+    "phpunit/phpunit": "~8.1",
     "doctrine/orm": "~2.6.0",
     "doctrine/common": ">=2.4,<2.8-dev"
   },

--- a/Neos.Utility.Schema/Tests/Unit/SchemaGeneratorTest.php
+++ b/Neos.Utility.Schema/Tests/Unit/SchemaGeneratorTest.php
@@ -23,7 +23,7 @@ class SchemaGeneratorTest extends \PHPUnit\Framework\TestCase
      */
     private $configurationGenerator;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->configurationGenerator = new SchemaGenerator();
     }

--- a/Neos.Utility.Schema/Tests/Unit/SchemaValidatorTest.php
+++ b/Neos.Utility.Schema/Tests/Unit/SchemaValidatorTest.php
@@ -24,7 +24,7 @@ class SchemaValidatorTest extends \PHPUnit\Framework\TestCase
      */
     protected $configurationValidator;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->configurationValidator = $this->getMockBuilder(SchemaValidator::class)->setMethods(['getError'])->getMock();
     }

--- a/Neos.Utility.Schema/composer.json
+++ b/Neos.Utility.Schema/composer.json
@@ -10,7 +10,7 @@
   },
   "require-dev": {
     "mikey179/vfsstream": "~1.6",
-    "phpunit/phpunit": "~7.1"
+    "phpunit/phpunit": "~8.1.3"
   },
   "autoload": {
     "psr-4": {

--- a/Neos.Utility.Schema/composer.json
+++ b/Neos.Utility.Schema/composer.json
@@ -10,7 +10,7 @@
   },
   "require-dev": {
     "mikey179/vfsstream": "~1.6",
-    "phpunit/phpunit": "~8.1.3"
+    "phpunit/phpunit": "~8.1"
   },
   "autoload": {
     "psr-4": {

--- a/Neos.Utility.Unicode/Tests/Unit/TextIteratorTest.php
+++ b/Neos.Utility.Unicode/Tests/Unit/TextIteratorTest.php
@@ -87,7 +87,7 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
             new TextIterator('Some string', 948);
             $this->fail('Constructor did not reject invalid TextIterator type.');
         } catch (Unicode\Exception $exception) {
-            $this->assertContains('Invalid iterator type in TextIterator constructor', $exception->getMessage(), 'Wrong error message.');
+            $this->assertStringContainsString('Invalid iterator type in TextIterator constructor', $exception->getMessage(), 'Wrong error message.');
         }
     }
 

--- a/Neos.Utility.Unicode/composer.json
+++ b/Neos.Utility.Unicode/composer.json
@@ -13,7 +13,7 @@
   },
   "require-dev": {
     "mikey179/vfsstream": "~1.6",
-    "phpunit/phpunit": "~7.1"
+    "phpunit/phpunit": "~8.1.3"
   },
   "autoload": {
     "psr-4": {

--- a/Neos.Utility.Unicode/composer.json
+++ b/Neos.Utility.Unicode/composer.json
@@ -13,7 +13,7 @@
   },
   "require-dev": {
     "mikey179/vfsstream": "~1.6",
-    "phpunit/phpunit": "~8.1.3"
+    "phpunit/phpunit": "~8.1"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,7 @@
     },
     "require-dev": {
         "mikey179/vfsstream": "~1.6",
-        "phpunit/phpunit": "~7.1",
+        "phpunit/phpunit": "~8.1.3",
         "neos/flow": "*",
         "doctrine/orm": "~2.6.0",
         "doctrine/common": ">=2.4,<2.8-dev"

--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,7 @@
     },
     "require-dev": {
         "mikey179/vfsstream": "~1.6",
-        "phpunit/phpunit": "~8.1.3",
+        "phpunit/phpunit": "~8.1",
         "neos/flow": "*",
         "doctrine/orm": "~2.6.0",
         "doctrine/common": ">=2.4,<2.8-dev"


### PR DESCRIPTION
This change raises the phpunit requirement to v8.1. This might be breaking for you as phpunit introduced return types on methods like `public setUp(): void` as well as `public tearDown(): void`. PHPUnit also deprecated a lot of methods. You might find [here](https://thephp.cc/news/2019/02/help-my-tests-stopped-working) some more background information about replacements for your assertions.

Resolves #1506 
