### PR TITLE
TASK: Clean up ignoredTags configuration with defaults from doctrine AnnotationReader

### DIFF
--- a/Neos.Flow/Configuration/Settings.Reflection.yaml
+++ b/Neos.Flow/Configuration/Settings.Reflection.yaml
@@ -7,17 +7,8 @@ Neos:
     reflection:
       # A list of tags to be ignored during reflection
       ignoredTags:
-        'api': true
-        'package': true
-        'subpackage': true
-        'license': true
-        'copyright': true
-        'author': true
         'const': true
-        'see': true
-        'todo': true
         'scope': true
-        'fixme': true
         'test': true
         'expectedException': true
         'expectedExceptionMessage': true
@@ -25,7 +16,6 @@ Neos:
         'depends': true
         'dataProvider': true
         'group': true
-        'codeCoverageIgnore': true
         'requires': true
         'Given': true
         'When': true


### PR DESCRIPTION
I removed all tags from `Settings.Reflection.yaml` that are already in the `$globalIgnoredNames` in `Doctrine\Common\Annotations\AnnotationReader`

There are even more of the ignoredTags in the current master of doctrine/annotations (see link in the issue), but it seems they are not yet in the 1.6.1 release of doctrine/annotations

Resolves #1532 