### PR TITLE
!!! BUGFIX: Simplify and strengthen the type matching pattern

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php
@@ -11,7 +11,6 @@ namespace Neos\Flow\ObjectManagement\Proxy;
  * source code.
  */
 
-use Doctrine\ORM\Mapping as ORM;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Reflection\ClassReflection;
 use Neos\Flow\Reflection\ReflectionService;

--- a/Neos.Flow/Tests/Unit/Persistence/RepositoryTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/RepositoryTest.php
@@ -13,7 +13,6 @@ namespace Neos\Flow\Tests\Unit\Persistence;
 
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\Persistence;
-use Neos\Flow\Tests\Persistence\Fixture;
 use PHPUnit\Framework\Error\Error;
 
 require_once('Fixture/Repository/NonstandardEntityRepository.php');

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Security/IfHasRoleViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Security/IfHasRoleViewHelper.php
@@ -12,7 +12,6 @@ namespace Neos\FluidAdaptor\ViewHelpers\Security;
  */
 
 
-use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Security\Account;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Security\Policy\PolicyService;

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/DateViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/DateViewHelperTest.php
@@ -12,7 +12,6 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Format;
  */
 
 use Neos\FluidAdaptor\Core\ViewHelper\Exception;
-use Neos\FluidAdaptor\ViewHelpers\Format;
 use Neos\Flow\I18n;
 
 require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');

--- a/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
+++ b/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
@@ -24,7 +24,7 @@ abstract class TypeHandling
     /**
      * A property type parse pattern.
      */
-    const PARSE_TYPE_PATTERN = '/^\\\\?(?P<type>integer|int|float|double|boolean|bool|string|DateTime(?:Immutable)?|[a-zA-Z0-9\\\\_]+|object|array|ArrayObject|SplObjectStorage|Doctrine\\\\Common\\\\Collections\\\\Collection|Doctrine\\\\Common\\\\Collections\\\\ArrayCollection)(?:<\\\\?(?P<elementType>[a-zA-Z0-9\\\\_]+)>)?/';
+    const PARSE_TYPE_PATTERN = '/^\\\\?(?P<type>[a-zA-Z0-9\\\\_]+)(?:<\\\\?(?P<elementType>[a-zA-Z0-9\\\\_]+)>)?(?:\s|$)/';
 
     /**
      * A type pattern to detect literal types.


### PR DESCRIPTION
This pattern was overspecified for common types, but at the same time not closed. Hence this was buggy for any type that started with one of the specified types, like a custom `DateTimeRange` type, which would be matched as `DateTime` only.

The new pattern will now just match any identifier made up of characters, digits, backslashes and underscores up to a whitespace or lineend, which also matches all the previously hard-coded types.

This is not breaking in the normal sense, but the change in a very core regex pattern can cause different behaviour in some edge-cases, hence why this bugfix is not applied to lowest maintained branch.

Followup for #1442