### PR TITLE
TASK: Use var_dump return parameter

### DIFF
--- a/Neos.FluidAdaptor/Classes/ViewHelpers/DebugViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/DebugViewHelper.php
@@ -78,10 +78,6 @@ class DebugViewHelper extends AbstractViewHelper
             $expressionToExamine = (is_object($expressionToExamine) ? get_class($expressionToExamine) : gettype($expressionToExamine));
         }
 
-        ob_start();
-        \Neos\Flow\var_dump($expressionToExamine, $this->arguments['title']);
-        $output = ob_get_contents();
-        ob_end_clean();
-        return $output;
+        return \Neos\Flow\var_dump($expressionToExamine, $this->arguments['title'], true);
     }
 }


### PR DESCRIPTION
**What I did**
When digging through the code I found this instance of capturing the output of `\Neos\Flow\var_dump` using `ob_get_contents` when `\Neos\Flow\var_dump` has a `$return` parameter itself.

**How I did it**
Using the `$return` parameter of `\Neos\Flow\var_dump`