### PR TITLE
BUGFIX: Remove deprecated PhpUnit functions from tests

### DIFF
--- a/Neos.Flow/Tests/Functional/I18n/Cldr/CldrRepositoryTest.php
+++ b/Neos.Flow/Tests/Functional/I18n/Cldr/CldrRepositoryTest.php
@@ -15,6 +15,7 @@ use Neos\Flow\I18n;
 use Neos\Flow\I18n\Cldr\CldrRepository;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Utility\Files;
+use Neos\Utility\ObjectAccess;
 
 /**
  * Testcase for the I18N CLDR Repository
@@ -64,9 +65,9 @@ class CldrRepositoryTest extends FunctionalTestCase
         $localeImplementingChaining = new I18n\Locale('de_DE');
 
         $cldrModel = $this->cldrRepository->getModelForLocale($localeImplementingChaining);
-
-        $this->assertAttributeContains(Files::concatenatePaths([$this->cldrBasePath, 'main/root.xml']), 'sourcePaths', $cldrModel);
-        $this->assertAttributeContains(Files::concatenatePaths([$this->cldrBasePath, 'main/de_DE.xml']), 'sourcePaths', $cldrModel);
-        $this->assertAttributeContains(Files::concatenatePaths([$this->cldrBasePath, 'main/de.xml']), 'sourcePaths', $cldrModel);
+        
+        $this->assertContains(Files::concatenatePaths([$this->cldrBasePath, 'main/root.xml']), ObjectAccess::getProperty($cldrModel, 'sourcePaths', true));
+        $this->assertContains(Files::concatenatePaths([$this->cldrBasePath, 'main/de_DE.xml']), ObjectAccess::getProperty($cldrModel, 'sourcePaths', true));
+        $this->assertContains(Files::concatenatePaths([$this->cldrBasePath, 'main/de.xml']), ObjectAccess::getProperty($cldrModel, 'sourcePaths', true));
     }
 }

--- a/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
@@ -19,6 +19,7 @@ use Neos\Flow\Persistence\Doctrine\QueryResult;
 use Neos\Flow\Persistence\Exception;
 use Neos\Flow\Persistence\Exception\ObjectValidationFailedException;
 use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Utility\ObjectAccess;
 
 /**
  * Testcase for persistence
@@ -76,11 +77,11 @@ class PersistenceTest extends FunctionalTestCase
 
         $allResults = $this->testEntityRepository->findAll();
         $this->assertInstanceOf(QueryResult::class, $allResults);
-        $this->assertAttributeInternalType('null', 'rows', $allResults, 'Query Result did not load the result collection lazily.');
+        $this->assertNull(ObjectAccess::getProperty($allResults, 'rows', true), 'Query Result did not load the result collection lazily.');
 
         $allResultsArray = $allResults->toArray();
         $this->assertStringContainsString('Flow', $allResultsArray[0]->getName());
-        $this->assertAttributeInternalType('array', 'rows', $allResults);
+        $this->assertIsArray(ObjectAccess::getProperty($allResults, 'rows', true));
     }
 
     /**
@@ -94,7 +95,7 @@ class PersistenceTest extends FunctionalTestCase
         $allResults = $this->testEntityRepository->findAll();
 
         $unserializedResults = unserialize(serialize($allResults));
-        $this->assertAttributeInternalType('null', 'rows', $unserializedResults, 'Query Result did not flush the result collection after serialization.');
+        $this->assertNull(ObjectAccess::getProperty($unserializedResults, 'rows', true), 'Query Result did not flush the result collection after serialization.');
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Http/BrowserTest.php
+++ b/Neos.Flow/Tests/Unit/Http/BrowserTest.php
@@ -108,12 +108,16 @@ class BrowserTest extends UnitTestCase
         $requestEngine
             ->expects($this->at(0))
             ->method('sendRequest')
-            ->with($this->attributeEqualTo('uri', $initialUri))
+            ->with($this->callback(function (Http\Request $request) use ($initialUri) {
+                return $request->getUri() == $initialUri;
+            }))
             ->will($this->returnValue($firstResponse));
         $requestEngine
             ->expects($this->at(1))
             ->method('sendRequest')
-            ->with($this->attributeEqualTo('uri', $redirectUri))
+            ->with($this->callback(function (Http\Request $request) use ($redirectUri) {
+                return $request->getUri() == $redirectUri;
+            }))
             ->will($this->returnValue($secondResponse));
 
         $this->browser->setRequestEngine($requestEngine);

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/CldrRepositoryTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/CldrRepositoryTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Tests\Unit\I18n\Cldr;
  * source code.
  */
 
