### PR TITLE
!!! TASK: Deprecate SaltedMd5HashingStrategy

### DIFF
--- a/Neos.Flow/Classes/Security/Cryptography/SaltedMd5HashingStrategy.php
+++ b/Neos.Flow/Classes/Security/Cryptography/SaltedMd5HashingStrategy.php
@@ -15,7 +15,7 @@ use Neos\Flow\Utility;
 
 /**
  * A salted MD5 based password hashing strategy
- *
+ * @deprecated since Flow 6.0, will be removed with Flow 7.0
  */
 class SaltedMd5HashingStrategy implements PasswordHashingStrategyInterface
 {

--- a/Neos.Utility.Arrays/Tests/Unit/ArraysTest.php
+++ b/Neos.Utility.Arrays/Tests/Unit/ArraysTest.php
@@ -602,7 +602,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
             $inputArray1,
             $inputArray2,
             function ($simpleType) {
-                return array('__convertedValue' => $simpleType);
+                return ['__convertedValue' => $simpleType];
             },
             function ($value) {
                 return true;


### PR DESCRIPTION
md5 is the most insecure hashing algo in existence and we shouldn't support that out of the box, especially not within the `Security` context. If someone has dire need for it in Flow 7.0+, he could always just copy the old strategy and plug it in.
See also https://tools.ietf.org/html/rfc6151


In order to migrate your existing Md5 hashes, you need to configure a different secure hashing strategy and run all your hashed passwords once through the `hashPassword()` upon next user entry.
```php
list($strategyIdentifier, ) = explode('=>', $account->getCredentialsSource(), 2);
if ($strategyIdentifier === 'saltedmd5') {
    $account->setCredentialsSource($this->hashService->hashPassword($password));
    $this->accountRepository->update($account);
}
```