### PR TITLE
BUGFIX: Respect Neos.Flow.http.baseUri path in UriBuilder

### DIFF
--- a/Neos.Flow/Classes/Mvc/Routing/Dto/ResolveContext.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Dto/ResolveContext.php
@@ -62,6 +62,15 @@ final class ResolveContext
         $this->routeValues = $routeValues;
         $this->forceAbsoluteUri = $forceAbsoluteUri;
         $this->uriPathPrefix = $uriPathPrefix;
+
+        // Only add base uri path for absolute uri, in case of relative uri the uri has to be relative to the given base uri
+        if ($forceAbsoluteUri) {
+            $this->uriPathPrefix = '/' . ltrim($this->uriPathPrefix, '/');
+
+            if ($baseUri->getPath() !== '') {
+                $this->uriPathPrefix = rtrim($baseUri->getPath(), '/') . $this->uriPathPrefix;
+            }
+        }
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
@@ -361,6 +361,114 @@ class RoutingTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function uriPathPrefixIsRespectedInRoute()
+    {
+        $routeValues = [
+            '@package' => 'Neos.Flow',
+            '@subpackage' => 'Tests\Functional\Http\Fixtures',
+            '@controller' => 'Foo',
+            '@action' => 'index',
+            '@format' => 'html'
+        ];
+        $baseUri = new Uri('http://localhost');
+        $actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, false, 'index.php/'));
+
+        $this->assertSame('index.php/neos/flow/test/http/foo', (string)$actualResult);
+    }
+
+    /**
+     * @test
+     */
+    public function uriPathPrefixIsRespectedInAbsoluteRoute()
+    {
+        $routeValues = [
+            '@package' => 'Neos.Flow',
+            '@subpackage' => 'Tests\Functional\Http\Fixtures',
+            '@controller' => 'Foo',
+            '@action' => 'index',
+            '@format' => 'html'
+        ];
+        $baseUri = new Uri('http://localhost');
+        $actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, true, 'index.php/'));
+
+        $this->assertSame('http://localhost/index.php/neos/flow/test/http/foo', (string)$actualResult);
+    }
+
+    /**
+     * @test
+     */
+    public function pathOfBaseUriIsRespectedInAbsoluteRoute()
+    {
+        $routeValues = [
+            '@package' => 'Neos.Flow',
+            '@subpackage' => 'Tests\Functional\Http\Fixtures',
+            '@controller' => 'Foo',
+            '@action' => 'index',
+            '@format' => 'html'
+        ];
+        $baseUri = new Uri('http://localhost/baz');
+        $actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, true));
+
+        $this->assertSame('http://localhost/baz/neos/flow/test/http/foo', (string)$actualResult);
+    }
+
+    /**
+     * @test
+     */
+    public function pathOfBaseUriIsRespectedInRoute()
+    {
+        $routeValues = [
+            '@package' => 'Neos.Flow',
+            '@subpackage' => 'Tests\Functional\Http\Fixtures',
+            '@controller' => 'Foo',
+            '@action' => 'index',
+            '@format' => 'html'
+        ];
+        $baseUri = new Uri('http://localhost/baz');
+        $actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, false));
+
+        $this->assertSame('neos/flow/test/http/foo', (string)$actualResult);
+    }
+
+    /**
+     * @test
+     */
+    public function pathOfBaseUriWithoutRewriteIsRespectedInRoute()
+    {
+        $routeValues = [
+            '@package' => 'Neos.Flow',
+            '@subpackage' => 'Tests\Functional\Http\Fixtures',
+            '@controller' => 'Foo',
+            '@action' => 'index',
+            '@format' => 'html'
+        ];
+        $baseUri = new Uri('http://localhost/baz');
+        $actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, false, 'index.php/'));
+
+        $this->assertSame('index.php/neos/flow/test/http/foo', (string)$actualResult);
+    }
+
+    /**
+     * @test
+     */
+    public function pathOfBaseUriWithoutRewriteIsRespectedInAbsoluteRoute()
+    {
+        $routeValues = [
+            '@package' => 'Neos.Flow',
+            '@subpackage' => 'Tests\Functional\Http\Fixtures',
+            '@controller' => 'Foo',
+            '@action' => 'index',
+            '@format' => 'html'
+        ];
+        $baseUri = new Uri('http://localhost/baz');
+        $actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, true, 'index.php/'));
+
+        $this->assertSame('http://localhost/baz/index.php/neos/flow/test/http/foo', (string)$actualResult);
+    }
+
+    /**
+     * @test
+     */
     public function explicitlySpecifiedRoutesOverruleConfiguredRoutes()
     {
         $routeValues = [


### PR DESCRIPTION
If Neos.Flow.http.baseUri contains a path, it was not respected
during uri building.

See: #1185
Resolves: #1215

**What I did**
Add path of `Neos.Flow.http.baseUri` to ResolveContext's uriPathPrefix.

**How to verify it**
Configure `Neos.Flow.http.baseUri` to be an absolute URI with path, build URI to any Controller.