### PR TITLE
!!! TASK: Remove deprecated methods from AuthenticationManagerInterface

### DIFF
--- a/Neos.Flow/Classes/Security/Authentication/AuthenticationManagerInterface.php
+++ b/Neos.Flow/Classes/Security/Authentication/AuthenticationManagerInterface.php
@@ -24,39 +24,11 @@ use Neos\Flow\Security\Exception\NoTokensAuthenticatedException;
 interface AuthenticationManagerInterface
 {
     /**
-     * Returns the tokens this manager is responsible for.
-     * Note: The order of the tokens in the array is important, as the tokens will be authenticated in the given order.
-     *
-     * @return array<TokenInterface> An array of tokens this manager is responsible for
-     * @deprecated Use the TokenAndProviderFactory
-     * @see TokenAndProviderFactoryInterface
-     */
-    public function getTokens();
-
-    /**
-     * Returns all configured authentication providers
-     *
-     * @return array Array of \Neos\Flow\Security\Authentication\AuthenticationProviderInterface
-     * @deprecated Use the TokenAndProviderFactory
-     * @see TokenAndProviderFactoryInterface
-     */
-    public function getProviders();
-
-    /**
-     * Sets the security context
-     *
-     * @param SecurityContext $securityContext The security context of the current request
-     * @return void
-     * @deprecated Just get it injected
-     */
-    public function setSecurityContext(SecurityContext $securityContext);
-
-    /**
      * Returns the security context
      *
      * @return SecurityContext $securityContext The security context of the current request
      */
-    public function getSecurityContext();
+    public function getSecurityContext(): SecurityContext;
 
     /**
      * Tries to authenticate the tokens in the security context, if needed.
@@ -66,19 +38,19 @@ interface AuthenticationManagerInterface
      * @throws AuthenticationRequiredException
      * @throws NoTokensAuthenticatedException
      */
-    public function authenticate();
+    public function authenticate(): void;
 
     /**
      * Checks if at least one token is authenticated
      *
-     * @return boolean
+     * @return bool
      */
-    public function isAuthenticated();
+    public function isAuthenticated(): bool;
 
     /**
      * Logs all active authentication tokens out
      *
      * @return void
      */
-    public function logout();
+    public function logout(): void;
 }

--- a/Neos.Flow/Classes/Security/Authentication/AuthenticationProviderManager.php
+++ b/Neos.Flow/Classes/Security/Authentication/AuthenticationProviderManager.php
@@ -17,6 +17,7 @@ use Neos\Flow\Security\Context;
 use Neos\Flow\Security\Exception\NoTokensAuthenticatedException;
 use Neos\Flow\Security\Exception\AuthenticationRequiredException;
 use Neos\Flow\Security\Exception;
+use Neos\Flow\Session\Exception\SessionNotStartedException;
 use Neos\Flow\Session\SessionManagerInterface;
 
 /**
@@ -55,9 +56,9 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
     protected $providerConfigurations;
 
     /**
-     * @var boolean
+     * @var bool
      */
-    protected $isAuthenticated = null;
+    protected $isAuthenticated;
 
     /**
      * @var bool
@@ -70,11 +71,11 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
     protected $authenticationStrategy;
 
     /**
-     * @param TokenAndProviderFactoryInterface $tokenAndProviderFacory
+     * @param TokenAndProviderFactoryInterface $tokenAndProviderFactory
      */
-    public function __construct(TokenAndProviderFactoryInterface $tokenAndProviderFacory)
+    public function __construct(TokenAndProviderFactoryInterface $tokenAndProviderFactory)
     {
-        $this->tokenAndProviderFactory = $tokenAndProviderFacory;
+        $this->tokenAndProviderFactory = $tokenAndProviderFactory;
     }
 
     /**
@@ -114,7 +115,7 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
      * @return void
      * @deprecated Just get it injected
      */
-    public function setSecurityContext(Context $securityContext)
+    public function setSecurityContext(Context $securityContext): void
     {
         $this->securityContext = $securityContext;
     }
