### PR TITLE
[SECURITY] Avoid OpenSSL padding oracle attacks

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Cryptography/RsaWalletServicePhp.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Cryptography/RsaWalletServicePhp.php
@@ -13,6 +13,7 @@ namespace TYPO3\Flow\Security\Cryptography;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Security\Exception as SecurityException;
+use TYPO3\Flow\Security\Exception;
 use TYPO3\Flow\Security\Exception\DecryptionNotAllowedException;
 use TYPO3\Flow\Security\Exception\InvalidKeyPairIdException;
 use TYPO3\Flow\Security\Exception\MissingConfigurationException;
@@ -42,6 +43,12 @@ class RsaWalletServicePhp implements RsaWalletServiceInterface
     protected $openSSLConfiguration = [];
 
     /**
+     * The padding to use for OpenSSL encryption/decryption
+     * @var int
+     */
+    protected $paddingAlgorithm = OPENSSL_PKCS1_PADDING;
+
+    /**
      * @var boolean
      */
     protected $saveKeysOnShutdown = true;
@@ -64,6 +71,10 @@ class RsaWalletServicePhp implements RsaWalletServiceInterface
             $this->keystorePathAndFilename = $settings['security']['cryptography']['RSAWalletServicePHP']['keystorePath'];
         } else {
             throw new MissingConfigurationException('The configuration setting TYPO3.Flow.security.cryptography.RSAWalletServicePHP.keystorePath is missing. Please specify it in your Settings.yaml file. Beware: This file must not be accessible by the public!', 1305711354);
+        }
+
+        if (isset($settings['security']['cryptography']['RSAWalletServicePHP']['paddingAlgorithm'])) {
+            $this->paddingAlgorithm = $settings['security']['cryptography']['RSAWalletServicePHP']['paddingAlgorithm'];
         }
     }
 
@@ -165,11 +176,18 @@ class RsaWalletServicePhp implements RsaWalletServiceInterface
      * @param string $plaintext The plaintext to encrypt
      * @param string $fingerprint The fingerprint to identify to correct public key
      * @return string The ciphertext
+     * @throws Exception If encryption failed for some other reason
      */
     public function encryptWithPublicKey($plaintext, $fingerprint)
     {
         $cipher = '';
-        openssl_public_encrypt($plaintext, $cipher, $this->getPublicKey($fingerprint)->getKeyString());
+        if (openssl_public_encrypt($plaintext, $cipher, $this->getPublicKey($fingerprint)->getKeyString(), $this->paddingAlgorithm) === false) {
+            $openSslErrors = [];
+            while (($errorMessage = openssl_error_string()) !== false) {
+                $openSslErrors[] = $errorMessage;
+            }
+            throw new Exception(sprintf('Encryption failed, OpenSSL error: %s', implode(chr(10), $openSslErrors)), 1556609369);
+        }
 
         return $cipher;
     }
@@ -184,6 +202,7 @@ class RsaWalletServicePhp implements RsaWalletServiceInterface
      * @return string The decrypted text
      * @throws InvalidKeyPairIdException If the given fingerprint identifies no valid keypair
      * @throws DecryptionNotAllowedException If the given fingerprint identifies a keypair for encrypted passwords
