### PR TITLE
TASK: Add section for configuration of trusted proxies in container

### DIFF
--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
@@ -339,7 +339,13 @@ By default, no proxies are trusted (unless the environment variable ``FLOW_HTTP_
 direct request informations will be used.
 If you specify trusted proxy addresses, by default only the ``X-Forwarded-*`` headers are accepted.
 
-You can specify the list of IP addresses or address ranges in comma separated format, which is useful for using the
+.. note::
+
+	On some container environments like ddev, the container acts as a proxy to provide port mapping and hence needs
+	to be allowed in this setting. To ease the development setup, Flow trusts all proxies by default in Development context.
+	You still need to configure the trustedProxies manually for Production.
+
+You can also specify the list of IP addresses or address ranges in comma separated format, which is useful for using the
 environment variable::
 
 	Neos:

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
@@ -342,11 +342,12 @@ If you specify trusted proxy addresses, by default only the ``X-Forwarded-*`` he
 .. note::
 
 	On some container environments like ddev, the container acts as a proxy to provide port mapping and hence needs
-	to be allowed in this setting. To ease the development setup, Flow trusts all proxies by default in Development context.
-	You still need to configure the trustedProxies manually for Production.
+	to be allowed in this setting. Otherwise the URLs generated will likely not work and end up with something along
+  the lines of 'https://flow.ddev.local:80'. Therefore you probably need to set ``Neos.Flow.http.trustedProxies.proxies``
+  setting to '*' in your Development environment ``Settings.yaml``.
 
-You can also specify the list of IP addresses or address ranges in comma separated format, which is useful for using the
-environment variable::
+You can also specify the list of IP addresses or address ranges in comma separated format, which is useful for using in the
+environment variable ``FLOW_HTTP_TRUSTED_PROXIES``::
 
 	Neos:
 	  Flow:


### PR DESCRIPTION
Adds a small note that mentions having to configure the trusted proxies in ddev and similar environments. Also explains that Flow therefore trusts all proxies by default in Development context.

Depends on #1586