### PR TITLE
!!! FEATURE: Add function helpers to Eel and remove magic `q`

### DIFF
--- a/Neos.Eel/Classes/FlowQuery/FlowQuery.php
+++ b/Neos.Eel/Classes/FlowQuery/FlowQuery.php
@@ -122,7 +122,7 @@ class FlowQuery implements ProtectedContextAwareInterface, \IteratorAggregate, \
 
     /**
      * The q function from eel
-     * @param mixed
+     * @param $element mixed
      * @return FlowQuery
      * @throws Exception
      */

--- a/Neos.Eel/Classes/FlowQuery/FlowQuery.php
+++ b/Neos.Eel/Classes/FlowQuery/FlowQuery.php
@@ -122,7 +122,7 @@ class FlowQuery implements ProtectedContextAwareInterface, \IteratorAggregate, \
 
     /**
      * The q function from eel
-     * @param $element mixed
+     * @param mixed $element
      * @return FlowQuery
      * @throws Exception
      */

--- a/Neos.Eel/Classes/FlowQuery/FlowQuery.php
+++ b/Neos.Eel/Classes/FlowQuery/FlowQuery.php
@@ -121,6 +121,17 @@ class FlowQuery implements ProtectedContextAwareInterface, \IteratorAggregate, \
     }
 
     /**
+     * The q function from eel
+     * @param mixed
+     * @return FlowQuery
+     * @throws Exception
+     */
+    public static function q($element): self
+    {
+        return new static(is_array($element) || $element instanceof \Traversable ? $element : [$element]);
+    }
+
+    /**
      * Setter for setting the operation resolver from the outside, only needed
      * to successfully run unit tests (hacky!)
      *

--- a/Neos.Eel/Classes/Utility.php
+++ b/Neos.Eel/Classes/Utility.php
@@ -37,8 +37,8 @@ class Utility
                 $currentPathBase = & $currentPathBase[$pathName];
             }
 
-            if (strpos($objectType, '::')) {
-                if (strpos($variableName, '.')) {
+            if (strpos($objectType, '::') !== false) {
+                if (strpos($variableName, '.') !== false) {
                     throw new Exception(sprintf('Function helpers are only allowed on root level, "%s" was given?', $variableName), 1557911015);
                 }
                 $currentPathBase = self::createClosureFromConfiguration($objectType);

--- a/Neos.Eel/Classes/Utility.php
+++ b/Neos.Eel/Classes/Utility.php
@@ -52,7 +52,7 @@ class Utility
     /**
      * Create a closure to be used as Helper for eel.
      *
-     * @param $objectConfiguration string className followed by two colone and the method name
+     * @param string $objectConfiguration className followed by two colone and the method name
      * @return callable
      */
     private static function createClosureFromConfiguration(string $objectConfiguration): callable

--- a/Neos.Eel/Classes/Utility.php
+++ b/Neos.Eel/Classes/Utility.php
@@ -36,10 +36,34 @@ class Utility
                 }
                 $currentPathBase = & $currentPathBase[$pathName];
             }
-            $currentPathBase = new $objectType();
-        }
 
+            if (strpos($objectType, '::')) {
+                if (strpos($variableName, '.')) {
+                    throw new Exception(sprintf('Function helpers are only allowed on root level, "%s" was given?', $variableName), 1557911015);
+                }
+                $currentPathBase = self::createClosureFromConfiguration($objectType);
+            } else {
+                $currentPathBase = new $objectType();
+            }
+        }
         return $defaultContextVariables;
+    }
+
+    /**
+     * Create a closure to be used as Helper for eel.
+     *
+     * @param $objectConfiguration string className followed by two colone and the method name
+     * @return callable
+     */
+    private static function createClosureFromConfiguration(string $objectConfiguration): callable
+    {
+        list($className, $methodName) = explode('::', $objectConfiguration, 2);
+        return function (...$arguments) use ($className, $methodName) {
+            return call_user_func_array(
+                [$className, $methodName],
+                $arguments
+            );
+        };
     }
 
     /**
@@ -62,16 +86,15 @@ class Utility
         $defaultContextVariables = self::getDefaultContextVariables($defaultContextConfiguration);
         $contextVariables = array_merge($defaultContextVariables, $contextVariables);
 
-        if (isset($contextVariables['q'])) {
-            throw new Exception('Context variable "q" not allowed, as it is already reserved for FlowQuery use.', 1410441819);
-        }
-
-        $contextVariables['q'] = function ($element) {
-            return new FlowQuery\FlowQuery(is_array($element) || $element instanceof \Traversable ? $element : [$element]);
-        };
-
         $context = new ProtectedContext($contextVariables);
-        $context->whitelist('q');
+
+        // Whitelist functions on the uppermost context level to allow calling them without
+        // implementing ProtectedContextAwareInterface which is impossible for functions
+        foreach ($contextVariables as $key => $value) {
+            if (is_callable($value)) {
+                $context->whitelist($key);
+            }
+        }
 
         return $eelEvaluator->evaluate($matches['exp'], $context);
     }


### PR DESCRIPTION
Function helpers are static functions that are available in Eel without a containing helper. This
change removes the default q variable and instead adds a static method `q` to the flowQuery
class that is used as helper function with the following configuration:

```
Neos:
  Fusion:
    defaultContext:
      q: 'Neos\Eel\FlowQuery\FlowQuery::q'
  ContentRepository:
    labelGenerator:
      eel:
        defaultContext:
          q: Neos\Eel\FlowQuery\FlowQuery::q
```
Note: Nested pathes as identifiers for function-helpers are not allowed and will raise an exception.

This is breaking as it makes it necessary to add the configuration above to Neos.Fusion and Neos.ContentRepository. Also custom code that uses FlowQuery and relies on q beeing always present will have to be adjusted.

Upgrade Instructions:

Only if you are using the EelUtility in to evaluate expressions with `q` AND are  using a custom defaultContextConfiguration you have to make sure that the configuration line `q: 'Neos\Eel\FlowQuery\FlowQuery::q'` is added to this configuration.