+use Neos\Utility\ObjectAccess;
 use org\bovigo\vfs\vfsStream;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\I18n;
@@ -51,7 +52,7 @@ class CldrRepositoryTest extends UnitTestCase
         file_put_contents('vfs://Foo/Bar.xml', '');
 
         $result = $this->repository->getModel('Bar');
-        $this->assertAttributeContains('vfs://Foo/Bar.xml', 'sourcePaths', $result);
+        $this->assertContains('vfs://Foo/Bar.xml', ObjectAccess::getProperty($result, 'sourcePaths', true));
 
         $result = $this->repository->getModel('NoSuchFile');
         $this->assertEquals(false, $result);
@@ -66,8 +67,8 @@ class CldrRepositoryTest extends UnitTestCase
         file_put_contents('vfs://Foo/Directory/en.xml', '');
 
         $result = $this->repository->getModelForLocale($this->dummyLocale, 'Directory');
-        $this->assertAttributeContains('vfs://Foo/Directory/root.xml', 'sourcePaths', $result);
-        $this->assertAttributeContains('vfs://Foo/Directory/en.xml', 'sourcePaths', $result);
+        $this->assertContains('vfs://Foo/Directory/root.xml', ObjectAccess::getProperty($result, 'sourcePaths', true));
+        $this->assertContains('vfs://Foo/Directory/en.xml', ObjectAccess::getProperty($result, 'sourcePaths', true));
 
         $result = $this->repository->getModelForLocale($this->dummyLocale, 'NoSuchDirectory');
         $this->assertEquals(null, $result);

