### PR TITLE
CLEANUP: Use var_dump return parameter

### DIFF
--- a/Neos.FluidAdaptor/Classes/ViewHelpers/DebugViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/DebugViewHelper.php
@@ -69,10 +69,6 @@ class DebugViewHelper extends AbstractViewHelper
             $expressionToExamine = (is_object($expressionToExamine) ? get_class($expressionToExamine) : gettype($expressionToExamine));
         }
 
-        ob_start();
-        \Neos\Flow\var_dump($expressionToExamine, $title);
-        $output = ob_get_contents();
-        ob_end_clean();
-        return $output;
+        return \Neos\Flow\var_dump($expressionToExamine, $title, true);
     }
 }


### PR DESCRIPTION
**What I did**
When digging through the code I found this instance of capturing the output of `\Neos\Flow\var_dump` using `ob_get_contents` when `\Neos\Flow\var_dump` has a `$return` parameter itself.

Note: I branched off of `4.0` because I thought that that version was still maintained. Turns out it is not and 5.0 is the lowest maintained version as of this month.

**How I did it**
Using the `$return` parameter of `\Neos\Flow\var_dump`

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
