### PR TITLE
FEATURE: Allow custom date formatting in DateTimeRangeValidator messages

### DIFF
--- a/Neos.Flow/Classes/Validation/Validator/DateTimeRangeValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/DateTimeRangeValidator.php
@@ -80,15 +80,15 @@ class DateTimeRangeValidator extends AbstractValidator
 
         if (isset($earliestDate) && isset($latestDate)) {
             if ($dateTime < $earliestDate || $dateTime > $latestDate) {
-                $this->addError('The given date must be between %s and %s', 1325615630, [$earliestDate->format('Y-m-d H:i:s'), $latestDate->format('Y-m-d H:i:s')]);
+                $this->addError('The given date must be between %s and %s', 1325615630, [$earliestDate, $latestDate]);
             }
         } elseif (isset($earliestDate)) {
             if ($dateTime < $earliestDate) {
-                $this->addError('The given date must be after %s', 1324315107, [$earliestDate->format('Y-m-d H:i:s')]);
+                $this->addError('The given date must be after %s', 1324315107, [$earliestDate]);
             }
         } elseif (isset($latestDate)) {
             if ($dateTime > $latestDate) {
-                $this->addError('The given date must be before %s', 1324315115, [$latestDate->format('Y-m-d H:i:s')]);
+                $this->addError('The given date must be before %s', 1324315115, [$latestDate]);
             }
         }
     }