--- a/Neos.Flow/Tests/Unit/Persistence/Generic/DataMapperTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Generic/DataMapperTest.php
@@ -16,6 +16,7 @@ use Neos\Flow\Reflection\ClassSchema;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\Persistence;
+use Neos\Utility\ObjectAccess;
 
 /**
  * Testcase for \Neos\Flow\Persistence\DataMapper
@@ -141,10 +142,10 @@ class DataMapperTest extends UnitTestCase
         $dataMapper = $this->getAccessibleMock(Persistence\Generic\DataMapper::class, ['dummy']);
         $dataMapper->injectReflectionService($mockReflectionService);
         $dataMapper->_call('thawProperties', $object, 1234, $objectData);
-        $this->assertAttributeEquals('firstValue', 'firstProperty', $object);
-        $this->assertAttributeEquals(1234, 'secondProperty', $object);
-        $this->assertAttributeEquals(1.234, 'thirdProperty', $object);
-        $this->assertAttributeEquals(false, 'fourthProperty', $object);
+        $this->assertEquals('firstValue', ObjectAccess::getProperty($object, 'firstProperty'));
+        $this->assertEquals(1234, ObjectAccess::getProperty($object, 'secondProperty'));
+        $this->assertEquals(1.234, ObjectAccess::getProperty($object, 'thirdProperty'));
+        $this->assertEquals(false, ObjectAccess::getProperty($object, 'fourthProperty'));
     }
 
     /**
@@ -174,7 +175,7 @@ class DataMapperTest extends UnitTestCase
         $dataMapper->injectReflectionService($mockReflectionService);
         $dataMapper->_call('thawProperties', $object, $objectData['identifier'], $objectData);
 
-        $this->assertAttributeEquals('c254d2e0-825a-11de-8a39-0800200c9a66', 'Persistence_Object_Identifier', $object);
+        $this->assertEquals('c254d2e0-825a-11de-8a39-0800200c9a66', ObjectAccess::getProperty($object, 'Persistence_Object_Identifier'));
     }
 
     /**
@@ -277,7 +278,7 @@ class DataMapperTest extends UnitTestCase
 
         // the order of setting those is important, but cannot be tested for now (static setProperty)
         $expected = [['secondProperty' => 'secondValue'],['firstProperty' => 'firstValue'],['thirdProperty' => 'thirdValue'],['Persistence_Object_Identifier' => '1234']];
-        $this->assertAttributeSame($expected, 'properties', $object);
+        $this->assertSame($expected, ObjectAccess::getProperty($object, 'properties', true));
     }
 
     /**
@@ -356,7 +357,7 @@ class DataMapperTest extends UnitTestCase
         $dataMapper->injectReflectionService($mockReflectionService);
         $dataMapper->_call('thawProperties', $object, $objectData['identifier'], $objectData);
 
-        $this->assertAttributeEquals(['My_Metadata' => 'Test'], 'Flow_Persistence_Metadata', $object);
+        $this->assertEquals(['My_Metadata' => 'Test'], ObjectAccess::getProperty($object, 'Flow_Persistence_Metadata'));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Persistence/Generic/PersistenceManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Generic/PersistenceManagerTest.php
@@ -20,6 +20,7 @@ use Neos\Flow\Persistence\Aspect\PersistenceMagicInterface;
 use Neos\Flow\Persistence\Generic;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\Tests\Persistence\Fixture;
+use Neos\Utility\ObjectAccess;
 
 /**
  * Testcase for the Persistence Manager
@@ -151,7 +152,7 @@ class PersistenceManagerTest extends UnitTestCase
         $persistenceManager = new Generic\PersistenceManager();
         $persistenceManager->add($someObject);
 
-        $this->assertAttributeContains($someObject, 'addedObjects', $persistenceManager);
+        $this->assertContains($someObject, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
     }
 
     /**
@@ -170,9 +171,9 @@ class PersistenceManagerTest extends UnitTestCase
 
         $persistenceManager->remove($object2);
 
-        $this->assertAttributeContains($object1, 'addedObjects', $persistenceManager);
-        $this->assertAttributeNotContains($object2, 'addedObjects', $persistenceManager);
-        $this->assertAttributeContains($object3, 'addedObjects', $persistenceManager);
+        $this->assertContains($object1, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
+        $this->assertNotContains($object2, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
+        $this->assertContains($object3, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
     }
 
     /**
@@ -194,9 +195,9 @@ class PersistenceManagerTest extends UnitTestCase
 
         $persistenceManager->remove($object2);
 
-        $this->assertAttributeContains($object1, 'addedObjects', $persistenceManager);
-        $this->assertAttributeNotContains($object2, 'addedObjects', $persistenceManager);
-        $this->assertAttributeContains($object3, 'addedObjects', $persistenceManager);
+        $this->assertContains($object1, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
+        $this->assertNotContains($object2, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
+        $this->assertContains($object3, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
     }
 
     /**
@@ -211,7 +212,7 @@ class PersistenceManagerTest extends UnitTestCase
         $persistenceManager = new Generic\PersistenceManager();
         $persistenceManager->remove($object);
 
-        $this->assertAttributeContains($object, 'removedObjects', $persistenceManager);
+        $this->assertContains($object, ObjectAccess::getProperty($persistenceManager, 'removedObjects', true));
     }
 
     /**
@@ -223,9 +224,9 @@ class PersistenceManagerTest extends UnitTestCase
         $persistenceManager = $this->getMockBuilder(\Neos\Flow\Persistence\Generic\PersistenceManager::class)->setMethods(['isNewObject'])->getMock();
         $persistenceManager->expects($this->any())->method('isNewObject')->willReturn(false);
 
-        $this->assertAttributeNotContains($object, 'changedObjects', $persistenceManager);
+        $this->assertNotContains($object, ObjectAccess::getProperty($persistenceManager, 'changedObjects', true));
         $persistenceManager->update($object);
-        $this->assertAttributeContains($object, 'changedObjects', $persistenceManager);
+        $this->assertContains($object, ObjectAccess::getProperty($persistenceManager, 'changedObjects', true));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/ResourceManagement/Streams/ResourceStreamWrapperTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/Streams/ResourceStreamWrapperTest.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Tests\Unit\ResourceManagement\Streams;
 
 use Neos\Flow\Package\FlowPackageInterface;
 use Neos\Flow\ResourceManagement\Exception;
+use Neos\Utility\ObjectAccess;
 use org\bovigo\vfs\vfsStream;
 use Neos\Flow\Package\PackageManager;
 use Neos\Flow\ResourceManagement\PersistentResource;
@@ -78,7 +79,7 @@ class ResourceStreamWrapperTest extends UnitTestCase
 
         $openedPathAndFilename = '';
         $this->assertTrue($this->resourceStreamWrapper->open('resource://' . $sha1Hash, 'r', 0, $openedPathAndFilename));
-        $this->assertAttributeSame($tempFile, 'handle', $this->resourceStreamWrapper);
+        $this->assertSame($tempFile, ObjectAccess::getProperty($this->resourceStreamWrapper, 'handle', true));
     }
 
     /**
@@ -96,7 +97,7 @@ class ResourceStreamWrapperTest extends UnitTestCase
 
         $openedPathAndFilename = '';
         $this->assertTrue($this->resourceStreamWrapper->open('resource://' . $sha1Hash, 'r', 0, $openedPathAndFilename));
-        $this->assertAttributeSame($tempFile, 'handle', $this->resourceStreamWrapper);
+        $this->assertSame($tempFile, ObjectAccess::getProperty($this->resourceStreamWrapper, 'handle', true));
     }
 
     /**

--- a/Neos.Utility.ObjectHandling/Tests/Unit/ObjectAccessTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/ObjectAccessTest.php
@@ -16,6 +16,7 @@ use Neos\Utility\ObjectHandling\Tests\Unit\Fixture\DummyClassWithGettersAndSette
 use Neos\Utility\ObjectHandling\Tests\Unit\Fixture\Model\EntityWithDoctrineProxy;
 use Neos\Utility\ObjectHandling\Tests\Unit\Fixture\ArrayAccessClass;
 use Neos\Utility\ObjectAccess;
+use Neos\Utility\TypeHandling;
 
 require_once('Fixture/DummyClassWithGettersAndSetters.php');
 require_once('Fixture/ArrayAccessClass.php');
@@ -170,7 +171,10 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
     public function setPropertySetsValueIfPropertyIsNotAccessibleWhenForceDirectAccessIsTrue()
     {
         $this->assertTrue(ObjectAccess::setProperty($this->dummyObject, 'unexposedProperty', 'was set anyway', true));
-        $this->assertAttributeEquals('was set anyway', 'unexposedProperty', $this->dummyObject);
+        $className = TypeHandling::getTypeForValue($this->dummyObject);
+        $propertyReflection = new \ReflectionProperty($className, 'unexposedProperty');
+        $propertyReflection->setAccessible(true);
+        $this->assertEquals('was set anyway', $propertyReflection->getValue($this->dummyObject));
     }
 
     /**
@@ -179,7 +183,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
     public function setPropertySetsValueIfPropertyDoesNotExistWhenForceDirectAccessIsTrue()
     {
         $this->assertTrue(ObjectAccess::setProperty($this->dummyObject, 'unknownProperty', 'was set anyway', true));
-        $this->assertAttributeEquals('was set anyway', 'unknownProperty', $this->dummyObject);
+        $this->assertEquals('was set anyway', $this->dummyObject->unknownProperty);
     }
 
     /**


### PR DESCRIPTION
Replace deprecated PhpUnit functions with supported alternatives.

Fixes https://github.com/neos/neos-development-collection/issues/2498