### PR TITLE
BUGFIX: Allow using Flow with PHP wrappers

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -758,6 +758,11 @@ class Scripts
             return;
         }
 
+        // Ensure the actual PHP binary is known before checking if it is correct. If empty, we ignore it because it is checked later in the script.
+        if (strlen($phpBinaryPathAndFilename) === 0) {
+            return;
+        }
+
         // Try to resolve which binary file PHP is pointing to
         exec($phpBinaryPathAndFilename . ' -r "echo PHP_BINARY;"', $output, $result);
         if ($result === 0 && sizeof($output) === 1) {

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -758,8 +758,15 @@ class Scripts
             return;
         }
 
-        // Resolve any symlinks that the configured php might be pointing to
-        $configuredPhpBinaryPathAndFilename = realpath($phpBinaryPathAndFilename);
+        // Try to resolve which binary file PHP is pointing to
+        exec($phpBinaryPathAndFilename . ' -r "echo PHP_BINARY;"', $output, $result);
+        if ($result === 0 && sizeof($output) === 1) {
+            // Resolve any wrapper
+            $configuredPhpBinaryPathAndFilename = $output[0];
+        } else {
+            // Resolve any symlinks that the configured php might be pointing to
+            $configuredPhpBinaryPathAndFilename = realpath($phpBinaryPathAndFilename);
+        }
 
         // if the configured PHP binary is empty here, the file does not exist. We ignore that here because it is checked later in the script.
         if ($configuredPhpBinaryPathAndFilename === false || strlen($configuredPhpBinaryPathAndFilename) === 0) {


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->



**What I did**

Add support for using a fallback to verify whether the `PHP_BINARY` for the currently configured PHP binary file matches the one being used currently.

The current logic only resolves the symlink, which may not always work, e.g. what if the `php` binary is being executed through a wrapper like this?

    #!/bin/sh
    . /path/to/setenv.sh
    exec /path/to/php.bin "$@"

(Where `php.bin` is the binary file and `setenv.sh` a script with sets environment variables - Wrappers like these are heavily used in Bitnami installations.)

**How I did it**

Before Flow compares which PHP binary is being used (and which it is supposedly configured to use), we run a PHP `exec` to print `PHP_BINARY`.

Then, we store the result and if no errors were thrown, use this as the detected PHP binary path to compare with. If any errors were detected (via the "exec" exit code), we use the original logic that resolves any symlink it's pointing to.

If it matches the existing one, it means everything went great, if not an error will be thrown like before.

**How to verify it**

- A correct PHP wrapper pointing to the PHP binary (e.g. php.bin) is allowed for being used for CLI subrequests (method `ensureCLISubrequestsUseCurrentlyRunningPhpBinary`).
- An invalid PHP wrapper fails when being used for CLI subrequests (method `ensureCLISubrequestsUseCurrentlyRunningPhpBinary`).

**Checklist**

- [x] Code follows the PSR-2 coding style - Checked
- [x] Tests have been created, run and adjusted as needed - Couldn't find any tests for this part
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html) - Using 4.3 branch
