### PR TITLE
FEATURE: Allow overwriting instead of merging in arrayMergeRecursiveWithCallback

### DIFF
--- a/Neos.Utility.Arrays/Classes/Arrays.php
+++ b/Neos.Utility.Arrays/Classes/Arrays.php
@@ -109,11 +109,20 @@ abstract class Arrays
      *
      * @param array $firstArray First array
      * @param array $secondArray Second array, overruling the first array
-     * @param callable $toArray The given closure will get a value that is not an array and has to return an array. This is to allow custom merging of simple types with (sub) arrays
+     * @param \Closure $toArray The given callable will get a value that is not an array and has to return an array.
+     *                          This is to allow custom merging of simple types with (sub) arrays
+     * @param \Closure|null $overrideFirst The given callable will determine whether the value of the first array should be overridden.
+     *                                     It should have the following signature $callable($key, ?array $firstValue = null, ?array $secondValue = null): bool
      * @return array Resulting array where $secondArray values has overruled $firstArray values
      */
-    public static function arrayMergeRecursiveOverruleWithCallback(array $firstArray, array $secondArray, \Closure $toArray): array
+    public static function arrayMergeRecursiveOverruleWithCallback(array $firstArray, array $secondArray, \Closure $toArray, ?\Closure $overrideFirst = null): array
     {
+        if (!$overrideFirst instanceof \Closure) {
+            $overrideFirst = function ($key, ?array $firstValue = null, ?array $secondValue = null): bool {
+                return false;
+            };
+        }
+
         $data = [&$firstArray, $secondArray];
         $entryCount = 1;
         for ($i = 0; $i < $entryCount; $i++) {
@@ -126,11 +135,16 @@ abstract class Arrays
                     if (!is_array($value)) {
                         $value = $toArray($value);
                     }
+
                     if (!is_array($firstArrayInner[$key])) {
                         $firstArrayInner[$key] = $toArray($firstArrayInner[$key]);
                     }
 
                     if (is_array($firstArrayInner[$key]) && is_array($value)) {
+                        if ($overrideFirst($key, $firstArrayInner[$key], $value)) {
+                            $firstArrayInner[$key] = $value;
+                        }
+
                         $data[] = &$firstArrayInner[$key];
                         $data[] = $value;
                         $entryCount++;

--- a/Neos.Utility.Arrays/Tests/Unit/ArraysTest.php
+++ b/Neos.Utility.Arrays/Tests/Unit/ArraysTest.php
@@ -572,4 +572,43 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
         });
         $this->assertSame($expected, $actual);
     }
+
+    /**
+     * @test
+     */
+    public function arrayMergeRecursiveCallbackOverrideFirstArrayValuesGivenClosure()
+    {
+        $inputArray1 = [
+            'k1' => 'v1',
+            'k2' => [
+                'k2.1' => 'v2.1'
+            ],
+        ];
+        $inputArray2 = [
+            'k2' => [
+                'k2.2' => 'v2.2'
+            ],
+            'k3' => 'v3'
+        ];
+        $expected = [
+            'k1' => 'v1',
+            'k2' => [
+                'k2.2' => 'v2.2'
+            ],
+            'k3' => 'v3'
+        ];
+
+        $actual = Arrays::arrayMergeRecursiveOverruleWithCallback(
+            $inputArray1,
+            $inputArray2,
+            function ($simpleType) {
+                return array('__convertedValue' => $simpleType);
+            },
+            function ($value) {
+                return true;
+            }
+        );
+
+        $this->assertSame($expected, $actual);
+    }
 }


### PR DESCRIPTION
This allows to specify a callback that determines whether the value of the first array is unset before merging.

**What I did**
An additional callback parameter is added to the ```Neos\Utility\Arrays:arrayMergeRecursiveOverruleWithCallback``` method. This allows to conditionally  unset the value of the first array before merging the second array value.

Needed for neos/neos-development-collection#2238

**How to verify it**
See the created test case.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
