### PR TITLE
BUGFIX: Automatically map DateTimeInterface to ORM type

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -729,6 +729,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
 
                 if (!isset($mapping['type'])) {
                     switch ($propertyMetaData['type']) {
+                        case 'DateTimeInterface': // fall through b/c fix for #1640
                         case 'DateTime':
                             $mapping['type'] = 'datetime';
                             break;

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/ExtendedTypesEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/ExtendedTypesEntity.php
@@ -78,6 +78,12 @@ class ExtendedTypesEntity
     protected $dateTimeImmutable;
 
     /**
+     * This is possible for b/c - see #1673
+     * @var \DateTimeInterface
+     */
+    protected $dateTimeInterface;
+
+    /**
      * @param \DateTime $time
      * @return $this
      */
@@ -165,6 +171,24 @@ class ExtendedTypesEntity
     public function getDateTimeImmutable()
     {
         return $this->dateTimeImmutable;
+    }
+
+    /**
+     * @param \DateTimeInterface $dateTime
+     * @return $this
+     */
+    public function setDateTimeInterface(\DateTimeInterface $dateTime = null)
+    {
+        $this->dateTimeInterface = $dateTime;
+        return $this;
+    }
+
+    /**
+     * @return \DateTimeInterface
+     */
+    public function getDateTimeInterface()
+    {
+        return $this->dateTimeInterface;
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/ExtendedTypesEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/ExtendedTypesEntity.php
@@ -80,6 +80,7 @@ class ExtendedTypesEntity
     /**
      * This is possible for b/c - see #1673
      * @var \DateTimeInterface
+     * @ORM\Column(nullable=true)
      */
     protected $dateTimeInterface;
 

--- a/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
@@ -559,7 +559,7 @@ class PersistenceTest extends FunctionalTestCase
     }
 
     /**
-     * This test covers a b/c "feature" that automatically maps @var \DateTimeInterface to doctrine `datetime` type without a @ORM\Column annotation
+     * This test covers a b/c "feature" that automatically maps var \DateTimeInterface to doctrine `datetime` type without a ORM\Column annotation
      * See #1673
      * @test
      */


### PR DESCRIPTION
Since #1640 a model with a property annotated like

```php
/**
 * @var \DateTimeInterface
 */
protected $someDateTime;
```

lead to an exception in annotation parsing, because the property does not contain a `@ORM\Column(type="...")` mapping.
This worked before, because the type parser interpreted `DateTimeInterface` as just `DateTime` due to the error prone regex matching. Since the regex fix above, `DateTimeInterface` will now be parsed as `DateTimeInterface` and the FlowAnnotationDriver does not automatically map that to an ORM type. This change works around that, by automatically mapping `DateTimeInterface` to the ORM type `datetime` to be b/c with previous behaviour.

Note though, that this is generally bad magic, because you might want your property to be something different from `DateTime` after reconstitution from the ORM, so the real fix should be that you explicitly specify the DateTime (sub-)class in the `@var` annotation and add a corresponding `@ORM\Column(type="...")`, possibly together with a custom DBAL type.

Related to #1672