### PR TITLE
TASK: Safelist branches for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: php
+branches:
+  only:
+  - /(master|\d+\.\d+)/
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
This prevents builds from running doubly on branches created on this repository for PRs, e.g. through the StyleCI bot or by github inline PRs.

See https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches