### PR TITLE
TASK: Raise PHP version by one minor version in travis.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,29 +2,29 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
+    - php: 7.2
       env: DB=mysql
       addons:
         mariadb: '10.2'
-    - php: 7.1
+    - php: 7.2
       env: DB=pgsql
       sudo: required
       addons:
         postgresql: "9.4"
-    - php: 7.1
+    - php: 7.2
       env: DB=mysql BEHAT=true
       addons:
         mariadb: '10.2'
-    - php: 7.1
+    - php: 7.2
       env: DB=pgsql BEHAT=true
       sudo: required
       addons:
         postgresql: "9.4"
-    - php: 7.2
+    - php: 7.3
       env: DB=mysql
       addons:
         mariadb: '10.2'
-    - php: 7.2
+    - php: 7.3
       env: DB=mysql BEHAT=true
       addons:
         mariadb: '10.2'


### PR DESCRIPTION
Raise PHP versions from 7.1 to 7.2 and 7.2 to 7.3 in the travis test matrix.