### PR TITLE
TASK: Loosen typo3 fluid dependency

### DIFF
--- a/Neos.FluidAdaptor/Classes/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
+++ b/Neos.FluidAdaptor/Classes/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
@@ -47,6 +47,8 @@ class NamespaceDetectionTemplateProcessor extends FluidNamespaceDetectionTemplat
 			)
 		)/xs';
 
+    const SPLIT_PATTERN_TEMPLATE_OPEN_NAMESPACETAG = '/xmlns:([a-z0-9\.]+)=("[^"]+"|\'[^\']+\')*/xi';
+
     /**
      * Pre-process the template source before it is
      * returned to the TemplateParser or passed to

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/dom-crawler": "~2.8.0",
         "symfony/console": "~2.8",
         "neos/composer-plugin": "^2.0.0",
-        "typo3fluid/fluid": "~2.1.3",
+        "typo3fluid/fluid": ">=2.1.3,<2.5.0",
         "ext-mbstring": "*"
     },
     "replace": {


### PR DESCRIPTION
This allows to install any version of TYPO3 Fluid >= 2.1.3, < 2.5.0 instead of the previously limiting to ~2.1.3
Since Flow 5.0+ requires TYPO3 Fluid 2.5.x, this is consistent.