--- a/Neos.Flow/Resources/Private/Translations/af/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/af/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="needs-translation">The given value is not a valid date</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="needs-translation">The given date must be between {0} and {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="needs-translation">The given date must be after {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be after {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="needs-translation">The given date must be before {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be before {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/ar/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/ar/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">القيمة المعطاة ليست تاريخاً صحيحاً</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">يجب أن يكون التاريخ المعين بين {0} و {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">يجب أن يكون التاريخ المعين بين {0,datetime,datetime} و {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="translated">يجب أن يكون التاريخ المعين بعد {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">يجب أن يكون التاريخ المعين بعد {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="translated">يجب أن يكون التاريخ المعين قبل {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">يجب أن يكون التاريخ المعين قبل {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/ca/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/ca/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="needs-translation">The given value is not a valid date</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="needs-translation">The given date must be between {0} and {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="needs-translation">The given date must be after {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be after {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="needs-translation">The given date must be before {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be before {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/cs/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/cs/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">Zadaná hodnota není platné datum</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">Datum musí být mezi {0} a {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">Datum musí být mezi {0,datetime,datetime} a {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="translated">Dané datum musí následovat po {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">Dané datum musí následovat po {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="translated">Dané datum musí být před {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">Dané datum musí být před {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/da/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/da/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">Den angivne værdi er ikke en gyldig dato</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve" approved="yes">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">Den angivne dato skal være mellem {0} og {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">Den angivne dato skal være mellem {0,datetime,datetime} og {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve" approved="yes">
-				<source>The given date must be after {0}</source>
-			<target state="translated">Den angivne dato skal være efter {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">Den angivne dato skal være efter {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve" approved="yes">
-				<source>The given date must be before {0}</source>
-			<target state="translated">Den angivne dato skal være før {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">Den angivne dato skal være før {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve" approved="yes">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/de/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/de/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">Der Wert ist kein gültiges Datum</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve" approved="yes">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">Das Datum muss zwischen {0} und {1} liegen</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">Das Datum muss zwischen {0,datetime,datetime} und {1,datetime,datetime} liegen</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve" approved="yes">
-				<source>The given date must be after {0}</source>
-			<target state="translated">Das Datum muss nach {0} liegen</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">Das Datum muss nach {0,datetime,datetime} liegen</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve" approved="yes">
-				<source>The given date must be before {0}</source>
-			<target state="translated">Das Datum muss vor {0} liegen</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">Das Datum muss vor {0,datetime,datetime} liegen</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve" approved="yes">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/el/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/el/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="needs-translation">The given value is not a valid date</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="needs-translation">The given date must be between {0} and {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="needs-translation">The given date must be after {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be after {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="needs-translation">The given date must be before {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be before {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/en/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/en/ValidationErrors.xlf
@@ -30,13 +30,13 @@
 				<source>The given value is not a valid date</source>
 			</trans-unit>
 			<trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
 			</trans-unit>
 			<trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
+				<source>The given date must be after {0,datetime,datetime}</source>
 			</trans-unit>
 			<trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
+				<source>The given date must be before {0,datetime,datetime}</source>
 			</trans-unit>
 
 			<!-- DateTimeValidator -->

--- a/Neos.Flow/Resources/Private/Translations/es/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/es/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">El valor dado no es una fecha válida</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">La fecha debe estar entre {0} y {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">La fecha debe estar entre {0,datetime,datetime} y {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="translated">La fecha debe ser posterior a {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">La fecha debe ser posterior a {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="translated">La fecha debe ser anterior a {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">La fecha debe ser anterior a {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/fi/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/fi/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">Annettu arvo ei ole kelvollinen päivämäärä</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve" approved="yes">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">Päivämäärän on oltava väliltä {0} ja {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">Päivämäärän on oltava väliltä {0,datetime,datetime} ja {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve" approved="yes">
-				<source>The given date must be after {0}</source>
-			<target state="translated">Päivämäärän on oltava jälkeen {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">Päivämäärän on oltava jälkeen {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve" approved="yes">
-				<source>The given date must be before {0}</source>
-			<target state="translated">Päivämäärän on oltava ennen {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">Päivämäärän on oltava ennen {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve" approved="yes">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/fr/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/fr/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">Ce n'est pas une date valide</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve" approved="yes">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">La date doit être comprise entre {0} et {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">La date doit être comprise entre {0,datetime,datetime} et {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve" approved="yes">
-				<source>The given date must be after {0}</source>
-			<target state="translated">La date doit être postérieure au {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">La date doit être postérieure au {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve" approved="yes">
-				<source>The given date must be before {0}</source>
-			<target state="translated">La date doit être antérieure {0}</target><alt-trans><target>La date doit être antérieure au {0}</target></alt-trans></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">La date doit être antérieure {0,datetime,datetime}</target><alt-trans><target>La date doit être antérieure au {0,datetime,datetime}</target></alt-trans></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve" approved="yes">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/he/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/he/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="needs-translation">The given value is not a valid date</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="needs-translation">The given date must be between {0} and {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="needs-translation">The given date must be after {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be after {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="needs-translation">The given date must be before {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be before {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/hi/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/hi/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target xml:lang="hi" state="needs-translation">The given value is not a valid date</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target xml:lang="hi" state="needs-translation">The given date must be between {0} and {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target xml:lang="hi" state="needs-translation">The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target xml:lang="hi" state="needs-translation">The given date must be after {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target xml:lang="hi" state="needs-translation">The given date must be after {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target xml:lang="hi" state="needs-translation">The given date must be before {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target xml:lang="hi" state="needs-translation">The given date must be before {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/hu/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/hu/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">A megadott érték nem érvényes dátum</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">A megadott dátumnak {0} és {1} között kell lennie</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">A megadott dátumnak {0,datetime,datetime} és {1,datetime,datetime} között kell lennie</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="translated">A megadott dátumnak {0} után kell lennie</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">A megadott dátumnak {0,datetime,datetime} után kell lennie</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="translated">A megadott dátumnak {0} előtt kell lennie</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">A megadott dátumnak {0,datetime,datetime} előtt kell lennie</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/id_ID/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/id_ID/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">Nilai yang diberikan bukanlah tanggal yang valid</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">Tanggal tertentu harus antara {0} dan {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">Tanggal tertentu harus antara {0,datetime,datetime} dan {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="translated">Tanggal tertentu harus setelah {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">Tanggal tertentu harus setelah {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="translated">Tanggal tertentu harus sebelum {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">Tanggal tertentu harus sebelum {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/it/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/it/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">Il valore specificato non è una data valida</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">La data specificata deve essere compresa tra {0} e {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">La data specificata deve essere compresa tra {0,datetime,datetime} e {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="translated">La data specificata deve essere successiva a {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">La data specificata deve essere successiva a {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="translated">La data specificata deve essere precedente a {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">La data specificata deve essere precedente a {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/ja/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/ja/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">指定された値は有効な日付ではありません</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">指定された日付は{0} から{1} の間でなければなりません</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">指定された日付は{0,datetime,datetime} から{1,datetime,datetime} の間でなければなりません</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="translated">指定された日付は{0} の後にする必要があります</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">指定された日付は{0,datetime,datetime} の後にする必要があります</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="translated">指定された日付は{0} より前でなければなりません</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">指定された日付は{0,datetime,datetime} より前でなければなりません</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/kk_KZ/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/kk_KZ/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="needs-translation">The given value is not a valid date</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="needs-translation">The given date must be between {0} and {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="needs-translation">The given date must be after {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be after {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="needs-translation">The given date must be before {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be before {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/km/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/km/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">តម្លៃដែលផ្ដល់អោយ គឺមិនត្រឹមត្រូវតាមកាលបរិឆ្ឆេទនោះទេ</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve" approved="yes">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">កាលបរិច្ឆេទដែលផ្ដល់អោយ ត្រូវតែនៅចន្លោះពី {០} ហើយនឹង {១}</target><alt-trans><target>កាលបិឆ្ឆេទដែលផ្ដល់អោយ ត្រូវតែនៅចន្លោះពី {០} ហើយនឹង {១}</target></alt-trans></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">កាលបរិច្ឆេទដែលផ្ដល់អោយ ត្រូវតែនៅចន្លោះពី {០,datetime,datetime} ហើយនឹង {១,datetime,datetime}</target><alt-trans><target>កាលបិឆ្ឆេទដែលផ្ដល់អោយ ត្រូវតែនៅចន្លោះពី {០,datetime,datetime} ហើយនឹង {១,datetime,datetime}</target></alt-trans></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve" approved="yes">
-				<source>The given date must be after {0}</source>
-			<target state="translated">កាលបរិច្ឆេទត្រូវនៅក្រោយ {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">កាលបរិច្ឆេទត្រូវនៅក្រោយ {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve" approved="yes">
-				<source>The given date must be before {0}</source>
-			<target state="translated">ថ្ងៃខែដែលអោយមកត្រូវមុនពេល {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">ថ្ងៃខែដែលអោយមកត្រូវមុនពេល {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve" approved="yes">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/ko/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/ko/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="needs-translation">The given value is not a valid date</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="needs-translation">The given date must be between {0} and {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="needs-translation">The given date must be after {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be after {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="needs-translation">The given date must be before {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be before {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/la/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/la/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target xml:lang="la-LA">crwdns6344:0crwdne6344:0</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target xml:lang="la-LA">crwdns6345:0{0}crwdnd6345:0{1}crwdne6345:0</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target xml:lang="la-LA">crwdns6345:0{0,datetime,datetime}crwdnd6345:0{1,datetime,datetime}crwdne6345:0</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target xml:lang="la-LA">crwdns6346:0{0}crwdne6346:0</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target xml:lang="la-LA">crwdns6346:0{0,datetime,datetime}crwdne6346:0</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target xml:lang="la-LA">crwdns6347:0{0}crwdne6347:0</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target xml:lang="la-LA">crwdns6347:0{0,datetime,datetime}crwdne6347:0</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/lv/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/lv/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">Noteiktā vērtība nav derīgs datums</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve" approved="yes">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">Dotajam datumam jābūt starp {0} un {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">Dotajam datumam jābūt starp {0,datetime,datetime} un {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve" approved="yes">
-				<source>The given date must be after {0}</source>
-			<target state="translated">Dotajam datumam jābūt pēc {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">Dotajam datumam jābūt pēc {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve" approved="yes">
-				<source>The given date must be before {0}</source>
-			<target state="translated">Dotajam datumam jābūt pirms {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">Dotajam datumam jābūt pirms {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve" approved="yes">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/mr/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/mr/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="needs-translation">The given value is not a valid date</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="needs-translation">The given date must be between {0} and {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="needs-translation">The given date must be after {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be after {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="needs-translation">The given date must be before {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be before {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/nl/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/nl/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">De opgegeven waarde is geen geldige datum</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve" approved="yes">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">De gegeven datum moet tussen {0} en {1} liggen</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">De gegeven datum moet tussen {0,datetime,datetime} en {1,datetime,datetime} liggen</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve" approved="yes">
-				<source>The given date must be after {0}</source>
-			<target state="translated">De opgegeven datum mag niet na {0} liggen</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">De opgegeven datum mag niet na {0,datetime,datetime} liggen</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve" approved="yes">
-				<source>The given date must be before {0}</source>
-			<target state="translated">De opgegeven datum moet voor {0} liggen</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">De opgegeven datum moet voor {0,datetime,datetime} liggen</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve" approved="yes">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/no/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/no/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">Den angitte verdien er ikke en gyldig dato</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">Den angitte datoen må være mellom {0} og {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">Den angitte datoen må være mellom {0,datetime,datetime} og {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="translated">Den angitte datoen må være etter {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">Den angitte datoen må være etter {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="translated">Den angitte datoen må være før {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">Den angitte datoen må være før {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/pl/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/pl/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">Podana wartość nie jest poprawną datą</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve" approved="yes">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">Podana data musi być pomiędzy {0} i {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">Podana data musi być pomiędzy {0,datetime,datetime} i {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve" approved="yes">
-				<source>The given date must be after {0}</source>
-			<target state="translated">Podana data musi być po {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">Podana data musi być po {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve" approved="yes">
-				<source>The given date must be before {0}</source>
-			<target state="translated">Podana data musi być przed {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">Podana data musi być przed {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve" approved="yes">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/ps/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/ps/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="needs-translation">The given value is not a valid date</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="needs-translation">The given date must be between {0} and {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="needs-translation">The given date must be after {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be after {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="needs-translation">The given date must be before {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be before {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/pt/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/pt/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="needs-translation">The given value is not a valid date</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="needs-translation">The given date must be between {0} and {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="needs-translation">The given date must be after {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be after {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="needs-translation">The given date must be before {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be before {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/pt_BR/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/pt_BR/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">o valor fornecido não é uma data válida</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">A data fornecida deve estar entre {0} e {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">A data fornecida deve estar entre {0,datetime,datetime} e {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="translated">A data fornecida deve ser depois da {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">A data fornecida deve ser depois da {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="translated">A data fornecida deve ser antes de {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">A data fornecida deve ser antes de {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/ro/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/ro/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">Valoarea dată nu este o dată validă</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">Data curentă trebuie să fie între {0} și {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">Data curentă trebuie să fie între {0,datetime,datetime} și {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="translated">Data curentă trebuie să fie după {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">Data curentă trebuie să fie după {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="translated">Data curentă trebuie să fie înainte de {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">Data curentă trebuie să fie înainte de {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/ru/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/ru/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">Заданное значение не является годной датой</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve" approved="yes">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">Заданная дата должна быть между {0} и {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">Заданная дата должна быть между {0,datetime,datetime} и {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve" approved="yes">
-				<source>The given date must be after {0}</source>
-			<target state="translated">Заданная дата должна быть позже {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">Заданная дата должна быть позже {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve" approved="yes">
-				<source>The given date must be before {0}</source>
-			<target state="translated">Заданная дата должна быть раньше {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">Заданная дата должна быть раньше {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve" approved="yes">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/sr/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/sr/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="needs-translation">The given value is not a valid date</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="needs-translation">The given date must be between {0} and {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="needs-translation">The given date must be after {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be after {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="needs-translation">The given date must be before {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be before {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/sv/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/sv/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">Det angivna värdet är inte ett giltigt datum</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">Det angivna datumet måste vara mellan {0} och {1}</target><alt-trans><target>Det givna datumet måste vara mellan {0} och {1}</target></alt-trans></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">Det angivna datumet måste vara mellan {0,datetime,datetime} och {1,datetime,datetime}</target><alt-trans><target>Det givna datumet måste vara mellan {0,datetime,datetime} och {1,datetime,datetime}</target></alt-trans></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="translated">Det angivna datumet måste vara efter {0}</target><alt-trans><target>Det givna datumet måste vara efter {0}</target></alt-trans></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">Det angivna datumet måste vara efter {0,datetime,datetime}</target><alt-trans><target>Det givna datumet måste vara efter {0,datetime,datetime}</target></alt-trans></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="translated">Det angivna datumet måste vara innan {0}</target><alt-trans><target>Det givna datumet måste vara innan {0}</target></alt-trans></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">Det angivna datumet måste vara innan {0,datetime,datetime}</target><alt-trans><target>Det givna datumet måste vara innan {0,datetime,datetime}</target></alt-trans></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/tl_PH/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/tl_PH/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="needs-translation">The given value is not a valid date</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="needs-translation">The given date must be between {0} and {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="needs-translation">The given date must be after {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be after {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="needs-translation">The given date must be before {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be before {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/tr/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/tr/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">Verilen değer geçerli bir tarih içermiyor</target><alt-trans><target>Verilen değer geçerli bir tarih değil</target></alt-trans></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">Verilen tarih {0} ile {1} arasında olmalıdır. Parantez içine minimum maksimum tarih değerlerini giriniz</target><alt-trans><target>Verilen tarih {0} ile {1} arasında olmalıdır</target></alt-trans></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">Verilen tarih {0,datetime,datetime} ile {1,datetime,datetime} arasında olmalıdır. Parantez içine minimum maksimum tarih değerlerini giriniz</target><alt-trans><target>Verilen tarih {0,datetime,datetime} ile {1,datetime,datetime} arasında olmalıdır</target></alt-trans></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="translated">Verilen tarih {0} 'den sonra olmalıdır Parantez içine başlangıç tarihi giriniz</target><alt-trans><target>Verilen tarih {0} 'den sonra olmalıdır</target></alt-trans></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">Verilen tarih {0,datetime,datetime} 'den sonra olmalıdır Parantez içine başlangıç tarihi giriniz</target><alt-trans><target>Verilen tarih {0,datetime,datetime} 'den sonra olmalıdır</target></alt-trans></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="translated">Verilen tarih {0} 'den önce olmalıdır. Parantez içine bitiş tarihi giriniz</target><alt-trans><target>Verilen tarih {0} 'den önce olmalıdır</target></alt-trans></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">Verilen tarih {0,datetime,datetime} 'den önce olmalıdır. Parantez içine bitiş tarihi giriniz</target><alt-trans><target>Verilen tarih {0,datetime,datetime} 'den önce olmalıdır</target></alt-trans></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/uk/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/uk/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="needs-translation">The given value is not a valid date</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="needs-translation">The given date must be between {0} and {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="needs-translation">The given date must be after {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be after {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="needs-translation">The given date must be before {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be before {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/vi/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/vi/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="needs-translation">The given value is not a valid date</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="needs-translation">The given date must be between {0} and {1}</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="needs-translation">The given date must be after {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be after {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="needs-translation">The given date must be before {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="needs-translation">The given date must be before {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/zh/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/zh/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">不是有效日期</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">日期必须在 {0} 到 {1}之间</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">日期必须在 {0,datetime,datetime} 到 {1,datetime,datetime}之间</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="translated">给定的日期必须在 {0} 之后</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">给定的日期必须在 {0,datetime,datetime} 之后</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="translated">给定的日期必须在 {0} 之前</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">给定的日期必须在 {0,datetime,datetime} 之前</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>

--- a/Neos.Flow/Resources/Private/Translations/zh_TW/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/zh_TW/ValidationErrors.xlf
@@ -26,14 +26,14 @@
 				<source>The given value is not a valid date</source>
 			<target state="translated">給予的值不是有效日期</target></trans-unit>
       <trans-unit id="1325615630" xml:space="preserve">
-				<source>The given date must be between {0} and {1}</source>
-			<target state="translated">給予的日期必須在 {0} 和 {1} 之間</target></trans-unit>
+				<source>The given date must be between {0,datetime,datetime} and {1,datetime,datetime}</source>
+			<target state="translated">給予的日期必須在 {0,datetime,datetime} 和 {1,datetime,datetime} 之間</target></trans-unit>
       <trans-unit id="1324315107" xml:space="preserve">
-				<source>The given date must be after {0}</source>
-			<target state="translated">給予的日期必須晚於 {0}</target></trans-unit>
+				<source>The given date must be after {0,datetime,datetime}</source>
+			<target state="translated">給予的日期必須晚於 {0,datetime,datetime}</target></trans-unit>
       <trans-unit id="1324315115" xml:space="preserve">
-				<source>The given date must be before {0}</source>
-			<target state="translated">給予的日期必須早於 {0}</target></trans-unit>
+				<source>The given date must be before {0,datetime,datetime}</source>
+			<target state="translated">給予的日期必須早於 {0,datetime,datetime}</target></trans-unit>
       <!-- DateTimeValidator -->
       <trans-unit id="1281454676" xml:space="preserve">
 				<source>The "locale" option can be only set to string identifier, or Locale object</source>


### PR DESCRIPTION
If you translated error messages from the DateTimeRangeValidator with the error codes
1325615630, 1324315107 and/or 1324315115
those now receive `DateTime` objects as parameters instead of preformatted date strings.
Therefore, you should adjust your message templates to format the parameters like
`{0,datetime,datetime}`

Fixes #574 
