### PR TITLE
BUGFIX: Return type hint should reflect nullable

### DIFF
--- a/Neos.Flow/Classes/Command/RoutingCommandController.php
+++ b/Neos.Flow/Classes/Command/RoutingCommandController.php
@@ -218,14 +218,14 @@ class RoutingCommandController extends CommandController
 
     /**
      * Returns the object name of the controller defined by the package, subpackage key and
-     * controller name
+     * controller name or NULL if the controller does not exist
      *
      * @param string $packageKey the package key of the controller
      * @param string $subPackageKey the subpackage key of the controller
      * @param string $controllerName the controller name excluding the "Controller" suffix
-     * @return string The controller's Object Name or NULL if the controller does not exist
+     * @return string|null The controller's Object Name or NULL if the controller does not exist
      */
-    protected function getControllerObjectName(string $packageKey, string $subPackageKey, string $controllerName): string
+    protected function getControllerObjectName(string $packageKey, string $subPackageKey, string $controllerName): ?string
     {
         $possibleObjectName = '@package\@subpackage\Controller\@controllerController';
         $possibleObjectName = str_replace('@package', str_replace('.', '\\', $packageKey), $possibleObjectName);


### PR DESCRIPTION
If no controller could be found for the given arguments RoutingCommandController:getControllerObjectName() returns null. The return type hint should reflect that to avoid a TypeError.