### PR TITLE
BUGFIX: Trust all proxies by default in Development context

### DIFF
--- a/Neos.Flow/Configuration/Development/Settings.yaml
+++ b/Neos.Flow/Configuration/Development/Settings.yaml
@@ -2,7 +2,7 @@
 # Configuration for the Flow Framework                                   #
 #                                                                        #
 # This file contains additions to the base configuration for the         #
-# Flow Framework when it runs in Testing context.                        #
+# Flow Framework when it runs in Development context.                        #
 #                                                                        #
 # Don't modify this file - instead put your own additions into the       #
 # global Configuration directory and its sub directories.                #
@@ -43,3 +43,7 @@ Neos:
         backendOptions:
           logFileURL: '%FLOW_PATH_DATA%Logs/I18n_Development.log'
           severityThreshold: '%LOG_DEBUG%'
+
+    http:
+      trustedProxies:
+        proxies: "*"


### PR DESCRIPTION
This fixes an issue when setting up Flow on ddev or similar, where the container acts as a proxy and overrides the request port. That would previously lead to web URLs getting generated with wrong ports, because request headers where not trusted by default, leading to errors in the browser when e.g. `https://flow.ddev.local:80` was opened.