### PR TITLE
BUGFIX: Allow a single '*' entry in trustedProxies

### DIFF
--- a/Neos.Flow/Classes/Http/Component/TrustedProxiesComponent.php
+++ b/Neos.Flow/Classes/Http/Component/TrustedProxiesComponent.php
@@ -44,7 +44,7 @@ class TrustedProxiesComponent implements ComponentInterface
         if ($this->settings['proxies'] === ['*']) {
             $this->settings['proxies'] = '*';
         }
-        if (!is_array($this->settings['proxies']) && $this->settings['proxies'] !== '*')) {
+        if (!is_array($this->settings['proxies']) && $this->settings['proxies'] !== '*') {
             throw new InvalidConfigurationException('The Neos.Flow.http.trustedProxies.proxies setting may only be an array of IP addresses or the single string "*". Got "' . var_export($this->settings['proxies'], true) . '" instead.', 1564659249);
         }
         if (is_array($this->settings['proxies']) && array_search('*', $this->settings['proxies'], true) !== false) {

--- a/Neos.Flow/Classes/Http/Component/TrustedProxiesComponent.php
+++ b/Neos.Flow/Classes/Http/Component/TrustedProxiesComponent.php
@@ -14,6 +14,7 @@ namespace Neos\Flow\Http\Component;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\Request;
 use Neos\Flow\Utility\Ip as IpUtility;
+use Neos\Flow\Configuration\Exception\InvalidConfigurationException;
 
 /**
  * HTTP component that checks request headers against a configured list of trusted proxy IP addresses.
@@ -26,10 +27,30 @@ class TrustedProxiesComponent implements ComponentInterface
     const HEADER_PROTOCOL = 'proto';
 
     /**
-     * @Flow\InjectConfiguration("http.trustedProxies")
      * @var array
      */
     protected $settings;
+
+    /**
+     * Injects the configuration settings
+     *
+     * @param array $settings
+     * @return void
+     * @throws InvalidConfigurationException
+     */
+    public function injectSettings(array $settings)
+    {
+        $this->settings = $settings['http']['trustedProxies'];
+        if ($this->settings['proxies'] === ['*']) {
+            $this->settings['proxies'] = '*';
+        }
+        if (!is_array($this->settings['proxies']) && $this->settings['proxies'] !== '*')) {
+            throw new InvalidConfigurationException('The Neos.Flow.http.trustedProxies.proxies setting may only be an array of IP addresses or the single string "*". Got "' . var_export($this->settings['proxies'], true) . '" instead.', 1564659249);
+        }
+        if (is_array($this->settings['proxies']) && array_search('*', $this->settings['proxies'], true) !== false) {
+            throw new InvalidConfigurationException('The Neos.Flow.http.trustedProxies.proxies setting is an array of IP addresses but also contains the string "*". Did you intend to allow all proxies? If so set the setting to the explicit string "*".', 1564659250);
+        }
+    }
 
     /**
      * @param ComponentContext $componentContext
@@ -124,7 +145,7 @@ class TrustedProxiesComponent implements ComponentInterface
         if (filter_var($ipAddress, FILTER_VALIDATE_IP) === false) {
             return false;
         }
-        if ($this->settings['proxies'] === '*' || $this->settings['proxies'] === ['*']) {
+        if ($this->settings['proxies'] === '*') {
             return true;
         }
         foreach ($this->settings['proxies'] as $ipPattern) {
@@ -182,7 +203,7 @@ class TrustedProxiesComponent implements ComponentInterface
             $trustedIpHeaders->next();
         }
 
-        if ($this->settings['proxies'] === '*' || $this->settings['proxies'] === ['*']) {
+        if ($this->settings['proxies'] === '*') {
             return $ipAddress;
         }
 

--- a/Neos.Flow/Classes/Http/Component/TrustedProxiesComponent.php
+++ b/Neos.Flow/Classes/Http/Component/TrustedProxiesComponent.php
@@ -124,7 +124,7 @@ class TrustedProxiesComponent implements ComponentInterface
         if (filter_var($ipAddress, FILTER_VALIDATE_IP) === false) {
             return false;
         }
-        if ($this->settings['proxies'] === '*') {
+        if ($this->settings['proxies'] === '*' || $this->settings['proxies'] === ['*']) {
             return true;
         }
         foreach ($this->settings['proxies'] as $ipPattern) {
@@ -182,7 +182,7 @@ class TrustedProxiesComponent implements ComponentInterface
             $trustedIpHeaders->next();
         }
 
-        if ($this->settings['proxies'] === '*') {
+        if ($this->settings['proxies'] === '*' || $this->settings['proxies'] === ['*']) {
             return $ipAddress;
         }
 


### PR DESCRIPTION
This makes the setting `Neos.Flow.http.trustedProxies.proxies` behave equal for a setting of
`"*"` or `["*"]` or `- "*"`.