+     * @throws Exception If decryption failed for some other reason
      */
     public function decrypt($cipher, $fingerprint)
     {
@@ -323,12 +342,19 @@ class RsaWalletServicePhp implements RsaWalletServiceInterface
      * @param string $cipher The ciphertext to decrypt
      * @param OpenSslRsaKey $privateKey The private key
      * @return string The decrypted plaintext
+     * @throws Exception
      */
     private function decryptWithPrivateKey($cipher, OpenSslRsaKey $privateKey)
     {
         $decrypted = '';
         $key = openssl_pkey_get_private($privateKey->getKeyString());
-        openssl_private_decrypt($cipher, $decrypted, $key);
+        if (openssl_private_decrypt($cipher, $decrypted, $key, $this->paddingAlgorithm) === false) {
+            $openSslErrors = [];
+            while (($errorMessage = openssl_error_string()) !== false) {
+                $openSslErrors[] = $errorMessage;
+            }
+            throw new Exception(sprintf('Decryption failed, OpenSSL error: %s', implode(chr(10), $openSslErrors)), 1556609762);
+        }
 
         return $decrypted;
     }

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Cryptography/RsaWalletServicePhp.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Cryptography/RsaWalletServicePhp.php
@@ -46,7 +46,7 @@ class RsaWalletServicePhp implements RsaWalletServiceInterface
      * The padding to use for OpenSSL encryption/decryption
      * @var int
      */
-    protected $paddingAlgorithm = OPENSSL_PKCS1_OAEP_PADDING;
+    protected $paddingAlgorithm;
 
     /**
      * @var boolean
@@ -59,6 +59,7 @@ class RsaWalletServicePhp implements RsaWalletServiceInterface
      * @param array $settings
      * @return void
      * @throws MissingConfigurationException
+     * @throws Exception
      */
     public function injectSettings(array $settings)
     {
@@ -73,8 +74,10 @@ class RsaWalletServicePhp implements RsaWalletServiceInterface
             throw new MissingConfigurationException('The configuration setting TYPO3.Flow.security.cryptography.RSAWalletServicePHP.keystorePath is missing. Please specify it in your Settings.yaml file. Beware: This file must not be accessible by the public!', 1305711354);
         }
 
-        if (isset($settings['security']['cryptography']['RSAWalletServicePHP']['paddingAlgorithm'])) {
+        if (isset($settings['security']['cryptography']['RSAWalletServicePHP']['paddingAlgorithm']) && is_int($settings['security']['cryptography']['RSAWalletServicePHP']['paddingAlgorithm'])) {
             $this->paddingAlgorithm = $settings['security']['cryptography']['RSAWalletServicePHP']['paddingAlgorithm'];
+        } else {
+            throw new Exception('The padding algorithm given in security.cryptography.RSAWalletServicePHP.paddingAlgorithm is not available.', 1556785429);
         }
     }
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Cryptography/RsaWalletServicePhp.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Cryptography/RsaWalletServicePhp.php
@@ -13,7 +13,6 @@ namespace TYPO3\Flow\Security\Cryptography;
 
 use TYPO3\Flow\Annotations as Flow;
 use TYPO3\Flow\Security\Exception as SecurityException;
-use TYPO3\Flow\Security\Exception;
 use TYPO3\Flow\Security\Exception\DecryptionNotAllowedException;
 use TYPO3\Flow\Security\Exception\InvalidKeyPairIdException;
 use TYPO3\Flow\Security\Exception\MissingConfigurationException;
@@ -59,7 +58,7 @@ class RsaWalletServicePhp implements RsaWalletServiceInterface
      * @param array $settings
      * @return void
      * @throws MissingConfigurationException
-     * @throws Exception
+     * @throws SecurityException
      */
     public function injectSettings(array $settings)
     {
@@ -77,7 +76,7 @@ class RsaWalletServicePhp implements RsaWalletServiceInterface
         if (isset($settings['security']['cryptography']['RSAWalletServicePHP']['paddingAlgorithm']) && is_int($settings['security']['cryptography']['RSAWalletServicePHP']['paddingAlgorithm'])) {
             $this->paddingAlgorithm = $settings['security']['cryptography']['RSAWalletServicePHP']['paddingAlgorithm'];
         } else {
-            throw new Exception('The padding algorithm given in security.cryptography.RSAWalletServicePHP.paddingAlgorithm is not available.', 1556785429);
+            throw new SecurityException('The padding algorithm given in security.cryptography.RSAWalletServicePHP.paddingAlgorithm is not available.', 1556785429);
         }
     }
 

--- a/TYPO3.Flow/Classes/TYPO3/Flow/Security/Cryptography/RsaWalletServicePhp.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Security/Cryptography/RsaWalletServicePhp.php
@@ -344,7 +344,7 @@ class RsaWalletServicePhp implements RsaWalletServiceInterface
      * @return string The decrypted plaintext
      * @throws Exception
      */
-    private function decryptWithPrivateKey($cipher, OpenSslRsaKey $privateKey, $paddingAlgorithm = null)
+    private function decryptWithPrivateKey($cipher, OpenSslRsaKey $privateKey)
     {
         $decrypted = '';
         $key = openssl_pkey_get_private($privateKey->getKeyString());

--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -627,9 +627,9 @@ TYPO3:
           keystorePath: '%FLOW_PATH_DATA%Persistent/RsaWalletData'
 
           # The padding to use when encrypting/decrypting data.
-          # The default is insecure, you should change it to
+          # The default OPENSSL_PKCS1_PADDING is insecure, you should change it to
           # OPENSSL_PKCS1_OAEP_PADDING
-          paddingAlgorithm: '%OPENSSL_PKCS1_PADDING%'
+          paddingAlgorithm: '%OPENSSL_PKCS1_OAEP_PADDING%'
 
           # Defines the openSSL configuration used for key handling.
           # See the PHP openSSL documentation for possible settings.

--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -627,7 +627,7 @@ TYPO3:
           keystorePath: '%FLOW_PATH_DATA%Persistent/RsaWalletData'
 
           # The padding to use when encrypting/decrypting data.
-          # The default OPENSSL_PKCS1_PADDING is insecure, you should change it to
+          # PHP's default OPENSSL_PKCS1_PADDING is insecure, thus we change it to
           # OPENSSL_PKCS1_OAEP_PADDING
           paddingAlgorithm: '%OPENSSL_PKCS1_OAEP_PADDING%'
 

--- a/TYPO3.Flow/Configuration/Settings.yaml
+++ b/TYPO3.Flow/Configuration/Settings.yaml
@@ -626,6 +626,11 @@ TYPO3:
           # Note: This file must not be accessible by the public!
           keystorePath: '%FLOW_PATH_DATA%Persistent/RsaWalletData'
 
+          # The padding to use when encrypting/decrypting data.
+          # The default is insecure, you should change it to
+          # OPENSSL_PKCS1_OAEP_PADDING
+          paddingAlgorithm: '%OPENSSL_PKCS1_PADDING%'
+
           # Defines the openSSL configuration used for key handling.
           # See the PHP openSSL documentation for possible settings.
           openSSLConfiguration: []

--- a/TYPO3.Flow/Tests/Unit/Security/Cryptography/RsaWalletServicePhpTest.php
+++ b/TYPO3.Flow/Tests/Unit/Security/Cryptography/RsaWalletServicePhpTest.php
@@ -42,8 +42,9 @@ class RsaWalletServicePhpTest extends UnitTestCase
     {
         vfsStream::setup('Foo');
         $settings['security']['cryptography']['RSAWalletServicePHP']['keystorePath'] = 'vfs://Foo/EncryptionKey';
+        $settings['security']['cryptography']['RSAWalletServicePHP']['paddingAlgorithm'] = OPENSSL_PKCS1_OAEP_PADDING;
         $settings['security']['cryptography']['RSAWalletServicePHP']['openSSLConfiguration']['digest_alg'] = 'sha1';
-        $settings['security']['cryptography']['RSAWalletServicePHP']['openSSLConfiguration']['private_key_bits'] = 384;
+        $settings['security']['cryptography']['RSAWalletServicePHP']['openSSLConfiguration']['private_key_bits'] = 1024;
         $settings['security']['cryptography']['RSAWalletServicePHP']['openSSLConfiguration']['private_key_type'] = OPENSSL_KEYTYPE_RSA;
 
         $this->rsaWalletService = $this->getAccessibleMock(RsaWalletServicePhp::class, ['dummy']);


### PR DESCRIPTION
This avoids OpenSSL Padding Oracle Information Disclosure by
allowing to specify the padding algorithm used in the RSA wallet
service.

Most probably you are not even affected, since only OpenSSL 1.0.1t
and 1.0.2h are vulnerable, but better safe than sorry.

The padding algorithm default is changed to OPENSSL_PKCS1_OAEP_PADDING,
but a fallback decryption is in place for all data that was encrypted with the
previously unsafe padding algorithm.
Therefore you should migrate all your existing encrypted data, by running it through
`decryptWithPrivateKey` and then again through `encryptWithPublicKey` ONCE.

Fixes #1566 