### PR TITLE
[BUGFIX] avoid problem with loading files in simplexml

### DIFF
--- a/Neos.Flow/Classes/I18n/AbstractXmlParser.php
+++ b/Neos.Flow/Classes/I18n/AbstractXmlParser.php
@@ -55,7 +55,7 @@ abstract class AbstractXmlParser
             throw new Exception\InvalidXmlFileException('The path "' . $sourcePath . '" does not point to an existing and accessible XML file.', 1328879703);
         }
         libxml_use_internal_errors(true);
-        $rootXmlNode = simplexml_load_file($sourcePath, 'SimpleXmlElement', \LIBXML_NOWARNING);
+        $rootXmlNode = simplexml_load_string(file_get_contents($sourcePath), 'SimpleXmlElement', \LIBXML_NOWARNING);
         if ($rootXmlNode === false) {
             $errors = [];
             foreach (libxml_get_errors() as $error) {


### PR DESCRIPTION
Workaround for https://bugs.php.net/bug.php?id=62577

fixes #1598


**What I did**

* applied PHP Storm Workaround

**How to verify it**

File is loading, tests pass

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
