### PR TITLE
BUGFIX: Omit sessionless tokens from session

### DIFF
--- a/Neos.Flow/Classes/Security/Context.php
+++ b/Neos.Flow/Classes/Security/Context.php
@@ -787,10 +787,8 @@ class Context
         $tokensForSession = array_filter(array_merge($this->inactiveTokens, $this->activeTokens), static function (TokenInterface $token) {
             return !$token instanceof SessionlessTokenInterface;
         });
-        if ($tokensForSession !== []) {
-            $sessionDataContainer = $this->objectManager->get(SessionDataContainer::class);
-            $sessionDataContainer->setSecurityTokens($tokensForSession);
-        }
+        $sessionDataContainer = $this->objectManager->get(SessionDataContainer::class);
+        $sessionDataContainer->setSecurityTokens($tokensForSession);
     }
 
     /**

--- a/Neos.Flow/Classes/Security/Context.php
+++ b/Neos.Flow/Classes/Security/Context.php
@@ -784,7 +784,7 @@ class Context
             $token->updateCredentials($this->request);
         }
 
-        $tokensForSession = array_filter(array_merge($this->inactiveTokens, $this->activeTokens), static function(TokenInterface $token) {
+        $tokensForSession = array_filter(array_merge($this->inactiveTokens, $this->activeTokens), static function (TokenInterface $token) {
             return !$token instanceof SessionlessTokenInterface;
         });
         if ($tokensForSession !== []) {

--- a/Neos.Flow/Classes/Security/SessionDataContainer.php
+++ b/Neos.Flow/Classes/Security/SessionDataContainer.php
@@ -49,12 +49,12 @@ class SessionDataContainer
      */
     public function setSecurityTokens(array $securityTokens)
     {
-        $this->securityTokens = array_filter(
-            $securityTokens,
-            function ($token) {
-                return (!$token instanceof SessionlessTokenInterface);
+        foreach ($securityTokens as $token) {
+            if ($token instanceof SessionlessTokenInterface) {
+                throw new \InvalidArgumentException(sprintf('Tokens implementing the SessionlessTokenInterface must not be stored in the session. Got: %s', get_class($token)), 1562670555);
             }
-        );
+        }
+        $this->securityTokens = $securityTokens;
     }
 
     /**

--- a/Neos.Flow/Classes/Security/SessionDataContainer.php
+++ b/Neos.Flow/Classes/Security/SessionDataContainer.php
@@ -3,6 +3,7 @@ namespace Neos\Flow\Security;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\RequestInterface;
+use Neos\Flow\Security\Authentication\Token\SessionlessTokenInterface;
 
 /**
  * @Flow\Scope("session")
@@ -48,7 +49,12 @@ class SessionDataContainer
      */
     public function setSecurityTokens(array $securityTokens)
     {
-        $this->securityTokens = $securityTokens;
+        $this->securityTokens = array_filter(
+            $securityTokens,
+            function ($token) {
+                return (!$token instanceof SessionlessTokenInterface);
+            }
+        );
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Security/ContextTest.php
+++ b/Neos.Flow/Tests/Unit/Security/ContextTest.php
@@ -15,6 +15,7 @@ use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Security\Authentication\AuthenticationManagerInterface;
 use Neos\Flow\Security\Account;
+use Neos\Flow\Security\Authentication\Token\SessionlessTokenInterface;
 use Neos\Flow\Security\Authentication\TokenAndProviderFactory;
 use Neos\Flow\Security\Authentication\TokenAndProviderFactoryInterface;
 use Neos\Flow\Security\Authentication\TokenInterface;
@@ -202,6 +203,54 @@ class ContextTest extends UnitTestCase
 
         $this->assertEquals([$token1, $token2, $token4], array_values($securityContext->_get('activeTokens')));
         $this->assertEquals([$token3, $token5], array_values($securityContext->_get('inactiveTokens')));
+    }
+
+    /**
+     * @test
+     */
+    public function initializeStoresSessionCompatibleTokensInSessionDataContainer()
+    {
+        /** @var Context $securityContext */
+        $securityContext = $this->getAccessibleMock(Context::class, ['dummy']);
+        $this->inject($securityContext, 'objectManager', $this->mockObjectManager);
+
+        $securityContext->injectSettings(['security' => ['authentication' => ['authenticationStrategy' => 'allTokens']]]);
+
+        $matchingRequestPattern = $this->getMockBuilder(RequestPatternInterface::class)->setMockClassName('SomeRequestPattern')->getMock();
+        $matchingRequestPattern->method('matchRequest')->willReturn(true);
+
+        $notMatchingRequestPattern = $this->getMockBuilder(RequestPatternInterface::class)->setMockClassName('SomeOtherRequestPattern')->getMock();
+        $notMatchingRequestPattern->method('matchRequest')->willReturn(false);
+
+        $inactiveToken = $this->createMock(TokenInterface::class);
+        $inactiveToken->expects($this->once())->method('hasRequestPatterns')->willReturn(true);
+        $inactiveToken->expects($this->once())->method('getRequestPatterns')->willReturn([$notMatchingRequestPattern]);
+        $inactiveToken->method('getAuthenticationProviderName')->willReturn('inactiveTokenProvider');
+        $inactiveToken->method('getAuthenticationStatus')->willReturn(TokenInterface::AUTHENTICATION_NEEDED);
+
+        $activeToken = $this->createMock(TokenInterface::class);
+        $activeToken->expects($this->once())->method('hasRequestPatterns')->willReturn(false);
+        $activeToken->method('getAuthenticationProviderName')->willReturn('activeTokenProvider');
+        $activeToken->method('getAuthenticationStatus')->willReturn(TokenInterface::AUTHENTICATION_NEEDED);
+
+        $sessionlessToken = $this->createMock([TokenInterface::class, SessionlessTokenInterface::class]);
+        $sessionlessToken->expects($this->once())->method('hasRequestPatterns')->willReturn(false);
+        $sessionlessToken->method('getAuthenticationProviderName')->willReturn('sessionlessTokenProvider');
+        $sessionlessToken->method('getAuthenticationStatus')->willReturn(TokenInterface::AUTHENTICATION_NEEDED);
+
+        $this->mockTokenAndProviderFactory = $this->createMock(TokenAndProviderFactoryInterface::class);
+        $this->mockTokenAndProviderFactory->expects($this->once())->method('getTokens')->willReturn([
+            $inactiveToken,
+            $activeToken,
+            $sessionlessToken,
+        ]);
+        $securityContext->_set('tokenAndProviderFactory', $this->mockTokenAndProviderFactory);
+        $securityContext->setRequest($this->mockActionRequest);
+
+        $expectedTokens = ['inactiveTokenProvider' => $inactiveToken, 'activeTokenProvider' => $activeToken];
+        $this->mockSessionDataContainer->expects($this->once())->method('setSecurityTokens')->with($expectedTokens);
+
+        $securityContext->initialize();
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Security/SessionDataContainerTest.php
+++ b/Neos.Flow/Tests/Unit/Security/SessionDataContainerTest.php
@@ -11,24 +11,11 @@ namespace Neos\Flow\Tests\Unit\Security;
  * source code.
  */
 
-use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\RequestInterface;
-use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Flow\Security\Authentication\AuthenticationManagerInterface;
-use Neos\Flow\Security\Account;
 use Neos\Flow\Security\Authentication\Token\SessionlessTokenInterface;
-use Neos\Flow\Security\Authentication\TokenAndProviderFactory;
-use Neos\Flow\Security\Authentication\TokenAndProviderFactoryInterface;
 use Neos\Flow\Security\Authentication\TokenInterface;
-use Neos\Flow\Security\Context;
-use Neos\Flow\Security\Policy;
-use Neos\Flow\Security\RequestPatternInterface;
 use Neos\Flow\Security\SessionDataContainer;
-use Neos\Flow\Session\SessionInterface;
-use Neos\Flow\Session\SessionManagerInterface;
 use Neos\Flow\Tests\UnitTestCase;
-use Neos\Flow\Security\Policy\Role;
-use Psr\Log\LoggerInterface;
 
 /**
  * Testcase for the SessionDataContainer

--- a/Neos.Flow/Tests/Unit/Security/SessionDataContainerTest.php
+++ b/Neos.Flow/Tests/Unit/Security/SessionDataContainerTest.php
@@ -1,0 +1,87 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Security;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Mvc\RequestInterface;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Flow\Security\Authentication\AuthenticationManagerInterface;
+use Neos\Flow\Security\Account;
+use Neos\Flow\Security\Authentication\Token\SessionlessTokenInterface;
+use Neos\Flow\Security\Authentication\TokenAndProviderFactory;
+use Neos\Flow\Security\Authentication\TokenAndProviderFactoryInterface;
+use Neos\Flow\Security\Authentication\TokenInterface;
+use Neos\Flow\Security\Context;
+use Neos\Flow\Security\Policy;
+use Neos\Flow\Security\RequestPatternInterface;
+use Neos\Flow\Security\SessionDataContainer;
+use Neos\Flow\Session\SessionInterface;
+use Neos\Flow\Session\SessionManagerInterface;
+use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Security\Policy\Role;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Testcase for the SessionDataContainer
+ */
+class SessionDataContainerTest extends UnitTestCase
+{
+
+    /**
+     * @var SessionDataContainer
+     */
+    private $sessionDataContainer;
+
+    public function setUp(): void
+    {
+        $this->sessionDataContainer = new SessionDataContainer();
+    }
+
+    /**
+     * @test
+     */
+    public function resetSetsDefaultValues(): void
+    {
+        $mockCsrfProtectionTokens = [
+            'mock' => true,
+        ];
+
+        $this->sessionDataContainer->setCsrfProtectionTokens($mockCsrfProtectionTokens);
+
+        /** @var RequestInterface $mockRequest */
+        $mockRequest = $this->getMockBuilder(RequestInterface::class)->getMock();
+        $this->sessionDataContainer->setInterceptedRequest($mockRequest);
+
+        $mockSecurityTokens = [
+            'someProvider' => $this->getMockBuilder(TokenInterface::class)->getMock()
+        ];
+        $this->sessionDataContainer->setSecurityTokens($mockSecurityTokens);
+
+        $this->sessionDataContainer->reset();
+
+        $this->assertSame([], $this->sessionDataContainer->getCsrfProtectionTokens());
+        $this->assertNull($this->sessionDataContainer->getInterceptedRequest());
+        $this->assertSame([], $this->sessionDataContainer->getSecurityTokens());
+    }
+
+    /**
+     * @test
+     */
+    public function setSecurityTokensThrowsExceptionWhenTryingToAddSessionlessTokens(): void
+    {
+        $mockSecurityTokens = [
+            'someProvider' => $this->getMockBuilder([TokenInterface::class, SessionlessTokenInterface::class])->getMock()
+        ];
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sessionDataContainer->setSecurityTokens($mockSecurityTokens);
+    }
+}


### PR DESCRIPTION
Without this fix, all security tokens – including those which are
implementations of SessionlessTokenInterface – are serialized and
added to the current session. This is a problem for sessionless
tokens, which need to be updated on every request on not just once
per session.

Fixes: #1666
Related: #1614