### PR TITLE
TASK: Fix name of index on PersistentResource.sha1

### DIFF
--- a/Neos.Flow/Classes/ResourceManagement/PersistentResource.php
+++ b/Neos.Flow/Classes/ResourceManagement/PersistentResource.php
@@ -25,7 +25,7 @@ use Neos\Flow\ResourceManagement\Exception as ResourceException;
  * Model representing a persistable resource
  *
  * @Flow\Entity
- * @ORM\Table(indexes={@ORM\Index(columns={"sha1"})})
+ * @ORM\Table(indexes={@ORM\Index(name="IDX_35DC14F03332102A",columns={"sha1"})})
  */
 class PersistentResource implements ResourceMetaDataInterface, CacheAwareInterface
 {


### PR DESCRIPTION
The name IDX_35DC14F03332102A is different from what Doctrine does
auto-generate, but needs to be used due to BC reasons with existing
migrations.

See https://github.com/neos/neos-development-collection/issues/2475
