### PR TITLE
FEATURE: Allow to skip validation of uninitialized proxies

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php
@@ -11,7 +11,6 @@ namespace Neos\Flow\ObjectManagement\Proxy;
  * source code.
  */
 
-use Doctrine\ORM\Mapping as ORM;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Reflection\ClassReflection;
 use Neos\Flow\Reflection\ReflectionService;

--- a/Neos.Flow/Classes/Validation/Validator/GenericObjectValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/GenericObjectValidator.php
@@ -25,7 +25,7 @@ class GenericObjectValidator extends AbstractValidator implements ObjectValidato
      * @var array
      */
     protected $supportedOptions = [
-        'skipUnInitializedProxies' => [false, 'The minimum value to accept', 'boolean']
+        'skipUnInitializedProxies' => [false, 'Whether proxies not yet initialized should be skipped during validation', 'boolean']
     ];
 
     /**

--- a/Neos.Flow/Classes/Validation/Validator/GenericObjectValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/GenericObjectValidator.php
@@ -24,6 +24,13 @@ class GenericObjectValidator extends AbstractValidator implements ObjectValidato
     /**
      * @var array
      */
+    protected $supportedOptions = [
+        'skipUnInitializedProxies' => [false, 'The minimum value to accept', 'boolean']
+    ];
+
+    /**
+     * @var array
+     */
     protected $propertyValidators = [];
 
     /**
@@ -55,9 +62,16 @@ class GenericObjectValidator extends AbstractValidator implements ObjectValidato
         if (!is_object($object)) {
             $this->addError('Object expected, %1$s given.', 1241099149, [gettype($object)]);
             return;
-        } elseif ($this->isValidatedAlready($object) === true) {
+        }
+
+        if ($this->isValidatedAlready($object) === true) {
             return;
         }
+
+        if ($this->options['skipUnInitializedProxies'] && $this->isUnInitializedProxy($object) === true) {
+            return;
+        }
+
         foreach ($this->propertyValidators as $propertyName => $validators) {
             $propertyValue = $this->getPropertyValue($object, $propertyName);
             $result = $this->checkProperty($propertyValue, $validators);
@@ -65,6 +79,15 @@ class GenericObjectValidator extends AbstractValidator implements ObjectValidato
                 $this->result->forProperty($propertyName)->merge($result);
             }
         }
+    }
+
+    /**
+     * @param $object
+     * @return boolean
+     */
+    protected function isUninitializedProxy($object)
+    {
+        return ($object instanceof \Doctrine\ORM\Proxy\Proxy && $object->__isInitialized() === false);
     }
 
     /**

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Validation.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Validation.rst
@@ -387,6 +387,11 @@ When implementing your own validators (see below), you need to pass the containe
 against it. See ``AbstractCompositeValidator`` and ``isValidatedAlready`` in the ``GenericObjectValidator``
 for examples of how to do this.
 
+Another optimization option of the ``GenericObjectValidator`` is the ``skipUnInitializedProxies`` flag. When
+set to true, it allows to skip validation of uninitialized proxy instances, to avoid recursions down into
+unchanged hierarchies. This can avoid loading of data for validation and is safe, if you can rely on your data
+not being changed and thus making an entity state invalid "from the outside."
+
 Writing Validators
 ==================
 

--- a/Neos.Flow/Tests/Unit/Persistence/RepositoryTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/RepositoryTest.php
@@ -13,7 +13,6 @@ namespace Neos\Flow\Tests\Unit\Persistence;
 
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\Persistence;
-use Neos\Flow\Tests\Persistence\Fixture;
 use PHPUnit\Framework\Error\Error;
 
 require_once('Fixture/Repository/NonstandardEntityRepository.php');

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Security/IfHasRoleViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Security/IfHasRoleViewHelper.php
@@ -12,7 +12,6 @@ namespace Neos\FluidAdaptor\ViewHelpers\Security;
  */
 
 
-use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Security\Account;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Security\Policy\PolicyService;

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/DateViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/DateViewHelperTest.php
@@ -12,7 +12,6 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Format;
  */
 
 use Neos\FluidAdaptor\Core\ViewHelper\Exception;
-use Neos\FluidAdaptor\ViewHelpers\Format;
 use Neos\Flow\I18n;
 
 require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');


### PR DESCRIPTION
The new option `skipUnInitializedProxies` allows to skip validation
of uninitialized proxy instances, to avoid recursions down into
unchanged hierarchies.