### PR TITLE
TASK: Make array indexing difference more visible

### DIFF
--- a/Neos.Utility.Schema/Classes/SchemaValidator.php
+++ b/Neos.Utility.Schema/Classes/SchemaValidator.php
@@ -352,8 +352,12 @@ class SchemaValidator
     protected function validateArrayType($value, array $schema, array $types = []): ErrorResult
     {
         $result = new ErrorResult();
-        if (is_array($value) === false || $this->isNumericallyIndexedArray($value) === false) {
+        if (is_array($value) === false) {
             $result->addError($this->createError('type=array', 'type=' . gettype($value)));
+            return $result;
+        }
+        if ($this->isNumericallyIndexedArray($value) === false) {
+            $result->addError($this->createError('type=array', 'type=dictionary'));
             return $result;
         }
 


### PR DESCRIPTION
Previously, if an array was expected but a non numerically indexed array (i.e. a "dictionary") was given, the error message would output `expected: type=array found: type=array`, which is totally confusing.

See https://github.com/neos/flow-development-collection/pull/1637