### PR TITLE
BUGFIX: resource:clean will remove resource from right collection

### DIFF
--- a/Neos.Flow/Classes/Command/ResourceCommandController.php
+++ b/Neos.Flow/Classes/Command/ResourceCommandController.php
@@ -222,7 +222,7 @@ class ResourceCommandController extends CommandController
             /* @var PersistentResource $resource */
             $stream = $resource->getStream();
             if (!is_resource($stream)) {
-                $brokenResources[] = $resource->getSha1();
+                $brokenResources[] = $this->persistenceManager->getIdentifierByObject($resource);
             }
         }
 
@@ -235,8 +235,8 @@ class ResourceCommandController extends CommandController
             /* @var ThumbnailRepository $thumbnailRepository */
             $thumbnailRepository = $this->objectManager->get(ThumbnailRepository::class);
 
-            foreach ($brokenResources as $key => $resourceSha1) {
-                $resource = $this->resourceRepository->findOneBySha1($resourceSha1);
+            foreach ($brokenResources as $key => $resourceIdentifier) {
+                $resource = $this->resourceRepository->findByIdentifier($resourceIdentifier);
                 $brokenResources[$key] = $resource;
                 $assets = $assetRepository->findByResource($resource);
                 if ($assets !== null) {

--- a/Neos.Flow/Classes/Command/ResourceCommandController.php
+++ b/Neos.Flow/Classes/Command/ResourceCommandController.php
@@ -237,9 +237,9 @@ class ResourceCommandController extends CommandController
                 $thumbnailRepository = $this->objectManager->get(ThumbnailRepository::class);
             }
 
-            foreach ($brokenResources as $resourceIdentifier) {
+            foreach ($brokenResources as $key => $resourceIdentifier) {
                 $resource = $this->resourceRepository->findByIdentifier($resourceIdentifier);
-                $brokenResources[] = $resource;
+                $brokenResources[$key] = $resource;
                 if ($mediaPackagePresent) {
                     $assets = $assetRepository->findByResource($resource);
                     if ($assets !== null) {

--- a/Neos.Flow/Classes/Command/ResourceCommandController.php
+++ b/Neos.Flow/Classes/Command/ResourceCommandController.php
@@ -237,9 +237,9 @@ class ResourceCommandController extends CommandController
                 $thumbnailRepository = $this->objectManager->get(ThumbnailRepository::class);
             }
 
-            foreach ($brokenResources as $key => $resourceIdentifier) {
+            foreach ($brokenResources as $resourceIdentifier) {
                 $resource = $this->resourceRepository->findByIdentifier($resourceIdentifier);
-                $brokenResources[$key] = $resource;
+                $brokenResources[] = $resource;
                 if ($mediaPackagePresent) {
                     $assets = $assetRepository->findByResource($resource);
                     if ($assets !== null) {

--- a/Neos.Flow/Classes/Command/ResourceCommandController.php
+++ b/Neos.Flow/Classes/Command/ResourceCommandController.php
@@ -270,7 +270,7 @@ class ResourceCommandController extends CommandController
                 case 'y':
                     $brokenAssetCounter = 0;
                     $brokenThumbnailCounter = 0;
-                    foreach ($brokenResources as $sha1 => $resource) {
+                    foreach ($brokenResources as $resource) {
                         $this->outputLine('- delete %s (%s) from "%s" collection', [
                             $resource->getFilename(),
                             $resource->getSha1(),

--- a/Neos.Flow/Classes/Command/ResourceCommandController.php
+++ b/Neos.Flow/Classes/Command/ResourceCommandController.php
@@ -229,22 +229,26 @@ class ResourceCommandController extends CommandController
         $this->output->progressFinish();
         $this->outputLine();
 
-        if ($mediaPackagePresent && count($brokenResources) > 0) {
-            /* @var AssetRepository $assetRepository */
-            $assetRepository = $this->objectManager->get(AssetRepository::class);
-            /* @var ThumbnailRepository $thumbnailRepository */
-            $thumbnailRepository = $this->objectManager->get(ThumbnailRepository::class);
+        if (count($brokenResources) > 0) {
+            if ($mediaPackagePresent) {
+                /* @var AssetRepository $assetRepository */
+                $assetRepository = $this->objectManager->get(AssetRepository::class);
+                /* @var ThumbnailRepository $thumbnailRepository */
+                $thumbnailRepository = $this->objectManager->get(ThumbnailRepository::class);
+            }
 
             foreach ($brokenResources as $key => $resourceIdentifier) {
                 $resource = $this->resourceRepository->findByIdentifier($resourceIdentifier);
                 $brokenResources[$key] = $resource;
-                $assets = $assetRepository->findByResource($resource);
-                if ($assets !== null) {
-                    $relatedAssets[$resource] = $assets;
-                }
-                $thumbnails = $thumbnailRepository->findByResource($resource);
-                if ($assets !== null) {
-                    $relatedThumbnails[$resource] = $thumbnails;
+                if ($mediaPackagePresent) {
+                    $assets = $assetRepository->findByResource($resource);
+                    if ($assets !== null) {
+                        $relatedAssets[$resource] = $assets;
+                    }
+                    $thumbnails = $thumbnailRepository->findByResource($resource);
+                    if ($assets !== null) {
+                        $relatedThumbnails[$resource] = $thumbnails;
+                    }
                 }
             }
         }


### PR DESCRIPTION
This fix makes sure `resource:clean` will remove broken resources from the right collection.

The problem is that you save the SHA1 for a broken resource. Now think about the following case: You have two resources with the same SHA1, but from two different collections (`persistent`/`temporary`). The resource inside the `temporary`-Collection was removed and now you run the command.

It will detect the missing resource from the `temporary`-Collection and add the SHA1 to `$brokenResources`. Now when iteration over `$brokenResources` to get the `PersistentResource` you are using `$this->resourceRepository->findOneBySha1($resourceSha1)`, which ignores the collection. So you can't be sure to get the `PersistentResource` from the `temporary`-Collection that you actually want, it's possible that you get the one from the `persistent`-Collection. This would result in deleting the wrong `PersistentResource` and not removing the broken resource but creating a new problem.

The fix just saves the identifier of the `PersistentResource` to `$brokenResources` and later detects the correct one agin by using `$this->resourceRepository->findByIdentifier($resourceIdentifier)`.