### PR TITLE
BUGFIX: Omit sessionless tokens from session

### DIFF
--- a/Neos.Flow/Classes/Security/Context.php
+++ b/Neos.Flow/Classes/Security/Context.php
@@ -785,7 +785,7 @@ class Context
     {
         $this->tokens = array_filter(
             array_merge($this->inactiveTokens, $this->activeTokens),
-            function ($token) {
+            static function ($token) {
                 return (!$token instanceof SessionlessTokenInterface);
             }
         );

--- a/Neos.Flow/Classes/Security/Context.php
+++ b/Neos.Flow/Classes/Security/Context.php
@@ -18,6 +18,7 @@ use Neos\Flow\Mvc\RequestInterface;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\Policy\Role;
+use Neos\Flow\Security\Authentication\Token\SessionlessTokenInterface;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Session\SessionManagerInterface;
 use Neos\Flow\Utility\Algorithms;
@@ -782,7 +783,12 @@ class Context
      */
     public function shutdownObject()
     {
-        $this->tokens = array_merge($this->inactiveTokens, $this->activeTokens);
+        $this->tokens = array_filter(
+            array_merge($this->inactiveTokens, $this->activeTokens),
+            function ($token) {
+                return (!$token instanceof SessionlessTokenInterface);
+            }
+        );
         $this->initialized = false;
     }
 


### PR DESCRIPTION
Without this fix, all security tokens – including those which are
implementations of SessionlessTokenInterface – are serialized and
added to the current session. This is a problem for sessionless
tokens, which need to be updated on every request on not just once
per session.

Backport of #1662
Fixes: #1666