### PR TITLE
BUGFIX: Remove Doctrine from require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,9 +103,7 @@
     },
     "require-dev": {
         "mikey179/vfsstream": "~1.6",
-        "phpunit/phpunit": "~6.0",
-        "doctrine/orm": "~2.5.0",
-        "doctrine/common": ">=2.4,<2.8-dev"
+        "phpunit/phpunit": "~6.0"
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
It's already a require, so the duplication just causes problems, when the versions don't match any more (as they do in current master).