### PR TITLE
BUGFIX: Avoid error in Debugger::findProxyAndShortFilePath()

### DIFF
--- a/Neos.Flow/Classes/Error/Debugger.php
+++ b/Neos.Flow/Classes/Error/Debugger.php
@@ -482,7 +482,7 @@ class Debugger
         $flowRoot = defined('FLOW_PATH_ROOT') ? FLOW_PATH_ROOT : '';
         $originalPath = $file;
         $proxyClassPathPosition = strpos($file, 'Flow_Object_Classes/');
-        if ($proxyClassPathPosition) {
+        if ($proxyClassPathPosition && is_file($file)) {
             $fileContent = @file($file);
             $originalPath = trim(substr($fileContent[count($fileContent) - 2], 19));
         }


### PR DESCRIPTION
If `$file` points to eval'd code, the `@file(…)` code does not return
an array, leading to `count()` being called on an incompatible value.