### PR TITLE
BUGFIX: Avoid unsupported operand types error

### DIFF
--- a/Neos.Flow/Classes/Session/Session.php
+++ b/Neos.Flow/Classes/Session/Session.php
@@ -612,6 +612,7 @@ class Session implements CookieEnabledInterface
      * @return integer The number of outdated entries removed
      * @throws \Neos\Cache\Exception
      * @throws NotSupportedByBackendException
+     * @throws Exception\SessionMetadataCorruptedException
      * @api
      */
     public function collectGarbage()
@@ -633,6 +634,9 @@ class Session implements CookieEnabledInterface
             $lastActivitySecondsAgo = $this->now - $sessionInfo['lastActivityTimestamp'];
             if ($lastActivitySecondsAgo > $this->inactivityTimeout) {
                 if ($sessionInfo['storageIdentifier'] === null) {
+                    if (!is_array($sessionInfo)) {
+                        $sessionInfo = ['sessionMetaData' => $sessionInfo];
+                    }
                     $this->logger->warning('SESSION INFO INVALID: ' . $sessionIdentifier, $sessionInfo + LogEnvironment::fromMethodName(__METHOD__));
                 } else {
                     $this->storageCache->flushByTag($sessionInfo['storageIdentifier']);

--- a/Neos.Flow/Classes/Session/Session.php
+++ b/Neos.Flow/Classes/Session/Session.php
@@ -612,7 +612,6 @@ class Session implements CookieEnabledInterface
      * @return integer The number of outdated entries removed
      * @throws \Neos\Cache\Exception
      * @throws NotSupportedByBackendException
-     * @throws Exception\SessionMetadataCorruptedException
      * @api
      */
     public function collectGarbage()

--- a/Neos.Flow/Tests/Unit/Session/SessionTest.php
+++ b/Neos.Flow/Tests/Unit/Session/SessionTest.php
@@ -1049,6 +1049,7 @@ class SessionTest extends UnitTestCase
         $this->inject($session, 'objectManager', $this->mockObjectManager);
         $this->inject($session, 'metaDataCache', $metaDataCache);
         $this->inject($session, 'storageCache', $storageCache);
+        $this->inject($session, 'logger', $this->createMock(LoggerInterface::class));
         $session->injectSettings($settings);
         $session->initializeObject();
 

--- a/Neos.Flow/Tests/Unit/Session/SessionTest.php
+++ b/Neos.Flow/Tests/Unit/Session/SessionTest.php
@@ -1035,6 +1035,27 @@ class SessionTest extends UnitTestCase
     }
 
     /**
+     * @test for #1674
+     */
+    public function garbageCollectionWorksCorrectlyWithInvalidMetadataEntry()
+    {
+        $settings = $this->settings;
+
+        $metaDataCache = $this->createCache('Meta');
+        $metaDataCache->set('foo', null);
+        $storageCache = $this->createCache('Storage');
+
+        $session = new Session();
+        $this->inject($session, 'objectManager', $this->mockObjectManager);
+        $this->inject($session, 'metaDataCache', $metaDataCache);
+        $this->inject($session, 'storageCache', $storageCache);
+        $session->injectSettings($settings);
+        $session->initializeObject();
+
+        $this->assertSame(0, $session->collectGarbage());
+    }
+
+    /**
      * @test
      */
     public function garbageCollectionIsOmittedIfInactivityTimeoutIsSetToZero()


### PR DESCRIPTION
Under some circumstances, the session metadata cache might iterate a non-array value and the following logging attempt failing with an unsupported operand type error for the `+` array concatenation. This change works around this error, by checking the `$sessionInfo` to be of type array and assigning a wrapper array otherwise.