@@ -124,34 +125,9 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
      *
      * @return Context $securityContext The security context of the current request
      */
-    public function getSecurityContext()
+    public function getSecurityContext(): Context
     {
         return $this->securityContext;
-    }
-
-    /**
-     * Returns clean tokens this manager is responsible for.
-     * Note: The order of the tokens in the array is important, as the tokens will be authenticated in the given order.
-     *
-     * @return array Array of TokenInterface this manager is responsible for
-     * @deprecated Use TokenAndProviderFactory
-     * @see TokenAndProviderFactoryInterface::getTokens()
-     */
-    public function getTokens()
-    {
-        return $this->tokenAndProviderFactory->getTokens();
-    }
-
-    /**
-     * Returns all configured authentication providers
-     *
-     * @return array Array of \Neos\Flow\Security\Authentication\AuthenticationProviderInterface
-     * @deprecated Use TokenAndProviderFactory
-     * @see TokenAndProviderFactoryInterface::getProviders()
-     */
-    public function getProviders()
-    {
-        return $this->tokenAndProviderFactory->getProviders();
     }
 
     /**
@@ -167,7 +143,7 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
      * @throws AuthenticationRequiredException
      * @throws NoTokensAuthenticatedException
      */
-    public function authenticate()
+    public function authenticate(): void
     {
         $this->isAuthenticated = false;
         $anyTokenAuthenticated = false;
@@ -236,7 +212,7 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
      * @return boolean
      * @throws Exception
      */
-    public function isAuthenticated()
+    public function isAuthenticated(): bool
     {
         if ($this->isAuthenticated === null) {
             try {
@@ -252,9 +228,9 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
      *
      * @return void
      * @throws Exception
-     * @throws \Neos\Flow\Session\Exception\SessionNotStartedException
+     * @throws SessionNotStartedException
      */
-    public function logout()
+    public function logout(): void
     {
         if ($this->isAuthenticated() !== true) {
             return;

--- a/Neos.Flow/Tests/Behavior/Features/Bootstrap/SecurityOperationsTrait.php
+++ b/Neos.Flow/Tests/Behavior/Features/Bootstrap/SecurityOperationsTrait.php
@@ -54,6 +54,11 @@ trait SecurityOperationsTrait
     protected $authenticationManager;
 
     /**
+     * @var Security\Authentication\TokenAndProviderFactoryInterface
+     */
+    protected $tokenAndProviderFactory;
+
+    /**
      * @var PolicyService
      */
     protected $policyService;
@@ -210,9 +215,10 @@ trait SecurityOperationsTrait
         $this->policyService = $this->objectManager->get(PolicyService::class);
         $this->accountRepository = $this->objectManager->get(Security\AccountRepository::class);
         $this->authenticationManager = $this->objectManager->get(AuthenticationProviderManager::class);
+        $this->tokenAndProviderFactory = $this->objectManager->get(Security\Authentication\TokenAndProviderFactoryInterface::class);
 
         // Making sure providers and tokens were actually build, so the singleton TestingProvider exists.
-        $this->authenticationManager->getProviders();
+        $this->tokenAndProviderFactory->getProviders();
 
         $this->testingProvider = $this->objectManager->get(TestingProvider::class);
         $this->testingProvider->setName('TestingProvider');


### PR DESCRIPTION
This removes `getTokens()`, `getProviders()` and `setSecurityContext()`
from `AuthenticationManagerInterface` and `AuthenticationProviderManager`.

Also return type declarations are set on the interface methods.

To adjust your code using any implementations of the interface, replace

- `$this->authenticationManager->getTokens()` with `$this->tokenAndProviderFactory->getTokens()`
- `$this->authenticationManager->getProviders()` with `$this->tokenAndProviderFactory->getProviders()`

(Of course you might need to add injections so the factory is available in
your code.)

If you implemented the interface yourself, remove the methods and use
injection instead of `setSecurityContext()`:

    /**
     * The security context of the current request
     *
     * @Flow\Inject
     * @var Neos\Flow\Security\Context
     */
    protected $securityContext;
