### PR TITLE
TASK: Refactor unit tests to static assert calls

### DIFF
--- a/Neos.Cache/Tests/Functional/Backend/RedisBackendTest.php
+++ b/Neos.Cache/Tests/Functional/Backend/RedisBackendTest.php
@@ -86,7 +86,7 @@ class RedisBackendTest extends BaseTestCase
     public function setAddsCacheEntry()
     {
         $this->backend->set('some_entry', 'foo');
-        $this->assertEquals('foo', $this->backend->get('some_entry'));
+        self::assertEquals('foo', $this->backend->get('some_entry'));
     }
 
     /**
@@ -97,7 +97,7 @@ class RedisBackendTest extends BaseTestCase
         $this->backend->set('some_entry', 'foo', ['tag1', 'tag2']);
         $this->backend->set('some_other_entry', 'foo', ['tag2', 'tag3']);
 
-        $this->assertEquals(['some_entry'], $this->backend->findIdentifiersByTag('tag1'));
+        self::assertEquals(['some_entry'], $this->backend->findIdentifiersByTag('tag1'));
         $expected = ['some_entry', 'some_other_entry'];
         $actual = $this->backend->findIdentifiersByTag('tag2');
 
@@ -105,8 +105,8 @@ class RedisBackendTest extends BaseTestCase
         natsort($actual);
         $actual = array_values($actual);
 
-        $this->assertEquals($expected, $actual);
-        $this->assertEquals(['some_other_entry'], $this->backend->findIdentifiersByTag('tag3'));
+        self::assertEquals($expected, $actual);
+        self::assertEquals(['some_other_entry'], $this->backend->findIdentifiersByTag('tag3'));
     }
 
     /**
@@ -122,7 +122,7 @@ class RedisBackendTest extends BaseTestCase
             $entryIdentifiers[] = $entryIdentifier;
         }
 
-        $this->assertEquals(['some_entry'], $entryIdentifiers);
+        self::assertEquals(['some_entry'], $entryIdentifiers);
     }
 
     /**
@@ -138,10 +138,10 @@ class RedisBackendTest extends BaseTestCase
             $actualEntries[] = $key;
         }
 
-        $this->assertCount(100, $actualEntries);
+        self::assertCount(100, $actualEntries);
 
         for ($i = 0; $i < 100; $i++) {
-            $this->assertContains('entry_' . $i, $actualEntries);
+            self::assertContains('entry_' . $i, $actualEntries);
         }
     }
 
@@ -150,12 +150,12 @@ class RedisBackendTest extends BaseTestCase
      */
     public function freezeFreezesTheCache()
     {
-        $this->assertFalse($this->backend->isFrozen());
+        self::assertFalse($this->backend->isFrozen());
         for ($i = 0; $i < 10; $i++) {
             $this->backend->set('entry_' . $i, 'foo');
         }
         $this->backend->freeze();
-        $this->assertTrue($this->backend->isFrozen());
+        self::assertTrue($this->backend->isFrozen());
     }
 
     /**
@@ -169,13 +169,13 @@ class RedisBackendTest extends BaseTestCase
         for ($i = 10; $i < 20; $i++) {
             $this->backend->set('entry_' . $i, 'foo', ['tag2']);
         }
-        $this->assertCount(10, $this->backend->findIdentifiersByTag('tag1'));
-        $this->assertCount(20, $this->backend->findIdentifiersByTag('tag2'));
+        self::assertCount(10, $this->backend->findIdentifiersByTag('tag1'));
+        self::assertCount(20, $this->backend->findIdentifiersByTag('tag2'));
 
         $count = $this->backend->flushByTag('tag1');
-        $this->assertEquals(10, $count, 'flushByTag returns amount of flushed entries');
-        $this->assertCount(0, $this->backend->findIdentifiersByTag('tag1'));
-        $this->assertCount(10, $this->backend->findIdentifiersByTag('tag2'));
+        self::assertEquals(10, $count, 'flushByTag returns amount of flushed entries');
+        self::assertCount(0, $this->backend->findIdentifiersByTag('tag1'));
+        self::assertCount(10, $this->backend->findIdentifiersByTag('tag2'));
     }
 
     /**
@@ -192,7 +192,7 @@ class RedisBackendTest extends BaseTestCase
             $entryIdentifiers[] = $entryIdentifier;
         }
 
-        $this->assertEquals([], $entryIdentifiers);
+        self::assertEquals([], $entryIdentifiers);
     }
 
     /**
@@ -203,9 +203,9 @@ class RedisBackendTest extends BaseTestCase
         for ($i = 0; $i < 10; $i++) {
             $this->backend->set('entry_' . $i, 'foo', ['tag1']);
         }
-        $this->assertTrue($this->backend->has('entry_5'));
+        self::assertTrue($this->backend->has('entry_5'));
         $this->backend->flush();
-        $this->assertFalse($this->backend->has('entry_5'));
+        self::assertFalse($this->backend->has('entry_5'));
     }
 
     /**
@@ -216,22 +216,22 @@ class RedisBackendTest extends BaseTestCase
         for ($i = 0; $i < 10; $i++) {
             $this->backend->set('entry_' . $i, 'foo', ['tag1']);
         }
-        $this->assertCount(10, $this->backend->findIdentifiersByTag('tag1'));
-        $this->assertEquals('foo', $this->backend->get('entry_1'));
+        self::assertCount(10, $this->backend->findIdentifiersByTag('tag1'));
+        self::assertEquals('foo', $this->backend->get('entry_1'));
         $actualEntries = [];
         foreach ($this->backend as $key => $value) {
             $actualEntries[] = $key;
         }
-        $this->assertCount(10, $actualEntries);
+        self::assertCount(10, $actualEntries);
 
         $this->backend->remove('entry_3');
-        $this->assertCount(9, $this->backend->findIdentifiersByTag('tag1'));
-        $this->assertFalse($this->backend->get('entry_3'));
+        self::assertCount(9, $this->backend->findIdentifiersByTag('tag1'));
+        self::assertFalse($this->backend->get('entry_3'));
         $actualEntries = [];
         foreach ($this->backend as $key => $value) {
             $actualEntries[] = $key;
         }
-        $this->assertCount(9, $actualEntries);
+        self::assertCount(9, $actualEntries);
     }
 
     /**
@@ -241,12 +241,12 @@ class RedisBackendTest extends BaseTestCase
     {
         $this->backend->set('entry1', 'foo', [], 1);
         sleep(2);
-        $this->assertFalse($this->backend->has('entry1'));
+        self::assertFalse($this->backend->has('entry1'));
 
         $actualEntries = [];
         foreach ($this->backend as $key => $value) {
             $actualEntries[] = $key;
         }
-        $this->assertEmpty($actualEntries, 'Entries should be empty');
+        self::assertEmpty($actualEntries, 'Entries should be empty');
     }
 }

--- a/Neos.Cache/Tests/Unit/Backend/AbstractBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/AbstractBackendTest.php
@@ -63,6 +63,6 @@ class AbstractBackendTest extends BaseTestCase
     {
         $className = get_class($this->backend);
         $backend = new $className(new EnvironmentConfiguration('Ultraman Neos Testing', '/some/path', PHP_MAXPATHLEN), ['someOption' => 'someValue']);
-        $this->assertSame('someValue', $backend->getSomeOption());
+        self::assertSame('someValue', $backend->getSomeOption());
     }
 }

--- a/Neos.Cache/Tests/Unit/Backend/ApcuBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/ApcuBackendTest.php
@@ -64,7 +64,7 @@ class ApcuBackendTest extends BaseTestCase
         $identifier = 'MyIdentifier' . md5(uniqid(mt_rand(), true));
         $backend->set($identifier, $data);
         $inCache = $backend->has($identifier);
-        $this->assertTrue($inCache, 'APCu backend failed to set and check entry');
+        self::assertTrue($inCache, 'APCu backend failed to set and check entry');
     }
 
     /**
@@ -77,7 +77,7 @@ class ApcuBackendTest extends BaseTestCase
         $identifier = 'MyIdentifier' . md5(uniqid(mt_rand(), true));
         $backend->set($identifier, $data);
         $fetchedData = $backend->get($identifier);
-        $this->assertEquals($data, $fetchedData, 'APCu backend failed to set and retrieve data');
+        self::assertEquals($data, $fetchedData, 'APCu backend failed to set and retrieve data');
     }
 
     /**
@@ -91,7 +91,7 @@ class ApcuBackendTest extends BaseTestCase
         $backend->set($identifier, $data);
         $backend->remove($identifier);
         $inCache = $backend->has($identifier);
-        $this->assertFalse($inCache, 'Failed to set and remove data from APCu backend');
+        self::assertFalse($inCache, 'Failed to set and remove data from APCu backend');
     }
 
     /**
@@ -106,7 +106,7 @@ class ApcuBackendTest extends BaseTestCase
         $otherData = 'some other data';
         $backend->set($identifier, $otherData);
         $fetchedData = $backend->get($identifier);
-        $this->assertEquals($otherData, $fetchedData, 'APCu backend failed to overwrite and retrieve data');
+        self::assertEquals($otherData, $fetchedData, 'APCu backend failed to overwrite and retrieve data');
     }
 
     /**
@@ -121,10 +121,10 @@ class ApcuBackendTest extends BaseTestCase
         $backend->set($identifier, $data, ['UnitTestTag%tag1', 'UnitTestTag%tag2']);
 
         $retrieved = $backend->findIdentifiersByTag('UnitTestTag%tag1');
-        $this->assertEquals($identifier, $retrieved[0], 'Could not retrieve expected entry by tag.');
+        self::assertEquals($identifier, $retrieved[0], 'Could not retrieve expected entry by tag.');
 
         $retrieved = $backend->findIdentifiersByTag('UnitTestTag%tag2');
-        $this->assertEquals($identifier, $retrieved[0], 'Could not retrieve expected entry by tag.');
+        self::assertEquals($identifier, $retrieved[0], 'Could not retrieve expected entry by tag.');
     }
 
     /**
@@ -140,7 +140,7 @@ class ApcuBackendTest extends BaseTestCase
         $backend->set($identifier, $data, ['UnitTestTag%tag3']);
 
         $retrieved = $backend->findIdentifiersByTag('UnitTestTag%tagX');
-        $this->assertEquals([], $retrieved, 'Found entry which should no longer exist.');
+        self::assertEquals([], $retrieved, 'Found entry which should no longer exist.');
     }
 
     /**
@@ -151,7 +151,7 @@ class ApcuBackendTest extends BaseTestCase
         $backend = $this->setUpBackend();
         $identifier = 'NonExistingIdentifier' . md5(uniqid(mt_rand(), true));
         $inCache = $backend->has($identifier);
-        $this->assertFalse($inCache, '"has" did not return false when checking on non existing identifier');
+        self::assertFalse($inCache, '"has" did not return false when checking on non existing identifier');
     }
 
     /**
@@ -162,7 +162,7 @@ class ApcuBackendTest extends BaseTestCase
         $backend = $this->setUpBackend();
         $identifier = 'NonExistingIdentifier' . md5(uniqid(mt_rand(), true));
         $inCache = $backend->remove($identifier);
-        $this->assertFalse($inCache, '"remove" did not return false when checking on non existing identifier');
+        self::assertFalse($inCache, '"remove" did not return false when checking on non existing identifier');
     }
 
     /**
@@ -179,9 +179,9 @@ class ApcuBackendTest extends BaseTestCase
 
         $backend->flushByTag('UnitTestTag%special');
 
-        $this->assertTrue($backend->has('BackendAPCUTest1'), 'BackendAPCUTest1');
-        $this->assertFalse($backend->has('BackendAPCUTest2'), 'BackendAPCUTest2');
-        $this->assertTrue($backend->has('BackendAPCUTest3'), 'BackendAPCUTest3');
+        self::assertTrue($backend->has('BackendAPCUTest1'), 'BackendAPCUTest1');
+        self::assertFalse($backend->has('BackendAPCUTest2'), 'BackendAPCUTest2');
+        self::assertTrue($backend->has('BackendAPCUTest3'), 'BackendAPCUTest3');
     }
 
     /**
@@ -198,9 +198,9 @@ class ApcuBackendTest extends BaseTestCase
 
         $backend->flush();
 
-        $this->assertFalse($backend->has('BackendAPCUTest1'), 'BackendAPCUTest1');
-        $this->assertFalse($backend->has('BackendAPCUTest2'), 'BackendAPCUTest2');
-        $this->assertFalse($backend->has('BackendAPCUTest3'), 'BackendAPCUTest3');
+        self::assertFalse($backend->has('BackendAPCUTest1'), 'BackendAPCUTest1');
+        self::assertFalse($backend->has('BackendAPCUTest2'), 'BackendAPCUTest2');
+        self::assertFalse($backend->has('BackendAPCUTest3'), 'BackendAPCUTest3');
     }
 
     /**
@@ -222,8 +222,8 @@ class ApcuBackendTest extends BaseTestCase
         $thatBackend->set('thatEntry', 'World!');
         $thatBackend->flush();
 
-        $this->assertEquals('Hello', $thisBackend->get('thisEntry'));
-        $this->assertFalse($thatBackend->has('thatEntry'));
+        self::assertEquals('Hello', $thisBackend->get('thisEntry'));
+        self::assertFalse($thatBackend->has('thatEntry'));
     }
 
     /**
@@ -239,8 +239,8 @@ class ApcuBackendTest extends BaseTestCase
         $identifier = 'tooLargeData' . md5(uniqid(mt_rand(), true));
         $backend->set($identifier, $data);
 
-        $this->assertTrue($backend->has($identifier));
-        $this->assertEquals($backend->get($identifier), $data);
+        self::assertTrue($backend->has($identifier));
+        self::assertEquals($backend->get($identifier), $data);
     }
 
     /**
@@ -266,11 +266,11 @@ class ApcuBackendTest extends BaseTestCase
         natsort($entries);
         $i = 0;
         foreach ($entries as $entryIdentifier => $data) {
-            $this->assertEquals(sprintf('entry-%s', $i), $entryIdentifier);
-            $this->assertEquals('some data ' . $i, $data);
+            self::assertEquals(sprintf('entry-%s', $i), $entryIdentifier);
+            self::assertEquals('some data ' . $i, $data);
             $i++;
         }
-        $this->assertEquals(100, $i);
+        self::assertEquals(100, $i);
     }
 
     /**

--- a/Neos.Cache/Tests/Unit/Backend/FileBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/FileBackendTest.php
@@ -78,7 +78,7 @@ class FileBackendTest extends BaseTestCase
         $backend = new FileBackend($mockEnvironmentConfiguration, ['cacheDirectory' => 'vfs://Foo/OtherDirectory']);
         $backend->setCache($mockCache);
 
-        $this->assertEquals('vfs://Foo/OtherDirectory/', $backend->getCacheDirectory());
+        self::assertEquals('vfs://Foo/OtherDirectory/', $backend->getCacheDirectory());
     }
 
     /**
@@ -96,7 +96,7 @@ class FileBackendTest extends BaseTestCase
         $backend = $this->prepareDefaultBackend();
         $backend->setCache($mockCache);
 
-        $this->assertEquals('vfs://Foo/Cache/Data/SomeCache/', $backend->getCacheDirectory());
+        self::assertEquals('vfs://Foo/Cache/Data/SomeCache/', $backend->getCacheDirectory());
     }
 
     /**
@@ -113,7 +113,7 @@ class FileBackendTest extends BaseTestCase
         $frontend = new PhpFrontend('SomeCache', $backend);
         $backend->setCache($frontend);
 
-        $this->assertEquals('vfs://Foo/Cache/Code/SomeCache/', $backend->getCacheDirectory());
+        self::assertEquals('vfs://Foo/Cache/Code/SomeCache/', $backend->getCacheDirectory());
     }
 
     /**
@@ -133,9 +133,9 @@ class FileBackendTest extends BaseTestCase
 
         $backend->set($entryIdentifier, $data);
 
-        $this->assertFileExists($pathAndFilename);
+        self::assertFileExists($pathAndFilename);
         $retrievedData = file_get_contents($pathAndFilename, null, null, 0, strlen($data));
-        $this->assertEquals($data, $retrievedData);
+        self::assertEquals($data, $retrievedData);
     }
 
     /**
@@ -157,9 +157,9 @@ class FileBackendTest extends BaseTestCase
         $backend->set($entryIdentifier, $data2, [], 200);
 
         $pathAndFilename = 'vfs://Foo/Cache/Data/UnitTestCache/' . $entryIdentifier;
-        $this->assertFileExists($pathAndFilename);
+        self::assertFileExists($pathAndFilename);
         $retrievedData = file_get_contents($pathAndFilename, null, null, 0, strlen($data2));
-        $this->assertEquals($data2, $retrievedData);
+        self::assertEquals($data2, $retrievedData);
     }
 
     /**
@@ -179,9 +179,9 @@ class FileBackendTest extends BaseTestCase
         $backend->set($entryIdentifier, $data, ['Tag1', 'Tag2']);
 
         $pathAndFilename = 'vfs://Foo/Cache/Data/UnitTestCache/' . $entryIdentifier;
-        $this->assertFileExists($pathAndFilename);
+        self::assertFileExists($pathAndFilename);
         $retrievedData = file_get_contents($pathAndFilename, null, null, strlen($data), 9);
-        $this->assertEquals('Tag1 Tag2', $retrievedData);
+        self::assertEquals('Tag1 Tag2', $retrievedData);
     }
 
     /**
@@ -248,8 +248,8 @@ class FileBackendTest extends BaseTestCase
         $this->inject($backend, 'environmentConfiguration', $mockEnvironmentConfiguration);
         $backend->setCache($mockCache);
 
-        $this->assertTrue($backend->isFrozen());
-        $this->assertEquals($data, $backend->get($entryIdentifier));
+        self::assertTrue($backend->isFrozen());
+        self::assertEquals($data, $backend->get($entryIdentifier));
     }
 
     /**
@@ -283,7 +283,7 @@ class FileBackendTest extends BaseTestCase
         $backend->set($entryIdentifier, $data, [], 100);
 
         $loadedData = $backend->get($entryIdentifier);
-        $this->assertEquals($data, $loadedData);
+        self::assertEquals($data, $loadedData);
     }
 
     /**
@@ -303,7 +303,7 @@ class FileBackendTest extends BaseTestCase
         $backend->expects($this->once())->method('isCacheFileExpired')->with('vfs://Foo/Cache/Data/UnitTestCache/ExpiredEntry')->will($this->returnValue(true));
         $backend->setCache($mockCache);
 
-        $this->assertFalse($backend->get('ExpiredEntry'));
+        self::assertFalse($backend->get('ExpiredEntry'));
     }
 
     /**
@@ -325,8 +325,8 @@ class FileBackendTest extends BaseTestCase
 
         $backend->set('foo', 'some data');
         $backend->freeze();
-        $this->assertEquals('some data', $backend->get('foo'));
-        $this->assertFalse($backend->get('bar'));
+        self::assertEquals('some data', $backend->get('foo'));
+        self::assertFalse($backend->get('bar'));
     }
 
     /**
@@ -345,8 +345,8 @@ class FileBackendTest extends BaseTestCase
         $data = 'some data' . microtime();
         $backend->set($entryIdentifier, $data);
 
-        $this->assertTrue($backend->has($entryIdentifier), 'has() did not return true.');
-        $this->assertFalse($backend->has($entryIdentifier . 'Not'), 'has() did not return false.');
+        self::assertTrue($backend->has($entryIdentifier), 'has() did not return true.');
+        self::assertFalse($backend->has($entryIdentifier . 'Not'), 'has() did not return false.');
     }
 
     /**
@@ -357,8 +357,8 @@ class FileBackendTest extends BaseTestCase
         $backend = $this->prepareDefaultBackend(['isCacheFileExpired']);
         $backend->expects($this->exactly(2))->method('isCacheFileExpired')->will($this->onConsecutiveCalls(true, false));
 
-        $this->assertFalse($backend->has('foo'));
-        $this->assertTrue($backend->has('bar'));
+        self::assertFalse($backend->has('foo'));
+        self::assertTrue($backend->has('bar'));
     }
 
     /**
@@ -380,8 +380,8 @@ class FileBackendTest extends BaseTestCase
 
         $backend->set('foo', 'some data');
         $backend->freeze();
-        $this->assertTrue($backend->has('foo'));
-        $this->assertFalse($backend->has('bar'));
+        self::assertTrue($backend->has('foo'));
+        self::assertFalse($backend->has('bar'));
     }
 
     /**
@@ -401,10 +401,10 @@ class FileBackendTest extends BaseTestCase
         $backend->setCache($mockCache);
 
         $backend->set($entryIdentifier, $data);
-        $this->assertFileExists($pathAndFilename);
+        self::assertFileExists($pathAndFilename);
 
         $backend->remove($entryIdentifier);
-        $this->assertFileNotExists($pathAndFilename);
+        self::assertFileNotExists($pathAndFilename);
     }
 
     /**
@@ -519,7 +519,7 @@ class FileBackendTest extends BaseTestCase
         $backend->set($entryIdentifier, $data);
 
         $loadedData = $backend->requireOnce($entryIdentifier);
-        $this->assertEquals('foo', $loadedData);
+        self::assertEquals('foo', $loadedData);
     }
 
     /**
@@ -541,7 +541,7 @@ class FileBackendTest extends BaseTestCase
         $backend->freeze();
 
         $loadedData = $backend->requireOnce('FooEntry');
-        $this->assertEquals('foo', $loadedData);
+        self::assertEquals('foo', $loadedData);
     }
 
     /**
@@ -614,9 +614,9 @@ class FileBackendTest extends BaseTestCase
         $expectedEntry = 'BackendFileTest2';
 
         $actualEntries = $backend->findIdentifiersByTag('UnitTestTag%special');
-        $this->assertIsArray($actualEntries);
+        self::assertIsArray($actualEntries);
 
-        $this->assertEquals($expectedEntry, array_pop($actualEntries));
+        self::assertEquals($expectedEntry, array_pop($actualEntries));
     }
 
     /**
@@ -635,8 +635,8 @@ class FileBackendTest extends BaseTestCase
         $backend->set('BackendFileTest2', $data, ['UnitTestTag%test', 'UnitTestTag%special'], -100);
         $backend->set('BackendFileTest3', $data, ['UnitTestTag%test']);
 
-        $this->assertSame([], $backend->findIdentifiersByTag('UnitTestTag%special'));
-        $this->assertSame(['BackendFileTest1', 'BackendFileTest3'], $backend->findIdentifiersByTag('UnitTestTag%test'));
+        self::assertSame([], $backend->findIdentifiersByTag('UnitTestTag%special'));
+        self::assertSame(['BackendFileTest1', 'BackendFileTest3'], $backend->findIdentifiersByTag('UnitTestTag%test'));
     }
 
     /**
@@ -654,13 +654,13 @@ class FileBackendTest extends BaseTestCase
         $backend->set('BackendFileTest1', $data);
         $backend->set('BackendFileTest2', $data);
 
-        $this->assertFileExists('vfs://Foo/Cache/Data/UnitTestCache/BackendFileTest1');
-        $this->assertFileExists('vfs://Foo/Cache/Data/UnitTestCache/BackendFileTest2');
+        self::assertFileExists('vfs://Foo/Cache/Data/UnitTestCache/BackendFileTest1');
+        self::assertFileExists('vfs://Foo/Cache/Data/UnitTestCache/BackendFileTest2');
 
         $backend->flush();
 
-        $this->assertFileNotExists('vfs://Foo/Cache/Data/UnitTestCache/BackendFileTest1');
-        $this->assertFileNotExists('vfs://Foo/Cache/Data/UnitTestCache/BackendFileTest2');
+        self::assertFileNotExists('vfs://Foo/Cache/Data/UnitTestCache/BackendFileTest1');
+        self::assertFileNotExists('vfs://Foo/Cache/Data/UnitTestCache/BackendFileTest2');
     }
 
     /**
@@ -694,12 +694,12 @@ class FileBackendTest extends BaseTestCase
         $backend->set('BackendFileTest1', $data);
         $backend->set('BackendFileTest2', $data);
 
-        $this->assertFileExists('vfs://Foo/Cache/Data/UnitTestCache/BackendFileTest1');
-        $this->assertFileExists('vfs://Foo/Cache/Data/UnitTestCache/BackendFileTest2');
+        self::assertFileExists('vfs://Foo/Cache/Data/UnitTestCache/BackendFileTest1');
+        self::assertFileExists('vfs://Foo/Cache/Data/UnitTestCache/BackendFileTest2');
 
         $backend->collectGarbage();
-        $this->assertFileNotExists('vfs://Foo/Cache/Data/UnitTestCache/BackendFileTest1');
-        $this->assertFileExists('vfs://Foo/Cache/Data/UnitTestCache/BackendFileTest2');
+        self::assertFileNotExists('vfs://Foo/Cache/Data/UnitTestCache/BackendFileTest1');
+        self::assertFileExists('vfs://Foo/Cache/Data/UnitTestCache/BackendFileTest2');
     }
 
     /**
@@ -714,9 +714,9 @@ class FileBackendTest extends BaseTestCase
         $backend->setCache($mockCache);
         $backend->freeze();
 
-        $this->assertTrue($backend->isFrozen());
+        self::assertTrue($backend->isFrozen());
         $backend->flush();
-        $this->assertFalse($backend->isFrozen());
+        self::assertFalse($backend->isFrozen());
     }
 
     /**
@@ -748,11 +748,11 @@ class FileBackendTest extends BaseTestCase
         natsort($entries);
         $i = 0;
         foreach ($entries as $entryIdentifier => $data) {
-            $this->assertEquals(sprintf('entry-%s', $i), $entryIdentifier);
-            $this->assertEquals('some data ' . $i, $data);
+            self::assertEquals(sprintf('entry-%s', $i), $entryIdentifier);
+            self::assertEquals('some data ' . $i, $data);
             $i++;
         }
-        $this->assertEquals(100, $i);
+        self::assertEquals(100, $i);
     }
 
     /**

--- a/Neos.Cache/Tests/Unit/Backend/MemcachedBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/MemcachedBackendTest.php
@@ -87,7 +87,7 @@ class MemcachedBackendTest extends BaseTestCase
         $identifier = 'MyIdentifier' . md5(uniqid(mt_rand(), true));
         $backend->set($identifier, $data);
         $inCache = $backend->has($identifier);
-        $this->assertTrue($inCache, 'Memcache failed to set and check entry');
+        self::assertTrue($inCache, 'Memcache failed to set and check entry');
     }
 
     /**
@@ -100,7 +100,7 @@ class MemcachedBackendTest extends BaseTestCase
         $identifier = 'MyIdentifier' . md5(uniqid(mt_rand(), true));
         $backend->set($identifier, $data);
         $fetchedData = $backend->get($identifier);
-        $this->assertEquals($data, $fetchedData, 'Memcache failed to set and retrieve data');
+        self::assertEquals($data, $fetchedData, 'Memcache failed to set and retrieve data');
     }
 
     /**
@@ -114,7 +114,7 @@ class MemcachedBackendTest extends BaseTestCase
         $backend->set($identifier, $data);
         $backend->remove($identifier);
         $inCache = $backend->has($identifier);
-        $this->assertFalse($inCache, 'Failed to set and remove data from Memcache');
+        self::assertFalse($inCache, 'Failed to set and remove data from Memcache');
     }
 
     /**
@@ -129,7 +129,7 @@ class MemcachedBackendTest extends BaseTestCase
         $otherData = 'some other data';
         $backend->set($identifier, $otherData);
         $fetchedData = $backend->get($identifier);
-        $this->assertEquals($otherData, $fetchedData, 'Memcache failed to overwrite and retrieve data');
+        self::assertEquals($otherData, $fetchedData, 'Memcache failed to overwrite and retrieve data');
     }
 
     /**
@@ -144,10 +144,10 @@ class MemcachedBackendTest extends BaseTestCase
         $backend->set($identifier, $data, ['UnitTestTag%tag1', 'UnitTestTag%tag2']);
 
         $retrieved = $backend->findIdentifiersByTag('UnitTestTag%tag1');
-        $this->assertEquals($identifier, $retrieved[0], 'Could not retrieve expected entry by tag.');
+        self::assertEquals($identifier, $retrieved[0], 'Could not retrieve expected entry by tag.');
 
         $retrieved = $backend->findIdentifiersByTag('UnitTestTag%tag2');
-        $this->assertEquals($identifier, $retrieved[0], 'Could not retrieve expected entry by tag.');
+        self::assertEquals($identifier, $retrieved[0], 'Could not retrieve expected entry by tag.');
     }
 
     /**
@@ -163,7 +163,7 @@ class MemcachedBackendTest extends BaseTestCase
         $backend->set($identifier, $data, ['UnitTestTag%tag3']);
 
         $retrieved = $backend->findIdentifiersByTag('UnitTestTag%tagX');
-        $this->assertEquals([], $retrieved, 'Found entry which should no longer exist.');
+        self::assertEquals([], $retrieved, 'Found entry which should no longer exist.');
     }
 
     /**
@@ -174,7 +174,7 @@ class MemcachedBackendTest extends BaseTestCase
         $backend = $this->setUpBackend();
         $identifier = 'NonExistingIdentifier' . md5(uniqid(mt_rand(), true));
         $inCache = $backend->has($identifier);
-        $this->assertFalse($inCache, '"has" did not return false when checking on non existing identifier');
+        self::assertFalse($inCache, '"has" did not return false when checking on non existing identifier');
     }
 
     /**
@@ -185,7 +185,7 @@ class MemcachedBackendTest extends BaseTestCase
         $backend = $this->setUpBackend();
         $identifier = 'NonExistingIdentifier' . md5(uniqid(mt_rand(), true));
         $inCache = $backend->remove($identifier);
-        $this->assertFalse($inCache, '"remove" did not return false when checking on non existing identifier');
+        self::assertFalse($inCache, '"remove" did not return false when checking on non existing identifier');
     }
 
     /**
@@ -202,9 +202,9 @@ class MemcachedBackendTest extends BaseTestCase
 
         $backend->flushByTag('UnitTestTag%special');
 
-        $this->assertTrue($backend->has('BackendMemcacheTest1'), 'BackendMemcacheTest1');
-        $this->assertFalse($backend->has('BackendMemcacheTest2'), 'BackendMemcacheTest2');
-        $this->assertTrue($backend->has('BackendMemcacheTest3'), 'BackendMemcacheTest3');
+        self::assertTrue($backend->has('BackendMemcacheTest1'), 'BackendMemcacheTest1');
+        self::assertFalse($backend->has('BackendMemcacheTest2'), 'BackendMemcacheTest2');
+        self::assertTrue($backend->has('BackendMemcacheTest3'), 'BackendMemcacheTest3');
     }
 
     /**
@@ -221,9 +221,9 @@ class MemcachedBackendTest extends BaseTestCase
 
         $backend->flush();
 
-        $this->assertFalse($backend->has('BackendMemcacheTest1'), 'BackendMemcacheTest1');
-        $this->assertFalse($backend->has('BackendMemcacheTest2'), 'BackendMemcacheTest2');
-        $this->assertFalse($backend->has('BackendMemcacheTest3'), 'BackendMemcacheTest3');
+        self::assertFalse($backend->has('BackendMemcacheTest1'), 'BackendMemcacheTest1');
+        self::assertFalse($backend->has('BackendMemcacheTest2'), 'BackendMemcacheTest2');
+        self::assertFalse($backend->has('BackendMemcacheTest3'), 'BackendMemcacheTest3');
     }
 
     /**
@@ -247,8 +247,8 @@ class MemcachedBackendTest extends BaseTestCase
         $thatBackend->set('thatEntry', 'World!');
         $thatBackend->flush();
 
-        $this->assertEquals('Hello', $thisBackend->get('thisEntry'));
-        $this->assertFalse($thatBackend->has('thatEntry'));
+        self::assertEquals('Hello', $thisBackend->get('thisEntry'));
+        self::assertFalse($thatBackend->has('thatEntry'));
     }
 
     /**
@@ -264,8 +264,8 @@ class MemcachedBackendTest extends BaseTestCase
         $data = str_repeat('abcde', 1024 * 1024);
         $backend->set('tooLargeData', $data);
 
-        $this->assertTrue($backend->has('tooLargeData'));
-        $this->assertEquals($backend->get('tooLargeData'), $data);
+        self::assertTrue($backend->has('tooLargeData'));
+        self::assertEquals($backend->get('tooLargeData'), $data);
     }
 
     /**

--- a/Neos.Cache/Tests/Unit/Backend/PdoBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/PdoBackendTest.php
@@ -58,7 +58,7 @@ class PdoBackendTest extends BaseTestCase
         $data = 'Some data';
         $identifier = 'MyIdentifier';
         $backend->set($identifier, $data);
-        $this->assertTrue($backend->has($identifier));
+        self::assertTrue($backend->has($identifier));
     }
 
     /**
@@ -71,7 +71,7 @@ class PdoBackendTest extends BaseTestCase
         $identifier = 'MyIdentifier';
         $backend->set($identifier, $data);
         $fetchedData = $backend->get($identifier);
-        $this->assertEquals($data, $fetchedData);
+        self::assertEquals($data, $fetchedData);
     }
 
     /**
@@ -84,7 +84,7 @@ class PdoBackendTest extends BaseTestCase
         $identifier = 'MyIdentifier';
         $backend->set($identifier, $data);
         $backend->remove($identifier);
-        $this->assertFalse($backend->has($identifier));
+        self::assertFalse($backend->has($identifier));
     }
 
     /**
@@ -99,7 +99,7 @@ class PdoBackendTest extends BaseTestCase
         $otherData = 'some other data';
         $backend->set($identifier, $otherData);
         $fetchedData = $backend->get($identifier);
-        $this->assertEquals($otherData, $fetchedData);
+        self::assertEquals($otherData, $fetchedData);
     }
 
     /**
@@ -114,10 +114,10 @@ class PdoBackendTest extends BaseTestCase
         $backend->set($entryIdentifier, $data, ['UnitTestTag%tag1', 'UnitTestTag%tag2']);
 
         $retrieved = $backend->findIdentifiersByTag('UnitTestTag%tag1');
-        $this->assertEquals($entryIdentifier, $retrieved[0]);
+        self::assertEquals($entryIdentifier, $retrieved[0]);
 
         $retrieved = $backend->findIdentifiersByTag('UnitTestTag%tag2');
-        $this->assertEquals($entryIdentifier, $retrieved[0]);
+        self::assertEquals($entryIdentifier, $retrieved[0]);
     }
 
     /**
@@ -133,7 +133,7 @@ class PdoBackendTest extends BaseTestCase
         $backend->set($entryIdentifier, $data, ['UnitTestTag%tag3']);
 
         $retrieved = $backend->findIdentifiersByTag('UnitTestTag%tag2');
-        $this->assertEquals([], $retrieved);
+        self::assertEquals([], $retrieved);
     }
 
     /**
@@ -143,7 +143,7 @@ class PdoBackendTest extends BaseTestCase
     {
         $backend = $this->setUpBackend();
         $identifier = 'NonExistingIdentifier';
-        $this->assertFalse($backend->has($identifier));
+        self::assertFalse($backend->has($identifier));
     }
 
     /**
@@ -153,7 +153,7 @@ class PdoBackendTest extends BaseTestCase
     {
         $backend = $this->setUpBackend();
         $identifier = 'NonExistingIdentifier';
-        $this->assertFalse($backend->remove($identifier));
+        self::assertFalse($backend->remove($identifier));
     }
 
     /**
@@ -170,9 +170,9 @@ class PdoBackendTest extends BaseTestCase
 
         $backend->flushByTag('UnitTestTag%special');
 
-        $this->assertTrue($backend->has('PdoBackendTest1'), 'PdoBackendTest1');
-        $this->assertFalse($backend->has('PdoBackendTest2'), 'PdoBackendTest2');
-        $this->assertTrue($backend->has('PdoBackendTest3'), 'PdoBackendTest3');
+        self::assertTrue($backend->has('PdoBackendTest1'), 'PdoBackendTest1');
+        self::assertFalse($backend->has('PdoBackendTest2'), 'PdoBackendTest2');
+        self::assertTrue($backend->has('PdoBackendTest3'), 'PdoBackendTest3');
     }
 
     /**
@@ -189,9 +189,9 @@ class PdoBackendTest extends BaseTestCase
 
         $backend->flush();
 
-        $this->assertFalse($backend->has('PdoBackendTest1'), 'PdoBackendTest1');
-        $this->assertFalse($backend->has('PdoBackendTest2'), 'PdoBackendTest2');
-        $this->assertFalse($backend->has('PdoBackendTest3'), 'PdoBackendTest3');
+        self::assertFalse($backend->has('PdoBackendTest1'), 'PdoBackendTest1');
+        self::assertFalse($backend->has('PdoBackendTest2'), 'PdoBackendTest2');
+        self::assertFalse($backend->has('PdoBackendTest3'), 'PdoBackendTest3');
     }
 
     /**
@@ -213,8 +213,8 @@ class PdoBackendTest extends BaseTestCase
         $thatBackend->set('thatEntry', 'World!');
         $thatBackend->flush();
 
-        $this->assertEquals('Hello', $thisBackend->get('thisEntry'));
-        $this->assertFalse($thatBackend->has('thatEntry'));
+        self::assertEquals('Hello', $thisBackend->get('thisEntry'));
+        self::assertFalse($thatBackend->has('thatEntry'));
     }
 
     /**

--- a/Neos.Cache/Tests/Unit/Backend/RedisBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/RedisBackendTest.php
@@ -83,7 +83,7 @@ class RedisBackendTest extends BaseTestCase
             ->with('Foo_Cache:tag:some_tag')
             ->will($this->returnValue(['entry_1', 'entry_2']));
 
-        $this->assertEquals(['entry_1', 'entry_2'], $this->backend->findIdentifiersByTag('some_tag'));
+        self::assertEquals(['entry_1', 'entry_2'], $this->backend->findIdentifiersByTag('some_tag'));
     }
 
     /**
@@ -175,7 +175,7 @@ class RedisBackendTest extends BaseTestCase
             ->with('Foo_Cache:entry:foo')
             ->will($this->returnValue('bar'));
 
-        $this->assertEquals('bar', $this->backend->get('foo'));
+        self::assertEquals('bar', $this->backend->get('foo'));
     }
 
     /**
@@ -188,7 +188,7 @@ class RedisBackendTest extends BaseTestCase
             ->with('Foo_Cache:entry:foo')
             ->will($this->returnValue(true));
 
-        $this->assertEquals(true, $this->backend->has('foo'));
+        self::assertEquals(true, $this->backend->has('foo'));
     }
 
     /**

--- a/Neos.Cache/Tests/Unit/Backend/SimpleFileBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/SimpleFileBackendTest.php
@@ -131,7 +131,7 @@ class SimpleFileBackendTest extends BaseTestCase
         mkdir('vfs://Temporary/Directory/OtherDirectory');
 
         $simpleFileBackend = $this->getSimpleFileBackend(['cacheDirectory' => 'vfs://Temporary/Directory/OtherDirectory']);
-        $this->assertEquals('vfs://Temporary/Directory/OtherDirectory/', $simpleFileBackend->getCacheDirectory());
+        self::assertEquals('vfs://Temporary/Directory/OtherDirectory/', $simpleFileBackend->getCacheDirectory());
     }
 
     /**
@@ -146,7 +146,7 @@ class SimpleFileBackendTest extends BaseTestCase
         mkdir('vfs://Temporary/Directory/Cache');
 
         $simpleFileBackend = $this->getSimpleFileBackend();
-        $this->assertEquals('vfs://Temporary/Directory/Cache/Data/SomeCache/', $simpleFileBackend->getCacheDirectory());
+        self::assertEquals('vfs://Temporary/Directory/Cache/Data/SomeCache/', $simpleFileBackend->getCacheDirectory());
     }
 
     /**
@@ -163,7 +163,7 @@ class SimpleFileBackendTest extends BaseTestCase
         mkdir('vfs://Temporary/Directory/Cache');
 
         $simpleFileBackend = $this->getSimpleFileBackend([], $mockPhpCacheFrontend);
-        $this->assertEquals('vfs://Temporary/Directory/Cache/Code/SomePhpCache/', $simpleFileBackend->getCacheDirectory());
+        self::assertEquals('vfs://Temporary/Directory/Cache/Code/SomePhpCache/', $simpleFileBackend->getCacheDirectory());
     }
 
     /**
@@ -180,9 +180,9 @@ class SimpleFileBackendTest extends BaseTestCase
         $simpleFileBackend = $this->getSimpleFileBackend();
         $simpleFileBackend->set($entryIdentifier, $data);
 
-        $this->assertFileExists($pathAndFilename);
+        self::assertFileExists($pathAndFilename);
         $retrievedData = file_get_contents($pathAndFilename);
-        $this->assertEquals($data, $retrievedData);
+        self::assertEquals($data, $retrievedData);
     }
 
     /**
@@ -201,9 +201,9 @@ class SimpleFileBackendTest extends BaseTestCase
         $simpleFileBackend->set($entryIdentifier, $data1);
         $simpleFileBackend->set($entryIdentifier, $data2);
 
-        $this->assertFileExists($pathAndFilename);
+        self::assertFileExists($pathAndFilename);
         $retrievedData = file_get_contents($pathAndFilename);
-        $this->assertEquals($data2, $retrievedData);
+        self::assertEquals($data2, $retrievedData);
     }
 
     /**
@@ -221,7 +221,7 @@ class SimpleFileBackendTest extends BaseTestCase
         $simpleFileBackend->set($entryIdentifier, $data1);
         $simpleFileBackend->set($entryIdentifier, $data2);
 
-        $this->assertSame($data2, $simpleFileBackend->get($entryIdentifier));
+        self::assertSame($data2, $simpleFileBackend->get($entryIdentifier));
     }
 
     /**
@@ -239,7 +239,7 @@ class SimpleFileBackendTest extends BaseTestCase
 
         unlink($pathAndFilename);
 
-        $this->assertFalse($simpleFileBackend->get($entryIdentifier));
+        self::assertFalse($simpleFileBackend->get($entryIdentifier));
     }
 
     /**
@@ -252,7 +252,7 @@ class SimpleFileBackendTest extends BaseTestCase
         $simpleFileBackend = $this->getSimpleFileBackend();
         $simpleFileBackend->set($entryIdentifier, 'some data');
 
-        $this->assertTrue($simpleFileBackend->has($entryIdentifier));
+        self::assertTrue($simpleFileBackend->has($entryIdentifier));
     }
 
     /**
@@ -263,7 +263,7 @@ class SimpleFileBackendTest extends BaseTestCase
         $simpleFileBackend = $this->getSimpleFileBackend();
         $simpleFileBackend->set('SomeEntryIdentifier', 'some data');
 
-        $this->assertFalse($simpleFileBackend->has('SomeNonExistingEntryIdentifier'));
+        self::assertFalse($simpleFileBackend->has('SomeNonExistingEntryIdentifier'));
     }
 
     /**
@@ -279,13 +279,13 @@ class SimpleFileBackendTest extends BaseTestCase
         $simpleFileBackend = $this->getSimpleFileBackend();
         $simpleFileBackend->set($entryIdentifier, 'some data');
 
-        $this->assertFileExists($pathAndFilename);
-        $this->assertTrue($simpleFileBackend->has($entryIdentifier));
+        self::assertFileExists($pathAndFilename);
+        self::assertTrue($simpleFileBackend->has($entryIdentifier));
 
         $simpleFileBackend->remove($entryIdentifier);
 
-        $this->assertFileNotExists($pathAndFilename);
-        $this->assertFalse($simpleFileBackend->has($entryIdentifier));
+        self::assertFileNotExists($pathAndFilename);
+        self::assertFalse($simpleFileBackend->has($entryIdentifier));
     }
 
     /**
@@ -382,7 +382,7 @@ class SimpleFileBackendTest extends BaseTestCase
         $simpleFileBackend->set($entryIdentifier, $data);
 
         $loadedData = $simpleFileBackend->requireOnce($entryIdentifier);
-        $this->assertEquals('foo', $loadedData);
+        self::assertEquals('foo', $loadedData);
     }
 
     /**
@@ -440,17 +440,17 @@ class SimpleFileBackendTest extends BaseTestCase
         $simpleFileBackend->set($entryIdentifier1, 'some data');
         $simpleFileBackend->set($entryIdentifier2, 'some more data');
 
-        $this->assertFileExists($pathAndFilename1);
-        $this->assertFileExists($pathAndFilename2);
-        $this->assertTrue($simpleFileBackend->has($entryIdentifier1));
-        $this->assertTrue($simpleFileBackend->has($entryIdentifier2));
+        self::assertFileExists($pathAndFilename1);
+        self::assertFileExists($pathAndFilename2);
+        self::assertTrue($simpleFileBackend->has($entryIdentifier1));
+        self::assertTrue($simpleFileBackend->has($entryIdentifier2));
 
         $simpleFileBackend->flush();
 
-        $this->assertFileNotExists($pathAndFilename1);
-        $this->assertFalse($simpleFileBackend->has($entryIdentifier1));
-        $this->assertFileNotExists($pathAndFilename2);
-        $this->assertFalse($simpleFileBackend->has($entryIdentifier2));
+        self::assertFileNotExists($pathAndFilename1);
+        self::assertFalse($simpleFileBackend->has($entryIdentifier1));
+        self::assertFileNotExists($pathAndFilename2);
+        self::assertFalse($simpleFileBackend->has($entryIdentifier2));
     }
 
     /**
@@ -473,10 +473,10 @@ class SimpleFileBackendTest extends BaseTestCase
         natsort($entries);
         $i = 0;
         foreach ($entries as $entryIdentifier => $data) {
-            $this->assertEquals(sprintf('entry-%s', $i), $entryIdentifier);
-            $this->assertEquals('some data ' . $i, $data);
+            self::assertEquals(sprintf('entry-%s', $i), $entryIdentifier);
+            self::assertEquals('some data ' . $i, $data);
             $i++;
         }
-        $this->assertEquals(100, $i);
+        self::assertEquals(100, $i);
     }
 }

--- a/Neos.Cache/Tests/Unit/Backend/TransientMemoryBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/TransientMemoryBackendTest.php
@@ -51,7 +51,7 @@ class TransientMemoryBackendTest extends BaseTestCase
         $identifier = 'MyIdentifier';
         $backend->set($identifier, $data);
         $inCache = $backend->has($identifier);
-        $this->assertTrue($inCache);
+        self::assertTrue($inCache);
     }
 
     /**
@@ -67,7 +67,7 @@ class TransientMemoryBackendTest extends BaseTestCase
         $identifier = 'MyIdentifier';
         $backend->set($identifier, $data);
         $fetchedData = $backend->get($identifier);
-        $this->assertEquals($data, $fetchedData);
+        self::assertEquals($data, $fetchedData);
     }
 
     /**
@@ -84,7 +84,7 @@ class TransientMemoryBackendTest extends BaseTestCase
         $backend->set($identifier, $data);
         $backend->remove($identifier);
         $inCache = $backend->has($identifier);
-        $this->assertFalse($inCache);
+        self::assertFalse($inCache);
     }
 
     /**
@@ -102,7 +102,7 @@ class TransientMemoryBackendTest extends BaseTestCase
         $otherData = 'some other data';
         $backend->set($identifier, $otherData);
         $fetchedData = $backend->get($identifier);
-        $this->assertEquals($otherData, $fetchedData);
+        self::assertEquals($otherData, $fetchedData);
     }
 
     /**
@@ -119,10 +119,10 @@ class TransientMemoryBackendTest extends BaseTestCase
         $backend->set($entryIdentifier, $data, ['UnitTestTag%tag1', 'UnitTestTag%tag2']);
 
         $retrieved = $backend->findIdentifiersByTag('UnitTestTag%tag1');
-        $this->assertEquals($entryIdentifier, $retrieved[0]);
+        self::assertEquals($entryIdentifier, $retrieved[0]);
 
         $retrieved = $backend->findIdentifiersByTag('UnitTestTag%tag2');
-        $this->assertEquals($entryIdentifier, $retrieved[0]);
+        self::assertEquals($entryIdentifier, $retrieved[0]);
     }
 
     /**
@@ -136,7 +136,7 @@ class TransientMemoryBackendTest extends BaseTestCase
 
         $identifier = 'NonExistingIdentifier';
         $inCache = $backend->has($identifier);
-        $this->assertFalse($inCache);
+        self::assertFalse($inCache);
     }
 
     /**
@@ -150,7 +150,7 @@ class TransientMemoryBackendTest extends BaseTestCase
 
         $identifier = 'NonExistingIdentifier';
         $inCache = $backend->remove($identifier);
-        $this->assertFalse($inCache);
+        self::assertFalse($inCache);
     }
 
     /**
@@ -169,9 +169,9 @@ class TransientMemoryBackendTest extends BaseTestCase
 
         $backend->flushByTag('UnitTestTag%special');
 
-        $this->assertTrue($backend->has('TransientMemoryBackendTest1'), 'TransientMemoryBackendTest1');
-        $this->assertFalse($backend->has('TransientMemoryBackendTest2'), 'TransientMemoryBackendTest2');
-        $this->assertTrue($backend->has('TransientMemoryBackendTest3'), 'TransientMemoryBackendTest3');
+        self::assertTrue($backend->has('TransientMemoryBackendTest1'), 'TransientMemoryBackendTest1');
+        self::assertFalse($backend->has('TransientMemoryBackendTest2'), 'TransientMemoryBackendTest2');
+        self::assertTrue($backend->has('TransientMemoryBackendTest3'), 'TransientMemoryBackendTest3');
     }
 
     /**
@@ -190,9 +190,9 @@ class TransientMemoryBackendTest extends BaseTestCase
 
         $backend->flush();
 
-        $this->assertFalse($backend->has('TransientMemoryBackendTest1'), 'TransientMemoryBackendTest1');
-        $this->assertFalse($backend->has('TransientMemoryBackendTest2'), 'TransientMemoryBackendTest2');
-        $this->assertFalse($backend->has('TransientMemoryBackendTest3'), 'TransientMemoryBackendTest3');
+        self::assertFalse($backend->has('TransientMemoryBackendTest1'), 'TransientMemoryBackendTest1');
+        self::assertFalse($backend->has('TransientMemoryBackendTest2'), 'TransientMemoryBackendTest2');
+        self::assertFalse($backend->has('TransientMemoryBackendTest3'), 'TransientMemoryBackendTest3');
     }
 
     /**

--- a/Neos.Cache/Tests/Unit/Frontend/AbstractFrontendTest.php
+++ b/Neos.Cache/Tests/Unit/Frontend/AbstractFrontendTest.php
@@ -39,7 +39,7 @@ class AbstractFrontendTest extends BaseTestCase
     {
         foreach (['x', 'someValue', '123fivesixseveneight', 'some&', 'ab_cd%', rawurlencode('resource://some/äöü$&% sadf'), str_repeat('x', 250)] as $identifier) {
             $cache = new StringFrontend($identifier, $this->mockBackend);
-            $this->assertInstanceOf(StringFrontend::class, $cache);
+            self::assertInstanceOf(StringFrontend::class, $cache);
         }
     }
 
@@ -53,7 +53,7 @@ class AbstractFrontendTest extends BaseTestCase
                 new StringFrontend($identifier, $this->mockBackend);
                 $this->fail('Identifier "' . $identifier . '" was not rejected.');
             } catch (\Exception $exception) {
-                $this->assertInstanceOf(\InvalidArgumentException::class, $exception);
+                self::assertInstanceOf(\InvalidArgumentException::class, $exception);
             }
         }
     }
@@ -142,7 +142,7 @@ class AbstractFrontendTest extends BaseTestCase
             ->getMock();
 
         foreach (['', 'abc def', 'foo!', 'bar:', 'some/', 'bla*', 'one+', 'äöü', str_repeat('x', 251), 'x$', '\\a', 'b#'] as $entryIdentifier) {
-            $this->assertFalse($cache->isValidEntryIdentifier($entryIdentifier), 'Invalid identifier "' . $entryIdentifier . '" was not rejected.');
+            self::assertFalse($cache->isValidEntryIdentifier($entryIdentifier), 'Invalid identifier "' . $entryIdentifier . '" was not rejected.');
         }
     }
 
@@ -159,7 +159,7 @@ class AbstractFrontendTest extends BaseTestCase
             ->getMock();
 
         foreach (['_', 'abc-def', 'foo', 'bar123', '3some', '_bl_a', 'some&', 'one%TWO', str_repeat('x', 250)] as $entryIdentifier) {
-            $this->assertTrue($cache->isValidEntryIdentifier($entryIdentifier), 'Valid identifier "' . $entryIdentifier . '" was not accepted.');
+            self::assertTrue($cache->isValidEntryIdentifier($entryIdentifier), 'Valid identifier "' . $entryIdentifier . '" was not accepted.');
         }
     }
 
@@ -176,7 +176,7 @@ class AbstractFrontendTest extends BaseTestCase
             ->getMock();
 
         foreach (['', 'abc def', 'foo!', 'bar:', 'some/', 'bla*', 'one+', 'äöü', str_repeat('x', 251), 'x$', '\\a', 'b#'] as $tag) {
-            $this->assertFalse($cache->isValidTag($tag), 'Invalid tag "' . $tag . '" was not rejected.');
+            self::assertFalse($cache->isValidTag($tag), 'Invalid tag "' . $tag . '" was not rejected.');
         }
     }
 
@@ -193,7 +193,7 @@ class AbstractFrontendTest extends BaseTestCase
             ->getMock();
 
         foreach (['abcdef', 'foo-bar', 'foo_baar', 'bar123', '3some', 'file%Thing', 'some&', '%x%', str_repeat('x', 250)] as $tag) {
-            $this->assertTrue($cache->isValidTag($tag), 'Valid tag "' . $tag . '" was not accepted.');
+            self::assertTrue($cache->isValidTag($tag), 'Valid tag "' . $tag . '" was not accepted.');
         }
     }
 }

--- a/Neos.Cache/Tests/Unit/Frontend/PhpFrontendTest.php
+++ b/Neos.Cache/Tests/Unit/Frontend/PhpFrontendTest.php
@@ -86,6 +86,6 @@ class PhpFrontendTest extends BaseTestCase
         $this->inject($cache, 'backend', $mockBackend);
 
         $result = $cache->requireOnce('Foo-Bar');
-        $this->assertSame('hello world!', $result);
+        self::assertSame('hello world!', $result);
     }
 }

--- a/Neos.Cache/Tests/Unit/Frontend/StringFrontendTest.php
+++ b/Neos.Cache/Tests/Unit/Frontend/StringFrontendTest.php
@@ -90,7 +90,7 @@ class StringFrontendTest extends BaseTestCase
         $backend->expects($this->once())->method('get')->will($this->returnValue('Just some value'));
 
         $cache = new StringFrontend('StringFrontend', $backend);
-        $this->assertEquals('Just some value', $cache->get('StringCacheTest'), 'The returned value was not the expected string.');
+        self::assertEquals('Just some value', $cache->get('StringCacheTest'), 'The returned value was not the expected string.');
     }
 
     /**
@@ -102,7 +102,7 @@ class StringFrontendTest extends BaseTestCase
         $backend->expects($this->once())->method('has')->with($this->equalTo('StringCacheTest'))->will($this->returnValue(true));
 
         $cache = new StringFrontend('StringFrontend', $backend);
-        $this->assertTrue($cache->has('StringCacheTest'), 'has() did not return true.');
+        self::assertTrue($cache->has('StringCacheTest'), 'has() did not return true.');
     }
 
     /**
@@ -116,7 +116,7 @@ class StringFrontendTest extends BaseTestCase
         $backend->expects($this->once())->method('remove')->with($this->equalTo($cacheIdentifier))->will($this->returnValue(true));
 
         $cache = new StringFrontend('StringFrontend', $backend);
-        $this->assertTrue($cache->remove($cacheIdentifier), 'remove() did not return true');
+        self::assertTrue($cache->remove($cacheIdentifier), 'remove() did not return true');
     }
 
     /**
@@ -157,7 +157,7 @@ class StringFrontendTest extends BaseTestCase
         $backend->expects($this->exactly(2))->method('get')->will($this->onConsecutiveCalls('one value', 'two value'));
 
         $cache = new StringFrontend('StringFrontend', $backend);
-        $this->assertEquals($entries, $cache->getByTag($tag), 'Did not receive the expected entries');
+        self::assertEquals($entries, $cache->getByTag($tag), 'Did not receive the expected entries');
     }
 
     /**

--- a/Neos.Cache/Tests/Unit/Frontend/VariableFrontendTest.php
+++ b/Neos.Cache/Tests/Unit/Frontend/VariableFrontendTest.php
@@ -104,7 +104,7 @@ class VariableFrontendTest extends BaseTestCase
         $backend->expects($this->once())->method('get')->will($this->returnValue(serialize('Just some value')));
 
         $cache = new VariableFrontend('VariableFrontend', $backend);
-        $this->assertEquals('Just some value', $cache->get('VariableCacheTest'), 'The returned value was not the expected string.');
+        self::assertEquals('Just some value', $cache->get('VariableCacheTest'), 'The returned value was not the expected string.');
     }
 
     /**
@@ -117,7 +117,7 @@ class VariableFrontendTest extends BaseTestCase
         $backend->expects($this->once())->method('get')->will($this->returnValue(serialize($theArray)));
 
         $cache = new VariableFrontend('VariableFrontend', $backend);
-        $this->assertEquals($theArray, $cache->get('VariableCacheTest'), 'The returned value was not the expected unserialized array.');
+        self::assertEquals($theArray, $cache->get('VariableCacheTest'), 'The returned value was not the expected unserialized array.');
     }
 
     /**
@@ -129,7 +129,7 @@ class VariableFrontendTest extends BaseTestCase
         $backend->expects($this->once())->method('get')->will($this->returnValue(serialize(false)));
 
         $cache = new VariableFrontend('VariableFrontend', $backend);
-        $this->assertFalse($cache->get('VariableCacheTest'), 'The returned value was not the false.');
+        self::assertFalse($cache->get('VariableCacheTest'), 'The returned value was not the false.');
     }
 
     /**
@@ -145,7 +145,7 @@ class VariableFrontendTest extends BaseTestCase
         $cache = new VariableFrontend('VariableFrontend', $backend);
         $cache->initializeObject();
 
-        $this->assertEquals($theArray, $cache->get('VariableCacheTest'), 'The returned value was not the expected unserialized array.');
+        self::assertEquals($theArray, $cache->get('VariableCacheTest'), 'The returned value was not the expected unserialized array.');
     }
 
     /**
@@ -157,7 +157,7 @@ class VariableFrontendTest extends BaseTestCase
         $backend->expects($this->once())->method('has')->with($this->equalTo('VariableCacheTest'))->will($this->returnValue(true));
 
         $cache = new VariableFrontend('VariableFrontend', $backend);
-        $this->assertTrue($cache->has('VariableCacheTest'), 'has() did not return true.');
+        self::assertTrue($cache->has('VariableCacheTest'), 'has() did not return true.');
     }
 
     /**
@@ -171,7 +171,7 @@ class VariableFrontendTest extends BaseTestCase
         $backend->expects($this->once())->method('remove')->with($this->equalTo($cacheIdentifier))->will($this->returnValue(true));
 
         $cache = new VariableFrontend('VariableFrontend', $backend);
-        $this->assertTrue($cache->remove($cacheIdentifier), 'remove() did not return true');
+        self::assertTrue($cache->remove($cacheIdentifier), 'remove() did not return true');
     }
 
     /**
@@ -212,7 +212,7 @@ class VariableFrontendTest extends BaseTestCase
         $backend->expects($this->exactly(2))->method('get')->will($this->onConsecutiveCalls(serialize('one value'), serialize('two value')));
 
         $cache = new VariableFrontend('VariableFrontend', $backend);
-        $this->assertEquals($entries, $cache->getByTag($tag), 'Did not receive the expected entries');
+        self::assertEquals($entries, $cache->getByTag($tag), 'Did not receive the expected entries');
     }
 
     /**
@@ -232,7 +232,7 @@ class VariableFrontendTest extends BaseTestCase
         $cache = new VariableFrontend('VariableFrontend', $backend);
         $cache->initializeObject();
 
-        $this->assertEquals($entries, $cache->getByTag($tag), 'Did not receive the expected entries');
+        self::assertEquals($entries, $cache->getByTag($tag), 'Did not receive the expected entries');
     }
 
     /**

--- a/Neos.Eel/Resources/Private/PHP/php-peg/tests/ParserInheritanceTest.php
+++ b/Neos.Eel/Resources/Private/PHP/php-peg/tests/ParserInheritanceTest.php
@@ -14,11 +14,11 @@ class ParserInheritanceTest extends ParserTestBase {
 			*/
 		');
 
-		$this->assertTrue($parser->matches('Foo', 'a'));
-		$this->assertTrue($parser->matches('Bar', 'a'));
+		self::assertTrue($parser->matches('Foo', 'a'));
+		self::assertTrue($parser->matches('Bar', 'a'));
 
-		$this->assertFalse($parser->matches('Foo', 'b'));
-		$this->assertFalse($parser->matches('Bar', 'b'));
+		self::assertFalse($parser->matches('Foo', 'b'));
+		self::assertFalse($parser->matches('Bar', 'b'));
 	}
 
 	public function testBasicInheritanceConstructFallback() {
@@ -32,10 +32,10 @@ class ParserInheritanceTest extends ParserTestBase {
 		');
 
 		$res = $parser->match('Foo', 'a');
-		$this->assertEquals($res['test'], 'test');
+		self::assertEquals($res['test'], 'test');
 
 		$res = $parser->match('Bar', 'a');
-		$this->assertEquals($res['test'], 'test');
+		self::assertEquals($res['test'], 'test');
 
 		$parser = $this->buildParser('
 			/*!* BasicInheritanceConstructFallbackParser2
@@ -47,14 +47,14 @@ class ParserInheritanceTest extends ParserTestBase {
 		');
 
 		$res = $parser->match('Foo', 'a');
-		$this->assertArrayHasKey('testa', $res);
-		$this->assertEquals($res['testa'], 'testa');
-		$this->assertArrayNotHasKey('testb', $res);
+		self::assertArrayHasKey('testa', $res);
+		self::assertEquals($res['testa'], 'testa');
+		self::assertArrayNotHasKey('testb', $res);
 
 		$res = $parser->match('Bar', 'a');
-		$this->assertArrayHasKey('testb', $res);
-		$this->assertEquals($res['testb'], 'testb');
-		$this->assertArrayNotHasKey('testa', $res);
+		self::assertArrayHasKey('testb', $res);
+		self::assertEquals($res['testb'], 'testb');
+		self::assertArrayNotHasKey('testa', $res);
 
 	}
 
@@ -69,10 +69,10 @@ class ParserInheritanceTest extends ParserTestBase {
 		');
 
 		$res = $parser->match('Foo', 'a');
-		$this->assertEquals($res['test'], 'test');
+		self::assertEquals($res['test'], 'test');
 
 		$res = $parser->match('Bar', 'a');
-		$this->assertEquals($res['test'], 'test');
+		self::assertEquals($res['test'], 'test');
 
 		$parser = $this->buildParser('
 			/*!* BasicInheritanceStoreFallbackParser2
@@ -86,21 +86,21 @@ class ParserInheritanceTest extends ParserTestBase {
 		');
 
 		$res = $parser->match('Foo', 'ab');
-		$this->assertArrayHasKey('testa', $res);
-		$this->assertEquals($res['testa'], 'testa');
-		$this->assertArrayNotHasKey('testb', $res);
+		self::assertArrayHasKey('testa', $res);
+		self::assertEquals($res['testa'], 'testa');
+		self::assertArrayNotHasKey('testb', $res);
 
 		$res = $parser->match('Bar', 'ab');
-		$this->assertArrayHasKey('testb', $res);
-		$this->assertEquals($res['testb'], 'testb');
-		$this->assertArrayNotHasKey('testa', $res);
+		self::assertArrayHasKey('testb', $res);
+		self::assertEquals($res['testb'], 'testb');
+		self::assertArrayNotHasKey('testa', $res);
 
 		$res = $parser->match('Baz', 'ab');
-		$this->assertArrayHasKey('testa', $res);
-		$this->assertEquals($res['testa'], 'testa');
-		$this->assertArrayHasKey('testc', $res);
-		$this->assertEquals($res['testc'], 'testc');
-		$this->assertArrayNotHasKey('testb', $res);
+		self::assertArrayHasKey('testa', $res);
+		self::assertEquals($res['testa'], 'testa');
+		self::assertArrayHasKey('testc', $res);
+		self::assertEquals($res['testc'], 'testc');
+		self::assertArrayNotHasKey('testb', $res);
 	}
 
 	public function testInheritanceByReplacement() {

--- a/Neos.Eel/Tests/Functional/FlowQuery/OperationResolverTest.php
+++ b/Neos.Eel/Tests/Functional/FlowQuery/OperationResolverTest.php
@@ -27,7 +27,7 @@ class OperationResolverTest extends FunctionalTestCase
      */
     public function isFinalOperationReturnsTrueForFinalOperations()
     {
-        $this->assertTrue($this->operationResolver->isFinalOperation('exampleFinalOperation'));
+        self::assertTrue($this->operationResolver->isFinalOperation('exampleFinalOperation'));
     }
 
     /**
@@ -35,7 +35,7 @@ class OperationResolverTest extends FunctionalTestCase
      */
     public function isFinalOperationReturnsFalseForNonFinalOperations()
     {
-        $this->assertFalse($this->operationResolver->isFinalOperation('exampleNonFinalOperation'));
+        self::assertFalse($this->operationResolver->isFinalOperation('exampleNonFinalOperation'));
     }
 
     /**
@@ -43,6 +43,6 @@ class OperationResolverTest extends FunctionalTestCase
      */
     public function higherPriorityOverridesLowerPriority()
     {
-        $this->assertInstanceOf(Fixtures\ExampleFinalOperationWithHigherPriority::class, $this->operationResolver->resolveOperation('exampleFinalOperation', []));
+        self::assertInstanceOf(Fixtures\ExampleFinalOperationWithHigherPriority::class, $this->operationResolver->resolveOperation('exampleFinalOperation', []));
     }
 }

--- a/Neos.Eel/Tests/Unit/AbstractEvaluatorTest.php
+++ b/Neos.Eel/Tests/Unit/AbstractEvaluatorTest.php
@@ -710,10 +710,10 @@ abstract class AbstractEvaluatorTest extends UnitTestCase
     protected function assertEvaluated($expected, $expression, $context)
     {
         $evaluator = $this->createEvaluator();
-        $this->assertSame($expected, $evaluator->evaluate($expression, $context));
+        self::assertSame($expected, $evaluator->evaluate($expression, $context));
 
         $wrappedExpression = '${' . $expression . '}';
-        $this->assertSame(1, preg_match(\Neos\Eel\Package::EelExpressionRecognizer, $wrappedExpression), 'The wrapped expression ' . $wrappedExpression . ' was not detected as Eel expression');
+        self::assertSame(1, preg_match(\Neos\Eel\Package::EelExpressionRecognizer, $wrappedExpression), 'The wrapped expression ' . $wrappedExpression . ' was not detected as Eel expression');
     }
 
     /**

--- a/Neos.Eel/Tests/Unit/CompilingEvaluatorTest.php
+++ b/Neos.Eel/Tests/Unit/CompilingEvaluatorTest.php
@@ -103,9 +103,9 @@ class CompilingEvaluatorTest extends AbstractEvaluatorTest
         $evaluator->injectExpressionCache($stringFrontendMock);
         // note, this is not a public method. We should expect expressions coming in here to be trimmed already.
         $code = $evaluator->_call('generateEvaluatorCode', trim($expression));
-        $this->assertSame($expected, $evaluator->evaluate($expression, $context), 'Code ' . $code . ' should evaluate to expected result');
+        self::assertSame($expected, $evaluator->evaluate($expression, $context), 'Code ' . $code . ' should evaluate to expected result');
 
         $wrappedExpression = '${' . $expression . '}';
-        $this->assertSame(1, preg_match(\Neos\Eel\Package::EelExpressionRecognizer, $wrappedExpression), 'The wrapped expression ' . $wrappedExpression . ' was not detected as Eel expression');
+        self::assertSame(1, preg_match(\Neos\Eel\Package::EelExpressionRecognizer, $wrappedExpression), 'The wrapped expression ' . $wrappedExpression . ' was not detected as Eel expression');
     }
 }

--- a/Neos.Eel/Tests/Unit/ContextTest.php
+++ b/Neos.Eel/Tests/Unit/ContextTest.php
@@ -45,7 +45,7 @@ class ContextTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $context = new Context($value);
         $unwrappedValue = $context->unwrap();
-        $this->assertSame($expectedUnwrappedValue, $unwrappedValue);
+        self::assertSame($expectedUnwrappedValue, $unwrappedValue);
     }
 
     /**
@@ -75,7 +75,7 @@ class ContextTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $context = new Context($value);
         $unwrappedValue = $context->unwrap();
-        $this->assertSame($expectedUnwrappedValue, $unwrappedValue);
+        self::assertSame($expectedUnwrappedValue, $unwrappedValue);
     }
 
     /**
@@ -106,7 +106,7 @@ class ContextTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $context = new Context($value);
         $getValue = $context->get($path);
-        $this->assertSame($getValue, $expectedGetValue);
+        self::assertSame($getValue, $expectedGetValue);
     }
 
     /**
@@ -143,6 +143,6 @@ class ContextTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $context = new Context($value);
         $getValue = $context->get($path);
-        $this->assertSame($getValue, $expectedGetValue);
+        self::assertSame($getValue, $expectedGetValue);
     }
 }

--- a/Neos.Eel/Tests/Unit/FlowQuery/FizzleParserTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/FizzleParserTest.php
@@ -31,11 +31,11 @@ class FizzleParserTest extends \Neos\Flow\Tests\UnitTestCase
         $parser->assertDoesntMatch('FilterGroup', 'foo[baz] foo2[baz2]');
 
         $actual = $parser->match('FilterGroup', 'foo[baz], blah');
-        $this->assertSame('foo', $actual['Filters'][0]['PropertyNameFilter']);
-        $this->assertSame('blah', $actual['Filters'][1]['PropertyNameFilter']);
+        self::assertSame('foo', $actual['Filters'][0]['PropertyNameFilter']);
+        self::assertSame('blah', $actual['Filters'][1]['PropertyNameFilter']);
 
         $actual = $parser->match('FilterGroup', 'blah');
-        $this->assertSame('blah', $actual['Filters'][0]['PropertyNameFilter']);
+        self::assertSame('blah', $actual['Filters'][0]['PropertyNameFilter']);
     }
 
     /**
@@ -54,18 +54,18 @@ class FizzleParserTest extends \Neos\Flow\Tests\UnitTestCase
         $parser->assertMatches('Filter', '[baz][foo="asdf"]');
 
         $actual = $parser->match('Filter', 'foo[baz][foo  =  asdf]');
-        $this->assertSame('foo', $actual['PropertyNameFilter']);
+        self::assertSame('foo', $actual['PropertyNameFilter']);
 
-        $this->assertSame('[baz]', $actual['AttributeFilters'][0]['text']);
-        $this->assertSame('baz', $actual['AttributeFilters'][0]['PropertyPath']);
-        $this->assertSame('[foo  =  asdf]', $actual['AttributeFilters'][1]['text']);
-        $this->assertSame('foo', $actual['AttributeFilters'][1]['PropertyPath']);
-        $this->assertSame('=', $actual['AttributeFilters'][1]['Operator']);
-        $this->assertSame('asdf', $actual['AttributeFilters'][1]['Operand']);
+        self::assertSame('[baz]', $actual['AttributeFilters'][0]['text']);
+        self::assertSame('baz', $actual['AttributeFilters'][0]['PropertyPath']);
+        self::assertSame('[foo  =  asdf]', $actual['AttributeFilters'][1]['text']);
+        self::assertSame('foo', $actual['AttributeFilters'][1]['PropertyPath']);
+        self::assertSame('=', $actual['AttributeFilters'][1]['Operator']);
+        self::assertSame('asdf', $actual['AttributeFilters'][1]['Operand']);
 
         $actual = $parser->match('Filter', '[baz]');
-        $this->assertSame('baz', $actual['AttributeFilters'][0]['PropertyPath']);
-        $this->assertSame('baz', $actual['AttributeFilters'][0]['Identifier'], 'Identifier key is added for compatibility');
+        self::assertSame('baz', $actual['AttributeFilters'][0]['PropertyPath']);
+        self::assertSame('baz', $actual['AttributeFilters'][0]['Identifier'], 'Identifier key is added for compatibility');
 
         $parser->assertDoesntMatch('Filter', '*');
     }
@@ -99,7 +99,7 @@ class FizzleParserTest extends \Neos\Flow\Tests\UnitTestCase
         $parser->assertDoesntMatch('PathFilter', 'foo');
 
         $actual = $parser->match('Filter', 'foo/bar');
-        $this->assertSame('foo/bar', $actual['PathFilter']);
+        self::assertSame('foo/bar', $actual['PathFilter']);
     }
 
     /**
@@ -141,9 +141,9 @@ class FizzleParserTest extends \Neos\Flow\Tests\UnitTestCase
         $parser = new ParserTestWrapper($this, FizzleParser::class);
 
         $actual = $parser->match('Filter', 'foo[foo=true]');
-        $this->assertSame(true, $actual['AttributeFilters'][0]['Operand']);
+        self::assertSame(true, $actual['AttributeFilters'][0]['Operand']);
 
         $actual = $parser->match('Filter', 'foo[foo= false]');
-        $this->assertSame(false, $actual['AttributeFilters'][0]['Operand']);
+        self::assertSame(false, $actual['AttributeFilters'][0]['Operand']);
     }
 }

--- a/Neos.Eel/Tests/Unit/FlowQuery/FlowQueryTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/FlowQueryTest.php
@@ -38,7 +38,7 @@ class FlowQueryTest extends UnitTestCase
         $flowQuery = new FlowQuery(['a', 'b', 'c']);
         $wrappedQuery = new FlowQuery($flowQuery);
 
-        $this->assertEquals($flowQuery->getContext(), $wrappedQuery->getContext());
+        self::assertEquals($flowQuery->getContext(), $wrappedQuery->getContext());
     }
 
     /**
@@ -50,9 +50,9 @@ class FlowQueryTest extends UnitTestCase
         $myObject2 = new \stdClass();
 
         $query = $this->createFlowQuery([$myObject, $myObject2]);
-        $this->assertInstanceOf(FlowQuery::class, $query->first());
-        $this->assertSame([$myObject], $query->first()->get());
-        $this->assertSame([$myObject], iterator_to_array($query->first()));
+        self::assertInstanceOf(FlowQuery::class, $query->first());
+        self::assertSame([$myObject], $query->first()->get());
+        self::assertSame([$myObject], iterator_to_array($query->first()));
     }
 
     /**
@@ -64,9 +64,9 @@ class FlowQueryTest extends UnitTestCase
         $myObject2 = new \stdClass();
 
         $query = $this->createFlowQuery([$myObject, $myObject2]);
-        $this->assertInstanceOf(FlowQuery::class, $query->last());
-        $this->assertSame([$myObject2], $query->last()->get());
-        $this->assertSame([$myObject2], iterator_to_array($query->last()));
+        self::assertInstanceOf(FlowQuery::class, $query->last());
+        self::assertSame([$myObject2], $query->last()->get());
+        self::assertSame([$myObject2], iterator_to_array($query->last()));
     }
 
     /**
@@ -79,13 +79,13 @@ class FlowQueryTest extends UnitTestCase
         $myObject3 = new \stdClass();
 
         $query = $this->createFlowQuery([$myObject, $myObject2, $myObject3]);
-        $this->assertInstanceOf(FlowQuery::class, $query->slice());
-        $this->assertSame([$myObject, $myObject2, $myObject3], $query->slice()->get());
-        $this->assertSame([$myObject, $myObject2, $myObject3], iterator_to_array($query->slice()));
-        $this->assertSame([$myObject, $myObject2], $query->slice(0, 2)->get());
-        $this->assertSame([$myObject, $myObject2], iterator_to_array($query->slice(0, 2)));
-        $this->assertSame([$myObject3], $query->slice(2)->get());
-        $this->assertSame([$myObject3], iterator_to_array($query->slice(2)));
+        self::assertInstanceOf(FlowQuery::class, $query->slice());
+        self::assertSame([$myObject, $myObject2, $myObject3], $query->slice()->get());
+        self::assertSame([$myObject, $myObject2, $myObject3], iterator_to_array($query->slice()));
+        self::assertSame([$myObject, $myObject2], $query->slice(0, 2)->get());
+        self::assertSame([$myObject, $myObject2], iterator_to_array($query->slice(0, 2)));
+        self::assertSame([$myObject3], $query->slice(2)->get());
+        self::assertSame([$myObject3], iterator_to_array($query->slice(2)));
     }
 
     /**
@@ -103,49 +103,49 @@ class FlowQueryTest extends UnitTestCase
         $query = $this->createFlowQuery([$myObject, $myObject2, $myObject3]);
 
 
-        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty *= bar]'));
-        $this->assertSame([$myObject], $query->filter('[arrayProperty *= bar]')->get());
+        self::assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty *= bar]'));
+        self::assertSame([$myObject], $query->filter('[arrayProperty *= bar]')->get());
 
-        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty *= foo]'));
-        $this->assertSame([$myObject, $myObject2], $query->filter('[arrayProperty *= foo]')->get());
+        self::assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty *= foo]'));
+        self::assertSame([$myObject, $myObject2], $query->filter('[arrayProperty *= foo]')->get());
 
-        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty *= ding]'));
-        $this->assertSame([], $query->filter('[arrayProperty *= ding]')->get());
+        self::assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty *= ding]'));
+        self::assertSame([], $query->filter('[arrayProperty *= ding]')->get());
 
-        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty *= fo]'));
-        $this->assertSame([], $query->filter('[arrayProperty *= fo]')->get());
-
-
-        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty ^= zing]'));
-        $this->assertSame([$myObject3], $query->filter('[arrayProperty ^= zing]')->get());
-
-        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty ^= foo]'));
-        $this->assertSame([$myObject, $myObject2], $query->filter('[arrayProperty ^= foo]')->get());
-
-        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty ^= ding]'));
-        $this->assertSame([], $query->filter('[arrayProperty ^= ding]')->get());
-
-        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty ^= zi]'));
-        $this->assertSame([], $query->filter('[arrayProperty ^= zi]')->get());
-
-        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty ^= bar]'));
-        $this->assertSame([], $query->filter('[arrayProperty ^= bar]')->get());
+        self::assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty *= fo]'));
+        self::assertSame([], $query->filter('[arrayProperty *= fo]')->get());
 
 
-        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty $= baz]'));
-        $this->assertSame([$myObject], $query->filter('[arrayProperty $= baz]')->get());
+        self::assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty ^= zing]'));
+        self::assertSame([$myObject3], $query->filter('[arrayProperty ^= zing]')->get());
 
-        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty $= zong]'));
-        $this->assertSame([$myObject2, $myObject3], $query->filter('[arrayProperty $= zong]')->get());
+        self::assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty ^= foo]'));
+        self::assertSame([$myObject, $myObject2], $query->filter('[arrayProperty ^= foo]')->get());
 
-        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty $= ding]'));
-        $this->assertSame([], $query->filter('[arrayProperty $= ding]')->get());
+        self::assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty ^= ding]'));
+        self::assertSame([], $query->filter('[arrayProperty ^= ding]')->get());
 
-        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty $= az]'));
-        $this->assertSame([], $query->filter('[arrayProperty $= az]')->get());
+        self::assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty ^= zi]'));
+        self::assertSame([], $query->filter('[arrayProperty ^= zi]')->get());
 
-        $this->assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty $= bar]'));
-        $this->assertSame([], $query->filter('[arrayProperty $= bar]')->get());
+        self::assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty ^= bar]'));
+        self::assertSame([], $query->filter('[arrayProperty ^= bar]')->get());
+
+
+        self::assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty $= baz]'));
+        self::assertSame([$myObject], $query->filter('[arrayProperty $= baz]')->get());
+
+        self::assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty $= zong]'));
+        self::assertSame([$myObject2, $myObject3], $query->filter('[arrayProperty $= zong]')->get());
+
+        self::assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty $= ding]'));
+        self::assertSame([], $query->filter('[arrayProperty $= ding]')->get());
+
+        self::assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty $= az]'));
+        self::assertSame([], $query->filter('[arrayProperty $= az]')->get());
+
+        self::assertInstanceOf(FlowQuery::class, $query->filter('[arrayProperty $= bar]'));
+        self::assertSame([], $query->filter('[arrayProperty $= bar]')->get());
     }
 
     /**
@@ -399,8 +399,8 @@ class FlowQueryTest extends UnitTestCase
     {
         $query = $this->createFlowQuery($sourceObjects);
         $filter = $query->filter($filterString);
-        $this->assertInstanceOf(FlowQuery::class, $filter);
-        $this->assertSame($expected, iterator_to_array($filter));
+        self::assertInstanceOf(FlowQuery::class, $filter);
+        self::assertSame($expected, iterator_to_array($filter));
     }
 
     /**
@@ -410,7 +410,7 @@ class FlowQueryTest extends UnitTestCase
     public function isCanFilterObjects($sourceObjects, $filterString, $expectedResultArray)
     {
         $query = $this->createFlowQuery($sourceObjects);
-        $this->assertSame(count($expectedResultArray) > 0, $query->is($filterString));
+        self::assertSame(count($expectedResultArray) > 0, $query->is($filterString));
     }
 
     /**
@@ -420,9 +420,9 @@ class FlowQueryTest extends UnitTestCase
     public function countReturnsCorrectNumber($sourceObjects, $filterString, $expectedResultArray)
     {
         $query = $this->createFlowQuery($sourceObjects);
-        $this->assertSame(count($expectedResultArray), $query->filter($filterString)->count());
-        $this->assertSame(count($sourceObjects), $query->count());
-        $this->assertSame(count($sourceObjects), count($query));
+        self::assertSame(count($expectedResultArray), $query->filter($filterString)->count());
+        self::assertSame(count($sourceObjects), $query->count());
+        self::assertSame(count($sourceObjects), count($query));
     }
 
     /**
@@ -438,20 +438,20 @@ class FlowQueryTest extends UnitTestCase
         $myObject3->stringProperty = "fing', 'fan33g', 'fong";
         $query = $this->createFlowQuery([$myObject, $myObject2, $myObject3]);
 
-        $this->assertInstanceOf(FlowQuery::class, $query->filter('[stringProperty $= 2]'));
-        $this->assertSame([$myObject], $query->filter('[stringProperty $= 2]')->get());
+        self::assertInstanceOf(FlowQuery::class, $query->filter('[stringProperty $= 2]'));
+        self::assertSame([$myObject], $query->filter('[stringProperty $= 2]')->get());
 
-        $this->assertInstanceOf(FlowQuery::class, $query->filter('[stringProperty *= 33]'));
-        $this->assertSame([$myObject3], $query->filter('[stringProperty *= 33]')->get());
+        self::assertInstanceOf(FlowQuery::class, $query->filter('[stringProperty *= 33]'));
+        self::assertSame([$myObject3], $query->filter('[stringProperty *= 33]')->get());
 
-        $this->assertInstanceOf(FlowQuery::class, $query->filter('[stringProperty *= "n33g"]'));
-        $this->assertSame([$myObject3], $query->filter('[stringProperty *= "n33g"]')->get());
+        self::assertInstanceOf(FlowQuery::class, $query->filter('[stringProperty *= "n33g"]'));
+        self::assertSame([$myObject3], $query->filter('[stringProperty *= "n33g"]')->get());
 
-        $this->assertInstanceOf(FlowQuery::class, $query->filter('[stringProperty $= "2"]'));
-        $this->assertSame([$myObject], $query->filter('[stringProperty $= "2"]')->get());
+        self::assertInstanceOf(FlowQuery::class, $query->filter('[stringProperty $= "2"]'));
+        self::assertSame([$myObject], $query->filter('[stringProperty $= "2"]')->get());
 
-        $this->assertInstanceOf(FlowQuery::class, $query->filter('[stringProperty *= 2]'));
-        $this->assertSame([$myObject], $query->filter('[stringProperty *= 2]')->get());
+        self::assertInstanceOf(FlowQuery::class, $query->filter('[stringProperty *= 2]'));
+        self::assertSame([$myObject], $query->filter('[stringProperty *= 2]')->get());
     }
 
     /**
@@ -546,10 +546,10 @@ class FlowQueryTest extends UnitTestCase
         foreach ($expressions as $expression) {
             eval('$result = ' . $expression . ';');
             if (!$isFinal) {
-                $this->assertInstanceOf(FlowQuery::class, $result);
+                self::assertInstanceOf(FlowQuery::class, $result);
                 $result = iterator_to_array($result);
             }
-            $this->assertSame($expectedResult, $result, 'Expression "' . $expression . '" did not match expected result');
+            self::assertSame($expectedResult, $result, 'Expression "' . $expression . '" did not match expected result');
         }
     }
 
@@ -589,7 +589,7 @@ class FlowQueryTest extends UnitTestCase
         $x->foo->foo = 'asdf';
         $query = $this->createFlowQuery([$x]);
         eval('$result = ' . $expression . ';');
-        $this->assertInstanceOf(FlowQuery::class, $result);
+        self::assertInstanceOf(FlowQuery::class, $result);
         $result->getIterator(); // Throws exception
     }
 

--- a/Neos.Eel/Tests/Unit/FlowQuery/Operations/AddOperationTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/Operations/AddOperationTest.php
@@ -37,7 +37,7 @@ class AddOperationTest extends \Neos\Flow\Tests\UnitTestCase
         $operation = new AddOperation();
         $operation->evaluate($flowQuery, $arguments);
 
-        $this->assertSame([$object1, $object2], $flowQuery->getContext());
+        self::assertSame([$object1, $object2], $flowQuery->getContext());
     }
 
     /**
@@ -58,7 +58,7 @@ class AddOperationTest extends \Neos\Flow\Tests\UnitTestCase
         $operation = new AddOperation();
         $operation->evaluate($flowQuery, $arguments);
 
-        $this->assertSame([$object1, $object2], $flowQuery->getContext());
+        self::assertSame([$object1, $object2], $flowQuery->getContext());
     }
 
     /**
@@ -79,6 +79,6 @@ class AddOperationTest extends \Neos\Flow\Tests\UnitTestCase
         $operation = new AddOperation();
         $operation->evaluate($flowQuery, $arguments);
 
-        $this->assertSame([$object1, $object2], $flowQuery->getContext());
+        self::assertSame([$object1, $object2], $flowQuery->getContext());
     }
 }

--- a/Neos.Eel/Tests/Unit/FlowQuery/Operations/ChildrenOperationTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/Operations/ChildrenOperationTest.php
@@ -47,6 +47,6 @@ class ChildrenOperationTest extends \Neos\Flow\Tests\UnitTestCase
         $operation = new ChildrenOperation();
         $operation->evaluate($flowQuery, $arguments);
 
-        $this->assertEquals($expected, $flowQuery->getContext());
+        self::assertEquals($expected, $flowQuery->getContext());
     }
 }

--- a/Neos.Eel/Tests/Unit/FlowQuery/Operations/RemoveOperationTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/Operations/RemoveOperationTest.php
@@ -37,7 +37,7 @@ class RemoveOperationTest extends \Neos\Flow\Tests\UnitTestCase
         $operation = new RemoveOperation();
         $operation->evaluate($flowQuery, $arguments);
 
-        $this->assertSame([$object1], $flowQuery->getContext());
+        self::assertSame([$object1], $flowQuery->getContext());
     }
 
     /**
@@ -58,7 +58,7 @@ class RemoveOperationTest extends \Neos\Flow\Tests\UnitTestCase
         $operation = new RemoveOperation();
         $operation->evaluate($flowQuery, $arguments);
 
-        $this->assertSame([$object1], $flowQuery->getContext());
+        self::assertSame([$object1], $flowQuery->getContext());
     }
 
     /**
@@ -79,6 +79,6 @@ class RemoveOperationTest extends \Neos\Flow\Tests\UnitTestCase
         $operation = new RemoveOperation();
         $operation->evaluate($flowQuery, $arguments);
 
-        $this->assertSame([$object1], $flowQuery->getContext());
+        self::assertSame([$object1], $flowQuery->getContext());
     }
 }

--- a/Neos.Eel/Tests/Unit/FlowQuery/Operations/SliceOperationTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/Operations/SliceOperationTest.php
@@ -43,6 +43,6 @@ class SliceOperationTest extends \Neos\Flow\Tests\UnitTestCase
         $operation = new SliceOperation();
         $operation->evaluate($flowQuery, $arguments);
 
-        $this->assertEquals($expected, $flowQuery->getContext());
+        self::assertEquals($expected, $flowQuery->getContext());
     }
 }

--- a/Neos.Eel/Tests/Unit/Helper/ArrayHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/ArrayHelperTest.php
@@ -44,7 +44,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new ArrayHelper();
         $result = call_user_func_array([$helper, 'concat'], $arguments);
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     public function joinExamples()
@@ -68,7 +68,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
         } else {
             $result = $helper->join($array);
         }
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     public function sliceExamples()
@@ -95,7 +95,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
         } else {
             $result = $helper->slice($array, $begin);
         }
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     public function reverseExamples()
@@ -116,7 +116,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new ArrayHelper();
         $result = $helper->reverse($array);
 
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     public function keysExamples()
@@ -137,7 +137,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new ArrayHelper();
         $result = $helper->keys($array);
 
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     public function lengthExamples()
@@ -157,7 +157,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new ArrayHelper();
         $result = $helper->length($array);
 
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     public function indexOfExamples()
@@ -182,7 +182,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
             $result = $helper->indexOf($array, $searchElement);
         }
 
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     public function isEmptyExamples()
@@ -202,7 +202,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new ArrayHelper();
         $result = $helper->isEmpty($array);
 
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     public function firstExamples()
@@ -223,7 +223,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new ArrayHelper();
         $result = $helper->first($array);
 
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     public function lastExamples()
@@ -244,7 +244,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new ArrayHelper();
         $result = $helper->last($array);
 
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     public function randomExamples()
@@ -265,7 +265,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new ArrayHelper();
         $result = $helper->random($array);
 
-        $this->assertEquals($expected, in_array($result, $array));
+        self::assertEquals($expected, in_array($result, $array));
     }
 
     public function sortExamples()
@@ -286,7 +286,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new ArrayHelper();
         $sortedArray = $helper->sort($array);
-        $this->assertEquals($expected, $sortedArray);
+        self::assertEquals($expected, $sortedArray);
     }
 
     public function shuffleExamples()
@@ -307,7 +307,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new ArrayHelper();
         $shuffledArray = $helper->shuffle($array);
-        $this->assertEquals($array, $shuffledArray);
+        self::assertEquals($array, $shuffledArray);
     }
 
     public function popExamples()
@@ -328,7 +328,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new ArrayHelper();
         $poppedArray = $helper->pop($array);
-        $this->assertEquals($expected, $poppedArray);
+        self::assertEquals($expected, $poppedArray);
     }
 
     public function pushExamples()
@@ -349,7 +349,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new ArrayHelper();
         $pushedArray = $helper->push($array, $element1, $element2);
-        $this->assertEquals($expected, $pushedArray);
+        self::assertEquals($expected, $pushedArray);
     }
 
     public function shiftExamples()
@@ -370,7 +370,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new ArrayHelper();
         $shiftedArray = $helper->shift($array);
-        $this->assertEquals($expected, $shiftedArray);
+        self::assertEquals($expected, $shiftedArray);
     }
 
     public function unshiftExamples()
@@ -391,7 +391,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new ArrayHelper();
         $unshiftedArray = $helper->unshift($array, $element1, $element2);
-        $this->assertEquals($expected, $unshiftedArray);
+        self::assertEquals($expected, $unshiftedArray);
     }
 
     public function spliceExamples()
@@ -412,7 +412,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new ArrayHelper();
         $splicedArray = $helper->splice($array, $offset, $length, $element1, $element2, $element3);
-        $this->assertEquals($expected, $splicedArray);
+        self::assertEquals($expected, $splicedArray);
     }
 
     /**
@@ -422,7 +422,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new ArrayHelper();
         $splicedArray = $helper->splice([0, 1, 2, 3, 4, 5], 2, 2);
-        $this->assertEquals([0, 1, 4, 5], $splicedArray);
+        self::assertEquals([0, 1, 4, 5], $splicedArray);
     }
 
     public function flipExamples()
@@ -442,7 +442,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new ArrayHelper();
         $result = $helper->flip($array);
 
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     public function rangeExamples()
@@ -471,7 +471,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new ArrayHelper();
         $result = call_user_func_array([$helper, 'range'], $arguments);
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
 
@@ -501,7 +501,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new ArrayHelper();
         $result = call_user_func_array([$helper, 'set'], $arguments);
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     public function mapExamples()
@@ -539,7 +539,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new ArrayHelper();
         $result = $helper->map($array, $callback);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function reduceExamples()
@@ -588,7 +588,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new ArrayHelper();
         $result = $helper->reduce($array, $callback, $initialValue);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function filterExamples()
@@ -626,7 +626,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new ArrayHelper();
         $result = $helper->filter($array, $callback);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function someExamples()
@@ -669,7 +669,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new ArrayHelper();
         $result = $helper->some($array, $callback);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function everyExamples()
@@ -712,6 +712,6 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new ArrayHelper();
         $result = $helper->every($array, $callback);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 }

--- a/Neos.Eel/Tests/Unit/Helper/DateHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/DateHelperTest.php
@@ -40,8 +40,8 @@ class DateHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new DateHelper();
         $result = $helper->parse($string, $format);
-        $this->assertInstanceOf(\DateTime::class, $result);
-        $this->assertEqualsWithDelta((float)$expected->format('U'), (float)$result->format('U'), 60, 'Timestamps should match');
+        self::assertInstanceOf(\DateTime::class, $result);
+        self::assertEqualsWithDelta((float)$expected->format('U'), (float)$result->format('U'), 60, 'Timestamps should match');
     }
 
     /**
@@ -66,7 +66,7 @@ class DateHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new DateHelper();
         $result = $helper->format($dateOrString, $format);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     /**
@@ -131,8 +131,8 @@ class DateHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new DateHelper();
         $result = $helper->now();
-        $this->assertInstanceOf(\DateTime::class, $result);
-        $this->assertEqualsWithDelta(time(), (integer)$result->format('U'), 1, 'Now should be now');
+        self::assertInstanceOf(\DateTime::class, $result);
+        self::assertEqualsWithDelta(time(), (integer)$result->format('U'), 1, 'Now should be now');
     }
 
     /**
@@ -143,8 +143,8 @@ class DateHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new DateHelper();
         $result = $helper->create('yesterday noon');
         $expected = new \DateTime('yesterday noon');
-        $this->assertInstanceOf(\DateTime::class, $result);
-        $this->assertEqualsWithDelta($expected->getTimestamp(), $result->getTimestamp(), 1, 'Created DateTime object should match expected');
+        self::assertInstanceOf(\DateTime::class, $result);
+        self::assertEqualsWithDelta($expected->getTimestamp(), $result->getTimestamp(), 1, 'Created DateTime object should match expected');
     }
 
     /**
@@ -154,9 +154,9 @@ class DateHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new DateHelper();
         $result = $helper->today();
-        $this->assertInstanceOf(\DateTime::class, $result);
+        self::assertInstanceOf(\DateTime::class, $result);
         $today = new \DateTime('today');
-        $this->assertEqualsWithDelta($today->getTimestamp(), $result->getTimestamp(), 1, 'Today should be today');
+        self::assertEqualsWithDelta($today->getTimestamp(), $result->getTimestamp(), 1, 'Today should be today');
     }
 
     /**
@@ -184,8 +184,8 @@ class DateHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new DateHelper();
         $result = $helper->$method($dateTime, $interval);
 
-        $this->assertEquals($timestamp, $dateTime->getTimeStamp(), 'DateTime should not be modified');
-        $this->assertEquals($expected, $result->format('Y-m-d H:i:s'));
+        self::assertEquals($timestamp, $dateTime->getTimeStamp(), 'DateTime should not be modified');
+        self::assertEquals($expected, $result->format('Y-m-d H:i:s'));
     }
 
     /**
@@ -198,9 +198,9 @@ class DateHelperTest extends \Neos\Flow\Tests\UnitTestCase
 
         $helper = new DateHelper();
         $result = $helper->diff($earlierTime, $futureTime);
-        $this->assertEquals(6, $result->d);
-        $this->assertEquals(23, $result->h);
-        $this->assertEquals(59, $result->i);
+        self::assertEquals(6, $result->d);
+        self::assertEquals(23, $result->h);
+        self::assertEquals(59, $result->i);
     }
 
     /**
@@ -211,12 +211,12 @@ class DateHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new DateHelper();
         $date = new \DateTime('2013-10-16 14:59:27');
 
-        $this->assertSame(2013, $helper->year($date));
-        $this->assertSame(10, $helper->month($date));
-        $this->assertSame(16, $helper->dayOfMonth($date));
+        self::assertSame(2013, $helper->year($date));
+        self::assertSame(10, $helper->month($date));
+        self::assertSame(16, $helper->dayOfMonth($date));
 
-        $this->assertSame(14, $helper->hour($date));
-        $this->assertSame(59, $helper->minute($date));
-        $this->assertSame(27, $helper->second($date));
+        self::assertSame(14, $helper->hour($date));
+        self::assertSame(59, $helper->minute($date));
+        self::assertSame(27, $helper->second($date));
     }
 }

--- a/Neos.Eel/Tests/Unit/Helper/JsonHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/JsonHelperTest.php
@@ -44,7 +44,7 @@ class JsonHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new JsonHelper();
         $result = $helper->stringify($value);
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     public function parseExamples()
@@ -79,6 +79,6 @@ class JsonHelperTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $helper = new JsonHelper();
         $result = call_user_func_array([$helper, 'parse'], $arguments);
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 }

--- a/Neos.Eel/Tests/Unit/Helper/MathHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/MathHelperTest.php
@@ -44,9 +44,9 @@ class MathHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new MathHelper();
         $result = $helper->round($value, $precision);
         if ($expected === static::NAN) {
-            $this->assertTrue(is_nan($result), 'Expected NAN');
+            self::assertTrue(is_nan($result), 'Expected NAN');
         } else {
-            $this->assertEqualsWithDelta($expected, $result, 0.0001, 'Rounded value did not match');
+            self::assertEqualsWithDelta($expected, $result, 0.0001, 'Rounded value did not match');
         }
     }
 
@@ -76,7 +76,7 @@ class MathHelperTest extends \Neos\Flow\Tests\UnitTestCase
             'Math' => $helper
         ]);
         $result = $evaluator->evaluate($method, $context);
-        $this->assertEqualsWithDelta($expected, $result, 0.001, 'Rounded value did not match');
+        self::assertEqualsWithDelta($expected, $result, 0.001, 'Rounded value did not match');
     }
 
     public function trigonometricExamples()
@@ -110,7 +110,7 @@ class MathHelperTest extends \Neos\Flow\Tests\UnitTestCase
             'Math' => $helper
         ]);
         $result = $evaluator->evaluate($method, $context);
-        $this->assertEqualsWithDelta($expected, $result, 0.001, 'Rounded value did not match');
+        self::assertEqualsWithDelta($expected, $result, 0.001, 'Rounded value did not match');
     }
 
     public function variousExamples()
@@ -211,9 +211,9 @@ class MathHelperTest extends \Neos\Flow\Tests\UnitTestCase
         ]);
         $result = $evaluator->evaluate($method, $context);
         if ($expected === static::NAN) {
-            $this->assertTrue(is_nan($result), 'Expected NAN, got value "' . $result . '"');
+            self::assertTrue(is_nan($result), 'Expected NAN, got value "' . $result . '"');
         } else {
-            $this->assertEqualsWithDelta($expected, $result, 0.001, 'Rounded value did not match');
+            self::assertEqualsWithDelta($expected, $result, 0.001, 'Rounded value did not match');
         }
     }
 
@@ -250,7 +250,7 @@ class MathHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new MathHelper();
         $result = $helper->$method($value);
 
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     /**
@@ -266,10 +266,10 @@ class MathHelperTest extends \Neos\Flow\Tests\UnitTestCase
             if ($ri !== $r1) {
                 $atLeastOneRandomResult = true;
             }
-            $this->assertLessThan(1.0, $ri, 'Result should be less than 1');
-            $this->assertGreaterThanOrEqual(0.0, $ri, 'Result should be greater than 0');
+            self::assertLessThan(1.0, $ri, 'Result should be less than 1');
+            self::assertGreaterThanOrEqual(0.0, $ri, 'Result should be greater than 0');
         }
-        $this->assertTrue($atLeastOneRandomResult, 'random() should return a random result');
+        self::assertTrue($atLeastOneRandomResult, 'random() should return a random result');
     }
 
     /**
@@ -287,9 +287,9 @@ class MathHelperTest extends \Neos\Flow\Tests\UnitTestCase
             if ($ri !== $r1) {
                 $atLeastOneRandomResult = true;
             }
-            $this->assertLessThanOrEqual($max, $ri);
-            $this->assertGreaterThanOrEqual($min, $ri);
+            self::assertLessThanOrEqual($max, $ri);
+            self::assertGreaterThanOrEqual($min, $ri);
         }
-        $this->assertTrue($atLeastOneRandomResult, 'random() should return a random result');
+        self::assertTrue($atLeastOneRandomResult, 'random() should return a random result');
     }
 }

--- a/Neos.Eel/Tests/Unit/Helper/SecurityHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/SecurityHelperTest.php
@@ -23,7 +23,7 @@ class SecurityHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new SecurityHelper();
         $this->inject($helper, 'securityContext', $mockSecurityContext);
 
-        $this->assertEquals('TheCsrfToken', $helper->csrfToken());
+        self::assertEquals('TheCsrfToken', $helper->csrfToken());
     }
 
     /**
@@ -48,7 +48,7 @@ class SecurityHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new SecurityHelper();
         $this->inject($helper, 'securityContext', $mockSecurityContext);
 
-        $this->assertTrue($helper->isAuthenticated());
+        self::assertTrue($helper->isAuthenticated());
     }
 
     /**
@@ -69,7 +69,7 @@ class SecurityHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new SecurityHelper();
         $this->inject($helper, 'securityContext', $mockSecurityContext);
 
-        $this->assertFalse($helper->isAuthenticated());
+        self::assertFalse($helper->isAuthenticated());
     }
 
     /**
@@ -85,7 +85,7 @@ class SecurityHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new SecurityHelper();
         $this->inject($helper, 'securityContext', $mockSecurityContext);
 
-        $this->assertFalse($helper->isAuthenticated());
+        self::assertFalse($helper->isAuthenticated());
     }
 
     /**
@@ -100,7 +100,7 @@ class SecurityHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new SecurityHelper();
         $this->inject($helper, 'securityContext', $mockSecurityContext);
 
-        $this->assertFalse($helper->isAuthenticated());
+        self::assertFalse($helper->isAuthenticated());
     }
 
     /**
@@ -118,7 +118,7 @@ class SecurityHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $this->inject($helper, 'securityContext', $mockSecurityContext);
         $this->inject($helper, 'privilegeManager', $mockPrivilegeManager);
 
-        $this->assertTrue($helper->hasAccess('somePrivilegeTarget', []));
+        self::assertTrue($helper->hasAccess('somePrivilegeTarget', []));
     }
 
     /**
@@ -136,7 +136,7 @@ class SecurityHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $this->inject($helper, 'securityContext', $mockSecurityContext);
         $this->inject($helper, 'privilegeManager', $mockPrivilegeManager);
 
-        $this->assertFalse($helper->hasAccess('somePrivilegeTarget', []));
+        self::assertFalse($helper->hasAccess('somePrivilegeTarget', []));
     }
 
     /**
@@ -153,7 +153,7 @@ class SecurityHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $this->inject($helper, 'securityContext', $mockSecurityContext);
         $this->inject($helper, 'privilegeManager', $mockPrivilegeManager);
 
-        $this->assertFalse($helper->hasAccess('somePrivilegeTarget', []));
+        self::assertFalse($helper->hasAccess('somePrivilegeTarget', []));
     }
 
     /**
@@ -167,7 +167,7 @@ class SecurityHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new SecurityHelper();
         $this->inject($helper, 'securityContext', $mockSecurityContext);
 
-        $this->assertNull($helper->getAccount());
+        self::assertNull($helper->getAccount());
     }
 
     /**
@@ -182,7 +182,7 @@ class SecurityHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new SecurityHelper();
         $this->inject($helper, 'securityContext', $mockSecurityContext);
 
-        $this->assertSame('this would be an account instance', $helper->getAccount());
+        self::assertSame('this would be an account instance', $helper->getAccount());
     }
 
     /**
@@ -191,7 +191,7 @@ class SecurityHelperTest extends \Neos\Flow\Tests\UnitTestCase
     public function hasRoleReturnsTrueForEverybodyRole()
     {
         $helper = new SecurityHelper();
-        $this->assertTrue($helper->hasRole('Neos.Flow:Everybody'));
+        self::assertTrue($helper->hasRole('Neos.Flow:Everybody'));
     }
 
     /**
@@ -205,7 +205,7 @@ class SecurityHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new SecurityHelper();
         $this->inject($helper, 'securityContext', $mockSecurityContext);
 
-        $this->assertFalse($helper->hasRole('Acme.Com:DummyRole'));
+        self::assertFalse($helper->hasRole('Acme.Com:DummyRole'));
     }
 
     /**
@@ -220,6 +220,6 @@ class SecurityHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $helper = new SecurityHelper();
         $this->inject($helper, 'securityContext', $mockSecurityContext);
 
-        $this->assertTrue($helper->hasRole('Acme.Com:GrantsAccess'));
+        self::assertTrue($helper->hasRole('Acme.Com:GrantsAccess'));
     }
 }

--- a/Neos.Eel/Tests/Unit/Helper/StringHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/StringHelperTest.php
@@ -43,7 +43,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->substr($string, $start, $length);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function substringExamples()
@@ -68,7 +68,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->substring($string, $start, $end);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function charAtExamples()
@@ -89,7 +89,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->charAt($string, $index);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function endsWithExamples()
@@ -110,7 +110,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->endsWith($string, $search, $position);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function chrExamples()
@@ -131,7 +131,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->chr($value);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function ordExamples()
@@ -152,7 +152,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->ord($value);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function indexOfExamples()
@@ -179,7 +179,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->indexOf($string, $search, $fromIndex);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function lastIndexOfExamples()
@@ -201,7 +201,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->lastIndexOf($string, $search, $fromIndex);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function pregMatchExamples()
@@ -219,7 +219,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->pregMatch($string, $pattern);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function pregMatchAllExamples()
@@ -237,7 +237,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->pregMatchAll($string, $pattern);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function pregReplaceExamples()
@@ -258,7 +258,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->pregReplace($string, $pattern, $replace);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function pregSplitExamples()
@@ -277,7 +277,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->pregSplit($string, $pattern, $limit);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function replaceExamples()
@@ -297,7 +297,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->replace($string, $search, $replace);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
 
@@ -319,7 +319,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->split($string, $separator, $limit);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function startsWithExamples()
@@ -341,7 +341,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->startsWith($string, $search, $position);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function firstLetterToUpperCaseExamples()
@@ -360,7 +360,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->firstLetterToUpperCase($string);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function firstLetterToLowerCaseExamples()
@@ -379,7 +379,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->firstLetterToLowerCase($string);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function toLowerCaseExamples()
@@ -397,7 +397,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->toLowerCase($string);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function toUpperCaseExamples()
@@ -415,7 +415,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->toUpperCase($string);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function isBlankExamples()
@@ -436,7 +436,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->isBlank($string);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function trimExamples()
@@ -457,7 +457,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->trim($string, $charlist);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function typeConversionExamples()
@@ -491,7 +491,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->$method($string);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function stripTagsExamples()
@@ -511,7 +511,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->stripTags($string, $allowedTags);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     /**
@@ -521,7 +521,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->nl2br('some' . chr(10) . 'string');
-        $this->assertSame('some<br />' . chr(10) . 'string', $result);
+        self::assertSame('some<br />' . chr(10) . 'string', $result);
     }
 
     /**
@@ -531,7 +531,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->rawUrlEncode('&foo|bar');
-        $this->assertSame('%26foo%7Cbar', $result);
+        self::assertSame('%26foo%7Cbar', $result);
     }
 
     public function htmlSpecialCharsExamples()
@@ -550,7 +550,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->htmlSpecialChars($string, $preserveEntities);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function cropExamples()
@@ -602,7 +602,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->$methodName($text, $maximumCharacters, $suffixString);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     /**
@@ -612,7 +612,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->md5('joh316');
-        $this->assertSame('bacb98acf97e0b6112b1d1b650b84971', $result);
+        self::assertSame('bacb98acf97e0b6112b1d1b650b84971', $result);
     }
 
     /**
@@ -622,7 +622,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->sha1('joh316');
-        $this->assertSame('063b3d108bed9f88fa618c6046de0dccadcf3158', $result);
+        self::assertSame('063b3d108bed9f88fa618c6046de0dccadcf3158', $result);
     }
 
     public function lengthExamples()
@@ -643,7 +643,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->length($input);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function wordCountExamples()
@@ -668,7 +668,7 @@ class StringHelperTest extends UnitTestCase
     {
         $helper = new StringHelper();
         $result = $helper->wordCount($input);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function base64encodeEncodesDataProvider()
@@ -691,7 +691,7 @@ class StringHelperTest extends UnitTestCase
     public function base64encodeEncodesTests($input, $expectedResult)
     {
         $helper = new StringHelper();
-        $this->assertSame($expectedResult, $helper->base64encode($input));
+        self::assertSame($expectedResult, $helper->base64encode($input));
     }
 
     public function base64decodeEncodesDataProvider()
@@ -713,7 +713,7 @@ class StringHelperTest extends UnitTestCase
     public function base64decodeEncodesTests($input, $expectedResult)
     {
         $helper = new StringHelper();
-        $this->assertSame($expectedResult, $helper->base64decode($input));
+        self::assertSame($expectedResult, $helper->base64decode($input));
     }
 
     /**
@@ -722,6 +722,6 @@ class StringHelperTest extends UnitTestCase
     public function base64decodeReturnsFalseIfGivenStringIsInvalidAndStrictModeIsSet()
     {
         $helper = new StringHelper();
-        $this->assertFalse($helper->base64decode('invälid input', true));
+        self::assertFalse($helper->base64decode('invälid input', true));
     }
 }

--- a/Neos.Eel/Tests/Unit/ProtectedContextTest.php
+++ b/Neos.Eel/Tests/Unit/ProtectedContextTest.php
@@ -71,7 +71,7 @@ class ProtectedContextTest extends UnitTestCase
         $evaluator = $this->createEvaluator();
         $result = $evaluator->evaluate('value.foo', $context);
 
-        $this->assertEquals('Bar', $result);
+        self::assertEquals('Bar', $result);
     }
 
     /**
@@ -88,7 +88,7 @@ class ProtectedContextTest extends UnitTestCase
 
         $result = $evaluator->evaluate('String.substr("Hello World", 6, 5)', $context);
 
-        $this->assertEquals('World', $result);
+        self::assertEquals('World', $result);
     }
 
     /**
@@ -127,7 +127,7 @@ class ProtectedContextTest extends UnitTestCase
         $evaluator = $this->createEvaluator();
 
         $result = $evaluator->evaluate('ident(value)', $context);
-        $this->assertEquals($securedObject, $result);
+        self::assertEquals($securedObject, $result);
 
         $evaluator->evaluate('ident(value).callMe("Foo")', $context);
     }
@@ -153,7 +153,7 @@ class ProtectedContextTest extends UnitTestCase
         $evaluator = $this->createEvaluator();
 
         $result = $evaluator->evaluate('Array.reverse(value)[0]', $context);
-        $this->assertEquals($securedObject, $result);
+        self::assertEquals($securedObject, $result);
 
         $evaluator->evaluate('Array.reverse(value)[0].callMe("Foo")', $context);
     }
@@ -179,7 +179,7 @@ class ProtectedContextTest extends UnitTestCase
         $evaluator = $this->createEvaluator();
 
         $result = $evaluator->evaluate('q(value).count()', $context);
-        $this->assertEquals(2, $result);
+        self::assertEquals(2, $result);
     }
 
     /**
@@ -198,7 +198,7 @@ class ProtectedContextTest extends UnitTestCase
         $evaluator = $this->createEvaluator();
 
         $result = $evaluator->evaluate('value.callMe("Foo")', $context);
-        $this->assertEquals('Hello, Foo!', $result);
+        self::assertEquals('Hello, Foo!', $result);
     }
 
     /**
@@ -212,7 +212,7 @@ class ProtectedContextTest extends UnitTestCase
 
         $evaluator = $this->createEvaluator();
         $result = $evaluator->evaluate('unknown.someMethod()', $context);
-        $this->assertEquals(null, $result);
+        self::assertEquals(null, $result);
     }
 
     /**

--- a/Neos.Eel/Tests/Unit/Validation/ExpressionSyntaxValidatorTest.php
+++ b/Neos.Eel/Tests/Unit/Validation/ExpressionSyntaxValidatorTest.php
@@ -19,7 +19,7 @@ class ExpressionSyntaxValidatorTest extends AbstractValidatorTestcase
      */
     public function validExpressionPasses()
     {
-        $this->assertFalse(
+        self::assertFalse(
             $this->validator->validate('foo.bar() * (18 + 2)')->hasErrors());
     }
 
@@ -28,7 +28,7 @@ class ExpressionSyntaxValidatorTest extends AbstractValidatorTestcase
      */
     public function invalidExpressionIsConsideredErroneous()
     {
-        $this->assertTrue(
+        self::assertTrue(
             $this->validator->validate('foo.bar( + (18 + 2)')->hasErrors());
     }
 
@@ -42,8 +42,8 @@ class ExpressionSyntaxValidatorTest extends AbstractValidatorTestcase
                 ->getFirstError()
                     ->getArguments();
 
-        $this->assertEquals('foo.bar( + (18 + 2)', $errorArguments[0]);
-        $this->assertEquals(7, $errorArguments[1]);
-        $this->assertEquals('( + (18 + 2)', $errorArguments[2]);
+        self::assertEquals('foo.bar( + (18 + 2)', $errorArguments[0]);
+        self::assertEquals(7, $errorArguments[1]);
+        self::assertEquals('( + (18 + 2)', $errorArguments[2]);
     }
 }

--- a/Neos.Error.Messages/Tests/Unit/MessageTest.php
+++ b/Neos.Error.Messages/Tests/Unit/MessageTest.php
@@ -26,7 +26,7 @@ class MessageTest extends \PHPUnit\Framework\TestCase
         $someMessage = 'The message';
         $someMessageCode = 12345;
         $message = new Message($someMessage, $someMessageCode);
-        $this->assertEquals($someMessage, $message->getMessage());
+        self::assertEquals($someMessage, $message->getMessage());
     }
 
     /**
@@ -37,7 +37,7 @@ class MessageTest extends \PHPUnit\Framework\TestCase
         $someArguments = ['Foo', 'Bar'];
         $someMessageCode = 12345;
         $message = new Message('', $someMessageCode, $someArguments);
-        $this->assertEquals($someArguments, $message->getArguments());
+        self::assertEquals($someArguments, $message->getArguments());
     }
 
     /**
@@ -48,7 +48,7 @@ class MessageTest extends \PHPUnit\Framework\TestCase
         $someMessage = 'The message';
         $someMessageCode = 12345;
         $message = new Message($someMessage, $someMessageCode);
-        $this->assertEquals($someMessageCode, $message->getCode());
+        self::assertEquals($someMessageCode, $message->getCode());
     }
 
     /**
@@ -59,7 +59,7 @@ class MessageTest extends \PHPUnit\Framework\TestCase
         $someMessage = 'The message';
         $someMessageCode = 12345;
         $message = new Message($someMessage, $someMessageCode);
-        $this->assertEquals($someMessage, $message->render());
+        self::assertEquals($someMessage, $message->render());
     }
 
     /**
@@ -74,7 +74,7 @@ class MessageTest extends \PHPUnit\Framework\TestCase
 
         $expectedResult = 'The message with Bar and Foo';
         $actualResult = $message->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -89,6 +89,6 @@ class MessageTest extends \PHPUnit\Framework\TestCase
 
         $expectedResult = 'The message with Bar and Foo';
         $actualResult = (string)$message;
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 }

--- a/Neos.Error.Messages/Tests/Unit/ResultTest.php
+++ b/Neos.Error.Messages/Tests/Unit/ResultTest.php
@@ -54,7 +54,7 @@ class ResultTest extends \PHPUnit\Framework\TestCase
         $this->result->$addMethodName($message);
 
         $getterMethodName = 'get' . $dataTypeInPlural;
-        $this->assertEquals([$message], $this->result->$getterMethodName());
+        self::assertEquals([$message], $this->result->$getterMethodName());
     }
 
     /**
@@ -68,7 +68,7 @@ class ResultTest extends \PHPUnit\Framework\TestCase
         $this->result->forProperty('foo')->$addMethodName($message);
 
         $getterMethodName = 'get' . $dataTypeInPlural;
-        $this->assertEquals([], $this->result->$getterMethodName());
+        self::assertEquals([], $this->result->$getterMethodName());
     }
 
     /**
@@ -84,7 +84,7 @@ class ResultTest extends \PHPUnit\Framework\TestCase
         $this->result->$addMethodName($message2);
 
         $getterMethodName = 'getFirst' . $dataTypeInSingular;
-        $this->assertSame($message1, $this->result->$getterMethodName());
+        self::assertSame($message1, $this->result->$getterMethodName());
     }
 
     /**
@@ -93,8 +93,8 @@ class ResultTest extends \PHPUnit\Framework\TestCase
     public function forPropertyShouldReturnSubResult()
     {
         $container2 = $this->result->forProperty('foo.bar');
-        $this->assertInstanceOf(Result::class, $container2);
-        $this->assertSame($container2, $this->result->forProperty('foo')->forProperty('bar'));
+        self::assertInstanceOf(Result::class, $container2);
+        self::assertSame($container2, $this->result->forProperty('foo')->forProperty('bar'));
     }
 
     /**
@@ -103,7 +103,7 @@ class ResultTest extends \PHPUnit\Framework\TestCase
     public function forPropertyWithEmptyStringShouldReturnSelf()
     {
         $container2 = $this->result->forProperty('');
-        $this->assertSame($container2, $this->result);
+        self::assertSame($container2, $this->result);
     }
 
     /**
@@ -112,7 +112,7 @@ class ResultTest extends \PHPUnit\Framework\TestCase
     public function forPropertyWithNullShouldReturnSelf()
     {
         $container2 = $this->result->forProperty(null);
-        $this->assertSame($container2, $this->result);
+        self::assertSame($container2, $this->result);
     }
 
     /**
@@ -126,7 +126,7 @@ class ResultTest extends \PHPUnit\Framework\TestCase
         $this->result->$addMethodName($message);
 
         $methodName = 'has' . $dataTypeInPlural;
-        $this->assertTrue($this->result->$methodName());
+        self::assertTrue($this->result->$methodName());
     }
 
     /**
@@ -140,7 +140,7 @@ class ResultTest extends \PHPUnit\Framework\TestCase
 
         $message = $this->getMockMessage($dataTypeInSingular);
         $this->result->forProperty('foo.bar')->$addMethodName($message);
-        $this->assertTrue($this->result->$methodName());
+        self::assertTrue($this->result->$methodName());
     }
 
     /**
@@ -153,7 +153,7 @@ class ResultTest extends \PHPUnit\Framework\TestCase
 
         $this->result->forProperty('foo.baz');
         $this->result->forProperty('foo.bar');
-        $this->assertFalse($this->result->$methodName());
+        self::assertFalse($this->result->$methodName());
     }
 
     /**
@@ -183,7 +183,7 @@ class ResultTest extends \PHPUnit\Framework\TestCase
             'foo.baz' => [$message2]
 
         ];
-        $this->assertEquals($expected, $this->result->$getMethodName());
+        self::assertEquals($expected, $this->result->$getMethodName());
     }
 
     /**
@@ -205,7 +205,7 @@ class ResultTest extends \PHPUnit\Framework\TestCase
             'foo.baz' => [$message2]
 
         ];
-        $this->assertEquals($expected, $this->result->$getMethodName());
+        self::assertEquals($expected, $this->result->$getMethodName());
     }
 
     /**
@@ -239,13 +239,13 @@ class ResultTest extends \PHPUnit\Framework\TestCase
 
         $this->result->merge($otherResult);
 
-        $this->assertSame([$notice1], $this->result->getNotices(), 'Notices are not merged correctly without recursion');
-        $this->assertSame([$notice3], $this->result->forProperty('foo')->getNotices(), 'Original sub-notices are overridden.');
-        $this->assertSame([$notice2], $this->result->forProperty('foo')->forProperty('bar')->getNotices(), 'Sub-notices are not copied.');
+        self::assertSame([$notice1], $this->result->getNotices(), 'Notices are not merged correctly without recursion');
+        self::assertSame([$notice3], $this->result->forProperty('foo')->getNotices(), 'Original sub-notices are overridden.');
+        self::assertSame([$notice2], $this->result->forProperty('foo')->forProperty('bar')->getNotices(), 'Sub-notices are not copied.');
 
-        $this->assertSame([$warning2, $warning3, $warning1], $this->result->getWarnings());
+        self::assertSame([$warning2, $warning3, $warning1], $this->result->getWarnings());
 
-        $this->assertSame([$error3], $this->result->getErrors());
-        $this->assertSame([$error1, $error2], $this->result->forProperty('foo')->getErrors());
+        self::assertSame([$error3], $this->result->getErrors());
+        self::assertSame([$error1, $error2], $this->result->forProperty('foo')->getErrors());
     }
 }

--- a/Neos.Flow.Log/Tests/Unit/Backend/AbstractBackendTest.php
+++ b/Neos.Flow.Log/Tests/Unit/Backend/AbstractBackendTest.php
@@ -52,6 +52,6 @@ class AbstractBackendTest extends UnitTestCase
     {
         $className = $this->backendClassName;
         $backend = new $className(['someOption' => 'someValue']);
-        $this->assertSame('someValue', $backend->getSomeOption());
+        self::assertSame('someValue', $backend->getSomeOption());
     }
 }

--- a/Neos.Flow.Log/Tests/Unit/Backend/FileBackendTest.php
+++ b/Neos.Flow.Log/Tests/Unit/Backend/FileBackendTest.php
@@ -37,7 +37,7 @@ class FileBackendTest extends UnitTestCase
         $logFileUrl = vfsStream::url('testDirectory') . '/test.log';
         $backend = new FileBackend(['logFileUrl' => $logFileUrl]);
         $backend->open();
-        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('test.log'));
+        self::assertTrue(vfsStreamWrapper::getRoot()->hasChild('test.log'));
     }
 
     /**
@@ -59,7 +59,7 @@ class FileBackendTest extends UnitTestCase
         $logFileUrl = vfsStream::url('testDirectory') . '/foo/test.log';
         $backend = new FileBackend(['logFileUrl' => $logFileUrl, 'createParentDirectories' => true]);
         $backend->open();
-        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('foo'));
+        self::assertTrue(vfsStreamWrapper::getRoot()->hasChild('foo'));
     }
 
     /**
@@ -74,7 +74,7 @@ class FileBackendTest extends UnitTestCase
         $backend->append('foo');
 
         $pidOffset = function_exists('posix_getpid') ? 10 : 0;
-        $this->assertSame(53 + $pidOffset + strlen(PHP_EOL), vfsStreamWrapper::getRoot()->getChild('test.log')->size());
+        self::assertSame(53 + $pidOffset + strlen(PHP_EOL), vfsStreamWrapper::getRoot()->getChild('test.log')->size());
     }
 
     /**
@@ -90,7 +90,7 @@ class FileBackendTest extends UnitTestCase
         $backend->append('foo');
 
         $pidOffset = function_exists('posix_getpid') ? 10 : 0;
-        $this->assertSame(68 + $pidOffset + strlen(PHP_EOL), vfsStreamWrapper::getRoot()->getChild('test.log')->size());
+        self::assertSame(68 + $pidOffset + strlen(PHP_EOL), vfsStreamWrapper::getRoot()->getChild('test.log')->size());
     }
 
     /**
@@ -105,7 +105,7 @@ class FileBackendTest extends UnitTestCase
 
         $backend->append('foo', LOG_INFO);
 
-        $this->assertSame(0, vfsStreamWrapper::getRoot()->getChild('test.log')->size());
+        self::assertSame(0, vfsStreamWrapper::getRoot()->getChild('test.log')->size());
     }
 
     /**
@@ -122,8 +122,8 @@ class FileBackendTest extends UnitTestCase
         $backend->setLogFilesToKeep(1);
         $backend->open();
 
-        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('test.log'));
-        $this->assertSame('', file_get_contents($logFileUrl));
-        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('test.log.1'));
+        self::assertTrue(vfsStreamWrapper::getRoot()->hasChild('test.log'));
+        self::assertSame('', file_get_contents($logFileUrl));
+        self::assertTrue(vfsStreamWrapper::getRoot()->hasChild('test.log.1'));
     }
 }

--- a/Neos.Flow.Log/Tests/Unit/Backend/JsonFileBackendTest.php
+++ b/Neos.Flow.Log/Tests/Unit/Backend/JsonFileBackendTest.php
@@ -41,7 +41,7 @@ class JsonFileBackendTest extends UnitTestCase
 
         $logLine = file_get_contents('vfs://testDirectory/test.log');
         $actualData = json_decode($logLine, true);
-        $this->assertNotFalse($actualData);
+        self::assertNotFalse($actualData);
 
         $expectedOrigin = [
             'packageKey' => 'Neos.Flow.Log',
@@ -49,16 +49,16 @@ class JsonFileBackendTest extends UnitTestCase
             'methodName' => __FUNCTION__
         ];
 
-        $this->assertGreaterThanOrEqual((new \DateTime($actualData['timestamp']))->getTimestamp(), time());
-        $this->assertEquals($actualData['severity'], 'warning');
-        $this->assertEquals($actualData['origin'], $expectedOrigin);
-        $this->assertEquals($actualData['message'], 'the log message');
-        $this->assertEquals($actualData['additionalData'], ['foo' => 'bar']);
-        $this->assertEquals($actualData['remoteIp'], '');
+        self::assertGreaterThanOrEqual((new \DateTime($actualData['timestamp']))->getTimestamp(), time());
+        self::assertEquals($actualData['severity'], 'warning');
+        self::assertEquals($actualData['origin'], $expectedOrigin);
+        self::assertEquals($actualData['message'], 'the log message');
+        self::assertEquals($actualData['additionalData'], ['foo' => 'bar']);
+        self::assertEquals($actualData['remoteIp'], '');
 
 
         if (function_exists('posix_getpid')) {
-            $this->assertEquals($actualData['processId'], posix_getpid());
+            self::assertEquals($actualData['processId'], posix_getpid());
         }
     }
 }

--- a/Neos.Flow.Log/Tests/Unit/Psr/LoggerTest.php
+++ b/Neos.Flow.Log/Tests/Unit/Psr/LoggerTest.php
@@ -59,7 +59,7 @@ class LoggerTest extends UnitTestCase
         try {
             $psrLogger->log($psrLogLevel, 'some message');
         } catch (\Throwable $throwable) {
-            $this->assertTrue($willError, $throwable->getMessage());
+            self::assertTrue($willError, $throwable->getMessage());
         }
     }
 

--- a/Neos.Flow/Tests/Functional/Aop/AopProxyTest.php
+++ b/Neos.Flow/Tests/Functional/Aop/AopProxyTest.php
@@ -24,7 +24,7 @@ class AopProxyTest extends FunctionalTestCase
     public function advicesAreExecutedAgainIfAnOverriddenMethodCallsItsParentMethod()
     {
         $targetClass = new Fixtures\ChildClassOfTargetClass01();
-        $this->assertEquals('Greetings, I just wanted to say: Hello World World', $targetClass->sayHello());
+        self::assertEquals('Greetings, I just wanted to say: Hello World World', $targetClass->sayHello());
     }
 
     /**
@@ -33,7 +33,7 @@ class AopProxyTest extends FunctionalTestCase
     public function anAdvicedParentMethodIsCalledCorrectlyIfANonAdvicedOverridingMethodCallsIt()
     {
         $targetClass = new Fixtures\ChildClassOfTargetClass01();
-        $this->assertEquals('Two plus two makes five! For big twos and small fives! That was smart, eh?', $targetClass->saySomethingSmart());
+        self::assertEquals('Two plus two makes five! For big twos and small fives! That was smart, eh?', $targetClass->saySomethingSmart());
     }
 
     /**
@@ -43,9 +43,9 @@ class AopProxyTest extends FunctionalTestCase
     {
         $proxiedClass = new Fixtures\EntityWithOptionalConstructorArguments('argument1', null, 'argument3');
 
-        $this->assertEquals('argument1', $proxiedClass->argument1);
-        $this->assertNull($proxiedClass->argument2);
-        $this->assertEquals('argument3', $proxiedClass->argument3);
+        self::assertEquals('argument1', $proxiedClass->argument1);
+        self::assertNull($proxiedClass->argument2);
+        self::assertEquals('argument3', $proxiedClass->argument3);
     }
 
     /**
@@ -54,7 +54,7 @@ class AopProxyTest extends FunctionalTestCase
     public function staticMethodsCannotBeAdvised()
     {
         $targetClass01 = new Fixtures\TargetClass01();
-        $this->assertSame('I won\'t take any advice', $targetClass01->someStaticMethod());
+        self::assertSame('I won\'t take any advice', $targetClass01->someStaticMethod());
     }
 
     /**
@@ -64,7 +64,7 @@ class AopProxyTest extends FunctionalTestCase
     {
         $targetClass = new Fixtures\ChildClassOfTargetClass01();
         $greeting = $targetClass->greet('Flow');
-        $this->assertEquals('Hello, me', $greeting);
+        self::assertEquals('Hello, me', $greeting);
     }
 
     /**
@@ -73,8 +73,8 @@ class AopProxyTest extends FunctionalTestCase
     public function cloneCanCallParentCloneMethod()
     {
         $entity = new Fixtures\PrototypeClassGsubsub();
-        $this->assertSame('real', $entity->realOrCloned);
+        self::assertSame('real', $entity->realOrCloned);
         $clone = clone $entity;
-        $this->assertSame('cloned!', $clone->realOrCloned);
+        self::assertSame('cloned!', $clone->realOrCloned);
     }
 }

--- a/Neos.Flow/Tests/Functional/Aop/FrameworkTest.php
+++ b/Neos.Flow/Tests/Functional/Aop/FrameworkTest.php
@@ -25,7 +25,7 @@ class FrameworkTest extends FunctionalTestCase
     public function resultOfSayHelloMethodIsModifiedByWorldAdvice()
     {
         $targetClass = new Fixtures\TargetClass01();
-        $this->assertSame('Hello World', $targetClass->sayHello());
+        self::assertSame('Hello World', $targetClass->sayHello());
     }
 
     /**
@@ -38,7 +38,7 @@ class FrameworkTest extends FunctionalTestCase
             $targetClass->sayHelloAndThrow(true);
         } catch (\Exception $exception) {
         }
-        $this->assertSame('Hello World', $targetClass->sayHelloAndThrow(false));
+        self::assertSame('Hello World', $targetClass->sayHelloAndThrow(false));
     }
 
     /**
@@ -47,8 +47,8 @@ class FrameworkTest extends FunctionalTestCase
     public function resultOfGreetMethodIsModifiedBySpecialNameAdvice()
     {
         $targetClass = new Fixtures\TargetClass01();
-        $this->assertSame('Hello, me', $targetClass->greet('Flow'));
-        $this->assertSame('Hello, Christopher', $targetClass->greet('Christopher'));
+        self::assertSame('Hello, me', $targetClass->greet('Flow'));
+        self::assertSame('Hello, Christopher', $targetClass->greet('Christopher'));
     }
 
     /**
@@ -62,11 +62,11 @@ class FrameworkTest extends FunctionalTestCase
         $splObjectStorage = new \SplObjectStorage();
         $splObjectStorage->attach($name);
         $targetClass->setCurrentName($name);
-        $this->assertEquals('Hello, special guest', $targetClass->greetMany($splObjectStorage));
+        self::assertEquals('Hello, special guest', $targetClass->greetMany($splObjectStorage));
         $targetClass->setCurrentName(null);
-        $this->assertEquals('Hello, Flow', $targetClass->greetMany($splObjectStorage));
+        self::assertEquals('Hello, Flow', $targetClass->greetMany($splObjectStorage));
         $targetClass->setCurrentName($otherName);
-        $this->assertEquals('Hello, Flow', $targetClass->greetMany($splObjectStorage));
+        self::assertEquals('Hello, Flow', $targetClass->greetMany($splObjectStorage));
     }
 
     /**
@@ -75,7 +75,7 @@ class FrameworkTest extends FunctionalTestCase
     public function constructorAdvicesAreInvoked()
     {
         $targetClass = new Fixtures\TargetClass01();
-        $this->assertSame('AVRO RJ100 is lousier than A-380', $targetClass->constructorResult);
+        self::assertSame('AVRO RJ100 is lousier than A-380', $targetClass->constructorResult);
     }
 
     /**
@@ -84,9 +84,9 @@ class FrameworkTest extends FunctionalTestCase
     public function withinPointcutsAlsoAcceptClassNames()
     {
         $targetClass = new Fixtures\TargetClass01();
-        $this->assertSame('Flow is Rocket Science', $targetClass->sayWhatFlowIs(), 'TargetClass01');
+        self::assertSame('Flow is Rocket Science', $targetClass->sayWhatFlowIs(), 'TargetClass01');
         $childClass = new Fixtures\ChildClassOfTargetClass01();
-        $this->assertSame('Flow is not Rocket Science', $childClass->sayWhatFlowIs(), 'Child class of TargetClass01');
+        self::assertSame('Flow is not Rocket Science', $childClass->sayWhatFlowIs(), 'Child class of TargetClass01');
     }
 
     /**
@@ -96,7 +96,7 @@ class FrameworkTest extends FunctionalTestCase
     {
         $className = Fixtures\TargetClass01::class;
         $targetClass = unserialize('O:' . strlen($className) . ':"' . $className . '":0:{};');
-        $this->assertSame('Hello, me', $targetClass->greet('Flow'));
+        self::assertSame('Hello, me', $targetClass->greet('Flow'));
     }
 
     /**
@@ -106,7 +106,7 @@ class FrameworkTest extends FunctionalTestCase
     {
         $targetClass = new Fixtures\TargetClass02();
         $targetClass->publicTargetMethod('foo');
-        $this->assertTrue($targetClass->afterReturningAdviceWasInvoked);
+        self::assertTrue($targetClass->afterReturningAdviceWasInvoked);
     }
 
     /**
@@ -122,7 +122,7 @@ class FrameworkTest extends FunctionalTestCase
     public function codeAfterTheAopCodeInTheProxyMethodIsOnlyCalledOnce()
     {
         $targetClass = new Fixtures\TargetClass01();
-        $this->assertEquals(1, $targetClass->initializeObjectCallCounter);
+        self::assertEquals(1, $targetClass->initializeObjectCallCounter);
     }
 
     /**
@@ -137,7 +137,7 @@ class FrameworkTest extends FunctionalTestCase
     {
         $targetClass = new Fixtures\TargetClass02();
         $result = $targetClass->publicTargetMethod('foo');
-        $this->assertEquals('foo bar', $result);
+        self::assertEquals('foo bar', $result);
     }
 
     /**
@@ -147,9 +147,9 @@ class FrameworkTest extends FunctionalTestCase
     {
         $targetClass = $this->objectManager->get(Fixtures\TargetClass01::class);
         $name = new Fixtures\Name('Neos');
-        $this->assertSame('Hello, old friend', $targetClass->greetObject($name), 'Aspect should greet with "old friend" if the name property equals "Neos"');
+        self::assertSame('Hello, old friend', $targetClass->greetObject($name), 'Aspect should greet with "old friend" if the name property equals "Neos"');
         $name = new Fixtures\Name('Christopher');
-        $this->assertSame('Hello, Christopher', $targetClass->greetObject($name));
+        self::assertSame('Hello, Christopher', $targetClass->greetObject($name));
     }
 
     /**
@@ -160,11 +160,11 @@ class FrameworkTest extends FunctionalTestCase
         $targetClass = $this->objectManager->get(Fixtures\TargetClass01::class);
         $name = new Fixtures\Name('Fusion');
         $targetClass->setCurrentName($name);
-        $this->assertSame('Hello, you', $targetClass->greetObject($name), 'Aspect should greet with "you" if the current name equals the name argument');
+        self::assertSame('Hello, you', $targetClass->greetObject($name), 'Aspect should greet with "you" if the current name equals the name argument');
 
         $name = new Fixtures\Name('Christopher');
         $targetClass->setCurrentName(null);
-        $this->assertSame('Hello, Christopher', $targetClass->greetObject($name), 'Aspect should greet with given name if the current name is not equal to the name argument');
+        self::assertSame('Hello, Christopher', $targetClass->greetObject($name), 'Aspect should greet with given name if the current name is not equal to the name argument');
     }
 
     /**
@@ -173,8 +173,8 @@ class FrameworkTest extends FunctionalTestCase
     public function globalObjectsAreSupportedInMethodRuntimeCondition()
     {
         $targetClass = $this->objectManager->get(Fixtures\TargetClass01::class);
-        $this->assertSame('Hello, superstar', $targetClass->greet('Robbie'), 'Aspect should greet with "superstar" if the global context getNameOfTheWeek equals the given name');
-        $this->assertSame('Hello, Christopher', $targetClass->greet('Christopher'), 'Aspect should greet with given name if the global context getNameOfTheWeek does not equal the given name');
+        self::assertSame('Hello, superstar', $targetClass->greet('Robbie'), 'Aspect should greet with "superstar" if the global context getNameOfTheWeek equals the given name');
+        self::assertSame('Hello, Christopher', $targetClass->greet('Christopher'), 'Aspect should greet with given name if the global context getNameOfTheWeek does not equal the given name');
     }
 
     /**
@@ -187,9 +187,9 @@ class FrameworkTest extends FunctionalTestCase
     {
         $targetClass = new Fixtures\TargetClass03();
 
-        $this->assertInstanceOf(Fixtures\Introduced01Interface::class, $targetClass);
-        $this->assertTrue(method_exists($targetClass, 'introducedMethod01'));
-        $this->assertTrue(method_exists($targetClass, 'introducedMethodWithArguments'));
+        self::assertInstanceOf(Fixtures\Introduced01Interface::class, $targetClass);
+        self::assertTrue(method_exists($targetClass, 'introducedMethod01'));
+        self::assertTrue(method_exists($targetClass, 'introducedMethodWithArguments'));
     }
 
     /**
@@ -199,7 +199,7 @@ class FrameworkTest extends FunctionalTestCase
     {
         $targetClass = new Fixtures\TargetClass01();
 
-        $this->assertEquals('I\'m the traitor', call_user_func([$targetClass, 'introducedTraitMethod']));
+        self::assertEquals('I\'m the traitor', call_user_func([$targetClass, 'introducedTraitMethod']));
     }
 
     /**
@@ -209,8 +209,8 @@ class FrameworkTest extends FunctionalTestCase
     {
         $targetClass = new Fixtures\TargetClass01();
 
-        $this->assertNotEquals('Hello from trait', $targetClass->sayHello());
-        $this->assertEquals('Hello World', $targetClass->sayHello());
+        self::assertNotEquals('Hello from trait', $targetClass->sayHello());
+        self::assertEquals('Hello World', $targetClass->sayHello());
     }
 
     /**
@@ -222,8 +222,8 @@ class FrameworkTest extends FunctionalTestCase
     {
         $targetClass = new Fixtures\TargetClass03();
 
-        $this->assertTrue(property_exists(get_class($targetClass), 'introducedPublicProperty'));
-        $this->assertTrue(property_exists(get_class($targetClass), 'introducedProtectedProperty'));
+        self::assertTrue(property_exists(get_class($targetClass), 'introducedPublicProperty'));
+        self::assertTrue(property_exists(get_class($targetClass), 'introducedProtectedProperty'));
     }
 
     /**
@@ -235,8 +235,8 @@ class FrameworkTest extends FunctionalTestCase
     {
         $targetClass = new Fixtures\TargetClass04();
 
-        $this->assertTrue(property_exists(get_class($targetClass), 'introducedPublicProperty'));
-        $this->assertTrue(property_exists(get_class($targetClass), 'introducedProtectedProperty'));
+        self::assertTrue(property_exists(get_class($targetClass), 'introducedPublicProperty'));
+        self::assertTrue(property_exists(get_class($targetClass), 'introducedProtectedProperty'));
     }
 
     /**
@@ -246,7 +246,7 @@ class FrameworkTest extends FunctionalTestCase
     {
         $targetClass = new Fixtures\TargetClass01();
         $result = $targetClass->greet('Andi');
-        $this->assertEquals('Hello, Robert', $result, 'The method argument "name" has not been changed as expected by the "changeNameArgumentAdvice".');
+        self::assertEquals('Hello, Robert', $result, 'The method argument "name" has not been changed as expected by the "changeNameArgumentAdvice".');
     }
 
     /**
@@ -256,8 +256,8 @@ class FrameworkTest extends FunctionalTestCase
     {
         $targetClass = new Fixtures\TargetClass03();
 
-        $this->assertSame(null, $targetClass->introducedPublicProperty);
-        $this->assertSame('thisIsADefaultValueBelieveItOrNot', $targetClass->introducedProtectedPropertyWithDefaultValue);
+        self::assertSame(null, $targetClass->introducedPublicProperty);
+        self::assertSame('thisIsADefaultValueBelieveItOrNot', $targetClass->introducedProtectedPropertyWithDefaultValue);
     }
 
     /**
@@ -271,7 +271,7 @@ class FrameworkTest extends FunctionalTestCase
 
         $targetClass = new Fixtures\TargetClassWithPhp7Features();
 
-        $this->assertSame('This is so NaN', $targetClass->methodWithStaticTypeDeclarations('The answer', 42, $targetClass));
+        self::assertSame('This is so NaN', $targetClass->methodWithStaticTypeDeclarations('The answer', 42, $targetClass));
     }
 
     /**
@@ -280,7 +280,7 @@ class FrameworkTest extends FunctionalTestCase
     public function finalClassesCanBeAdvised()
     {
         $targetClass = new Fixtures\TargetClassWithFinalModifier();
-        $this->assertSame('nothing is final!', $targetClass->someMethod());
+        self::assertSame('nothing is final!', $targetClass->someMethod());
     }
 
     /**
@@ -289,7 +289,7 @@ class FrameworkTest extends FunctionalTestCase
     public function finalMethodsCanBeAdvised()
     {
         $targetClass = new Fixtures\TargetClass01();
-        $this->assertSame('I am final. But, as said, nothing is final!', $targetClass->someFinalMethod());
+        self::assertSame('I am final. But, as said, nothing is final!', $targetClass->someFinalMethod());
     }
 
     /**
@@ -298,7 +298,7 @@ class FrameworkTest extends FunctionalTestCase
     public function finalMethodsStayFinalEvenIfTheyAreNotAdvised()
     {
         $targetClass = new Fixtures\TargetClass01();
-        $this->assertTrue((new \ReflectionMethod($targetClass, 'someOtherFinalMethod'))->isFinal());
+        self::assertTrue((new \ReflectionMethod($targetClass, 'someOtherFinalMethod'))->isFinal());
     }
 
     /**
@@ -312,7 +312,7 @@ class FrameworkTest extends FunctionalTestCase
 
         $targetClass = new Fixtures\TargetClassWithPhp7Features();
 
-        $this->assertSame('adviced: it works', $targetClass->methodWithStaticScalarReturnTypeDeclaration());
+        self::assertSame('adviced: it works', $targetClass->methodWithStaticScalarReturnTypeDeclaration());
     }
 
     /**
@@ -326,7 +326,7 @@ class FrameworkTest extends FunctionalTestCase
 
         $targetClass = new Fixtures\TargetClassWithPhp7Features();
 
-        $this->assertInstanceOf(Fixtures\TargetClassWithPhp7Features::class, $targetClass->methodWithStaticObjectReturnTypeDeclaration());
+        self::assertInstanceOf(Fixtures\TargetClassWithPhp7Features::class, $targetClass->methodWithStaticObjectReturnTypeDeclaration());
     }
 
 
@@ -344,7 +344,7 @@ class FrameworkTest extends FunctionalTestCase
     //
     //        $targetClass = new Fixtures\TargetClassWithPhp71Features();
     //
-    //        $this->assertSame('adviced: NULL', $targetClass->methodWithNullableScalarReturnTypeDeclaration());
+    //        self::assertSame('adviced: NULL', $targetClass->methodWithNullableScalarReturnTypeDeclaration());
     //    }
     //
     //    /**
@@ -358,6 +358,6 @@ class FrameworkTest extends FunctionalTestCase
     //
     //        $targetClass = new Fixtures\TargetClassWithPhp71Features();
     //
-    //        $this->assertNull($targetClass->methodWithNullableObjectReturnTypeDeclaration());
+    //        self::assertNull($targetClass->methodWithNullableObjectReturnTypeDeclaration());
     //    }
 }

--- a/Neos.Flow/Tests/Functional/Aop/PointcutExpressionTest.php
+++ b/Neos.Flow/Tests/Functional/Aop/PointcutExpressionTest.php
@@ -25,6 +25,6 @@ class PointcutExpressionTest extends FunctionalTestCase
     public function settingFilterMatchesIfSpecifiedSettingIsEnabled()
     {
         $target = new Fixtures\PointcutExpressionTestingTarget();
-        $this->assertSame('pointcutExpressionSettingFilterOptionA on', $target->testSettingFilter());
+        self::assertSame('pointcutExpressionSettingFilterOptionA on', $target->testSettingFilter());
     }
 }

--- a/Neos.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
+++ b/Neos.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
@@ -179,7 +179,7 @@ class ConfigurationValidationTest extends FunctionalTestCase
             }
             $this->fail($output);
         }
-        $this->assertFalse($validationResult->hasErrors());
+        self::assertFalse($validationResult->hasErrors());
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/Configuration/SchemaValidationTest.php
+++ b/Neos.Flow/Tests/Functional/Configuration/SchemaValidationTest.php
@@ -100,6 +100,6 @@ class SchemaValidationTest extends FunctionalTestCase
         $hasErrors = $result->hasErrors();
 
         $message = sprintf('Schema-file "%s" is not valid: %s', $schemaFile, $result->getFirstError());
-        $this->assertFalse($hasErrors, $message);
+        self::assertFalse($hasErrors, $message);
     }
 }

--- a/Neos.Flow/Tests/Functional/Error/DebuggerTest.php
+++ b/Neos.Flow/Tests/Functional/Error/DebuggerTest.php
@@ -43,7 +43,7 @@ class DebuggerTest extends FunctionalTestCase
     public function ignoredClassesCanBeOverwrittenBySettings()
     {
         $object = new ApplicationContext('Development');
-        $this->assertEquals(sprintf('%s prototype object', ApplicationContext::class), Debugger::renderDump($object, 0, true));
+        self::assertEquals(sprintf('%s prototype object', ApplicationContext::class), Debugger::renderDump($object, 0, true));
         Debugger::clearState();
 
         $currentConfiguration = ObjectAccess::getProperty($this->configurationManager, 'configurations', true);
@@ -51,6 +51,6 @@ class DebuggerTest extends FunctionalTestCase
         $newConfiguration = Arrays::arrayMergeRecursiveOverrule($currentConfiguration, $configurationOverwrite);
         ObjectAccess::setProperty($this->configurationManager, 'configurations', $newConfiguration, true);
 
-        $this->assertStringContainsString('rootContextString', Debugger::renderDump($object, 0, true));
+        self::assertStringContainsString('rootContextString', Debugger::renderDump($object, 0, true));
     }
 }

--- a/Neos.Flow/Tests/Functional/Http/Client/BrowserTest.php
+++ b/Neos.Flow/Tests/Functional/Http/Client/BrowserTest.php
@@ -50,7 +50,7 @@ class BrowserTest extends FunctionalTestCase
     public function redirectsAreFollowed()
     {
         $response = $this->browser->request('http://localhost/test/http/redirecting');
-        $this->assertEquals('arrived.', $response->getContent());
+        self::assertEquals('arrived.', $response->getContent());
     }
 
     /**
@@ -62,8 +62,8 @@ class BrowserTest extends FunctionalTestCase
     {
         $this->browser->setFollowRedirects(false);
         $response = $this->browser->request('http://localhost/test/http/redirecting');
-        $this->assertStringNotContainsString('arrived.', $response->getContent());
-        $this->assertEquals(303, $response->getStatusCode());
-        $this->assertEquals('http://localhost/test/http/redirecting/tohere', $response->getHeader('Location'));
+        self::assertStringNotContainsString('arrived.', $response->getContent());
+        self::assertEquals(303, $response->getStatusCode());
+        self::assertEquals('http://localhost/test/http/redirecting/tohere', $response->getHeader('Location'));
     }
 }

--- a/Neos.Flow/Tests/Functional/Http/Client/CurlEngineTest.php
+++ b/Neos.Flow/Tests/Functional/Http/Client/CurlEngineTest.php
@@ -46,7 +46,7 @@ class CurlEngineTest extends FunctionalTestCase
         $this->browser->getRequestEngine()->setOption(CURLOPT_FOLLOWLOCATION, true);
         $this->browser->setFollowRedirects(false);
         $response = $this->browser->request('http://www.neos.io');
-        $this->assertStringStartsWith('<!DOCTYPE html>', $response->getContent());
+        self::assertStringStartsWith('<!DOCTYPE html>', $response->getContent());
     }
 
     /**
@@ -57,6 +57,6 @@ class CurlEngineTest extends FunctionalTestCase
     public function getRequestReturnsResponse()
     {
         $response = $this->browser->request('http://www.neos.io');
-        $this->assertStringContainsString('This website is powered by Neos', $response->getContent());
+        self::assertStringContainsString('This website is powered by Neos', $response->getContent());
     }
 }

--- a/Neos.Flow/Tests/Functional/Http/Client/InternalRequestEngineTest.php
+++ b/Neos.Flow/Tests/Functional/Http/Client/InternalRequestEngineTest.php
@@ -55,6 +55,6 @@ class InternalRequestEngineTest extends FunctionalTestCase
     public function securityContextContainsTokens()
     {
         $response = $this->browser->request('http://localhost/test/security/restricted');
-        $this->assertEquals('1222268609', $response->getHeader('X-Flow-ExceptionCode'));
+        self::assertEquals('1222268609', $response->getHeader('X-Flow-ExceptionCode'));
     }
 }

--- a/Neos.Flow/Tests/Functional/I18n/Cldr/CldrRepositoryTest.php
+++ b/Neos.Flow/Tests/Functional/I18n/Cldr/CldrRepositoryTest.php
@@ -65,9 +65,9 @@ class CldrRepositoryTest extends FunctionalTestCase
         $localeImplementingChaining = new I18n\Locale('de_DE');
 
         $cldrModel = $this->cldrRepository->getModelForLocale($localeImplementingChaining);
-        
-        $this->assertContains(Files::concatenatePaths([$this->cldrBasePath, 'main/root.xml']), ObjectAccess::getProperty($cldrModel, 'sourcePaths', true));
-        $this->assertContains(Files::concatenatePaths([$this->cldrBasePath, 'main/de_DE.xml']), ObjectAccess::getProperty($cldrModel, 'sourcePaths', true));
-        $this->assertContains(Files::concatenatePaths([$this->cldrBasePath, 'main/de.xml']), ObjectAccess::getProperty($cldrModel, 'sourcePaths', true));
+
+        self::assertContains(Files::concatenatePaths([$this->cldrBasePath, 'main/root.xml']), ObjectAccess::getProperty($cldrModel, 'sourcePaths', true));
+        self::assertContains(Files::concatenatePaths([$this->cldrBasePath, 'main/de_DE.xml']), ObjectAccess::getProperty($cldrModel, 'sourcePaths', true));
+        self::assertContains(Files::concatenatePaths([$this->cldrBasePath, 'main/de.xml']), ObjectAccess::getProperty($cldrModel, 'sourcePaths', true));
     }
 }

--- a/Neos.Flow/Tests/Functional/I18n/FormatResolverTest.php
+++ b/Neos.Flow/Tests/Functional/I18n/FormatResolverTest.php
@@ -56,7 +56,7 @@ class FormatResolverTest extends FunctionalTestCase
     public function formatResolverWithDatetimeReplacesCorrectValues($stringWithPlaceholders, $arguments, $locale, $expected)
     {
         $result = $this->formatResolver->resolvePlaceholders($stringWithPlaceholders, $arguments, $locale);
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     /**
@@ -67,6 +67,6 @@ class FormatResolverTest extends FunctionalTestCase
         $actualFormatter = new Fixtures\SampleFormatter;
         $locale = new I18n\Locale('de');
         $testResult = $this->formatResolver->resolvePlaceholders(sprintf('{0,%s}', Fixtures\SampleFormatter::class), ['foo'], $locale);
-        $this->assertEquals($actualFormatter->format('foo', $locale), $testResult);
+        self::assertEquals($actualFormatter->format('foo', $locale), $testResult);
     }
 }

--- a/Neos.Flow/Tests/Functional/I18n/TranslatorTest.php
+++ b/Neos.Flow/Tests/Functional/I18n/TranslatorTest.php
@@ -54,7 +54,7 @@ class TranslatorTest extends FunctionalTestCase
     public function simpleTranslationByIdWorks($id, $locale, $translation)
     {
         $result = $this->translator->translateById($id, [], null, $locale, 'Main', 'Neos.Flow');
-        $this->assertEquals($translation, $result);
+        self::assertEquals($translation, $result);
     }
 
     /**
@@ -75,7 +75,7 @@ class TranslatorTest extends FunctionalTestCase
     public function simpleTranslationByLabelWorks($label, $locale, $translation)
     {
         $result = $this->translator->translateByOriginalLabel($label, [], null, $locale, 'Main', 'Neos.Flow');
-        $this->assertEquals($translation, $result);
+        self::assertEquals($translation, $result);
     }
 
     /**
@@ -96,7 +96,7 @@ class TranslatorTest extends FunctionalTestCase
     public function translationByLabelUsesPlaceholders($label, $arguments, $translation)
     {
         $result = $this->translator->translateByOriginalLabel($label, $arguments, null, new I18n\Locale('en'), 'ValidationErrors', 'Neos.Flow');
-        $this->assertEquals($translation, $result);
+        self::assertEquals($translation, $result);
     }
 
     /**
@@ -105,6 +105,6 @@ class TranslatorTest extends FunctionalTestCase
     public function translationByIdReturnsNullOnFailure()
     {
         $result = $this->translator->translateById('non-existing-id');
-        $this->assertNull($result);
+        self::assertNull($result);
     }
 }

--- a/Neos.Flow/Tests/Functional/I18n/Xliff/Service/XliffFileProviderTest.php
+++ b/Neos.Flow/Tests/Functional/I18n/Xliff/Service/XliffFileProviderTest.php
@@ -115,7 +115,7 @@ class XliffFileProviderTest extends FunctionalTestCase
     public function fileProviderReturnsUnchangedContentForFileWithoutOverride()
     {
         $fileData = $this->fileProvider->getMergedFileData('Vendor.BasePackage:Unmerged', new Locale('de'));
-        $this->assertSame([
+        self::assertSame([
             'key1' => [
                 [
                     'source' => 'Source string',
@@ -131,7 +131,7 @@ class XliffFileProviderTest extends FunctionalTestCase
     public function fileProviderMergesOverrideFromLaterLoadedPackageDeclaredByOriginalAndProductName()
     {
         $fileData = $this->fileProvider->getMergedFileData('Vendor.BasePackage:Main', new Locale('de'));
-        $this->assertSame([
+        self::assertSame([
             'key1' => [
                 [
                     'source' => 'Source string',
@@ -147,7 +147,7 @@ class XliffFileProviderTest extends FunctionalTestCase
     public function fileProviderReturnsLaterLoadedPackageDeclarationByOriginalAndProductNameIfNoOriginalPresent()
     {
         $fileData = $this->fileProvider->getMergedFileData('Vendor.BasePackage:WithoutBase', new Locale('de'));
-        $this->assertSame([
+        self::assertSame([
             'key1' => [
                 [
                     'source' => 'Additional source string',
@@ -163,7 +163,7 @@ class XliffFileProviderTest extends FunctionalTestCase
     public function fileProviderDoesNotMergeOverrideFromEarlierLoadedPackageDeclaredByOriginalAndProductName()
     {
         $fileData = $this->fileProvider->getMergedFileData('Vendor.DependentPackage:Main', new Locale('de'));
-        $this->assertSame([
+        self::assertSame([
             'key1' => [
                 [
                     'source' => 'Source string',
@@ -180,7 +180,7 @@ class XliffFileProviderTest extends FunctionalTestCase
     {
         $fileData = $this->fileProvider->getMergedFileData('Vendor.BasePackage:GlobalOverride', new Locale('en'));
 
-        $this->assertSame([
+        self::assertSame([
             'key1' => [
                 [
                     'source' => 'Source string',
@@ -197,7 +197,7 @@ class XliffFileProviderTest extends FunctionalTestCase
     {
         $fileData = $this->fileProvider->getMergedFileData('Vendor.BasePackage:GlobalOverride', new Locale('de'));
 
-        $this->assertSame([
+        self::assertSame([
             'key1' => [
                 [
                     'source' => 'Source string',

--- a/Neos.Flow/Tests/Functional/Log/Utility/LogEnvironmentTest.php
+++ b/Neos.Flow/Tests/Functional/Log/Utility/LogEnvironmentTest.php
@@ -58,6 +58,6 @@ class LogEnvironmentTest extends FunctionalTestCase
     public function fromMethodName($method, $expected)
     {
         $actual = LogEnvironment::fromMethodName($method);
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }

--- a/Neos.Flow/Tests/Functional/Mvc/AbstractControllerTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/AbstractControllerTest.php
@@ -49,7 +49,7 @@ class AbstractControllerTest extends FunctionalTestCase
     public function forwardPassesRequestToActionWithoutArguments()
     {
         $response = $this->browser->request('http://localhost/test/mvc/abstractcontrollertesta/forward?actionName=second');
-        $this->assertEquals('Second action was called', $response->getContent());
+        self::assertEquals('Second action was called', $response->getContent());
     }
 
     /**
@@ -61,7 +61,7 @@ class AbstractControllerTest extends FunctionalTestCase
     public function forwardPassesRequestToActionWithArguments()
     {
         $response = $this->browser->request('http://localhost/test/mvc/abstractcontrollertesta/forward?actionName=third&arguments[firstArgument]=foo&arguments[secondArgument]=bar');
-        $this->assertEquals('thirdAction-foo-bar--default', $response->getContent());
+        self::assertEquals('thirdAction-foo-bar--default', $response->getContent());
     }
 
     /**
@@ -73,6 +73,6 @@ class AbstractControllerTest extends FunctionalTestCase
     public function forwardPassesRequestToActionWithInternalArgumentsContainingObjects()
     {
         $response = $this->browser->request('http://localhost/test/mvc/abstractcontrollertesta/forward?actionName=fourth&passSomeObjectArguments=1&arguments[nonObject1]=First&arguments[nonObject2]=42');
-        $this->assertEquals('fourthAction-First-42-Neos\Error\Messages\Message', $response->getContent());
+        self::assertEquals('fourthAction-First-42-Neos\Error\Messages\Message', $response->getContent());
     }
 }

--- a/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
@@ -71,8 +71,8 @@ class ActionControllerTest extends FunctionalTestCase
     public function defaultActionSpecifiedInRouteIsCalledAndResponseIsReturned()
     {
         $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertesta');
-        $this->assertEquals('First action was called', $response->getContent());
-        $this->assertEquals('200 OK', $response->getStatus());
+        self::assertEquals('First action was called', $response->getContent());
+        self::assertEquals('200 OK', $response->getStatus());
     }
 
     /**
@@ -84,8 +84,8 @@ class ActionControllerTest extends FunctionalTestCase
     public function actionSpecifiedInActionRequestIsCalledAndResponseIsReturned()
     {
         $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertesta/second');
-        $this->assertEquals('Second action was called', $response->getContent());
-        $this->assertEquals('200 OK', $response->getStatus());
+        self::assertEquals('Second action was called', $response->getContent());
+        self::assertEquals('200 OK', $response->getStatus());
     }
 
     /**
@@ -97,7 +97,7 @@ class ActionControllerTest extends FunctionalTestCase
     public function queryStringOfAGetRequestIsParsedAndPassedToActionAsArguments()
     {
         $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertesta/third?secondArgument=bar&firstArgument=foo&third=baz');
-        $this->assertEquals('thirdAction-foo-bar-baz-default', $response->getContent());
+        self::assertEquals('thirdAction-foo-bar-baz-default', $response->getContent());
     }
 
     /**
@@ -106,7 +106,7 @@ class ActionControllerTest extends FunctionalTestCase
     public function defaultTemplateIsResolvedAndUsedAccordingToConventions()
     {
         $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertesta/fourth?emailAddress=example@neos.io');
-        $this->assertEquals('Fourth action <b>example@neos.io</b>', $response->getContent());
+        self::assertEquals('Fourth action <b>example@neos.io</b>', $response->getContent());
     }
 
     /**
@@ -122,7 +122,7 @@ class ActionControllerTest extends FunctionalTestCase
         $request->setHeader('Content-Length', 54);
 
         $response = $this->browser->sendRequest($request);
-        $this->assertEquals('putAction-first value-getValue', $response->getContent());
+        self::assertEquals('putAction-first value-getValue', $response->getContent());
     }
 
     /**
@@ -135,7 +135,7 @@ class ActionControllerTest extends FunctionalTestCase
         $request = Request::create(new Uri('http://localhost/test/mvc/actioncontrollertestc/non-existing-id'), 'GET');
 
         $response = $this->browser->sendRequest($request);
-        $this->assertSame(404, $response->getStatusCode());
+        self::assertSame(404, $response->getStatusCode());
     }
 
 
@@ -152,7 +152,7 @@ class ActionControllerTest extends FunctionalTestCase
         $request->setContent('<xml></xml>');
 
         $response = $this->browser->sendRequest($request);
-        $this->assertSame(406, $response->getStatusCode());
+        self::assertSame(406, $response->getStatusCode());
     }
 
     /**
@@ -169,7 +169,7 @@ class ActionControllerTest extends FunctionalTestCase
         $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertestb/showobjectargument', 'POST', $arguments);
 
         $expectedResult = '-invalid-';
-        $this->assertEquals($expectedResult, $response->getContent());
+        self::assertEquals($expectedResult, $response->getContent());
     }
 
     /**
@@ -179,7 +179,7 @@ class ActionControllerTest extends FunctionalTestCase
     public function ignoreValidationAnnotationIsObservedWithAndWithoutDollarSign()
     {
         $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertesta/ignorevalidation?brokenArgument1=toolong&brokenArgument2=tooshort');
-        $this->assertEquals('action was called', $response->getContent());
+        self::assertEquals('action was called', $response->getContent());
     }
 
     /**
@@ -193,7 +193,7 @@ class ActionControllerTest extends FunctionalTestCase
         $request->setContent('{"putArgument":"first value"}');
 
         $response = $this->browser->sendRequest($request);
-        $this->assertEquals('putAction-first value-getValue', $response->getContent());
+        self::assertEquals('putAction-first value-getValue', $response->getContent());
     }
 
     /**
@@ -210,7 +210,7 @@ class ActionControllerTest extends FunctionalTestCase
         $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertestb/requiredobject', 'POST', $arguments);
 
         $expectedResult = 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->requiredObjectAction().' . PHP_EOL;
-        $this->assertEquals($expectedResult, $response->getContent());
+        self::assertEquals($expectedResult, $response->getContent());
     }
 
     /**
@@ -227,7 +227,7 @@ class ActionControllerTest extends FunctionalTestCase
         $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertestb/optionalobject', 'POST', $arguments);
 
         $expectedResult = 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->optionalObjectAction().' . PHP_EOL;
-        $this->assertEquals($expectedResult, $response->getContent());
+        self::assertEquals($expectedResult, $response->getContent());
     }
 
     /**
@@ -238,7 +238,7 @@ class ActionControllerTest extends FunctionalTestCase
         $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertestb/optionalobject');
 
         $expectedResult = 'null';
-        $this->assertEquals($expectedResult, $response->getContent());
+        self::assertEquals($expectedResult, $response->getContent());
     }
 
     /**
@@ -249,7 +249,7 @@ class ActionControllerTest extends FunctionalTestCase
         $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertestb/optionalannotatedobject');
 
         $expectedResult = 'null';
-        $this->assertEquals($expectedResult, $response->getContent());
+        self::assertEquals($expectedResult, $response->getContent());
     }
 
     /**
@@ -266,7 +266,7 @@ class ActionControllerTest extends FunctionalTestCase
         $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertestb/notvalidatedgroupobject', 'POST', $arguments);
 
         $expectedResult = '-invalid-';
-        $this->assertEquals($expectedResult, $response->getContent());
+        self::assertEquals($expectedResult, $response->getContent());
     }
 
     /**
@@ -288,7 +288,7 @@ class ActionControllerTest extends FunctionalTestCase
         $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertestb/notvalidatedgroupcollection', 'POST', $arguments);
 
         $expectedResult = '-invalid-';
-        $this->assertEquals($expectedResult, $response->getContent());
+        self::assertEquals($expectedResult, $response->getContent());
     }
 
     /**
@@ -309,7 +309,7 @@ class ActionControllerTest extends FunctionalTestCase
         $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertestb/notvalidatedgroupobject', 'POST', $arguments);
 
         $expectedResult = '-invalid-';
-        $this->assertEquals($expectedResult, $response->getContent());
+        self::assertEquals($expectedResult, $response->getContent());
     }
 
     /**
@@ -326,7 +326,7 @@ class ActionControllerTest extends FunctionalTestCase
         $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertestb/validatedgroupobject', 'POST', $arguments);
 
         $expectedResult = 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->validatedGroupObjectAction().' . PHP_EOL;
-        $this->assertEquals($expectedResult, $response->getContent());
+        self::assertEquals($expectedResult, $response->getContent());
     }
 
     /**
@@ -348,7 +348,7 @@ class ActionControllerTest extends FunctionalTestCase
         $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertestb/validatedgroupcollection', 'POST', $arguments);
 
         $expectedResult = 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->validatedGroupCollectionAction().' . PHP_EOL;
-        $this->assertEquals($expectedResult, $response->getContent());
+        self::assertEquals($expectedResult, $response->getContent());
     }
 
     /**
@@ -368,7 +368,7 @@ class ActionControllerTest extends FunctionalTestCase
         $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertestb/validatedgroupobject', 'POST', $arguments);
 
         $expectedResult = 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->validatedGroupObjectAction().' . PHP_EOL;
-        $this->assertEquals($expectedResult, $response->getContent());
+        self::assertEquals($expectedResult, $response->getContent());
     }
 
     /**
@@ -437,7 +437,7 @@ class ActionControllerTest extends FunctionalTestCase
 
         $uri = str_replace('{@action}', strtolower($action), 'http://localhost/test/mvc/actioncontrollertestb/{@action}');
         $response = $this->browser->request($uri, 'POST', $arguments);
-        $this->assertTrue(strpos(trim($response->getContent()), (string)$expectedResult) === 0, sprintf('The resulting string did not start with the expected string. Expected: "%s", Actual: "%s"', $expectedResult, $response->getContent()));
+        self::assertTrue(strpos(trim($response->getContent()), (string)$expectedResult) === 0, sprintf('The resulting string did not start with the expected string. Expected: "%s", Actual: "%s"', $expectedResult, $response->getContent()));
     }
 
     /**
@@ -472,6 +472,6 @@ class ActionControllerTest extends FunctionalTestCase
         $request = Request::create(new Uri('http://localhost/test/mvc/actioncontrollertestc/' . $identifier . '/update'), 'POST', $form);
 
         $response = $this->browser->sendRequest($request);
-        $this->assertSame('Entity "Foo" updated', $response->getContent());
+        self::assertSame('Entity "Foo" updated', $response->getContent());
     }
 }

--- a/Neos.Flow/Tests/Functional/Mvc/ActionRequestTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/ActionRequestTest.php
@@ -34,8 +34,8 @@ class ActionRequestTest extends FunctionalTestCase
 
         /* @var $unserializedActionRequest ActionRequest */
         $unserializedActionRequest = unserialize($serializedActionRequest);
-        $this->assertNull($unserializedActionRequest->getParentRequest(), 'Parent HTTP request should be NULL after deserialization');
-        $this->assertSame('foo', $unserializedActionRequest->getControllerActionName());
+        self::assertNull($unserializedActionRequest->getParentRequest(), 'Parent HTTP request should be NULL after deserialization');
+        self::assertSame('foo', $unserializedActionRequest->getControllerActionName());
     }
 
     /**
@@ -51,6 +51,6 @@ class ActionRequestTest extends FunctionalTestCase
 
         /* @var $unserializedActionRequest ActionRequest */
         $unserializedActionRequest = unserialize($serializedActionRequest);
-        $this->assertNotNull($unserializedActionRequest->getParentRequest(), 'Parent action request should not be NULL after deserialization');
+        self::assertNotNull($unserializedActionRequest->getParentRequest(), 'Parent action request should not be NULL after deserialization');
     }
 }

--- a/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
@@ -79,8 +79,8 @@ class RoutingTest extends FunctionalTestCase
         $request = Request::create(new Uri($requestUri), 'GET');
         $matchResults = $this->router->route(new RouteContext($request, RouteParameters::createEmpty()));
         $actionRequest = $this->createActionRequest($request, $matchResults);
-        $this->assertEquals(ActionControllerTestAController::class, $actionRequest->getControllerObjectName());
-        $this->assertEquals('first', $actionRequest->getControllerActionName());
+        self::assertEquals(ActionControllerTestAController::class, $actionRequest->getControllerObjectName());
+        self::assertEquals('first', $actionRequest->getControllerActionName());
     }
 
     /**
@@ -92,8 +92,8 @@ class RoutingTest extends FunctionalTestCase
         $request = Request::create(new Uri($requestUri), 'POST');
         $matchResults = $this->router->route(new RouteContext($request, RouteParameters::createEmpty()));
         $actionRequest = $this->createActionRequest($request, $matchResults);
-        $this->assertEquals(ActionControllerTestAController::class, $actionRequest->getControllerObjectName());
-        $this->assertEquals('second', $actionRequest->getControllerActionName());
+        self::assertEquals(ActionControllerTestAController::class, $actionRequest->getControllerObjectName());
+        self::assertEquals('second', $actionRequest->getControllerActionName());
     }
 
     /**
@@ -214,12 +214,12 @@ class RoutingTest extends FunctionalTestCase
             if ($matchedRoute === null) {
                 $this->fail('Expected route "' . $expectedMatchingRouteName . '" to match, but no route matched request URI "' . $requestUri . '"');
             } else {
-                $this->assertEquals('Neos.Flow :: Functional Test: ' . $expectedMatchingRouteName, $matchedRoute->getName());
+                self::assertEquals('Neos.Flow :: Functional Test: ' . $expectedMatchingRouteName, $matchedRoute->getName());
             }
         }
-        $this->assertEquals($expectedControllerObjectName, $actionRequest->getControllerObjectName());
+        self::assertEquals($expectedControllerObjectName, $actionRequest->getControllerObjectName());
         if ($expectedArguments !== null) {
-            $this->assertEquals($expectedArguments, $actionRequest->getArguments());
+            self::assertEquals($expectedArguments, $actionRequest->getArguments());
         }
     }
 
@@ -297,10 +297,10 @@ class RoutingTest extends FunctionalTestCase
             if ($resolvedRoute === null) {
                 $this->fail('Expected route "' . $expectedResolvedRouteName . '" to resolve');
             } else {
-                $this->assertEquals('Neos.Flow :: Functional Test: ' . $expectedResolvedRouteName, $resolvedRoute->getName());
+                self::assertEquals('Neos.Flow :: Functional Test: ' . $expectedResolvedRouteName, $resolvedRoute->getName());
             }
         }
-        $this->assertEquals($expectedResolvedUriPath, $resolvedUriPath);
+        self::assertEquals($expectedResolvedUriPath, $resolvedUriPath);
     }
 
     /**
@@ -337,7 +337,7 @@ class RoutingTest extends FunctionalTestCase
         );
 
         $response = $this->browser->request('http://localhost/http-method-test/', $requestMethod);
-        $this->assertEquals($expectedStatus, $response->getStatus());
+        self::assertEquals($expectedStatus, $response->getStatus());
     }
 
     /**
@@ -355,7 +355,7 @@ class RoutingTest extends FunctionalTestCase
         $baseUri = new Uri('http://localhost');
         $actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, false));
 
-        $this->assertSame('neos/flow/test/http/foo', (string)$actualResult);
+        self::assertSame('neos/flow/test/http/foo', (string)$actualResult);
     }
 
     /**
@@ -385,7 +385,7 @@ class RoutingTest extends FunctionalTestCase
         $this->router->setRoutesConfiguration($routesConfiguration);
         $baseUri = new Uri('http://localhost');
         $actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, false));
-        $this->assertSame('custom/uri/pattern', (string)$actualResult);
+        self::assertSame('custom/uri/pattern', (string)$actualResult);
 
         // reset router configuration for following tests
         $this->router->setRoutesConfiguration(null);

--- a/Neos.Flow/Tests/Functional/Mvc/ViewsConfiguration/ViewsConfigurationTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/ViewsConfiguration/ViewsConfigurationTest.php
@@ -69,9 +69,9 @@ class ViewsConfigurationTest extends FunctionalTestCase
     public function templatePathAndFilenameIsChanged()
     {
         $response = $this->browser->request('http://localhost/test/mvc/viewsconfigurationa/first');
-        $this->assertEquals('Changed on Package Level', $response->getContent());
+        self::assertEquals('Changed on Package Level', $response->getContent());
         $response = $this->browser->request('http://localhost/test/mvc/viewsconfigurationb/first');
-        $this->assertEquals('Changed on Controller Level', $response->getContent());
+        self::assertEquals('Changed on Controller Level', $response->getContent());
     }
 
     /**
@@ -82,7 +82,7 @@ class ViewsConfigurationTest extends FunctionalTestCase
     public function viewObjectNameChanged()
     {
         $response = $this->browser->request('http://localhost/test/mvc/viewsconfigurationc/index');
-        $this->assertEquals(Fixtures\TemplateView::class, $response->getContent());
+        self::assertEquals(Fixtures\TemplateView::class, $response->getContent());
     }
 
     /**
@@ -95,6 +95,6 @@ class ViewsConfigurationTest extends FunctionalTestCase
         }
 
         $response = $this->browser->request('http://localhost/test/mvc/viewsconfigurationa/widget');
-        $this->assertEquals('Changed on Package Level', trim($response->getContent()));
+        self::assertEquals('Changed on Package Level', trim($response->getContent()));
     }
 }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ConfigurationTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ConfigurationTest.php
@@ -28,6 +28,6 @@ class ConfigurationTest extends FunctionalTestCase
         $instance = $this->objectManager->get(Fixtures\PrototypeClassD::class);
         /** @var $instanceE Fixtures\PrototypeClassE */
         $instanceE = ObjectAccess::getProperty($instance, 'objectE', true);
-        $this->assertEquals('The constructor set value', $instanceE->getNullValue());
+        self::assertEquals('The constructor set value', $instanceE->getNullValue());
     }
 }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
@@ -43,7 +43,7 @@ class DependencyInjectionTest extends FunctionalTestCase
         $objectA = $this->objectManager->get(Fixtures\SingletonClassA::class);
         $objectB = $this->objectManager->get(Fixtures\SingletonClassB::class);
 
-        $this->assertSame($objectB, $objectA->getObjectB());
+        self::assertSame($objectB, $objectA->getObjectB());
     }
 
     /**
@@ -54,8 +54,8 @@ class DependencyInjectionTest extends FunctionalTestCase
         $objectC = $this->objectManager->get(Fixtures\SingletonClassC::class);
 
         // Note: The "requiredArgument" and "thirdOptionalArgument" are defined in the Objects.yaml of the Flow package (testing context)
-        $this->assertSame('this is required', $objectC->requiredArgument);
-        $this->assertEquals(['thisIs' => ['anArray' => 'asProperty']], $objectC->thirdOptionalArgument);
+        self::assertSame('this is required', $objectC->requiredArgument);
+        self::assertEquals(['thisIs' => ['anArray' => 'asProperty']], $objectC->thirdOptionalArgument);
     }
 
     /**
@@ -66,11 +66,11 @@ class DependencyInjectionTest extends FunctionalTestCase
         $objectC = $this->objectManager->get(Fixtures\SingletonClassC::class);
 
         // Note: The arguments are defined in the Objects.yaml of the Flow package (testing context)
-        $this->assertSame('a defined string', $objectC->getProtectedStringPropertySetViaObjectsYaml());
-        $this->assertSame(42.101010, $objectC->getProtectedFloatPropertySetViaObjectsYaml());
-        $this->assertSame(['iAm' => ['aConfigured' => 'arrayValue']], $objectC->getProtectedArrayPropertySetViaObjectsYaml());
-        $this->assertTrue($objectC->getProtectedBooleanTruePropertySetViaObjectsYaml());
-        $this->assertFalse($objectC->getProtectedBooleanFalsePropertySetViaObjectsYaml());
+        self::assertSame('a defined string', $objectC->getProtectedStringPropertySetViaObjectsYaml());
+        self::assertSame(42.101010, $objectC->getProtectedFloatPropertySetViaObjectsYaml());
+        self::assertSame(['iAm' => ['aConfigured' => 'arrayValue']], $objectC->getProtectedArrayPropertySetViaObjectsYaml());
+        self::assertTrue($objectC->getProtectedBooleanTruePropertySetViaObjectsYaml());
+        self::assertFalse($objectC->getProtectedBooleanFalsePropertySetViaObjectsYaml());
     }
 
     /**
@@ -81,7 +81,7 @@ class DependencyInjectionTest extends FunctionalTestCase
         $objectC = $this->objectManager->get(Fixtures\SingletonClassC::class);
 
         // Note: The argument is defined in the Objects.yaml of the Flow package (testing context)
-        $this->assertSame(['has' => 'some default value', 'and' => 'something from Objects.yaml'], $objectC->getProtectedArrayPropertyWithSetterSetViaObjectsYaml());
+        self::assertSame(['has' => 'some default value', 'and' => 'something from Objects.yaml'], $objectC->getProtectedArrayPropertyWithSetterSetViaObjectsYaml());
     }
 
     /**
@@ -94,7 +94,7 @@ class DependencyInjectionTest extends FunctionalTestCase
         $singletonA = $this->objectManager->get(Fixtures\SingletonClassA::class);
 
         $prototypeA = unserialize('O:' . strlen($className) . ':"' . $className . '":0:{};');
-        $this->assertSame($singletonA, $prototypeA->getSingletonA());
+        self::assertSame($singletonA, $prototypeA->getSingletonA());
     }
 
     /**
@@ -104,8 +104,8 @@ class DependencyInjectionTest extends FunctionalTestCase
     {
         $prototypeA = $this->objectManager->get(Fixtures\PrototypeClassAishInterface::class);
 
-        $this->assertInstanceOf(Fixtures\PrototypeClassA::class, $prototypeA);
-        $this->assertSame('value defined in Objects.yaml', $prototypeA->getSomeProperty());
+        self::assertInstanceOf(Fixtures\PrototypeClassA::class, $prototypeA);
+        self::assertSame('value defined in Objects.yaml', $prototypeA->getSomeProperty());
     }
 
     /**
@@ -116,7 +116,7 @@ class DependencyInjectionTest extends FunctionalTestCase
         $objectC = $this->objectManager->get(Fixtures\SingletonClassC::class);
 
         // Note: The "settingsArgument" is defined in the Settings.yaml of the Flow package (testing context)
-        $this->assertSame('setting injected singleton value', $objectC->settingsArgument);
+        self::assertSame('setting injected singleton value', $objectC->settingsArgument);
     }
 
     /**
@@ -127,7 +127,7 @@ class DependencyInjectionTest extends FunctionalTestCase
         $objectD = $this->objectManager->get(Fixtures\SingletonClassD::class);
 
         // Note: The "settingsArgument" is defined in the Settings.yaml of the Flow package (testing context)
-        $this->assertSame('setting injected property value', $objectD->prototypeClassC->settingsArgument);
+        self::assertSame('setting injected property value', $objectD->prototypeClassC->settingsArgument);
     }
 
     /**
@@ -138,8 +138,8 @@ class DependencyInjectionTest extends FunctionalTestCase
         $objectD = $this->objectManager->get(Fixtures\SingletonClassD::class);
 
         // Note: The "prototypeClassA" is defined with a custom factory in the Objects.yaml of the Flow package (testing context)
-        $this->assertNotNull($objectD->prototypeClassA);
-        $this->assertSame('value defined in Objects.yaml', $objectD->prototypeClassA->getSomeProperty());
+        self::assertNotNull($objectD->prototypeClassA);
+        self::assertSame('value defined in Objects.yaml', $objectD->prototypeClassA->getSomeProperty());
     }
 
     /**
@@ -150,8 +150,8 @@ class DependencyInjectionTest extends FunctionalTestCase
         $objectG = $this->objectManager->get(Fixtures\SingletonClassG::class);
 
         // Note: The "prototypeClassA" is defined with a custom factory in the Objects.yaml of the Flow package (testing context)
-        $this->assertNotNull($objectG->prototypeA);
-        $this->assertSame('Constructor injection with factory', $objectG->prototypeA->getSomeProperty());
+        self::assertNotNull($objectG->prototypeA);
+        self::assertSame('Constructor injection with factory', $objectG->prototypeA->getSomeProperty());
     }
 
     /**
@@ -160,7 +160,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     public function onCreationOfObjectInjectionInParentClassIsDoneOnlyOnce()
     {
         $prototypeDsub = $this->objectManager->get(Fixtures\PrototypeClassDsub::class);
-        $this->assertSame(1, $prototypeDsub->injectionRuns);
+        self::assertSame(1, $prototypeDsub->injectionRuns);
     }
 
     /**
@@ -171,7 +171,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     public function injectedPropertiesAreAvailableInInitializeObjectEvenIfTheClassHasBeenExtended()
     {
         $prototypeDsub = $this->objectManager->get(Fixtures\PrototypeClassDsub::class);
-        $this->assertFalse($prototypeDsub->injectedPropertyWasUnavailable);
+        self::assertFalse($prototypeDsub->injectedPropertyWasUnavailable);
     }
 
     /**
@@ -181,7 +181,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     {
         $objectF = $this->objectManager->get(Fixtures\SingletonClassF::class);
 
-        $this->assertNull($objectF->getNullValue());
+        self::assertNull($objectF->getNullValue());
     }
 
     /**
@@ -191,7 +191,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     {
         $objectE = $this->objectManager->get(Fixtures\PrototypeClassE::class, null);
 
-        $this->assertNull($objectE->getNullValue());
+        self::assertNull($objectE->getNullValue());
     }
 
     /**
@@ -201,7 +201,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     {
         $nonNamespacedDependencies = new Fixtures\ClassWithNonNamespacedDependencies();
         $classB = $this->objectManager->get(Fixtures\SingletonClassB::class);
-        $this->assertSame($classB, $nonNamespacedDependencies->getSingletonClassB());
+        self::assertSame($classB, $nonNamespacedDependencies->getSingletonClassB());
     }
 
     /**
@@ -211,7 +211,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     {
         $nonNamespacedDependencies = new Fixtures\ClassWithNonNamespacedDependencies();
         $aClassFromSubNamespace = $this->objectManager->get(Fixtures\SubNamespace\AnotherClass::class);
-        $this->assertSame($aClassFromSubNamespace, $nonNamespacedDependencies->getClassFromSubNamespace());
+        self::assertSame($aClassFromSubNamespace, $nonNamespacedDependencies->getClassFromSubNamespace());
     }
 
     /**
@@ -221,7 +221,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     {
         $classWithInjectedConfiguration = new Fixtures\ClassWithInjectedConfiguration();
         $actualSettings = $this->configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.Flow');
-        $this->assertSame($actualSettings, $classWithInjectedConfiguration->getSettings());
+        self::assertSame($actualSettings, $classWithInjectedConfiguration->getSettings());
     }
 
 
@@ -233,7 +233,7 @@ class DependencyInjectionTest extends FunctionalTestCase
         $classWithInjectedConfiguration = new Fixtures\ClassWithInjectedConfiguration();
 
         $actualSettings = $this->configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.Flow');
-        $this->assertSame($actualSettings, $classWithInjectedConfiguration->getInjectedSpecifiedPackageSettings());
+        self::assertSame($actualSettings, $classWithInjectedConfiguration->getInjectedSpecifiedPackageSettings());
     }
 
     /**
@@ -244,7 +244,7 @@ class DependencyInjectionTest extends FunctionalTestCase
         $classWithInjectedConfiguration = new Fixtures\ClassWithInjectedConfiguration();
 
         $actualSettings = $this->configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.Flow');
-        $this->assertSame($actualSettings, $classWithInjectedConfiguration->getInjectedCurrentPackageSettings());
+        self::assertSame($actualSettings, $classWithInjectedConfiguration->getInjectedCurrentPackageSettings());
     }
 
     /**
@@ -253,7 +253,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     public function injectionOfNonExistingSettingsOverridesDefaultValue()
     {
         $classWithInjectedConfiguration = new Fixtures\ClassWithInjectedConfiguration();
-        $this->assertNull($classWithInjectedConfiguration->getNonExistingSetting());
+        self::assertNull($classWithInjectedConfiguration->getNonExistingSetting());
     }
 
     /**
@@ -262,7 +262,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     public function injectionOfSingleSettings()
     {
         $classWithInjectedConfiguration = new Fixtures\ClassWithInjectedConfiguration();
-        $this->assertSame('injected setting', $classWithInjectedConfiguration->getInjectedSettingA());
+        self::assertSame('injected setting', $classWithInjectedConfiguration->getInjectedSettingA());
     }
 
     /**
@@ -271,7 +271,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     public function injectionOfSingleSettingsFromSpecificPackage()
     {
         $classWithInjectedConfiguration = new Fixtures\ClassWithInjectedConfiguration();
-        $this->assertSame('injected setting', $classWithInjectedConfiguration->getInjectedSettingB());
+        self::assertSame('injected setting', $classWithInjectedConfiguration->getInjectedSettingB());
     }
 
     /**
@@ -280,7 +280,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     public function injectionOfConfigurationCallsRespectiveSetterIfItExists()
     {
         $classWithInjectedConfiguration = new Fixtures\ClassWithInjectedConfiguration();
-        $this->assertSame('INJECTED SETTING', $classWithInjectedConfiguration->getInjectedSettingWithSetter());
+        self::assertSame('INJECTED SETTING', $classWithInjectedConfiguration->getInjectedSettingWithSetter());
     }
 
     /**
@@ -289,7 +289,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     public function injectionOfOtherConfigurationTypes()
     {
         $classWithInjectedConfiguration = new Fixtures\ClassWithInjectedConfiguration();
-        $this->assertSame($this->configurationManager->getConfiguration('Views'), $classWithInjectedConfiguration->getInjectedViewsConfiguration());
+        self::assertSame($this->configurationManager->getConfiguration('Views'), $classWithInjectedConfiguration->getInjectedViewsConfiguration());
     }
 
     /**
@@ -306,7 +306,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     public function transitivePrototypeDependenciesWithExplicitObjectConfigurationAreConstructedCorrectly()
     {
         $classWithTransitivePrototypeDependency = new ClassWithTransitivePrototypeDependency();
-        $this->assertEquals('Hello World!', $classWithTransitivePrototypeDependency->getTestValue());
+        self::assertEquals('Hello World!', $classWithTransitivePrototypeDependency->getTestValue());
     }
 
     /**
@@ -315,6 +315,6 @@ class DependencyInjectionTest extends FunctionalTestCase
     public function dependencyInjectionWorksForFinalClasses()
     {
         $object = $this->objectManager->get(FinalClassWithDependencies::class);
-        $this->assertInstanceOf(SingletonClassA::class, $object->dependency);
+        self::assertInstanceOf(SingletonClassA::class, $object->dependency);
     }
 }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/LazyDependencyInjectionTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/LazyDependencyInjectionTest.php
@@ -28,15 +28,15 @@ class LazyDependencyInjectionTest extends FunctionalTestCase
         $this->objectManager->forgetInstance(Fixtures\SingletonClassA::class);
 
         $object = $this->objectManager->get(Fixtures\ClassWithLazyDependencies::class);
-        $this->assertInstanceOf(DependencyProxy::class, $object->lazyA);
+        self::assertInstanceOf(DependencyProxy::class, $object->lazyA);
 
         $actualObjectB = $object->lazyA->getObjectB();
         $this->assertNotInstanceOf(DependencyProxy::class, $object->lazyA);
 
         $objectA = $this->objectManager->get(Fixtures\SingletonClassA::class);
         $expectedObjectB = $this->objectManager->get(Fixtures\SingletonClassB::class);
-        $this->assertSame($objectA, $object->lazyA);
-        $this->assertSame($expectedObjectB, $actualObjectB);
+        self::assertSame($objectA, $object->lazyA);
+        self::assertSame($expectedObjectB, $actualObjectB);
     }
 
     /**
@@ -45,7 +45,7 @@ class LazyDependencyInjectionTest extends FunctionalTestCase
     public function dependencyIsInjectedDirectlyIfLazyIsTurnedOff()
     {
         $object = $this->objectManager->get(Fixtures\ClassWithLazyDependencies::class);
-        $this->assertInstanceOf(Fixtures\SingletonClassC::class, $object->eagerC);
+        self::assertInstanceOf(Fixtures\SingletonClassC::class, $object->eagerC);
     }
 
     /**
@@ -59,13 +59,13 @@ class LazyDependencyInjectionTest extends FunctionalTestCase
         $object1 = $this->objectManager->get(Fixtures\ClassWithLazyDependencies::class);
         $object2 = $this->objectManager->get(Fixtures\AnotherClassWithLazyDependencies::class);
 
-        $this->assertInstanceOf(DependencyProxy::class, $object1->lazyA);
-        $this->assertInstanceOf(DependencyProxy::class, $object2->lazyA);
+        self::assertInstanceOf(DependencyProxy::class, $object1->lazyA);
+        self::assertInstanceOf(DependencyProxy::class, $object2->lazyA);
 
         $object2->lazyA->getObjectB();
 
         $objectA = $this->objectManager->get(Fixtures\SingletonClassA::class);
-        $this->assertSame($objectA, $object1->lazyA);
-        $this->assertSame($objectA, $object2->lazyA);
+        self::assertSame($objectA, $object1->lazyA);
+        self::assertSame($objectA, $object2->lazyA);
     }
 }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ObjectManagerTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ObjectManagerTest.php
@@ -26,8 +26,8 @@ class ObjectManagerTest extends FunctionalTestCase
         $objectByInterface = $this->objectManager->get(Fixtures\InterfaceA::class);
         $objectByClassName = $this->objectManager->get(Fixtures\InterfaceAImplementation::class);
 
-        $this->assertInstanceOf(Fixtures\InterfaceAImplementation::class, $objectByInterface);
-        $this->assertInstanceOf(Fixtures\InterfaceAImplementation::class, $objectByClassName);
+        self::assertInstanceOf(Fixtures\InterfaceAImplementation::class, $objectByInterface);
+        self::assertInstanceOf(Fixtures\InterfaceAImplementation::class, $objectByClassName);
     }
 
     /**
@@ -38,7 +38,7 @@ class ObjectManagerTest extends FunctionalTestCase
         $instanceA = new Fixtures\PrototypeClassB();
         $instanceB = new Fixtures\PrototypeClassB();
 
-        $this->assertNotSame($instanceA, $instanceB);
+        self::assertNotSame($instanceA, $instanceB);
     }
 
     /**
@@ -49,7 +49,7 @@ class ObjectManagerTest extends FunctionalTestCase
         $objectByInterface = $this->objectManager->get(Fixtures\InterfaceA::class);
         $objectByClassName = $this->objectManager->get(Fixtures\InterfaceAImplementation::class);
 
-        $this->assertSame($objectByInterface, $objectByClassName);
+        self::assertSame($objectByInterface, $objectByClassName);
     }
 
     /**
@@ -66,6 +66,6 @@ class ObjectManagerTest extends FunctionalTestCase
          */
         \Neos\Flow\Core\Bootstrap::$staticObjectManager->shutdown();
 
-        $this->assertTrue($entity->isDestructed());
+        self::assertTrue($entity->isDestructed());
     }
 }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ObjectSerializationTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ObjectSerializationTest.php
@@ -26,19 +26,19 @@ class ObjectSerializationTest extends FunctionalTestCase
     {
         $object = $this->objectManager->get(Fixtures\ClassToBeSerialized::class);
         $object->interfaceDeclaredSingletonButImplementationIsPrototype->getSingletonA();
-        $this->assertInstanceOf(Fixtures\PrototypeClassA::class, $object->interfaceDeclaredSingletonButImplementationIsPrototype);
+        self::assertInstanceOf(Fixtures\PrototypeClassA::class, $object->interfaceDeclaredSingletonButImplementationIsPrototype);
 
         $object->prototypeB->setSomeProperty('This is not a coffee machine.');
 
         $serializedObject = serialize($object);
         $object = unserialize($serializedObject);
 
-        $this->assertInstanceOf(Fixtures\ClassToBeSerialized::class, $object);
+        self::assertInstanceOf(Fixtures\ClassToBeSerialized::class, $object);
         $object->interfaceDeclaredSingletonButImplementationIsPrototype->getSingletonA();
-        $this->assertInstanceOf(Fixtures\PrototypeClassA::class, $object->interfaceDeclaredSingletonButImplementationIsPrototype);
-        $this->assertInstanceOf(Fixtures\SingletonClassC::class, $object->eagerC);
+        self::assertInstanceOf(Fixtures\PrototypeClassA::class, $object->interfaceDeclaredSingletonButImplementationIsPrototype);
+        self::assertInstanceOf(Fixtures\SingletonClassC::class, $object->eagerC);
 
-        $this->assertEquals(null, $object->prototypeB->getSomeProperty(), 'An injected prototype instance will be overwritten with a fresh instance on unserialize.');
+        self::assertEquals(null, $object->prototypeB->getSomeProperty(), 'An injected prototype instance will be overwritten with a fresh instance on unserialize.');
     }
 
     /**
@@ -48,13 +48,13 @@ class ObjectSerializationTest extends FunctionalTestCase
     {
         $object = $this->objectManager->get(Fixtures\ClassToBeSerialized::class);
         $object->interfaceDeclaredSingletonButImplementationIsPrototype->getSingletonA();
-        $this->assertInstanceOf(Fixtures\PrototypeClassA::class, $object->interfaceDeclaredSingletonButImplementationIsPrototype);
+        self::assertInstanceOf(Fixtures\PrototypeClassA::class, $object->interfaceDeclaredSingletonButImplementationIsPrototype);
 
         $propertiesToBeSerialized = $object->__sleep();
 
         // Note that the privateProperty is not serialized as it was declared in the parent class of the proxy.
-        $this->assertCount(2, $propertiesToBeSerialized);
-        $this->assertContains('someProperty', $propertiesToBeSerialized);
-        $this->assertContains('protectedProperty', $propertiesToBeSerialized);
+        self::assertCount(2, $propertiesToBeSerialized);
+        self::assertContains('someProperty', $propertiesToBeSerialized);
+        self::assertContains('protectedProperty', $propertiesToBeSerialized);
     }
 }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
@@ -29,9 +29,9 @@ class ProxyCompilerTest extends FunctionalTestCase
         $class = new ClassReflection(Fixtures\PrototypeClassA::class);
         $method = $class->getMethod('setSomeProperty');
 
-        $this->assertTrue($class->implementsInterface(ProxyInterface::class));
-        $this->assertTrue($class->isTaggedWith('scope'));
-        $this->assertTrue($method->isTaggedWith('session'));
+        self::assertTrue($class->implementsInterface(ProxyInterface::class));
+        self::assertTrue($class->isTaggedWith('scope'));
+        self::assertTrue($method->isTaggedWith('session'));
     }
 
     /**
@@ -43,7 +43,7 @@ class ProxyCompilerTest extends FunctionalTestCase
         $expectedResult = 'This is a example doc comment which should be copied' . chr(10) . 'to the proxy class.';
         $actualResult = $class->getDescription();
 
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -54,7 +54,7 @@ class ProxyCompilerTest extends FunctionalTestCase
         $class = new ClassReflection(Fixtures\PrototypeClassA::class);
         $method = $class->getMethod('getSingletonA');
 
-        $this->assertEquals(['SingletonClassA The singleton class A'], $method->getTagValues('return'));
+        self::assertEquals(['SingletonClassA The singleton class A'], $method->getTagValues('return'));
     }
 
     /**
@@ -65,7 +65,7 @@ class ProxyCompilerTest extends FunctionalTestCase
         $class = new ClassReflection(Fixtures\PrototypeClassA::class);
         $method = $class->getMethod('setSomeProperty');
 
-        $this->assertEquals(['string $someProperty The property value'], $method->getTagValues('param'));
+        self::assertEquals(['string $someProperty The property value'], $method->getTagValues('param'));
     }
 
     /**
@@ -76,7 +76,7 @@ class ProxyCompilerTest extends FunctionalTestCase
         $class = new ClassReflection(Fixtures\PrototypeClassA::class);
         $method = $class->getMethod('setSomeProperty');
 
-        $this->assertEquals(['autoStart=true'], $method->getTagValues('session'));
+        self::assertEquals(['autoStart=true'], $method->getTagValues('session'));
     }
 
     /**
@@ -94,14 +94,14 @@ class ProxyCompilerTest extends FunctionalTestCase
     public function setInstanceOfSubClassDoesNotOverrideParentClass()
     {
         $singletonE = $this->objectManager->get(Fixtures\SingletonClassE::class);
-        $this->assertEquals(Fixtures\SingletonClassE::class, get_class($singletonE));
+        self::assertEquals(Fixtures\SingletonClassE::class, get_class($singletonE));
 
         $singletonEsub = $this->objectManager->get(Fixtures\SingletonClassEsub::class);
-        $this->assertEquals(Fixtures\SingletonClassEsub::class, get_class($singletonEsub));
+        self::assertEquals(Fixtures\SingletonClassEsub::class, get_class($singletonEsub));
 
         $singletonE2 = $this->objectManager->get(Fixtures\SingletonClassE::class);
-        $this->assertEquals(Fixtures\SingletonClassE::class, get_class($singletonE2));
-        $this->assertSame($singletonE, $singletonE2);
+        self::assertEquals(Fixtures\SingletonClassE::class, get_class($singletonE2));
+        self::assertSame($singletonE, $singletonE2);
     }
 
     /**
@@ -117,8 +117,8 @@ class ProxyCompilerTest extends FunctionalTestCase
         $prototypeF = null;
 
         $prototypeF = unserialize($serializedObject);
-        $this->assertSame($prototypeF->getNonTransientProperty(), 'bar');
-        $this->assertSame($prototypeF->getTransientProperty(), null);
+        self::assertSame($prototypeF->getNonTransientProperty(), 'bar');
+        self::assertSame($prototypeF->getTransientProperty(), null);
     }
 
     /**
@@ -127,6 +127,6 @@ class ProxyCompilerTest extends FunctionalTestCase
     public function proxiedFinalClassesAreStillFinal()
     {
         $reflectionClass = new ClassReflection(Fixtures\FinalClassWithDependencies::class);
-        $this->assertTrue($reflectionClass->isFinal());
+        self::assertTrue($reflectionClass->isFinal());
     }
 }

--- a/Neos.Flow/Tests/Functional/Persistence/Aspect/PersistenceMagicAspectTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Aspect/PersistenceMagicAspectTest.php
@@ -51,7 +51,7 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
     public function aspectDoesNotIntroduceUuidIdentifierToEntitiesWithCustomIdProperties()
     {
         $entity = new Fixtures\AnnotatedIdEntity();
-        $this->assertNull($this->persistenceManager->getIdentifierByObject($entity));
+        self::assertNull($this->persistenceManager->getIdentifierByObject($entity));
     }
 
     /**
@@ -61,9 +61,9 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
     {
         $entity = new Fixtures\AnnotatedIdEntity();
         $clonedEntity = clone $entity;
-        $this->assertObjectNotHasAttribute('Flow_Persistence_clone', $entity);
+        self::assertObjectNotHasAttribute('Flow_Persistence_clone', $entity);
         $this->assertObjectHasAttribute('Flow_Persistence_clone', $clonedEntity);
-        $this->assertTrue($clonedEntity->Flow_Persistence_clone);
+        self::assertTrue($clonedEntity->Flow_Persistence_clone);
     }
 
     /**
@@ -74,7 +74,7 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
         $valueObject = new Fixtures\TestValueObject('value');
 
         $this->assertObjectHasAttribute('Persistence_Object_Identifier', $valueObject);
-        $this->assertNotEmpty($this->persistenceManager->getIdentifierByObject($valueObject));
+        self::assertNotEmpty($this->persistenceManager->getIdentifierByObject($valueObject));
     }
 
     /**
@@ -83,7 +83,7 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
      */
     public function valueObjectsWithTheSamePropertyValuesAreEqual($valueObject1, $valueObject2)
     {
-        $this->assertEquals($this->persistenceManager->getIdentifierByObject($valueObject1), $this->persistenceManager->getIdentifierByObject($valueObject2));
+        self::assertEquals($this->persistenceManager->getIdentifierByObject($valueObject1), $this->persistenceManager->getIdentifierByObject($valueObject2));
     }
 
     public function sameValueObjectDataProvider()
@@ -101,7 +101,7 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
      */
     public function valueObjectWithDifferentPropertyValuesAreNotEqual($valueObject1, $valueObject2)
     {
-        $this->assertNotEquals($this->persistenceManager->getIdentifierByObject($valueObject1), $this->persistenceManager->getIdentifierByObject($valueObject2));
+        self::assertNotEquals($this->persistenceManager->getIdentifierByObject($valueObject1), $this->persistenceManager->getIdentifierByObject($valueObject2));
     }
 
     public function differentValueObjectDataProvider()
@@ -121,7 +121,7 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
         $valueObject1 = new Fixtures\TestValueObjectWithConstructorLogic('value1', 'value2');
         $valueObject2 = new Fixtures\TestValueObjectWithConstructorLogicAndInversedPropertyOrder('value2', 'value1');
 
-        $this->assertNotEquals($this->persistenceManager->getIdentifierByObject($valueObject1), $this->persistenceManager->getIdentifierByObject($valueObject2));
+        self::assertNotEquals($this->persistenceManager->getIdentifierByObject($valueObject1), $this->persistenceManager->getIdentifierByObject($valueObject2));
     }
 
     /**
@@ -132,7 +132,7 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
         $valueObject1 = new Fixtures\TestValueObjectWithTransientProperties('value1', 'thisDoesntRegardPersistenceWhatSoEver');
         $valueObject2 = new Fixtures\TestValueObjectWithTransientProperties('value1', 'reallyThisPropertyIsTransient');
 
-        $this->assertEquals($this->persistenceManager->getIdentifierByObject($valueObject1), $this->persistenceManager->getIdentifierByObject($valueObject2));
+        self::assertEquals($this->persistenceManager->getIdentifierByObject($valueObject1), $this->persistenceManager->getIdentifierByObject($valueObject2));
     }
 
     /**
@@ -144,8 +144,8 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
         $valueObject2 = new Fixtures\TestValueObjectWithDateTimeProperty(new \DateTime('01.01.2013 00:00', new \DateTimeZone('CEST')));
         $valueObject3 = new Fixtures\TestValueObjectWithDateTimeProperty(new \DateTime('01.01.2013 00:00', new \DateTimeZone('GMT')));
 
-        $this->assertNotEquals($this->persistenceManager->getIdentifierByObject($valueObject1), $this->persistenceManager->getIdentifierByObject($valueObject2));
-        $this->assertEquals($this->persistenceManager->getIdentifierByObject($valueObject1), $this->persistenceManager->getIdentifierByObject($valueObject3));
+        self::assertNotEquals($this->persistenceManager->getIdentifierByObject($valueObject1), $this->persistenceManager->getIdentifierByObject($valueObject2));
+        self::assertEquals($this->persistenceManager->getIdentifierByObject($valueObject1), $this->persistenceManager->getIdentifierByObject($valueObject3));
     }
 
     /**
@@ -161,7 +161,7 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
         $valueObject2 = new Fixtures\TestValueObjectWithSubValueObjectProperties($subValueObject2, 'test');
         $valueObject3 = new Fixtures\TestValueObjectWithSubValueObjectProperties($subValueObject3, 'test');
 
-        $this->assertEquals($this->persistenceManager->getIdentifierByObject($valueObject1), $this->persistenceManager->getIdentifierByObject($valueObject2));
-        $this->assertNotEquals($this->persistenceManager->getIdentifierByObject($valueObject1), $this->persistenceManager->getIdentifierByObject($valueObject3));
+        self::assertEquals($this->persistenceManager->getIdentifierByObject($valueObject1), $this->persistenceManager->getIdentifierByObject($valueObject2));
+        self::assertNotEquals($this->persistenceManager->getIdentifierByObject($valueObject1), $this->persistenceManager->getIdentifierByObject($valueObject3));
     }
 }

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/AggregateTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/AggregateTest.php
@@ -63,12 +63,12 @@ class AggregateTest extends FunctionalTestCase
         $imageIdentifier = $this->persistenceManager->getIdentifierByObject($image);
 
         $retrievedImage = $this->persistenceManager->getObjectByIdentifier($imageIdentifier, Fixtures\Image::class);
-        $this->assertSame($image, $retrievedImage);
+        self::assertSame($image, $retrievedImage);
 
         $this->postRepository->remove($post);
         $this->persistenceManager->persistAll();
 
-        $this->assertTrue($this->persistenceManager->isNewObject($retrievedImage));
+        self::assertTrue($this->persistenceManager->isNewObject($retrievedImage));
     }
 
     /**
@@ -88,13 +88,13 @@ class AggregateTest extends FunctionalTestCase
         $commentIdentifier = $this->persistenceManager->getIdentifierByObject($comment);
 
         $retrievedComment = $this->persistenceManager->getObjectByIdentifier($commentIdentifier, Fixtures\Comment::class);
-        $this->assertSame($comment, $retrievedComment);
+        self::assertSame($comment, $retrievedComment);
 
         $this->postRepository->remove($post);
         $this->persistenceManager->persistAll();
 
         $retrievedComment = $this->persistenceManager->getObjectByIdentifier($commentIdentifier, Fixtures\Comment::class);
-        $this->assertSame($comment, $retrievedComment);
+        self::assertSame($comment, $retrievedComment);
     }
 
     /**
@@ -118,6 +118,6 @@ class AggregateTest extends FunctionalTestCase
         $this->persistenceManager->persistAll();
 
         // if all goes well the value object is not deleted
-        $this->assertTrue(true);
+        self::assertTrue(true);
     }
 }

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/IndexedCollectionTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/IndexedCollectionTest.php
@@ -62,12 +62,12 @@ class IndexedCollectionTest extends FunctionalTestCase
 
         $entityWithIndexedRelation = $this->persistenceManager->getObjectByIdentifier($id, Fixtures\EntityWithIndexedRelation::class);
         for ($i = 0; $i < 3; $i++) {
-            $this->assertArrayHasKey('Author' . (string) $i, $entityWithIndexedRelation->getAnnotatedIdentitiesEntities());
+            self::assertArrayHasKey('Author' . (string) $i, $entityWithIndexedRelation->getAnnotatedIdentitiesEntities());
         }
-        $this->assertArrayNotHasKey(0, $entityWithIndexedRelation->getAnnotatedIdentitiesEntities());
+        self::assertArrayNotHasKey(0, $entityWithIndexedRelation->getAnnotatedIdentitiesEntities());
 
-        $this->assertArrayHasKey('test', $entityWithIndexedRelation->getRelatedIndexEntities());
-        $this->assertArrayNotHasKey(0, $entityWithIndexedRelation->getRelatedIndexEntities());
-        $this->assertInstanceOf(Fixtures\RelatedIndexEntity::class, $entityWithIndexedRelation->getRelatedIndexEntities()->get('test'));
+        self::assertArrayHasKey('test', $entityWithIndexedRelation->getRelatedIndexEntities());
+        self::assertArrayNotHasKey(0, $entityWithIndexedRelation->getRelatedIndexEntities());
+        self::assertInstanceOf(Fixtures\RelatedIndexEntity::class, $entityWithIndexedRelation->getRelatedIndexEntities()->get('test'));
     }
 }

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/LazyLoadingTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/LazyLoadingTest.php
@@ -71,7 +71,7 @@ class LazyLoadingTest extends FunctionalTestCase
 
         $loadedRelatedEntity = $loadedEntity->getRelatedEntity();
 
-        $this->assertNotNull($loadedRelatedEntity->getObjectManager());
+        self::assertNotNull($loadedRelatedEntity->getObjectManager());
     }
 
     /**
@@ -97,7 +97,7 @@ class LazyLoadingTest extends FunctionalTestCase
 
         $loadedRelatedEntity = $loadedEntity->getRelatedEntity();
 
-        $this->assertEquals($loadedRelatedEntity->sayHello(), 'Hello Andi!');
+        self::assertEquals($loadedRelatedEntity->sayHello(), 'Hello Andi!');
     }
 
     /**
@@ -129,7 +129,7 @@ class LazyLoadingTest extends FunctionalTestCase
          * The CleanupObject is just a helper object to test that shutdownObject() on the Fixtures\Image is called
          */
         $cleanupObject = new Fixtures\CleanupObject();
-        $this->assertFalse($cleanupObject->getState());
+        self::assertFalse($cleanupObject->getState());
         $post->getImage()->setRelatedObject($cleanupObject);
 
         /*
@@ -138,6 +138,6 @@ class LazyLoadingTest extends FunctionalTestCase
          */
         \Neos\Flow\Core\Bootstrap::$staticObjectManager->shutdown();
 
-        $this->assertTrue($cleanupObject->getState());
+        self::assertTrue($cleanupObject->getState());
     }
 }

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriverTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriverTest.php
@@ -46,7 +46,7 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
         $classMetadata = new ClassMetadata(Fixtures\Post::class);
         $driver = $this->objectManager->get(FlowAnnotationDriver::class);
         $driver->loadMetadataForClass(Fixtures\Post::class, $classMetadata);
-        $this->assertTrue($classMetadata->hasLifecycleCallbacks('prePersist'));
+        self::assertTrue($classMetadata->hasLifecycleCallbacks('prePersist'));
     }
 
     /**
@@ -57,7 +57,7 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
         $classMetadata = new ClassMetadata(Fixtures\Comment::class);
         $driver = $this->objectManager->get(FlowAnnotationDriver::class);
         $driver->loadMetadataForClass(Fixtures\Comment::class, $classMetadata);
-        $this->assertTrue($classMetadata->hasLifecycleCallbacks('prePersist'));
+        self::assertTrue($classMetadata->hasLifecycleCallbacks('prePersist'));
     }
 
     /**
@@ -68,7 +68,7 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
         $classMetadata = new ClassMetadata(Fixtures\UnproxiedTestEntity::class);
         $driver = $this->objectManager->get(FlowAnnotationDriver::class);
         $driver->loadMetadataForClass(Fixtures\UnproxiedTestEntity::class, $classMetadata);
-        $this->assertFalse($classMetadata->hasLifecycleCallbacks(\Doctrine\ORM\Events::postLoad));
+        self::assertFalse($classMetadata->hasLifecycleCallbacks(\Doctrine\ORM\Events::postLoad));
     }
 
     /**
@@ -79,7 +79,7 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
         $classMetadata = new ClassMetadata(Fixtures\Post::class);
         $driver = $this->objectManager->get(FlowAnnotationDriver::class);
         $driver->loadMetadataForClass(Fixtures\Post::class, $classMetadata);
-        $this->assertSame(\Doctrine\ORM\Mapping\ClassMetadata::INHERITANCE_TYPE_JOINED, $classMetadata->inheritanceType);
+        self::assertSame(\Doctrine\ORM\Mapping\ClassMetadata::INHERITANCE_TYPE_JOINED, $classMetadata->inheritanceType);
     }
 
     /**
@@ -90,7 +90,7 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
         $classMetadata = new ClassMetadata(Fixtures\AbstractEntity::class);
         $driver = $this->objectManager->get(FlowAnnotationDriver::class);
         $driver->loadMetadataForClass(Fixtures\AbstractEntity::class, $classMetadata);
-        $this->assertSame(\Doctrine\ORM\Mapping\ClassMetadata::INHERITANCE_TYPE_NONE, $classMetadata->inheritanceType);
+        self::assertSame(\Doctrine\ORM\Mapping\ClassMetadata::INHERITANCE_TYPE_NONE, $classMetadata->inheritanceType);
     }
 
     /**
@@ -101,9 +101,9 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
         $classMetadata = new ClassMetadata(Fixtures\CompositeKeyTestEntity::class);
         $driver = $this->objectManager->get(FlowAnnotationDriver::class);
         $driver->loadMetadataForClass(Fixtures\CompositeKeyTestEntity::class, $classMetadata);
-        $this->assertTrue($classMetadata->isIdentifierComposite);
-        $this->assertTrue($classMetadata->containsForeignIdentifier);
-        $this->assertEquals($classMetadata->identifier, ['name', 'relatedEntity']);
+        self::assertTrue($classMetadata->isIdentifierComposite);
+        self::assertTrue($classMetadata->containsForeignIdentifier);
+        self::assertEquals($classMetadata->identifier, ['name', 'relatedEntity']);
     }
 
     /**
@@ -167,18 +167,18 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
         $driver = $this->objectManager->get(FlowAnnotationDriver::class);
         $driver->loadMetadataForClass(Fixtures\Post::class, $classMetadata);
 
-        $this->assertEquals($expectedTitleMapping, $classMetadata->getFieldMapping('title'), 'mapping for "title" not as expected');
+        self::assertEquals($expectedTitleMapping, $classMetadata->getFieldMapping('title'), 'mapping for "title" not as expected');
         $imageAssociationMapping = $classMetadata->getAssociationMapping('image');
         $thumbnailAssociationMapping = $classMetadata->getAssociationMapping('thumbnail');
         foreach (array_keys($expectedImageAssociationMapping) as $key) {
-            $this->assertEquals($expectedImageAssociationMapping[$key], $imageAssociationMapping[$key], 'mapping for "image" not as expected');
-            $this->assertNotEquals($expectedImageAssociationMapping[$key], $thumbnailAssociationMapping[$key], 'mapping for "thumbnail" not as expected');
+            self::assertEquals($expectedImageAssociationMapping[$key], $imageAssociationMapping[$key], 'mapping for "image" not as expected');
+            self::assertNotEquals($expectedImageAssociationMapping[$key], $thumbnailAssociationMapping[$key], 'mapping for "thumbnail" not as expected');
         }
 
         $commentAssociationMapping = $classMetadata->getAssociationMapping('comment');
-        $this->assertEquals(1, count($commentAssociationMapping['joinColumns']));
+        self::assertEquals(1, count($commentAssociationMapping['joinColumns']));
         foreach (array_keys($expectedCommentAssociationMapping) as $key) {
-            $this->assertEquals($expectedCommentAssociationMapping[$key], $commentAssociationMapping[$key], 'mapping for "comment" not as expected');
+            self::assertEquals($expectedCommentAssociationMapping[$key], $commentAssociationMapping[$key], 'mapping for "comment" not as expected');
         }
     }
 
@@ -229,7 +229,7 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
 
         $relatedAssociationMapping = $classMetadata->getAssociationMapping('related');
         foreach (array_keys($expectedRelatedAssociationMapping) as $key) {
-            $this->assertEquals($expectedRelatedAssociationMapping[$key], $relatedAssociationMapping[$key]);
+            self::assertEquals($expectedRelatedAssociationMapping[$key], $relatedAssociationMapping[$key]);
         }
     }
 
@@ -246,13 +246,13 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
 
         /* The annotation should be available at ManyToMany relations */
         $relatedAssociationMapping = $classMetadata->getAssociationMapping('annotatedIdentitiesEntities');
-        $this->assertArrayHasKey('indexBy', $relatedAssociationMapping);
-        $this->assertEquals('author', $relatedAssociationMapping['indexBy']);
+        self::assertArrayHasKey('indexBy', $relatedAssociationMapping);
+        self::assertEquals('author', $relatedAssociationMapping['indexBy']);
 
         /* The annotation should be available at OneToMany relations */
         $relatedAssociationMapping = $classMetadata->getAssociationMapping('relatedIndexEntities');
-        $this->assertArrayHasKey('indexBy', $relatedAssociationMapping);
-        $this->assertEquals('sorting', $relatedAssociationMapping['indexBy']);
+        self::assertArrayHasKey('indexBy', $relatedAssociationMapping);
+        self::assertEquals('sorting', $relatedAssociationMapping['indexBy']);
     }
 
     /**
@@ -265,9 +265,9 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
         $driver->loadMetadataForClass(TargetClass04::class, $classMetadata);
 
         $fieldNames = $classMetadata->getFieldNames();
-        $this->assertContains('introducedProtectedProperty', $fieldNames);
-        $this->assertContains('introducedPublicProperty', $fieldNames);
-        $this->assertNotContains('introducedTransientProperty', $fieldNames);
+        self::assertContains('introducedProtectedProperty', $fieldNames);
+        self::assertContains('introducedPublicProperty', $fieldNames);
+        self::assertNotContains('introducedTransientProperty', $fieldNames);
     }
 
     /**
@@ -280,24 +280,24 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
         $driver->loadMetadataForClass(Fixtures\OneToOneEntity::class, $classMetadata);
 
         $selfReferencingMapping = $classMetadata->getAssociationMapping('selfReferencing');
-        $this->assertNotEmpty($selfReferencingMapping['joinColumns']);
-        $this->assertTrue($selfReferencingMapping['isOwningSide']);
+        self::assertNotEmpty($selfReferencingMapping['joinColumns']);
+        self::assertTrue($selfReferencingMapping['isOwningSide']);
 
         $bidirectionalMapping = $classMetadata->getAssociationMapping('bidirectionalRelation');
-        $this->assertNotEmpty($bidirectionalMapping['joinColumns']);
-        $this->assertEquals('bidirectionalRelation', $bidirectionalMapping['inversedBy']);
-        $this->assertTrue($bidirectionalMapping['isOwningSide']);
+        self::assertNotEmpty($bidirectionalMapping['joinColumns']);
+        self::assertEquals('bidirectionalRelation', $bidirectionalMapping['inversedBy']);
+        self::assertTrue($bidirectionalMapping['isOwningSide']);
 
         $classMetadata2 = new ClassMetadata(Fixtures\OneToOneEntity2::class);
         $driver->loadMetadataForClass(Fixtures\OneToOneEntity2::class, $classMetadata2);
         $bidirectionalMapping2 = $classMetadata2->getAssociationMapping('bidirectionalRelation');
-        $this->assertFalse(isset($bidirectionalMapping2['joinColumns']));
-        $this->assertEquals('bidirectionalRelation', $bidirectionalMapping2['mappedBy']);
-        $this->assertFalse($bidirectionalMapping2['isOwningSide']);
+        self::assertFalse(isset($bidirectionalMapping2['joinColumns']));
+        self::assertEquals('bidirectionalRelation', $bidirectionalMapping2['mappedBy']);
+        self::assertFalse($bidirectionalMapping2['isOwningSide']);
 
         $unidirectionalMapping = $classMetadata->getAssociationMapping('unidirectionalRelation');
-        $this->assertNotEmpty($unidirectionalMapping['joinColumns']);
-        $this->assertTrue($unidirectionalMapping['isOwningSide']);
+        self::assertNotEmpty($unidirectionalMapping['joinColumns']);
+        self::assertTrue($unidirectionalMapping['isOwningSide']);
 
         /** @var EntityManagerInterface $entityManager */
         $entityManager = $this->objectManager->get(EntityManagerInterface::class);
@@ -306,7 +306,7 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
         /* @var $foreignKey \Doctrine\DBAL\Schema\ForeignKeyConstraint */
         foreach ($schema->getTable('persistence_onetooneentity2')->getForeignKeys() as $foreignKey) {
             if ($foreignKey->getForeignTableName() === 'persistence_onetooneentity') {
-                $this->assertTrue(false);
+                self::assertTrue(false);
             }
         }
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/PersistClonedRelatedEntitiesTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/PersistClonedRelatedEntitiesTest.php
@@ -68,7 +68,7 @@ class PersistClonedRelatedEntitiesTest extends FunctionalTestCase
 
         $clonedEntityIdentifier = $this->persistenceManager->getIdentifierByObject($clonedRelatedEntity);
         $clonedLoadedEntity = $this->testEntityRepository->findByIdentifier($clonedEntityIdentifier);
-        $this->assertInstanceOf(Fixtures\TestEntity::class, $clonedLoadedEntity);
+        self::assertInstanceOf(Fixtures\TestEntity::class, $clonedLoadedEntity);
     }
 
     /**
@@ -87,7 +87,7 @@ class PersistClonedRelatedEntitiesTest extends FunctionalTestCase
         $entity->setRelatedEntity($relatedEntity);
 
         $clonedRelatedEntity = clone $entity->getRelatedEntity();
-        $this->assertNotNull($clonedRelatedEntity->getEmbedded(), 'Unproxied clone embedded is null');
+        self::assertNotNull($clonedRelatedEntity->getEmbedded(), 'Unproxied clone embedded is null');
 
         $this->testEntityRepository->add($entity);
         $this->testEntityRepository->add($relatedEntity);
@@ -98,8 +98,8 @@ class PersistClonedRelatedEntitiesTest extends FunctionalTestCase
         $loadedEntity = $this->testEntityRepository->findByIdentifier($entityIdentifier);
 
         $clonedRelatedEntity = clone $loadedEntity->getRelatedEntity();
-        $this->assertNotNull($clonedRelatedEntity->getRelatedValueObject(), 'Proxied clone value object is null');
-        $this->assertNotNull($clonedRelatedEntity->getEmbedded(), 'Proxied clone embedded is null');
-        $this->assertEquals('Foo', $clonedRelatedEntity->getEmbedded()->getValue());
+        self::assertNotNull($clonedRelatedEntity->getRelatedValueObject(), 'Proxied clone value object is null');
+        self::assertNotNull($clonedRelatedEntity->getEmbedded(), 'Proxied clone embedded is null');
+        self::assertEquals('Foo', $clonedRelatedEntity->getEmbedded()->getValue());
     }
 }

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/QueryTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/QueryTest.php
@@ -68,8 +68,8 @@ class QueryTest extends FunctionalTestCase
         $serializedQuery = serialize($query);
         $unserializedQuery = unserialize($serializedQuery);
 
-        $this->assertEquals(1, $unserializedQuery->execute()->count());
-        $this->assertEquals([$testEntity1], $unserializedQuery->execute()->toArray());
+        self::assertEquals(1, $unserializedQuery->execute()->count());
+        self::assertEquals([$testEntity1], $unserializedQuery->execute()->toArray());
     }
 
     /**
@@ -109,8 +109,8 @@ class QueryTest extends FunctionalTestCase
 
         $serializedQuery = serialize($query);
         $unserializedQuery = unserialize($serializedQuery);
-        $this->assertEquals(1, $unserializedQuery->execute()->count());
-        $this->assertEquals([$testEntity1], $unserializedQuery->execute()->toArray());
+        self::assertEquals(1, $unserializedQuery->execute()->count());
+        self::assertEquals([$testEntity1], $unserializedQuery->execute()->toArray());
     }
 
     /**
@@ -137,7 +137,7 @@ class QueryTest extends FunctionalTestCase
 
         $query = new Query(Fixtures\TestEntity::class);
 
-        $this->assertEquals(3, $query->execute()->count());
+        self::assertEquals(3, $query->execute()->count());
     }
 
     /**
@@ -164,7 +164,7 @@ class QueryTest extends FunctionalTestCase
 
         $query = new Query(Fixtures\TestEntity::class);
 
-        $this->assertEquals(2, $query->setLimit(2)->execute()->count());
+        self::assertEquals(2, $query->setLimit(2)->execute()->count());
     }
 
     /**
@@ -191,7 +191,7 @@ class QueryTest extends FunctionalTestCase
 
         $query = new Query(Fixtures\TestEntity::class);
 
-        $this->assertEquals(1, $query->setOffset(2)->execute()->count());
+        self::assertEquals(1, $query->setOffset(2)->execute()->count());
     }
 
     /**
@@ -235,7 +235,7 @@ class QueryTest extends FunctionalTestCase
         $query = new Query(Fixtures\TestEntity::class);
         $entities = $query->matching($query->equals('subEntities.content', 'value'))->setDistinct()->setLimit(2)->execute()->toArray();
 
-        $this->assertEquals(2, count($entities));
+        self::assertEquals(2, count($entities));
     }
 
     /**
@@ -285,7 +285,7 @@ class QueryTest extends FunctionalTestCase
         $constraint = $query->logicalAnd($query->equals('subEntities.content', 'foo'), $query->equals('subEntities.someProperty', 'yup'));
         $entities = $query->matching($constraint)->execute()->toArray();
 
-        $this->assertEquals(1, count($entities));
+        self::assertEquals(1, count($entities));
     }
 
     /**
@@ -318,15 +318,15 @@ class QueryTest extends FunctionalTestCase
 
         $serializedQuery = serialize($query);
         $unserializedQuery = unserialize($serializedQuery);
-        $this->assertEquals(1, $unserializedQuery->execute()->count());
-        $this->assertEquals([$testEntity2], $unserializedQuery->execute()->toArray());
+        self::assertEquals(1, $unserializedQuery->execute()->count());
+        self::assertEquals([$testEntity2], $unserializedQuery->execute()->toArray());
     }
 
     protected function assertQueryEquals(Query $expected, Query $actual)
     {
-        $this->assertEquals($expected->getConstraint(), $actual->getConstraint());
-        $this->assertEquals($expected->getOrderings(), $actual->getOrderings());
-        $this->assertEquals($expected->getOffset(), $actual->getOffset());
-        $this->assertEquals($expected->getLimit(), $actual->getLimit());
+        self::assertEquals($expected->getConstraint(), $actual->getConstraint());
+        self::assertEquals($expected->getOrderings(), $actual->getOrderings());
+        self::assertEquals($expected->getOffset(), $actual->getOffset());
+        self::assertEquals($expected->getLimit(), $actual->getLimit());
     }
 }

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/RepositoryTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/RepositoryTest.php
@@ -75,14 +75,14 @@ class RepositoryTest extends FunctionalTestCase
         unset($post);
 
         $post = $this->postRepository->findOneByTitle('Modified Sample');
-        $this->assertNull($post);
+        self::assertNull($post);
 
         // The following assertions won't work because findOneByTitle() will get the _modified_ post
         // because it is still in Doctrine's identity map:
 
         // $post = $this->postRepository->findOneByTitle('Sample');
-        // $this->assertNotNull($post);
-        // $this->assertEquals('Sample', $post->getTitle());
+        // self::assertNotNull($post);
+        // self::assertEquals('Sample', $post->getTitle());
     }
 
     /**
@@ -105,8 +105,8 @@ class RepositoryTest extends FunctionalTestCase
         $this->persistenceManager->persistAll();
 
         $post = $this->postRepository->findOneByTitle('Modified Sample');
-        $this->assertNotNull($post);
-        $this->assertEquals('Modified Sample', $post->getTitle());
+        self::assertNotNull($post);
+        self::assertEquals('Modified Sample', $post->getTitle());
     }
 
     /**
@@ -123,7 +123,7 @@ class RepositoryTest extends FunctionalTestCase
         $this->persistenceManager->persistAll();
 
         $superEntity = $this->superEntityRepository->findOneByContent('this is the super entity');
-        $this->assertEquals('this is the super entity', $superEntity->getContent());
+        self::assertEquals('this is the super entity', $superEntity->getContent());
     }
 
     /**
@@ -140,7 +140,7 @@ class RepositoryTest extends FunctionalTestCase
         $this->persistenceManager->persistAll();
 
         $subEntity = $this->superEntityRepository->findOneByContent('this is the sub entity');
-        $this->assertEquals('this is the sub entity', $subEntity->getContent());
+        self::assertEquals('this is the sub entity', $subEntity->getContent());
     }
 
     /**
@@ -161,7 +161,7 @@ class RepositoryTest extends FunctionalTestCase
         $this->persistenceManager->persistAll();
 
         $subEntity = $this->superEntityRepository->findOneByContent('this is the sub entity');
-        $this->assertNull($subEntity);
+        self::assertNull($subEntity);
     }
 
     /**
@@ -184,8 +184,8 @@ class RepositoryTest extends FunctionalTestCase
         $this->persistenceManager->persistAll();
 
         $subEntity = $this->superEntityRepository->findOneByContent('updated sub entity content');
-        $this->assertNotNull($subEntity);
-        $this->assertEquals('updated sub entity content', $subEntity->getContent());
+        self::assertNotNull($subEntity);
+        self::assertEquals('updated sub entity content', $subEntity->getContent());
     }
 
     /**
@@ -205,7 +205,7 @@ class RepositoryTest extends FunctionalTestCase
 
         $this->persistenceManager->persistAll();
 
-        $this->assertEquals(2, $this->superEntityRepository->countAll());
+        self::assertEquals(2, $this->superEntityRepository->countAll());
     }
 
     /**
@@ -225,7 +225,7 @@ class RepositoryTest extends FunctionalTestCase
 
         $this->persistenceManager->persistAll();
 
-        $this->assertEquals(2, $this->superEntityRepository->findAll()->count());
+        self::assertEquals(2, $this->superEntityRepository->findAll()->count());
     }
 
     /**
@@ -252,7 +252,7 @@ class RepositoryTest extends FunctionalTestCase
             $expectedCount++;
         }
 
-        $this->assertEquals(2, $expectedCount);
+        self::assertEquals(2, $expectedCount);
     }
 
     /**
@@ -270,7 +270,7 @@ class RepositoryTest extends FunctionalTestCase
         $this->persistenceManager->persistAll();
 
         $subEntity = $this->superEntityRepository->findByIdentifier($identifier);
-        $this->assertEquals('this is the sub entity', $subEntity->getContent());
+        self::assertEquals('this is the sub entity', $subEntity->getContent());
     }
 
     /**
@@ -300,10 +300,10 @@ class RepositoryTest extends FunctionalTestCase
         $this->persistenceManager->persistAll();
 
         $subSubEntity = $this->superEntityRepository->findAll()->getFirst();
-        $this->assertEquals('this is the sub sub entity', $subSubEntity->getContent());
+        self::assertEquals('this is the sub sub entity', $subSubEntity->getContent());
 
         $subSubEntity = $this->subSubEntityRepository->findAll()->getFirst();
-        $this->assertEquals('this is the sub sub entity - touched by SubSubEntityRepository', $subSubEntity->getContent());
+        self::assertEquals('this is the sub sub entity - touched by SubSubEntityRepository', $subSubEntity->getContent());
     }
 
     /**
@@ -312,9 +312,9 @@ class RepositoryTest extends FunctionalTestCase
     public function findAllReturnsQueryResult()
     {
         $this->postRepository = $this->objectManager->get(Fixtures\PostRepository::class);
-        $this->assertInstanceOf(Repository::class, $this->postRepository, 'Repository under test should be a Doctrine Repository');
+        self::assertInstanceOf(Repository::class, $this->postRepository, 'Repository under test should be a Doctrine Repository');
 
         $result = $this->postRepository->findAll();
-        $this->assertInstanceOf(QueryResultInterface::class, $result, 'findAll should return a QueryResult object');
+        self::assertInstanceOf(QueryResultInterface::class, $result, 'findAll should return a QueryResult object');
     }
 }

--- a/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
@@ -64,7 +64,7 @@ class PersistenceTest extends FunctionalTestCase
         $this->insertExampleEntity();
 
         $testEntity = $this->testEntityRepository->findAll()->getFirst();
-        $this->assertEquals('Flow', $testEntity->getName());
+        self::assertEquals('Flow', $testEntity->getName());
     }
 
     /**
@@ -76,12 +76,12 @@ class PersistenceTest extends FunctionalTestCase
         $this->insertExampleEntity();
 
         $allResults = $this->testEntityRepository->findAll();
-        $this->assertInstanceOf(QueryResult::class, $allResults);
-        $this->assertNull(ObjectAccess::getProperty($allResults, 'rows', true), 'Query Result did not load the result collection lazily.');
+        self::assertInstanceOf(QueryResult::class, $allResults);
+        self::assertNull(ObjectAccess::getProperty($allResults, 'rows', true), 'Query Result did not load the result collection lazily.');
 
         $allResultsArray = $allResults->toArray();
-        $this->assertStringContainsString('Flow', $allResultsArray[0]->getName());
-        $this->assertIsArray(ObjectAccess::getProperty($allResults, 'rows', true));
+        self::assertStringContainsString('Flow', $allResultsArray[0]->getName());
+        self::assertIsArray(ObjectAccess::getProperty($allResults, 'rows', true));
     }
 
     /**
@@ -95,7 +95,7 @@ class PersistenceTest extends FunctionalTestCase
         $allResults = $this->testEntityRepository->findAll();
 
         $unserializedResults = unserialize(serialize($allResults));
-        $this->assertNull(ObjectAccess::getProperty($unserializedResults, 'rows', true), 'Query Result did not flush the result collection after serialization.');
+        self::assertNull(ObjectAccess::getProperty($unserializedResults, 'rows', true), 'Query Result did not flush the result collection after serialization.');
     }
 
     /**
@@ -107,11 +107,11 @@ class PersistenceTest extends FunctionalTestCase
         $this->insertExampleEntity();
 
         $allResults = $this->testEntityRepository->findAll();
-        $this->assertEquals(1, count($allResults->toArray()), 'Not correct number of entities found before running test.');
+        self::assertEquals(1, count($allResults->toArray()), 'Not correct number of entities found before running test.');
 
         $unserializedResults = unserialize(serialize($allResults));
-        $this->assertEquals(1, count($unserializedResults->toArray()));
-        $this->assertEquals('Flow', $unserializedResults[0]->getName());
+        self::assertEquals(1, count($unserializedResults->toArray()));
+        self::assertEquals('Flow', $unserializedResults[0]->getName());
     }
 
     /**
@@ -124,10 +124,10 @@ class PersistenceTest extends FunctionalTestCase
         $this->insertExampleEntity('Neos');
 
         $allResults = $this->testEntityRepository->findAll();
-        $this->assertEquals('Flow', $allResults->getFirst()->getName());
+        self::assertEquals('Flow', $allResults->getFirst()->getName());
 
         $numberOfTotalResults = count($allResults->toArray());
-        $this->assertEquals(2, $numberOfTotalResults);
+        self::assertEquals(2, $numberOfTotalResults);
     }
 
     /**
@@ -140,7 +140,7 @@ class PersistenceTest extends FunctionalTestCase
 
         $clonedEntity = clone $testEntity;
         $secondIdentifier = $this->persistenceManager->getIdentifierByObject($clonedEntity);
-        $this->assertNotEquals($firstIdentifier, $secondIdentifier);
+        self::assertNotEquals($firstIdentifier, $secondIdentifier);
     }
 
     /**
@@ -176,8 +176,8 @@ class PersistenceTest extends FunctionalTestCase
         $testEntityWithArrayPropertyUnserialized = unserialize($serializedData);
         $arrayPropertyAfterUnserialize = $testEntityWithArrayPropertyUnserialized->getArrayProperty();
 
-        $this->assertNotSame($testEntityWithArrayProperty, $testEntityWithArrayPropertyUnserialized);
-        $this->assertEquals('Neos', $arrayPropertyAfterUnserialize['some']['nestedArray']['key']->getName(), 'The entity inside the array property has not been updated to the current persistend state after wakeup.');
+        self::assertNotSame($testEntityWithArrayProperty, $testEntityWithArrayPropertyUnserialized);
+        self::assertEquals('Neos', $arrayPropertyAfterUnserialize['some']['nestedArray']['key']->getName(), 'The entity inside the array property has not been updated to the current persistend state after wakeup.');
     }
 
     /**
@@ -188,7 +188,7 @@ class PersistenceTest extends FunctionalTestCase
         $expectedEntity = new Fixtures\TestEntity();
         $uuid = $this->persistenceManager->getIdentifierByObject($expectedEntity);
         $actualEntity = $this->persistenceManager->getObjectByIdentifier($uuid, Fixtures\TestEntity::class);
-        $this->assertSame($expectedEntity, $actualEntity);
+        self::assertSame($expectedEntity, $actualEntity);
     }
 
     /**
@@ -212,7 +212,7 @@ class PersistenceTest extends FunctionalTestCase
 
         $testEntities = $this->testEntityRepository->findAll();
 
-        $this->assertSame($testEntities[0]->getRelatedValueObject(), $testEntities[1]->getRelatedValueObject());
+        self::assertSame($testEntities[0]->getRelatedValueObject(), $testEntities[1]->getRelatedValueObject());
     }
 
     /**
@@ -245,8 +245,8 @@ class PersistenceTest extends FunctionalTestCase
 
         $testEntities = $this->testEntityRepository->findAll();
 
-        $this->assertSame($testEntities[0]->getRelatedValueObject(), $testEntities[1]->getRelatedValueObject());
-        $this->assertSame($testEntities[1]->getRelatedValueObject(), $testEntities[2]->getRelatedValueObject());
+        self::assertSame($testEntities[0]->getRelatedValueObject(), $testEntities[1]->getRelatedValueObject());
+        self::assertSame($testEntities[1]->getRelatedValueObject(), $testEntities[2]->getRelatedValueObject());
     }
 
     /**
@@ -258,9 +258,9 @@ class PersistenceTest extends FunctionalTestCase
         $entityManager = $this->objectManager->get(\Doctrine\ORM\EntityManagerInterface::class);
         $schemaTool = new SchemaTool($entityManager);
         $classMetaData = $entityManager->getClassMetadata(Fixtures\TestEntity::class);
-        $this->assertTrue($classMetaData->hasField('embeddedValueObject.value'), 'ClassMetadata is not correctly embedded');
+        self::assertTrue($classMetaData->hasField('embeddedValueObject.value'), 'ClassMetadata is not correctly embedded');
         $schema = $schemaTool->getSchemaFromMetadata([$classMetaData]);
-        $this->assertTrue($schema->getTable('persistence_testentity')->hasColumn('embeddedvalueobjectvalue'), 'Database schema is missing embedded field');
+        self::assertTrue($schema->getTable('persistence_testentity')->hasColumn('embeddedvalueobjectvalue'), 'Database schema is missing embedded field');
 
         $valueObject = new Fixtures\TestEmbeddedValueObject('someValue');
         $testEntity = new Fixtures\TestEntity();
@@ -273,7 +273,7 @@ class PersistenceTest extends FunctionalTestCase
 
         /* @var $testEntity Fixtures\TestEntity */
         $testEntity = $this->testEntityRepository->findAll()->getFirst();
-        $this->assertEquals('someValue', $testEntity->getEmbeddedValueObject()->getValue());
+        self::assertEquals('someValue', $testEntity->getEmbeddedValueObject()->getValue());
     }
 
     /**
@@ -356,9 +356,9 @@ class PersistenceTest extends FunctionalTestCase
         $this->insertExampleEntity();
         $this->persistenceManager->persistAll();
         $eventSubscriber = $this->objectManager->get(Fixtures\EventSubscriber::class);
-        $this->assertTrue($eventSubscriber->preFlushCalled, 'Assert that preFlush event was triggered.');
-        $this->assertTrue($eventSubscriber->onFlushCalled, 'Assert that onFlush event was triggered.');
-        $this->assertTrue($eventSubscriber->postFlushCalled, 'Assert that postFlush event was triggered.');
+        self::assertTrue($eventSubscriber->preFlushCalled, 'Assert that preFlush event was triggered.');
+        self::assertTrue($eventSubscriber->onFlushCalled, 'Assert that onFlush event was triggered.');
+        self::assertTrue($eventSubscriber->postFlushCalled, 'Assert that postFlush event was triggered.');
     }
 
     /**
@@ -370,9 +370,9 @@ class PersistenceTest extends FunctionalTestCase
         $this->insertExampleEntity();
         $this->persistenceManager->persistAll();
         $eventSubscriber = $this->objectManager->get(Fixtures\EventListener::class);
-        $this->assertTrue($eventSubscriber->preFlushCalled, 'Assert that preFlush event was triggered.');
-        $this->assertTrue($eventSubscriber->onFlushCalled, 'Assert that onFlush event was triggered.');
-        $this->assertTrue($eventSubscriber->postFlushCalled, 'Assert that postFlush event was triggered.');
+        self::assertTrue($eventSubscriber->preFlushCalled, 'Assert that preFlush event was triggered.');
+        self::assertTrue($eventSubscriber->onFlushCalled, 'Assert that onFlush event was triggered.');
+        self::assertTrue($eventSubscriber->postFlushCalled, 'Assert that postFlush event was triggered.');
     }
 
     /**
@@ -415,7 +415,7 @@ class PersistenceTest extends FunctionalTestCase
 
         $this->persistenceManager->whitelistObject($testEntity);
         $this->persistenceManager->persistAll(true);
-        $this->assertTrue(true);
+        self::assertTrue(true);
     }
 
     /**
@@ -432,16 +432,16 @@ class PersistenceTest extends FunctionalTestCase
         /**  @var Fixtures\ExtendedTypesEntity $persistedExtendedTypesEntity */
         $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
 
-        $this->assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
-        $this->assertNull($persistedExtendedTypesEntity->getCommonObject(), 'Common Object');
-        $this->assertNull($persistedExtendedTypesEntity->getDateTime(), 'DateTime');
-        $this->assertNull($persistedExtendedTypesEntity->getDateTimeTz(), 'DateTimeTz');
-        $this->assertNull($persistedExtendedTypesEntity->getDate(), 'Date');
-        $this->assertNull($persistedExtendedTypesEntity->getTime(), 'Time');
+        self::assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertNull($persistedExtendedTypesEntity->getCommonObject(), 'Common Object');
+        self::assertNull($persistedExtendedTypesEntity->getDateTime(), 'DateTime');
+        self::assertNull($persistedExtendedTypesEntity->getDateTimeTz(), 'DateTimeTz');
+        self::assertNull($persistedExtendedTypesEntity->getDate(), 'Date');
+        self::assertNull($persistedExtendedTypesEntity->getTime(), 'Time');
 
         // These types always returns an array, never NULL, even if the property is nullable
-        $this->assertEquals([], $persistedExtendedTypesEntity->getSimpleArray(), 'Simple Array');
-        $this->assertEquals([], $persistedExtendedTypesEntity->getJsonArray(), 'Json Array');
+        self::assertEquals([], $persistedExtendedTypesEntity->getSimpleArray(), 'Simple Array');
+        self::assertEquals([], $persistedExtendedTypesEntity->getJsonArray(), 'Json Array');
     }
 
     /**
@@ -466,9 +466,9 @@ class PersistenceTest extends FunctionalTestCase
         /**  @var Fixtures\ExtendedTypesEntity $persistedExtendedTypesEntity */
         $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
 
-        $this->assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
-        $this->assertInstanceOf(Fixtures\CommonObject::class, $persistedExtendedTypesEntity->getCommonObject());
-        $this->assertEquals('foo', $persistedExtendedTypesEntity->getCommonObject()->getFoo());
+        self::assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertInstanceOf(Fixtures\CommonObject::class, $persistedExtendedTypesEntity->getCommonObject());
+        self::assertEquals('foo', $persistedExtendedTypesEntity->getCommonObject()->getFoo());
     }
 
     /**
@@ -486,8 +486,8 @@ class PersistenceTest extends FunctionalTestCase
         /**  @var Fixtures\ExtendedTypesEntity $persistedExtendedTypesEntity */
         $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
 
-        $this->assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
-        $this->assertEquals(['foo' => 'bar'], $persistedExtendedTypesEntity->getJsonArray());
+        self::assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertEquals(['foo' => 'bar'], $persistedExtendedTypesEntity->getJsonArray());
     }
 
     /**
@@ -512,10 +512,10 @@ class PersistenceTest extends FunctionalTestCase
         // Restore test env timezone
         ini_restore('date.timezone');
 
-        $this->assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
-        $this->assertInstanceOf('DateTime', $persistedExtendedTypesEntity->getDateTime());
-        $this->assertNotEquals($dateTimeTz->getTimestamp(), $persistedExtendedTypesEntity->getDateTime()->getTimestamp());
-        $this->assertEquals('Arctic/Longyearbyen', $persistedExtendedTypesEntity->getDateTime()->getTimezone()->getName());
+        self::assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertInstanceOf('DateTime', $persistedExtendedTypesEntity->getDateTime());
+        self::assertNotEquals($dateTimeTz->getTimestamp(), $persistedExtendedTypesEntity->getDateTime()->getTimestamp());
+        self::assertEquals('Arctic/Longyearbyen', $persistedExtendedTypesEntity->getDateTime()->getTimezone()->getName());
     }
 
     /**
@@ -532,10 +532,10 @@ class PersistenceTest extends FunctionalTestCase
 
         /**  @var Fixtures\ExtendedTypesEntity $persistedExtendedTypesEntity */
         $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
-        $this->assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
-        $this->assertInstanceOf('DateTime', $persistedExtendedTypesEntity->getDateTime());
-        $this->assertEquals($dateTimeTz->getTimestamp(), $persistedExtendedTypesEntity->getDateTime()->getTimestamp());
-        $this->assertEquals(ini_get('date.timezone'), $persistedExtendedTypesEntity->getDateTime()->getTimezone()->getName());
+        self::assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertInstanceOf('DateTime', $persistedExtendedTypesEntity->getDateTime());
+        self::assertEquals($dateTimeTz->getTimestamp(), $persistedExtendedTypesEntity->getDateTime()->getTimestamp());
+        self::assertEquals(ini_get('date.timezone'), $persistedExtendedTypesEntity->getDateTime()->getTimezone()->getName());
     }
 
     /**
@@ -552,10 +552,10 @@ class PersistenceTest extends FunctionalTestCase
 
         /**  @var Fixtures\ExtendedTypesEntity $persistedExtendedTypesEntity */
         $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
-        $this->assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
-        $this->assertInstanceOf('DateTimeImmutable', $persistedExtendedTypesEntity->getDateTimeImmutable());
-        $this->assertEquals($dateTimeTz->getTimestamp(), $persistedExtendedTypesEntity->getDateTimeImmutable()->getTimestamp());
-        $this->assertEquals(ini_get('date.timezone'), $persistedExtendedTypesEntity->getDateTimeImmutable()->getTimezone()->getName());
+        self::assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertInstanceOf('DateTimeImmutable', $persistedExtendedTypesEntity->getDateTimeImmutable());
+        self::assertEquals($dateTimeTz->getTimestamp(), $persistedExtendedTypesEntity->getDateTimeImmutable()->getTimestamp());
+        self::assertEquals(ini_get('date.timezone'), $persistedExtendedTypesEntity->getDateTimeImmutable()->getTimezone()->getName());
     }
 
     /**
@@ -574,11 +574,11 @@ class PersistenceTest extends FunctionalTestCase
 
         /**  @var Fixtures\ExtendedTypesEntity $persistedExtendedTypesEntity */
         $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
-        $this->assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
         // We don't get the same instance out that we put in.
-        $this->assertInstanceOf('DateTime', $persistedExtendedTypesEntity->getDateTimeInterface());
-        $this->assertEquals($dateTimeTz->getTimestamp(), $persistedExtendedTypesEntity->getDateTimeInterface()->getTimestamp());
-        $this->assertEquals(ini_get('date.timezone'), $persistedExtendedTypesEntity->getDateTimeInterface()->getTimezone()->getName());
+        self::assertInstanceOf('DateTime', $persistedExtendedTypesEntity->getDateTimeInterface());
+        self::assertEquals($dateTimeTz->getTimestamp(), $persistedExtendedTypesEntity->getDateTimeInterface()->getTimestamp());
+        self::assertEquals(ini_get('date.timezone'), $persistedExtendedTypesEntity->getDateTimeInterface()->getTimezone()->getName());
     }
 
     /**
@@ -609,10 +609,10 @@ class PersistenceTest extends FunctionalTestCase
         // Restore test env timezone
         ini_restore('date.timezone');
 
-        $this->assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
-        $this->assertInstanceOf('DateTime', $persistedExtendedTypesEntity->getDateTimeTz());
-        $this->assertNotEquals($dateTimeTz->getTimestamp(), $persistedExtendedTypesEntity->getDateTimeTz()->getTimestamp());
-        $this->assertEquals(ini_get('datetime.timezone'), $persistedExtendedTypesEntity->getDateTimeTz()->getTimezone()->getName());
+        self::assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertInstanceOf('DateTime', $persistedExtendedTypesEntity->getDateTimeTz());
+        self::assertNotEquals($dateTimeTz->getTimestamp(), $persistedExtendedTypesEntity->getDateTimeTz()->getTimestamp());
+        self::assertEquals(ini_get('datetime.timezone'), $persistedExtendedTypesEntity->getDateTimeTz()->getTimezone()->getName());
     }
 
     /**
@@ -629,8 +629,8 @@ class PersistenceTest extends FunctionalTestCase
 
         /**  @var Fixtures\ExtendedTypesEntity $persistedExtendedTypesEntity */
         $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
-        $this->assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
-        $this->assertEquals('2008-11-16', $persistedExtendedTypesEntity->getDate()->format('Y-m-d'));
+        self::assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertEquals('2008-11-16', $persistedExtendedTypesEntity->getDate()->format('Y-m-d'));
     }
 
     /**
@@ -647,8 +647,8 @@ class PersistenceTest extends FunctionalTestCase
 
         /**  @var Fixtures\ExtendedTypesEntity $persistedExtendedTypesEntity */
         $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
-        $this->assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
-        $this->assertEquals('19:03:30', $persistedExtendedTypesEntity->getTime()->format('H:i:s'));
+        self::assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertEquals('19:03:30', $persistedExtendedTypesEntity->getTime()->format('H:i:s'));
     }
 
     /**
@@ -666,8 +666,8 @@ class PersistenceTest extends FunctionalTestCase
         /**  @var Fixtures\ExtendedTypesEntity $persistedExtendedTypesEntity */
         $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
 
-        $this->assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
-        $this->assertEquals(['bar'], $persistedExtendedTypesEntity->getSimpleArray());
+        self::assertInstanceOf(Fixtures\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertEquals(['bar'], $persistedExtendedTypesEntity->getSimpleArray());
     }
 
     /**
@@ -683,7 +683,7 @@ class PersistenceTest extends FunctionalTestCase
         $testEntity = $this->testEntityRepository->findAll()->getFirst();
         $testEntity->setName('Another name');
         $this->testEntityRepository->update($testEntity);
-        $this->assertTrue($this->persistenceManager->hasUnpersistedChanges());
+        self::assertTrue($this->persistenceManager->hasUnpersistedChanges());
     }
 
     /**
@@ -720,9 +720,9 @@ class PersistenceTest extends FunctionalTestCase
         $entityManager = $this->objectManager->get(EntityManagerInterface::class);
         $schemaTool = new SchemaTool($entityManager);
         $metaData = $entityManager->getClassMetadata(Fixtures\TestEntity::class);
-        $this->assertTrue($metaData->hasField('embedded.value'), 'ClassMetadata does not contain embedded value');
+        self::assertTrue($metaData->hasField('embedded.value'), 'ClassMetadata does not contain embedded value');
         $schema = $schemaTool->getSchemaFromMetadata([$metaData]);
-        $this->assertTrue($schema->getTable('persistence_testentity')->hasColumn('embedded_value'), 'Database schema does not contain embedded value field');
+        self::assertTrue($schema->getTable('persistence_testentity')->hasColumn('embedded_value'), 'Database schema does not contain embedded value field');
 
         $embeddable = new Fixtures\TestEmbeddable('someValue');
         $testEntity = new Fixtures\TestEntity();
@@ -735,6 +735,6 @@ class PersistenceTest extends FunctionalTestCase
 
         /* @var $testEntity Fixtures\TestEntity */
         $testEntity = $this->testEntityRepository->findAll()->getFirst();
-        $this->assertEquals('someValue', $testEntity->getEmbedded()->getValue());
+        self::assertEquals('someValue', $testEntity->getEmbedded()->getValue());
     }
 }

--- a/Neos.Flow/Tests/Functional/Property/PropertyMapperTest.php
+++ b/Neos.Flow/Tests/Functional/Property/PropertyMapperTest.php
@@ -54,9 +54,9 @@ class PropertyMapperTest extends FunctionalTestCase
         ];
 
         $result = $this->propertyMapper->convert($source, Fixtures\TestEntity::class);
-        $this->assertSame('Robert Skaarhoj', $result->getName());
-        $this->assertSame(25, $result->getAge());
-        $this->assertSame(1.5, $result->getAverageNumberOfKids());
+        self::assertSame('Robert Skaarhoj', $result->getName());
+        self::assertSame(25, $result->getAge());
+        self::assertSame(1.5, $result->getAverageNumberOfKids());
     }
 
     /**
@@ -71,9 +71,9 @@ class PropertyMapperTest extends FunctionalTestCase
         ];
 
         $result = $this->propertyMapper->convert($source, Fixtures\TestEntity::class);
-        $this->assertSame('Robert Skaarhoj', $result->getName());
-        $this->assertSame(25, $result->getAge());
-        $this->assertSame(1.5, $result->getAverageNumberOfKids());
+        self::assertSame('Robert Skaarhoj', $result->getName());
+        self::assertSame(25, $result->getAge());
+        self::assertSame(1.5, $result->getAverageNumberOfKids());
     }
 
     /**
@@ -89,9 +89,9 @@ class PropertyMapperTest extends FunctionalTestCase
         ];
 
         $result = $this->propertyMapper->convert($source, Fixtures\TestClass::class);
-        $this->assertSame('Christopher', $result->getName());
-        $this->assertSame(187, $result->getSize());
-        $this->assertSame(true, $result->getSignedCla());
+        self::assertSame('Christopher', $result->getName());
+        self::assertSame(187, $result->getSize());
+        self::assertSame(true, $result->getSignedCla());
     }
 
     /**
@@ -106,8 +106,8 @@ class PropertyMapperTest extends FunctionalTestCase
         ];
 
         $result = $this->propertyMapper->convert($source, Fixtures\TestValueobject::class);
-        $this->assertSame('Christopher', $result->getName());
-        $this->assertSame(28, $result->getAge());
+        self::assertSame('Christopher', $result->getName());
+        self::assertSame(28, $result->getAge());
     }
 
     /**
@@ -121,8 +121,8 @@ class PropertyMapperTest extends FunctionalTestCase
         ];
 
         $result = $this->propertyMapper->convert($source, \Neos\Flow\Tests\Functional\Property\Fixtures\TestEmbeddedValueobject::class);
-        $this->assertSame('Christopher', $result->getName());
-        $this->assertSame(28, $result->getAge());
+        self::assertSame('Christopher', $result->getName());
+        self::assertSame(28, $result->getAge());
     }
 
     /**
@@ -136,8 +136,8 @@ class PropertyMapperTest extends FunctionalTestCase
         ];
 
         $result = $this->propertyMapper->convert($source, Fixtures\TestClass::class);
-        $this->assertSame('42', $result->getName());
-        $this->assertSame(23, $result->getSize());
+        self::assertSame('42', $result->getName());
+        self::assertSame(23, $result->getSize());
     }
 
     /**
@@ -155,7 +155,7 @@ class PropertyMapperTest extends FunctionalTestCase
         $configuration->setTypeConverterOption(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED, true);
 
         $result = $this->propertyMapper->convert($source, Fixtures\TestEntity::class, $configuration);
-        $this->assertInstanceOf(Fixtures\TestEntitySubclass::class, $result);
+        self::assertInstanceOf(Fixtures\TestEntitySubclass::class, $result);
     }
 
     /**
@@ -189,7 +189,7 @@ class PropertyMapperTest extends FunctionalTestCase
         $configuration->setTypeConverterOption(ObjectConverter::class, ObjectConverter::CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED, true);
 
         $result = $this->propertyMapper->convert($source, Fixtures\TestClass::class, $configuration);
-        $this->assertInstanceOf(Fixtures\TestSubclass::class, $result);
+        self::assertInstanceOf(Fixtures\TestSubclass::class, $result);
     }
 
     /**
@@ -222,9 +222,9 @@ class PropertyMapperTest extends FunctionalTestCase
         ];
 
         $result = $this->propertyMapper->convert($source, Fixtures\TestEntity::class);
-        $this->assertSame('Egon Olsen', $result->getName());
-        $this->assertSame(42, $result->getAge());
-        $this->assertSame(5.5, $result->getAverageNumberOfKids());
+        self::assertSame('Egon Olsen', $result->getName());
+        self::assertSame(42, $result->getAge());
+        self::assertSame(5.5, $result->getAverageNumberOfKids());
     }
 
     /**
@@ -240,9 +240,9 @@ class PropertyMapperTest extends FunctionalTestCase
         ];
 
         $result = $this->propertyMapper->convert($source, Fixtures\TestEntity::class);
-        $this->assertSame('Egon Olsen', $result->getName());
-        $this->assertSame(42, $result->getAge());
-        $this->assertSame(null, $result->getAverageNumberOfKids());
+        self::assertSame('Egon Olsen', $result->getName());
+        self::assertSame(42, $result->getAge());
+        self::assertSame(null, $result->getAverageNumberOfKids());
     }
 
     /**
@@ -256,7 +256,7 @@ class PropertyMapperTest extends FunctionalTestCase
             'relatedEntity' => $relatedEntity,
         ];
         $result = $this->propertyMapper->convert($source, Fixtures\TestEntity::class);
-        $this->assertSame($relatedEntity, $result->getRelatedEntity());
+        self::assertSame($relatedEntity, $result->getRelatedEntity());
     }
 
     /**
@@ -271,7 +271,7 @@ class PropertyMapperTest extends FunctionalTestCase
         $entity->setName('Egon Olsen');
 
         $result = $this->propertyMapper->convert($entity, Fixtures\TestEntity::class);
-        $this->assertSame($entity, $result);
+        self::assertSame($entity, $result);
     }
 
     /**
@@ -285,7 +285,7 @@ class PropertyMapperTest extends FunctionalTestCase
         $entity->setName('Egon Olsen');
 
         $result = $this->propertyMapper->convert([$entity], 'array<Neos\Flow\Tests\Functional\Property\Fixtures\TestEntity>');
-        $this->assertSame([$entity], $result);
+        self::assertSame([$entity], $result);
     }
 
     /**
@@ -305,7 +305,7 @@ class PropertyMapperTest extends FunctionalTestCase
         $configuration->skipUnknownProperties();
 
         $mappingResult = $this->propertyMapper->convert($source, Fixtures\TestClass::class, $configuration);
-        $this->assertInstanceOf(Fixtures\TestClass::class, $mappingResult);
+        self::assertInstanceOf(Fixtures\TestClass::class, $mappingResult);
     }
 
     /**
@@ -345,7 +345,7 @@ class PropertyMapperTest extends FunctionalTestCase
         $configuration->setTypeConverterOption(PersistentObjectConverter::class, ObjectConverter::CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED, true);
 
         $theHorse = $this->propertyMapper->convert($source, Fixtures\TestEntity::class, $configuration);
-        $this->assertInstanceOf(Fixtures\TestEntitySubclassWithNewField::class, $theHorse);
+        self::assertInstanceOf(Fixtures\TestEntitySubclassWithNewField::class, $theHorse);
     }
 
     /**
@@ -420,9 +420,9 @@ class PropertyMapperTest extends FunctionalTestCase
 
         $account = $this->propertyMapper->convert($source, Account::class, $configuration);
 
-        $this->assertInstanceOf(Account::class, $account);
-        $this->assertEquals(2, count($account->getRoles()));
-        $this->assertEquals($expectedRoleIdentifiers, array_keys($account->getRoles()));
+        self::assertInstanceOf(Account::class, $account);
+        self::assertEquals(2, count($account->getRoles()));
+        self::assertEquals($expectedRoleIdentifiers, array_keys($account->getRoles()));
     }
 
     /**
@@ -445,7 +445,7 @@ class PropertyMapperTest extends FunctionalTestCase
 
         $result = $this->propertyMapper->convert($source, 'string');
 
-        $this->assertSame($entityIdentifier, $result);
+        self::assertSame($entityIdentifier, $result);
     }
 
     /**
@@ -454,11 +454,11 @@ class PropertyMapperTest extends FunctionalTestCase
     public function getTargetPropertyNameShouldReturnTheUnmodifiedPropertyNameWithoutConfiguration()
     {
         $defaultConfiguration = $this->propertyMapper->buildPropertyMappingConfiguration();
-        $this->assertTrue($defaultConfiguration->getConfigurationValue(\Neos\Flow\Property\TypeConverter\PersistentObjectConverter::class, \Neos\Flow\Property\TypeConverter\PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED));
-        $this->assertTrue($defaultConfiguration->getConfigurationValue(\Neos\Flow\Property\TypeConverter\PersistentObjectConverter::class, \Neos\Flow\Property\TypeConverter\PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED));
+        self::assertTrue($defaultConfiguration->getConfigurationValue(\Neos\Flow\Property\TypeConverter\PersistentObjectConverter::class, \Neos\Flow\Property\TypeConverter\PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED));
+        self::assertTrue($defaultConfiguration->getConfigurationValue(\Neos\Flow\Property\TypeConverter\PersistentObjectConverter::class, \Neos\Flow\Property\TypeConverter\PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED));
 
-        $this->assertNull($defaultConfiguration->getConfigurationFor('foo')->getConfigurationValue(\Neos\Flow\Property\TypeConverter\PersistentObjectConverter::class, \Neos\Flow\Property\TypeConverter\PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED));
-        $this->assertNull($defaultConfiguration->getConfigurationFor('foo')->getConfigurationValue(\Neos\Flow\Property\TypeConverter\PersistentObjectConverter::class, \Neos\Flow\Property\TypeConverter\PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED));
+        self::assertNull($defaultConfiguration->getConfigurationFor('foo')->getConfigurationValue(\Neos\Flow\Property\TypeConverter\PersistentObjectConverter::class, \Neos\Flow\Property\TypeConverter\PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED));
+        self::assertNull($defaultConfiguration->getConfigurationFor('foo')->getConfigurationValue(\Neos\Flow\Property\TypeConverter\PersistentObjectConverter::class, \Neos\Flow\Property\TypeConverter\PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED));
     }
 
     /**
@@ -467,6 +467,6 @@ class PropertyMapperTest extends FunctionalTestCase
     public function foo()
     {
         $actualResult = $this->propertyMapper->convert(true, 'int');
-        $this->assertSame(42, $actualResult);
+        self::assertSame(42, $actualResult);
     }
 }

--- a/Neos.Flow/Tests/Functional/Property/TypeConverter/FloatConverterTest.php
+++ b/Neos.Flow/Tests/Functional/Property/TypeConverter/FloatConverterTest.php
@@ -65,7 +65,7 @@ class FloatConverterTest extends FunctionalTestCase
         $configuration->setTypeConverterOption(FloatConverter::class, 'locale', $locale);
 
         $actualResult = $this->converter->convertFrom($source, 'float', [], $configuration);
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -77,9 +77,9 @@ class FloatConverterTest extends FunctionalTestCase
         $configuration->setTypeConverterOption(FloatConverter::class, 'locale', 'de');
 
         $actualResult = $this->converter->convertFrom('12,777777', 'float', [], $configuration);
-        $this->assertInstanceOf(FlowError::class, $actualResult);
+        self::assertInstanceOf(FlowError::class, $actualResult);
 
-        $this->assertInstanceOf(FlowError::class, $this->converter->convertFrom('84,00', 'float'));
+        self::assertInstanceOf(FlowError::class, $this->converter->convertFrom('84,00', 'float'));
     }
 
     /**
@@ -99,7 +99,7 @@ class FloatConverterTest extends FunctionalTestCase
      */
     public function convertFromDoesntUseLocaleParserIfNoConfigurationGiven()
     {
-        $this->assertEquals(84, $this->converter->convertFrom('84.000', 'float'));
-        $this->assertEquals(84.42, $this->converter->convertFrom('84.42', 'float'));
+        self::assertEquals(84, $this->converter->convertFrom('84.000', 'float'));
+        self::assertEquals(84.42, $this->converter->convertFrom('84.42', 'float'));
     }
 }

--- a/Neos.Flow/Tests/Functional/Property/TypeConverter/ObjectConverterTest.php
+++ b/Neos.Flow/Tests/Functional/Property/TypeConverter/ObjectConverterTest.php
@@ -49,7 +49,7 @@ class ObjectConverterTest extends FunctionalTestCase
                 $expectedTargetType);
 
         $actual = $this->converter->getTypeOfChildProperty('irrelevant', $propertyName, $configuration);
-        $this->assertEquals($expectedTargetType, $actual);
+        self::assertEquals($expectedTargetType, $actual);
     }
 
     /**
@@ -62,7 +62,7 @@ class ObjectConverterTest extends FunctionalTestCase
             'dummy',
             new PropertyMappingConfiguration()
         );
-        $this->assertEquals('float', $actual);
+        self::assertEquals('float', $actual);
     }
 
     /**
@@ -75,7 +75,7 @@ class ObjectConverterTest extends FunctionalTestCase
             'attributeWithStringTypeAnnotation',
             new PropertyMappingConfiguration()
         );
-        $this->assertEquals('string', $actual);
+        self::assertEquals('string', $actual);
     }
 
     /**
@@ -103,7 +103,7 @@ class ObjectConverterTest extends FunctionalTestCase
             'somePublicProperty',
             $configuration
         );
-        $this->assertEquals('float', $actual);
+        self::assertEquals('float', $actual);
     }
 
     /**
@@ -122,9 +122,9 @@ class ObjectConverterTest extends FunctionalTestCase
             new PropertyMappingConfiguration()
         );
 
-        $this->assertEquals('theValue set via Constructor', ObjectAccess::getProperty($convertedObject, 'propertyMeantForConstructorUsage', true));
-        $this->assertEquals('theValue set via Setter', ObjectAccess::getProperty($convertedObject, 'propertyMeantForSetterUsage', true));
-        $this->assertEquals('theValue', ObjectAccess::getProperty($convertedObject, 'propertyMeantForPublicUsage', true));
+        self::assertEquals('theValue set via Constructor', ObjectAccess::getProperty($convertedObject, 'propertyMeantForConstructorUsage', true));
+        self::assertEquals('theValue set via Setter', ObjectAccess::getProperty($convertedObject, 'propertyMeantForSetterUsage', true));
+        self::assertEquals('theValue', ObjectAccess::getProperty($convertedObject, 'propertyMeantForPublicUsage', true));
     }
 
     /**
@@ -140,7 +140,7 @@ class ObjectConverterTest extends FunctionalTestCase
             'someUnknownProperty',
             $configuration
         );
-        $this->assertNull($result);
+        self::assertNull($result);
     }
 
     /**
@@ -156,7 +156,7 @@ class ObjectConverterTest extends FunctionalTestCase
             'someUnknownProperty',
             $configuration
         );
-        $this->assertNull($result);
+        self::assertNull($result);
     }
 
     /**
@@ -168,7 +168,7 @@ class ObjectConverterTest extends FunctionalTestCase
             'irrelevant',
             \Neos\Flow\Tests\Functional\Property\Fixtures\TestClassWithSingletonConstructorInjection::class
         );
-        $this->assertInstanceOf(\Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\InterfaceAImplementation::class, $convertedObject->getSingletonClass());
+        self::assertInstanceOf(\Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\InterfaceAImplementation::class, $convertedObject->getSingletonClass());
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/Property/TypeConverter/PersistentObjectConverterTest.php
+++ b/Neos.Flow/Tests/Functional/Property/TypeConverter/PersistentObjectConverterTest.php
@@ -47,8 +47,8 @@ class PersistentObjectConverterTest extends FunctionalTestCase
     public function entityWithImmutablePropertyIsCreatedCorrectly()
     {
         $result = $this->propertyMapper->convert($this->sourceProperties, Fixtures\TestEntityWithImmutableProperty::class);
-        $this->assertInstanceOf(Fixtures\TestEntityWithImmutableProperty::class, $result);
-        $this->assertEquals('Christian M', $result->getName());
+        self::assertInstanceOf(Fixtures\TestEntityWithImmutableProperty::class, $result);
+        self::assertEquals('Christian M', $result->getName());
     }
 
     /**
@@ -69,8 +69,8 @@ class PersistentObjectConverterTest extends FunctionalTestCase
 
         $result = $this->propertyMapper->convert($update, Fixtures\TestEntityWithImmutableProperty::class);
 
-        $this->assertInstanceOf(Fixtures\TestEntityWithImmutableProperty::class, $result);
-        $this->assertEquals('Christian M', $result->getName());
+        self::assertInstanceOf(Fixtures\TestEntityWithImmutableProperty::class, $result);
+        self::assertEquals('Christian M', $result->getName());
     }
 
     /**
@@ -92,8 +92,8 @@ class PersistentObjectConverterTest extends FunctionalTestCase
 
         $result = $this->propertyMapper->convert($update, Fixtures\TestEntityWithImmutableProperty::class);
 
-        $this->assertInstanceOf(Fixtures\TestEntityWithImmutableProperty::class, $result);
-        $this->assertEquals('Christian M', $result->getName());
+        self::assertInstanceOf(Fixtures\TestEntityWithImmutableProperty::class, $result);
+        self::assertEquals('Christian M', $result->getName());
     }
 
     /**
@@ -116,7 +116,7 @@ class PersistentObjectConverterTest extends FunctionalTestCase
 
         $result = $this->propertyMapper->convert($update, Fixtures\TestEntityWithImmutableProperty::class);
 
-        $this->assertInstanceOf(Fixtures\TestEntityWithImmutableProperty::class, $result);
-        $this->assertEquals('Christian M', $result->getName());
+        self::assertInstanceOf(Fixtures\TestEntityWithImmutableProperty::class, $result);
+        self::assertEquals('Christian M', $result->getName());
     }
 }

--- a/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
@@ -39,8 +39,8 @@ class ReflectionServiceTest extends FunctionalTestCase
     {
         $classSchema = $this->reflectionService->getClassSchema(Reflection\Fixtures\ClassSchemaFixture::class);
 
-        $this->assertNotNull($classSchema);
-        $this->assertSame(Reflection\Fixtures\ClassSchemaFixture::class, $classSchema->getClassName());
+        self::assertNotNull($classSchema);
+        self::assertSame(Reflection\Fixtures\ClassSchemaFixture::class, $classSchema->getClassName());
     }
 
     /**
@@ -74,7 +74,7 @@ class ReflectionServiceTest extends FunctionalTestCase
             ],
             'skipcsrfprotection' => []
         ];
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -82,10 +82,10 @@ class ReflectionServiceTest extends FunctionalTestCase
      */
     public function aggregateRootAssignmentsInHierarchiesAreCorrect()
     {
-        $this->assertEquals(Reflection\Fixtures\Repository\SuperEntityRepository::class, $this->reflectionService->getClassSchema(Reflection\Fixtures\Model\SuperEntity::class)->getRepositoryClassName());
-        $this->assertEquals(Reflection\Fixtures\Repository\SuperEntityRepository::class, $this->reflectionService->getClassSchema(Reflection\Fixtures\Model\SubEntity::class)->getRepositoryClassName());
-        $this->assertEquals(Reflection\Fixtures\Repository\SubSubEntityRepository::class, $this->reflectionService->getClassSchema(Reflection\Fixtures\Model\SubSubEntity::class)->getRepositoryClassName());
-        $this->assertEquals(Reflection\Fixtures\Repository\SubSubEntityRepository::class, $this->reflectionService->getClassSchema(Reflection\Fixtures\Model\SubSubSubEntity::class)->getRepositoryClassName());
+        self::assertEquals(Reflection\Fixtures\Repository\SuperEntityRepository::class, $this->reflectionService->getClassSchema(Reflection\Fixtures\Model\SuperEntity::class)->getRepositoryClassName());
+        self::assertEquals(Reflection\Fixtures\Repository\SuperEntityRepository::class, $this->reflectionService->getClassSchema(Reflection\Fixtures\Model\SubEntity::class)->getRepositoryClassName());
+        self::assertEquals(Reflection\Fixtures\Repository\SubSubEntityRepository::class, $this->reflectionService->getClassSchema(Reflection\Fixtures\Model\SubSubEntity::class)->getRepositoryClassName());
+        self::assertEquals(Reflection\Fixtures\Repository\SubSubEntityRepository::class, $this->reflectionService->getClassSchema(Reflection\Fixtures\Model\SubSubSubEntity::class)->getRepositoryClassName());
     }
 
     /**
@@ -95,7 +95,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     {
         $varTagValues = $this->reflectionService->getPropertyTagValues(Reflection\Fixtures\AnnotatedClassWithUseStatements::class, 'reflectionService', 'var');
         $expected = [ReflectionService::class];
-        $this->assertSame($expected, $varTagValues);
+        self::assertSame($expected, $varTagValues);
     }
 
     /**
@@ -105,7 +105,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     {
         $varTagValues = $this->reflectionService->getPropertyTagValues(Reflection\Fixtures\AnnotatedClassWithUseStatements::class, 'subSubEntity', 'var');
         $expected = [Reflection\Fixtures\Model\SubSubEntity::class];
-        $this->assertSame($expected, $varTagValues);
+        self::assertSame($expected, $varTagValues);
     }
 
     /**
@@ -115,7 +115,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     {
         $varTagValues = $this->reflectionService->getPropertyTagValues(Reflection\Fixtures\AnnotatedClassWithUseStatements::class, 'superEntity', 'var');
         $expected = [Reflection\Fixtures\Model\SuperEntity::class];
-        $this->assertSame($expected, $varTagValues);
+        self::assertSame($expected, $varTagValues);
     }
 
     /**
@@ -125,7 +125,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     {
         $varTagValues = $this->reflectionService->getPropertyTagValues(Reflection\Fixtures\AnnotatedClassWithUseStatements::class, 'annotatedClass', 'var');
         $expected = [Reflection\Fixtures\AnnotatedClass::class];
-        $this->assertSame($expected, $varTagValues);
+        self::assertSame($expected, $varTagValues);
     }
 
     /**
@@ -135,7 +135,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     {
         $varTagValues = $this->reflectionService->getPropertyTagValues(Reflection\Fixtures\AnnotatedClassWithUseStatements::class, 'subEntity', 'var');
         $expected = [Reflection\Fixtures\Model\SubEntity::class];
-        $this->assertSame($expected, $varTagValues);
+        self::assertSame($expected, $varTagValues);
     }
 
     /**
@@ -144,9 +144,9 @@ class ReflectionServiceTest extends FunctionalTestCase
     public function domainModelPropertyTypesAreExpandedWithUseStatementsInClassSchema()
     {
         $classSchema = $this->reflectionService->getClassSchema(Reflection\Fixtures\Model\EntityWithUseStatements::class);
-        $this->assertEquals(Reflection\Fixtures\Model\SubSubEntity::class, $classSchema->getProperty('subSubEntity')['type']);
+        self::assertEquals(Reflection\Fixtures\Model\SubSubEntity::class, $classSchema->getProperty('subSubEntity')['type']);
 
-        $this->assertEquals(Persistence\Fixtures\SubEntity::class, $classSchema->getProperty('propertyFromOtherNamespace')['type']);
+        self::assertEquals(Persistence\Fixtures\SubEntity::class, $classSchema->getProperty('propertyFromOtherNamespace')['type']);
     }
 
     /**
@@ -158,7 +158,7 @@ class ReflectionServiceTest extends FunctionalTestCase
 
         $expectedType = Reflection\Fixtures\Model\SubEntity::class;
         $actualType = $methodParameters['parameter']['type'];
-        $this->assertSame($expectedType, $actualType);
+        self::assertSame($expectedType, $actualType);
     }
 
     /**
@@ -170,7 +170,7 @@ class ReflectionServiceTest extends FunctionalTestCase
 
         $expectedType = Persistence\Fixtures\SubEntity::class;
         $actualType = $methodParameters['parameter']['type'];
-        $this->assertSame($expectedType, $actualType);
+        self::assertSame($expectedType, $actualType);
     }
 
     /**
@@ -182,7 +182,7 @@ class ReflectionServiceTest extends FunctionalTestCase
 
         $expectedType = Reflection\Fixtures\Model\SubEntity::class;
         $actualType = $methodParameters['parameter']['type'];
-        $this->assertSame($expectedType, $actualType);
+        self::assertSame($expectedType, $actualType);
     }
 
     /**
@@ -194,7 +194,7 @@ class ReflectionServiceTest extends FunctionalTestCase
 
         $expectedType = Reflection\Fixtures\Model\SubEntity::class . '|null';
         $actualType = $methodParameters['parameter']['type'];
-        $this->assertSame($expectedType, $actualType);
+        self::assertSame($expectedType, $actualType);
     }
 
     /**
@@ -206,7 +206,7 @@ class ReflectionServiceTest extends FunctionalTestCase
 
         $expectedType = 'float';
         $actualType = $methodParameters['parameter']['type'];
-        $this->assertSame($expectedType, $actualType);
+        self::assertSame($expectedType, $actualType);
     }
 
     /**
@@ -217,12 +217,12 @@ class ReflectionServiceTest extends FunctionalTestCase
         $className = Reflection\Fixtures\DummyClassWithProperties::class;
 
         $varTagValues = $this->reflectionService->getPropertyTagValues($className, 'intProperty', 'var');
-        $this->assertCount(1, $varTagValues);
-        $this->assertEquals('integer', $varTagValues[0]);
+        self::assertCount(1, $varTagValues);
+        self::assertEquals('integer', $varTagValues[0]);
 
         $varTagValues = $this->reflectionService->getPropertyTagValues($className, 'integerProperty', 'var');
-        $this->assertCount(1, $varTagValues);
-        $this->assertEquals('integer', $varTagValues[0]);
+        self::assertCount(1, $varTagValues);
+        self::assertEquals('integer', $varTagValues[0]);
     }
 
     /**
@@ -233,12 +233,12 @@ class ReflectionServiceTest extends FunctionalTestCase
         $className = Reflection\Fixtures\DummyClassWithProperties::class;
 
         $varTagValues = $this->reflectionService->getPropertyTagValues($className, 'boolProperty', 'var');
-        $this->assertCount(1, $varTagValues);
-        $this->assertEquals('boolean', $varTagValues[0]);
+        self::assertCount(1, $varTagValues);
+        self::assertEquals('boolean', $varTagValues[0]);
 
         $varTagValues = $this->reflectionService->getPropertyTagValues($className, 'booleanProperty', 'var');
-        $this->assertCount(1, $varTagValues);
-        $this->assertEquals('boolean', $varTagValues[0]);
+        self::assertCount(1, $varTagValues);
+        self::assertEquals('boolean', $varTagValues[0]);
     }
 
     /**
@@ -249,7 +249,7 @@ class ReflectionServiceTest extends FunctionalTestCase
         $methodParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\AnnotatedClass::class, 'intAndIntegerParameters');
 
         foreach ($methodParameters as $methodParameter) {
-            $this->assertEquals('integer', $methodParameter['type']);
+            self::assertEquals('integer', $methodParameter['type']);
         }
     }
 
@@ -263,15 +263,15 @@ class ReflectionServiceTest extends FunctionalTestCase
         $reverseAnnotatedNullableMethodParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\AnnotatedClass::class, 'reverseAnnotatedNullableParameter');
         $annotatedAndNativeNullableMethodParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\AnnotatedClass::class, 'annotatedAndNativeNullableParameter');
 
-        $this->assertTrue($nativeNullableMethodParameters['nullable']['allowsNull']);
-        $this->assertTrue($annotatedNullableMethodParameters['nullable']['allowsNull']);
-        $this->assertTrue($reverseAnnotatedNullableMethodParameters['nullable']['allowsNull']);
-        $this->assertTrue($annotatedAndNativeNullableMethodParameters['nullable']['allowsNull']);
+        self::assertTrue($nativeNullableMethodParameters['nullable']['allowsNull']);
+        self::assertTrue($annotatedNullableMethodParameters['nullable']['allowsNull']);
+        self::assertTrue($reverseAnnotatedNullableMethodParameters['nullable']['allowsNull']);
+        self::assertTrue($annotatedAndNativeNullableMethodParameters['nullable']['allowsNull']);
 
-        $this->assertEquals(Reflection\Fixtures\AnnotatedClass::class, $nativeNullableMethodParameters['nullable']['type']);
-        $this->assertEquals(Reflection\Fixtures\AnnotatedClass::class . '|null', $annotatedNullableMethodParameters['nullable']['type']);
-        $this->assertEquals(Reflection\Fixtures\AnnotatedClass::class . '|null', $reverseAnnotatedNullableMethodParameters['nullable']['type']);
-        $this->assertEquals(Reflection\Fixtures\AnnotatedClass::class . '|null', $annotatedAndNativeNullableMethodParameters['nullable']['type']);
+        self::assertEquals(Reflection\Fixtures\AnnotatedClass::class, $nativeNullableMethodParameters['nullable']['type']);
+        self::assertEquals(Reflection\Fixtures\AnnotatedClass::class . '|null', $annotatedNullableMethodParameters['nullable']['type']);
+        self::assertEquals(Reflection\Fixtures\AnnotatedClass::class . '|null', $reverseAnnotatedNullableMethodParameters['nullable']['type']);
+        self::assertEquals(Reflection\Fixtures\AnnotatedClass::class . '|null', $annotatedAndNativeNullableMethodParameters['nullable']['type']);
     }
 
     /**
@@ -281,8 +281,8 @@ class ReflectionServiceTest extends FunctionalTestCase
     {
         $methodWithTypeHintsParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\DummyClassWithTypeHints::class, 'methodWithScalarTypeHints');
 
-        $this->assertEquals('int', $methodWithTypeHintsParameters['integer']['type']);
-        $this->assertEquals('string', $methodWithTypeHintsParameters['string']['type']);
+        self::assertEquals('int', $methodWithTypeHintsParameters['integer']['type']);
+        self::assertEquals('string', $methodWithTypeHintsParameters['string']['type']);
     }
 
     /**
@@ -291,7 +291,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     public function arrayTypeHintsWorkCorrectly()
     {
         $methodWithTypeHintsParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\DummyClassWithTypeHints::class, 'methodWithArrayTypeHint');
-        $this->assertEquals('array', $methodWithTypeHintsParameters['array']['type']);
+        self::assertEquals('array', $methodWithTypeHintsParameters['array']['type']);
     }
 
     /**
@@ -300,6 +300,6 @@ class ReflectionServiceTest extends FunctionalTestCase
     public function annotatedArrayTypeHintsWorkCorrectly()
     {
         $methodWithTypeHintsParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\DummyClassWithTypeHints::class, 'methodWithArrayTypeHintAndAnnotation');
-        $this->assertEquals('array<string>', $methodWithTypeHintsParameters['array']['type']);
+        self::assertEquals('array<string>', $methodWithTypeHintsParameters['array']['type']);
     }
 }

--- a/Neos.Flow/Tests/Functional/ResourceManagement/PersistentResourceTest.php
+++ b/Neos.Flow/Tests/Functional/ResourceManagement/PersistentResourceTest.php
@@ -48,6 +48,6 @@ class PersistentResourceTest extends FunctionalTestCase
     public function fileGetContentsReturnFixtureContentForResourceUri()
     {
         $resource = $this->resourceManager->importResourceFromContent('fixture', 'fixture.txt');
-        $this->assertEquals('fixture', file_get_contents('resource://' . $resource->getSha1()));
+        self::assertEquals('fixture', file_get_contents('resource://' . $resource->getSha1()));
     }
 }

--- a/Neos.Flow/Tests/Functional/Security/AccountFactoryTest.php
+++ b/Neos.Flow/Tests/Functional/Security/AccountFactoryTest.php
@@ -41,10 +41,10 @@ class AccountFactoryTest extends FunctionalTestCase
 
         $actualAccount = $factory->createAccountWithPassword('username', 'password', ['Neos.Flow:Administrator', 'Neos.Flow:Customer'], 'OtherProvider');
 
-        $this->assertEquals('username', $actualAccount->getAccountIdentifier());
-        $this->assertEquals('OtherProvider', $actualAccount->getAuthenticationProviderName());
+        self::assertEquals('username', $actualAccount->getAccountIdentifier());
+        self::assertEquals('OtherProvider', $actualAccount->getAuthenticationProviderName());
 
-        $this->assertTrue($actualAccount->hasRole($this->policyService->getRole('Neos.Flow:Administrator')));
-        $this->assertTrue($actualAccount->hasRole($this->policyService->getRole('Neos.Flow:Customer')));
+        self::assertTrue($actualAccount->hasRole($this->policyService->getRole('Neos.Flow:Administrator')));
+        self::assertTrue($actualAccount->hasRole($this->policyService->getRole('Neos.Flow:Customer')));
     }
 }

--- a/Neos.Flow/Tests/Functional/Security/AccountTest.php
+++ b/Neos.Flow/Tests/Functional/Security/AccountTest.php
@@ -44,7 +44,7 @@ class AccountTest extends FunctionalTestCase
     public function freshAccountIsActive()
     {
         $this->account->setExpirationDate(null);
-        $this->assertTrue($this->account->isActive());
+        self::assertTrue($this->account->isActive());
     }
 
     /**
@@ -53,7 +53,7 @@ class AccountTest extends FunctionalTestCase
     public function expiredAccountIsInActive()
     {
         $this->account->setExpirationDate((new \DateTime("now"))->sub(new \DateInterval("PT1H")));
-        $this->assertFalse($this->account->isActive());
+        self::assertFalse($this->account->isActive());
     }
 
     /**
@@ -62,6 +62,6 @@ class AccountTest extends FunctionalTestCase
     public function notYetExpiredAccountIsInActive()
     {
         $this->account->setExpirationDate((new \DateTime("now"))->add(new \DateInterval("PT1H")));
-        $this->assertTrue($this->account->isActive());
+        self::assertTrue($this->account->isActive());
     }
 }

--- a/Neos.Flow/Tests/Functional/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
+++ b/Neos.Flow/Tests/Functional/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
@@ -66,11 +66,11 @@ class PersistedUsernamePasswordProviderTest extends FunctionalTestCase
 
         $this->persistedUsernamePasswordProvider->authenticate($this->authenticationToken);
 
-        $this->assertTrue($this->authenticationToken->isAuthenticated());
+        self::assertTrue($this->authenticationToken->isAuthenticated());
 
         $account = $this->accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName('username', 'myTestProvider');
-        $this->assertEquals((new \DateTime())->format(\DateTime::W3C), $account->getLastSuccessfulAuthenticationDate()->format(\DateTime::W3C));
-        $this->assertEquals(0, $account->getFailedAuthenticationCount());
+        self::assertEquals((new \DateTime())->format(\DateTime::W3C), $account->getLastSuccessfulAuthenticationDate()->format(\DateTime::W3C));
+        self::assertEquals(0, $account->getFailedAuthenticationCount());
     }
 
     /**
@@ -82,10 +82,10 @@ class PersistedUsernamePasswordProviderTest extends FunctionalTestCase
 
         $this->persistedUsernamePasswordProvider->authenticate($this->authenticationToken);
 
-        $this->assertFalse($this->authenticationToken->isAuthenticated());
+        self::assertFalse($this->authenticationToken->isAuthenticated());
 
         $account = $this->accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName('username', 'myTestProvider');
-        $this->assertEquals(1, $account->getFailedAuthenticationCount());
+        self::assertEquals(1, $account->getFailedAuthenticationCount());
     }
 
 
@@ -98,7 +98,7 @@ class PersistedUsernamePasswordProviderTest extends FunctionalTestCase
 
         $this->persistedUsernamePasswordProvider->authenticate($this->authenticationToken);
 
-        $this->assertFalse($this->authenticationToken->isAuthenticated());
+        self::assertFalse($this->authenticationToken->isAuthenticated());
     }
 
 
@@ -111,7 +111,7 @@ class PersistedUsernamePasswordProviderTest extends FunctionalTestCase
         $this->persistedUsernamePasswordProvider->authenticate($this->authenticationToken);
 
         $account = $this->accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName('username', 'myTestProvider');
-        $this->assertEquals(1, $account->getFailedAuthenticationCount());
+        self::assertEquals(1, $account->getFailedAuthenticationCount());
 
         $expectedResetDateTime = new \DateTimeImmutable();
 
@@ -119,7 +119,7 @@ class PersistedUsernamePasswordProviderTest extends FunctionalTestCase
         $this->persistedUsernamePasswordProvider->authenticate($this->authenticationToken);
 
         $account = $this->accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName('username', 'myTestProvider');
-        $this->assertGreaterThanOrEqual($expectedResetDateTime->format('U'), $account->getLastSuccessfulAuthenticationDate()->format('U'));
-        $this->assertEquals(0, $account->getFailedAuthenticationCount());
+        self::assertGreaterThanOrEqual($expectedResetDateTime->format('U'), $account->getLastSuccessfulAuthenticationDate()->format('U'));
+        self::assertEquals(0, $account->getFailedAuthenticationCount());
     }
 }

--- a/Neos.Flow/Tests/Functional/Security/AuthenticationTest.php
+++ b/Neos.Flow/Tests/Functional/Security/AuthenticationTest.php
@@ -135,7 +135,7 @@ class AuthenticationTest extends FunctionalTestCase
         $request = Request::create($uri);
         $request->setHeader('Authorization', 'Basic ' . base64_encode('functional_test_account:a_very_secure_long_password'));
         $response = $this->browser->sendRequest($request);
-        $this->assertSame(
+        self::assertSame(
             'HttpBasicTestController success!' . chr(10) . 'Neos.Flow:Everybody' . chr(10) . 'Neos.Flow:AuthenticatedUser' . chr(10) . 'Neos.Flow:Administrator' . chr(10),
             $response->getContent()
         );
@@ -151,7 +151,7 @@ class AuthenticationTest extends FunctionalTestCase
         $arguments['__authentication']['Neos']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['password'] = 'a_very_secure_long_password';
 
         $response = $this->browser->request('http://localhost/test/security/authentication/usernamepassword', 'POST', $arguments);
-        $this->assertSame(
+        self::assertSame(
             'UsernamePasswordTestController success!' . chr(10) . 'Neos.Flow:Everybody' . chr(10) . 'Neos.Flow:AuthenticatedUser' . chr(10) . 'Neos.Flow:Administrator' . chr(10),
             $response->getContent()
         );
@@ -163,7 +163,7 @@ class AuthenticationTest extends FunctionalTestCase
     public function failedAuthenticationCallsOnAuthenticationFailureMethod()
     {
         $response = $this->browser->request('http://localhost/test/security/authentication');
-        $this->assertStringContainsString('Uncaught Exception in Flow #42: Failure Method Exception', $response->getContent());
+        self::assertStringContainsString('Uncaught Exception in Flow #42: Failure Method Exception', $response->getContent());
     }
 
     /**
@@ -175,7 +175,7 @@ class AuthenticationTest extends FunctionalTestCase
         $request = Request::create($uri);
         $request->setHeader('Authorization', 'Basic ' . base64_encode('functional_test_account:a_very_secure_long_password'));
         $response = $this->browser->sendRequest($request);
-        $this->assertEmpty($response->getCookies());
+        self::assertEmpty($response->getCookies());
     }
 
     /**
@@ -188,7 +188,7 @@ class AuthenticationTest extends FunctionalTestCase
         $arguments['__authentication']['Neos']['Flow']['Security']['Authentication']['Token']['UsernamePassword']['password'] = 'a_very_secure_long_password';
 
         $response = $this->browser->request('http://localhost/test/security/authentication/usernamepassword', 'POST', $arguments);
-        $this->assertNotEmpty($response->getHeader('Set-Cookie'));
+        self::assertNotEmpty($response->getHeader('Set-Cookie'));
     }
 
     /**
@@ -197,6 +197,6 @@ class AuthenticationTest extends FunctionalTestCase
     public function noSessionIsStartedIfAUnrestrictedActionIsCalled()
     {
         $response = $this->browser->request('http://localhost/test/security/restricted/public');
-        $this->assertEmpty($response->getCookies());
+        self::assertEmpty($response->getCookies());
     }
 }

--- a/Neos.Flow/Tests/Functional/Security/Authorization/Privilege/Entity/Doctrine/ContentSecurityTest.php
+++ b/Neos.Flow/Tests/Functional/Security/Authorization/Privilege/Entity/Doctrine/ContentSecurityTest.php
@@ -96,10 +96,10 @@ class ContentSecurityTest extends FunctionalTestCase
         $this->persistenceManager->clearState();
 
         $result = $this->restrictableEntityDoctrineRepository->findAllWithDql();
-        $this->assertTrue(count($result) === 2);
+        self::assertTrue(count($result) === 2);
 
-        $this->assertNotNull($this->persistenceManager->getObjectByIdentifier($defaultEntityIdentifier, Fixtures\RestrictableEntity::class));
-        $this->assertNotNull($this->persistenceManager->getObjectByIdentifier($hiddenEntityIdentifier, Fixtures\RestrictableEntity::class));
+        self::assertNotNull($this->persistenceManager->getObjectByIdentifier($defaultEntityIdentifier, Fixtures\RestrictableEntity::class));
+        self::assertNotNull($this->persistenceManager->getObjectByIdentifier($hiddenEntityIdentifier, Fixtures\RestrictableEntity::class));
 
         $this->restrictableEntityDoctrineRepository->removeAll();
         $this->persistenceManager->persistAll();
@@ -126,10 +126,10 @@ class ContentSecurityTest extends FunctionalTestCase
         $this->persistenceManager->clearState();
 
         $result = $this->restrictableEntityDoctrineRepository->findAllWithDql();
-        $this->assertTrue(count($result) === 1);
+        self::assertTrue(count($result) === 1);
 
-        $this->assertNotNull($this->persistenceManager->getObjectByIdentifier($defaultEntityIdentifier, Fixtures\RestrictableEntity::class));
-        $this->assertNull($this->persistenceManager->getObjectByIdentifier($hiddenEntityIdentifier, Fixtures\RestrictableEntity::class));
+        self::assertNotNull($this->persistenceManager->getObjectByIdentifier($defaultEntityIdentifier, Fixtures\RestrictableEntity::class));
+        self::assertNull($this->persistenceManager->getObjectByIdentifier($hiddenEntityIdentifier, Fixtures\RestrictableEntity::class));
 
         $this->restrictableEntityDoctrineRepository->removeAll();
         $this->persistenceManager->persistAll();
@@ -156,10 +156,10 @@ class ContentSecurityTest extends FunctionalTestCase
         $this->persistenceManager->clearState();
 
         $result = $this->restrictableEntityDoctrineRepository->findAllWithDql();
-        $this->assertTrue(count($result) === 1);
+        self::assertTrue(count($result) === 1);
 
-        $this->assertNotNull($this->persistenceManager->getObjectByIdentifier($defaultEntityIdentifier, Fixtures\RestrictableEntity::class));
-        $this->assertNull($this->persistenceManager->getObjectByIdentifier($deletedEntityIdentifier, Fixtures\RestrictableEntity::class));
+        self::assertNotNull($this->persistenceManager->getObjectByIdentifier($defaultEntityIdentifier, Fixtures\RestrictableEntity::class));
+        self::assertNull($this->persistenceManager->getObjectByIdentifier($deletedEntityIdentifier, Fixtures\RestrictableEntity::class));
 
         $this->restrictableEntityDoctrineRepository->removeAll();
         $this->persistenceManager->persistAll();
@@ -186,10 +186,10 @@ class ContentSecurityTest extends FunctionalTestCase
         $this->persistenceManager->clearState();
 
         $result = $this->restrictableEntityDoctrineRepository->findAllWithDql();
-        $this->assertTrue(count($result) === 2);
+        self::assertTrue(count($result) === 2);
 
-        $this->assertNotNull($this->persistenceManager->getObjectByIdentifier($defaultEntityIdentifier, Fixtures\RestrictableEntity::class));
-        $this->assertNotNull($this->persistenceManager->getObjectByIdentifier($deletedEntityIdentifier, Fixtures\RestrictableEntity::class));
+        self::assertNotNull($this->persistenceManager->getObjectByIdentifier($defaultEntityIdentifier, Fixtures\RestrictableEntity::class));
+        self::assertNotNull($this->persistenceManager->getObjectByIdentifier($deletedEntityIdentifier, Fixtures\RestrictableEntity::class));
 
         $this->restrictableEntityDoctrineRepository->removeAll();
         $this->persistenceManager->persistAll();
@@ -214,10 +214,10 @@ class ContentSecurityTest extends FunctionalTestCase
         $this->persistenceManager->clearState();
 
         $result = $this->restrictableEntityDoctrineRepository->findAllWithDql();
-        $this->assertTrue(count($result) === 0);
+        self::assertTrue(count($result) === 0);
 
-        $this->assertNull($this->persistenceManager->getObjectByIdentifier($defaultEntityIdentifier, Fixtures\RestrictableEntity::class));
-        $this->assertNull($this->persistenceManager->getObjectByIdentifier($hiddenEntityIdentifier, Fixtures\RestrictableEntity::class));
+        self::assertNull($this->persistenceManager->getObjectByIdentifier($defaultEntityIdentifier, Fixtures\RestrictableEntity::class));
+        self::assertNull($this->persistenceManager->getObjectByIdentifier($hiddenEntityIdentifier, Fixtures\RestrictableEntity::class));
 
         $this->restrictableEntityDoctrineRepository->removeAll();
         $this->persistenceManager->persistAll();
@@ -252,10 +252,10 @@ class ContentSecurityTest extends FunctionalTestCase
         $this->persistenceManager->clearState();
 
         $result = $this->restrictableEntityDoctrineRepository->findAllWithDql();
-        $this->assertTrue(count($result) === 1);
+        self::assertTrue(count($result) === 1);
 
-        $this->assertNotNull($this->persistenceManager->getObjectByIdentifier($ownEntityIdentifier, Fixtures\RestrictableEntity::class));
-        $this->assertNull($this->persistenceManager->getObjectByIdentifier($othersEntityIdentifier, Fixtures\RestrictableEntity::class));
+        self::assertNotNull($this->persistenceManager->getObjectByIdentifier($ownEntityIdentifier, Fixtures\RestrictableEntity::class));
+        self::assertNull($this->persistenceManager->getObjectByIdentifier($othersEntityIdentifier, Fixtures\RestrictableEntity::class));
 
         $this->restrictableEntityDoctrineRepository->removeAll();
         $this->persistenceManager->persistAll();
@@ -290,10 +290,10 @@ class ContentSecurityTest extends FunctionalTestCase
         $this->persistenceManager->clearState();
 
         $result = $this->restrictableEntityDoctrineRepository->findAllWithDql();
-        $this->assertTrue(count($result) === 2);
+        self::assertTrue(count($result) === 2);
 
-        $this->assertNotNull($this->persistenceManager->getObjectByIdentifier($ownEntityIdentifier, Fixtures\RestrictableEntity::class));
-        $this->assertNotNull($this->persistenceManager->getObjectByIdentifier($othersEntityIdentifier, Fixtures\RestrictableEntity::class));
+        self::assertNotNull($this->persistenceManager->getObjectByIdentifier($ownEntityIdentifier, Fixtures\RestrictableEntity::class));
+        self::assertNotNull($this->persistenceManager->getObjectByIdentifier($othersEntityIdentifier, Fixtures\RestrictableEntity::class));
 
         $this->restrictableEntityDoctrineRepository->removeAll();
         $this->persistenceManager->persistAll();
@@ -328,10 +328,10 @@ class ContentSecurityTest extends FunctionalTestCase
         $this->persistenceManager->clearState();
 
         $result = $this->restrictableEntityDoctrineRepository->findAllWithDql();
-        $this->assertTrue(count($result) === 1);
+        self::assertTrue(count($result) === 1);
 
-        $this->assertNotNull($this->persistenceManager->getObjectByIdentifier($ownEntityIdentifier, Fixtures\RestrictableEntity::class));
-        $this->assertNull($this->persistenceManager->getObjectByIdentifier($andisEntityIdentifier, Fixtures\RestrictableEntity::class));
+        self::assertNotNull($this->persistenceManager->getObjectByIdentifier($ownEntityIdentifier, Fixtures\RestrictableEntity::class));
+        self::assertNull($this->persistenceManager->getObjectByIdentifier($andisEntityIdentifier, Fixtures\RestrictableEntity::class));
 
         $this->restrictableEntityDoctrineRepository->removeAll();
         $this->persistenceManager->persistAll();
@@ -366,10 +366,10 @@ class ContentSecurityTest extends FunctionalTestCase
         $this->persistenceManager->clearState();
 
         $result = $this->restrictableEntityDoctrineRepository->findAllWithDql();
-        $this->assertTrue(count($result) === 2);
+        self::assertTrue(count($result) === 2);
 
-        $this->assertNotNull($this->persistenceManager->getObjectByIdentifier($ownEntityIdentifier, Fixtures\RestrictableEntity::class));
-        $this->assertNotNull($this->persistenceManager->getObjectByIdentifier($andisEntityIdentifier, Fixtures\RestrictableEntity::class));
+        self::assertNotNull($this->persistenceManager->getObjectByIdentifier($ownEntityIdentifier, Fixtures\RestrictableEntity::class));
+        self::assertNotNull($this->persistenceManager->getObjectByIdentifier($andisEntityIdentifier, Fixtures\RestrictableEntity::class));
 
         $this->restrictableEntityDoctrineRepository->removeAll();
         $this->persistenceManager->persistAll();
@@ -398,10 +398,10 @@ class ContentSecurityTest extends FunctionalTestCase
         $this->persistenceManager->clearState();
 
         $result = $this->testEntityADoctrineRepository->findAllWithDql();
-        $this->assertTrue(count($result) === 1);
+        self::assertTrue(count($result) === 1);
 
-        $this->assertNull($this->persistenceManager->getObjectByIdentifier($testEntityAIdentifier, Fixtures\TestEntityA::class));
-        $this->assertNotNull($this->persistenceManager->getObjectByIdentifier($testEntityA2Identifier, Fixtures\TestEntityA::class));
+        self::assertNull($this->persistenceManager->getObjectByIdentifier($testEntityAIdentifier, Fixtures\TestEntityA::class));
+        self::assertNotNull($this->persistenceManager->getObjectByIdentifier($testEntityA2Identifier, Fixtures\TestEntityA::class));
 
         $this->restrictableEntityDoctrineRepository->removeAll();
         $this->persistenceManager->persistAll();
@@ -430,10 +430,10 @@ class ContentSecurityTest extends FunctionalTestCase
         $this->persistenceManager->clearState();
 
         $result = $this->testEntityADoctrineRepository->findAllWithDql();
-        $this->assertTrue(count($result) === 2);
+        self::assertTrue(count($result) === 2);
 
-        $this->assertNotNull($this->persistenceManager->getObjectByIdentifier($testEntityAIdentifier, Fixtures\TestEntityA::class));
-        $this->assertNotNull($this->persistenceManager->getObjectByIdentifier($testEntityA2Identifier, Fixtures\TestEntityA::class));
+        self::assertNotNull($this->persistenceManager->getObjectByIdentifier($testEntityAIdentifier, Fixtures\TestEntityA::class));
+        self::assertNotNull($this->persistenceManager->getObjectByIdentifier($testEntityA2Identifier, Fixtures\TestEntityA::class));
 
         $this->restrictableEntityDoctrineRepository->removeAll();
         $this->persistenceManager->persistAll();
@@ -473,10 +473,10 @@ class ContentSecurityTest extends FunctionalTestCase
         $this->persistenceManager->clearState();
 
         $result = $this->testEntityADoctrineRepository->findAllWithDql();
-        $this->assertTrue(count($result) === 1);
+        self::assertTrue(count($result) === 1);
 
-        $this->assertNotNull($this->persistenceManager->getObjectByIdentifier($testEntityAIdentifier, Fixtures\TestEntityA::class));
-        $this->assertNull($this->persistenceManager->getObjectByIdentifier($testEntityA2Identifier, Fixtures\TestEntityA::class));
+        self::assertNotNull($this->persistenceManager->getObjectByIdentifier($testEntityAIdentifier, Fixtures\TestEntityA::class));
+        self::assertNull($this->persistenceManager->getObjectByIdentifier($testEntityA2Identifier, Fixtures\TestEntityA::class));
 
         $this->restrictableEntityDoctrineRepository->removeAll();
         $this->persistenceManager->persistAll();
@@ -514,10 +514,10 @@ class ContentSecurityTest extends FunctionalTestCase
         $this->persistenceManager->clearState();
 
         $result = $this->testEntityADoctrineRepository->findAllWithDql();
-        $this->assertTrue(count($result) === 2);
+        self::assertTrue(count($result) === 2);
 
-        $this->assertNotNull($this->persistenceManager->getObjectByIdentifier($testEntityAIdentifier, Fixtures\TestEntityA::class));
-        $this->assertNotNull($this->persistenceManager->getObjectByIdentifier($testEntityA2Identifier, Fixtures\TestEntityA::class));
+        self::assertNotNull($this->persistenceManager->getObjectByIdentifier($testEntityAIdentifier, Fixtures\TestEntityA::class));
+        self::assertNotNull($this->persistenceManager->getObjectByIdentifier($testEntityA2Identifier, Fixtures\TestEntityA::class));
 
         $this->restrictableEntityDoctrineRepository->removeAll();
         $this->persistenceManager->persistAll();
@@ -551,10 +551,10 @@ class ContentSecurityTest extends FunctionalTestCase
         $this->persistenceManager->clearState();
 
         $result = $this->testEntityCDoctrineRepository->findAllWithDql();
-        $this->assertTrue(count($result) === 1);
+        self::assertTrue(count($result) === 1);
 
-        $this->assertNotNull($this->persistenceManager->getObjectByIdentifier($testEntityCIdentifier, Fixtures\TestEntityC::class));
-        $this->assertNull($this->persistenceManager->getObjectByIdentifier($testEntityC2Identifier, Fixtures\TestEntityC::class));
+        self::assertNotNull($this->persistenceManager->getObjectByIdentifier($testEntityCIdentifier, Fixtures\TestEntityC::class));
+        self::assertNull($this->persistenceManager->getObjectByIdentifier($testEntityC2Identifier, Fixtures\TestEntityC::class));
         $this->restrictableEntityDoctrineRepository->removeAll();
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();
@@ -579,10 +579,10 @@ class ContentSecurityTest extends FunctionalTestCase
         $this->persistenceManager->clearState();
 
         $result = $this->testEntityCDoctrineRepository->findAllWithDql();
-        $this->assertTrue(count($result) === 0);
+        self::assertTrue(count($result) === 0);
 
-        $this->assertNull($this->persistenceManager->getObjectByIdentifier($testEntityCIdentifier, Fixtures\TestEntityC::class));
-        $this->assertNull($this->persistenceManager->getObjectByIdentifier($testEntityC2Identifier, Fixtures\TestEntityC::class));
+        self::assertNull($this->persistenceManager->getObjectByIdentifier($testEntityCIdentifier, Fixtures\TestEntityC::class));
+        self::assertNull($this->persistenceManager->getObjectByIdentifier($testEntityC2Identifier, Fixtures\TestEntityC::class));
         $this->restrictableEntityDoctrineRepository->removeAll();
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();
@@ -613,9 +613,9 @@ class ContentSecurityTest extends FunctionalTestCase
         $this->persistenceManager->clearState();
 
         $result = $this->testEntityCDoctrineRepository->findAllWithDql();
-        $this->assertTrue(count($result) === 0);
+        self::assertTrue(count($result) === 0);
 
-        $this->assertNull($this->persistenceManager->getObjectByIdentifier($testEntityCIdentifier, Fixtures\TestEntityC::class));
+        self::assertNull($this->persistenceManager->getObjectByIdentifier($testEntityCIdentifier, Fixtures\TestEntityC::class));
 
         $this->restrictableEntityDoctrineRepository->removeAll();
         $this->persistenceManager->persistAll();
@@ -630,9 +630,9 @@ class ContentSecurityTest extends FunctionalTestCase
         $testEntityCIdentifier = $this->setupContainsRelationForOneToMany();
 
         $result = $this->testEntityCDoctrineRepository->findAllWithDql();
-        $this->assertTrue(count($result) === 0);
+        self::assertTrue(count($result) === 0);
 
-        $this->assertNull($this->persistenceManager->getObjectByIdentifier($testEntityCIdentifier, Fixtures\TestEntityC::class));
+        self::assertNull($this->persistenceManager->getObjectByIdentifier($testEntityCIdentifier, Fixtures\TestEntityC::class));
 
         $this->restrictableEntityDoctrineRepository->removeAll();
         $this->persistenceManager->persistAll();
@@ -650,9 +650,9 @@ class ContentSecurityTest extends FunctionalTestCase
         $this->authenticateRoles(['Neos.Flow:Customer']);
 
         $result = $this->testEntityCDoctrineRepository->findAllWithDql();
-        $this->assertTrue(count($result) === 1);
+        self::assertTrue(count($result) === 1);
 
-        $this->assertInstanceOf(Fixtures\TestEntityC::class, $this->persistenceManager->getObjectByIdentifier($testEntityCIdentifier, Fixtures\TestEntityC::class));
+        self::assertInstanceOf(Fixtures\TestEntityC::class, $this->persistenceManager->getObjectByIdentifier($testEntityCIdentifier, Fixtures\TestEntityC::class));
 
         $this->restrictableEntityDoctrineRepository->removeAll();
         $this->persistenceManager->persistAll();
@@ -667,9 +667,9 @@ class ContentSecurityTest extends FunctionalTestCase
         $testEntityCIdentifier = $this->setupContainsRelationForManyToMany();
 
         $result = $this->testEntityCDoctrineRepository->findAllWithDql();
-        $this->assertTrue(count($result) === 0);
+        self::assertTrue(count($result) === 0);
 
-        $this->assertNull($this->persistenceManager->getObjectByIdentifier($testEntityCIdentifier, Fixtures\TestEntityC::class));
+        self::assertNull($this->persistenceManager->getObjectByIdentifier($testEntityCIdentifier, Fixtures\TestEntityC::class));
 
         $this->restrictableEntityDoctrineRepository->removeAll();
         $this->persistenceManager->persistAll();
@@ -687,9 +687,9 @@ class ContentSecurityTest extends FunctionalTestCase
         $this->authenticateRoles(['Neos.Flow:Customer']);
 
         $result = $this->testEntityCDoctrineRepository->findAllWithDql();
-        $this->assertTrue(count($result) === 1);
+        self::assertTrue(count($result) === 1);
 
-        $this->assertInstanceOf(Fixtures\TestEntityC::class, $this->persistenceManager->getObjectByIdentifier($testEntityCIdentifier, Fixtures\TestEntityC::class));
+        self::assertInstanceOf(Fixtures\TestEntityC::class, $this->persistenceManager->getObjectByIdentifier($testEntityCIdentifier, Fixtures\TestEntityC::class));
 
         $this->restrictableEntityDoctrineRepository->removeAll();
         $this->persistenceManager->persistAll();

--- a/Neos.Flow/Tests/Functional/Security/Authorization/Privilege/Entity/Doctrine/EntityPrivilegeExpressionEvaluatorTest.php
+++ b/Neos.Flow/Tests/Functional/Security/Authorization/Privilege/Entity/Doctrine/EntityPrivilegeExpressionEvaluatorTest.php
@@ -75,8 +75,8 @@ class EntityPrivilegeExpressionEvaluatorTest extends FunctionalTestCase
         $entityManager = $this->objectManager->get(EntityManagerInterface::class);
         $sqlFilter = new SqlFilter($entityManager);
 
-        $this->assertEquals(Fixtures\RestrictableEntity::class, $result['entityType']);
-        $this->assertEquals($expectedSqlCode, $result['conditionGenerator']->getSql($sqlFilter, $entityManager->getClassMetadata(Fixtures\RestrictableEntity::class), 't0'));
+        self::assertEquals(Fixtures\RestrictableEntity::class, $result['entityType']);
+        self::assertEquals($expectedSqlCode, $result['conditionGenerator']->getSql($sqlFilter, $entityManager->getClassMetadata(Fixtures\RestrictableEntity::class), 't0'));
     }
 
     /**
@@ -92,8 +92,8 @@ class EntityPrivilegeExpressionEvaluatorTest extends FunctionalTestCase
         $entityManager = $this->objectManager->get(EntityManagerInterface::class);
         $sqlFilter = new SqlFilter($entityManager);
 
-        $this->assertEquals(TestEntityC::class, $result['entityType']);
-        $this->assertEquals('(t0.persistence_object_identifier IN (SELECT n0_.manytoonetorelatedentityc AS sclr_0 FROM neos_flow_tests_functional_security_fixtures_testentityd n0_ WHERE n0_.persistence_object_identifier = \'c1ed7ad7-3618-4e0d-bcf8-c849a505dfe1\'))',
+        self::assertEquals(TestEntityC::class, $result['entityType']);
+        self::assertEquals('(t0.persistence_object_identifier IN (SELECT n0_.manytoonetorelatedentityc AS sclr_0 FROM neos_flow_tests_functional_security_fixtures_testentityd n0_ WHERE n0_.persistence_object_identifier = \'c1ed7ad7-3618-4e0d-bcf8-c849a505dfe1\'))',
             $result['conditionGenerator']->getSql($sqlFilter, $entityManager->getClassMetadata(TestEntityC::class), 't0')
         );
     }
@@ -111,8 +111,8 @@ class EntityPrivilegeExpressionEvaluatorTest extends FunctionalTestCase
         $entityManager = $this->objectManager->get(EntityManagerInterface::class);
         $sqlFilter = new SqlFilter($entityManager);
 
-        $this->assertEquals(TestEntityC::class, $result['entityType']);
-        $this->assertEquals('(t0.persistence_object_identifier IN (SELECT flow_fixtures_testentityc FROM neos_flow_tests_functiona_09cce_manytomanytorelatedentityd_join WHERE flow_fixtures_testentityd = \'c1ed7ad7-3618-4e0d-bcf8-c849a505dfe1\'))',
+        self::assertEquals(TestEntityC::class, $result['entityType']);
+        self::assertEquals('(t0.persistence_object_identifier IN (SELECT flow_fixtures_testentityc FROM neos_flow_tests_functiona_09cce_manytomanytorelatedentityd_join WHERE flow_fixtures_testentityd = \'c1ed7ad7-3618-4e0d-bcf8-c849a505dfe1\'))',
             $result['conditionGenerator']->getSql($sqlFilter, $entityManager->getClassMetadata(TestEntityC::class), 't0')
         );
     }

--- a/Neos.Flow/Tests/Functional/Security/Policy/PolicyTest.php
+++ b/Neos.Flow/Tests/Functional/Security/Policy/PolicyTest.php
@@ -39,12 +39,12 @@ class PolicyTest extends FunctionalTestCase
             }
         }
 
-        $this->assertEquals(2, count($this->securityContext->getRoles()));
+        self::assertEquals(2, count($this->securityContext->getRoles()));
 
-        $this->assertTrue($this->securityContext->hasRole('Neos.Flow:Everybody'), 'Everybody - hasRole()');
-        $this->assertTrue($hasEverybodyRole, 'Everybody - getRoles()');
+        self::assertTrue($this->securityContext->hasRole('Neos.Flow:Everybody'), 'Everybody - hasRole()');
+        self::assertTrue($hasEverybodyRole, 'Everybody - getRoles()');
 
-        $this->assertTrue($this->securityContext->hasRole('Neos.Flow:Anonymous'), 'Anonymous - hasRole()');
-        $this->assertTrue($hasAnonymousRole, 'Anonymous - getRoles()');
+        self::assertTrue($this->securityContext->hasRole('Neos.Flow:Anonymous'), 'Anonymous - hasRole()');
+        self::assertTrue($hasAnonymousRole, 'Anonymous - getRoles()');
     }
 }

--- a/Neos.Flow/Tests/Functional/Session/SessionManagementTest.php
+++ b/Neos.Flow/Tests/Functional/Session/SessionManagementTest.php
@@ -44,7 +44,7 @@ class SessionManagementTest extends FunctionalTestCase
     {
         $session1 = $this->objectManager->get(Session\SessionInterface::class);
         $session2 = $this->objectManager->get(Session\SessionInterface::class);
-        $this->assertSame($session1, $session2);
+        self::assertSame($session1, $session2);
     }
 
     /**
@@ -54,7 +54,7 @@ class SessionManagementTest extends FunctionalTestCase
     {
         $session1 = $this->objectManager->get(Session\Session::class);
         $session2 = $this->objectManager->get(Session\Session::class);
-        $this->assertNotSame($session1, $session2);
+        self::assertNotSame($session1, $session2);
     }
 
     /**
@@ -70,8 +70,8 @@ class SessionManagementTest extends FunctionalTestCase
         $otherInjectedSession = $this->objectManager->get(Session\SessionInterface::class);
 
         $retrievedSession = $sessionManager->getCurrentSession();
-        $this->assertSame($injectedSession, $retrievedSession);
-        $this->assertSame($otherInjectedSession, $retrievedSession);
+        self::assertSame($injectedSession, $retrievedSession);
+        self::assertSame($otherInjectedSession, $retrievedSession);
     }
 
     /**
@@ -100,11 +100,11 @@ class SessionManagementTest extends FunctionalTestCase
     public function aSessionUsedInAFunctionalTestVirtualBrowserSendsCookiesOnEachRequest()
     {
         $response = $this->browser->request('http://localhost/test/session');
-        $this->assertTrue($response->hasHeader('Set-Cookie'), 'Available Cookies are: ' . implode(', ', array_keys($response->getHeader('Set-Cookie'))));
-        $this->assertStringContainsString('Flow_Testing_Session', implode(',', $response->getHeader('Set-Cookie')));
+        self::assertTrue($response->hasHeader('Set-Cookie'), 'Available Cookies are: ' . implode(', ', array_keys($response->getHeader('Set-Cookie'))));
+        self::assertStringContainsString('Flow_Testing_Session', implode(',', $response->getHeader('Set-Cookie')));
 
         $response = $this->browser->request('http://localhost/test/session');
-        $this->assertTrue($response->hasHeader('Set-Cookie'), 'Available Cookies are: ' . implode(', ', array_keys($response->getHeader('Set-Cookie'))));
-        $this->assertStringContainsString('Flow_Testing_Session', implode(',', $response->getHeader('Set-Cookie')));
+        self::assertTrue($response->hasHeader('Set-Cookie'), 'Available Cookies are: ' . implode(', ', array_keys($response->getHeader('Set-Cookie'))));
+        self::assertStringContainsString('Flow_Testing_Session', implode(',', $response->getHeader('Set-Cookie')));
     }
 }

--- a/Neos.Flow/Tests/Functional/SignalSlot/SignalSlotTest.php
+++ b/Neos.Flow/Tests/Functional/SignalSlot/SignalSlotTest.php
@@ -30,11 +30,11 @@ class SignalSlotTest extends FunctionalTestCase
         $dispatcher->connect(Fixtures\SubClass::class, 'something', $subClass, 'somethingSlot');
 
         $subClass->triggerSomethingSignalFromSubClass();
-        $this->assertTrue($subClass->slotWasCalled, 'from sub class');
+        self::assertTrue($subClass->slotWasCalled, 'from sub class');
 
         $subClass->slotWasCalled = false;
 
         $subClass->triggerSomethingSignalFromAbstractClass();
-        $this->assertTrue($subClass->slotWasCalled, 'from abstract class');
+        self::assertTrue($subClass->slotWasCalled, 'from abstract class');
     }
 }

--- a/Neos.Flow/Tests/Functional/Utility/NowTest.php
+++ b/Neos.Flow/Tests/Functional/Utility/NowTest.php
@@ -26,6 +26,6 @@ class NowTest extends FunctionalTestCase
     {
         $now = $this->objectManager->get(Utility\Now::class);
         $alsoNow = $this->objectManager->get(Utility\Now::class);
-        $this->assertSame($now->getTimeStamp(), $alsoNow->getTimeStamp());
+        self::assertSame($now->getTimeStamp(), $alsoNow->getTimeStamp());
     }
 }

--- a/Neos.Flow/Tests/Functional/Validation/ValidationTest.php
+++ b/Neos.Flow/Tests/Functional/Validation/ValidationTest.php
@@ -69,11 +69,11 @@ class ValidationTest extends FunctionalTestCase
         $entityIdentifier = $this->persistenceManager->getIdentifierByObject($entity);
         $validArguments = ['entity' => ['__identity' => $entityIdentifier, 'name' => 'long enough name']];
         $response = $this->browser->request('http://localhost/test/validation/entity/update', 'POST', $validArguments);
-        $this->assertSame('Entity "long enough name" updated', $response->getContent());
+        self::assertSame('Entity "long enough name" updated', $response->getContent());
 
         $invalidArguments = ['entity' => ['__identity' => $entityIdentifier, 'name' => 'xx']];
         $response = $this->browser->request('http://localhost/test/validation/entity/update', 'POST', $invalidArguments);
-        $this->assertSame('An error occurred while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\EntityController->updateAction().' . PHP_EOL . 'Error for entity.name:  This field must contain at least 3 characters.' . PHP_EOL, $response->getContent());
+        self::assertSame('An error occurred while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\EntityController->updateAction().' . PHP_EOL . 'Error for entity.name:  This field must contain at least 3 characters.' . PHP_EOL, $response->getContent());
     }
 
     /**
@@ -98,7 +98,7 @@ class ValidationTest extends FunctionalTestCase
 
         $invalidArguments = ['entity' => ['__identity' => $entityIdentifier, 'name' => 'long enough name', 'subEntities' => [['__identity' => $subEntityIdentifier, 'content' => '']]]];
         $response = $this->browser->request('http://localhost/test/validation/entity/update', 'POST', $invalidArguments);
-        $this->assertSame('An error occurred while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\EntityController->updateAction().' . PHP_EOL . 'Error for entity.subEntities.0.content:  This property is required.' . PHP_EOL, $response->getContent());
+        self::assertSame('An error occurred while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\EntityController->updateAction().' . PHP_EOL . 'Error for entity.subEntities.0.content:  This property is required.' . PHP_EOL, $response->getContent());
     }
 
     /**
@@ -133,7 +133,7 @@ class ValidationTest extends FunctionalTestCase
             ]
         ];
         $response = $this->browser->request('http://localhost/test/validation/entity/update', 'POST', $invalidArguments);
-        $this->assertSame('An error occurred while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\EntityController->updateAction().' . PHP_EOL . 'Error for entity.name:  This field must contain at least 3 characters.' . PHP_EOL, $response->getContent());
+        self::assertSame('An error occurred while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\EntityController->updateAction().' . PHP_EOL . 'Error for entity.name:  This field must contain at least 3 characters.' . PHP_EOL, $response->getContent());
     }
 
     /**
@@ -169,7 +169,7 @@ class ValidationTest extends FunctionalTestCase
             ]
         ];
         $response = $this->browser->request('http://localhost/test/validation/entity/update', 'POST', $invalidArguments);
-        $this->assertNotSame('An error occurred while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\EntityController->updateAction().' . PHP_EOL . 'Error for entity.relatedEntity.name:  This field must contain at least 3 characters.' . PHP_EOL, $response->getContent());
-        $this->assertSame(200, $response->getStatusCode());
+        self::assertNotSame('An error occurred while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\EntityController->updateAction().' . PHP_EOL . 'Error for entity.relatedEntity.name:  This field must contain at least 3 characters.' . PHP_EOL, $response->getContent());
+        self::assertSame(200, $response->getStatusCode());
     }
 }

--- a/Neos.Flow/Tests/Functional/Validation/Validator/UniqueEntityValidatorTest.php
+++ b/Neos.Flow/Tests/Functional/Validation/Validator/UniqueEntityValidatorTest.php
@@ -57,11 +57,11 @@ class UniqueEntityValidatorTest extends \Neos\Flow\Tests\FunctionalTestCase
 
         $differentPost = new Post();
         $differentPost->setTitle('A different title');
-        $this->assertFalse($validator->validate($differentPost)->hasErrors());
+        self::assertFalse($validator->validate($differentPost)->hasErrors());
 
         $nextPost = new Post();
         $nextPost->setTitle('The title of the initial post');
-        $this->assertTrue($validator->validate($nextPost)->hasErrors());
+        self::assertTrue($validator->validate($nextPost)->hasErrors());
     }
 
     /**
@@ -81,16 +81,16 @@ class UniqueEntityValidatorTest extends \Neos\Flow\Tests\FunctionalTestCase
         $richardsOtherBook = new AnnotatedIdentitiesEntity();
         $richardsOtherBook->setTitle('The Plague Dogs');
         $richardsOtherBook->setAuthor('Richard Adams');
-        $this->assertFalse($validator->validate($richardsOtherBook)->hasErrors());
+        self::assertFalse($validator->validate($richardsOtherBook)->hasErrors());
 
         $otherWatershipDown = new AnnotatedIdentitiesEntity();
         $otherWatershipDown->setTitle('Watership Down');
         $otherWatershipDown->setAuthor('Martin Rosen');
-        $this->assertFalse($validator->validate($otherWatershipDown)->hasErrors());
+        self::assertFalse($validator->validate($otherWatershipDown)->hasErrors());
 
         $sameWatershipDown = new AnnotatedIdentitiesEntity();
         $sameWatershipDown->setTitle('Watership Down');
         $sameWatershipDown->setAuthor('Richard Adams');
-        $this->assertTrue($validator->validate($sameWatershipDown)->hasErrors());
+        self::assertTrue($validator->validate($sameWatershipDown)->hasErrors());
     }
 }

--- a/Neos.Flow/Tests/Unit/Aop/Advice/AroundAdviceTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Advice/AroundAdviceTest.php
@@ -41,7 +41,7 @@ class AroundAdviceTest extends UnitTestCase
         });
         $result = $advice->invoke($mockJoinPoint);
 
-        $this->assertEquals($result, 'result', 'The around advice did not return the result value as expected.');
+        self::assertEquals($result, 'result', 'The around advice did not return the result value as expected.');
     }
 
     /**
@@ -69,6 +69,6 @@ class AroundAdviceTest extends UnitTestCase
         });
         $result = $advice->invoke($mockJoinPoint);
 
-        $this->assertEquals($result, 'result', 'The around advice did not return the result value as expected.');
+        self::assertEquals($result, 'result', 'The around advice did not return the result value as expected.');
     }
 }

--- a/Neos.Flow/Tests/Unit/Aop/Builder/AbstractMethodInterceptorBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Builder/AbstractMethodInterceptorBuilderTest.php
@@ -96,7 +96,7 @@ class AbstractMethodInterceptorBuilderTest extends UnitTestCase
         $builder->injectReflectionService($mockReflectionService);
 
         $actualCode = $builder->_call('buildMethodArgumentsArrayCode', $className, 'foo');
-        $this->assertSame($expectedCode, $actualCode);
+        self::assertSame($expectedCode, $actualCode);
     }
 
     /**
@@ -107,7 +107,7 @@ class AbstractMethodInterceptorBuilderTest extends UnitTestCase
         $builder = $this->getAccessibleMock(AbstractMethodInterceptorBuilder::class, ['build'], [], '', false);
 
         $actualCode = $builder->_call('buildMethodArgumentsArrayCode', null, 'foo');
-        $this->assertSame('', $actualCode);
+        self::assertSame('', $actualCode);
     }
 
     /**
@@ -168,6 +168,6 @@ class AbstractMethodInterceptorBuilderTest extends UnitTestCase
         $expectedCode = '$this->Flow_Aop_Proxy_originalConstructorArguments[\'arg1\'], $this->Flow_Aop_Proxy_originalConstructorArguments[\'arg2\'], $this->Flow_Aop_Proxy_originalConstructorArguments[\'arg3\'], $this->Flow_Aop_Proxy_originalConstructorArguments[\'arg4\'], $this->Flow_Aop_Proxy_originalConstructorArguments[\'arg5\']';
         $actualCode = $builder->_call('buildSavedConstructorParametersCode', $className);
 
-        $this->assertSame($expectedCode, $actualCode);
+        self::assertSame($expectedCode, $actualCode);
     }
 }

--- a/Neos.Flow/Tests/Unit/Aop/Builder/ClassNameIndexTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Builder/ClassNameIndexTest.php
@@ -30,7 +30,7 @@ class ClassNameIndexTest extends UnitTestCase
         $index2->setClassNames(['\Foo\Baz', '\Foo\Blubb']);
         $intersectedIndex = $index1->intersect($index2);
 
-        $this->assertEquals(['\Foo\Baz'], $intersectedIndex->getClassNames());
+        self::assertEquals(['\Foo\Baz'], $intersectedIndex->getClassNames());
     }
 
     /**
@@ -44,7 +44,7 @@ class ClassNameIndexTest extends UnitTestCase
         $index2->setClassNames(['\Foo\Baz', '\Foo\Blubb']);
         $index1->applyIntersect($index2);
 
-        $this->assertEquals(['\Foo\Baz'], $index1->getClassNames());
+        self::assertEquals(['\Foo\Baz'], $index1->getClassNames());
     }
 
     /**
@@ -59,7 +59,7 @@ class ClassNameIndexTest extends UnitTestCase
         $intersectedIndex = $index1->union($index2);
         $intersectedIndex->sort();
 
-        $this->assertEquals(['\Foo\Bar', '\Foo\Baz', '\Foo\Blubb'], $intersectedIndex->getClassNames());
+        self::assertEquals(['\Foo\Bar', '\Foo\Baz', '\Foo\Blubb'], $intersectedIndex->getClassNames());
     }
 
     /**
@@ -74,7 +74,7 @@ class ClassNameIndexTest extends UnitTestCase
         $index1->applyUnion($index2);
         $index1->sort();
 
-        $this->assertEquals(['\Foo\Bar', '\Foo\Baz', '\Foo\Blubb'], $index1->getClassNames());
+        self::assertEquals(['\Foo\Bar', '\Foo\Baz', '\Foo\Blubb'], $index1->getClassNames());
     }
 
     /**
@@ -89,6 +89,6 @@ class ClassNameIndexTest extends UnitTestCase
 
         $filteredIndex = $index1->filterByPrefix('\Foo');
 
-        $this->assertEquals(['\Foo\Bar', '\Foo\Baz', '\Foo\Blubb'], $filteredIndex->getClassNames());
+        self::assertEquals(['\Foo\Bar', '\Foo\Baz', '\Foo\Blubb'], $filteredIndex->getClassNames());
     }
 }

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutClassAnnotatedWithFilterTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutClassAnnotatedWithFilterTest.php
@@ -31,8 +31,8 @@ class PointcutClassAnnotatedWithFilterTest extends UnitTestCase
         $filter = new Aop\Pointcut\PointcutClassAnnotatedWithFilter('Acme\Some\Annotation');
         $filter->injectReflectionService($mockReflectionService);
 
-        $this->assertTrue($filter->matches('Acme\Some\Class', 'foo', 'Acme\Some\Other\Class', 1234));
-        $this->assertFalse($filter->matches('Acme\Some\Class', 'foo', 'Acme\Some\Other\Class', 1234));
+        self::assertTrue($filter->matches('Acme\Some\Class', 'foo', 'Acme\Some\Other\Class', 1234));
+        self::assertFalse($filter->matches('Acme\Some\Class', 'foo', 'Acme\Some\Other\Class', 1234));
     }
 
     /**
@@ -66,6 +66,6 @@ class PointcutClassAnnotatedWithFilterTest extends UnitTestCase
 
         $result = $classAnnotatedWithFilter->reduceTargetClassNames($availableClassNamesIndex);
 
-        $this->assertEquals($expectedClassNamesIndex, $result, 'The wrong class names have been filtered');
+        self::assertEquals($expectedClassNamesIndex, $result, 'The wrong class names have been filtered');
     }
 }

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutClassNameFilterTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutClassNameFilterTest.php
@@ -34,15 +34,15 @@ class PointcutClassNameFilterTest extends UnitTestCase
 
         $classFilter = new Aop\Pointcut\PointcutClassNameFilter('Neos\Virtual\Foo\Bar');
         $classFilter->injectReflectionService($mockReflectionService);
-        $this->assertTrue($classFilter->matches('Neos\Virtual\Foo\Bar', '', '', 1), 'No. 1');
+        self::assertTrue($classFilter->matches('Neos\Virtual\Foo\Bar', '', '', 1), 'No. 1');
 
         $classFilter = new Aop\Pointcut\PointcutClassNameFilter('.*Virtual.*');
         $classFilter->injectReflectionService($mockReflectionService);
-        $this->assertTrue($classFilter->matches('Neos\Virtual\Foo\Bar', '', '', 1), 'No. 2');
+        self::assertTrue($classFilter->matches('Neos\Virtual\Foo\Bar', '', '', 1), 'No. 2');
 
         $classFilter = new Aop\Pointcut\PointcutClassNameFilter('Neos\Firtual.*');
         $classFilter->injectReflectionService($mockReflectionService);
-        $this->assertFalse($classFilter->matches('Neos\Virtual\Foo\Bar', '', '', 1), 'No. 3');
+        self::assertFalse($classFilter->matches('Neos\Virtual\Foo\Bar', '', '', 1), 'No. 3');
     }
 
     /**
@@ -70,7 +70,7 @@ class PointcutClassNameFilterTest extends UnitTestCase
         $classNameFilter = new Aop\Pointcut\PointcutClassNameFilter('TestPackage\Subpackage\SubSubPackage\Class3');
         $result = $classNameFilter->reduceTargetClassNames($availableClassNamesIndex);
 
-        $this->assertEquals($expectedClassNamesIndex, $result, 'The wrong class names have been filtered');
+        self::assertEquals($expectedClassNamesIndex, $result, 'The wrong class names have been filtered');
     }
 
     /**
@@ -99,6 +99,6 @@ class PointcutClassNameFilterTest extends UnitTestCase
         $classNameFilter = new Aop\Pointcut\PointcutClassNameFilter('TestPackage\Subpackage\.*');
         $result = $classNameFilter->reduceTargetClassNames($availableClassNamesIndex);
 
-        $this->assertEquals($expectedClassNamesIndex, $result, 'The wrong class names have been filtered');
+        self::assertEquals($expectedClassNamesIndex, $result, 'The wrong class names have been filtered');
     }
 }

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutClassTypeFilterTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutClassTypeFilterTest.php
@@ -54,7 +54,7 @@ class PointcutClassTypeFilterTest extends UnitTestCase
 
         $result = $classTypeFilter->reduceTargetClassNames($availableClassNamesIndex);
 
-        $this->assertEquals($expectedClassNamesIndex, $result, 'The wrong class names have been filtered');
+        self::assertEquals($expectedClassNamesIndex, $result, 'The wrong class names have been filtered');
     }
 
     /**
@@ -93,6 +93,6 @@ class PointcutClassTypeFilterTest extends UnitTestCase
 
         $result = $classTypeFilter->reduceTargetClassNames($availableClassNamesIndex);
 
-        $this->assertEquals($expectedClassNamesIndex, $result, 'The wrong class names have been filtered');
+        self::assertEquals($expectedClassNamesIndex, $result, 'The wrong class names have been filtered');
     }
 }

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutExpressionParserTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutExpressionParserTest.php
@@ -214,7 +214,7 @@ class PointcutExpressionParserTest extends UnitTestCase
         foreach ($filters as $operatorAndFilter) {
             list(, $filter) = $operatorAndFilter;
             if ($filter instanceof Aop\Pointcut\PointcutMethodNameFilter) {
-                $this->assertEquals('protected', $filter->getMethodVisibility());
+                self::assertEquals('protected', $filter->getMethodVisibility());
                 return;
             }
         }
@@ -267,7 +267,7 @@ class PointcutExpressionParserTest extends UnitTestCase
         $parser = $this->getAccessibleMock(PointcutExpressionParser::class, ['dummy'], [], '', false);
 
         $result = $parser->_call('getArgumentConstraintsFromMethodArgumentsPattern', $methodArgumentsPattern);
-        $this->assertEquals($expectedConditions, $result, 'The argument condition string has not been parsed as expected.');
+        self::assertEquals($expectedConditions, $result, 'The argument condition string has not been parsed as expected.');
     }
 
     /**
@@ -380,7 +380,7 @@ class PointcutExpressionParserTest extends UnitTestCase
         $parser = $this->getAccessibleMock(PointcutExpressionParser::class, ['dummy'], [], '', false);
         $result = $parser->_call('getRuntimeEvaluationConditionsFromEvaluateString', $evaluateString);
 
-        $this->assertEquals($result, $expectedRuntimeEvaluationsDefinition, 'The string has not been parsed correctly.');
+        self::assertEquals($result, $expectedRuntimeEvaluationsDefinition, 'The string has not been parsed correctly.');
     }
 
     /**
@@ -417,8 +417,8 @@ class PointcutExpressionParserTest extends UnitTestCase
         $filter = $filters[0][1];
         $annotation = ObjectAccess::getProperty($filter, 'annotation', true);
         $annotationValueConstraints = ObjectAccess::getProperty($filter, 'annotationValueConstraints', true);
-        $this->assertEquals($expectedAnnotation, $annotation);
-        $this->assertEquals($expectedAnnotationValueConstraints, $annotationValueConstraints);
+        self::assertEquals($expectedAnnotation, $annotation);
+        self::assertEquals($expectedAnnotationValueConstraints, $annotationValueConstraints);
     }
 
     /**
@@ -455,7 +455,7 @@ class PointcutExpressionParserTest extends UnitTestCase
         $filter = $filters[0][1];
         $annotation = ObjectAccess::getProperty($filter, 'annotation', true);
         $annotationValueConstraints = ObjectAccess::getProperty($filter, 'annotationValueConstraints', true);
-        $this->assertEquals($expectedAnnotation, $annotation);
-        $this->assertEquals($expectedAnnotationValueConstraints, $annotationValueConstraints);
+        self::assertEquals($expectedAnnotation, $annotation);
+        self::assertEquals($expectedAnnotationValueConstraints, $annotationValueConstraints);
     }
 }

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutFilterCompositeTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutFilterCompositeTest.php
@@ -77,7 +77,7 @@ class PointcutFilterCompositeTest extends UnitTestCase
 
         $pointcutFilterComposite->matches('className', 'methodName', 'methodDeclaringClassName', 1);
 
-        $this->assertEquals($expectedRuntimeEvaluations, $pointcutFilterComposite->getRuntimeEvaluationsDefinition());
+        self::assertEquals($expectedRuntimeEvaluations, $pointcutFilterComposite->getRuntimeEvaluationsDefinition());
     }
 
     /**
@@ -107,7 +107,7 @@ class PointcutFilterCompositeTest extends UnitTestCase
         $pointcutFilterComposite->addFilter('||', $mockPointcutFilter3);
         $pointcutFilterComposite->addFilter('||!', $mockPointcutFilter4);
 
-        $this->assertTrue($pointcutFilterComposite->matches('someClass', 'someMethod', 'someDeclaringClass', 1));
+        self::assertTrue($pointcutFilterComposite->matches('someClass', 'someMethod', 'someDeclaringClass', 1));
     }
 
     /**
@@ -127,7 +127,7 @@ class PointcutFilterCompositeTest extends UnitTestCase
         $pointcutFilterComposite->addFilter('&&', $mockPointcutFilter1);
         $pointcutFilterComposite->addFilter('&&!', $mockPointcutFilter2);
 
-        $this->assertTrue($pointcutFilterComposite->matches('someClass', 'someMethod', 'someDeclaringClass', 1));
+        self::assertTrue($pointcutFilterComposite->matches('someClass', 'someMethod', 'someDeclaringClass', 1));
     }
 
     /**
@@ -147,7 +147,7 @@ class PointcutFilterCompositeTest extends UnitTestCase
         $pointcutFilterComposite->addFilter('&&', $mockPointcutFilter1);
         $pointcutFilterComposite->addFilter('&&!', $mockPointcutFilter2);
 
-        $this->assertFalse($pointcutFilterComposite->matches('someClass', 'someMethod', 'someDeclaringClass', 1));
+        self::assertFalse($pointcutFilterComposite->matches('someClass', 'someMethod', 'someDeclaringClass', 1));
     }
 
     /**
@@ -167,7 +167,7 @@ class PointcutFilterCompositeTest extends UnitTestCase
         $pointcutFilterComposite->addFilter('&&!', $mockPointcutFilter1);
         $pointcutFilterComposite->addFilter('&&', $mockPointcutFilter2);
 
-        $this->assertFalse($pointcutFilterComposite->matches('someClass', 'someMethod', 'someDeclaringClass', 1));
+        self::assertFalse($pointcutFilterComposite->matches('someClass', 'someMethod', 'someDeclaringClass', 1));
     }
 
     /**
@@ -225,7 +225,7 @@ class PointcutFilterCompositeTest extends UnitTestCase
                             ]
         ];
 
-        $this->assertEquals($expectedResult, $pointcutFilterComposite->getRuntimeEvaluationsDefinition(), 'The runtime evaluations definition has not been added correctly to the pointcut filter composite.');
+        self::assertEquals($expectedResult, $pointcutFilterComposite->getRuntimeEvaluationsDefinition(), 'The runtime evaluations definition has not been added correctly to the pointcut filter composite.');
     }
 
     /**
@@ -274,8 +274,8 @@ class PointcutFilterCompositeTest extends UnitTestCase
 
         $result = $pointcutFilterComposite->getRuntimeEvaluationsClosureCode();
 
-        $this->assertTrue($pointcutFilterComposite->_call('hasRuntimeEvaluationsDefinition'));
-        $this->assertEquals($expectedResult, $result, 'The wrong Code has been built.');
+        self::assertTrue($pointcutFilterComposite->_call('hasRuntimeEvaluationsDefinition'));
+        self::assertEquals($expectedResult, $result, 'The wrong Code has been built.');
     }
 
     /**
@@ -324,8 +324,8 @@ class PointcutFilterCompositeTest extends UnitTestCase
 
         $result = $pointcutFilterComposite->getRuntimeEvaluationsClosureCode();
 
-        $this->assertTrue($pointcutFilterComposite->_call('hasRuntimeEvaluationsDefinition'));
-        $this->assertEquals($expectedResult, $result, 'The wrong Code has been built.');
+        self::assertTrue($pointcutFilterComposite->_call('hasRuntimeEvaluationsDefinition'));
+        self::assertEquals($expectedResult, $result, 'The wrong Code has been built.');
     }
 
     /**
@@ -340,8 +340,8 @@ class PointcutFilterCompositeTest extends UnitTestCase
 
         $result = $pointcutFilterComposite->getRuntimeEvaluationsClosureCode();
 
-        $this->assertFalse($pointcutFilterComposite->_call('hasRuntimeEvaluationsDefinition'));
-        $this->assertEquals($expectedResult, $result, 'The wrong Code has been built.');
+        self::assertFalse($pointcutFilterComposite->_call('hasRuntimeEvaluationsDefinition'));
+        self::assertEquals($expectedResult, $result, 'The wrong Code has been built.');
     }
 
     /**
@@ -368,7 +368,7 @@ class PointcutFilterCompositeTest extends UnitTestCase
 
         $expectedResult = '($joinPoint->getMethodArgument(\'identifier\') > 3 && $joinPoint->getMethodArgument(\'identifier\') <= 5)';
 
-        $this->assertEquals($expectedResult, $result, 'The wrong Code has been built.');
+        self::assertEquals($expectedResult, $result, 'The wrong Code has been built.');
     }
 
     /**
@@ -403,7 +403,7 @@ class PointcutFilterCompositeTest extends UnitTestCase
 
         $expectedResult = '($joinPoint->getMethodArgument(\'identifier\') == \Neos\Utility\ObjectAccess::getPropertyPath($currentObject, \'bar.baz\') && $joinPoint->getMethodArgument(\'identifier\') != \Neos\Utility\ObjectAccess::getPropertyPath($globalObjects[\'party\'], \'bar.baz\') && \Neos\Utility\ObjectAccess::getPropertyPath($joinPoint->getMethodArgument(\'some\'), \'object.property\') != \Neos\Utility\ObjectAccess::getPropertyPath($currentObject, \'object.with.another.property\'))';
 
-        $this->assertEquals($expectedResult, $result, 'The wrong Code has been built.');
+        self::assertEquals($expectedResult, $result, 'The wrong Code has been built.');
     }
 
     /**
@@ -428,7 +428,7 @@ class PointcutFilterCompositeTest extends UnitTestCase
 
         $expectedResult = '((array(\'usage1\', \'usage2\', "usage3") instanceof \SplObjectStorage || array(\'usage1\', \'usage2\', "usage3") instanceof \Doctrine\Common\Collections\Collection ? $joinPoint->getMethodArgument(\'identifier\') !== NULL && array(\'usage1\', \'usage2\', "usage3")->contains($joinPoint->getMethodArgument(\'identifier\')) : in_array($joinPoint->getMethodArgument(\'identifier\'), array(\'usage1\', \'usage2\', "usage3"))))';
 
-        $this->assertEquals($expectedResult, $result, 'The wrong Code has been built.');
+        self::assertEquals($expectedResult, $result, 'The wrong Code has been built.');
     }
 
     /**
@@ -455,7 +455,7 @@ class PointcutFilterCompositeTest extends UnitTestCase
 
         $expectedResult = '((!empty(array_intersect($joinPoint->getMethodArgument(\'identifier\'), array(\'usage1\', \'usage2\', "usage3")))) && (!empty(array_intersect($joinPoint->getMethodArgument(\'identifier\'), \Neos\Utility\ObjectAccess::getPropertyPath($currentObject, \'accounts\')))))';
 
-        $this->assertEquals($expectedResult, $result, 'The wrong Code has been built.');
+        self::assertEquals($expectedResult, $result, 'The wrong Code has been built.');
     }
 
     /**
@@ -482,7 +482,7 @@ class PointcutFilterCompositeTest extends UnitTestCase
 
         $expectedResult = '(\Neos\Utility\ObjectAccess::getPropertyPath($currentObject, \'some.thing\') != \Neos\Utility\ObjectAccess::getPropertyPath($globalObjects[\'party\'], \'name\') && \Neos\Utility\ObjectAccess::getPropertyPath($globalObjects[\'party\'], \'account.accountIdentifier\') == "admin")';
 
-        $this->assertEquals($expectedResult, $result, 'The wrong Code has been built.');
+        self::assertEquals($expectedResult, $result, 'The wrong Code has been built.');
     }
 
     /**
@@ -504,7 +504,7 @@ class PointcutFilterCompositeTest extends UnitTestCase
 
         $expectedResult = '((array("foo", \Neos\Utility\ObjectAccess::getPropertyPath($globalObjects[\'party\'], \'name\'), 5) instanceof \SplObjectStorage || array("foo", \Neos\Utility\ObjectAccess::getPropertyPath($globalObjects[\'party\'], \'name\'), 5) instanceof \Doctrine\Common\Collections\Collection ? \Neos\Utility\ObjectAccess::getPropertyPath($currentObject, \'some.thing\') !== NULL && array("foo", \Neos\Utility\ObjectAccess::getPropertyPath($globalObjects[\'party\'], \'name\'), 5)->contains(\Neos\Utility\ObjectAccess::getPropertyPath($currentObject, \'some.thing\')) : in_array(\Neos\Utility\ObjectAccess::getPropertyPath($currentObject, \'some.thing\'), array("foo", \Neos\Utility\ObjectAccess::getPropertyPath($globalObjects[\'party\'], \'name\'), 5))))';
 
-        $this->assertEquals($expectedResult, $result, 'The wrong Code has been built.');
+        self::assertEquals($expectedResult, $result, 'The wrong Code has been built.');
     }
 
     /**
@@ -531,7 +531,7 @@ class PointcutFilterCompositeTest extends UnitTestCase
 
         $expectedResult = '((!empty(array_intersect(\Neos\Utility\ObjectAccess::getPropertyPath($currentObject, \'some.thing\'), array("foo", \Neos\Utility\ObjectAccess::getPropertyPath($globalObjects[\'party\'], \'name\'), 5)))) && (!empty(array_intersect(\Neos\Utility\ObjectAccess::getPropertyPath($currentObject, \'some.thing\'), \Neos\Utility\ObjectAccess::getPropertyPath($globalObjects[\'party\'], \'accounts\')))))';
 
-        $this->assertEquals($expectedResult, $result, 'The wrong Code has been built.');
+        self::assertEquals($expectedResult, $result, 'The wrong Code has been built.');
     }
 
     /**
@@ -540,15 +540,15 @@ class PointcutFilterCompositeTest extends UnitTestCase
     public function hasRuntimeEvaluationsDefinitionConsidersGlobalAndFilterRuntimeEvaluationsDefinitions()
     {
         $pointcutFilterComposite = $this->getAccessibleMock(Pointcut\PointcutFilterComposite::class, ['dummy'], [], '', false);
-        $this->assertFalse($pointcutFilterComposite->hasRuntimeEvaluationsDefinition());
+        self::assertFalse($pointcutFilterComposite->hasRuntimeEvaluationsDefinition());
 
         $pointcutFilterComposite->_set('globalRuntimeEvaluationsDefinition', ['foo', 'bar']);
         $pointcutFilterComposite->_set('runtimeEvaluationsDefinition', []);
-        $this->assertTrue($pointcutFilterComposite->hasRuntimeEvaluationsDefinition());
+        self::assertTrue($pointcutFilterComposite->hasRuntimeEvaluationsDefinition());
 
         $pointcutFilterComposite->_set('globalRuntimeEvaluationsDefinition', []);
         $pointcutFilterComposite->_set('runtimeEvaluationsDefinition', ['bar']);
-        $this->assertTrue($pointcutFilterComposite->hasRuntimeEvaluationsDefinition());
+        self::assertTrue($pointcutFilterComposite->hasRuntimeEvaluationsDefinition());
     }
 
     /**
@@ -585,6 +585,6 @@ class PointcutFilterCompositeTest extends UnitTestCase
 
         $result = $pointcutFilterComposite->reduceTargetClassNames($availableClassNamesIndex);
 
-        $this->assertEquals($expectedClassNamesIndex, $result, 'The wrong class names have been filtered');
+        self::assertEquals($expectedClassNamesIndex, $result, 'The wrong class names have been filtered');
     }
 }

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutFilterTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutFilterTest.php
@@ -56,7 +56,7 @@ class PointcutFilterTest extends UnitTestCase
 
         $pointcutFilter = new Aop\Pointcut\PointcutFilter('Aspect', 'pointcut');
         $pointcutFilter->injectProxyClassBuilder($mockProxyClassBuilder);
-        $this->assertTrue($pointcutFilter->matches($className, $methodName, $methodDeclaringClassName, $pointcutQueryIdentifier));
+        self::assertTrue($pointcutFilter->matches($className, $methodName, $methodDeclaringClassName, $pointcutQueryIdentifier));
     }
 
     /**
@@ -72,7 +72,7 @@ class PointcutFilterTest extends UnitTestCase
 
         $pointcutFilter = new Aop\Pointcut\PointcutFilter('Aspect', 'pointcut');
         $pointcutFilter->injectProxyClassBuilder($mockProxyClassBuilder);
-        $this->assertEquals(['evaluations'], $pointcutFilter->getRuntimeEvaluationsDefinition(), 'Something different from an array was returned.');
+        self::assertEquals(['evaluations'], $pointcutFilter->getRuntimeEvaluationsDefinition(), 'Something different from an array was returned.');
     }
 
     /**
@@ -85,7 +85,7 @@ class PointcutFilterTest extends UnitTestCase
 
         $pointcutFilter = new Aop\Pointcut\PointcutFilter('Aspect', 'pointcut');
         $pointcutFilter->injectProxyClassBuilder($mockProxyClassBuilder);
-        $this->assertEquals([], $pointcutFilter->getRuntimeEvaluationsDefinition(), 'The definition array has not been returned as exptected.');
+        self::assertEquals([], $pointcutFilter->getRuntimeEvaluationsDefinition(), 'The definition array has not been returned as exptected.');
     }
 
     /**
@@ -103,7 +103,7 @@ class PointcutFilterTest extends UnitTestCase
         $pointcutFilter = new Aop\Pointcut\PointcutFilter('Aspect', 'pointcut');
         $pointcutFilter->injectProxyClassBuilder($mockProxyClassBuilder);
 
-        $this->assertEquals($resultClassNameIndex, $pointcutFilter->reduceTargetClassNames(new Aop\Builder\ClassNameIndex()));
+        self::assertEquals($resultClassNameIndex, $pointcutFilter->reduceTargetClassNames(new Aop\Builder\ClassNameIndex()));
     }
 
     /**
@@ -119,6 +119,6 @@ class PointcutFilterTest extends UnitTestCase
 
         $inputClassNameIndex = new Aop\Builder\ClassNameIndex();
 
-        $this->assertSame($inputClassNameIndex, $pointcutFilter->reduceTargetClassNames($inputClassNameIndex));
+        self::assertSame($inputClassNameIndex, $pointcutFilter->reduceTargetClassNames($inputClassNameIndex));
     }
 }

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutMethodAnnotatedWithFilterTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutMethodAnnotatedWithFilterTest.php
@@ -31,8 +31,8 @@ class PointcutMethodAnnotatedWithFilterTest extends UnitTestCase
         $filter = new Aop\Pointcut\PointcutMethodAnnotatedWithFilter('Acme\Some\Annotation');
         $filter->injectReflectionService($mockReflectionService);
 
-        $this->assertTrue($filter->matches(__CLASS__, __FUNCTION__, __CLASS__, 1234));
-        $this->assertFalse($filter->matches(__CLASS__, __FUNCTION__, __CLASS__, 1234));
+        self::assertTrue($filter->matches(__CLASS__, __FUNCTION__, __CLASS__, 1234));
+        self::assertFalse($filter->matches(__CLASS__, __FUNCTION__, __CLASS__, 1234));
     }
 
     /**
@@ -45,8 +45,8 @@ class PointcutMethodAnnotatedWithFilterTest extends UnitTestCase
         $filter = new Aop\Pointcut\PointcutMethodAnnotatedWithFilter('Acme\Some\Annotation');
         $filter->injectReflectionService($mockReflectionService);
 
-        $this->assertFalse($filter->matches(__CLASS__, __FUNCTION__, null, 1234));
-        $this->assertFalse($filter->matches(__CLASS__, 'foo', __CLASS__, 1234));
+        self::assertFalse($filter->matches(__CLASS__, __FUNCTION__, null, 1234));
+        self::assertFalse($filter->matches(__CLASS__, 'foo', __CLASS__, 1234));
     }
 
     /**
@@ -80,6 +80,6 @@ class PointcutMethodAnnotatedWithFilterTest extends UnitTestCase
 
         $result = $methodAnnotatedWithFilter->reduceTargetClassNames($availableClassNamesIndex);
 
-        $this->assertEquals($expectedClassNamesIndex, $result, 'The wrong class names have been filtered');
+        self::assertEquals($expectedClassNamesIndex, $result, 'The wrong class names have been filtered');
     }
 }

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutMethodNameFilterTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutMethodNameFilterTest.php
@@ -37,7 +37,7 @@ class PointcutMethodNameFilterTest extends UnitTestCase
         $mockReflectionService->expects($this->any())->method('isMethodFinal')->with($className, 'someFinalMethod')->will($this->returnValue(true));
         $methodNameFilter = new Aop\Pointcut\PointcutMethodNameFilter('someFinalMethod');
         $methodNameFilter->injectReflectionService($mockReflectionService);
-        $this->assertTrue($methodNameFilter->matches($className, 'someFinalMethod', $className, 1));
+        self::assertTrue($methodNameFilter->matches($className, 'someFinalMethod', $className, 1));
     }
 
     /**
@@ -61,17 +61,17 @@ class PointcutMethodNameFilterTest extends UnitTestCase
 
         $methodNameFilter = new Aop\Pointcut\PointcutMethodNameFilter('some.*', 'public');
         $methodNameFilter->injectReflectionService($mockReflectionService);
-        $this->assertTrue($methodNameFilter->matches(__CLASS__, 'somePublicMethod', $className, 1));
-        $this->assertFalse($methodNameFilter->matches(__CLASS__, 'someProtectedMethod', $className, 1));
-        $this->assertFalse($methodNameFilter->matches(__CLASS__, 'somePrivateMethod', $className, 1));
-        $this->assertFalse($methodNameFilter->matches(__CLASS__, 'somePublicMethod', null, 1));
+        self::assertTrue($methodNameFilter->matches(__CLASS__, 'somePublicMethod', $className, 1));
+        self::assertFalse($methodNameFilter->matches(__CLASS__, 'someProtectedMethod', $className, 1));
+        self::assertFalse($methodNameFilter->matches(__CLASS__, 'somePrivateMethod', $className, 1));
+        self::assertFalse($methodNameFilter->matches(__CLASS__, 'somePublicMethod', null, 1));
 
         $methodNameFilter = new Aop\Pointcut\PointcutMethodNameFilter('some.*', 'protected');
         $methodNameFilter->injectReflectionService($mockReflectionService);
-        $this->assertFalse($methodNameFilter->matches(__CLASS__, 'somePublicMethod', $className, 1));
-        $this->assertTrue($methodNameFilter->matches(__CLASS__, 'someProtectedMethod', $className, 1));
-        $this->assertFalse($methodNameFilter->matches(__CLASS__, 'somePrivateMethod', $className, 1));
-        $this->assertFalse($methodNameFilter->matches(__CLASS__, 'someProtectedMethod', null, 1));
+        self::assertFalse($methodNameFilter->matches(__CLASS__, 'somePublicMethod', $className, 1));
+        self::assertTrue($methodNameFilter->matches(__CLASS__, 'someProtectedMethod', $className, 1));
+        self::assertFalse($methodNameFilter->matches(__CLASS__, 'somePrivateMethod', $className, 1));
+        self::assertFalse($methodNameFilter->matches(__CLASS__, 'someProtectedMethod', null, 1));
     }
 
     /**
@@ -117,8 +117,8 @@ class PointcutMethodNameFilterTest extends UnitTestCase
 
         $methodNameFilter->matches(__CLASS__, 'somePublicMethod', $className, 1);
 
-        $this->assertTrue($methodNameFilter->matches(__CLASS__, 'someOtherPublicMethod', $className, 1));
-        $this->assertTrue($methodNameFilter->matches(__CLASS__, 'someThirdMethod', $className, 1));
+        self::assertTrue($methodNameFilter->matches(__CLASS__, 'someOtherPublicMethod', $className, 1));
+        self::assertTrue($methodNameFilter->matches(__CLASS__, 'someThirdMethod', $className, 1));
     }
 
     /**
@@ -139,6 +139,6 @@ class PointcutMethodNameFilterTest extends UnitTestCase
 
         $methodNameFilter = new Aop\Pointcut\PointcutMethodNameFilter('some.*', null, $argumentConstraints);
 
-        $this->assertEquals($expectedRuntimeEvaluations, $methodNameFilter->getRuntimeEvaluationsDefinition(), 'The argument constraint definitions have not been returned as expected.');
+        self::assertEquals($expectedRuntimeEvaluations, $methodNameFilter->getRuntimeEvaluationsDefinition(), 'The argument constraint definitions have not been returned as expected.');
     }
 }

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutSettingFilterTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutSettingFilterTest.php
@@ -32,7 +32,7 @@ class PointcutSettingFilterTest extends UnitTestCase
 
         $filter = new Aop\Pointcut\PointcutSettingFilter('package.foo.bar.baz.value');
         $filter->injectConfigurationManager($mockConfigurationManager);
-        $this->assertTrue($filter->matches('', '', '', 1));
+        self::assertTrue($filter->matches('', '', '', 1));
     }
 
     /**
@@ -47,7 +47,7 @@ class PointcutSettingFilterTest extends UnitTestCase
 
         $filter = new Aop\Pointcut\PointcutSettingFilter('package.foo.bar.baz.value');
         $filter->injectConfigurationManager($mockConfigurationManager);
-        $this->assertFalse($filter->matches('', '', '', 1));
+        self::assertFalse($filter->matches('', '', '', 1));
     }
 
     /**
@@ -77,7 +77,7 @@ class PointcutSettingFilterTest extends UnitTestCase
 
         $filter = new Aop\Pointcut\PointcutSettingFilter('package.foo.bar.baz.value');
         $filter->injectConfigurationManager($mockConfigurationManager);
-        $this->assertFalse($filter->matches('', '', '', 1));
+        self::assertFalse($filter->matches('', '', '', 1));
     }
 
     /**
@@ -92,7 +92,7 @@ class PointcutSettingFilterTest extends UnitTestCase
 
         $filter = new Aop\Pointcut\PointcutSettingFilter('package.foo.bar.baz.value');
         $filter->injectConfigurationManager($mockConfigurationManager);
-        $this->assertTrue($filter->matches('', '', '', 1));
+        self::assertTrue($filter->matches('', '', '', 1));
     }
 
     /**
@@ -107,7 +107,7 @@ class PointcutSettingFilterTest extends UnitTestCase
 
         $filter = new Aop\Pointcut\PointcutSettingFilter('package.foo.bar.baz.value = \'option value\'');
         $filter->injectConfigurationManager($mockConfigurationManager);
-        $this->assertTrue($filter->matches('', '', '', 1));
+        self::assertTrue($filter->matches('', '', '', 1));
     }
 
     /**
@@ -122,7 +122,7 @@ class PointcutSettingFilterTest extends UnitTestCase
 
         $filter = new Aop\Pointcut\PointcutSettingFilter('package.foo.bar.baz.value = "option value"');
         $filter->injectConfigurationManager($mockConfigurationManager);
-        $this->assertTrue($filter->matches('', '', '', 1));
+        self::assertTrue($filter->matches('', '', '', 1));
     }
 
     /**
@@ -137,7 +137,7 @@ class PointcutSettingFilterTest extends UnitTestCase
 
         $filter = new Aop\Pointcut\PointcutSettingFilter('package.foo.bar.baz.value = \'some value\'');
         $filter->injectConfigurationManager($mockConfigurationManager);
-        $this->assertFalse($filter->matches('', '', '', 1));
+        self::assertFalse($filter->matches('', '', '', 1));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutTest.php
@@ -34,7 +34,7 @@ class PointcutTest extends UnitTestCase
         $mockPointcutFilterComposite->expects($this->once())->method('matches')->with($className, $methodName, $className, 1)->will($this->returnValue(true));
 
         $pointcut = $this->getMockBuilder(Pointcut\Pointcut::class)->setMethods(['dummy'])->setConstructorArgs([$pointcutExpression, $mockPointcutFilterComposite, $aspectClassName])->getMock();
-        $this->assertTrue($pointcut->matches($className, $methodName, $className, 1));
+        self::assertTrue($pointcut->matches($className, $methodName, $className, 1));
     }
 
     /**
@@ -67,7 +67,7 @@ class PointcutTest extends UnitTestCase
         $mockPointcutFilterComposite = $this->getMockBuilder(Pointcut\PointcutFilterComposite::class)->disableOriginalConstructor()->setMethods(['matches'])->getMock();
 
         $pointcut = $this->getMockBuilder(Pointcut\Pointcut::class)->setMethods(['dummy'])->setConstructorArgs([$pointcutExpression, $mockPointcutFilterComposite, $aspectClassName])->getMock();
-        $this->assertSame($pointcutExpression, $pointcut->getPointcutExpression());
+        self::assertSame($pointcutExpression, $pointcut->getPointcutExpression());
     }
 
     /**
@@ -81,7 +81,7 @@ class PointcutTest extends UnitTestCase
         $mockPointcutFilterComposite = $this->getMockBuilder(Pointcut\PointcutFilterComposite::class)->disableOriginalConstructor()->setMethods(['matches'])->getMock();
 
         $pointcut = $this->getMockBuilder(Pointcut\Pointcut::class)->setMethods(['dummy'])->setConstructorArgs([$pointcutExpression, $mockPointcutFilterComposite, $aspectClassName])->getMock();
-        $this->assertSame($aspectClassName, $pointcut->getAspectClassName());
+        self::assertSame($aspectClassName, $pointcut->getAspectClassName());
     }
 
     /**
@@ -95,7 +95,7 @@ class PointcutTest extends UnitTestCase
         $mockPointcutFilterComposite = $this->getMockBuilder(Pointcut\PointcutFilterComposite::class)->disableOriginalConstructor()->setMethods(['matches'])->getMock();
 
         $pointcut = $this->getMockBuilder(Pointcut\Pointcut::class)->setMethods(['dummy'])->setConstructorArgs([$pointcutExpression, $mockPointcutFilterComposite, $aspectClassName, 'PointcutMethod'])->getMock();
-        $this->assertSame('PointcutMethod', $pointcut->getPointcutMethodName());
+        self::assertSame('PointcutMethod', $pointcut->getPointcutMethodName());
     }
 
     /**
@@ -112,7 +112,7 @@ class PointcutTest extends UnitTestCase
 
         $pointcut = new Pointcut\Pointcut($pointcutExpression, $mockPointcutFilterComposite, $aspectClassName, $className);
 
-        $this->assertEquals(['runtimeEvaluationsDefinition'], $pointcut->getRuntimeEvaluationsDefinition(), 'The runtime evaluations definition has not been returned as expected.');
+        self::assertEquals(['runtimeEvaluationsDefinition'], $pointcut->getRuntimeEvaluationsDefinition(), 'The runtime evaluations definition has not been returned as expected.');
     }
 
     /**
@@ -132,6 +132,6 @@ class PointcutTest extends UnitTestCase
 
         $pointcut = new Pointcut\Pointcut($pointcutExpression, $mockPointcutFilterComposite, $aspectClassName, $className);
 
-        $this->assertEquals($resultClassNameIndex, $pointcut->reduceTargetClassNames($targetClassNameIndex));
+        self::assertEquals($resultClassNameIndex, $pointcut->reduceTargetClassNames($targetClassNameIndex));
     }
 }

--- a/Neos.Flow/Tests/Unit/Cache/CacheFactoryTest.php
+++ b/Neos.Flow/Tests/Unit/Cache/CacheFactoryTest.php
@@ -79,7 +79,7 @@ class CacheFactoryTest extends UnitTestCase
         $factory->injectEnvironmentConfiguration($this->mockEnvironmentConfiguration);
 
         $cache = $factory->create('TYPO3_Flow_Cache_FactoryTest_Cache', VariableFrontend::class, NullBackend::class);
-        $this->assertInstanceOf(VariableFrontend::class, $cache);
+        self::assertInstanceOf(VariableFrontend::class, $cache);
     }
 
     /**
@@ -91,7 +91,7 @@ class CacheFactoryTest extends UnitTestCase
         $factory->injectEnvironmentConfiguration($this->mockEnvironmentConfiguration);
 
         $cache = $factory->create('TYPO3_Flow_Cache_FactoryTest_Cache', VariableFrontend::class, FileBackend::class);
-        $this->assertInstanceOf(FileBackend::class, $cache->getBackend());
+        self::assertInstanceOf(FileBackend::class, $cache->getBackend());
     }
 
     /**
@@ -110,6 +110,6 @@ class CacheFactoryTest extends UnitTestCase
         // createDirectoryRecursively() in the setCache method.
         mkdir('vfs://Temporary/Directory/Cache');
 
-        $this->assertEquals(FLOW_PATH_DATA . 'Persistent/Cache/Data/Persistent_Cache/', $cache->getBackend()->getCacheDirectory());
+        self::assertEquals(FLOW_PATH_DATA . 'Persistent/Cache/Data/Persistent_Cache/', $cache->getBackend()->getCacheDirectory());
     }
 }

--- a/Neos.Flow/Tests/Unit/Cache/CacheManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Cache/CacheManagerTest.php
@@ -105,7 +105,7 @@ class CacheManagerTest extends UnitTestCase
         $this->cacheManager->registerCache($cache1);
         $this->cacheManager->registerCache($cache2);
 
-        $this->assertSame($cache2, $this->cacheManager->getCache('cache2'), 'The cache returned by getCache() was not the same I registered.');
+        self::assertSame($cache2, $this->cacheManager->getCache('cache2'), 'The cache returned by getCache() was not the same I registered.');
     }
 
     /**
@@ -132,8 +132,8 @@ class CacheManagerTest extends UnitTestCase
         $cache1->expects($this->atLeastOnce())->method('getIdentifier')->will($this->returnValue('cache1'));
         $this->cacheManager->registerCache($cache1);
 
-        $this->assertTrue($this->cacheManager->hasCache('cache1'), 'hasCache() did not return true.');
-        $this->assertFalse($this->cacheManager->hasCache('cache2'), 'hasCache() did not return false.');
+        self::assertTrue($this->cacheManager->hasCache('cache1'), 'hasCache() did not return true.');
+        self::assertFalse($this->cacheManager->hasCache('cache2'), 'hasCache() did not return false.');
     }
 
     /**
@@ -149,8 +149,8 @@ class CacheManagerTest extends UnitTestCase
         $cache2->expects($this->atLeastOnce())->method('getIdentifier')->will($this->returnValue('cache2'));
         $this->cacheManager->registerCache($cache2, true);
 
-        $this->assertFalse($this->cacheManager->isCachePersistent('cache1'));
-        $this->assertTrue($this->cacheManager->isCachePersistent('cache2'));
+        self::assertFalse($this->cacheManager->isCachePersistent('cache1'));
+        self::assertTrue($this->cacheManager->isCachePersistent('cache2'));
     }
 
     /**
@@ -216,7 +216,7 @@ class CacheManagerTest extends UnitTestCase
     {
         file_put_contents('vfs://Foo/AvailableProxyClasses.php', '// dummy');
         $this->cacheManager->flushCaches();
-        $this->assertFileNotExists('vfs://Foo/AvailableProxyClasses.php');
+        self::assertFileNotExists('vfs://Foo/AvailableProxyClasses.php');
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Cli/CommandManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/CommandManagerTest.php
@@ -64,10 +64,10 @@ class CommandManagerTest extends UnitTestCase
         $commandManager->injectObjectManager($mockObjectManager);
 
         $commands = $commandManager->getAvailableCommands();
-        $this->assertEquals(3, count($commands));
-        $this->assertEquals('neos.flow.tests.unit.cli.fixtures:mocka:foo', $commands[0]->getCommandIdentifier());
-        $this->assertEquals('neos.flow.tests.unit.cli.fixtures:mocka:bar', $commands[1]->getCommandIdentifier());
-        $this->assertEquals('neos.flow.tests.unit.cli.fixtures:mockb:baz', $commands[2]->getCommandIdentifier());
+        self::assertEquals(3, count($commands));
+        self::assertEquals('neos.flow.tests.unit.cli.fixtures:mocka:foo', $commands[0]->getCommandIdentifier());
+        self::assertEquals('neos.flow.tests.unit.cli.fixtures:mocka:bar', $commands[1]->getCommandIdentifier());
+        self::assertEquals('neos.flow.tests.unit.cli.fixtures:mockb:baz', $commands[2]->getCommandIdentifier());
     }
 
     /**
@@ -80,7 +80,7 @@ class CommandManagerTest extends UnitTestCase
         $mockCommands = [$mockCommand];
         $this->commandManager->expects($this->once())->method('getAvailableCommands')->will($this->returnValue($mockCommands));
 
-        $this->assertSame($mockCommand, $this->commandManager->getCommandByIdentifier('package.key:controller:command'));
+        self::assertSame($mockCommand, $this->commandManager->getCommandByIdentifier('package.key:controller:command'));
     }
 
     /**
@@ -93,7 +93,7 @@ class CommandManagerTest extends UnitTestCase
         $mockCommands = [$mockCommand];
         $this->commandManager->expects($this->once())->method('getAvailableCommands')->will($this->returnValue($mockCommands));
 
-        $this->assertSame($mockCommand, $this->commandManager->getCommandByIdentifier('   Package.Key:conTroLler:Command  '));
+        self::assertSame($mockCommand, $this->commandManager->getCommandByIdentifier('   Package.Key:conTroLler:Command  '));
     }
 
     /**
@@ -106,8 +106,8 @@ class CommandManagerTest extends UnitTestCase
         $mockCommands = [$mockCommand];
         $this->commandManager->expects($this->atLeastOnce())->method('getAvailableCommands')->will($this->returnValue($mockCommands));
 
-        $this->assertSame($mockCommand, $this->commandManager->getCommandByIdentifier('package.key:controller:command'));
-        $this->assertSame($mockCommand, $this->commandManager->getCommandByIdentifier('key:controller:command'));
+        self::assertSame($mockCommand, $this->commandManager->getCommandByIdentifier('package.key:controller:command'));
+        self::assertSame($mockCommand, $this->commandManager->getCommandByIdentifier('key:controller:command'));
     }
 
     /**
@@ -172,7 +172,7 @@ class CommandManagerTest extends UnitTestCase
         $mockCommands = [$mockCommand1, $mockCommand2];
         $this->commandManager->expects($this->once())->method('getAvailableCommands')->will($this->returnValue($mockCommands));
 
-        $this->assertSame([], $this->commandManager->getCommandsByIdentifier('nonexistingpackage'));
+        self::assertSame([], $this->commandManager->getCommandsByIdentifier('nonexistingpackage'));
     }
 
     /**
@@ -192,7 +192,7 @@ class CommandManagerTest extends UnitTestCase
         $this->commandManager->expects($this->once())->method('getAvailableCommands')->will($this->returnValue($mockCommands));
 
         $expectedResult = [$mockCommand3, $mockCommand4];
-        $this->assertSame($expectedResult, $this->commandManager->getCommandsByIdentifier('packagekey'));
+        self::assertSame($expectedResult, $this->commandManager->getCommandsByIdentifier('packagekey'));
     }
 
     /**
@@ -203,7 +203,7 @@ class CommandManagerTest extends UnitTestCase
         $mockHelpCommand = $this->getMockBuilder(Cli\Command::class)->disableOriginalConstructor()->getMock();
         $mockHelpCommand->expects($this->once())->method('getCommandIdentifier')->will($this->returnValue('neos.flow:help:help'));
         $commandIdentifier = $this->commandManager->getShortestIdentifierForCommand($mockHelpCommand);
-        $this->assertSame('help', $commandIdentifier);
+        self::assertSame('help', $commandIdentifier);
     }
 
     /**
@@ -219,7 +219,7 @@ class CommandManagerTest extends UnitTestCase
         $this->commandManager->expects($this->atLeastOnce())->method('getAvailableCommands')->will($this->returnValue($mockCommands));
 
         $commandIdentifier = $this->commandManager->getShortestIdentifierForCommand($mockCustomHelpCommand);
-        $this->assertSame('package:help:help', $commandIdentifier);
+        self::assertSame('package:help:help', $commandIdentifier);
     }
 
     /**
@@ -238,10 +238,10 @@ class CommandManagerTest extends UnitTestCase
         $mockCommands = [$mockCommand1, $mockCommand2, $mockCommand3, $mockCommand4];
         $this->commandManager->expects($this->atLeastOnce())->method('getAvailableCommands')->will($this->returnValue($mockCommands));
 
-        $this->assertSame('key:controller:command', $this->commandManager->getShortestIdentifierForCommand($mockCommand1));
-        $this->assertSame('controller2:command', $this->commandManager->getShortestIdentifierForCommand($mockCommand2));
-        $this->assertSame('packagekey:controller:command', $this->commandManager->getShortestIdentifierForCommand($mockCommand3));
-        $this->assertSame('controller:othercommand', $this->commandManager->getShortestIdentifierForCommand($mockCommand4));
+        self::assertSame('key:controller:command', $this->commandManager->getShortestIdentifierForCommand($mockCommand1));
+        self::assertSame('controller2:command', $this->commandManager->getShortestIdentifierForCommand($mockCommand2));
+        self::assertSame('packagekey:controller:command', $this->commandManager->getShortestIdentifierForCommand($mockCommand3));
+        self::assertSame('controller:othercommand', $this->commandManager->getShortestIdentifierForCommand($mockCommand4));
     }
 
     /**
@@ -256,7 +256,7 @@ class CommandManagerTest extends UnitTestCase
         $mockCommands = [$mockCommand1, $mockCommand2];
         $this->commandManager->expects($this->atLeastOnce())->method('getAvailableCommands')->willReturn($mockCommands);
 
-        $this->assertSame('package.key:controller:command', $this->commandManager->getShortestIdentifierForCommand($mockCommand1));
-        $this->assertSame('otherpackage.key:controller:command', $this->commandManager->getShortestIdentifierForCommand($mockCommand2));
+        self::assertSame('package.key:controller:command', $this->commandManager->getShortestIdentifierForCommand($mockCommand1));
+        self::assertSame('otherpackage.key:controller:command', $this->commandManager->getShortestIdentifierForCommand($mockCommand2));
     }
 }

--- a/Neos.Flow/Tests/Unit/Cli/CommandTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/CommandTest.php
@@ -70,7 +70,7 @@ class CommandTest extends UnitTestCase
     public function constructRendersACommandIdentifierByTheGivenControllerAndCommandName($controllerClassName, $commandName, $expectedCommandIdentifier)
     {
         $command = new Cli\Command($controllerClassName, $commandName);
-        $this->assertEquals($expectedCommandIdentifier, $command->getCommandIdentifier());
+        self::assertEquals($expectedCommandIdentifier, $command->getCommandIdentifier());
     }
 
     /**
@@ -79,7 +79,7 @@ class CommandTest extends UnitTestCase
     public function hasArgumentsReturnsFalseIfCommandExpectsNoArguments()
     {
         $this->methodReflection->expects($this->atLeastOnce())->method('getParameters')->will($this->returnValue([]));
-        $this->assertFalse($this->command->hasArguments());
+        self::assertFalse($this->command->hasArguments());
     }
 
     /**
@@ -89,7 +89,7 @@ class CommandTest extends UnitTestCase
     {
         $parameterReflection = $this->createMock(ParameterReflection::class, [], [[__CLASS__, 'dummyMethod'], 'arg']);
         $this->methodReflection->expects($this->atLeastOnce())->method('getParameters')->will($this->returnValue([$parameterReflection]));
-        $this->assertTrue($this->command->hasArguments());
+        self::assertTrue($this->command->hasArguments());
     }
 
     /**
@@ -98,7 +98,7 @@ class CommandTest extends UnitTestCase
     public function getArgumentDefinitionsReturnsEmptyArrayIfCommandExpectsNoArguments()
     {
         $this->methodReflection->expects($this->atLeastOnce())->method('getParameters')->will($this->returnValue([]));
-        $this->assertSame([], $this->command->getArgumentDefinitions());
+        self::assertSame([], $this->command->getArgumentDefinitions());
     }
 
     /**
@@ -119,6 +119,6 @@ class CommandTest extends UnitTestCase
             new Cli\CommandArgumentDefinition('argument2', false, 'argument2 description')
         ];
         $actualResult = $this->command->getArgumentDefinitions();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 }

--- a/Neos.Flow/Tests/Unit/Cli/ConsoleOutputTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/ConsoleOutputTest.php
@@ -60,7 +60,7 @@ class ConsoleOutputTest extends UnitTestCase
         $string = 'simple output';
         $this->consoleOutput->output($string);
 
-        $this->assertSame($string, $this->getActualConsoleOutput());
+        self::assertSame($string, $this->getActualConsoleOutput());
     }
 
     /**
@@ -71,7 +71,7 @@ class ConsoleOutputTest extends UnitTestCase
         $string = 'simple line';
         $this->consoleOutput->outputLine($string);
 
-        $this->assertSame($string . PHP_EOL, $this->getActualConsoleOutput());
+        self::assertSame($string . PHP_EOL, $this->getActualConsoleOutput());
     }
 
     /**
@@ -92,7 +92,7 @@ class ConsoleOutputTest extends UnitTestCase
             '  content and one line is longer than 79 characters, it\'s exactly this line to' . PHP_EOL .
             '  be precice ' . PHP_EOL;
 
-        $this->assertSame($formattedString, $this->getActualConsoleOutput());
+        self::assertSame($formattedString, $this->getActualConsoleOutput());
     }
 
     /**
@@ -103,7 +103,7 @@ class ConsoleOutputTest extends UnitTestCase
         $this->answerNo();
         $userAnswer = $this->consoleOutput->askConfirmation('Is this a test?');
 
-        $this->assertSame(false, $userAnswer);
+        self::assertSame(false, $userAnswer);
     }
 
     /**
@@ -114,7 +114,7 @@ class ConsoleOutputTest extends UnitTestCase
         $this->answerYes();
         $userAnswer = $this->consoleOutput->askConfirmation('Are you lying?');
 
-        $this->assertSame(true, $userAnswer);
+        self::assertSame(true, $userAnswer);
     }
 
     /**
@@ -125,7 +125,7 @@ class ConsoleOutputTest extends UnitTestCase
         $this->answerYes();
         $this->consoleOutput->ask('Is this a test?');
 
-        $this->assertSame('Is this a test?', $this->getActualConsoleOutput());
+        self::assertSame('Is this a test?', $this->getActualConsoleOutput());
     }
 
     /**
@@ -136,7 +136,7 @@ class ConsoleOutputTest extends UnitTestCase
         $this->answerYes();
         $this->consoleOutput->ask(['First line', 'Second line']);
 
-        $this->assertSame('First line'.PHP_EOL.'Second line', $this->getActualConsoleOutput());
+        self::assertSame('First line'.PHP_EOL.'Second line', $this->getActualConsoleOutput());
     }
 
     /**
@@ -155,7 +155,7 @@ class ConsoleOutputTest extends UnitTestCase
 
         $userAnswer = $this->consoleOutput->askAndValidate('Enter a number higher than 4', $validator);
 
-        $this->assertSame('5', $userAnswer);
+        self::assertSame('5', $userAnswer);
     }
 
     /**
@@ -181,7 +181,7 @@ class ConsoleOutputTest extends UnitTestCase
      */
     public function questionWasAskedFallBackToDefaultAnswer()
     {
-        $this->assertSame('Not Sure', $this->consoleOutput->ask('Enter your name', 'Not Sure'));
+        self::assertSame('Not Sure', $this->consoleOutput->ask('Enter your name', 'Not Sure'));
     }
 
     /**
@@ -191,7 +191,7 @@ class ConsoleOutputTest extends UnitTestCase
     {
         $this->consoleOutput->outputTable([['column1', 'column2']], ['header 1', 'header 2']);
 
-        $this->assertSame(
+        self::assertSame(
             '+----------+----------+' . PHP_EOL .
             '| header 1 | header 2 |' . PHP_EOL .
             '+----------+----------+' . PHP_EOL .
@@ -209,7 +209,7 @@ class ConsoleOutputTest extends UnitTestCase
         $this->consoleOutput->progressAdvance();
         $this->consoleOutput->progressSet(50);
         $this->consoleOutput->progressFinish();
-        $this->assertSame(
+        self::assertSame(
             '   0/100 [>---------------------------]   0%' . PHP_EOL .
             '   1/100 [>---------------------------]   1%' . PHP_EOL .
             '  50/100 [==============>-------------]  50%' . PHP_EOL .
@@ -228,7 +228,7 @@ class ConsoleOutputTest extends UnitTestCase
         ];
         $userAnswer = $this->consoleOutput->select('Is this a good test?', $choices, 'yes', true);
 
-        $this->assertEquals(
+        self::assertEquals(
             'Is this a good test?' . PHP_EOL .
             '  [n] No' . PHP_EOL .
             '  [y] Yes' . PHP_EOL .
@@ -236,7 +236,7 @@ class ConsoleOutputTest extends UnitTestCase
             $this->getActualConsoleOutput()
         );
 
-        $this->assertSame(['y'], $userAnswer, 'The answer is the key, NOT the value from the choices');
+        self::assertSame(['y'], $userAnswer, 'The answer is the key, NOT the value from the choices');
     }
 
     /**
@@ -252,7 +252,7 @@ class ConsoleOutputTest extends UnitTestCase
         ];
         $userAnswer = $this->consoleOutput->select('Is this a good test?', $choices, 1, true);
 
-        $this->assertEquals(
+        self::assertEquals(
             'Is this a good test?' . PHP_EOL .
             '  [1] No' . PHP_EOL .
             '  [2] Yes' . PHP_EOL .
@@ -260,7 +260,7 @@ class ConsoleOutputTest extends UnitTestCase
             $this->getActualConsoleOutput()
         );
 
-        $this->assertSame(['Yes'], $userAnswer, 'The answer is the value, NOT the key from the choices');
+        self::assertSame(['Yes'], $userAnswer, 'The answer is the value, NOT the key from the choices');
     }
 
     /**
@@ -275,7 +275,7 @@ class ConsoleOutputTest extends UnitTestCase
         ];
         $userAnswer = $this->consoleOutput->select('Is this a good test?', $choices, 'yes', true);
 
-        $this->assertSame(['yes'], $userAnswer, 'The default value is returned');
+        self::assertSame(['yes'], $userAnswer, 'The default value is returned');
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php
@@ -82,8 +82,8 @@ class RequestBuilderTest extends UnitTestCase
         $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->will($this->returnValue([]));
 
         $request = $this->requestBuilder->build('acme.test:default:list');
-        $this->assertSame('Acme\Test\Command\DefaultCommandController', $request->getControllerObjectName());
-        $this->assertSame('list', $request->getControllerCommandName(), 'The CLI request specifying a package, controller and action name did not return a request object pointing to the expected action.');
+        self::assertSame('Acme\Test\Command\DefaultCommandController', $request->getControllerObjectName());
+        self::assertSame('list', $request->getControllerCommandName(), 'The CLI request specifying a package, controller and action name did not return a request object pointing to the expected action.');
     }
 
     /**
@@ -101,7 +101,7 @@ class RequestBuilderTest extends UnitTestCase
         $this->requestBuilder->injectCommandManager($mockCommandManager);
 
         $request = $this->requestBuilder->build('test:default:list');
-        $this->assertSame(HelpCommandController::class, $request->getControllerObjectName());
+        self::assertSame(HelpCommandController::class, $request->getControllerObjectName());
     }
 
     /**
@@ -118,10 +118,10 @@ class RequestBuilderTest extends UnitTestCase
         $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $request = $this->requestBuilder->build('acme.test:default:list --test-argument=value --test-argument2=value2');
-        $this->assertTrue($request->hasArgument('testArgument'), 'The given "testArgument" was not found in the built request.');
-        $this->assertTrue($request->hasArgument('testArgument2'), 'The given "testArgument2" was not found in the built request.');
-        $this->assertSame($request->getArgument('testArgument'), 'value', 'The "testArgument" had not the given value.');
-        $this->assertSame($request->getArgument('testArgument2'), 'value2', 'The "testArgument2" had not the given value.');
+        self::assertTrue($request->hasArgument('testArgument'), 'The given "testArgument" was not found in the built request.');
+        self::assertTrue($request->hasArgument('testArgument2'), 'The given "testArgument2" was not found in the built request.');
+        self::assertSame($request->getArgument('testArgument'), 'value', 'The "testArgument" had not the given value.');
+        self::assertSame($request->getArgument('testArgument2'), 'value2', 'The "testArgument2" had not the given value.');
     }
 
     /**
@@ -140,14 +140,14 @@ class RequestBuilderTest extends UnitTestCase
         $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $request = $this->requestBuilder->build('acme.test:default:list --test-argument= value --test-argument2 =value2 --test-argument3 = value3 --test-argument4=value4');
-        $this->assertTrue($request->hasArgument('testArgument'), 'The given "testArgument" was not found in the built request.');
-        $this->assertTrue($request->hasArgument('testArgument2'), 'The given "testArgument2" was not found in the built request.');
-        $this->assertTrue($request->hasArgument('testArgument3'), 'The given "testArgument3" was not found in the built request.');
-        $this->assertTrue($request->hasArgument('testArgument4'), 'The given "testArgument4" was not found in the built request.');
-        $this->assertSame($request->getArgument('testArgument'), 'value', 'The "testArgument" had not the given value.');
-        $this->assertSame($request->getArgument('testArgument2'), 'value2', 'The "testArgument2" had not the given value.');
-        $this->assertSame($request->getArgument('testArgument3'), 'value3', 'The "testArgument3" had not the given value.');
-        $this->assertSame($request->getArgument('testArgument4'), 'value4', 'The "testArgument4" had not the given value.');
+        self::assertTrue($request->hasArgument('testArgument'), 'The given "testArgument" was not found in the built request.');
+        self::assertTrue($request->hasArgument('testArgument2'), 'The given "testArgument2" was not found in the built request.');
+        self::assertTrue($request->hasArgument('testArgument3'), 'The given "testArgument3" was not found in the built request.');
+        self::assertTrue($request->hasArgument('testArgument4'), 'The given "testArgument4" was not found in the built request.');
+        self::assertSame($request->getArgument('testArgument'), 'value', 'The "testArgument" had not the given value.');
+        self::assertSame($request->getArgument('testArgument2'), 'value2', 'The "testArgument2" had not the given value.');
+        self::assertSame($request->getArgument('testArgument3'), 'value3', 'The "testArgument3" had not the given value.');
+        self::assertSame($request->getArgument('testArgument4'), 'value4', 'The "testArgument4" had not the given value.');
     }
 
     /**
@@ -165,12 +165,12 @@ class RequestBuilderTest extends UnitTestCase
         $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $request = $this->requestBuilder->build('acme.test:default:list -d valued -f=valuef -a = valuea');
-        $this->assertTrue($request->hasArgument('d'), 'The given "d" was not found in the built request.');
-        $this->assertTrue($request->hasArgument('f'), 'The given "f" was not found in the built request.');
-        $this->assertTrue($request->hasArgument('a'), 'The given "a" was not found in the built request.');
-        $this->assertSame($request->getArgument('d'), 'valued', 'The "d" had not the given value.');
-        $this->assertSame($request->getArgument('f'), 'valuef', 'The "f" had not the given value.');
-        $this->assertSame($request->getArgument('a'), 'valuea', 'The "a" had not the given value.');
+        self::assertTrue($request->hasArgument('d'), 'The given "d" was not found in the built request.');
+        self::assertTrue($request->hasArgument('f'), 'The given "f" was not found in the built request.');
+        self::assertTrue($request->hasArgument('a'), 'The given "a" was not found in the built request.');
+        self::assertSame($request->getArgument('d'), 'valued', 'The "d" had not the given value.');
+        self::assertSame($request->getArgument('f'), 'valuef', 'The "f" had not the given value.');
+        self::assertSame($request->getArgument('a'), 'valuea', 'The "a" had not the given value.');
     }
 
     /**
@@ -200,29 +200,29 @@ class RequestBuilderTest extends UnitTestCase
         $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $request = $this->requestBuilder->build('acme.test:default:list --test-argument=value --test-argument2= value2 -k --test-argument-3 = value3 --test-argument4=value4 -f valuef -d=valued -a = valuea -c --testArgument7 --test-argument5 = 5 --test-argument6 -j kjk -m');
-        $this->assertTrue($request->hasArgument('testArgument'), 'The given "testArgument" was not found in the built request.');
-        $this->assertTrue($request->hasArgument('testArgument2'), 'The given "testArgument2" was not found in the built request.');
-        $this->assertTrue($request->hasArgument('k'), 'The given "k" was not found in the built request.');
-        $this->assertTrue($request->hasArgument('testArgument3'), 'The given "testArgument3" was not found in the built request.');
-        $this->assertTrue($request->hasArgument('testArgument4'), 'The given "testArgument4" was not found in the built request.');
-        $this->assertTrue($request->hasArgument('f'), 'The given "f" was not found in the built request.');
-        $this->assertTrue($request->hasArgument('d'), 'The given "d" was not found in the built request.');
-        $this->assertTrue($request->hasArgument('a'), 'The given "a" was not found in the built request.');
-        $this->assertTrue($request->hasArgument('c'), 'The given "d" was not found in the built request.');
-        $this->assertTrue($request->hasArgument('testArgument7'), 'The given "testArgument7" was not found in the built request.');
-        $this->assertTrue($request->hasArgument('testArgument5'), 'The given "testArgument5" was not found in the built request.');
-        $this->assertTrue($request->hasArgument('testArgument6'), 'The given "testArgument6" was not found in the built request.');
-        $this->assertTrue($request->hasArgument('j'), 'The given "j" was not found in the built request.');
-        $this->assertTrue($request->hasArgument('m'), 'The given "m" was not found in the built request.');
-        $this->assertSame($request->getArgument('testArgument'), 'value', 'The "testArgument" had not the given value.');
-        $this->assertSame($request->getArgument('testArgument2'), 'value2', 'The "testArgument2" had not the given value.');
-        $this->assertSame($request->getArgument('testArgument3'), 'value3', 'The "testArgument3" had not the given value.');
-        $this->assertSame($request->getArgument('testArgument4'), 'value4', 'The "testArgument4" had not the given value.');
-        $this->assertSame($request->getArgument('f'), 'valuef', 'The "f" had not the given value.');
-        $this->assertSame($request->getArgument('d'), 'valued', 'The "d" had not the given value.');
-        $this->assertSame($request->getArgument('a'), 'valuea', 'The "a" had not the given value.');
-        $this->assertSame($request->getArgument('testArgument5'), '5', 'The "testArgument4" had not the given value.');
-        $this->assertSame($request->getArgument('j'), 'kjk', 'The "j" had not the given value.');
+        self::assertTrue($request->hasArgument('testArgument'), 'The given "testArgument" was not found in the built request.');
+        self::assertTrue($request->hasArgument('testArgument2'), 'The given "testArgument2" was not found in the built request.');
+        self::assertTrue($request->hasArgument('k'), 'The given "k" was not found in the built request.');
+        self::assertTrue($request->hasArgument('testArgument3'), 'The given "testArgument3" was not found in the built request.');
+        self::assertTrue($request->hasArgument('testArgument4'), 'The given "testArgument4" was not found in the built request.');
+        self::assertTrue($request->hasArgument('f'), 'The given "f" was not found in the built request.');
+        self::assertTrue($request->hasArgument('d'), 'The given "d" was not found in the built request.');
+        self::assertTrue($request->hasArgument('a'), 'The given "a" was not found in the built request.');
+        self::assertTrue($request->hasArgument('c'), 'The given "d" was not found in the built request.');
+        self::assertTrue($request->hasArgument('testArgument7'), 'The given "testArgument7" was not found in the built request.');
+        self::assertTrue($request->hasArgument('testArgument5'), 'The given "testArgument5" was not found in the built request.');
+        self::assertTrue($request->hasArgument('testArgument6'), 'The given "testArgument6" was not found in the built request.');
+        self::assertTrue($request->hasArgument('j'), 'The given "j" was not found in the built request.');
+        self::assertTrue($request->hasArgument('m'), 'The given "m" was not found in the built request.');
+        self::assertSame($request->getArgument('testArgument'), 'value', 'The "testArgument" had not the given value.');
+        self::assertSame($request->getArgument('testArgument2'), 'value2', 'The "testArgument2" had not the given value.');
+        self::assertSame($request->getArgument('testArgument3'), 'value3', 'The "testArgument3" had not the given value.');
+        self::assertSame($request->getArgument('testArgument4'), 'value4', 'The "testArgument4" had not the given value.');
+        self::assertSame($request->getArgument('f'), 'valuef', 'The "f" had not the given value.');
+        self::assertSame($request->getArgument('d'), 'valued', 'The "d" had not the given value.');
+        self::assertSame($request->getArgument('a'), 'valuea', 'The "a" had not the given value.');
+        self::assertSame($request->getArgument('testArgument5'), '5', 'The "testArgument4" had not the given value.');
+        self::assertSame($request->getArgument('j'), 'kjk', 'The "j" had not the given value.');
     }
 
     /**
@@ -236,8 +236,8 @@ class RequestBuilderTest extends UnitTestCase
         $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $request = $this->requestBuilder->build('acme.test:default:list --test-argument=value');
-        $this->assertTrue($request->hasArgument('testArgument'), 'The given "testArgument" was not found in the built request.');
-        $this->assertSame($request->getArgument('testArgument'), 'value', 'The "testArgument" had not the given value.');
+        self::assertTrue($request->hasArgument('testArgument'), 'The given "testArgument" was not found in the built request.');
+        self::assertSame($request->getArgument('testArgument'), 'value', 'The "testArgument" had not the given value.');
     }
 
     /**
@@ -252,12 +252,12 @@ class RequestBuilderTest extends UnitTestCase
         $this->mockCommandManager->expects($this->any())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $request = $this->requestBuilder->build('acme.test:default:list --test-argument1 firstArgumentValue --test-argument2 secondArgumentValue');
-        $this->assertSame('firstArgumentValue', $request->getArgument('testArgument1'));
-        $this->assertSame('secondArgumentValue', $request->getArgument('testArgument2'));
+        self::assertSame('firstArgumentValue', $request->getArgument('testArgument1'));
+        self::assertSame('secondArgumentValue', $request->getArgument('testArgument2'));
 
         $request = $this->requestBuilder->build('acme.test:default:list firstArgumentValue secondArgumentValue');
-        $this->assertSame('firstArgumentValue', $request->getArgument('testArgument1'));
-        $this->assertSame('secondArgumentValue', $request->getArgument('testArgument2'));
+        self::assertSame('firstArgumentValue', $request->getArgument('testArgument1'));
+        self::assertSame('secondArgumentValue', $request->getArgument('testArgument2'));
     }
 
     /**
@@ -274,10 +274,10 @@ class RequestBuilderTest extends UnitTestCase
         $this->mockCommandManager->expects($this->once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will($this->returnValue($methodParameters));
 
         $request = $this->requestBuilder->build('acme.test:default:list --some -option=value file1 file2');
-        $this->assertSame('list', $request->getControllerCommandName());
-        $this->assertTrue($request->getArgument('some'));
-        $this->assertSame('file1', $request->getArgument('argument1'));
-        $this->assertSame('file2', $request->getArgument('argument2'));
+        self::assertSame('list', $request->getControllerCommandName());
+        self::assertTrue($request->getArgument('some'));
+        self::assertSame('file1', $request->getArgument('argument1'));
+        self::assertSame('file2', $request->getArgument('argument2'));
     }
 
     /**
@@ -294,8 +294,8 @@ class RequestBuilderTest extends UnitTestCase
         $expectedArguments = ['testArgument1' => 'firstArgumentValue', 'testArgument2' => 'secondArgumentValue'];
 
         $request = $this->requestBuilder->build('acme.test:default:list --test-argument1=firstArgumentValue --test-argument2 secondArgumentValue exceedingArgument1');
-        $this->assertSame($expectedArguments, $request->getArguments());
-        $this->assertSame(['exceedingArgument1'], $request->getExceedingArguments());
+        self::assertSame($expectedArguments, $request->getArguments());
+        self::assertSame(['exceedingArgument1'], $request->getExceedingArguments());
     }
 
     /**
@@ -343,7 +343,7 @@ class RequestBuilderTest extends UnitTestCase
         $expectedArguments = ['requiredArgument1' => 'firstArgumentValue', 'requiredArgument2' => 'secondArgumentValue', 'booleanOption' => true];
 
         $request = $this->requestBuilder->build('acme.test:default:list --booleanOption firstArgumentValue secondArgumentValue');
-        $this->assertEquals($expectedArguments, $request->getArguments());
+        self::assertEquals($expectedArguments, $request->getArguments());
     }
 
     /**
@@ -361,7 +361,7 @@ class RequestBuilderTest extends UnitTestCase
         $expectedArguments = ['requiredArgument1' => 'firstArgumentValue', 'requiredArgument2' => 'secondArgumentValue'];
 
         $request = $this->requestBuilder->build('acme.test:default:list firstArgumentValue secondArgumentValue true');
-        $this->assertSame($expectedArguments, $request->getArguments());
+        self::assertSame($expectedArguments, $request->getArguments());
     }
 
     /**
@@ -379,7 +379,7 @@ class RequestBuilderTest extends UnitTestCase
         $expectedExceedingArguments = ['true'];
 
         $request = $this->requestBuilder->build('acme.test:default:list firstArgumentValue secondArgumentValue true');
-        $this->assertSame($expectedExceedingArguments, $request->getExceedingArguments());
+        self::assertSame($expectedExceedingArguments, $request->getExceedingArguments());
     }
 
     /**
@@ -400,7 +400,7 @@ class RequestBuilderTest extends UnitTestCase
         $expectedArguments = ['b1' => true, 'b2' => true, 'b3' => true, 'b4' => false, 'b5' => false, 'b6' => false];
 
         $request = $this->requestBuilder->build('acme.test:default:list --b2 y --b1 1 --b3 true --b4 false --b5 n --b6 0');
-        $this->assertEquals($expectedArguments, $request->getArguments());
+        self::assertEquals($expectedArguments, $request->getArguments());
     }
 
     /**
@@ -439,6 +439,6 @@ class RequestBuilderTest extends UnitTestCase
         $expectedArguments = ['requiredArgument1' => 'firstArgumentValue', 'requiredArgument2' => $expectedResult];
 
         $request = $this->requestBuilder->build('acme.test:default:list firstArgumentValue ' . $quotedArgument);
-        $this->assertEquals($expectedArguments, $request->getArguments());
+        self::assertEquals($expectedArguments, $request->getArguments());
     }
 }

--- a/Neos.Flow/Tests/Unit/Cli/RequestTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/RequestTest.php
@@ -30,7 +30,7 @@ class RequestTest extends UnitTestCase
         $request->setControllerCommandName('flush');
 
         $command = $request->getCommand();
-        $this->assertEquals('neos.flow:cache:flush', $command->getCommandIdentifier());
+        self::assertEquals('neos.flow:cache:flush', $command->getCommandIdentifier());
     }
 
     /**
@@ -47,6 +47,6 @@ class RequestTest extends UnitTestCase
         $request->setControllerCommandName('drink');
 
         $command = $request->getCommand();
-        $this->assertEquals('neos.flow:beer:drink', $command->getCommandIdentifier());
+        self::assertEquals('neos.flow:beer:drink', $command->getCommandIdentifier());
     }
 }

--- a/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -71,7 +71,7 @@ class ConfigurationManagerTest extends UnitTestCase
         $configurationManager->_set('configurations', $configurations);
 
         $actualConfiguration = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'SomePackage');
-        $this->assertSame($expectedConfiguration, $actualConfiguration);
+        self::assertSame($expectedConfiguration, $actualConfiguration);
     }
 
     /**
@@ -143,7 +143,7 @@ class ConfigurationManagerTest extends UnitTestCase
 
         foreach ($expectedConfigurations as $configurationType => $expectedConfiguration) {
             $actualConfiguration = $configurationManager->getConfiguration($configurationType);
-            $this->assertSame($expectedConfiguration, $actualConfiguration);
+            self::assertSame($expectedConfiguration, $actualConfiguration);
         }
     }
 
@@ -173,11 +173,11 @@ class ConfigurationManagerTest extends UnitTestCase
         foreach ($expectedConfigurations as $configurationType => $expectedConfiguration) {
             $configurationManager->registerConfigurationType($configurationType, ConfigurationManager::CONFIGURATION_PROCESSING_TYPE_SETTINGS);
             $actualConfiguration = $configurationManager->getConfiguration($configurationType);
-            $this->assertSame($expectedConfiguration, $actualConfiguration);
+            self::assertSame($expectedConfiguration, $actualConfiguration);
         }
 
         $expectedConfigurationTypes = ['Caches', 'Objects', 'Routes', 'Policy', 'Settings', 'Custom'];
-        $this->assertEquals($expectedConfigurationTypes, $configurationManager->getAvailableConfigurationTypes());
+        self::assertEquals($expectedConfigurationTypes, $configurationManager->getAvailableConfigurationTypes());
     }
 
     /**
@@ -217,7 +217,7 @@ class ConfigurationManagerTest extends UnitTestCase
             'bar' => 'A'
         ];
 
-        $this->assertSame($expectedSettings, $actualConfigurations[ConfigurationManager::CONFIGURATION_TYPE_SETTINGS]['PackageA']);
+        self::assertSame($expectedSettings, $actualConfigurations[ConfigurationManager::CONFIGURATION_TYPE_SETTINGS]['PackageA']);
     }
 
     /**
@@ -245,7 +245,7 @@ class ConfigurationManagerTest extends UnitTestCase
             ]
         ];
 
-        $this->assertSame($expectedSettings, $actualConfigurations[ConfigurationManager::CONFIGURATION_TYPE_SETTINGS]);
+        self::assertSame($expectedSettings, $actualConfigurations[ConfigurationManager::CONFIGURATION_TYPE_SETTINGS]);
     }
 
     /**
@@ -381,7 +381,7 @@ class ConfigurationManagerTest extends UnitTestCase
             ]
         ];
 
-        $this->assertSame($expectedSettings, $actualConfigurations[ConfigurationManager::CONFIGURATION_TYPE_OBJECTS]);
+        self::assertSame($expectedSettings, $actualConfigurations[ConfigurationManager::CONFIGURATION_TYPE_OBJECTS]);
     }
 
     /**
@@ -492,7 +492,7 @@ class ConfigurationManagerTest extends UnitTestCase
             ]
         ];
 
-        $this->assertSame($expectedCachesConfiguration, $actualConfigurations[ConfigurationManager::CONFIGURATION_TYPE_CACHES]);
+        self::assertSame($expectedCachesConfiguration, $actualConfigurations[ConfigurationManager::CONFIGURATION_TYPE_CACHES]);
     }
 
     /**
@@ -597,10 +597,10 @@ EOD;
         $configurationManager->expects($this->any())->method('constructConfigurationCachePath')->willReturn('notfound.php', $cachedConfigurationsPathAndFilename);
         $configurationManager->_set('configurations', ['foo' => 'untouched']);
         $configurationManager->_call('loadConfigurationCache');
-        $this->assertSame(['foo' => 'untouched'], $configurationManager->_get('configurations'));
+        self::assertSame(['foo' => 'untouched'], $configurationManager->_get('configurations'));
 
         $configurationManager->_call('loadConfigurationCache');
-        $this->assertSame(['bar' => 'touched'], $configurationManager->_get('configurations'));
+        self::assertSame(['bar' => 'touched'], $configurationManager->_get('configurations'));
     }
 
     /**
@@ -625,7 +625,7 @@ EOD;
                 ]
             ]
         ];
-        $this->assertEquals($expectedConfiguration, $actualConfigurations[ConfigurationManager::CONFIGURATION_TYPE_SETTINGS]);
+        self::assertEquals($expectedConfiguration, $actualConfigurations[ConfigurationManager::CONFIGURATION_TYPE_SETTINGS]);
     }
 
     /**
@@ -688,8 +688,8 @@ EOD;
         $settingsPhpString = var_export($settings, true);
         $configurationManager = $this->getAccessibleMock(ConfigurationManager::class, ['dummy'], [], '', false);
         $processedPhpString = $configurationManager->_call('replaceVariablesInPhpString', $settingsPhpString);
-        $this->assertStringContainsString("'baz' => (defined('PHP_VERSION') ? constant('PHP_VERSION') : null)", $processedPhpString);
-        $this->assertStringContainsString("'to' => (defined('FLOW_PATH_ROOT') ? constant('FLOW_PATH_ROOT') : null)", $processedPhpString);
+        self::assertStringContainsString("'baz' => (defined('PHP_VERSION') ? constant('PHP_VERSION') : null)", $processedPhpString);
+        self::assertStringContainsString("'to' => (defined('FLOW_PATH_ROOT') ? constant('FLOW_PATH_ROOT') : null)", $processedPhpString);
     }
 
     /**
@@ -712,10 +712,10 @@ EOD;
         $processedPhpString = $configurationManager->_call('replaceVariablesInPhpString', $settingsPhpString);
         $settings = eval('return ' . $processedPhpString . ';');
         $this->assertIsInt($settings['anIntegerConstant']);
-        $this->assertSame(PHP_VERSION_ID, $settings['anIntegerConstant']);
+        self::assertSame(PHP_VERSION_ID, $settings['anIntegerConstant']);
 
         $this->assertIsString($settings['casted']['to']['string']);
-        $this->assertSame('Version id is ' . PHP_VERSION_ID, $settings['casted']['to']['string']);
+        self::assertSame('Version id is ' . PHP_VERSION_ID, $settings['casted']['to']['string']);
     }
 
     /**
@@ -739,9 +739,9 @@ EOD;
         $processedPhpString = $configurationManager->_call('replaceVariablesInPhpString', $settingsPhpString);
         $settings = eval('return ' . $processedPhpString . ';');
 
-        $this->assertSame(ConfigurationManager::CONFIGURATION_TYPE_POLICY, $settings['baz']);
-        $this->assertSame(Bootstrap::MINIMUM_PHP_VERSION, $settings['inspiring']['people']['to']);
-        $this->assertSame(FlowPackageInterface::DIRECTORY_CLASSES, $settings['inspiring']['people']['share']);
+        self::assertSame(ConfigurationManager::CONFIGURATION_TYPE_POLICY, $settings['baz']);
+        self::assertSame(Bootstrap::MINIMUM_PHP_VERSION, $settings['inspiring']['people']['to']);
+        self::assertSame(FlowPackageInterface::DIRECTORY_CLASSES, $settings['inspiring']['people']['share']);
     }
 
     /**
@@ -771,10 +771,10 @@ EOD;
         $processedPhpString = $configurationManager->_call('replaceVariablesInPhpString', $settingsPhpString);
         $settings = eval('return ' . $processedPhpString . ';');
 
-        $this->assertSame($envVarValue, $settings['bar']);
-        $this->assertSame($envVarValue . ' inspiring people ' . $envVarValue . ' to share', $settings['baz']);
-        $this->assertSame($envVarValue, $settings['inspiring']['people']['to']);
-        $this->assertSame('foo ' . $envVarValue . ' bar', $settings['inspiring']['people']['share']);
+        self::assertSame($envVarValue, $settings['bar']);
+        self::assertSame($envVarValue . ' inspiring people ' . $envVarValue . ' to share', $settings['baz']);
+        self::assertSame($envVarValue, $settings['inspiring']['people']['to']);
+        self::assertSame('foo ' . $envVarValue . ' bar', $settings['inspiring']['people']['share']);
 
         putenv($envVarName);
     }
@@ -843,7 +843,7 @@ EOD;
             ]
         ];
 
-        $this->assertSame($expectedRoutesConfiguration, $actualConfigurations[ConfigurationManager::CONFIGURATION_TYPE_ROUTES]);
+        self::assertSame($expectedRoutesConfiguration, $actualConfigurations[ConfigurationManager::CONFIGURATION_TYPE_ROUTES]);
     }
 
     /**
@@ -979,7 +979,7 @@ EOD;
             ],
         ];
 
-        $this->assertSame($expectedRoutesConfiguration, $actualConfigurations[ConfigurationManager::CONFIGURATION_TYPE_ROUTES]);
+        self::assertSame($expectedRoutesConfiguration, $actualConfigurations[ConfigurationManager::CONFIGURATION_TYPE_ROUTES]);
     }
 
     /**
@@ -1111,7 +1111,7 @@ EOD;
             ],
         ];
 
-        $this->assertSame($expectedRoutesConfiguration, $actualConfigurations[ConfigurationManager::CONFIGURATION_TYPE_ROUTES]);
+        self::assertSame($expectedRoutesConfiguration, $actualConfigurations[ConfigurationManager::CONFIGURATION_TYPE_ROUTES]);
     }
 
     /**
@@ -1347,7 +1347,7 @@ EOD;
         $RouteConfigurationProcessor = $this->getAccessibleMock(RouteConfigurationProcessor::class, ['dummy'], [], '', false);
         $actualResult = $RouteConfigurationProcessor->_call('buildSubrouteConfigurations', $routesConfiguration, $subRoutesConfiguration, 'WelcomeSubroutes', []);
 
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -1426,7 +1426,7 @@ EOD;
         $routeConfigurationProcessor = $this->getAccessibleMock(RouteConfigurationProcessor::class, ['dummy'], [], '', false);
         $actualResult = $routeConfigurationProcessor->_call('buildSubrouteConfigurations', $routesConfiguration, $subRoutesConfiguration, 'WelcomeSubroutes', $subRouteOptions);
 
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -1464,7 +1464,7 @@ EOD;
             ],
         ];
 
-        $this->assertSame($expectedRoutesConfiguration, $actualConfigurations['Views']);
+        self::assertSame($expectedRoutesConfiguration, $actualConfigurations['Views']);
     }
 
 
@@ -1535,7 +1535,7 @@ EOD;
         $configurationManager->registerConfigurationType('MyCustomConfiguration', ConfigurationManager::CONFIGURATION_PROCESSING_TYPE_SETTINGS);
         $configurationManager->_call('loadConfiguration', 'MyCustomConfiguration', $this->getMockPackages());
         $configuration = $configurationManager->getConfiguration('MyCustomConfiguration');
-        $this->assertArrayHasKey('SomeKey', $configuration);
+        self::assertArrayHasKey('SomeKey', $configuration);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Configuration/Source/YamlSourceTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/Source/YamlSourceTest.php
@@ -38,7 +38,7 @@ class YamlSourceTest extends UnitTestCase
     {
         $configurationSource = new YamlSource();
         $configuration = $configurationSource->load('/ThisFileDoesNotExist');
-        $this->assertEquals([], $configuration, 'No empty array was returned.');
+        self::assertEquals([], $configuration, 'No empty array was returned.');
     }
 
     /**
@@ -49,7 +49,7 @@ class YamlSourceTest extends UnitTestCase
         $pathAndFilename = __DIR__ . '/../Fixture/YAMLConfigurationFile';
         $configurationSource = new YamlSource();
         $configuration = $configurationSource->load($pathAndFilename);
-        $this->assertTrue($configuration['configurationFileHasBeenLoaded'], 'The option has not been set by the fixture.');
+        self::assertTrue($configuration['configurationFileHasBeenLoaded'], 'The option has not been set by the fixture.');
     }
 
     /**
@@ -68,7 +68,7 @@ class YamlSourceTest extends UnitTestCase
         $configurationSource->save($pathAndFilename, $mockConfiguration);
 
         $yaml = 'configurationFileHasBeenLoaded: true' . chr(10) . 'foo:' . chr(10) . '  bar: Baz' . chr(10);
-        $this->assertStringContainsString($yaml, file_get_contents($pathAndFilename . '.yaml'), 'Configuration was not written to the file as expected.');
+        self::assertStringContainsString($yaml, file_get_contents($pathAndFilename . '.yaml'), 'Configuration was not written to the file as expected.');
     }
 
     /**
@@ -87,7 +87,7 @@ class YamlSourceTest extends UnitTestCase
         $configurationSource->save($pathAndFilename, $mockConfiguration);
 
         $yaml = 'configurationFileHasBeenLoaded: true' . chr(10) . 'foo:' . chr(10) . '  \'Foo.Bar:Baz\': \'a quoted key\'' . chr(10);
-        $this->assertStringContainsString($yaml, file_get_contents($pathAndFilename . '.yaml'), 'Configuration was not written to the file as expected.');
+        self::assertStringContainsString($yaml, file_get_contents($pathAndFilename . '.yaml'), 'Configuration was not written to the file as expected.');
     }
 
     /**
@@ -103,8 +103,8 @@ class YamlSourceTest extends UnitTestCase
         $configurationSource->save($pathAndFilename, ['configurationFileHasBeenLoaded' => true]);
 
         $yaml = file_get_contents($pathAndFilename . '.yaml');
-        $this->assertStringContainsString('# This comment should stay' . chr(10) . chr(10), $yaml, 'Header comment was removed from file.');
-        $this->assertStringNotContainsString('Test: foo', $yaml);
+        self::assertStringContainsString('# This comment should stay' . chr(10) . chr(10), $yaml, 'Header comment was removed from file.');
+        self::assertStringNotContainsString('Test: foo', $yaml);
     }
 
     /**
@@ -126,7 +126,7 @@ class YamlSourceTest extends UnitTestCase
         $pathAndFilename = __DIR__ . '/../Fixture/YAMLConfigurationFile';
         $configurationSource = new YamlSource();
         $configuration = $configurationSource->load($pathAndFilename);
-        $this->assertSame($expectedConfiguration, $configuration);
+        self::assertSame($expectedConfiguration, $configuration);
     }
 
     /**
@@ -149,7 +149,7 @@ class YamlSourceTest extends UnitTestCase
         $pathAndFilename = __DIR__ . '/../Fixture/SplitYamlConfigurationFile';
         $configurationSource = new YamlSource();
         $configuration = $configurationSource->load($pathAndFilename, true);
-        $this->assertSame($expectedConfiguration, $configuration);
+        self::assertSame($expectedConfiguration, $configuration);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Core/ApplicationContextTest.php
+++ b/Neos.Flow/Tests/Unit/Core/ApplicationContextTest.php
@@ -45,7 +45,7 @@ class ApplicationContextTest extends UnitTestCase
     public function contextStringCanBeSetInConstructorAndReadByCallingToString($allowedContext)
     {
         $context = new ApplicationContext($allowedContext);
-        $this->assertSame($allowedContext, (string)$context);
+        self::assertSame($allowedContext, (string)$context);
     }
 
     /**
@@ -135,10 +135,10 @@ class ApplicationContextTest extends UnitTestCase
     public function contextMethodsReturnTheCorrectValues($contextName, $isDevelopment, $isProduction, $isTesting, $parentContext)
     {
         $context = new ApplicationContext($contextName);
-        $this->assertSame($isDevelopment, $context->isDevelopment());
-        $this->assertSame($isProduction, $context->isProduction());
-        $this->assertSame($isTesting, $context->isTesting());
-        $this->assertSame((string)$parentContext, (string)$context->getParent());
+        self::assertSame($isDevelopment, $context->isDevelopment());
+        self::assertSame($isProduction, $context->isProduction());
+        self::assertSame($isTesting, $context->isTesting());
+        self::assertSame((string)$parentContext, (string)$context->getParent());
     }
 
     /**
@@ -148,9 +148,9 @@ class ApplicationContextTest extends UnitTestCase
     {
         $context = new ApplicationContext('Production/Foo/Bar');
         $parentContext = $context->getParent();
-        $this->assertSame('Production/Foo', (string) $parentContext);
+        self::assertSame('Production/Foo', (string) $parentContext);
 
         $rootContext = $parentContext->getParent();
-        $this->assertSame('Production', (string) $rootContext);
+        self::assertSame('Production', (string) $rootContext);
     }
 }

--- a/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
+++ b/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
@@ -44,22 +44,22 @@ class ScriptsTest extends UnitTestCase
 
         $message = 'The command must contain the current ini because it is not explicitly set in settings.';
         $actual = $this->scriptsMock->_call('buildSubprocessCommand', 'flow:foo:identifier', $settings);
-        $this->assertStringContainsString(sprintf(' -c %s ', escapeshellarg(php_ini_loaded_file())), $actual, $message);
+        self::assertStringContainsString(sprintf(' -c %s ', escapeshellarg(php_ini_loaded_file())), $actual, $message);
 
         $settings['core']['subRequestPhpIniPathAndFilename'] = null;
         $message = 'The command must contain the current ini because it is explicitly set, but NULL, in settings.';
         $actual = $this->scriptsMock->_call('buildSubprocessCommand', 'flow:foo:identifier', $settings);
-        $this->assertStringContainsString(sprintf(' -c %s ', escapeshellarg(php_ini_loaded_file())), $actual, $message);
+        self::assertStringContainsString(sprintf(' -c %s ', escapeshellarg(php_ini_loaded_file())), $actual, $message);
 
         $settings['core']['subRequestPhpIniPathAndFilename'] = '/foo/ini/path';
         $message = 'The command must contain a specified ini file path because it is set in settings.';
         $actual = $this->scriptsMock->_call('buildSubprocessCommand', 'flow:foo:identifier', $settings);
-        $this->assertStringContainsString(sprintf(' -c %s ', escapeshellarg('/foo/ini/path')), $actual, $message);
+        self::assertStringContainsString(sprintf(' -c %s ', escapeshellarg('/foo/ini/path')), $actual, $message);
 
         $settings['core']['subRequestPhpIniPathAndFilename'] = false;
         $message = 'The command must not contain an ini file path because it is set to false in settings.';
         $actual = $this->scriptsMock->_call('buildSubprocessCommand', 'flow:foo:identifier', $settings);
-        $this->assertStringNotContainsString(' -c ', $actual, $message);
+        self::assertStringNotContainsString(' -c ', $actual, $message);
     }
 
     /**
@@ -74,7 +74,7 @@ class ScriptsTest extends UnitTestCase
         ]];
         $actual = $this->scriptsMock->_call('buildSubprocessCommand', 'flow:foo:identifier', $settings);
 
-        $this->assertStringContainsString(sprintf(' -d %s=%s ', escapeshellarg('someSetting'), escapeshellarg('withValue')), $actual);
-        $this->assertStringContainsString(sprintf(' -d %s ', escapeshellarg('someFlagSettingWithoutValue')), $actual);
+        self::assertStringContainsString(sprintf(' -d %s=%s ', escapeshellarg('someSetting'), escapeshellarg('withValue')), $actual);
+        self::assertStringContainsString(sprintf(' -d %s ', escapeshellarg('someFlagSettingWithoutValue')), $actual);
     }
 }

--- a/Neos.Flow/Tests/Unit/Core/BootstrapTest.php
+++ b/Neos.Flow/Tests/Unit/Core/BootstrapTest.php
@@ -49,7 +49,7 @@ class BootstrapTest extends UnitTestCase
             $bootstrap->registerCompiletimeCommand($compiletimeCommandControllerIdentifier);
         }
 
-        $this->assertSame($expectedResult, $bootstrap->isCompiletimeCommand($givenCommandIdentifier));
+        self::assertSame($expectedResult, $bootstrap->isCompiletimeCommand($givenCommandIdentifier));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Core/ClassLoaderTest.php
+++ b/Neos.Flow/Tests/Unit/Core/ClassLoaderTest.php
@@ -108,7 +108,7 @@ class ClassLoaderTest extends UnitTestCase
         file_put_contents('vfs://Test/Packages/Application/Acme.MyApp/Classes/Acme/MyApp/SubDirectory/ClassInSubDirectory.php', '<?php ' . __CLASS__ . '::$testClassWasLoaded = true; ?>');
 
         $this->classLoader->loadClass('Acme\MyApp\SubDirectory\ClassInSubDirectory');
-        $this->assertTrue(self::$testClassWasLoaded);
+        self::assertTrue(self::$testClassWasLoaded);
     }
 
     /**
@@ -125,7 +125,7 @@ class ClassLoaderTest extends UnitTestCase
         $this->classLoader->setPackages($this->mockPackages);
 
         $this->classLoader->loadClass('Acme\MyApp\Tests\Functional\Essentials\LawnMowerTest');
-        $this->assertTrue(self::$testClassWasLoaded);
+        self::assertTrue(self::$testClassWasLoaded);
     }
 
     /**
@@ -137,7 +137,7 @@ class ClassLoaderTest extends UnitTestCase
         file_put_contents('vfs://Test/Packages/Application/Acme.MyApp/Classes/Acme/MyApp/SubDirectory/A/B/C/D/E.php', '<?php ' . __CLASS__ . '::$testClassWasLoaded = true; ?>');
 
         $this->classLoader->loadClass('Acme\MyApp\SubDirectory\A\B\C\D\E');
-        $this->assertTrue(self::$testClassWasLoaded);
+        self::assertTrue(self::$testClassWasLoaded);
     }
 
     /**
@@ -152,7 +152,7 @@ class ClassLoaderTest extends UnitTestCase
         file_put_contents('vfs://Test/Packages/Application/Acme.MyAppAddon/Classes/Acme/MyAppAddon/Class.php', '<?php ' . __CLASS__ . '::$testClassWasLoaded = true; ?>');
 
         $this->classLoader->loadClass('Acme\MyAppAddon\Class');
-        $this->assertTrue(self::$testClassWasLoaded);
+        self::assertTrue(self::$testClassWasLoaded);
     }
 
     /**
@@ -166,7 +166,7 @@ class ClassLoaderTest extends UnitTestCase
         file_put_contents('vfs://Test/Packages/Application/Acme.MyApp/Classes/Acme/MyApp/Foo.php', '<?php ' . __CLASS__ . '::$testClassWasLoaded = true; ?>');
 
         $this->classLoader->loadClass('Acme\MyApp_Foo');
-        $this->assertTrue(self::$testClassWasLoaded);
+        self::assertTrue(self::$testClassWasLoaded);
     }
 
     /**
@@ -180,7 +180,7 @@ class ClassLoaderTest extends UnitTestCase
         file_put_contents('vfs://Test/Packages/Application/Acme.MyApp/Classes/Acme/MyApp/My_Underscore/Foo.php', '<?php ' . __CLASS__ . '::$testClassWasLoaded = true; ?>');
 
         $this->classLoader->loadClass('Acme\MyApp\My_Underscore\Foo');
-        $this->assertTrue(self::$testClassWasLoaded);
+        self::assertTrue(self::$testClassWasLoaded);
     }
 
     /**
@@ -194,7 +194,7 @@ class ClassLoaderTest extends UnitTestCase
         file_put_contents('vfs://Test/Packages/Application/Acme.MyApp/Classes/Acme/MyApp/Foo1.php', '<?php ' . __CLASS__ . '::$testClassWasLoaded = true; ?>');
 
         $this->classLoader->loadClass('Acme_MyApp_Foo1');
-        $this->assertTrue(self::$testClassWasLoaded);
+        self::assertTrue(self::$testClassWasLoaded);
     }
 
     /**
@@ -206,7 +206,7 @@ class ClassLoaderTest extends UnitTestCase
         file_put_contents('vfs://Test/Packages/Application/Acme.MyApp/Classes/Acme/MyApp/Foo2.php', '<?php ' . __CLASS__ . '::$testClassWasLoaded = true; ?>');
 
         $this->classLoader->loadClass('\Acme\MyApp\Foo2');
-        $this->assertTrue(self::$testClassWasLoaded);
+        self::assertTrue(self::$testClassWasLoaded);
     }
 
     /**
@@ -222,7 +222,7 @@ class ClassLoaderTest extends UnitTestCase
         file_put_contents('vfs://Test/Packages/Application/Acme.MyAppAddon/Classes/Acme/MyAppAddon/Class.php', '<?php ' . __CLASS__ . '::$testClassWasLoaded = true; ?>');
 
         $this->classLoader->loadClass('Acme\MyAppAddon\Class');
-        $this->assertFalse(self::$testClassWasLoaded);
+        self::assertFalse(self::$testClassWasLoaded);
     }
 
     /**
@@ -247,7 +247,7 @@ class ClassLoaderTest extends UnitTestCase
         $this->mockPackages['Acme.MyApp'] = $this->mockPackage1;
         $this->classLoader->setPackages($this->mockPackages);
         $this->classLoader->loadClass('Acme\MyApp\Foo');
-        $this->assertTrue(self::$testClassWasLoaded);
+        self::assertTrue(self::$testClassWasLoaded);
     }
 
     /**
@@ -285,12 +285,12 @@ class ClassLoaderTest extends UnitTestCase
         $this->classLoader->setPackages($packages);
 
         $this->classLoader->loadClass('TestPackage\Subscriber\Foo');
-        $this->assertTrue(self::$testClassWasLoaded);
+        self::assertTrue(self::$testClassWasLoaded);
 
         self::$testClassWasLoaded = false;
 
         $this->classLoader->loadClass('TestPackage\Subscriber\Log\Bar');
-        $this->assertTrue(self::$testClassWasLoaded);
+        self::assertTrue(self::$testClassWasLoaded);
     }
 
     /**
@@ -330,6 +330,6 @@ class ClassLoaderTest extends UnitTestCase
 
 
         $this->classLoader->loadClass('TestPackage\Foo\Bar3');
-        $this->assertTrue(self::$testClassWasOverwritten);
+        self::assertTrue(self::$testClassWasOverwritten);
     }
 }

--- a/Neos.Flow/Tests/Unit/Core/LockManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Core/LockManagerTest.php
@@ -59,8 +59,8 @@ class LockManagerTest extends UnitTestCase
      */
     public function constructorDoesNotRemoveLockFilesIfTheyAreNotExpired()
     {
-        $this->assertFileExists($this->mockLockFile->url());
-        $this->assertFileExists($this->mockLockFlagFile->url());
+        self::assertFileExists($this->mockLockFile->url());
+        self::assertFileExists($this->mockLockFlagFile->url());
     }
 
     /**
@@ -69,13 +69,13 @@ class LockManagerTest extends UnitTestCase
     public function constructorRemovesExpiredLockFiles()
     {
         $this->mockLockFlagFile->lastModified(time() - (LockManager::LOCKFILE_MAXIMUM_AGE + 1));
-        $this->assertFileExists($this->mockLockFile->url());
-        $this->assertFileExists($this->mockLockFlagFile->url());
+        self::assertFileExists($this->mockLockFile->url());
+        self::assertFileExists($this->mockLockFlagFile->url());
 
         $this->lockManager->__construct();
 
-        $this->assertFileNotExists($this->mockLockFile->url());
-        $this->assertFileNotExists($this->mockLockFlagFile->url());
+        self::assertFileNotExists($this->mockLockFile->url());
+        self::assertFileNotExists($this->mockLockFlagFile->url());
     }
 
     /**
@@ -83,7 +83,7 @@ class LockManagerTest extends UnitTestCase
      */
     public function isSiteLockedReturnsTrueIfTheFlagFileExists()
     {
-        $this->assertTrue($this->lockManager->isSiteLocked());
+        self::assertTrue($this->lockManager->isSiteLocked());
     }
 
     /**
@@ -92,7 +92,7 @@ class LockManagerTest extends UnitTestCase
     public function isSiteLockedReturnsFalseIfTheFlagFileDoesNotExist()
     {
         unlink($this->mockLockFlagFile->url());
-        $this->assertFalse($this->lockManager->isSiteLocked());
+        self::assertFalse($this->lockManager->isSiteLocked());
     }
 
     /**
@@ -122,7 +122,7 @@ class LockManagerTest extends UnitTestCase
         $mockLockFlagFilePathAndName = $this->mockLockFlagFile->url();
         unlink($mockLockFlagFilePathAndName);
         $this->lockManager->lockSiteOrExit();
-        $this->assertFileExists($mockLockFlagFilePathAndName);
+        self::assertFileExists($mockLockFlagFilePathAndName);
     }
 
     /**
@@ -135,7 +135,7 @@ class LockManagerTest extends UnitTestCase
 
         $this->lockManager->lockSiteOrExit();
 
-        $this->assertNotEquals($oldLastModifiedTimestamp, $this->mockLockFlagFile->filemtime());
+        self::assertNotEquals($oldLastModifiedTimestamp, $this->mockLockFlagFile->filemtime());
     }
 
     /**
@@ -168,7 +168,7 @@ class LockManagerTest extends UnitTestCase
         $this->inject($this->lockManager, 'lockResource', $mockLockResource);
 
         $this->lockManager->unlockSite();
-        $this->assertFalse(is_resource($mockLockResource));
+        self::assertFalse(is_resource($mockLockResource));
     }
 
     /**
@@ -177,6 +177,6 @@ class LockManagerTest extends UnitTestCase
     public function unlockSiteRemovesLockFlagFile()
     {
         $this->lockManager->unlockSite();
-        $this->assertFileNotExists($this->mockLockFlagFile->url());
+        self::assertFileNotExists($this->mockLockFlagFile->url());
     }
 }

--- a/Neos.Flow/Tests/Unit/Error/DebugExceptionHandlerTest.php
+++ b/Neos.Flow/Tests/Unit/Error/DebugExceptionHandlerTest.php
@@ -104,6 +104,6 @@ Third line'
         $expectedResult = ['subject' => $expectedSubject, 'body' => $expectedBody];
         $actualResult = $debugExceptionHandler->_call('splitExceptionMessage', $message);
 
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 }

--- a/Neos.Flow/Tests/Unit/Error/DebuggerTest.php
+++ b/Neos.Flow/Tests/Unit/Error/DebuggerTest.php
@@ -42,7 +42,7 @@ class DebuggerTest extends UnitTestCase
     {
         $object = new \stdClass();
         $object->__IS_PROXY__ = true;
-        $this->assertRegExp('/\sclass=\"debug\-proxy\"/', Debugger::renderDump($object, 0, false));
+        self::assertRegExp('/\sclass=\"debug\-proxy\"/', Debugger::renderDump($object, 0, false));
     }
 
     /**
@@ -51,7 +51,7 @@ class DebuggerTest extends UnitTestCase
     public function ignoredClassesRegexContainsFallback()
     {
         $ignoredClassesRegex = Debugger::getIgnoredClassesRegex();
-        $this->assertStringContainsString('Neos\\\\Flow\\\\Core\\\\.*', $ignoredClassesRegex);
+        self::assertStringContainsString('Neos\\\\Flow\\\\Core\\\\.*', $ignoredClassesRegex);
     }
 
     /**
@@ -60,6 +60,6 @@ class DebuggerTest extends UnitTestCase
     public function ignoredClassesAreNotRendered()
     {
         $object = new ApplicationContext('Development');
-        $this->assertEquals('Neos\Flow\Core\ApplicationContext object', Debugger::renderDump($object, 0, true));
+        self::assertEquals('Neos\Flow\Core\ApplicationContext object', Debugger::renderDump($object, 0, true));
     }
 }

--- a/Neos.Flow/Tests/Unit/Error/ErrorTest.php
+++ b/Neos.Flow/Tests/Unit/Error/ErrorTest.php
@@ -27,7 +27,7 @@ class ErrorTest extends UnitTestCase
         $errorMessage = 'The message';
         $error = new FlowError($errorMessage, 0);
 
-        $this->assertEquals($errorMessage, $error->getMessage());
+        self::assertEquals($errorMessage, $error->getMessage());
     }
 
     /**
@@ -38,6 +38,6 @@ class ErrorTest extends UnitTestCase
         $errorCode = 123456789;
         $error = new FlowError('', $errorCode);
 
-        $this->assertEquals($errorCode, $error->getCode());
+        self::assertEquals($errorCode, $error->getCode());
     }
 }

--- a/Neos.Flow/Tests/Unit/Http/AbstractMessageTest.php
+++ b/Neos.Flow/Tests/Unit/Http/AbstractMessageTest.php
@@ -27,12 +27,12 @@ class AbstractMessageTest extends UnitTestCase
     {
         $message = $this->getAbstractMessageMock();
 
-        $this->assertFalse($message->hasHeader('MyHeader'));
+        self::assertFalse($message->hasHeader('MyHeader'));
 
         $message->setHeader('MyHeader', 'MyValue');
-        $this->assertTrue($message->hasHeader('MyHeader'));
+        self::assertTrue($message->hasHeader('MyHeader'));
 
-        $this->assertEquals('MyValue', $message->getHeader('MyHeader'));
+        self::assertEquals('MyValue', $message->getHeader('MyHeader'));
     }
 
     /**
@@ -45,7 +45,7 @@ class AbstractMessageTest extends UnitTestCase
         $message->setHeader('MyHeader', 'OtherValue');
 
         $expectedHeaders = ['MyHeader' => ['OtherValue']];
-        $this->assertEquals($expectedHeaders, $message->getHeaders()->getAll());
+        self::assertEquals($expectedHeaders, $message->getHeaders()->getAll());
     }
 
     /**
@@ -58,7 +58,7 @@ class AbstractMessageTest extends UnitTestCase
         $message->setHeader('MyHeader', 'OtherValue', false);
 
         $expectedHeaders = ['MyHeader' => ['MyValue', 'OtherValue']];
-        $this->assertEquals($expectedHeaders, $message->getHeaders()->getAll());
+        self::assertEquals($expectedHeaders, $message->getHeaders()->getAll());
     }
 
     /**
@@ -69,10 +69,10 @@ class AbstractMessageTest extends UnitTestCase
         $message = $this->getAbstractMessageMock();
 
         $message->setHeader('MyHeader', 'MyValue');
-        $this->assertEquals('MyValue', $message->getHeader('MyHeader'));
+        self::assertEquals('MyValue', $message->getHeader('MyHeader'));
 
         $message->setHeader('MyHeader', 'OtherValue', false);
-        $this->assertEquals(['MyValue', 'OtherValue'], $message->getHeader('MyHeader'));
+        self::assertEquals(['MyValue', 'OtherValue'], $message->getHeader('MyHeader'));
     }
 
     /**
@@ -85,16 +85,16 @@ class AbstractMessageTest extends UnitTestCase
         $message = $this->getAbstractMessageMock();
 
         $message->setHeader('Content-Type', 'text/plain', true);
-        $this->assertEquals('text/plain; charset=UTF-8', $message->getHeader('Content-Type'));
+        self::assertEquals('text/plain; charset=UTF-8', $message->getHeader('Content-Type'));
 
         $message->setHeader('Content-Type', 'text/plain', true);
         $message->setCharset('Shift_JIS');
-        $this->assertEquals('text/plain; charset=Shift_JIS', $message->getHeader('Content-Type'));
-        $this->assertEquals('Shift_JIS', $message->getCharset());
+        self::assertEquals('text/plain; charset=Shift_JIS', $message->getHeader('Content-Type'));
+        self::assertEquals('Shift_JIS', $message->getCharset());
 
         $message->setHeader('Content-Type', 'image/jpeg', true);
         $message->setCharset('Shift_JIS');
-        $this->assertEquals('image/jpeg', $message->getHeader('Content-Type'));
+        self::assertEquals('image/jpeg', $message->getHeader('Content-Type'));
     }
 
     /**
@@ -104,7 +104,7 @@ class AbstractMessageTest extends UnitTestCase
     {
         $message = $this->getAbstractMessageMock();
 
-        $this->assertEquals('UTF-8', $message->getCharset());
+        self::assertEquals('UTF-8', $message->getCharset());
     }
 
     /**
@@ -118,18 +118,18 @@ class AbstractMessageTest extends UnitTestCase
         $message->setHeader('Content-Type', 'text/html; charset=UTF-8');
 
         $message->setCharset('UTF-16');
-        $this->assertEquals('text/html; charset=UTF-16', $message->getHeader('Content-Type'));
+        self::assertEquals('text/html; charset=UTF-16', $message->getHeader('Content-Type'));
 
         $message->setHeader('Content-Type', 'text/plain; charset=UTF-16');
         $message->setCharset('ISO-8859-1');
-        $this->assertEquals('text/plain; charset=ISO-8859-1', $message->getHeader('Content-Type'));
+        self::assertEquals('text/plain; charset=ISO-8859-1', $message->getHeader('Content-Type'));
 
         $message->setHeader('Content-Type', 'image/png');
         $message->setCharset('UTF-8');
-        $this->assertEquals('image/png', $message->getHeader('Content-Type'));
+        self::assertEquals('image/png', $message->getHeader('Content-Type'));
 
         $message->setHeader('Content-Type', 'Text/Plain');
-        $this->assertEquals('Text/Plain; charset=UTF-8', $message->getHeader('Content-Type'));
+        self::assertEquals('Text/Plain; charset=UTF-8', $message->getHeader('Content-Type'));
     }
 
     /**
@@ -143,7 +143,7 @@ class AbstractMessageTest extends UnitTestCase
 
         $message->setHeader('Content-Type', 'text/plain;charset=UTF-16');
         $message->setCharset('ISO-8859-1');
-        $this->assertEquals('text/plain; charset=ISO-8859-1', $message->getHeader('Content-Type'));
+        self::assertEquals('text/plain; charset=ISO-8859-1', $message->getHeader('Content-Type'));
     }
 
     /**
@@ -157,7 +157,7 @@ class AbstractMessageTest extends UnitTestCase
 
         $message->setHeader('Content-Type', 'text/plain; charSet=UTF-16; x-foo=bar');
         $message->setCharset('ISO-8859-1');
-        $this->assertEquals('text/plain; charset=ISO-8859-1; x-foo=bar', $message->getHeader('Content-Type'));
+        self::assertEquals('text/plain; charset=ISO-8859-1; x-foo=bar', $message->getHeader('Content-Type'));
     }
 
     /**
@@ -168,7 +168,7 @@ class AbstractMessageTest extends UnitTestCase
         $message = $this->getAbstractMessageMock();
 
         $message->setContent('Two households, both alike in dignity, In fair Verona, where we lay our scene');
-        $this->assertEquals('Two households, both alike in dignity, In fair Verona, where we lay our scene', $message->getContent());
+        self::assertEquals('Two households, both alike in dignity, In fair Verona, where we lay our scene', $message->getContent());
     }
 
     /**
@@ -177,7 +177,7 @@ class AbstractMessageTest extends UnitTestCase
     public function setterMethodsAreChainable()
     {
         $message = $this->getAbstractMessageMock();
-        $this->assertSame($message,
+        self::assertSame($message,
             $message->setContent('Foo')->setCharset('UTF-8')->setHeader('X-Foo', 'Bar')
         );
     }
@@ -191,12 +191,12 @@ class AbstractMessageTest extends UnitTestCase
         $message = $this->getAbstractMessageMock();
         $message->setCookie($cookie);
 
-        $this->assertSame($cookie, $message->getCookie('foo'));
-        $this->assertSame($cookie, $message->getHeaders()->getCookie('foo'));
-        $this->assertSame(['foo' => $cookie], $message->getCookies());
-        $this->assertTrue($message->hasCookie('foo'));
+        self::assertSame($cookie, $message->getCookie('foo'));
+        self::assertSame($cookie, $message->getHeaders()->getCookie('foo'));
+        self::assertSame(['foo' => $cookie], $message->getCookies());
+        self::assertTrue($message->hasCookie('foo'));
         $message->removeCookie('foo');
-        $this->assertFalse($message->hasCookie('foo'));
+        self::assertFalse($message->hasCookie('foo'));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Http/BrowserTest.php
+++ b/Neos.Flow/Tests/Unit/Http/BrowserTest.php
@@ -66,9 +66,9 @@ class BrowserTest extends UnitTestCase
         $this->browser->addAutomaticRequestHeader('Content-Type', 'text/plain');
         $this->browser->request('http://localhost/foo');
 
-        $this->assertTrue($this->browser->getLastRequest()->hasHeader('X-Test-Header'));
-        $this->assertSame('Acme', $this->browser->getLastRequest()->getHeader('X-Test-Header'));
-        $this->assertStringContainsString('text/plain', $this->browser->getLastRequest()->getHeader('Content-Type'));
+        self::assertTrue($this->browser->getLastRequest()->hasHeader('X-Test-Header'));
+        self::assertSame('Acme', $this->browser->getLastRequest()->getHeader('X-Test-Header'));
+        self::assertStringContainsString('text/plain', $this->browser->getLastRequest()->getHeader('Content-Type'));
     }
 
     /**
@@ -87,7 +87,7 @@ class BrowserTest extends UnitTestCase
         $this->browser->addAutomaticRequestHeader('X-Test-Header', 'Acme');
         $this->browser->removeAutomaticRequestHeader('X-Test-Header');
         $this->browser->request('http://localhost/foo');
-        $this->assertFalse($this->browser->getLastRequest()->hasHeader('X-Test-Header'));
+        self::assertFalse($this->browser->getLastRequest()->hasHeader('X-Test-Header'));
     }
 
     /**
@@ -122,7 +122,7 @@ class BrowserTest extends UnitTestCase
 
         $this->browser->setRequestEngine($requestEngine);
         $actual = $this->browser->request($initialUri);
-        $this->assertSame($secondResponse, $actual);
+        self::assertSame($secondResponse, $actual);
     }
 
     /**
@@ -142,7 +142,7 @@ class BrowserTest extends UnitTestCase
 
         $this->browser->setRequestEngine($requestEngine);
         $actual = $this->browser->request('http://localhost/createSomeResource');
-        $this->assertSame($twoZeroOneResponse, $actual);
+        self::assertSame($twoZeroOneResponse, $actual);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Http/Component/ComponentContextTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Component/ComponentContextTest.php
@@ -47,7 +47,7 @@ class ComponentContextTest extends UnitTestCase
      */
     public function getHttpRequestReturnsTheCurrentRequest()
     {
-        $this->assertSame($this->mockHttpRequest, $this->componentContext->getHttpRequest());
+        self::assertSame($this->mockHttpRequest, $this->componentContext->getHttpRequest());
     }
 
     /**
@@ -58,7 +58,7 @@ class ComponentContextTest extends UnitTestCase
         /** @var Http\Request $mockNewHttpRequest */
         $mockNewHttpRequest = $this->getMockBuilder(Http\Request::class)->disableOriginalConstructor()->getMock();
         $this->componentContext->replaceHttpRequest($mockNewHttpRequest);
-        $this->assertSame($mockNewHttpRequest, $this->componentContext->getHttpRequest());
+        self::assertSame($mockNewHttpRequest, $this->componentContext->getHttpRequest());
     }
 
     /**
@@ -66,7 +66,7 @@ class ComponentContextTest extends UnitTestCase
      */
     public function getHttpResponseReturnsTheCurrentResponse()
     {
-        $this->assertSame($this->mockHttpResponse, $this->componentContext->getHttpResponse());
+        self::assertSame($this->mockHttpResponse, $this->componentContext->getHttpResponse());
     }
 
     /**
@@ -77,7 +77,7 @@ class ComponentContextTest extends UnitTestCase
         /** @var Http\Response $mockNewHttpResponse */
         $mockNewHttpResponse = $this->getMockBuilder(Http\Response::class)->disableOriginalConstructor()->getMock();
         $this->componentContext->replaceHttpResponse($mockNewHttpResponse);
-        $this->assertSame($mockNewHttpResponse, $this->componentContext->getHttpResponse());
+        self::assertSame($mockNewHttpResponse, $this->componentContext->getHttpResponse());
     }
 
 
@@ -86,7 +86,7 @@ class ComponentContextTest extends UnitTestCase
      */
     public function getParameterReturnsNullIfTheSpecifiedParameterIsNotDefined()
     {
-        $this->assertNull($this->componentContext->getParameter('Some\Component\ClassName', 'nonExistingParameter'));
+        self::assertNull($this->componentContext->getParameter('Some\Component\ClassName', 'nonExistingParameter'));
     }
 
     /**
@@ -95,6 +95,6 @@ class ComponentContextTest extends UnitTestCase
     public function setParameterStoresTheGivenParameter()
     {
         $this->componentContext->setParameter('Some\Component\ClassName', 'someParameter', 'someParameterValue');
-        $this->assertSame('someParameterValue', $this->componentContext->getParameter('Some\Component\ClassName', 'someParameter'));
+        self::assertSame('someParameterValue', $this->componentContext->getParameter('Some\Component\ClassName', 'someParameter'));
     }
 }

--- a/Neos.Flow/Tests/Unit/Http/Component/TrustedProxiesComponentTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Component/TrustedProxiesComponentTest.php
@@ -108,7 +108,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
 
         $request = Request::create(new Uri('https://dev.blog.rob/foo/bar?baz=quux&coffee=due'), 'GET', [], [], $server);
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertSame(2727, $trustedRequest->getPort());
+        self::assertSame(2727, $trustedRequest->getPort());
     }
 
     /**
@@ -133,7 +133,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
 
         $request = Request::create(new Uri('https://[2a00:f48:1008::212:183:10]:2727/foo/bar?baz=quux&coffee=due'), 'GET', [], [], $server);
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertSame(2727, $trustedRequest->getPort());
+        self::assertSame(2727, $trustedRequest->getPort());
     }
 
     /**
@@ -179,7 +179,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
 
         $request = Request::create(new Uri('http://flow.neos.io'), 'GET', [], [], array_replace($defaultServerEnvironment, $serverEnvironment));
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertSame($expectedIpAddress, $trustedRequest->getClientIpAddress());
+        self::assertSame($expectedIpAddress, $trustedRequest->getClientIpAddress());
     }
 
     /**
@@ -217,10 +217,10 @@ class TrustedProxiesComponentTest extends UnitTestCase
         $this->withTrustedProxiesSettings(['proxies' => '*', 'headers' => 'Forwarded']);
         $request = Request::create(new Uri('http://flow.neos.io'), 'GET', [], [], array_replace($defaultServerEnvironment, $serverEnvironment));
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertSame($expectedIpAddress, $trustedRequest->getAttribute(Request::ATTRIBUTE_CLIENT_IP));
-        $this->assertSame($expectedProto, $trustedRequest->getUri()->getScheme());
-        $this->assertSame($expectedHost, $trustedRequest->getUri()->getHost());
-        $this->assertSame($expectedPort, $trustedRequest->getUri()->getPort());
+        self::assertSame($expectedIpAddress, $trustedRequest->getAttribute(Request::ATTRIBUTE_CLIENT_IP));
+        self::assertSame($expectedProto, $trustedRequest->getUri()->getScheme());
+        self::assertSame($expectedHost, $trustedRequest->getUri()->getHost());
+        self::assertSame($expectedPort, $trustedRequest->getUri()->getPort());
     }
 
     /**
@@ -235,9 +235,9 @@ class TrustedProxiesComponentTest extends UnitTestCase
 
         $request = Request::create(new Uri('http://acme.com'), 'GET', [], [], $server);
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertEquals('https://acme.com', (string)$trustedRequest->getUri());
-        $this->assertEquals('https', $trustedRequest->getUri()->getScheme());
-        $this->assertTrue($trustedRequest->isSecure());
+        self::assertEquals('https://acme.com', (string)$trustedRequest->getUri());
+        self::assertEquals('https', $trustedRequest->getUri()->getScheme());
+        self::assertTrue($trustedRequest->isSecure());
     }
 
     /**
@@ -252,9 +252,9 @@ class TrustedProxiesComponentTest extends UnitTestCase
 
         $request = Request::create(new Uri('https://acme.com'), 'GET', [], [], $server);
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertEquals('http://acme.com', (string)$trustedRequest->getUri());
-        $this->assertEquals('http', $trustedRequest->getUri()->getScheme());
-        $this->assertFalse($trustedRequest->isSecure());
+        self::assertEquals('http://acme.com', (string)$trustedRequest->getUri());
+        self::assertEquals('http', $trustedRequest->getUri()->getScheme());
+        self::assertFalse($trustedRequest->isSecure());
     }
 
     /**
@@ -264,7 +264,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
     {
         $request = Request::create(new Uri('https://acme.com'), 'GET');
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertTrue($trustedRequest->getAttribute(Request::ATTRIBUTE_TRUSTED_PROXY));
+        self::assertTrue($trustedRequest->getAttribute(Request::ATTRIBUTE_TRUSTED_PROXY));
     }
 
     /**
@@ -275,7 +275,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
         $this->withTrustedProxiesSettings(['proxies' => ['127.0.0.0/24']]);
         $request = Request::create(new Uri('https://acme.com'), 'GET');
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertTrue($trustedRequest->getAttribute(Request::ATTRIBUTE_TRUSTED_PROXY));
+        self::assertTrue($trustedRequest->getAttribute(Request::ATTRIBUTE_TRUSTED_PROXY));
     }
 
     /**
@@ -286,7 +286,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
         $this->withTrustedProxiesSettings(['proxies' => []]);
         $request = Request::create(new Uri('https://acme.com'), 'GET');
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertFalse($trustedRequest->getAttribute(Request::ATTRIBUTE_TRUSTED_PROXY));
+        self::assertFalse($trustedRequest->getAttribute(Request::ATTRIBUTE_TRUSTED_PROXY));
     }
 
     /**
@@ -297,7 +297,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
         $this->withTrustedProxiesSettings(['proxies' => ['10.0.0.1/24']]);
         $request = Request::create(new Uri('https://acme.com'), 'GET');
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertFalse($trustedRequest->getAttribute(Request::ATTRIBUTE_TRUSTED_PROXY));
+        self::assertFalse($trustedRequest->getAttribute(Request::ATTRIBUTE_TRUSTED_PROXY));
     }
 
     /**
@@ -308,7 +308,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
         $this->withTrustedProxiesSettings(['proxies' => [], 'headers' => [TrustedProxiesComponent::HEADER_CLIENT_IP => 'X-Forwarded-For']]);
         $request = Request::create(new Uri('https://acme.com'), 'GET', [], [], ['HTTP_X_FORWARDED_FOR' => '10.0.0.1']);
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertEquals('127.0.0.1', $trustedRequest->getAttribute(Request::ATTRIBUTE_CLIENT_IP));
+        self::assertEquals('127.0.0.1', $trustedRequest->getAttribute(Request::ATTRIBUTE_CLIENT_IP));
     }
 
     /**
@@ -319,7 +319,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
         $this->withTrustedProxiesSettings(['proxies' => ['127.0.0.1'], 'headers' => []]);
         $request = Request::create(new Uri('https://acme.com'), 'GET', [], [], ['HTTP_X_FORWARDED_FOR' => '10.0.0.1']);
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertEquals('127.0.0.1', $trustedRequest->getAttribute(Request::ATTRIBUTE_CLIENT_IP));
+        self::assertEquals('127.0.0.1', $trustedRequest->getAttribute(Request::ATTRIBUTE_CLIENT_IP));
     }
 
     /**
@@ -330,7 +330,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
         $this->withTrustedProxiesSettings(['proxies' => ['127.0.0.1'], 'headers' => [TrustedProxiesComponent::HEADER_CLIENT_IP => 'X-Forwarded-For']]);
         $request = Request::create(new Uri('https://acme.com'), 'GET', [], [], ['HTTP_X_FORWARDED_FOR' => '13.0.0.1']);
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertEquals('13.0.0.1', $trustedRequest->getAttribute(Request::ATTRIBUTE_CLIENT_IP));
+        self::assertEquals('13.0.0.1', $trustedRequest->getAttribute(Request::ATTRIBUTE_CLIENT_IP));
     }
 
     /**
@@ -341,7 +341,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
         $this->withTrustedProxiesSettings(['proxies' => '*', 'headers' => [TrustedProxiesComponent::HEADER_CLIENT_IP => 'X-Forwarded-For']]);
         $request = Request::create(new Uri('https://acme.com'), 'GET', [], [], ['HTTP_X_FORWARDED_FOR' => '13.0.0.1, 13.0.0.2, 13.0.0.3']);
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertEquals('13.0.0.1', $trustedRequest->getAttribute(Request::ATTRIBUTE_CLIENT_IP));
+        self::assertEquals('13.0.0.1', $trustedRequest->getAttribute(Request::ATTRIBUTE_CLIENT_IP));
     }
 
     /**
@@ -352,7 +352,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
         $this->withTrustedProxiesSettings(['proxies' => ['127.0.0.1','10.0.0.1/24'], 'headers' => [TrustedProxiesComponent::HEADER_CLIENT_IP => 'X-Forwarded-For']]);
         $request = Request::create(new Uri('https://acme.com'), 'GET', [], [], ['HTTP_X_FORWARDED_FOR' => '198.155.23.17, 215.0.0.1, 10.0.0.1, 10.0.0.2']);
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertEquals('215.0.0.1', $trustedRequest->getAttribute(Request::ATTRIBUTE_CLIENT_IP));
+        self::assertEquals('215.0.0.1', $trustedRequest->getAttribute(Request::ATTRIBUTE_CLIENT_IP));
     }
 
     /**
@@ -363,7 +363,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
         $this->withTrustedProxiesSettings(['proxies' => '*', 'headers' => [TrustedProxiesComponent::HEADER_CLIENT_IP => 'X-Forwarded-Ip']]);
         $request = Request::create(new Uri('https://acme.com'), 'GET', [], [], ['HTTP_X_FORWARDED_FOR' => '10.0.0.1']);
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertEquals('127.0.0.1', $trustedRequest->getAttribute(Request::ATTRIBUTE_CLIENT_IP));
+        self::assertEquals('127.0.0.1', $trustedRequest->getAttribute(Request::ATTRIBUTE_CLIENT_IP));
     }
 
     /**
@@ -374,7 +374,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
         $this->withTrustedProxiesSettings(['proxies' => '*', 'headers' => []]);
         $request = Request::create(new Uri('http://acme.com'), 'GET', [], [], ['HTTP_X_FORWARDED_PORT' => '443']);
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertEquals(80, $trustedRequest->getPort());
+        self::assertEquals(80, $trustedRequest->getPort());
     }
 
     /**
@@ -385,7 +385,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
         $this->withTrustedProxiesSettings(['proxies' => '*', 'headers' => []]);
         $request = Request::create(new Uri('http://acme.com'), 'GET', [], [], ['HTTP_X_FORWARDED_PROTO' => 'https']);
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertEquals('http', $trustedRequest->getUri()->getScheme());
+        self::assertEquals('http', $trustedRequest->getUri()->getScheme());
     }
 
     /**
@@ -396,7 +396,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
         $this->withTrustedProxiesSettings(['proxies' => '*', 'headers' => []]);
         $request = Request::create(new Uri('http://acme.com'), 'GET', [], [], ['HTTP_X_FORWARDED_HOST' => 'neos.io']);
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertEquals('acme.com', $trustedRequest->getUri()->getHost());
+        self::assertEquals('acme.com', $trustedRequest->getUri()->getHost());
     }
 
     /**
@@ -406,7 +406,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
     {
         $request = Request::create(new Uri('http://acme.com'), 'GET', [], [], ['HTTP_X_FORWARDED_HOST' => 'neos.io']);
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertEquals('neos.io', $trustedRequest->getUri()->getHost());
+        self::assertEquals('neos.io', $trustedRequest->getUri()->getHost());
     }
 
     /**
@@ -416,7 +416,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
     {
         $request = Request::create(new Uri('http://acme.com'), 'GET', [], [], ['HTTP_X_FORWARDED_HOST' => 'neos.io:443']);
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertEquals(443, $trustedRequest->getUri()->getPort());
+        self::assertEquals(443, $trustedRequest->getUri()->getPort());
     }
 
     /**
@@ -426,7 +426,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
     {
         $request = Request::create(new Uri('http://acme.com'), 'GET', [], [], ['HTTP_X_FORWARDED_HOST' => ':443']);
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertEquals(443, $trustedRequest->getUri()->getPort());
+        self::assertEquals(443, $trustedRequest->getUri()->getPort());
     }
 
     /**
@@ -436,7 +436,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
     {
         $request = Request::create(new Uri('http://acme.com'), 'GET', [], [], ['HTTP_X_FORWARDED_HOST' => 'neos.io:443', 'HTTP_X_FORWARDED_PROTO' => 'http']);
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertEquals(443, $trustedRequest->getUri()->getPort());
+        self::assertEquals(443, $trustedRequest->getUri()->getPort());
     }
 
     /**
@@ -446,7 +446,7 @@ class TrustedProxiesComponentTest extends UnitTestCase
     {
         $request = Request::create(new Uri('http://acme.com'), 'GET', [], [], ['HTTP_X_FORWARDED_PORT' => 8080, 'HTTP_X_FORWARDED_HOST' => 'neos.io:443']);
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertEquals(8080, $trustedRequest->getUri()->getPort());
+        self::assertEquals(8080, $trustedRequest->getUri()->getPort());
     }
 
     /**
@@ -581,6 +581,6 @@ class TrustedProxiesComponentTest extends UnitTestCase
         }
         $request = Request::create(new Uri($requestUri), 'GET', [], [], $server);
         $trustedRequest = $this->callWithRequest($request);
-        $this->assertEquals($expectedUri, (string)$trustedRequest->getUri());
+        self::assertEquals($expectedUri, (string)$trustedRequest->getUri());
     }
 }

--- a/Neos.Flow/Tests/Unit/Http/ContentStreamTest.php
+++ b/Neos.Flow/Tests/Unit/Http/ContentStreamTest.php
@@ -34,6 +34,6 @@ class ContentStreamTest extends UnitTestCase
         $someContent = 'Lorem ipsum
         dolor';
         $contentStream = ContentStream::fromContents($someContent);
-        $this->assertSame($someContent, $contentStream->getContents());
+        self::assertSame($someContent, $contentStream->getContents());
     }
 }

--- a/Neos.Flow/Tests/Unit/Http/CookieTest.php
+++ b/Neos.Flow/Tests/Unit/Http/CookieTest.php
@@ -77,7 +77,7 @@ class CookieTest extends UnitTestCase
     public function constructorAcceptsValidCookieNames($cookieName)
     {
         $cookie = new Cookie($cookieName);
-        $this->assertEquals($cookieName, $cookie->getName());
+        self::assertEquals($cookieName, $cookie->getName());
     }
 
     /**
@@ -86,18 +86,18 @@ class CookieTest extends UnitTestCase
     public function getValueReturnsTheSetValue()
     {
         $cookie = new Cookie('foo', 'bar');
-        $this->assertEquals('bar', $cookie->getValue());
+        self::assertEquals('bar', $cookie->getValue());
 
         $cookie = new Cookie('foo', 'bar');
         $cookie->setValue('baz');
-        $this->assertEquals('baz', $cookie->getValue());
+        self::assertEquals('baz', $cookie->getValue());
 
         $cookie = new Cookie('foo', true);
-        $this->assertSame(true, $cookie->getValue());
+        self::assertSame(true, $cookie->getValue());
 
         $uri = new Uri('http://localhost');
         $cookie = new Cookie('foo', $uri);
-        $this->assertSame($uri, $cookie->getValue());
+        self::assertSame($uri, $cookie->getValue());
     }
 
     /**
@@ -130,13 +130,13 @@ class CookieTest extends UnitTestCase
     public function getExpiresAlwaysReturnsAUnixTimestamp()
     {
         $cookie = new Cookie('foo', 'bar', 1345110803);
-        $this->assertSame(1345110803, $cookie->getExpires());
+        self::assertSame(1345110803, $cookie->getExpires());
 
         $cookie = new Cookie('foo', 'bar', \DateTime::createFromFormat('U', 1345110803));
-        $this->assertSame(1345110803, $cookie->getExpires());
+        self::assertSame(1345110803, $cookie->getExpires());
 
         $cookie = new Cookie('foo', 'bar');
-        $this->assertSame(0, $cookie->getExpires());
+        self::assertSame(0, $cookie->getExpires());
     }
 
     /**
@@ -154,10 +154,10 @@ class CookieTest extends UnitTestCase
     public function getMaximumAgeReturnsTheMaximumAge()
     {
         $cookie = new Cookie('foo', 'bar');
-        $this->assertSame(null, $cookie->getMaximumAge());
+        self::assertSame(null, $cookie->getMaximumAge());
 
         $cookie = new Cookie('foo', 'bar', 0, 120);
-        $this->assertSame(120, $cookie->getMaximumAge());
+        self::assertSame(120, $cookie->getMaximumAge());
     }
 
     /**
@@ -192,7 +192,7 @@ class CookieTest extends UnitTestCase
     public function getDomainReturnsDomain()
     {
         $cookie = new Cookie('foo', 'bar', 0, null, 'flow.neos.io');
-        $this->assertSame('flow.neos.io', $cookie->getDomain());
+        self::assertSame('flow.neos.io', $cookie->getDomain());
     }
 
     /**
@@ -225,10 +225,10 @@ class CookieTest extends UnitTestCase
     public function getPathReturnsPath()
     {
         $cookie = new Cookie('foo', 'bar');
-        $this->assertSame('/', $cookie->getPath());
+        self::assertSame('/', $cookie->getPath());
 
         $cookie = new Cookie('foo', 'bar', 0, null, 'flow.neos.io', '/about/us');
-        $this->assertSame('/about/us', $cookie->getPath());
+        self::assertSame('/about/us', $cookie->getPath());
     }
 
     /**
@@ -237,10 +237,10 @@ class CookieTest extends UnitTestCase
     public function isSecureReturnsSecureFlag()
     {
         $cookie = new Cookie('foo', 'bar');
-        $this->assertFalse($cookie->isSecure());
+        self::assertFalse($cookie->isSecure());
 
         $cookie = new Cookie('foo', 'bar', 0, null, 'neos.io', '/', true);
-        $this->assertTrue($cookie->isSecure());
+        self::assertTrue($cookie->isSecure());
     }
 
     /**
@@ -249,10 +249,10 @@ class CookieTest extends UnitTestCase
     public function isHttpOnlyReturnsHttpOnlyFlag()
     {
         $cookie = new Cookie('foo', 'bar');
-        $this->assertTrue($cookie->isHttpOnly());
+        self::assertTrue($cookie->isHttpOnly());
 
         $cookie = new Cookie('foo', 'bar', 0, null, 'neos.io', '/', false, false);
-        $this->assertFalse($cookie->isHttpOnly());
+        self::assertFalse($cookie->isHttpOnly());
     }
 
     /**
@@ -261,13 +261,13 @@ class CookieTest extends UnitTestCase
     public function isExpiredTellsIfTheCookieIsExpired()
     {
         $cookie = new Cookie('foo', 'bar');
-        $this->assertFalse($cookie->isExpired());
+        self::assertFalse($cookie->isExpired());
 
         $cookie->expire();
-        $this->assertTrue($cookie->isExpired());
+        self::assertTrue($cookie->isExpired());
 
         $cookie = new Cookie('foo', 'bar', 500);
-        $this->assertTrue($cookie->isExpired());
+        self::assertTrue($cookie->isExpired());
     }
 
     /**
@@ -312,7 +312,7 @@ class CookieTest extends UnitTestCase
      */
     public function stringRepresentationOfCookieIsValidSetCookieFieldValue(Cookie $cookie, $expectedString)
     {
-        $this->assertEquals($expectedString, (string)$cookie);
+        self::assertEquals($expectedString, (string)$cookie);
     }
 
     /**
@@ -320,8 +320,8 @@ class CookieTest extends UnitTestCase
      */
     public function createCookieFromRawReturnsNullIfBasicNameOrValueAreNotSatisfied()
     {
-        $this->assertNull(Cookie::createFromRawSetCookieHeader('Foobar'), 'The cookie without a = char at all is not discarded.');
-        $this->assertNull(Cookie::createFromRawSetCookieHeader('=Foobar'), 'The cookie with only a leading = char, hence without a name, is not discarded.');
+        self::assertNull(Cookie::createFromRawSetCookieHeader('Foobar'), 'The cookie without a = char at all is not discarded.');
+        self::assertNull(Cookie::createFromRawSetCookieHeader('=Foobar'), 'The cookie with only a leading = char, hence without a name, is not discarded.');
     }
 
     /**
@@ -330,8 +330,8 @@ class CookieTest extends UnitTestCase
     public function createCookieFromRawDoesntCareAboutUnkownAttributeValues()
     {
         $cookie = Cookie::createFromRawSetCookieHeader('ckName=someValue; someproperty=itsvalue');
-        $this->assertEquals('ckName', $cookie->getName());
-        $this->assertEquals('someValue', $cookie->getValue());
+        self::assertEquals('ckName', $cookie->getName());
+        self::assertEquals('someValue', $cookie->getValue());
     }
 
     /**
@@ -340,7 +340,7 @@ class CookieTest extends UnitTestCase
     public function createCookieFromRawParsesExpiryDateCorrectly()
     {
         $cookie = Cookie::createFromRawSetCookieHeader('ckName=someValue; Expires=Sun, 16-Oct-2022 17:53:36 GMT');
-        $this->assertSame(1665942816, $cookie->getExpires());
+        self::assertSame(1665942816, $cookie->getExpires());
     }
 
     /**
@@ -349,7 +349,7 @@ class CookieTest extends UnitTestCase
     public function createCookieFromRawAssumesExpiryDateZeroIfItCannotBeParsed()
     {
         $cookie = Cookie::createFromRawSetCookieHeader('ckName=someValue; Expires=trythis');
-        $this->assertSame(0, $cookie->getExpires());
+        self::assertSame(0, $cookie->getExpires());
     }
 
     /**
@@ -358,7 +358,7 @@ class CookieTest extends UnitTestCase
     public function createCookieFromRawParsesMaxAgeCorrectly()
     {
         $cookie = Cookie::createFromRawSetCookieHeader('ckName=someValue; Max-Age=-20');
-        $this->assertSame(-20, $cookie->getMaximumAge());
+        self::assertSame(-20, $cookie->getMaximumAge());
     }
 
     /**
@@ -367,7 +367,7 @@ class CookieTest extends UnitTestCase
     public function createCookieFromRawIgnoresMaxAgeIfInvalid()
     {
         $cookie = Cookie::createFromRawSetCookieHeader('ckName=someValue; Max-Age=--foo');
-        $this->assertNull($cookie->getMaximumAge());
+        self::assertNull($cookie->getMaximumAge());
     }
 
     /**
@@ -376,7 +376,7 @@ class CookieTest extends UnitTestCase
     public function createCookieFromRawIgnoresDomainAttributeIfValueIsEmpty()
     {
         $cookie = Cookie::createFromRawSetCookieHeader('ckName=someValue; Domain=; more=nothing');
-        $this->assertNull($cookie->getDomain());
+        self::assertNull($cookie->getDomain());
     }
 
     /**
@@ -385,7 +385,7 @@ class CookieTest extends UnitTestCase
     public function createCookieFromRawRemovesLeadingDotForDomainIfPresent()
     {
         $cookie = Cookie::createFromRawSetCookieHeader('ckName=someValue; Domain=.example.org');
-        $this->assertEquals('example.org', $cookie->getDomain());
+        self::assertEquals('example.org', $cookie->getDomain());
     }
 
     /**
@@ -394,7 +394,7 @@ class CookieTest extends UnitTestCase
     public function createCookieFromRawLowerCasesDomainName()
     {
         $cookie = Cookie::createFromRawSetCookieHeader('ckName=someValue; Domain=EXample.org');
-        $this->assertEquals('example.org', $cookie->getDomain());
+        self::assertEquals('example.org', $cookie->getDomain());
     }
 
     /**
@@ -403,7 +403,7 @@ class CookieTest extends UnitTestCase
     public function createCookieFromRawAssumesDefaultPathIfNoLeadingSlashIsPresent()
     {
         $cookie = Cookie::createFromRawSetCookieHeader('ckName=someValue; Path=foo');
-        $this->assertEquals('/', $cookie->getPath());
+        self::assertEquals('/', $cookie->getPath());
     }
 
     /**
@@ -412,7 +412,7 @@ class CookieTest extends UnitTestCase
     public function createCookieFromRawUsesPathCorrectly()
     {
         $cookie = Cookie::createFromRawSetCookieHeader('ckName=someValue; Path=/foo');
-        $this->assertEquals('/foo', $cookie->getPath());
+        self::assertEquals('/foo', $cookie->getPath());
     }
 
     /**
@@ -421,7 +421,7 @@ class CookieTest extends UnitTestCase
     public function createCookieFromRawSetsSecureIfPresent()
     {
         $cookie = Cookie::createFromRawSetCookieHeader('ckName=someValue; Secure; more=nothing');
-        $this->assertTrue($cookie->isSecure());
+        self::assertTrue($cookie->isSecure());
     }
 
     /**
@@ -430,6 +430,6 @@ class CookieTest extends UnitTestCase
     public function createCookieFromRawSetsHttpOnlyIfPresent()
     {
         $cookie = Cookie::createFromRawSetCookieHeader('ckName=someValue; HttpOnly; more=nothing');
-        $this->assertTrue($cookie->isHttpOnly());
+        self::assertTrue($cookie->isHttpOnly());
     }
 }

--- a/Neos.Flow/Tests/Unit/Http/HeadersTest.php
+++ b/Neos.Flow/Tests/Unit/Http/HeadersTest.php
@@ -26,9 +26,9 @@ class HeadersTest extends UnitTestCase
     public function headerFieldsCanBeSpecifiedToTheConstructor()
     {
         $headers = new Headers(['User-Agent' => 'Espresso Machine', 'Server' => ['Foo', 'Bar']]);
-        $this->assertSame('Espresso Machine', $headers->get('User-Agent'));
-        $this->assertSame(['Foo', 'Bar'], $headers->get('Server'));
-        $this->assertTrue($headers->has('Server'));
+        self::assertSame('Espresso Machine', $headers->get('User-Agent'));
+        self::assertSame(['Foo', 'Bar'], $headers->get('Server'));
+        self::assertTrue($headers->has('Server'));
     }
 
     /**
@@ -43,8 +43,8 @@ class HeadersTest extends UnitTestCase
 
         $headers = Headers::createFromServer($server);
 
-        $this->assertEquals('Robusta', $headers->get('Foo'));
-        $this->assertEquals('Arabica', $headers->get('Bar-Baz'));
+        self::assertEquals('Robusta', $headers->get('Foo'));
+        self::assertEquals('Arabica', $headers->get('Bar-Baz'));
     }
 
     /**
@@ -60,8 +60,8 @@ class HeadersTest extends UnitTestCase
         $headers = Headers::createFromServer($server);
 
         $expectedValue = 'Basic ' . base64_encode('robert:mysecretpassword, containing a : colon ;-)');
-        $this->assertEquals($expectedValue, $headers->get('Authorization'));
-        $this->assertFalse($headers->has('User'));
+        self::assertEquals($expectedValue, $headers->get('Authorization'));
+        self::assertFalse($headers->has('User'));
     }
 
     /**
@@ -72,7 +72,7 @@ class HeadersTest extends UnitTestCase
         $headers = new Headers();
         $headers->set('Host', 'myhost.com');
         $headers->set('Host', 'yourhost.com');
-        $this->assertSame('yourhost.com', $headers->get('Host'));
+        self::assertSame('yourhost.com', $headers->get('Host'));
     }
 
     /**
@@ -83,7 +83,7 @@ class HeadersTest extends UnitTestCase
         $headers = new Headers();
         $headers->set('X-Powered-By', 'Flow');
         $headers->set('X-Powered-By', 'Neos', false);
-        $this->assertSame(['Flow', 'Neos'], $headers->get('X-Powered-By'));
+        self::assertSame(['Flow', 'Neos'], $headers->get('X-Powered-By'));
     }
 
     /**
@@ -93,8 +93,8 @@ class HeadersTest extends UnitTestCase
     {
         $headers = new Headers();
         $headers->set('X-Powered-By', 'Flow');
-        $this->assertFalse($headers->has('X-Empowered-By'));
-        $this->assertNull($headers->get('X-Empowered-By'));
+        self::assertFalse($headers->has('X-Empowered-By'));
+        self::assertNull($headers->get('X-Empowered-By'));
     }
 
     /**
@@ -106,7 +106,7 @@ class HeadersTest extends UnitTestCase
         $headers = new Headers($specifiedFields);
 
         $expectedFields = ['X-Coffee' => ['Arabica'], 'Host' => ['myhost.com']];
-        $this->assertEquals($expectedFields, $headers->getAll());
+        self::assertEquals($expectedFields, $headers->getAll());
     }
 
     /**
@@ -117,12 +117,12 @@ class HeadersTest extends UnitTestCase
         $expectedFields = ['Last-Modified' => ['Tue, 24 May 2012 12:00:00 +0000']];
         $headers = new Headers($expectedFields);
 
-        $this->assertEquals($expectedFields, $headers->getAll());
+        self::assertEquals($expectedFields, $headers->getAll());
 
         $expectedFields['Cache-Control'] = ['public, max-age=60'];
         $headers->setCacheControlDirective('public');
         $headers->setCacheControlDirective('max-age', 60);
-        $this->assertEquals($expectedFields, $headers->getAll());
+        self::assertEquals($expectedFields, $headers->getAll());
     }
 
     /**
@@ -143,10 +143,10 @@ class HeadersTest extends UnitTestCase
         $headers = new Headers();
 
         $headers->set('Last-Modified', $now);
-        $this->assertEquals($nowInGmt->format(DATE_RFC2822), $headers->get('Last-Modified')->format(DATE_RFC2822));
+        self::assertEquals($nowInGmt->format(DATE_RFC2822), $headers->get('Last-Modified')->format(DATE_RFC2822));
 
         $headers->set('X-Test-Run-At', $now);
-        $this->assertEquals($nowInGmt->format(DATE_RFC2822), $headers->get('X-Test-Run-At')->format(DATE_RFC2822));
+        self::assertEquals($nowInGmt->format(DATE_RFC2822), $headers->get('X-Test-Run-At')->format(DATE_RFC2822));
     }
 
     /**
@@ -160,7 +160,7 @@ class HeadersTest extends UnitTestCase
         $headers->remove('X-Coffee');
         $headers->remove('X-This-Does-Not-Exist-Anyway');
 
-        $this->assertEquals(['Host' => ['myhost.com']], $headers->getAll());
+        self::assertEquals(['Host' => ['myhost.com']], $headers->getAll());
     }
 
     /**
@@ -171,7 +171,7 @@ class HeadersTest extends UnitTestCase
         $headers = new Headers();
         $cookie = new Cookie('Dark-Chocolate-Chip');
         $headers->setCookie($cookie);
-        $this->assertSame($cookie, $headers->getCookie('Dark-Chocolate-Chip'));
+        self::assertSame($cookie, $headers->getCookie('Dark-Chocolate-Chip'));
     }
 
     /**
@@ -182,9 +182,9 @@ class HeadersTest extends UnitTestCase
         $headers = new Headers();
         $headers->setCookie(new Cookie('Dark-Chocolate-Chip'));
 
-        $this->assertTrue($headers->hasCookie('Dark-Chocolate-Chip'));
+        self::assertTrue($headers->hasCookie('Dark-Chocolate-Chip'));
         $headers->removeCookie('Dark-Chocolate-Chip');
-        $this->assertFalse($headers->hasCookie('Dark-Chocolate-Chip'));
+        self::assertFalse($headers->hasCookie('Dark-Chocolate-Chip'));
     }
 
     /**
@@ -206,7 +206,7 @@ class HeadersTest extends UnitTestCase
         $headers->eatCookie('Coffee-Fudge-Mess');
         unset($cookies['Coffee-Fudge-Mess']);
 
-        $this->assertEquals($cookies, $headers->getCookies());
+        self::assertEquals($cookies, $headers->getCookies());
     }
 
     /**
@@ -217,13 +217,13 @@ class HeadersTest extends UnitTestCase
         $headers = new Headers();
         $headers->set('Cookie', ['cookie1=the+value+number+1; cookie2=the+value+number+2;  Cookie-Thing3="' . urlencode('Fön + x = \'test\'') . '"']);
 
-        $this->assertTrue($headers->hasCookie('cookie1'));
-        $this->assertEquals('the value number 1', $headers->getCookie('cookie1')->getValue());
+        self::assertTrue($headers->hasCookie('cookie1'));
+        self::assertEquals('the value number 1', $headers->getCookie('cookie1')->getValue());
 
-        $this->assertTrue($headers->hasCookie('cookie2'));
-        $this->assertEquals('the value number 2', $headers->getCookie('cookie2')->getValue());
+        self::assertTrue($headers->hasCookie('cookie2'));
+        self::assertEquals('the value number 2', $headers->getCookie('cookie2')->getValue());
 
-        $this->assertEquals('Fön + x = \'test\'', $headers->getCookie('Cookie-Thing3')->getValue());
+        self::assertEquals('Fön + x = \'test\'', $headers->getCookie('Cookie-Thing3')->getValue());
     }
 
     /**
@@ -236,8 +236,8 @@ class HeadersTest extends UnitTestCase
         $headers = new Headers();
         $headers->set('Cookie', ['cookie1=the+value+number+1; =foo']);
 
-        $this->assertTrue($headers->hasCookie('cookie1'));
-        $this->assertEquals('the value number 1', $headers->getCookie('cookie1')->getValue());
+        self::assertTrue($headers->hasCookie('cookie1'));
+        self::assertEquals('the value number 1', $headers->getCookie('cookie1')->getValue());
     }
 
     /**
@@ -248,8 +248,8 @@ class HeadersTest extends UnitTestCase
         $headers = new Headers();
         $headers->set('Cookie', ['cookie-valid=this+is+valid; cookie[invalid]=this+is+invalid']);
 
-        $this->assertTrue($headers->hasCookie('cookie-valid'));
-        $this->assertFalse($headers->hasCookie('cookie[invalid]'));
+        self::assertTrue($headers->hasCookie('cookie-valid'));
+        self::assertFalse($headers->hasCookie('cookie[invalid]'));
     }
 
     /**
@@ -277,10 +277,10 @@ class HeadersTest extends UnitTestCase
     {
         $headers = new Headers();
 
-        $this->assertFalse($headers->has('Cache-Control'));
+        self::assertFalse($headers->has('Cache-Control'));
         $headers->set('Cache-Control', $rawFieldValue);
-        $this->assertTrue($headers->has('Cache-Control'));
-        $this->assertEquals($renderedFieldValue, $headers->get('Cache-Control'));
+        self::assertTrue($headers->has('Cache-Control'));
+        self::assertEquals($renderedFieldValue, $headers->get('Cache-Control'));
     }
 
     /**
@@ -292,7 +292,7 @@ class HeadersTest extends UnitTestCase
 
         $headers->setCacheControlDirective('public');
         $headers->set('Cache-Control', 'max-age=600, must-revalidate');
-        $this->assertEquals('max-age=600, must-revalidate', $headers->get('Cache-Control'));
+        self::assertEquals('max-age=600, must-revalidate', $headers->get('Cache-Control'));
     }
 
     /**
@@ -305,19 +305,19 @@ class HeadersTest extends UnitTestCase
         $headers = new Headers();
 
         $headers->setCacheControlDirective('public');
-        $this->assertEquals('public', $headers->get('Cache-Control'));
+        self::assertEquals('public', $headers->get('Cache-Control'));
 
         $headers->setCacheControlDirective('private');
-        $this->assertEquals('private', $headers->get('Cache-Control'));
+        self::assertEquals('private', $headers->get('Cache-Control'));
 
         $headers->setCacheControlDirective('private', 'X-Flow-Powered');
-        $this->assertEquals('private="X-Flow-Powered"', $headers->get('Cache-Control'));
+        self::assertEquals('private="X-Flow-Powered"', $headers->get('Cache-Control'));
 
         $headers->setCacheControlDirective('no-cache', 'X-Flow-Powered');
-        $this->assertEquals('no-cache="X-Flow-Powered"', $headers->get('Cache-Control'));
+        self::assertEquals('no-cache="X-Flow-Powered"', $headers->get('Cache-Control'));
 
         $headers->setCacheControlDirective('no-cache');
-        $this->assertEquals('no-cache', $headers->get('Cache-Control'));
+        self::assertEquals('no-cache', $headers->get('Cache-Control'));
     }
 
     /**
@@ -344,15 +344,15 @@ class HeadersTest extends UnitTestCase
 
         $headers->setCacheControlDirective('private');
         $headers->removeCacheControlDirective('private');
-        $this->assertEquals(null, $headers->get('Cache-Control'));
+        self::assertEquals(null, $headers->get('Cache-Control'));
 
         $headers->setCacheControlDirective('public');
         $headers->removeCacheControlDirective('public');
-        $this->assertEquals(null, $headers->get('Cache-Control'));
+        self::assertEquals(null, $headers->get('Cache-Control'));
 
         $headers->setCacheControlDirective('no-cache');
         $headers->removeCacheControlDirective('no-cache');
-        $this->assertEquals(null, $headers->get('Cache-Control'));
+        self::assertEquals(null, $headers->get('Cache-Control'));
     }
 
     /**
@@ -365,13 +365,13 @@ class HeadersTest extends UnitTestCase
         $headers = new Headers();
 
         $headers->setCacheControlDirective('no-store');
-        $this->assertEquals('no-store', $headers->get('Cache-Control'));
+        self::assertEquals('no-store', $headers->get('Cache-Control'));
 
         $headers->setCacheControlDirective('public');
-        $this->assertEquals('public, no-store', $headers->get('Cache-Control'));
+        self::assertEquals('public, no-store', $headers->get('Cache-Control'));
 
         $headers->removeCacheControlDirective('no-store');
-        $this->assertEquals('public', $headers->get('Cache-Control'));
+        self::assertEquals('public', $headers->get('Cache-Control'));
     }
 
     /**
@@ -384,16 +384,16 @@ class HeadersTest extends UnitTestCase
         $headers = new Headers();
 
         $headers->setCacheControlDirective('max-age', 120);
-        $this->assertEquals('max-age=120', $headers->get('Cache-Control'));
+        self::assertEquals('max-age=120', $headers->get('Cache-Control'));
 
         $headers->setCacheControlDirective('s-maxage', 60);
-        $this->assertEquals('max-age=120, s-maxage=60', $headers->get('Cache-Control'));
+        self::assertEquals('max-age=120, s-maxage=60', $headers->get('Cache-Control'));
 
         $headers->removeCacheControlDirective('max-age');
-        $this->assertEquals('s-maxage=60', $headers->get('Cache-Control'));
+        self::assertEquals('s-maxage=60', $headers->get('Cache-Control'));
 
         $headers->removeCacheControlDirective('s-maxage');
-        $this->assertEquals(null, $headers->get('Cache-Control'));
+        self::assertEquals(null, $headers->get('Cache-Control'));
     }
 
     /**
@@ -408,11 +408,11 @@ class HeadersTest extends UnitTestCase
         $headers->setCacheControlDirective('no-transform');
         $headers->setCacheControlDirective('public');
 
-        $this->assertEquals('public, no-transform', $headers->get('Cache-Control'));
+        self::assertEquals('public, no-transform', $headers->get('Cache-Control'));
 
         $headers->removeCacheControlDirective('no-transform');
 
-        $this->assertEquals('public', $headers->get('Cache-Control'));
+        self::assertEquals('public', $headers->get('Cache-Control'));
     }
 
     /**
@@ -425,11 +425,11 @@ class HeadersTest extends UnitTestCase
         $headers = new Headers();
 
         $headers->setCacheControlDirective('must-revalidate');
-        $this->assertEquals('must-revalidate', $headers->get('Cache-Control'));
+        self::assertEquals('must-revalidate', $headers->get('Cache-Control'));
 
         $headers->removeCacheControlDirective('must-revalidate');
         $headers->setCacheControlDirective('proxy-revalidate');
-        $this->assertEquals('proxy-revalidate', $headers->get('Cache-Control'));
+        self::assertEquals('proxy-revalidate', $headers->get('Cache-Control'));
     }
 
     /**
@@ -461,12 +461,12 @@ class HeadersTest extends UnitTestCase
     public function getCacheControlDirectiveReturnsTheSpecifiedDirectiveValueIfPresent($name, $value)
     {
         $headers = new Headers();
-        $this->assertNull($headers->getCacheControlDirective($name));
+        self::assertNull($headers->getCacheControlDirective($name));
         if ($value === true) {
             $headers->setCacheControlDirective($name);
         } else {
             $headers->setCacheControlDirective($name, $value);
         }
-        $this->assertEquals($value, $headers->getCacheControlDirective($name));
+        self::assertEquals($value, $headers->getCacheControlDirective($name));
     }
 }

--- a/Neos.Flow/Tests/Unit/Http/RequestTest.php
+++ b/Neos.Flow/Tests/Unit/Http/RequestTest.php
@@ -79,8 +79,8 @@ class RequestTest extends UnitTestCase
 
         $request = Request::createFromEnvironment();
 
-        $this->assertEquals('GET', $request->getMethod());
-        $this->assertEquals('http://dev.blog.rob/posts/2011/11/28/laboriosam-soluta-est-minus-molestiae?getKey1=getValue1&getKey2=getValue2', (string)$request->getUri());
+        self::assertEquals('GET', $request->getMethod());
+        self::assertEquals('http://dev.blog.rob/posts/2011/11/28/laboriosam-soluta-est-minus-molestiae?getKey1=getValue1&getKey2=getValue2', (string)$request->getUri());
 
         $_SERVER = $server;
     }
@@ -101,7 +101,7 @@ class RequestTest extends UnitTestCase
 
         $request = Request::createFromEnvironment();
 
-        $this->assertEquals('http://localhost/', (string)$request->getUri());
+        self::assertEquals('http://localhost/', (string)$request->getUri());
 
         $_SERVER = $server;
     }
@@ -129,8 +129,8 @@ class RequestTest extends UnitTestCase
         ];
 
         $request = new Request($get, $post, $files, $server);
-        $this->assertEquals('https', $request->getUri()->getScheme());
-        $this->assertTrue($request->isSecure());
+        self::assertEquals('https', $request->getUri()->getScheme());
+        self::assertTrue($request->isSecure());
     }
 
     /**
@@ -141,20 +141,20 @@ class RequestTest extends UnitTestCase
         $uri = new Uri('http://flow.neos.io/foo/bar?baz=1&quux=true#at-the-very-bottom');
         $request = Request::create($uri);
 
-        $this->assertEquals('GET', $request->getMethod());
-        $this->assertEquals($uri, $request->getUri());
-        $this->assertEquals('HTTP/1.1', $request->getVersion());
+        self::assertEquals('GET', $request->getMethod());
+        self::assertEquals($uri, $request->getUri());
+        self::assertEquals('HTTP/1.1', $request->getVersion());
 
         $uri = new Uri('https://flow.neos.io/foo/bar?baz=1&quux=true#at-the-very-bottom');
         $request = Request::create($uri);
 
-        $this->assertEquals($uri, $request->getUri());
+        self::assertEquals($uri, $request->getUri());
 
         $uri = new Uri('http://flow.neos.io/foo/bar?baz=1&quux=true#at-the-very-bottom');
         $request = Request::create($uri, 'POST');
 
-        $this->assertEquals('POST', $request->getMethod());
-        $this->assertEquals($uri, $request->getUri());
+        self::assertEquals('POST', $request->getMethod());
+        self::assertEquals($uri, $request->getUri());
     }
 
     /**
@@ -166,8 +166,8 @@ class RequestTest extends UnitTestCase
         $request = Request::create($uri);
         $request->setVersion('HTTP/1.0');
 
-        $this->assertEquals('HTTP/1.0', $request->getVersion());
-        $this->assertStringEndsWith("HTTP/1.0\r\n", $request->getRequestLine());
+        self::assertEquals('HTTP/1.0', $request->getVersion());
+        self::assertStringEndsWith("HTTP/1.0\r\n", $request->getRequestLine());
     }
 
     /**
@@ -229,7 +229,7 @@ class RequestTest extends UnitTestCase
     {
         $uri = new Uri('http://flow.neos.io');
         $request = Request::create($uri, $originalMethod, $arguments, [], $server);
-        $this->assertEquals($expectedMethod, $request->getMethod());
+        self::assertEquals($expectedMethod, $request->getMethod());
     }
 
     /**
@@ -243,7 +243,7 @@ class RequestTest extends UnitTestCase
         $uri = new Uri('http://flow.neos.io/foo');
         $request = Request::create($uri, 'POST');
 
-        $this->assertEquals('application/x-www-form-urlencoded', $request->getHeaders()->get('Content-Type'));
+        self::assertEquals('application/x-www-form-urlencoded', $request->getHeaders()->get('Content-Type'));
     }
 
     /**
@@ -255,8 +255,8 @@ class RequestTest extends UnitTestCase
         $request = Request::create($uri);
 
         $subRequest = new ActionRequest($request);
-        $this->assertInstanceOf(ActionRequest::class, $subRequest);
-        $this->assertSame($request, $subRequest->getParentRequest());
+        self::assertInstanceOf(ActionRequest::class, $subRequest);
+        self::assertSame($request, $subRequest->getParentRequest());
     }
 
     /**
@@ -280,7 +280,7 @@ class RequestTest extends UnitTestCase
     {
         $request = Request::create(new Uri('http://flow.neos.io'));
         $request->setMethod($validMethod);
-        $this->assertSame($validMethod, $request->getMethod());
+        self::assertSame($validMethod, $request->getMethod());
     }
 
     /**
@@ -300,7 +300,7 @@ class RequestTest extends UnitTestCase
 
         $uri = new Uri('http://dev.blog.rob/foo/bar');
         $request = new Request([], [], [], $server);
-        $this->assertEquals($uri, $request->getUri());
+        self::assertEquals($uri, $request->getUri());
     }
 
     /**
@@ -318,7 +318,7 @@ class RequestTest extends UnitTestCase
         $this->inject($request, 'inputStreamUri', 'vfs://Foo/content.txt');
 
         $actualContent = $request->getContent();
-        $this->assertEquals($expectedContent, $actualContent);
+        self::assertEquals($expectedContent, $actualContent);
     }
 
     /**
@@ -338,7 +338,7 @@ class RequestTest extends UnitTestCase
         $resource = $request->getContent(true);
         $actualContent = fread($resource, strlen($expectedContent));
 
-        $this->assertSame($expectedContent, $actualContent);
+        self::assertSame($expectedContent, $actualContent);
     }
 
     /**
@@ -379,7 +379,7 @@ class RequestTest extends UnitTestCase
             'User-Agent: Flow/' . FLOW_VERSION_BRANCH . ".x\r\n" .
             "Content-Type: application/x-www-form-urlencoded\r\n";
 
-        $this->assertEquals($expectedHeaders, $request->renderHeaders());
+        self::assertEquals($expectedHeaders, $request->renderHeaders());
     }
 
     /**
@@ -405,7 +405,7 @@ class RequestTest extends UnitTestCase
             "\r\n" .
             'putArgument=first value';
 
-        $this->assertEquals($expectedRawRequest, (string)$request);
+        self::assertEquals($expectedRawRequest, (string)$request);
     }
 
     /**
@@ -437,7 +437,7 @@ class RequestTest extends UnitTestCase
         if ($rawValues !== null) {
             $request->setHeader('Accept', $rawValues);
         }
-        $this->assertSame($expectedMediaTypes, $request->getAcceptedMediaTypes());
+        self::assertSame($expectedMediaTypes, $request->getAcceptedMediaTypes());
     }
 
     /**
@@ -470,7 +470,7 @@ class RequestTest extends UnitTestCase
         if ($preferredTypes !== null) {
             $request->setHeader('Accept', $preferredTypes);
         }
-        $this->assertSame($negotiatedType, $request->getNegotiatedMediaType($supportedTypes));
+        self::assertSame($negotiatedType, $request->getNegotiatedMediaType($supportedTypes));
     }
 
     /**
@@ -487,7 +487,7 @@ class RequestTest extends UnitTestCase
         ];
 
         $request = new Request([], [], [], $server);
-        $this->assertEquals('http://dev.blog.rob/', (string)$request->getBaseUri());
+        self::assertEquals('http://dev.blog.rob/', (string)$request->getBaseUri());
 
         $server = [
             'HTTP_HOST' => 'dev.blog.rob',
@@ -498,7 +498,7 @@ class RequestTest extends UnitTestCase
         ];
 
         $request = new Request([], [], [], $server);
-        $this->assertEquals('http://dev.blog.rob/', (string)$request->getBaseUri());
+        self::assertEquals('http://dev.blog.rob/', (string)$request->getBaseUri());
 
         $server = [
             'HTTP_HOST' => 'dev.blog.rob',
@@ -508,7 +508,7 @@ class RequestTest extends UnitTestCase
         ];
 
         $request = new Request([], [], [], $server);
-        $this->assertEquals('http://dev.blog.rob/', (string)$request->getBaseUri());
+        self::assertEquals('http://dev.blog.rob/', (string)$request->getBaseUri());
     }
 
     /**
@@ -528,7 +528,7 @@ class RequestTest extends UnitTestCase
 
         $baseUri = new Uri('http://prod.blog.rob/');
         $request->setBaseUri($baseUri);
-        $this->assertEquals('http://prod.blog.rob/', (string)$request->getBaseUri());
+        self::assertEquals('http://prod.blog.rob/', (string)$request->getBaseUri());
     }
 
     /**
@@ -550,7 +550,7 @@ class RequestTest extends UnitTestCase
     public function getArgumentsReturnsGetAndPostArguments($method, $uriString, $postArguments, $filesArguments, $expectedArguments)
     {
         $request = Request::create(new Uri($uriString), $method, $postArguments, [], $filesArguments);
-        $this->assertEquals($expectedArguments, $request->getArguments());
+        self::assertEquals($expectedArguments, $request->getArguments());
     }
 
     /**
@@ -559,10 +559,10 @@ class RequestTest extends UnitTestCase
     public function singleArgumentsCanBeCheckedAndRetrieved()
     {
         $request = Request::create(new Uri('http://dev.blog.rob/foo/bar?baz=quux&coffee=due'));
-        $this->assertTrue($request->hasArgument('baz'));
-        $this->assertEquals('quux', $request->getArgument('baz'));
-        $this->assertFalse($request->hasArgument('tea'));
-        $this->assertNull($request->getArgument('tea'));
+        self::assertTrue($request->hasArgument('baz'));
+        self::assertEquals('quux', $request->getArgument('baz'));
+        self::assertFalse($request->hasArgument('tea'));
+        self::assertNull($request->getArgument('tea'));
     }
 
     /**
@@ -571,7 +571,7 @@ class RequestTest extends UnitTestCase
     public function httpHostIsNotAppendedByColonIfNoExplicitPortIsGiven()
     {
         $request = Request::create(new Uri('http://dev.blog.rob/noPort/isGivenHere'));
-        $this->assertEquals('dev.blog.rob', $request->getHeader('Host'));
+        self::assertEquals('dev.blog.rob', $request->getHeader('Host'));
     }
 
     /**
@@ -581,8 +581,8 @@ class RequestTest extends UnitTestCase
     public function standardPortsAreRecognizedCorrectly()
     {
         $request = Request::create(new Uri('http://dev.blog.rob:80/foo/bar?baz=quux&coffee=due'));
-        $this->assertSame(80, $request->getUri()->getPort());
-        $this->assertSame(80, $request->getPort());
+        self::assertSame(80, $request->getUri()->getPort());
+        self::assertSame(80, $request->getPort());
     }
 
     /**
@@ -592,8 +592,8 @@ class RequestTest extends UnitTestCase
     public function nonStandardPortIsRecognizedCorrectly()
     {
         $request = Request::create(new Uri('http://dev.blog.rob:8080/foo/bar?baz=quux&coffee=due'));
-        $this->assertSame(8080, $request->getUri()->getPort());
-        $this->assertSame(8080, $request->getPort());
+        self::assertSame(8080, $request->getUri()->getPort());
+        self::assertSame(8080, $request->getPort());
     }
 
     /**
@@ -606,7 +606,7 @@ class RequestTest extends UnitTestCase
         $reflectedServerProperty = new \ReflectionProperty(get_class($request), 'server');
         $reflectedServerProperty->setAccessible(true);
         $serverValue = $reflectedServerProperty->getValue($request);
-        $this->assertSame(8080, $serverValue['SERVER_PORT']);
+        self::assertSame(8080, $serverValue['SERVER_PORT']);
     }
 
     /**
@@ -616,7 +616,7 @@ class RequestTest extends UnitTestCase
     public function nonStandardHttpsPortIsAddedToHttpHost()
     {
         $request = Request::create(new Uri('https://dev.blog.rob:44343/foo/bar?baz=quux&coffee=due'));
-        $this->assertSame(44343, $request->getUri()->getPort());
+        self::assertSame(44343, $request->getUri()->getPort());
     }
 
     /**
@@ -626,7 +626,7 @@ class RequestTest extends UnitTestCase
     public function standardHttpsPortIsRecognizedCorrectly()
     {
         $request = Request::create(new Uri('https://dev.blog.rob/foo/bar?baz=quux&coffee=due'));
-        $this->assertSame(443, $request->getUri()->getPort());
+        self::assertSame(443, $request->getUri()->getPort());
     }
 
     /**
@@ -639,7 +639,7 @@ class RequestTest extends UnitTestCase
         $reflectedServerProperty = new \ReflectionProperty(get_class($request), 'server');
         $reflectedServerProperty->setAccessible(true);
         $serverValue = $reflectedServerProperty->getValue($request);
-        $this->assertSame(44343, $serverValue['SERVER_PORT']);
+        self::assertSame(44343, $serverValue['SERVER_PORT']);
     }
 
     /**
@@ -652,7 +652,7 @@ class RequestTest extends UnitTestCase
         $request = Request::create(new Uri('http://dev.blog.rob/?foo=bar'), 'POST');
         $request->setContent($fileHandler);
 
-        $this->assertSame($fileHandler, $request->getContent());
+        self::assertSame($fileHandler, $request->getContent());
     }
 
     /**
@@ -665,9 +665,9 @@ class RequestTest extends UnitTestCase
         $request = Request::create(new Uri('http://dev.blog.rob/?foo=bar'), 'POST');
         $request->setContent($streamHandler);
 
-        $this->assertSame($streamHandler, $request->getContent());
-        $this->assertEquals('application/octet-stream', $request->getHeader('Content-Type'));
-        $this->assertEquals(filesize(__FILE__), $request->getHeader('Content-Length'));
+        self::assertSame($streamHandler, $request->getContent());
+        self::assertEquals('application/octet-stream', $request->getHeader('Content-Type'));
+        self::assertEquals(filesize(__FILE__), $request->getHeader('Content-Length'));
     }
 
     /**
@@ -678,19 +678,19 @@ class RequestTest extends UnitTestCase
     public function isMethodSafeReturnsTrueIfTheRequestMethodIsGetOrHead()
     {
         $request = Request::create(new Uri('http://acme.com'), 'GET');
-        $this->assertTrue($request->isMethodSafe());
+        self::assertTrue($request->isMethodSafe());
 
         $request = Request::create(new Uri('http://acme.com'), 'HEAD');
-        $this->assertTrue($request->isMethodSafe());
+        self::assertTrue($request->isMethodSafe());
 
         $request = Request::create(new Uri('http://acme.com'), 'POST');
-        $this->assertFalse($request->isMethodSafe());
+        self::assertFalse($request->isMethodSafe());
 
         $request = Request::create(new Uri('http://acme.com'), 'PUT');
-        $this->assertFalse($request->isMethodSafe());
+        self::assertFalse($request->isMethodSafe());
 
         $request = Request::create(new Uri('http://acme.com'), 'DELETE');
-        $this->assertFalse($request->isMethodSafe());
+        self::assertFalse($request->isMethodSafe());
     }
 
     /**
@@ -883,7 +883,7 @@ class RequestTest extends UnitTestCase
         ];
 
         $result = UploadedFilesHelper::untangleFilesArray($convolutedFiles);
-        $this->assertSame($untangledFiles, $result);
+        self::assertSame($untangledFiles, $result);
     }
 
     /**
@@ -941,7 +941,7 @@ class RequestTest extends UnitTestCase
         ];
 
         $result = UploadedFilesHelper::untangleFilesArray($convolutedFiles);
-        $this->assertSame($untangledFiles, $result);
+        self::assertSame($untangledFiles, $result);
     }
 
     /**
@@ -982,7 +982,7 @@ class RequestTest extends UnitTestCase
         ];
 
         $result = UploadedFilesHelper::untangleFilesArray($convolutedFiles);
-        $this->assertSame($untangledFiles, $result);
+        self::assertSame($untangledFiles, $result);
     }
 
     /**
@@ -1012,7 +1012,7 @@ class RequestTest extends UnitTestCase
     {
         $request = $this->getAccessibleMock(Request::class, ['dummy'], [], '', false);
         $actualValues = $request->_call('parseContentNegotiationQualityValues', $rawValues);
-        $this->assertSame($expectedValues, $actualValues);
+        self::assertSame($expectedValues, $actualValues);
     }
 
     /**
@@ -1023,7 +1023,7 @@ class RequestTest extends UnitTestCase
         $request = Request::create(new Uri('http://dev.blog.rob/amnesia/spray'), 'GET');
         $relativePath = $request->getRelativePath();
 
-        $this->assertSame($relativePath, 'amnesia/spray');
+        self::assertSame($relativePath, 'amnesia/spray');
     }
 
     /**
@@ -1034,7 +1034,7 @@ class RequestTest extends UnitTestCase
         $request = Request::create(new Uri('http://dev.blog.rob/'), 'GET');
         $relativePath = $request->getRelativePath();
 
-        $this->assertSame($relativePath, '');
+        self::assertSame($relativePath, '');
     }
 
     /**
@@ -1065,7 +1065,7 @@ class RequestTest extends UnitTestCase
             'REQUEST_URI' => $requestUri
         ];
         $request = new Request([], [], [], $server);
-        $this->assertEquals($expectedUri, (string)$request->getUri());
+        self::assertEquals($expectedUri, (string)$request->getUri());
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Http/ResponseTest.php
+++ b/Neos.Flow/Tests/Unit/Http/ResponseTest.php
@@ -29,7 +29,7 @@ class ResponseTest extends UnitTestCase
     {
         $response = new Response();
         $headers = $response->renderHeaders();
-        $this->assertEquals('HTTP/1.1 200 OK', $headers[0]);
+        self::assertEquals('HTTP/1.1 200 OK', $headers[0]);
     }
 
     /**
@@ -81,20 +81,20 @@ class ResponseTest extends UnitTestCase
     public function createFromRawSetsHeadersAndStatusCodeCorrectly($rawResponse, $expectedHeaders, $expectedStatusCode)
     {
         $response = Response::createFromRaw($rawResponse);
-        $this->assertEquals('HTTP/1.1', $response->getVersion());
+        self::assertEquals('HTTP/1.1', $response->getVersion());
 
         foreach ($expectedHeaders as $fieldName => $fieldValue) {
-            $this->assertTrue($response->hasHeader($fieldName), sprintf('Response does not have expected header %s', $fieldName));
-            $this->assertEquals($fieldValue, $response->getHeader($fieldName));
+            self::assertTrue($response->hasHeader($fieldName), sprintf('Response does not have expected header %s', $fieldName));
+            self::assertEquals($fieldValue, $response->getHeader($fieldName));
         }
         foreach ($response->getHeaders()->getAll() as $fieldName => $fieldValue) {
-            $this->assertTrue(isset($expectedHeaders[$fieldName]), sprintf('Response has unexpected header %s', $fieldName));
+            self::assertTrue(isset($expectedHeaders[$fieldName]), sprintf('Response has unexpected header %s', $fieldName));
         }
 
-        $this->assertEquals($expectedStatusCode, $response->getStatusCode());
+        self::assertEquals($expectedStatusCode, $response->getStatusCode());
 
         $expectedContent = "<!DOCTYPE html>\n<html>\nthe body\n</html>";
-        $this->assertEquals($expectedContent, $response->getContent());
+        self::assertEquals($expectedContent, $response->getContent());
     }
 
     /**
@@ -103,24 +103,24 @@ class ResponseTest extends UnitTestCase
     public function createFromRawSetsCookiesCorrectly()
     {
         $response = Response::createFromRaw(file_get_contents(__DIR__ . '/../Fixtures/RawResponse-1.txt'));
-        $this->assertCount(4, $response->getCookies());
+        self::assertCount(4, $response->getCookies());
 
-        $this->assertInstanceOf(Http\Cookie::class, $response->getCookie('tg'));
-        $this->assertEquals('426148', $response->getCookie('tg')->getValue());
-        $this->assertEquals(1665942816, $response->getCookie('tg')->getExpires());
+        self::assertInstanceOf(Http\Cookie::class, $response->getCookie('tg'));
+        self::assertEquals('426148', $response->getCookie('tg')->getValue());
+        self::assertEquals(1665942816, $response->getCookie('tg')->getExpires());
 
-        $this->assertInstanceOf(Http\Cookie::class, $response->getCookie('dmvk'));
-        $this->assertEquals('507d9f20317a5', $response->getCookie('dmvk')->getValue());
-        $this->assertEquals('example.org', $response->getCookie('dmvk')->getDomain());
+        self::assertInstanceOf(Http\Cookie::class, $response->getCookie('dmvk'));
+        self::assertEquals('507d9f20317a5', $response->getCookie('dmvk')->getValue());
+        self::assertEquals('example.org', $response->getCookie('dmvk')->getDomain());
 
-        $this->assertInstanceOf(Http\Cookie::class, $response->getCookie('ql_n'));
-        $this->assertEquals('0', $response->getCookie('ql_n')->getValue());
+        self::assertInstanceOf(Http\Cookie::class, $response->getCookie('ql_n'));
+        self::assertEquals('0', $response->getCookie('ql_n')->getValue());
 
-        $this->assertInstanceOf(Http\Cookie::class, $response->getCookie('masscast'));
-        $this->assertEquals('null', $response->getCookie('masscast')->getValue());
+        self::assertInstanceOf(Http\Cookie::class, $response->getCookie('masscast'));
+        self::assertEquals('null', $response->getCookie('masscast')->getValue());
 
         foreach ($response->getCookies() as $cookie) {
-            $this->assertEquals('/', $cookie->getPath());
+            self::assertEquals('/', $cookie->getPath());
         }
     }
 
@@ -139,7 +139,7 @@ class ResponseTest extends UnitTestCase
     public function startLineEqualsStatusLine()
     {
         $response = Response::createFromRaw(file_get_contents(__DIR__ . '/../Fixtures/RawResponse-1.txt'));
-        $this->assertEquals($response->getStartLine(), $response->getStatusLine());
+        self::assertEquals($response->getStartLine(), $response->getStatusLine());
     }
 
     /**
@@ -150,8 +150,8 @@ class ResponseTest extends UnitTestCase
         $response = Response::createFromRaw(file_get_contents(__DIR__ . '/../Fixtures/RawResponse-1.txt'));
         $response->setVersion('HTTP/1.0');
 
-        $this->assertEquals('HTTP/1.0', $response->getVersion());
-        $this->assertStringStartsWith('HTTP/1.0', $response->getStatusLine());
+        self::assertEquals('HTTP/1.0', $response->getVersion());
+        self::assertStringStartsWith('HTTP/1.0', $response->getStatusLine());
     }
 
     /**
@@ -162,7 +162,7 @@ class ResponseTest extends UnitTestCase
         $response = new Response();
         $response->setStatus(400, 'Really Bad Request');
         $headers = $response->renderHeaders();
-        $this->assertEquals('HTTP/1.1 400 Really Bad Request', $headers[0]);
+        self::assertEquals('HTTP/1.1 400 Really Bad Request', $headers[0]);
     }
 
     /**
@@ -172,7 +172,7 @@ class ResponseTest extends UnitTestCase
     {
         $response = new Response();
         $response->setStatus(924);
-        $this->assertEquals('924 Unknown Status', $response->getStatus());
+        self::assertEquals('924 Unknown Status', $response->getStatus());
     }
 
     /**
@@ -192,7 +192,7 @@ class ResponseTest extends UnitTestCase
     {
         $response = new Response();
         $response->setStatus(418);
-        $this->assertEquals('418 Sono Vibiemme', $response->getStatus());
+        self::assertEquals('418 Sono Vibiemme', $response->getStatus());
     }
 
     /**
@@ -203,7 +203,7 @@ class ResponseTest extends UnitTestCase
         $response = new Response();
 
         $response->setStatus(418);
-        $this->assertEquals(418, $response->getStatusCode());
+        self::assertEquals(418, $response->getStatusCode());
     }
 
     /**
@@ -225,7 +225,7 @@ class ResponseTest extends UnitTestCase
 
 
 
-        $this->assertEquals($expectedHeaders, $response->renderHeaders());
+        self::assertEquals($expectedHeaders, $response->renderHeaders());
     }
 
     /**
@@ -245,7 +245,7 @@ class ResponseTest extends UnitTestCase
             'MyHeader: MyValue-3',
         ];
 
-        $this->assertEquals($expectedHeaders, $response->renderHeaders());
+        self::assertEquals($expectedHeaders, $response->renderHeaders());
     }
 
     /**
@@ -256,7 +256,7 @@ class ResponseTest extends UnitTestCase
     public function contentTypeHeaderWithMediaTypeTextHtmlIsAddedByDefault()
     {
         $response = new Response();
-        $this->assertEquals('text/html; charset=UTF-8', $response->getHeader('Content-Type'));
+        self::assertEquals('text/html; charset=UTF-8', $response->getHeader('Content-Type'));
     }
 
     /**
@@ -269,7 +269,7 @@ class ResponseTest extends UnitTestCase
         $response = new Response();
         $response->setNow($now);
 
-        $this->assertEquals('Tue, 22 May 2012 10:00:00 +0000', $response->getHeader('Date')->format(DATE_RFC2822));
+        self::assertEquals('Tue, 22 May 2012 10:00:00 +0000', $response->getHeader('Date')->format(DATE_RFC2822));
     }
 
     /**
@@ -284,7 +284,7 @@ class ResponseTest extends UnitTestCase
         $response->setNow($now);
 
         $date = $response->getHeader('Date');
-        $this->assertEquals($now->getTimestamp(), $date->getTimestamp());
+        self::assertEquals($now->getTimestamp(), $date->getTimestamp());
     }
 
     /**
@@ -296,10 +296,10 @@ class ResponseTest extends UnitTestCase
         $response = new Response();
 
         $response->setDate($now);
-        $this->assertEquals($now, $response->getDate());
+        self::assertEquals($now, $response->getDate());
 
         $response->setDate('Tue, 22 May 2012 12:00:00 GMT');
-        $this->assertEquals($now, $response->getDate());
+        self::assertEquals($now, $response->getDate());
     }
 
     /**
@@ -312,9 +312,9 @@ class ResponseTest extends UnitTestCase
         $response = new Response();
         $response->setNow($date);
 
-        $this->assertNull($response->getLastModified());
+        self::assertNull($response->getLastModified());
         $response->setLastModified($fig);
-        $this->assertEquals($fig, $response->getLastModified());
+        self::assertEquals($fig, $response->getLastModified());
     }
 
     /**
@@ -330,7 +330,7 @@ class ResponseTest extends UnitTestCase
         $response = new Response();
         $response->setNow($now);
         $response->setExpires($later);
-        $this->assertEquals($later, $response->getExpires());
+        self::assertEquals($later, $response->getExpires());
     }
 
     /**
@@ -345,7 +345,7 @@ class ResponseTest extends UnitTestCase
         $response->setNow($now);
         $response->setHeader('Date', $sixtySecondsAgo);
 
-        $this->assertEquals(60, $response->getAge());
+        self::assertEquals(60, $response->getAge());
     }
 
     /**
@@ -359,7 +359,7 @@ class ResponseTest extends UnitTestCase
         $response->setNow($now);
         $response->setHeader('Age', 123);
 
-        $this->assertSame(123, $response->getAge());
+        self::assertSame(123, $response->getAge());
     }
 
     /**
@@ -373,7 +373,7 @@ class ResponseTest extends UnitTestCase
         $response->setNow(new \DateTime());
 
         $response->setPublic();
-        $this->assertEquals('public', $response->getHeader('Cache-Control'));
+        self::assertEquals('public', $response->getHeader('Cache-Control'));
     }
 
     /**
@@ -387,7 +387,7 @@ class ResponseTest extends UnitTestCase
         $response->setNow(new \DateTime());
 
         $response->setPrivate();
-        $this->assertEquals('private', $response->getHeader('Cache-Control'));
+        self::assertEquals('private', $response->getHeader('Cache-Control'));
     }
 
     /**
@@ -401,8 +401,8 @@ class ResponseTest extends UnitTestCase
         $response->setNow(new \DateTime());
 
         $response->setMaximumAge(60);
-        $this->assertEquals('max-age=60', $response->getHeader('Cache-Control'));
-        $this->assertSame(60, $response->getMaximumAge());
+        self::assertEquals('max-age=60', $response->getHeader('Cache-Control'));
+        self::assertSame(60, $response->getMaximumAge());
     }
 
     /**
@@ -416,8 +416,8 @@ class ResponseTest extends UnitTestCase
         $response->setNow(new \DateTime());
 
         $response->setSharedMaximumAge(60);
-        $this->assertEquals('s-maxage=60', $response->getHeader('Cache-Control'));
-        $this->assertSame(60, $response->getSharedMaximumAge());
+        self::assertEquals('s-maxage=60', $response->getHeader('Cache-Control'));
+        self::assertSame(60, $response->getSharedMaximumAge());
     }
 
     /**
@@ -432,7 +432,7 @@ class ResponseTest extends UnitTestCase
 
         $response->setHeader('Cache-Control', 'no-cache, max-age=240');
         $response->makeStandardsCompliant($request);
-        $this->assertEquals('no-cache', $response->getHeader('Cache-Control'));
+        self::assertEquals('no-cache', $response->getHeader('Cache-Control'));
     }
 
     /**
@@ -454,7 +454,7 @@ class ResponseTest extends UnitTestCase
             $response->setStatus($statusCode);
             $response->setContent('Body Language');
             $response->makeStandardsCompliant($request);
-            $this->assertEquals('', $response->getContent());
+            self::assertEquals('', $response->getContent());
         }
     }
 
@@ -474,7 +474,7 @@ class ResponseTest extends UnitTestCase
         $response->setHeader('Transfer-Encoding', 'chunked');
         $response->setHeader('Content-Length', strlen($content));
         $response->makeStandardsCompliant($request);
-        $this->assertFalse($response->hasHeader('Content-Length'));
+        self::assertFalse($response->hasHeader('Content-Length'));
     }
 
     /**
@@ -498,7 +498,7 @@ class ResponseTest extends UnitTestCase
 
         $response->setContent($content);
         $response->makeStandardsCompliant($request);
-        $this->assertEquals(strlen($content), $response->getHeader('Content-Length'));
+        self::assertEquals(strlen($content), $response->getHeader('Content-Length'));
     }
 
     /**
@@ -522,13 +522,13 @@ class ResponseTest extends UnitTestCase
         $response = new Response();
         $response->setContent($content);
         $response->makeStandardsCompliant($request);
-        $this->assertEquals('', $response->getContent());
-        $this->assertEquals(strlen($content), $response->getHeader('Content-Length'));
+        self::assertEquals('', $response->getContent());
+        self::assertEquals(strlen($content), $response->getHeader('Content-Length'));
 
         $response = new Response();
         $response->setHeader('Content-Length', 275);
         $response->makeStandardsCompliant($request);
-        $this->assertEquals(275, $response->getHeader('Content-Length'));
+        self::assertEquals(275, $response->getHeader('Content-Length'));
     }
 
     /**
@@ -548,8 +548,8 @@ class ResponseTest extends UnitTestCase
         $response->setMaximumAge(60);
         $response->setExpires($later);
         $response->makeStandardsCompliant($request);
-        $this->assertSame(null, $response->getHeaders()->getCacheControlDirective('max-age'));
-        $this->assertEquals($later, $response->getExpires());
+        self::assertSame(null, $response->getHeaders()->getCacheControlDirective('max-age'));
+        self::assertEquals($later, $response->getExpires());
     }
 
     /**
@@ -570,8 +570,8 @@ class ResponseTest extends UnitTestCase
         $response->setContent('Some Content');
         $response->makeStandardsCompliant($request);
 
-        $this->assertSame(304, $response->getStatusCode());
-        $this->assertSame('', $response->getContent());
+        self::assertSame(304, $response->getStatusCode());
+        self::assertSame('', $response->getContent());
     }
 
     /**
@@ -589,7 +589,7 @@ class ResponseTest extends UnitTestCase
         $request->setHeader('If-Unmodified-Since', $unmodifiedSince);
         $response->setHeader('Last-Modified', $lastModified);
         $response->makeStandardsCompliant($request);
-        $this->assertSame(412, $response->getStatusCode());
+        self::assertSame(412, $response->getStatusCode());
 
         $response = new Response();
         $unmodifiedSince = \DateTime::createFromFormat(DATE_RFC2822, 'Tue, 15 May 2012 09:00:00 GMT');
@@ -598,7 +598,7 @@ class ResponseTest extends UnitTestCase
         $response->setHeader('Last-Modified', $lastModified);
         $response->makeStandardsCompliant($request);
 
-        $this->assertSame(200, $response->getStatusCode());
+        self::assertSame(200, $response->getStatusCode());
     }
 
     /**
@@ -609,7 +609,7 @@ class ResponseTest extends UnitTestCase
         $parentResponse = new Response();
 
         $response = new Response($parentResponse);
-        $this->assertSame($parentResponse, $response->getParentResponse());
+        self::assertSame($parentResponse, $response->getParentResponse());
     }
 
     /**
@@ -622,11 +622,11 @@ class ResponseTest extends UnitTestCase
         $response->setContent('Two households, both alike in dignity, ');
         $response->appendContent('In fair Verona, where we lay our scene');
 
-        $this->assertEquals('Two households, both alike in dignity, In fair Verona, where we lay our scene', $response->getContent());
+        self::assertEquals('Two households, both alike in dignity, In fair Verona, where we lay our scene', $response->getContent());
 
         $response->setContent('For never was a story of more woe, Than this of Juliet and her Romeo.');
-        $this->assertEquals('For never was a story of more woe, Than this of Juliet and her Romeo.', $response->getContent());
-        $this->assertEquals('For never was a story of more woe, Than this of Juliet and her Romeo.', (string)$response);
+        self::assertEquals('For never was a story of more woe, Than this of Juliet and her Romeo.', $response->getContent());
+        self::assertEquals('For never was a story of more woe, Than this of Juliet and her Romeo.', (string)$response);
     }
 
     /**
@@ -635,7 +635,7 @@ class ResponseTest extends UnitTestCase
     public function setterMethodsAreChainable()
     {
         $response = new Response();
-        $this->assertSame($response,
+        self::assertSame($response,
             $response->setContent('Foo')
                 ->appendContent('Bar')
                 ->setStatus(404)
@@ -671,6 +671,6 @@ class ResponseTest extends UnitTestCase
     {
         $response = new Response();
         $response->setContent($content);
-        $this->assertSame($expectedString, (string)$response);
+        self::assertSame($expectedString, (string)$response);
     }
 }

--- a/Neos.Flow/Tests/Unit/Http/UriTemplateTest.php
+++ b/Neos.Flow/Tests/Unit/Http/UriTemplateTest.php
@@ -128,6 +128,6 @@ class UriTemplateTest extends UnitTestCase
     public function uriTemplatesAreExpandedCorrectly($templateString, array $variables, $expectedString)
     {
         $expandedTemplate = UriTemplate::expand($templateString, $variables);
-        $this->assertEquals($expectedString, $expandedTemplate);
+        self::assertEquals($expectedString, $expandedTemplate);
     }
 }

--- a/Neos.Flow/Tests/Unit/Http/UriTest.php
+++ b/Neos.Flow/Tests/Unit/Http/UriTest.php
@@ -41,7 +41,7 @@ class UriTest extends UnitTestCase
             $uri->getArguments() == ['argument1' => 'value1', 'argument2' => 'value2', 'argument3' => ['subargument1' => 'subvalue1']] &&
             $uri->getFragment() == 'anchor'
         );
-        $this->assertTrue($check, 'The valid and complete URI has not been correctly transformed to an URI object');
+        self::assertTrue($check, 'The valid and complete URI has not been correctly transformed to an URI object');
     }
 
     /**
@@ -70,7 +70,7 @@ class UriTest extends UnitTestCase
     public function urisCanBeConvertedForthAndBackWithoutLoss($uriString)
     {
         $uri = new Uri($uriString);
-        $this->assertSame($uriString, (string)$uri);
+        self::assertSame($uriString, (string)$uri);
     }
 
     /**
@@ -83,7 +83,7 @@ class UriTest extends UnitTestCase
         $uri = new Uri('/no/scheme/or/host');
         $uri->setScheme('http');
         $uri->setHost('localhost');
-        $this->assertSame('http://localhost/no/scheme/or/host', (string)$uri);
+        self::assertSame('http://localhost/no/scheme/or/host', (string)$uri);
     }
 
     /**
@@ -92,12 +92,12 @@ class UriTest extends UnitTestCase
     public function toStringOmitsStandardPorts()
     {
         $uri = new Uri('http://flow.neos.io');
-        $this->assertSame('http://flow.neos.io', (string)$uri);
-        $this->assertSame(80, $uri->getPort());
+        self::assertSame('http://flow.neos.io', (string)$uri);
+        self::assertSame(80, $uri->getPort());
 
         $uri = new Uri('https://flow.neos.io');
-        $this->assertSame('https://flow.neos.io', (string)$uri);
-        $this->assertSame(443, $uri->getPort());
+        self::assertSame('https://flow.neos.io', (string)$uri);
+        self::assertSame(443, $uri->getPort());
     }
 
     /**
@@ -115,7 +115,7 @@ class UriTest extends UnitTestCase
             $uri->getQuery() == 'argumentäöü1=value%C3%A5%C3%B8%E2%82%AC%C5%93' &&
             $uri->getArguments() == ['argumentäöü1' => 'valueåø€œ']
         );
-        $this->assertTrue($check, 'The URI with special arguments has not been correctly transformed to an URI object');
+        self::assertTrue($check, 'The URI with special arguments has not been correctly transformed to an URI object');
     }
 
     /**
@@ -137,7 +137,7 @@ class UriTest extends UnitTestCase
     public function constructorParsesHostCorrectly($uriString, $expectedHost)
     {
         $uri = new Uri($uriString);
-        $this->assertSame($expectedHost, $uri->getHost());
+        self::assertSame($expectedHost, $uri->getHost());
     }
 
     /**
@@ -148,7 +148,7 @@ class UriTest extends UnitTestCase
     {
         $uri = new Uri('');
         $uri->setHost($plainHost);
-        $this->assertEquals($plainHost, $uri->getHost());
+        self::assertEquals($plainHost, $uri->getHost());
     }
 
     /**
@@ -177,7 +177,7 @@ class UriTest extends UnitTestCase
     public function stringRepresentationIsCorrect($uriString)
     {
         $uri = new Uri($uriString);
-        $this->assertEquals($uriString, (string)$uri, 'The string representation of the URI is not equal to the original URI string.');
+        self::assertEquals($uriString, (string)$uri, 'The string representation of the URI is not equal to the original URI string.');
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/CldrModelTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/CldrModelTest.php
@@ -56,7 +56,7 @@ class CldrModelTest extends UnitTestCase
     {
         $sampleParsedFilesMerged = require(__DIR__ . '/../Fixtures/MockParsedCldrFilesMerged.php');
 
-        $this->assertEquals($sampleParsedFilesMerged, $this->model->getRawData('/'));
+        self::assertEquals($sampleParsedFilesMerged, $this->model->getRawData('/'));
     }
 
     /**
@@ -65,8 +65,8 @@ class CldrModelTest extends UnitTestCase
     public function returnsRawArrayCorrectly()
     {
         $result = $this->model->getRawArray('dates/calendars/calendar[@type="gregorian"]/months/monthContext[@type="format"]/monthWidth[@type="abbreviated"]');
-        $this->assertEquals(2, count($result));
-        $this->assertEquals('jan', $result['month[@type="1"]']);
+        self::assertEquals(2, count($result));
+        self::assertEquals('jan', $result['month[@type="1"]']);
     }
 
     /**
@@ -75,10 +75,10 @@ class CldrModelTest extends UnitTestCase
     public function returnsElementCorrectly()
     {
         $result = $this->model->getElement('localeDisplayNames/localeDisplayPattern/localePattern');
-        $this->assertEquals('{0} ({1})', $result);
+        self::assertEquals('{0} ({1})', $result);
 
         $result = $this->model->getElement('localeDisplayNames/variants');
-        $this->assertEquals(false, $result);
+        self::assertEquals(false, $result);
     }
 
     /**
@@ -89,7 +89,7 @@ class CldrModelTest extends UnitTestCase
     public function getRawArrayAlwaysReturnsArrayOrFalse()
     {
         $result = $this->model->getRawArray('localeDisplayNames/localeDisplayPattern/localePattern');
-        $this->assertEquals(false, $result);
+        self::assertEquals(false, $result);
     }
 
     /**
@@ -100,8 +100,8 @@ class CldrModelTest extends UnitTestCase
         $sampleNodeString1 = 'calendar';
         $sampleNodeString2 = 'calendar[@type="gregorian"]';
 
-        $this->assertEquals('calendar', $this->model->getNodeName($sampleNodeString1));
-        $this->assertEquals('calendar', $this->model->getNodeName($sampleNodeString2));
+        self::assertEquals('calendar', $this->model->getNodeName($sampleNodeString1));
+        self::assertEquals('calendar', $this->model->getNodeName($sampleNodeString2));
     }
 
     /**
@@ -111,8 +111,8 @@ class CldrModelTest extends UnitTestCase
     {
         $sampleNodeString = 'dateFormatLength[@type="medium"][@alt="proposed"]';
 
-        $this->assertEquals('medium', $this->model->getAttributeValue($sampleNodeString, 'type'));
-        $this->assertEquals('proposed', $this->model->getAttributeValue($sampleNodeString, 'alt'));
-        $this->assertEquals(false, $this->model->getAttributeValue($sampleNodeString, 'dateFormatLength'));
+        self::assertEquals('medium', $this->model->getAttributeValue($sampleNodeString, 'type'));
+        self::assertEquals('proposed', $this->model->getAttributeValue($sampleNodeString, 'alt'));
+        self::assertEquals(false, $this->model->getAttributeValue($sampleNodeString, 'dateFormatLength'));
     }
 }

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/CldrParserTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/CldrParserTest.php
@@ -31,6 +31,6 @@ class CldrParserTest extends UnitTestCase
         $parser = new I18n\Cldr\CldrParser();
 
         $result = $parser->getParsedData($sampleFilenamePath);
-        $this->assertEquals($sampleParsedData, $result);
+        self::assertEquals($sampleParsedData, $result);
     }
 }

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/CldrRepositoryTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/CldrRepositoryTest.php
@@ -52,10 +52,10 @@ class CldrRepositoryTest extends UnitTestCase
         file_put_contents('vfs://Foo/Bar.xml', '');
 
         $result = $this->repository->getModel('Bar');
-        $this->assertContains('vfs://Foo/Bar.xml', ObjectAccess::getProperty($result, 'sourcePaths', true));
+        self::assertContains('vfs://Foo/Bar.xml', ObjectAccess::getProperty($result, 'sourcePaths', true));
 
         $result = $this->repository->getModel('NoSuchFile');
-        $this->assertEquals(false, $result);
+        self::assertEquals(false, $result);
     }
 
     /**
@@ -67,10 +67,10 @@ class CldrRepositoryTest extends UnitTestCase
         file_put_contents('vfs://Foo/Directory/en.xml', '');
 
         $result = $this->repository->getModelForLocale($this->dummyLocale, 'Directory');
-        $this->assertContains('vfs://Foo/Directory/root.xml', ObjectAccess::getProperty($result, 'sourcePaths', true));
-        $this->assertContains('vfs://Foo/Directory/en.xml', ObjectAccess::getProperty($result, 'sourcePaths', true));
+        self::assertContains('vfs://Foo/Directory/root.xml', ObjectAccess::getProperty($result, 'sourcePaths', true));
+        self::assertContains('vfs://Foo/Directory/en.xml', ObjectAccess::getProperty($result, 'sourcePaths', true));
 
         $result = $this->repository->getModelForLocale($this->dummyLocale, 'NoSuchDirectory');
-        $this->assertEquals(null, $result);
+        self::assertEquals(null, $result);
     }
 }

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/CurrencyReaderTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/CurrencyReaderTest.php
@@ -76,7 +76,7 @@ class CurrencyReaderTest extends UnitTestCase
     public function returnsCorrectFraction($currencyCode, $digits, $rounding)
     {
         $result = $this->reader->getFraction($currencyCode);
-        $this->assertSame($digits, $result['digits']);
-        $this->assertSame($rounding, $result['rounding']);
+        self::assertSame($digits, $result['digits']);
+        self::assertSame($rounding, $result['rounding']);
     }
 }

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/DatesReaderTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/DatesReaderTest.php
@@ -78,7 +78,7 @@ class DatesReaderTest extends UnitTestCase
         $reader->initializeObject();
 
         $result = $reader->parseFormatFromCldr($this->sampleLocale, I18n\Cldr\Reader\DatesReader::FORMAT_TYPE_DATE, I18n\Cldr\Reader\DatesReader::FORMAT_LENGTH_DEFAULT);
-        $this->assertEquals('mockParsedFormat', $result);
+        self::assertEquals('mockParsedFormat', $result);
 
         $reader->shutdownObject();
     }
@@ -105,7 +105,7 @@ class DatesReaderTest extends UnitTestCase
         $reader->initializeObject();
 
         $result = $reader->parseFormatFromCldr($this->sampleLocale, I18n\Cldr\Reader\DatesReader::FORMAT_TYPE_DATETIME, I18n\Cldr\Reader\DatesReader::FORMAT_LENGTH_FULL);
-        $this->assertEquals([['foo '], 'h', 'm', 's', [' '], 'd', 'M', 'y', [' bar']], $result);
+        self::assertEquals([['foo '], 'h', 'm', 's', [' '], 'd', 'M', 'y', [' bar']], $result);
         $reader->shutdownObject();
     }
 
@@ -142,11 +142,11 @@ class DatesReaderTest extends UnitTestCase
         $reader->initializeObject();
 
         $result = $reader->getLocalizedLiteralsForLocale($this->sampleLocale);
-        $this->assertEquals('January', $result['months']['format']['wide'][1]);
-        $this->assertEquals('Sat', $result['days']['format']['abbreviated']['sat']);
-        $this->assertEquals('1', $result['quarters']['format']['narrow'][1]);
-        $this->assertEquals('a.m.', $result['dayPeriods']['stand-alone']['wide']['am']);
-        $this->assertEquals('Anno Domini', $result['eras']['eraNames'][1]);
+        self::assertEquals('January', $result['months']['format']['wide'][1]);
+        self::assertEquals('Sat', $result['days']['format']['abbreviated']['sat']);
+        self::assertEquals('1', $result['quarters']['format']['narrow'][1]);
+        self::assertEquals('a.m.', $result['dayPeriods']['stand-alone']['wide']['am']);
+        self::assertEquals('Anno Domini', $result['eras']['eraNames'][1]);
 
         $reader->shutdownObject();
     }
@@ -178,6 +178,6 @@ class DatesReaderTest extends UnitTestCase
         $reader = $this->getAccessibleMock(I18n\Cldr\Reader\DatesReader::class, ['dummy']);
 
         $result = $reader->_call('parseFormat', $format);
-        $this->assertEquals($expectedResult, $result);
+        self::assertEquals($expectedResult, $result);
     }
 }

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/NumbersReaderTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/NumbersReaderTest.php
@@ -89,7 +89,7 @@ class NumbersReaderTest extends UnitTestCase
         $reader->initializeObject();
 
         $result = $reader->parseFormatFromCldr($this->sampleLocale, I18n\Cldr\Reader\NumbersReader::FORMAT_TYPE_DECIMAL);
-        $this->assertEquals('mockParsedFormat', $result);
+        self::assertEquals('mockParsedFormat', $result);
 
         $reader->shutdownObject();
     }
@@ -118,7 +118,7 @@ class NumbersReaderTest extends UnitTestCase
         $reader = $this->getAccessibleMock(I18n\Cldr\Reader\NumbersReader::class, ['dummy']);
 
         $result = $reader->_call('parseFormat', $format);
-        $this->assertEquals($expectedResult, $result);
+        self::assertEquals($expectedResult, $result);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/PluralsReaderTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/PluralsReaderTest.php
@@ -102,7 +102,7 @@ class PluralsReaderTest extends UnitTestCase
         foreach ($quantities as $value) {
             list($quantity, $pluralForm) = $value;
             $result = $this->reader->getPluralForm($quantity, $locale);
-            $this->assertEquals($pluralForm, $result);
+            self::assertEquals($pluralForm, $result);
         }
     }
 }

--- a/Neos.Flow/Tests/Unit/I18n/DetectorTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/DetectorTest.php
@@ -77,7 +77,7 @@ class DetectorTest extends UnitTestCase
     public function detectingBestMatchingLocaleFromHttpAcceptLanguageHeaderWorksCorrectly($acceptLanguageHeader, $expectedResult)
     {
         $locale = $this->detector->detectLocaleFromHttpHeader($acceptLanguageHeader);
-        $this->assertEquals($expectedResult, $locale);
+        self::assertEquals($expectedResult, $locale);
     }
 
     /**
@@ -101,6 +101,6 @@ class DetectorTest extends UnitTestCase
     public function detectingBestMatchingLocaleFromLocaleIdentifierWorksCorrectly($localeIdentifier, $expectedResult)
     {
         $locale = $this->detector->detectLocaleFromLocaleTag($localeIdentifier);
-        $this->assertEquals($expectedResult, $locale);
+        self::assertEquals($expectedResult, $locale);
     }
 }

--- a/Neos.Flow/Tests/Unit/I18n/EelHelper/TranslationHelperTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/EelHelper/TranslationHelperTest.php
@@ -64,7 +64,7 @@ class TranslationHelperTest extends UnitTestCase
 
 
         $result = $mockTranslationHelper->translate('SomeId', 'SomeValue', ['a', 'couple', 'of', 'arguments'], 'SomeSource', 'Some.PackageKey', 42, 'SomeLocale');
-        $this->assertEquals('I am a translation result', $result);
+        self::assertEquals('I am a translation result', $result);
     }
 
     /**
@@ -94,7 +94,7 @@ class TranslationHelperTest extends UnitTestCase
             ->willReturn($mockTranslationParameterToken);
 
         $result = $mockTranslationHelper->translate('Some.PackageKey:SomeSource:SomeId');
-        $this->assertEquals('I am a translation result', $result);
+        self::assertEquals('I am a translation result', $result);
     }
 
     /**
@@ -108,7 +108,7 @@ class TranslationHelperTest extends UnitTestCase
             ->willReturn('TranslationParameterTokenWithPreconfiguredId');
 
         $result = $mockTranslationHelper->id('SomeId');
-        $this->assertEquals('TranslationParameterTokenWithPreconfiguredId', $result);
+        self::assertEquals('TranslationParameterTokenWithPreconfiguredId', $result);
     }
 
     /**
@@ -122,6 +122,6 @@ class TranslationHelperTest extends UnitTestCase
             ->willReturn('TranslationParameterTokenWithPreconfiguredValue');
 
         $result = $mockTranslationHelper->value('SomeValue');
-        $this->assertEquals('TranslationParameterTokenWithPreconfiguredValue', $result);
+        self::assertEquals('TranslationParameterTokenWithPreconfiguredValue', $result);
     }
 }

--- a/Neos.Flow/Tests/Unit/I18n/FormatResolverTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/FormatResolverTest.php
@@ -47,10 +47,10 @@ class FormatResolverTest extends UnitTestCase
         $formatResolver->expects($this->exactly(2))->method('getFormatter')->with('number')->will($this->returnValue($mockNumberFormatter));
 
         $result = $formatResolver->resolvePlaceholders('Foo {0,number}, bar {1,number,percent}', [1, 2], $this->sampleLocale);
-        $this->assertEquals('Foo 1.0, bar 200%', $result);
+        self::assertEquals('Foo 1.0, bar 200%', $result);
 
         $result = $formatResolver->resolvePlaceHolders('Foo {0}{1} Bar', ['{', '}'], $this->sampleLocale);
-        $this->assertEquals('Foo {} Bar', $result);
+        self::assertEquals('Foo {} Bar', $result);
     }
 
     /**
@@ -60,7 +60,7 @@ class FormatResolverTest extends UnitTestCase
     {
         $formatResolver = new I18n\FormatResolver();
         $result = $formatResolver->resolvePlaceholders('{0}', [123], $this->sampleLocale);
-        $this->assertEquals('123', $result);
+        self::assertEquals('123', $result);
     }
 
     /**
@@ -167,7 +167,7 @@ class FormatResolverTest extends UnitTestCase
         $formatResolver->injectObjectManager($mockObjectManager);
         $this->inject($formatResolver, 'reflectionService', $mockReflectionService);
         $actual = $formatResolver->resolvePlaceholders('{0,Acme\Foobar\Formatter\SampleFormatter}', [123], $this->sampleLocale);
-        $this->assertEquals('FormatterOutput42', $actual);
+        self::assertEquals('FormatterOutput42', $actual);
     }
 
     /**
@@ -204,7 +204,7 @@ class FormatResolverTest extends UnitTestCase
         $formatResolver->injectObjectManager($mockObjectManager);
         $this->inject($formatResolver, 'reflectionService', $mockReflectionService);
         $actual = $formatResolver->resolvePlaceholders('{0,acme\Foo\SampleFormatter}', [123], $this->sampleLocale);
-        $this->assertEquals('FormatterOutput42', $actual);
+        self::assertEquals('FormatterOutput42', $actual);
     }
 
     /**
@@ -215,6 +215,6 @@ class FormatResolverTest extends UnitTestCase
         $formatResolver = $this->getMockBuilder(I18n\FormatResolver::class)->setMethods(['dummy'])->getMock();
 
         $result = $formatResolver->resolvePlaceholders('Key {keyName} is {valueName}', ['keyName' => 'foo', 'valueName' => 'bar'], $this->sampleLocale);
-        $this->assertEquals('Key foo is bar', $result);
+        self::assertEquals('Key foo is bar', $result);
     }
 }

--- a/Neos.Flow/Tests/Unit/I18n/Formatter/DatetimeFormatterTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Formatter/DatetimeFormatterTest.php
@@ -65,13 +65,13 @@ class DatetimeFormatterTest extends UnitTestCase
         $formatter->expects($this->at(2))->method('formatTime')->with($this->sampleDateTime, $this->sampleLocale, I18n\Cldr\Reader\DatesReader::FORMAT_LENGTH_FULL)->will($this->returnValue('bar3'));
 
         $result = $formatter->format($this->sampleDateTime, $this->sampleLocale);
-        $this->assertEquals('bar1', $result);
+        self::assertEquals('bar1', $result);
 
         $result = $formatter->format($this->sampleDateTime, $this->sampleLocale, [I18n\Cldr\Reader\DatesReader::FORMAT_TYPE_DATE]);
-        $this->assertEquals('bar2', $result);
+        self::assertEquals('bar2', $result);
 
         $result = $formatter->format($this->sampleDateTime, $this->sampleLocale, [I18n\Cldr\Reader\DatesReader::FORMAT_TYPE_TIME, I18n\Cldr\Reader\DatesReader::FORMAT_LENGTH_FULL]);
-        $this->assertEquals('bar3', $result);
+        self::assertEquals('bar3', $result);
     }
 
     /**
@@ -101,7 +101,7 @@ class DatetimeFormatterTest extends UnitTestCase
         $formatter = $this->getAccessibleMock(I18n\Formatter\DatetimeFormatter::class, ['dummy']);
 
         $result = $formatter->_call('doFormattingWithParsedFormat', $this->sampleDateTime, $parsedFormat, $this->sampleLocalizedLiterals);
-        $this->assertEquals($expectedResult, $result);
+        self::assertEquals($expectedResult, $result);
     }
 
     /**
@@ -131,7 +131,7 @@ class DatetimeFormatterTest extends UnitTestCase
         $formatter->injectDatesReader($mockDatesReader);
 
         $result = $formatter->formatDateTimeWithCustomPattern($this->sampleDateTime, $format, $this->sampleLocale);
-        $this->assertEquals($expectedResult, $result);
+        self::assertEquals($expectedResult, $result);
     }
 
     /**
@@ -176,6 +176,6 @@ class DatetimeFormatterTest extends UnitTestCase
 
         $methodName = 'format' . ucfirst($formatType);
         $result = $formatter->$methodName($this->sampleDateTime, $this->sampleLocale, $formatLength);
-        $this->assertEquals($expectedResult, $result);
+        self::assertEquals($expectedResult, $result);
     }
 }

--- a/Neos.Flow/Tests/Unit/I18n/Formatter/NumberFormatterTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Formatter/NumberFormatterTest.php
@@ -96,10 +96,10 @@ class NumberFormatterTest extends UnitTestCase
         $formatter->expects($this->at(1))->method('formatPercentNumber')->with($sampleNumber, $this->sampleLocale, NumbersReader::FORMAT_LENGTH_DEFAULT)->will($this->returnValue('bar2'));
 
         $result = $formatter->format($sampleNumber, $this->sampleLocale);
-        $this->assertEquals('bar1', $result);
+        self::assertEquals('bar1', $result);
 
         $result = $formatter->format($sampleNumber, $this->sampleLocale, ['percent']);
-        $this->assertEquals('bar2', $result);
+        self::assertEquals('bar2', $result);
     }
 
     /**
@@ -128,7 +128,7 @@ class NumberFormatterTest extends UnitTestCase
     {
         $formatter = $this->getAccessibleMock(I18n\Formatter\NumberFormatter::class, ['dummy']);
         $result = $formatter->_call('doFormattingWithParsedFormat', $number, $parsedFormat, $this->sampleLocalizedSymbols);
-        $this->assertEquals($expectedResult, $result);
+        self::assertEquals($expectedResult, $result);
     }
 
     /**
@@ -171,7 +171,7 @@ class NumberFormatterTest extends UnitTestCase
         $formatter->injectNumbersReader($mockNumbersReader);
 
         $result = $formatter->formatNumberWithCustomPattern($number, $format, $this->sampleLocale);
-        $this->assertEquals($expectedResult, $result);
+        self::assertEquals($expectedResult, $result);
     }
 
     /**
@@ -248,6 +248,6 @@ class NumberFormatterTest extends UnitTestCase
             $methodName = 'format' . ucfirst($formatType) . 'Number';
             $result = $formatter->$methodName($number, $this->sampleLocale);
         }
-        $this->assertEquals($expectedResult, $result);
+        self::assertEquals($expectedResult, $result);
     }
 }

--- a/Neos.Flow/Tests/Unit/I18n/LocaleCollectionTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/LocaleCollectionTest.php
@@ -53,7 +53,7 @@ class LocaleCollectionTest extends UnitTestCase
             $this->localeCollection->addLocale($locale);
         }
 
-        $this->assertEquals($this->locales[3], $this->localeCollection->getParentLocaleOf($this->locales[1]));
+        self::assertEquals($this->locales[3], $this->localeCollection->getParentLocaleOf($this->locales[1]));
     }
 
     /**
@@ -63,8 +63,8 @@ class LocaleCollectionTest extends UnitTestCase
     {
         $localeShouldBeAdded = $this->localeCollection->addLocale($this->locales[0]);
         $localeShouldNotBeAdded = $this->localeCollection->addLocale(new I18n\Locale('en'));
-        $this->assertTrue($localeShouldBeAdded);
-        $this->assertFalse($localeShouldNotBeAdded);
+        self::assertTrue($localeShouldBeAdded);
+        self::assertFalse($localeShouldNotBeAdded);
     }
 
     /**
@@ -76,9 +76,9 @@ class LocaleCollectionTest extends UnitTestCase
             $this->localeCollection->addLocale($locale);
         }
 
-        $this->assertEquals($this->locales[1], $this->localeCollection->findBestMatchingLocale($this->locales[1]));
-        $this->assertEquals($this->locales[1], $this->localeCollection->findBestMatchingLocale(new I18n\Locale('pl_PL_DVORAK')));
-        $this->assertNull($this->localeCollection->findBestMatchingLocale(new I18n\Locale('sv')));
+        self::assertEquals($this->locales[1], $this->localeCollection->findBestMatchingLocale($this->locales[1]));
+        self::assertEquals($this->locales[1], $this->localeCollection->findBestMatchingLocale(new I18n\Locale('pl_PL_DVORAK')));
+        self::assertNull($this->localeCollection->findBestMatchingLocale(new I18n\Locale('sv')));
     }
 
     /**
@@ -90,7 +90,7 @@ class LocaleCollectionTest extends UnitTestCase
             $this->localeCollection->addLocale($locale);
         }
 
-        $this->assertNull($this->localeCollection->getParentLocaleOf(new I18n\Locale('sv')));
-        $this->assertNull($this->localeCollection->getParentLocaleOf($this->locales[0]));
+        self::assertNull($this->localeCollection->getParentLocaleOf(new I18n\Locale('sv')));
+        self::assertNull($this->localeCollection->getParentLocaleOf($this->locales[0]));
     }
 }

--- a/Neos.Flow/Tests/Unit/I18n/LocaleTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/LocaleTest.php
@@ -49,28 +49,28 @@ class LocaleTest extends UnitTestCase
     public function theConstructorRecognizesTheMostImportantValidLocaleIdentifiers()
     {
         $locale = new I18n\Locale('de');
-        $this->assertEquals('de', $locale->getLanguage());
-        $this->assertNull($locale->getScript());
-        $this->assertNull($locale->getRegion());
-        $this->assertNull($locale->getVariant());
+        self::assertEquals('de', $locale->getLanguage());
+        self::assertNull($locale->getScript());
+        self::assertNull($locale->getRegion());
+        self::assertNull($locale->getVariant());
 
         $locale = new I18n\Locale('de_DE');
-        $this->assertEquals('de', $locale->getLanguage());
-        $this->assertEquals('DE', $locale->getRegion());
-        $this->assertNull($locale->getScript());
-        $this->assertNull($locale->getVariant());
+        self::assertEquals('de', $locale->getLanguage());
+        self::assertEquals('DE', $locale->getRegion());
+        self::assertNull($locale->getScript());
+        self::assertNull($locale->getVariant());
 
         $locale = new I18n\Locale('en_Latn_US');
-        $this->assertEquals('en', $locale->getLanguage());
-        $this->assertEquals('Latn', $locale->getScript());
-        $this->assertEquals('US', $locale->getRegion());
-        $this->assertNull($locale->getVariant());
+        self::assertEquals('en', $locale->getLanguage());
+        self::assertEquals('Latn', $locale->getScript());
+        self::assertEquals('US', $locale->getRegion());
+        self::assertNull($locale->getVariant());
 
         $locale = new I18n\Locale('AR-arab_ae');
-        $this->assertEquals('ar', $locale->getLanguage());
-        $this->assertEquals('Arab', $locale->getScript());
-        $this->assertEquals('AE', $locale->getRegion());
-        $this->assertNull($locale->getVariant());
+        self::assertEquals('ar', $locale->getLanguage());
+        self::assertEquals('Arab', $locale->getScript());
+        self::assertEquals('AE', $locale->getRegion());
+        self::assertNull($locale->getVariant());
     }
 
     /**
@@ -79,12 +79,12 @@ class LocaleTest extends UnitTestCase
     public function producesCorrectLocaleIdentifierWhenStringCasted()
     {
         $locale = new I18n\Locale('de_DE');
-        $this->assertEquals('de_DE', (string)$locale);
+        self::assertEquals('de_DE', (string)$locale);
 
         $locale = new I18n\Locale('en_Latn_US');
-        $this->assertEquals('en_Latn_US', (string)$locale);
+        self::assertEquals('en_Latn_US', (string)$locale);
 
         $locale = new I18n\Locale('AR-arab_ae');
-        $this->assertEquals('ar_Arab_AE', (string)$locale);
+        self::assertEquals('ar_Arab_AE', (string)$locale);
     }
 }

--- a/Neos.Flow/Tests/Unit/I18n/LocaleTypeConverterTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/LocaleTypeConverterTest.php
@@ -38,9 +38,9 @@ class LocaleTypeConverterTest extends UnitTestCase
      */
     public function checkMetadata()
     {
-        $this->assertEquals(['string'], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
-        $this->assertEquals(I18n\Locale::class, $this->converter->getSupportedTargetType(), 'Target type does not match');
-        $this->assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
+        self::assertEquals(['string'], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
+        self::assertEquals(I18n\Locale::class, $this->converter->getSupportedTargetType(), 'Target type does not match');
+        self::assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
     }
 
     /**
@@ -48,7 +48,7 @@ class LocaleTypeConverterTest extends UnitTestCase
      */
     public function convertFromShouldReturnLocale()
     {
-        $this->assertInstanceOf(I18n\Locale::class, $this->converter->convertFrom('de', 'irrelevant'));
+        self::assertInstanceOf(I18n\Locale::class, $this->converter->convertFrom('de', 'irrelevant'));
     }
 
     /**
@@ -56,7 +56,7 @@ class LocaleTypeConverterTest extends UnitTestCase
      */
     public function canConvertFromShouldReturnTrue()
     {
-        $this->assertTrue($this->converter->canConvertFrom('de', I18n\Locale::class));
+        self::assertTrue($this->converter->canConvertFrom('de', I18n\Locale::class));
     }
 
     /**
@@ -64,6 +64,6 @@ class LocaleTypeConverterTest extends UnitTestCase
      */
     public function getSourceChildPropertiesToBeConvertedShouldReturnEmptyArray()
     {
-        $this->assertEmpty($this->converter->getSourceChildPropertiesToBeConverted('something'));
+        self::assertEmpty($this->converter->getSourceChildPropertiesToBeConverted('something'));
     }
 }

--- a/Neos.Flow/Tests/Unit/I18n/Parser/DatetimeParserTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Parser/DatetimeParserTest.php
@@ -96,7 +96,7 @@ class DatetimeParserTest extends UnitTestCase
     {
         $parser = $this->getAccessibleMock(I18n\Parser\DatetimeParser::class, ['dummy']);
         $result = $parser->_call('doParsingInStrictMode', $datetimeToParse, $parsedFormat, $this->sampleLocalizedLiterals);
-        $this->assertEquals($expectedParsedDatetime, $result);
+        self::assertEquals($expectedParsedDatetime, $result);
     }
 
     /**
@@ -107,7 +107,7 @@ class DatetimeParserTest extends UnitTestCase
     {
         $parser = $this->getAccessibleMock(I18n\Parser\DatetimeParser::class, ['dummy']);
         $result = $parser->_call('doParsingInStrictMode', $datetimeToParse, $parsedFormat, $this->sampleLocalizedLiterals);
-        $this->assertEquals(false, $result);
+        self::assertEquals(false, $result);
     }
 
     /**
@@ -118,7 +118,7 @@ class DatetimeParserTest extends UnitTestCase
     {
         $parser = $this->getAccessibleMock(I18n\Parser\DatetimeParser::class, ['dummy']);
         $result = $parser->_call('doParsingInLenientMode', $datetimeToParse, $parsedFormat, $this->sampleLocalizedLiterals);
-        $this->assertEquals($expectedParsedDatetime, $result);
+        self::assertEquals($expectedParsedDatetime, $result);
     }
 
     /**
@@ -129,6 +129,6 @@ class DatetimeParserTest extends UnitTestCase
     {
         $parser = $this->getAccessibleMock(I18n\Parser\DatetimeParser::class, ['dummy']);
         $result = $parser->_call('doParsingInLenientMode', $datetimeToParse, $parsedFormat, $this->sampleLocalizedLiterals);
-        $this->assertEquals($expectedParsedDatetime, $result);
+        self::assertEquals($expectedParsedDatetime, $result);
     }
 }

--- a/Neos.Flow/Tests/Unit/I18n/Parser/NumberParserTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Parser/NumberParserTest.php
@@ -120,7 +120,7 @@ class NumberParserTest extends UnitTestCase
     {
         $parser = $this->getAccessibleMock(I18n\Parser\NumberParser::class, ['dummy']);
         $result = $parser->_call('doParsingInStrictMode', $numberToParse, $parsedFormat, $this->sampleLocalizedSymbols);
-        $this->assertEquals($expectedParsedNumber, $result);
+        self::assertEquals($expectedParsedNumber, $result);
     }
 
     /**
@@ -131,7 +131,7 @@ class NumberParserTest extends UnitTestCase
     {
         $parser = $this->getAccessibleMock(I18n\Parser\NumberParser::class, ['dummy']);
         $result = $parser->_call('doParsingInStrictMode', $numberToParse, $parsedFormat, $this->sampleLocalizedSymbols);
-        $this->assertEquals(false, $result);
+        self::assertEquals(false, $result);
     }
 
     /**
@@ -142,7 +142,7 @@ class NumberParserTest extends UnitTestCase
     {
         $parser = $this->getAccessibleMock(I18n\Parser\NumberParser::class, ['dummy']);
         $result = $parser->_call('doParsingInLenientMode', $numberToParse, $parsedFormat, $this->sampleLocalizedSymbols);
-        $this->assertEquals($expectedParsedNumber, $result);
+        self::assertEquals($expectedParsedNumber, $result);
     }
 
     /**
@@ -153,7 +153,7 @@ class NumberParserTest extends UnitTestCase
     {
         $parser = $this->getAccessibleMock(I18n\Parser\NumberParser::class, ['dummy']);
         $result = $parser->_call('doParsingInLenientMode', $numberToParse, $parsedFormat, $this->sampleLocalizedSymbols);
-        $this->assertEquals($expectedParsedNumber, $result);
+        self::assertEquals($expectedParsedNumber, $result);
     }
 
     /**
@@ -170,7 +170,7 @@ class NumberParserTest extends UnitTestCase
         $parser->injectNumbersReader($mockNumbersReader);
 
         $result = $parser->parseNumberWithCustomPattern($numberToParse, $stringFormat, $this->sampleLocale, true);
-        $this->assertEquals($expectedParsedNumber, $result);
+        self::assertEquals($expectedParsedNumber, $result);
     }
 
     /**
@@ -189,6 +189,6 @@ class NumberParserTest extends UnitTestCase
         $methodName = 'parse' . ucfirst($formatType) . 'Number';
         $result = $formatter->$methodName($numberToParse, $this->sampleLocale);
 
-        $this->assertEquals($expectedParsedNumber, $result);
+        self::assertEquals($expectedParsedNumber, $result);
     }
 }

--- a/Neos.Flow/Tests/Unit/I18n/ServiceTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/ServiceTest.php
@@ -49,7 +49,7 @@ class ServiceTest extends UnitTestCase
         $service->expects($this->atLeastOnce())->method('getLocaleChain')->with($desiredLocale)->will($this->returnValue($localeChain));
 
         list($result, ) = $service->getLocalizedFilename($filename, $desiredLocale);
-        $this->assertEquals($expectedFilename, $result);
+        self::assertEquals($expectedFilename, $result);
     }
 
     /**
@@ -71,7 +71,7 @@ class ServiceTest extends UnitTestCase
         $service->expects($this->atLeastOnce())->method('getLocaleChain')->with($desiredLocale)->will($this->returnValue($localeChain));
 
         list($result, ) = $service->getLocalizedFilename($filename, $desiredLocale);
-        $this->assertEquals($expectedFilename, $result);
+        self::assertEquals($expectedFilename, $result);
     }
 
     /**
@@ -88,7 +88,7 @@ class ServiceTest extends UnitTestCase
         $service = new I18n\Service();
 
         list($result, ) = $service->getLocalizedFilename($filename, new I18n\Locale('en_GB'), true);
-        $this->assertEquals($expectedFilename, $result);
+        self::assertEquals($expectedFilename, $result);
     }
 
     /**
@@ -105,7 +105,7 @@ class ServiceTest extends UnitTestCase
         $service = new I18n\Service();
 
         list($result, ) = $service->getLocalizedFilename($filename, new I18n\Locale('en_GB'), true);
-        $this->assertEquals($expectedFilename, $result);
+        self::assertEquals($expectedFilename, $result);
     }
 
     /**
@@ -118,7 +118,7 @@ class ServiceTest extends UnitTestCase
         $service = new I18n\Service();
 
         list($result, ) = $service->getLocalizedFilename($filename, new I18n\Locale('pl'), true);
-        $this->assertEquals($filename, $result);
+        self::assertEquals($filename, $result);
     }
 
     /**
@@ -134,7 +134,7 @@ class ServiceTest extends UnitTestCase
         $service->expects($this->atLeastOnce())->method('getLocaleChain')->with($desiredLocale)->will($this->returnValue($localeChain));
 
         list($result, ) = $service->getLocalizedFilename($filename, $desiredLocale);
-        $this->assertEquals($filename, $result);
+        self::assertEquals($filename, $result);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/I18n/TranslationProvider/XliffTranslationProviderTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/TranslationProvider/XliffTranslationProviderTest.php
@@ -85,7 +85,7 @@ class XliffTranslationProviderTest extends UnitTestCase
         $translationProvider->injectFileProvider($this->mockFileProvider);
 
         $result = $translationProvider->getTranslationByOriginalLabel('Source string', $this->sampleLocale, I18n\Cldr\Reader\PluralsReader::RULE_ONE, $this->sampleSourceName, $this->samplePackageKey);
-        $this->assertEquals('Übersetzte Zeichenkette', $result);
+        self::assertEquals('Übersetzte Zeichenkette', $result);
     }
 
     /**
@@ -108,7 +108,7 @@ class XliffTranslationProviderTest extends UnitTestCase
         $translationProvider->injectFileProvider($this->mockFileProvider);
 
         $result = $translationProvider->getTranslationById('key1', $this->sampleLocale, I18n\Cldr\Reader\PluralsReader::RULE_ONE, $this->sampleSourceName, $this->samplePackageKey);
-        $this->assertEquals('Übersetzte Zeichenkette', $result);
+        self::assertEquals('Übersetzte Zeichenkette', $result);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/I18n/TranslatorTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/TranslatorTest.php
@@ -79,7 +79,7 @@ class TranslatorTest extends UnitTestCase
         $this->translator->injectFormatResolver($mockFormatResolver);
 
         $result = $this->translator->translateByOriginalLabel('Untranslated label', ['value1', 'value2'], 1, null, 'source', 'packageKey');
-        $this->assertEquals('Formatted and translated label', $result);
+        self::assertEquals('Formatted and translated label', $result);
     }
 
     /**
@@ -98,7 +98,7 @@ class TranslatorTest extends UnitTestCase
         $this->translator->injectTranslationProvider($mockTranslationProvider);
 
         $result = $this->translator->translateByOriginalLabel('original label', [], null, null, 'source', 'packageKey');
-        $this->assertEquals('original label', $result);
+        self::assertEquals('original label', $result);
     }
 
     /**
@@ -121,7 +121,7 @@ class TranslatorTest extends UnitTestCase
         $this->translator->injectFormatResolver($mockFormatResolver);
 
         $result = $this->translator->translateByOriginalLabel('original {0}', ['label'], null, null, 'source', 'packageKey');
-        $this->assertEquals('original label', $result);
+        self::assertEquals('original label', $result);
     }
 
     /**
@@ -143,7 +143,7 @@ class TranslatorTest extends UnitTestCase
         $this->translator->injectTranslationProvider($mockTranslationProvider);
 
         $result = $this->translator->translateByOriginalLabel('original label', [], null, null, 'source', 'packageKey');
-        $this->assertEquals('translated label', $result);
+        self::assertEquals('translated label', $result);
     }
 
     /**
@@ -162,7 +162,7 @@ class TranslatorTest extends UnitTestCase
         $this->translator->injectTranslationProvider($mockTranslationProvider);
 
         $result = $this->translator->translateById('id', [], null, $this->defaultLocale, 'source', 'packageKey');
-        $this->assertNull($result);
+        self::assertNull($result);
     }
 
     /**
@@ -184,7 +184,7 @@ class TranslatorTest extends UnitTestCase
         $this->translator->injectTranslationProvider($mockTranslationProvider);
 
         $result = $this->translator->translateById('id', [], null, $this->defaultLocale, 'source', 'packageKey');
-        $this->assertEquals('translatedId', $result);
+        self::assertEquals('translatedId', $result);
     }
 
     /**
@@ -198,7 +198,7 @@ class TranslatorTest extends UnitTestCase
         $this->translator->injectTranslationProvider($mockTranslationProvider);
 
         $result = $this->translator->translateById('id', [], null, $this->defaultLocale, 'source', 'packageKey');
-        $this->assertEquals('translatedId', $result);
+        self::assertEquals('translatedId', $result);
     }
 
     /**
@@ -220,7 +220,7 @@ class TranslatorTest extends UnitTestCase
         $this->translator->injectPluralsReader($mockPluralsReader);
 
         $result = $this->translator->translateByOriginalLabel('Untranslated label', [1.0], null, null, 'source', 'packageKey');
-        $this->assertEquals('Formatted and translated label', $result);
+        self::assertEquals('Formatted and translated label', $result);
     }
 
     /**
@@ -242,7 +242,7 @@ class TranslatorTest extends UnitTestCase
         $this->translator->injectPluralsReader($mockPluralsReader);
 
         $result = $this->translator->translateById('id', [1.0], null, null, 'source', 'packageKey');
-        $this->assertEquals('Formatted and translated label', $result);
+        self::assertEquals('Formatted and translated label', $result);
     }
 
     /**
@@ -275,7 +275,7 @@ class TranslatorTest extends UnitTestCase
 
         $this->translator->injectTranslationProvider($mockTranslationProvider);
         $actualResult = $this->translator->translateByOriginalLabel($originalLabel);
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -308,6 +308,6 @@ class TranslatorTest extends UnitTestCase
 
         $this->translator->injectTranslationProvider($mockTranslationProvider);
         $actualResult = $this->translator->translateById($id);
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 }

--- a/Neos.Flow/Tests/Unit/I18n/UtilityTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/UtilityTest.php
@@ -41,7 +41,7 @@ class UtilityTest extends UnitTestCase
     public function httpAcceptLanguageHeadersAreParsedCorrectly($acceptLanguageHeader, array $expectedResult)
     {
         $languages = I18n\Utility::parseAcceptLanguageHeader($acceptLanguageHeader);
-        $this->assertEquals($expectedResult, $languages);
+        self::assertEquals($expectedResult, $languages);
     }
 
     /**
@@ -69,7 +69,7 @@ class UtilityTest extends UnitTestCase
     public function localeIdentifiersAreCorrectlyExtractedFromFilename($filename, $expectedResult)
     {
         $result = I18n\Utility::extractLocaleTagFromFilename($filename);
-        $this->assertEquals($expectedResult, $result);
+        self::assertEquals($expectedResult, $result);
     }
 
     /**
@@ -98,7 +98,7 @@ class UtilityTest extends UnitTestCase
     {
         $expectedResult = ($comparison === 'beginning' || $comparison === 'both') ? true : false;
         $result = I18n\Utility::stringBeginsWith($haystack, $needle);
-        $this->assertEquals($expectedResult, $result);
+        self::assertEquals($expectedResult, $result);
     }
 
     /**
@@ -109,6 +109,6 @@ class UtilityTest extends UnitTestCase
     {
         $expectedResult = ($comparison === 'ending' || $comparison === 'both') ? true : false;
         $result = I18n\Utility::stringEndsWith($haystack, $needle);
-        $this->assertEquals($expectedResult, $result);
+        self::assertEquals($expectedResult, $result);
     }
 }

--- a/Neos.Flow/Tests/Unit/I18n/Xliff/Model/FileAdapterTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Xliff/Model/FileAdapterTest.php
@@ -43,16 +43,16 @@ class FileAdapterTest extends UnitTestCase
         $fileAdapter = new I18n\Xliff\Model\FileAdapter($this->mockParsedXliffFile, new I18n\Locale('de'));
 
         $result = $fileAdapter->getTargetBySource('Source string');
-        $this->assertEquals('Übersetzte Zeichenkette', $result);
+        self::assertEquals('Übersetzte Zeichenkette', $result);
 
         $result = $fileAdapter->getTargetBySource('Source singular', 0);
-        $this->assertEquals('Übersetzte Einzahl', $result);
+        self::assertEquals('Übersetzte Einzahl', $result);
 
         $result = $fileAdapter->getTargetBySource('Source singular', 2);
-        $this->assertEquals('Übersetzte Mehrzahl 2', $result);
+        self::assertEquals('Übersetzte Mehrzahl 2', $result);
 
         $result = $fileAdapter->getTargetBySource('Not existing label');
-        $this->assertFalse($result);
+        self::assertFalse($result);
     }
 
     /**
@@ -63,10 +63,10 @@ class FileAdapterTest extends UnitTestCase
         $fileAdapter = new I18n\Xliff\Model\FileAdapter($this->mockParsedXliffFile, new I18n\Locale('de'));
 
         $result = $fileAdapter->getTargetByTransUnitId('key1');
-        $this->assertEquals('Übersetzte Zeichenkette', $result);
+        self::assertEquals('Übersetzte Zeichenkette', $result);
 
         $result = $fileAdapter->getTargetByTransUnitId('key2', 1);
-        $this->assertEquals('Übersetzte Mehrzahl 1', $result);
+        self::assertEquals('Übersetzte Mehrzahl 1', $result);
 
         $mockLogger = $this->getMockBuilder(LoggerInterface::class)
             ->disableOriginalConstructor()
@@ -74,7 +74,7 @@ class FileAdapterTest extends UnitTestCase
         $this->inject($fileAdapter, 'i18nLogger', $mockLogger);
 
         $result = $fileAdapter->getTargetByTransUnitId('not.existing');
-        $this->assertFalse($result);
+        self::assertFalse($result);
     }
 
     /**
@@ -85,7 +85,7 @@ class FileAdapterTest extends UnitTestCase
         $fileAdapter = new I18n\Xliff\Model\FileAdapter($this->mockParsedXliffFile, new I18n\Locale('en_US'));
 
         $result = $fileAdapter->getTargetByTransUnitId('key3');
-        $this->assertEquals('No target', $result);
+        self::assertEquals('No target', $result);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/I18n/Xliff/V12/XliffParserTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Xliff/V12/XliffParserTest.php
@@ -29,7 +29,7 @@ class XliffParserTest extends UnitTestCase
 
         $parser = new I18n\Xliff\V12\XliffParser();
         $result = $parser->getParsedData($mockFilenamePath);
-        $this->assertEquals($mockParsedData, $result);
+        self::assertEquals($mockParsedData, $result);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Monitor/ChangeDetectionStrategy/ModificationTimeStrategyTest.php
+++ b/Neos.Flow/Tests/Unit/Monitor/ChangeDetectionStrategy/ModificationTimeStrategyTest.php
@@ -50,7 +50,7 @@ class ModificationTimeStrategyTest extends \Neos\Flow\Tests\UnitTestCase
         $fileUrl = vfsStream::url('testDirectory') . '/test.txt';
 
         $status = $this->strategy->getFileStatus($fileUrl);
-        $this->assertSame(\Neos\Flow\Monitor\ChangeDetectionStrategy\ChangeDetectionStrategyInterface::STATUS_UNCHANGED, $status);
+        self::assertSame(\Neos\Flow\Monitor\ChangeDetectionStrategy\ChangeDetectionStrategyInterface::STATUS_UNCHANGED, $status);
     }
 
     /**
@@ -65,7 +65,7 @@ class ModificationTimeStrategyTest extends \Neos\Flow\Tests\UnitTestCase
         clearstatcache();
         $status = $this->strategy->getFileStatus($fileUrl);
 
-        $this->assertSame(\Neos\Flow\Monitor\ChangeDetectionStrategy\ChangeDetectionStrategyInterface::STATUS_UNCHANGED, $status);
+        self::assertSame(\Neos\Flow\Monitor\ChangeDetectionStrategy\ChangeDetectionStrategyInterface::STATUS_UNCHANGED, $status);
     }
 
     /**
@@ -77,7 +77,7 @@ class ModificationTimeStrategyTest extends \Neos\Flow\Tests\UnitTestCase
         file_put_contents($fileUrl, 'test data');
 
         $status = $this->strategy->getFileStatus($fileUrl);
-        $this->assertSame(\Neos\Flow\Monitor\ChangeDetectionStrategy\ChangeDetectionStrategyInterface::STATUS_CREATED, $status);
+        self::assertSame(\Neos\Flow\Monitor\ChangeDetectionStrategy\ChangeDetectionStrategyInterface::STATUS_CREATED, $status);
     }
 
     /**
@@ -92,7 +92,7 @@ class ModificationTimeStrategyTest extends \Neos\Flow\Tests\UnitTestCase
         unlink($fileUrl);
         $status = $this->strategy->getFileStatus($fileUrl);
 
-        $this->assertSame(\Neos\Flow\Monitor\ChangeDetectionStrategy\ChangeDetectionStrategyInterface::STATUS_DELETED, $status);
+        self::assertSame(\Neos\Flow\Monitor\ChangeDetectionStrategy\ChangeDetectionStrategyInterface::STATUS_DELETED, $status);
     }
 
     /**
@@ -108,6 +108,6 @@ class ModificationTimeStrategyTest extends \Neos\Flow\Tests\UnitTestCase
         clearstatcache();
         $status = $this->strategy->getFileStatus($fileUrl);
 
-        $this->assertSame(\Neos\Flow\Monitor\ChangeDetectionStrategy\ChangeDetectionStrategyInterface::STATUS_CHANGED, $status);
+        self::assertSame(\Neos\Flow\Monitor\ChangeDetectionStrategy\ChangeDetectionStrategyInterface::STATUS_CHANGED, $status);
     }
 }

--- a/Neos.Flow/Tests/Unit/Monitor/FileMonitorTest.php
+++ b/Neos.Flow/Tests/Unit/Monitor/FileMonitorTest.php
@@ -54,7 +54,7 @@ class FileMonitorTest extends UnitTestCase
     {
         $monitor = new FileMonitor('Flow_Test');
         $monitor->monitorFile(__FILE__);
-        $this->assertSame([$this->unixStylePathAndFilename], $monitor->getMonitoredFiles());
+        self::assertSame([$this->unixStylePathAndFilename], $monitor->getMonitoredFiles());
     }
 
     /**
@@ -65,7 +65,7 @@ class FileMonitorTest extends UnitTestCase
         $monitor = new FileMonitor('Flow_Test');
         $monitor->monitorFile(__FILE__);
         $monitor->monitorFile(__FILE__);
-        $this->assertSame([$this->unixStylePathAndFilename], $monitor->getMonitoredFiles());
+        self::assertSame([$this->unixStylePathAndFilename], $monitor->getMonitoredFiles());
     }
 
     /**
@@ -75,7 +75,7 @@ class FileMonitorTest extends UnitTestCase
     {
         $monitor = new FileMonitor('Flow_Test');
         $monitor->monitorDirectory(__DIR__);
-        $this->assertSame([Files::getNormalizedPath($this->unixStylePath)], $monitor->getMonitoredDirectories());
+        self::assertSame([Files::getNormalizedPath($this->unixStylePath)], $monitor->getMonitoredDirectories());
     }
 
     /**
@@ -86,7 +86,7 @@ class FileMonitorTest extends UnitTestCase
         $monitor = new FileMonitor('Flow_Test');
         $monitor->monitorDirectory(__DIR__);
         $monitor->monitorDirectory(__DIR__ . '/');
-        $this->assertSame([Files::getNormalizedPath($this->unixStylePath)], $monitor->getMonitoredDirectories());
+        self::assertSame([Files::getNormalizedPath($this->unixStylePath)], $monitor->getMonitoredDirectories());
     }
 
     /**
@@ -141,7 +141,7 @@ class FileMonitorTest extends UnitTestCase
         $mockMonitor->injectChangeDetectionStrategy($mockStrategy);
         $result = $mockMonitor->_call('detectChangedFiles', [__FILE__ . '1', __FILE__ . '2']);
 
-        $this->assertEquals([__FILE__ . '1' => ChangeDetectionStrategyInterface::STATUS_CREATED], $result);
+        self::assertEquals([__FILE__ . '1' => ChangeDetectionStrategyInterface::STATUS_CREATED], $result);
     }
 
     /**
@@ -267,10 +267,10 @@ class FileMonitorTest extends UnitTestCase
         $fileMonitor->monitorDirectory($testPath);
         $fileMonitor->detectChanges();
 
-        $this->assertEquals([
+        self::assertEquals([
             $testPath . '/test.txt' => ChangeDetectionStrategyInterface::STATUS_CREATED
         ], $fileMonitor->_get('changedFiles'));
-        $this->assertCount(1, $fileMonitor->_get('changedPaths'));
+        self::assertCount(1, $fileMonitor->_get('changedPaths'));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Mvc/ActionRequestTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/ActionRequestTest.php
@@ -55,10 +55,10 @@ class ActionRequestTest extends UnitTestCase
      */
     public function anHttpRequestOrActionRequestIsRequiredAsParentRequest()
     {
-        $this->assertSame($this->mockHttpRequest, $this->actionRequest->getParentRequest());
+        self::assertSame($this->mockHttpRequest, $this->actionRequest->getParentRequest());
 
         $anotherActionRequest = new ActionRequest($this->actionRequest);
-        $this->assertSame($this->actionRequest, $anotherActionRequest->getParentRequest());
+        self::assertSame($this->actionRequest, $anotherActionRequest->getParentRequest());
     }
 
     /**
@@ -78,9 +78,9 @@ class ActionRequestTest extends UnitTestCase
         $anotherActionRequest = new ActionRequest($this->actionRequest);
         $yetAnotherActionRequest = new ActionRequest($anotherActionRequest);
 
-        $this->assertSame($this->mockHttpRequest, $this->actionRequest->getHttpRequest());
-        $this->assertSame($this->mockHttpRequest, $yetAnotherActionRequest->getHttpRequest());
-        $this->assertSame($this->mockHttpRequest, $anotherActionRequest->getHttpRequest());
+        self::assertSame($this->mockHttpRequest, $this->actionRequest->getHttpRequest());
+        self::assertSame($this->mockHttpRequest, $yetAnotherActionRequest->getHttpRequest());
+        self::assertSame($this->mockHttpRequest, $anotherActionRequest->getHttpRequest());
     }
 
     /**
@@ -91,9 +91,9 @@ class ActionRequestTest extends UnitTestCase
         $anotherActionRequest = new ActionRequest($this->actionRequest);
         $yetAnotherActionRequest = new ActionRequest($anotherActionRequest);
 
-        $this->assertSame($this->actionRequest, $this->actionRequest->getMainRequest());
-        $this->assertSame($this->actionRequest, $yetAnotherActionRequest->getMainRequest());
-        $this->assertSame($this->actionRequest, $anotherActionRequest->getMainRequest());
+        self::assertSame($this->actionRequest, $this->actionRequest->getMainRequest());
+        self::assertSame($this->actionRequest, $yetAnotherActionRequest->getMainRequest());
+        self::assertSame($this->actionRequest, $anotherActionRequest->getMainRequest());
     }
 
     /**
@@ -104,9 +104,9 @@ class ActionRequestTest extends UnitTestCase
         $anotherActionRequest = new ActionRequest($this->actionRequest);
         $yetAnotherActionRequest = new ActionRequest($anotherActionRequest);
 
-        $this->assertTrue($this->actionRequest->isMainRequest());
-        $this->assertFalse($anotherActionRequest->isMainRequest());
-        $this->assertFalse($yetAnotherActionRequest->isMainRequest());
+        self::assertTrue($this->actionRequest->isMainRequest());
+        self::assertFalse($anotherActionRequest->isMainRequest());
+        self::assertFalse($yetAnotherActionRequest->isMainRequest());
     }
 
     /**
@@ -120,11 +120,11 @@ class ActionRequestTest extends UnitTestCase
         $mockObjectManager->expects($this->any())->method('get')->will($this->returnValue($mockDispatcher));
         $this->inject($this->actionRequest, 'objectManager', $mockObjectManager);
 
-        $this->assertFalse($this->actionRequest->isDispatched());
+        self::assertFalse($this->actionRequest->isDispatched());
         $this->actionRequest->setDispatched(true);
-        $this->assertTrue($this->actionRequest->isDispatched());
+        self::assertTrue($this->actionRequest->isDispatched());
         $this->actionRequest->setDispatched(false);
-        $this->assertFalse($this->actionRequest->isDispatched());
+        self::assertFalse($this->actionRequest->isDispatched());
     }
 
     /**
@@ -146,7 +146,7 @@ class ActionRequestTest extends UnitTestCase
         $this->actionRequest->setControllerSubPackageKey('Some\Subpackage');
         $this->actionRequest->setControllerName('SomeController');
 
-        $this->assertEquals('SomePackage\Some\SubPackage\Controller\SomeControllerController', $this->actionRequest->getControllerObjectName());
+        self::assertEquals('SomePackage\Some\SubPackage\Controller\SomeControllerController', $this->actionRequest->getControllerObjectName());
     }
 
     /**
@@ -168,7 +168,7 @@ class ActionRequestTest extends UnitTestCase
         $this->actionRequest->setControllerSubPackageKey('Some\Subpackage');
         $this->actionRequest->setControllerName('SomeController');
 
-        $this->assertEquals('', $this->actionRequest->getControllerObjectName());
+        self::assertEquals('', $this->actionRequest->getControllerObjectName());
     }
 
     /**
@@ -235,9 +235,9 @@ class ActionRequestTest extends UnitTestCase
         $this->inject($this->actionRequest, 'objectManager', $mockObjectManager);
 
         $this->actionRequest->setControllerObjectName($objectName);
-        $this->assertSame($parts['controllerPackageKey'], $this->actionRequest->getControllerPackageKey());
-        $this->assertSame($parts['controllerSubpackageKey'], $this->actionRequest->getControllerSubpackageKey());
-        $this->assertSame($parts['controllerName'], $this->actionRequest->getControllerName());
+        self::assertSame($parts['controllerPackageKey'], $this->actionRequest->getControllerPackageKey());
+        self::assertSame($parts['controllerSubpackageKey'], $this->actionRequest->getControllerSubpackageKey());
+        self::assertSame($parts['controllerName'], $this->actionRequest->getControllerName());
     }
 
     /**
@@ -264,7 +264,7 @@ class ActionRequestTest extends UnitTestCase
         $actionRequest->expects($this->once())->method('getControllerObjectName')->will($this->returnValue('Neos\MyPackage\Controller\Foo\BarController'));
 
         $actionRequest->setControllerName('foo\bar');
-        $this->assertEquals('Foo\Bar', $actionRequest->getControllerName());
+        self::assertEquals('Foo\Bar', $actionRequest->getControllerName());
     }
 
     /**
@@ -277,7 +277,7 @@ class ActionRequestTest extends UnitTestCase
         $actionRequest->expects($this->once())->method('getControllerObjectName')->will($this->returnValue(''));
 
         $actionRequest->setControllerName('foo\bar');
-        $this->assertEquals('foo\bar', $actionRequest->getControllerName());
+        self::assertEquals('foo\bar', $actionRequest->getControllerName());
     }
 
     /**
@@ -296,7 +296,7 @@ class ActionRequestTest extends UnitTestCase
 
         $actionRequest->setControllerPackageKey('neos.mypackage');
         $actionRequest->setControllerSubpackageKey('some\subpackage');
-        $this->assertEquals('Some\SubPackage', $actionRequest->getControllerSubpackageKey());
+        self::assertEquals('Some\SubPackage', $actionRequest->getControllerSubpackageKey());
     }
 
     /**
@@ -314,7 +314,7 @@ class ActionRequestTest extends UnitTestCase
         $this->inject($actionRequest, 'packageManager', $mockPackageManager);
 
         $actionRequest->setControllerPackageKey('neos.mypackage');
-        $this->assertNull($actionRequest->getControllerSubpackageKey());
+        self::assertNull($actionRequest->getControllerSubpackageKey());
     }
 
     /**
@@ -333,7 +333,7 @@ class ActionRequestTest extends UnitTestCase
 
         $actionRequest->setControllerPackageKey('neos.mypackage');
         $actionRequest->setControllerSubpackageKey('some\subpackage');
-        $this->assertEquals('some\subpackage', $actionRequest->getControllerSubpackageKey());
+        self::assertEquals('some\subpackage', $actionRequest->getControllerSubpackageKey());
     }
 
     /**
@@ -369,7 +369,7 @@ class ActionRequestTest extends UnitTestCase
         $actionRequest->expects($this->once())->method('getControllerObjectName')->will($this->returnValue(''));
 
         $actionRequest->setControllerActionName('theAction');
-        $this->assertEquals('theAction', $actionRequest->getControllerActionName());
+        self::assertEquals('theAction', $actionRequest->getControllerActionName());
     }
 
     /**
@@ -420,7 +420,7 @@ class ActionRequestTest extends UnitTestCase
         $actionRequest->_set('objectManager', $mockObjectManager);
 
         $actionRequest->setControllerActionName('somegreat');
-        $this->assertEquals('someGreat', $actionRequest->getControllerActionName());
+        self::assertEquals('someGreat', $actionRequest->getControllerActionName());
     }
 
     /**
@@ -429,7 +429,7 @@ class ActionRequestTest extends UnitTestCase
     public function aSingleArgumentCanBeSetWithSetArgumentAndRetrievedWithGetArgument()
     {
         $this->actionRequest->setArgument('someArgumentName', 'theValue');
-        $this->assertEquals('theValue', $this->actionRequest->getArgument('someArgumentName'));
+        self::assertEquals('theValue', $this->actionRequest->getArgument('someArgumentName'));
     }
 
     /**
@@ -461,7 +461,7 @@ class ActionRequestTest extends UnitTestCase
         ];
 
         $this->actionRequest->setArguments($arguments);
-        $this->assertEquals($arguments, $this->actionRequest->getArguments());
+        self::assertEquals($arguments, $this->actionRequest->getArguments());
     }
 
     /**
@@ -471,9 +471,9 @@ class ActionRequestTest extends UnitTestCase
     {
         $this->actionRequest->setArgument('__someInternalArgument', 'theValue');
 
-        $this->assertFalse($this->actionRequest->hasArgument('__someInternalArgument'));
-        $this->assertEquals('theValue', $this->actionRequest->getInternalArgument('__someInternalArgument'));
-        $this->assertEquals(['__someInternalArgument' => 'theValue'], $this->actionRequest->getInternalArguments());
+        self::assertFalse($this->actionRequest->hasArgument('__someInternalArgument'));
+        self::assertEquals('theValue', $this->actionRequest->getInternalArgument('__someInternalArgument'));
+        self::assertEquals(['__someInternalArgument' => 'theValue'], $this->actionRequest->getInternalArguments());
     }
 
     /**
@@ -485,7 +485,7 @@ class ActionRequestTest extends UnitTestCase
 
         $this->actionRequest->setArgument('__someInternalArgument', $someObject);
 
-        $this->assertSame($someObject, $this->actionRequest->getInternalArgument('__someInternalArgument'));
+        self::assertSame($someObject, $this->actionRequest->getInternalArgument('__someInternalArgument'));
     }
 
     /**
@@ -495,8 +495,8 @@ class ActionRequestTest extends UnitTestCase
     {
         $this->actionRequest->setArgument('--typo3-flow-foo-viewhelper-paginate', ['@controller' => 'Foo', 'page' => 5]);
 
-        $this->assertFalse($this->actionRequest->hasArgument('--typo3-flow-foo-viewhelper-paginate'));
-        $this->assertEquals(['typo3-flow-foo-viewhelper-paginate' => ['@controller' => 'Foo', 'page' => 5]], $this->actionRequest->getPluginArguments());
+        self::assertFalse($this->actionRequest->hasArgument('--typo3-flow-foo-viewhelper-paginate'));
+        self::assertEquals(['typo3-flow-foo-viewhelper-paginate' => ['@controller' => 'Foo', 'page' => 5]], $this->actionRequest->getPluginArguments());
     }
 
     /**
@@ -504,9 +504,9 @@ class ActionRequestTest extends UnitTestCase
      */
     public function argumentNamespaceCanBeSpecified()
     {
-        $this->assertSame('', $this->actionRequest->getArgumentNamespace());
+        self::assertSame('', $this->actionRequest->getArgumentNamespace());
         $this->actionRequest->setArgumentNamespace('someArgumentNamespace');
-        $this->assertSame('someArgumentNamespace', $this->actionRequest->getArgumentNamespace());
+        self::assertSame('someArgumentNamespace', $this->actionRequest->getArgumentNamespace());
     }
 
     /**
@@ -515,13 +515,13 @@ class ActionRequestTest extends UnitTestCase
     public function theRepresentationFormatCanBeSetAndRetrieved()
     {
         $this->actionRequest->setFormat('html');
-        $this->assertEquals('html', $this->actionRequest->getFormat());
+        self::assertEquals('html', $this->actionRequest->getFormat());
 
         $this->actionRequest->setFormat('doc');
-        $this->assertEquals('doc', $this->actionRequest->getFormat());
+        self::assertEquals('doc', $this->actionRequest->getFormat());
 
         $this->actionRequest->setFormat('hTmL');
-        $this->assertEquals('html', $this->actionRequest->getFormat());
+        self::assertEquals('html', $this->actionRequest->getFormat());
     }
 
     /**
@@ -532,8 +532,8 @@ class ActionRequestTest extends UnitTestCase
         $this->actionRequest->setDispatched(true);
         $cloneRequest = clone $this->actionRequest;
 
-        $this->assertTrue($this->actionRequest->isDispatched());
-        $this->assertFalse($cloneRequest->isDispatched());
+        self::assertTrue($this->actionRequest->isDispatched());
+        self::assertFalse($cloneRequest->isDispatched());
     }
 
     /**
@@ -584,7 +584,7 @@ class ActionRequestTest extends UnitTestCase
         $this->inject($this->actionRequest, 'packageManager', $mockPackageManager);
         $this->actionRequest->setControllerPackageKey('acme.testpackage');
 
-        $this->assertEquals('Acme.Testpackage', $this->actionRequest->getControllerPackageKey());
+        self::assertEquals('Acme.Testpackage', $this->actionRequest->getControllerPackageKey());
     }
 
     /**
@@ -595,7 +595,7 @@ class ActionRequestTest extends UnitTestCase
         $this->actionRequest->setArguments(['__internalArgument' => 'action request']);
 
         $expectedResult = ['__internalArgument' => 'action request'];
-        $this->assertSame($expectedResult, $this->actionRequest->getInternalArguments());
+        self::assertSame($expectedResult, $this->actionRequest->getInternalArguments());
     }
 
     /**
@@ -606,7 +606,7 @@ class ActionRequestTest extends UnitTestCase
         $this->actionRequest->setArguments(['--pluginArgument' => 'action request']);
 
         $expectedResult = ['pluginArgument' => 'action request'];
-        $this->assertSame($expectedResult, $this->actionRequest->getPluginArguments());
+        self::assertSame($expectedResult, $this->actionRequest->getPluginArguments());
     }
 
     /**
@@ -616,7 +616,7 @@ class ActionRequestTest extends UnitTestCase
     {
         $argumentValue = 'amnesia spray';
         $this->actionRequest->setArgument(123, $argumentValue);
-        $this->assertTrue($this->actionRequest->hasArgument('123'));
-        $this->assertEquals($argumentValue, $this->actionRequest->getArgument('123'));
+        self::assertTrue($this->actionRequest->hasArgument('123'));
+        self::assertEquals($argumentValue, $this->actionRequest->getArgument('123'));
     }
 }

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
@@ -84,13 +84,13 @@ class AbstractControllerTest extends UnitTestCase
         $controller = $this->getAccessibleMock(AbstractController::class, ['processRequest']);
         $this->inject($controller, 'flashMessageContainer', new FlashMessageContainer());
 
-        $this->assertFalse($request->isDispatched());
+        self::assertFalse($request->isDispatched());
         $controller->_call('initializeController', $request, $this->actionResponse);
 
-        $this->assertTrue($request->isDispatched());
-        $this->assertInstanceOf(Arguments::class, $controller->_get('arguments'));
-        $this->assertSame($request, $controller->_get('uriBuilder')->getRequest());
-        $this->assertSame($request, $controller->getControllerContext()->getRequest());
+        self::assertTrue($request->isDispatched());
+        self::assertInstanceOf(Arguments::class, $controller->_get('arguments'));
+        self::assertSame($request, $controller->_get('uriBuilder')->getRequest());
+        self::assertSame($request, $controller->getControllerContext()->getRequest());
     }
 
     /**
@@ -133,7 +133,7 @@ class AbstractControllerTest extends UnitTestCase
         $this->inject($controller, 'flashMessageContainer', $flashMessageContainer);
 
         $controller->addFlashMessage($messageBody, $messageTitle, $severity, $messageArguments, $messageCode);
-        $this->assertEquals([$expectedMessage], $flashMessageContainer->getMessages());
+        self::assertEquals([$expectedMessage], $flashMessageContainer->getMessages());
     }
 
     /**
@@ -199,7 +199,7 @@ class AbstractControllerTest extends UnitTestCase
 
         // all arguments of the current controller must be reset, in case the controller is called again later:
         $arguments = $controller->_get('arguments');
-        $this->assertFalse($arguments->hasArgument('foo'));
+        self::assertFalse($arguments->hasArgument('foo'));
     }
 
     /**
@@ -342,7 +342,7 @@ class AbstractControllerTest extends UnitTestCase
         } catch (StopActionException $e) {
         }
 
-        $this->assertSame(303, $this->actionResponse->getStatusCode());
+        self::assertSame(303, $this->actionResponse->getStatusCode());
     }
 
     /**
@@ -360,7 +360,7 @@ class AbstractControllerTest extends UnitTestCase
         } catch (StopActionException $e) {
         }
 
-        $this->assertSame($uri, $this->actionResponse->getHeader('Location'));
+        self::assertSame($uri, $this->actionResponse->getHeader('Location'));
     }
 
     /**
@@ -378,7 +378,7 @@ class AbstractControllerTest extends UnitTestCase
         } catch (StopActionException $e) {
         }
 
-        $this->assertNull($this->actionResponse->getHeader('Location'));
+        self::assertNull($this->actionResponse->getHeader('Location'));
     }
 
     /**
@@ -408,9 +408,9 @@ class AbstractControllerTest extends UnitTestCase
         } catch (StopActionException $e) {
         }
 
-        $this->assertSame(404, $this->actionResponse->getStatusCode());
-        $this->assertSame('404 File Really Not Found', $this->actionResponse->getStatus());
-        $this->assertSame($message, $this->actionResponse->getContent());
+        self::assertSame(404, $this->actionResponse->getStatusCode());
+        self::assertSame('404 File Really Not Found', $this->actionResponse->getStatus());
+        self::assertSame($message, $this->actionResponse->getContent());
     }
 
     /**
@@ -426,9 +426,9 @@ class AbstractControllerTest extends UnitTestCase
         } catch (StopActionException $e) {
         }
 
-        $this->assertSame(404, $this->actionResponse->getStatusCode());
-        $this->assertSame('404 Not Found', $this->actionResponse->getStatus());
-        $this->assertSame('404 Not Found', $this->actionResponse->getContent());
+        self::assertSame(404, $this->actionResponse->getStatusCode());
+        self::assertSame('404 Not Found', $this->actionResponse->getStatus());
+        self::assertSame('404 Not Found', $this->actionResponse->getContent());
     }
 
     /**
@@ -457,8 +457,8 @@ class AbstractControllerTest extends UnitTestCase
         $this->mockActionRequest->expects($this->at(3))->method('getArgument')->with('baz')->will($this->returnValue('quux'));
 
         $controller->_call('mapRequestArgumentsToControllerArguments');
-        $this->assertEquals('bar', $controllerArguments['foo']->getValue());
-        $this->assertEquals('quux', $controllerArguments['baz']->getValue());
+        self::assertEquals('bar', $controllerArguments['foo']->getValue());
+        self::assertEquals('quux', $controllerArguments['baz']->getValue());
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/ActionControllerTest.php
@@ -81,7 +81,7 @@ class ActionControllerTest extends UnitTestCase
     {
         $this->mockObjectManager->expects($this->once())->method('getCaseSensitiveObjectName')->with('some\package\subpackage\view\thecontroller\theactiontheformat')->will($this->returnValue('ResolvedObjectName'));
 
-        $this->assertSame('ResolvedObjectName', $this->actionController->_call('resolveViewObjectName'));
+        self::assertSame('ResolvedObjectName', $this->actionController->_call('resolveViewObjectName'));
     }
 
     /**
@@ -92,7 +92,7 @@ class ActionControllerTest extends UnitTestCase
         $this->mockObjectManager->expects($this->at(0))->method('getCaseSensitiveObjectName')->with('some\package\subpackage\view\thecontroller\theactiontheformat')->will($this->returnValue(false));
         $this->mockObjectManager->expects($this->at(1))->method('getCaseSensitiveObjectName')->with('some\package\subpackage\view\thecontroller\theaction')->will($this->returnValue('ResolvedObjectName'));
 
-        $this->assertSame('ResolvedObjectName', $this->actionController->_call('resolveViewObjectName'));
+        self::assertSame('ResolvedObjectName', $this->actionController->_call('resolveViewObjectName'));
     }
 
     /**
@@ -104,7 +104,7 @@ class ActionControllerTest extends UnitTestCase
         $this->mockObjectManager->expects($this->at(0))->method('getCaseSensitiveObjectName')->with('some\package\subpackage\view\thecontroller\theactiontheformat')->will($this->returnValue(false));
         $this->mockObjectManager->expects($this->at(1))->method('getCaseSensitiveObjectName')->with('some\package\subpackage\view\thecontroller\theaction')->will($this->returnValue(false));
 
-        $this->assertSame('Some\Custom\View\Object\Name', $this->actionController->_call('resolveViewObjectName'));
+        self::assertSame('Some\Custom\View\Object\Name', $this->actionController->_call('resolveViewObjectName'));
     }
 
     /**
@@ -113,7 +113,7 @@ class ActionControllerTest extends UnitTestCase
     public function resolveViewReturnsViewResolvedByResolveViewObjectName()
     {
         $this->mockObjectManager->expects($this->atLeastOnce())->method('getCaseSensitiveObjectName')->with('some\package\subpackage\view\thecontroller\theactiontheformat')->will($this->returnValue(SimpleTemplateView::class));
-        $this->assertInstanceOf(SimpleTemplateView::class, $this->actionController->_call('resolveView'));
+        self::assertInstanceOf(SimpleTemplateView::class, $this->actionController->_call('resolveView'));
     }
 
     /**
@@ -123,7 +123,7 @@ class ActionControllerTest extends UnitTestCase
     {
         $this->mockObjectManager->expects($this->any())->method('getCaseSensitiveObjectName')->will($this->returnValue(false));
         $this->actionController->_set('defaultViewObjectName', SimpleTemplateView::class);
-        $this->assertInstanceOf(SimpleTemplateView::class, $this->actionController->_call('resolveView'));
+        self::assertInstanceOf(SimpleTemplateView::class, $this->actionController->_call('resolveView'));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/ArgumentTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/ArgumentTest.php
@@ -77,8 +77,8 @@ class ArgumentTest extends UnitTestCase
      */
     public function passingDataTypeToConstructorReallySetsTheDataType()
     {
-        $this->assertEquals('string', $this->simpleValueArgument->getDataType(), 'The specified data type has not been set correctly.');
-        $this->assertEquals('someName', $this->simpleValueArgument->getName(), 'The specified name has not been set correctly.');
+        self::assertEquals('string', $this->simpleValueArgument->getDataType(), 'The specified data type has not been set correctly.');
+        self::assertEquals('someName', $this->simpleValueArgument->getName(), 'The specified name has not been set correctly.');
     }
 
     /**
@@ -87,8 +87,8 @@ class ArgumentTest extends UnitTestCase
     public function setRequiredShouldProvideFluentInterfaceAndReallySetRequiredState()
     {
         $returnedArgument = $this->simpleValueArgument->setRequired(true);
-        $this->assertSame($this->simpleValueArgument, $returnedArgument, 'The returned argument is not the original argument.');
-        $this->assertTrue($this->simpleValueArgument->isRequired());
+        self::assertSame($this->simpleValueArgument, $returnedArgument, 'The returned argument is not the original argument.');
+        self::assertTrue($this->simpleValueArgument->isRequired());
     }
 
     /**
@@ -97,8 +97,8 @@ class ArgumentTest extends UnitTestCase
     public function setDefaultValueShouldProvideFluentInterfaceAndReallySetDefaultValue()
     {
         $returnedArgument = $this->simpleValueArgument->setDefaultValue('default');
-        $this->assertSame($this->simpleValueArgument, $returnedArgument, 'The returned argument is not the original argument.');
-        $this->assertSame('default', $this->simpleValueArgument->getDefaultValue());
+        self::assertSame($this->simpleValueArgument, $returnedArgument, 'The returned argument is not the original argument.');
+        self::assertSame('default', $this->simpleValueArgument->getDefaultValue());
     }
 
     /**
@@ -108,8 +108,8 @@ class ArgumentTest extends UnitTestCase
     {
         $mockValidator = $this->createMock(ValidatorInterface::class);
         $returnedArgument = $this->simpleValueArgument->setValidator($mockValidator);
-        $this->assertSame($this->simpleValueArgument, $returnedArgument, 'The returned argument is not the original argument.');
-        $this->assertSame($mockValidator, $this->simpleValueArgument->getValidator());
+        self::assertSame($this->simpleValueArgument, $returnedArgument, 'The returned argument is not the original argument.');
+        self::assertSame($mockValidator, $this->simpleValueArgument->getValidator());
     }
 
     /**
@@ -118,7 +118,7 @@ class ArgumentTest extends UnitTestCase
     public function setValueProvidesFluentInterface()
     {
         $returnedArgument = $this->simpleValueArgument->setValue(null);
-        $this->assertSame($this->simpleValueArgument, $returnedArgument, 'The returned argument is not the original argument.');
+        self::assertSame($this->simpleValueArgument, $returnedArgument, 'The returned argument is not the original argument.');
     }
 
 
@@ -129,7 +129,7 @@ class ArgumentTest extends UnitTestCase
     {
         $this->simpleValueArgument = new Mvc\Controller\Argument('dummy', 'string');
         $this->simpleValueArgument->setValue(null);
-        $this->assertNull($this->simpleValueArgument->getValue());
+        self::assertNull($this->simpleValueArgument->getValue());
     }
 
     /**
@@ -154,7 +154,7 @@ class ArgumentTest extends UnitTestCase
     public function setValueShouldCallPropertyMapperCorrectlyAndStoreResultInValue()
     {
         $this->setupPropertyMapperAndSetValue();
-        $this->assertSame('convertedValue', $this->simpleValueArgument->getValue());
+        self::assertSame('convertedValue', $this->simpleValueArgument->getValue());
     }
 
     /**
@@ -162,7 +162,7 @@ class ArgumentTest extends UnitTestCase
      */
     public function setValueShouldBeFluentInterface()
     {
-        $this->assertSame($this->simpleValueArgument, $this->setupPropertyMapperAndSetValue());
+        self::assertSame($this->simpleValueArgument, $this->setupPropertyMapperAndSetValue());
     }
 
     /**
@@ -179,7 +179,7 @@ class ArgumentTest extends UnitTestCase
 
         $this->simpleValueArgument->setValidator($mockValidator);
         $this->setupPropertyMapperAndSetValue();
-        $this->assertEquals([$error], $this->simpleValueArgument->getValidationResults()->getErrors());
+        self::assertEquals([$error], $this->simpleValueArgument->getValidationResults()->getErrors());
     }
 
     /**
@@ -187,7 +187,7 @@ class ArgumentTest extends UnitTestCase
      */
     public function defaultPropertyMappingConfigurationDoesNotAllowCreationOrModificationOfObjects()
     {
-        $this->assertNull($this->simpleValueArgument->getPropertyMappingConfiguration()->getConfigurationValue(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED));
-        $this->assertNull($this->simpleValueArgument->getPropertyMappingConfiguration()->getConfigurationValue(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED));
+        self::assertNull($this->simpleValueArgument->getPropertyMappingConfiguration()->getConfigurationValue(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED));
+        self::assertNull($this->simpleValueArgument->getPropertyMappingConfiguration()->getConfigurationValue(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED));
     }
 }

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/ArgumentsTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/ArgumentsTest.php
@@ -31,7 +31,7 @@ class ArgumentsTest extends UnitTestCase
         $newArgument = new Argument('argumentName1234', 'Text');
 
         $arguments->addArgument($newArgument);
-        $this->assertSame($newArgument, $arguments->getArgument('argumentName1234'), 'The added and retrieved argument is not the same.');
+        self::assertSame($newArgument, $arguments->getArgument('argumentName1234'), 'The added and retrieved argument is not the same.');
     }
 
     /**
@@ -47,7 +47,7 @@ class ArgumentsTest extends UnitTestCase
         $secondArgument = new Argument('argumentName1234', 'Text');
         $arguments->addArgument($secondArgument);
 
-        $this->assertSame($secondArgument, $arguments->getArgument('argumentName1234'), 'The added and retrieved argument is not the same.');
+        self::assertSame($secondArgument, $arguments->getArgument('argumentName1234'), 'The added and retrieved argument is not the same.');
     }
 
     /**
@@ -58,8 +58,8 @@ class ArgumentsTest extends UnitTestCase
         $arguments = new Arguments();
         $argument = new Argument('argumentName1234', 'Text');
         $arguments[] = $argument;
-        $this->assertTrue($arguments->hasArgument('argumentName1234'), 'Added argument does not exist.');
-        $this->assertSame($argument, $arguments->getArgument('argumentName1234'), 'Added and retrieved arguments are not the same.');
+        self::assertTrue($arguments->hasArgument('argumentName1234'), 'Added argument does not exist.');
+        self::assertSame($argument, $arguments->getArgument('argumentName1234'), 'Added and retrieved arguments are not the same.');
     }
 
     /**
@@ -69,7 +69,7 @@ class ArgumentsTest extends UnitTestCase
     {
         $arguments = new Arguments();
         $newArgument = $arguments->addNewArgument('someArgument');
-        $this->assertSame($newArgument, $arguments['someArgument'], 'Argument retrieved by array access is not the one we added.');
+        self::assertSame($newArgument, $arguments['someArgument'], 'Argument retrieved by array access is not the one we added.');
     }
 
     /**
@@ -82,7 +82,7 @@ class ArgumentsTest extends UnitTestCase
             $arguments->getArgument('someArgument');
             $this->fail('getArgument() did not throw an exception although the specified argument does not exist.');
         } catch (NoSuchArgumentException $exception) {
-            $this->assertTrue(true);
+            self::assertTrue(true);
         }
     }
 
@@ -92,9 +92,9 @@ class ArgumentsTest extends UnitTestCase
     public function issetReturnsCorrectResult()
     {
         $arguments = new Arguments();
-        $this->assertFalse(isset($arguments['someArgument']), 'isset() did not return false.');
+        self::assertFalse(isset($arguments['someArgument']), 'isset() did not return false.');
         $arguments->addNewArgument('someArgument');
-        $this->assertTrue(isset($arguments['someArgument']), 'isset() did not return true.');
+        self::assertTrue(isset($arguments['someArgument']), 'isset() did not return true.');
     }
 
     /**
@@ -108,7 +108,7 @@ class ArgumentsTest extends UnitTestCase
         $arguments->addNewArgument('third');
 
         $expectedArgumentNames = ['first', 'second', 'third'];
-        $this->assertEquals($expectedArgumentNames, $arguments->getArgumentNames(), 'Returned argument names were not as expected.');
+        self::assertEquals($expectedArgumentNames, $arguments->getArgumentNames(), 'Returned argument names were not as expected.');
     }
 
     /**
@@ -118,12 +118,12 @@ class ArgumentsTest extends UnitTestCase
     {
         $arguments = new Arguments();
         $addedArgument = $arguments->addNewArgument('dummyName');
-        $this->assertInstanceOf(Argument::class, $addedArgument, 'addNewArgument() either did not add a new argument or did not return it.');
+        self::assertInstanceOf(Argument::class, $addedArgument, 'addNewArgument() either did not add a new argument or did not return it.');
 
         $retrievedArgument = $arguments['dummyName'];
-        $this->assertSame($addedArgument, $retrievedArgument, 'The added and the retrieved argument are not the same.');
+        self::assertSame($addedArgument, $retrievedArgument, 'The added and the retrieved argument are not the same.');
 
-        $this->assertEquals('dummyName', $addedArgument->getName(), 'The name of the added argument is not as expected.');
+        self::assertEquals('dummyName', $addedArgument->getName(), 'The name of the added argument is not as expected.');
     }
 
     /**
@@ -133,7 +133,7 @@ class ArgumentsTest extends UnitTestCase
     {
         $arguments = new Arguments();
         $addedArgument = $arguments->addNewArgument('dummyName', 'Text', true);
-        $this->assertTrue($addedArgument->isRequired(), 'addNewArgument() did not create an argument that is marked as required.');
+        self::assertTrue($addedArgument->isRequired(), 'addNewArgument() did not create an argument that is marked as required.');
     }
 
     /**
@@ -144,7 +144,7 @@ class ArgumentsTest extends UnitTestCase
         $arguments = new Arguments();
         $defaultValue = 'Default Value 42';
         $addedArgument = $arguments->addNewArgument('dummyName', 'Text', false, $defaultValue);
-        $this->assertEquals($defaultValue, $addedArgument->getValue(), 'addNewArgument() did not store the default value in the argument.');
+        self::assertEquals($defaultValue, $addedArgument->getValue(), 'addNewArgument() did not store the default value in the argument.');
     }
 
     /**
@@ -167,7 +167,7 @@ class ArgumentsTest extends UnitTestCase
 
         $arguments->removeAll();
 
-        $this->assertFalse($arguments->hasArgument('foo'));
+        self::assertFalse($arguments->hasArgument('foo'));
     }
 
     /**
@@ -193,7 +193,7 @@ class ArgumentsTest extends UnitTestCase
         $arguments = new Arguments();
         $arguments->addArgument($argument1);
         $arguments->addArgument($argument2);
-        $this->assertSame(['name1' => [$error1], 'name2' => [$error2]], $arguments->getValidationResults()->getFlattenedErrors());
+        self::assertSame(['name1' => [$error1], 'name2' => [$error2]], $arguments->getValidationResults()->getFlattenedErrors());
     }
 
     /**
@@ -204,6 +204,6 @@ class ArgumentsTest extends UnitTestCase
         $arguments = new Arguments();
         $argument = $arguments->addNewArgument('someArgumentName');
 
-        $this->assertEquals('string', $argument->getDataType());
+        self::assertEquals('string', $argument->getDataType());
     }
 }

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/CommandControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/CommandControllerTest.php
@@ -95,9 +95,9 @@ class CommandControllerTest extends UnitTestCase
         $mockArguments->addNewArgument('foo');
         $this->inject($this->commandController, 'arguments', $mockArguments);
 
-        $this->assertCount(1, $this->commandController->_get('arguments'));
+        self::assertCount(1, $this->commandController->_get('arguments'));
         $this->commandController->processRequest($mockRequest, $mockResponse);
-        $this->assertCount(0, $this->commandController->_get('arguments'));
+        self::assertCount(0, $this->commandController->_get('arguments'));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/FlashMessageContainerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/FlashMessageContainerTest.php
@@ -43,11 +43,11 @@ class FlashMessageContainerTest extends UnitTestCase
         $this->flashMessageContainer->addMessage($messages[1]);
         $returnedFlashMessages = $this->flashMessageContainer->getMessages();
 
-        $this->assertEquals(count($returnedFlashMessages), 2);
+        self::assertEquals(count($returnedFlashMessages), 2);
 
         $i = 0;
         foreach ($returnedFlashMessages as $flashMessage) {
-            $this->assertEquals($flashMessage, $messages[$i++]);
+            self::assertEquals($flashMessage, $messages[$i++]);
         }
     }
 
@@ -59,7 +59,7 @@ class FlashMessageContainerTest extends UnitTestCase
         $message1 = new FlowError\Message('This is a test message');
         $this->flashMessageContainer->addMessage($message1);
         $this->flashMessageContainer->flush();
-        $this->assertEquals([], $this->flashMessageContainer->getMessages());
+        self::assertEquals([], $this->flashMessageContainer->getMessages());
     }
 
     /**
@@ -75,14 +75,14 @@ class FlashMessageContainerTest extends UnitTestCase
         $this->flashMessageContainer->addMessage($messages[1]);
         $returnedFlashMessages = $this->flashMessageContainer->getMessagesAndFlush();
 
-        $this->assertEquals(count($returnedFlashMessages), 2);
+        self::assertEquals(count($returnedFlashMessages), 2);
 
         $i = 0;
         foreach ($returnedFlashMessages as $flashMessage) {
-            $this->assertEquals($flashMessage, $messages[$i++]);
+            self::assertEquals($flashMessage, $messages[$i++]);
         }
 
-        $this->assertEquals([], $this->flashMessageContainer->getMessages());
+        self::assertEquals([], $this->flashMessageContainer->getMessages());
     }
 
     /**
@@ -99,11 +99,11 @@ class FlashMessageContainerTest extends UnitTestCase
 
         $filteredFlashMessages = $this->flashMessageContainer->getMessages(FlowError\Message::SEVERITY_NOTICE);
 
-        $this->assertEquals(count($filteredFlashMessages), 1);
+        self::assertEquals(count($filteredFlashMessages), 1);
 
         reset($filteredFlashMessages);
         $flashMessage = current($filteredFlashMessages);
-        $this->assertEquals($messages[0], $flashMessage);
+        self::assertEquals($messages[0], $flashMessage);
     }
 
     /**
@@ -120,13 +120,13 @@ class FlashMessageContainerTest extends UnitTestCase
 
         $filteredFlashMessages = $this->flashMessageContainer->getMessagesAndFlush(FlowError\Message::SEVERITY_NOTICE);
 
-        $this->assertEquals(count($filteredFlashMessages), 1);
+        self::assertEquals(count($filteredFlashMessages), 1);
 
         reset($filteredFlashMessages);
         $flashMessage = current($filteredFlashMessages);
-        $this->assertEquals($messages[0], $flashMessage);
+        self::assertEquals($messages[0], $flashMessage);
 
-        $this->assertEquals([], $this->flashMessageContainer->getMessages(FlowError\Message::SEVERITY_NOTICE));
-        $this->assertEquals([$messages[1]], array_values($this->flashMessageContainer->getMessages()));
+        self::assertEquals([], $this->flashMessageContainer->getMessages(FlowError\Message::SEVERITY_NOTICE));
+        self::assertEquals([$messages[1]], array_values($this->flashMessageContainer->getMessages()));
     }
 }

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/MvcPropertyMappingConfigurationServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/MvcPropertyMappingConfigurationServiceTest.php
@@ -153,7 +153,7 @@ class MvcPropertyMappingConfigurationServiceTest extends UnitTestCase
 
         $expected = serialize($formFieldArray) . $mockHash;
         $actual = $requestHashService->_call('serializeAndHashFormFieldArray', $formFieldArray);
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -190,7 +190,7 @@ class MvcPropertyMappingConfigurationServiceTest extends UnitTestCase
             'nonExistingArgument' => 1
         ];
         $arguments = $this->initializePropertyMappingConfiguration($trustedProperties);
-        $this->assertFalse($arguments->hasArgument('nonExistingArgument'));
+        self::assertFalse($arguments->hasArgument('nonExistingArgument'));
     }
 
     /**
@@ -208,13 +208,13 @@ class MvcPropertyMappingConfigurationServiceTest extends UnitTestCase
         ];
         $arguments = $this->initializePropertyMappingConfiguration($trustedProperties);
         $propertyMappingConfiguration = $arguments->getArgument('foo')->getPropertyMappingConfiguration();
-        $this->assertTrue($propertyMappingConfiguration->getConfigurationValue(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED));
-        $this->assertNull($propertyMappingConfiguration->getConfigurationValue(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED));
-        $this->assertFalse($propertyMappingConfiguration->shouldMap('someProperty'));
+        self::assertTrue($propertyMappingConfiguration->getConfigurationValue(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED));
+        self::assertNull($propertyMappingConfiguration->getConfigurationValue(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED));
+        self::assertFalse($propertyMappingConfiguration->shouldMap('someProperty'));
 
-        $this->assertTrue($propertyMappingConfiguration->forProperty('nested')->getConfigurationValue(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED));
-        $this->assertNull($propertyMappingConfiguration->forProperty('nested')->getConfigurationValue(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED));
-        $this->assertFalse($propertyMappingConfiguration->forProperty('nested')->shouldMap('someProperty'));
+        self::assertTrue($propertyMappingConfiguration->forProperty('nested')->getConfigurationValue(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED));
+        self::assertNull($propertyMappingConfiguration->forProperty('nested')->getConfigurationValue(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED));
+        self::assertFalse($propertyMappingConfiguration->forProperty('nested')->shouldMap('someProperty'));
     }
 
     /**
@@ -229,13 +229,13 @@ class MvcPropertyMappingConfigurationServiceTest extends UnitTestCase
         ];
         $arguments = $this->initializePropertyMappingConfiguration($trustedProperties);
         $propertyMappingConfiguration = $arguments->getArgument('foo')->getPropertyMappingConfiguration();
-        $this->assertNull($propertyMappingConfiguration->getConfigurationValue(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED));
-        $this->assertTrue($propertyMappingConfiguration->getConfigurationValue(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED));
-        $this->assertFalse($propertyMappingConfiguration->shouldMap('someProperty'));
+        self::assertNull($propertyMappingConfiguration->getConfigurationValue(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED));
+        self::assertTrue($propertyMappingConfiguration->getConfigurationValue(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED));
+        self::assertFalse($propertyMappingConfiguration->shouldMap('someProperty'));
 
-        $this->assertNull($propertyMappingConfiguration->forProperty('bar')->getConfigurationValue(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED));
-        $this->assertTrue($propertyMappingConfiguration->forProperty('bar')->getConfigurationValue(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED));
-        $this->assertFalse($propertyMappingConfiguration->forProperty('bar')->shouldMap('someProperty'));
+        self::assertNull($propertyMappingConfiguration->forProperty('bar')->getConfigurationValue(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED));
+        self::assertTrue($propertyMappingConfiguration->forProperty('bar')->getConfigurationValue(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED));
+        self::assertFalse($propertyMappingConfiguration->forProperty('bar')->shouldMap('someProperty'));
     }
 
     /**
@@ -250,8 +250,8 @@ class MvcPropertyMappingConfigurationServiceTest extends UnitTestCase
         ];
         $arguments = $this->initializePropertyMappingConfiguration($trustedProperties);
         $propertyMappingConfiguration = $arguments->getArgument('foo')->getPropertyMappingConfiguration();
-        $this->assertFalse($propertyMappingConfiguration->shouldMap('someProperty'));
-        $this->assertTrue($propertyMappingConfiguration->shouldMap('bar'));
+        self::assertFalse($propertyMappingConfiguration->shouldMap('someProperty'));
+        self::assertTrue($propertyMappingConfiguration->shouldMap('bar'));
     }
 
     /**
@@ -268,9 +268,9 @@ class MvcPropertyMappingConfigurationServiceTest extends UnitTestCase
         ];
         $arguments = $this->initializePropertyMappingConfiguration($trustedProperties);
         $propertyMappingConfiguration = $arguments->getArgument('foo')->getPropertyMappingConfiguration();
-        $this->assertFalse($propertyMappingConfiguration->shouldMap('someProperty'));
-        $this->assertTrue($propertyMappingConfiguration->shouldMap('bar'));
-        $this->assertTrue($propertyMappingConfiguration->forProperty('bar')->shouldMap('foo'));
+        self::assertFalse($propertyMappingConfiguration->shouldMap('someProperty'));
+        self::assertTrue($propertyMappingConfiguration->shouldMap('bar'));
+        self::assertTrue($propertyMappingConfiguration->forProperty('bar')->shouldMap('foo'));
     }
 
 

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/MvcPropertyMappingConfigurationTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/MvcPropertyMappingConfigurationTest.php
@@ -52,6 +52,6 @@ class MvcPropertyMappingConfigurationTest extends UnitTestCase
     public function respectiveMethodsProvideFluentInterface($methodToTestForFluentInterface, array $argumentsForMethod = [])
     {
         $actualResult = call_user_func_array([$this->mvcPropertyMappingConfiguration, $methodToTestForFluentInterface], $argumentsForMethod);
-        $this->assertSame($this->mvcPropertyMappingConfiguration, $actualResult);
+        self::assertSame($this->mvcPropertyMappingConfiguration, $actualResult);
     }
 }

--- a/Neos.Flow/Tests/Unit/Mvc/DispatchComponentTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/DispatchComponentTest.php
@@ -214,7 +214,7 @@ class DispatchComponentTest extends UnitTestCase
         $componentContext->setParameter(DispatchComponent::class, 'actionRequest', $this->mockActionRequest);
         $this->dispatchComponent->handle($componentContext);
         // TODO: This can be cleaned for next major when ActionResponse and HttpResponse are cleanly separated.
-        $this->assertInstanceOf(ActionResponse::class, $componentContext->getHttpResponse());
+        self::assertInstanceOf(ActionResponse::class, $componentContext->getHttpResponse());
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Mvc/DispatcherTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/DispatcherTest.php
@@ -372,7 +372,7 @@ class DispatcherTest extends UnitTestCase
         $dispatcher = $this->getAccessibleMock(Dispatcher::class, null);
         $dispatcher->injectObjectManager($mockObjectManager);
 
-        $this->assertEquals($mockController, $dispatcher->_call('resolveController', $mockRequest));
+        self::assertEquals($mockController, $dispatcher->_call('resolveController', $mockRequest));
     }
 
     /**
@@ -394,7 +394,7 @@ class DispatcherTest extends UnitTestCase
         $dispatcher = $this->getAccessibleMock(Dispatcher::class, ['dummy']);
         $dispatcher->injectObjectManager($mockObjectManager);
 
-        $this->assertEquals($mockController, $dispatcher->_call('resolveController', $mockRequest));
+        self::assertEquals($mockController, $dispatcher->_call('resolveController', $mockRequest));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Mvc/ResponseTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/ResponseTest.php
@@ -29,6 +29,6 @@ class ResponseTest extends UnitTestCase
 
         $expected = 'SomeContent';
         $actual = $response->__toString();
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/MatchResultTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/MatchResultTest.php
@@ -27,7 +27,7 @@ class MatchResultTest extends UnitTestCase
     {
         $matchedValue = new \stdClass();
         $matchResult = new MatchResult($matchedValue);
-        $this->assertSame($matchedValue, $matchResult->getMatchedValue());
+        self::assertSame($matchedValue, $matchResult->getMatchedValue());
     }
 
     /**
@@ -36,7 +36,7 @@ class MatchResultTest extends UnitTestCase
     public function hasTagsIsFalseByDefault()
     {
         $matchResult = new MatchResult('matchedValue');
-        $this->assertFalse($matchResult->hasTags());
+        self::assertFalse($matchResult->hasTags());
     }
 
     /**
@@ -46,7 +46,7 @@ class MatchResultTest extends UnitTestCase
     {
         $tags = RouteTags::createEmpty();
         $matchResult = new MatchResult('matchedValue', $tags);
-        $this->assertTrue($matchResult->hasTags());
+        self::assertTrue($matchResult->hasTags());
     }
 
     /**
@@ -55,7 +55,7 @@ class MatchResultTest extends UnitTestCase
     public function getTagsReturnsNullByDefault()
     {
         $matchResult = new MatchResult('matchedValue');
-        $this->assertNull($matchResult->getTags());
+        self::assertNull($matchResult->getTags());
     }
 
     /**
@@ -65,6 +65,6 @@ class MatchResultTest extends UnitTestCase
     {
         $tags = RouteTags::createEmpty()->withTag('foo');
         $matchResult = new MatchResult('matchedValue', $tags);
-        $this->assertSame($tags, $matchResult->getTags());
+        self::assertSame($tags, $matchResult->getTags());
     }
 }

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/RouteContextTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/RouteContextTest.php
@@ -70,7 +70,7 @@ class RouteContextTest extends UnitTestCase
         $this->mockHttpRequest2->expects($this->atLeastOnce())->method('getMethod')->will($this->returnValue('POST'));
         $cacheIdentifier2 = (new RouteContext($this->mockHttpRequest2, RouteParameters::createEmpty()))->getCacheEntryIdentifier();
 
-        $this->assertSame($cacheIdentifier1, $cacheIdentifier2);
+        self::assertSame($cacheIdentifier1, $cacheIdentifier2);
     }
 
     /**
@@ -84,7 +84,7 @@ class RouteContextTest extends UnitTestCase
         $this->mockUri2->expects($this->atLeastOnce())->method('getHost')->will($this->returnValue('host2.io'));
         $cacheIdentifier2 = (new RouteContext($this->mockHttpRequest2, RouteParameters::createEmpty()))->getCacheEntryIdentifier();
 
-        $this->assertNotSame($cacheIdentifier1, $cacheIdentifier2);
+        self::assertNotSame($cacheIdentifier1, $cacheIdentifier2);
     }
 
     /**
@@ -98,7 +98,7 @@ class RouteContextTest extends UnitTestCase
         $this->mockHttpRequest2->expects($this->atLeastOnce())->method('getRelativePath')->will($this->returnValue('relative/path2'));
         $cacheIdentifier2 = (new RouteContext($this->mockHttpRequest2, RouteParameters::createEmpty()))->getCacheEntryIdentifier();
 
-        $this->assertNotSame($cacheIdentifier1, $cacheIdentifier2);
+        self::assertNotSame($cacheIdentifier1, $cacheIdentifier2);
     }
 
     /**
@@ -112,7 +112,7 @@ class RouteContextTest extends UnitTestCase
         $this->mockHttpRequest2->expects($this->atLeastOnce())->method('getMethod')->will($this->returnValue('POST'));
         $cacheIdentifier2 = (new RouteContext($this->mockHttpRequest2, RouteParameters::createEmpty()))->getCacheEntryIdentifier();
 
-        $this->assertNotSame($cacheIdentifier1, $cacheIdentifier2);
+        self::assertNotSame($cacheIdentifier1, $cacheIdentifier2);
     }
 
     /**
@@ -126,7 +126,7 @@ class RouteContextTest extends UnitTestCase
         $this->mockUri2->expects($this->any())->method('getScheme')->will($this->returnValue('https'));
         $cacheIdentifier2 = (new RouteContext($this->mockHttpRequest2, RouteParameters::createEmpty()))->getCacheEntryIdentifier();
 
-        $this->assertSame($cacheIdentifier1, $cacheIdentifier2);
+        self::assertSame($cacheIdentifier1, $cacheIdentifier2);
     }
 
     /**
@@ -140,7 +140,7 @@ class RouteContextTest extends UnitTestCase
         $this->mockUri2->expects($this->any())->method('getQuery')->will($this->returnValue('query2'));
         $cacheIdentifier2 = (new RouteContext($this->mockHttpRequest2, RouteParameters::createEmpty()))->getCacheEntryIdentifier();
 
-        $this->assertSame($cacheIdentifier1, $cacheIdentifier2);
+        self::assertSame($cacheIdentifier1, $cacheIdentifier2);
     }
 
     /**
@@ -154,7 +154,7 @@ class RouteContextTest extends UnitTestCase
         $this->mockUri2->expects($this->any())->method('getFragment')->will($this->returnValue('fragment2'));
         $cacheIdentifier2 = (new RouteContext($this->mockHttpRequest2, RouteParameters::createEmpty()))->getCacheEntryIdentifier();
 
-        $this->assertSame($cacheIdentifier1, $cacheIdentifier2);
+        self::assertSame($cacheIdentifier1, $cacheIdentifier2);
     }
 
     /**
@@ -168,6 +168,6 @@ class RouteContextTest extends UnitTestCase
         $parameters2 = $parameters1->withParameter('newParameter', 'someValue');
         $cacheIdentifier2 = (new RouteContext($this->mockHttpRequest1, $parameters2))->getCacheEntryIdentifier();
 
-        $this->assertNotSame($cacheIdentifier1, $cacheIdentifier2);
+        self::assertNotSame($cacheIdentifier1, $cacheIdentifier2);
     }
 }

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/RouteParametersTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/RouteParametersTest.php
@@ -69,7 +69,7 @@ class RouteParametersTest extends UnitTestCase
     {
         $originalParameters = RouteParameters::createEmpty();
         $originalParameters->withParameter('someParameter', 'someValue');
-        $this->assertFalse($originalParameters->has('someParameter'));
+        self::assertFalse($originalParameters->has('someParameter'));
     }
 
     /**
@@ -78,7 +78,7 @@ class RouteParametersTest extends UnitTestCase
     public function withParameterReturnsANewInstanceWithTheGivenParameter()
     {
         $originalParameters = RouteParameters::createEmpty()->withParameter('someParameter', 'someValue');
-        $this->assertSame('someValue', $originalParameters->getValue('someParameter'));
+        self::assertSame('someValue', $originalParameters->getValue('someParameter'));
     }
 
     /**
@@ -88,6 +88,6 @@ class RouteParametersTest extends UnitTestCase
     {
         $originalParameters = RouteParameters::createEmpty()->withParameter('someParameter', 'someValue');
         $originalParameters = $originalParameters->withParameter('someParameter', 'overriddenValue');
-        $this->assertSame('overriddenValue', $originalParameters->getValue('someParameter'));
+        self::assertSame('overriddenValue', $originalParameters->getValue('someParameter'));
     }
 }

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/RouteTagsTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/RouteTagsTest.php
@@ -44,7 +44,7 @@ class RouteTagsTest extends UnitTestCase
     public function createFromTagCreatesANewInstanceWithTheGivenTag()
     {
         $tags = RouteTags::createFromTag('foo');
-        $this->assertSame(['foo'], $tags->getTags());
+        self::assertSame(['foo'], $tags->getTags());
     }
 
     /**
@@ -53,7 +53,7 @@ class RouteTagsTest extends UnitTestCase
     public function createFromArrayCreatesAnInstanceWithAllGivenTags()
     {
         $tags = RouteTags::createFromArray(['foo', 'bar', 'baz']);
-        $this->assertSame(['foo', 'bar', 'baz'], $tags->getTags());
+        self::assertSame(['foo', 'bar', 'baz'], $tags->getTags());
     }
 
     /**
@@ -82,7 +82,7 @@ class RouteTagsTest extends UnitTestCase
         $tags1 = RouteTags::createEmpty()->withTag('foo')->withTag('bar');
         $tags2 = RouteTags::createEmpty()->withTag('foo')->withTag('baz');
         $mergedTags = $tags1->merge($tags2);
-        $this->assertSame(['foo', 'bar', 'baz'], $mergedTags->getTags());
+        self::assertSame(['foo', 'bar', 'baz'], $mergedTags->getTags());
     }
 
     /**
@@ -93,7 +93,7 @@ class RouteTagsTest extends UnitTestCase
         $tags1 = RouteTags::createEmpty()->withTag('foo');
         $tags2 = $tags1->withTag('foo');
 
-        $this->assertSame($tags1, $tags2);
+        self::assertSame($tags1, $tags2);
     }
 
     /**
@@ -104,7 +104,7 @@ class RouteTagsTest extends UnitTestCase
         $tags1 = RouteTags::createEmpty()->withTag('foo');
         $tags2 = $tags1->withTag('bar');
 
-        $this->assertTrue($tags2->has('bar'));
+        self::assertTrue($tags2->has('bar'));
     }
 
     /**
@@ -115,6 +115,6 @@ class RouteTagsTest extends UnitTestCase
         $tags1 = RouteTags::createEmpty()->withTag('foo');
         $tags1->withTag('bar');
 
-        $this->assertFalse($tags1->has('bar'));
+        self::assertFalse($tags1->has('bar'));
     }
 }

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/UriConstraintsTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/UriConstraintsTest.php
@@ -30,7 +30,7 @@ class UriConstraintsTest extends UnitTestCase
         $uriConstraints2 = UriConstraints::create()->withPath('some/overridden/path');
 
         $mergedUriConstraints = $uriConstraints1->merge($uriConstraints2);
-        $this->assertSame('some/overridden/path', $mergedUriConstraints->getPathConstraint());
+        self::assertSame('some/overridden/path', $mergedUriConstraints->getPathConstraint());
     }
 
     public function applyToDataProvider()
@@ -96,7 +96,7 @@ class UriConstraintsTest extends UnitTestCase
         $this->inject($uriConstraints, 'constraints', $constraints);
 
         $resultingUri = $uriConstraints->applyTo(new Uri($templateUri), $forceAbsoluteUri);
-        $this->assertSame($expectedUri, (string)$resultingUri);
+        self::assertSame($expectedUri, (string)$resultingUri);
     }
 
     /**
@@ -108,7 +108,7 @@ class UriConstraintsTest extends UnitTestCase
         $expectedResult = [
             UriConstraints::CONSTRAINT_SCHEME => 'scheme-constraint'
         ];
-        $this->assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
+        self::assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
     }
 
     /**
@@ -120,7 +120,7 @@ class UriConstraintsTest extends UnitTestCase
         $expectedResult = [
             UriConstraints::CONSTRAINT_HOST => 'host-constraint'
         ];
-        $this->assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
+        self::assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
     }
 
     /**
@@ -135,7 +135,7 @@ class UriConstraintsTest extends UnitTestCase
                 'replacePrefixes' => ['replace', 'prefixes'],
             ]
         ];
-        $this->assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
+        self::assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
     }
 
     /**
@@ -150,7 +150,7 @@ class UriConstraintsTest extends UnitTestCase
                 'replaceSuffixes' => ['replace', 'suffixes'],
             ]
         ];
-        $this->assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
+        self::assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
     }
 
 
@@ -163,7 +163,7 @@ class UriConstraintsTest extends UnitTestCase
         $expectedResult = [
             UriConstraints::CONSTRAINT_PORT => 1234
         ];
-        $this->assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
+        self::assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
     }
 
     /**
@@ -175,7 +175,7 @@ class UriConstraintsTest extends UnitTestCase
         $expectedResult = [
             UriConstraints::CONSTRAINT_PATH => 'path-constraint'
         ];
-        $this->assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
+        self::assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
     }
 
     /**
@@ -187,7 +187,7 @@ class UriConstraintsTest extends UnitTestCase
         $expectedResult = [
             UriConstraints::CONSTRAINT_PATH_PREFIX => 'path-prefix-constraint'
         ];
-        $this->assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
+        self::assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
     }
 
     /**
@@ -199,7 +199,7 @@ class UriConstraintsTest extends UnitTestCase
         $expectedResult = [
             UriConstraints::CONSTRAINT_PATH_PREFIX => 'prefix2prefix1'
         ];
-        $this->assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
+        self::assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
     }
 
     /**
@@ -211,7 +211,7 @@ class UriConstraintsTest extends UnitTestCase
         $expectedResult = [
             UriConstraints::CONSTRAINT_PATH_PREFIX => 'prefix1prefix2'
         ];
-        $this->assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
+        self::assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
     }
 
     /**
@@ -223,7 +223,7 @@ class UriConstraintsTest extends UnitTestCase
         $expectedResult = [
             UriConstraints::CONSTRAINT_PATH_SUFFIX => 'path-suffix-constraint'
         ];
-        $this->assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
+        self::assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
     }
 
     /**
@@ -235,7 +235,7 @@ class UriConstraintsTest extends UnitTestCase
         $expectedResult = [
             UriConstraints::CONSTRAINT_PATH_SUFFIX => 'suffix1suffix2'
         ];
-        $this->assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
+        self::assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
     }
 
     /**
@@ -247,7 +247,7 @@ class UriConstraintsTest extends UnitTestCase
         $expectedResult = [
             UriConstraints::CONSTRAINT_PATH_SUFFIX => 'suffix2suffix1'
         ];
-        $this->assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
+        self::assertSame($expectedResult, ObjectAccess::getProperty($uriConstraints, 'constraints', true));
     }
 
     /**
@@ -255,7 +255,7 @@ class UriConstraintsTest extends UnitTestCase
      */
     public function getPathConstraintReturnsNullByDefault()
     {
-        $this->assertNull(UriConstraints::create()->getPathConstraint());
+        self::assertNull(UriConstraints::create()->getPathConstraint());
     }
 
     /**
@@ -267,6 +267,6 @@ class UriConstraintsTest extends UnitTestCase
             ->withPath('some/path')
             ->withPathPrefix('prefix')
             ->withPathSuffix('suffix');
-        $this->assertSame('some/path', $uriConstraints->getPathConstraint());
+        self::assertSame('some/path', $uriConstraints->getPathConstraint());
     }
 }

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/DynamicRoutePartTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/DynamicRoutePartTest.php
@@ -51,10 +51,10 @@ class DynamicRoutePartTest extends UnitTestCase
         $this->dynamicRoutPart->setName('foo');
 
         $routePath = null;
-        $this->assertFalse($this->dynamicRoutPart->match($routePath), 'Dynamic Route Part should not match if $routePath is NULL.');
+        self::assertFalse($this->dynamicRoutPart->match($routePath), 'Dynamic Route Part should not match if $routePath is NULL.');
 
         $routePath = '';
-        $this->assertFalse($this->dynamicRoutPart->match($routePath), 'Dynamic Route Part should not match if $routePath is empty.');
+        self::assertFalse($this->dynamicRoutPart->match($routePath), 'Dynamic Route Part should not match if $routePath is empty.');
     }
 
     /**
@@ -66,7 +66,7 @@ class DynamicRoutePartTest extends UnitTestCase
         $this->dynamicRoutPart->setDefaultValue('bar');
 
         $routePath = '';
-        $this->assertFalse($this->dynamicRoutPart->match($routePath), 'Dynamic Route Part should not match if $routePath is empty.');
+        self::assertFalse($this->dynamicRoutPart->match($routePath), 'Dynamic Route Part should not match if $routePath is empty.');
     }
 
     /**
@@ -76,7 +76,7 @@ class DynamicRoutePartTest extends UnitTestCase
     {
         $routePath = 'foo';
 
-        $this->assertFalse($this->dynamicRoutPart->match($routePath), 'Dynamic Route Part should not match if name is not set.');
+        self::assertFalse($this->dynamicRoutPart->match($routePath), 'Dynamic Route Part should not match if name is not set.');
     }
 
 
@@ -92,7 +92,7 @@ class DynamicRoutePartTest extends UnitTestCase
         $routePath = 'firstSegment/secondSegment';
         $matchResult = $this->dynamicRoutPart->match($routePath);
 
-        $this->assertEquals('firstSegment', $matchResult->getMatchedValue(), 'value of Dynamic Route Part should be equal to first request path segment after successful match.');
+        self::assertEquals('firstSegment', $matchResult->getMatchedValue(), 'value of Dynamic Route Part should be equal to first request path segment after successful match.');
     }
 
     /**
@@ -107,7 +107,7 @@ class DynamicRoutePartTest extends UnitTestCase
         $routePath = 'some%20%5c%20special%20%c3%b6%c3%a4%c3%bc%c3%9f/secondSegment';
         $matchResult = $this->dynamicRoutPart->match($routePath);
 
-        $this->assertEquals('some \ special öäüß', $matchResult->getMatchedValue(), 'value of Dynamic Route Part should be equal to first request path segment after successful match.');
+        self::assertEquals('some \ special öäüß', $matchResult->getMatchedValue(), 'value of Dynamic Route Part should be equal to first request path segment after successful match.');
     }
 
     /**
@@ -121,7 +121,7 @@ class DynamicRoutePartTest extends UnitTestCase
         $routePath = 'bar/foo/test';
         $this->dynamicRoutPart->match($routePath);
 
-        $this->assertSame('/foo/test', $routePath, 'Dynamic Route Part should shorten request path by one segment on successful match.');
+        self::assertSame('/foo/test', $routePath, 'Dynamic Route Part should shorten request path by one segment on successful match.');
     }
 
     /**
@@ -133,7 +133,7 @@ class DynamicRoutePartTest extends UnitTestCase
 
         $routePath = 'foo/bar';
 
-        $this->assertFalse($this->dynamicRoutPart->match($routePath), 'Dynamic Route Part should not match if request Path has more than one segment and no split string is set.');
+        self::assertFalse($this->dynamicRoutPart->match($routePath), 'Dynamic Route Part should not match if request Path has more than one segment and no split string is set.');
     }
 
     /**
@@ -146,7 +146,7 @@ class DynamicRoutePartTest extends UnitTestCase
 
         $routePath = 'foo/bar';
 
-        $this->assertFalse($this->dynamicRoutPart->match($routePath), 'Dynamic Route Part should not match if request Path has more than one segment and does not contain split string.');
+        self::assertFalse($this->dynamicRoutPart->match($routePath), 'Dynamic Route Part should not match if request Path has more than one segment and does not contain split string.');
     }
 
     /**
@@ -159,7 +159,7 @@ class DynamicRoutePartTest extends UnitTestCase
         $routePath = 'bar';
 
         $matchResult = $this->dynamicRoutPart->match($routePath);
-        $this->assertEquals('bar', $matchResult->getMatchedValue(), 'Dynamic Route Part should match if request Path has only one segment and no split string is set.');
+        self::assertEquals('bar', $matchResult->getMatchedValue(), 'Dynamic Route Part should match if request Path has only one segment and no split string is set.');
     }
 
     /**
@@ -173,7 +173,7 @@ class DynamicRoutePartTest extends UnitTestCase
         $routePath = 'bar';
 
         $matchResult = $this->dynamicRoutPart->match($routePath);
-        $this->assertEquals('bar', $matchResult->getMatchedValue(), 'Dynamic Route Part should match if request Path has only one segment and does not contain split string.');
+        self::assertEquals('bar', $matchResult->getMatchedValue(), 'Dynamic Route Part should match if request Path has only one segment and does not contain split string.');
     }
 
     /**
@@ -186,7 +186,7 @@ class DynamicRoutePartTest extends UnitTestCase
 
         $routePath = '-foo/bar';
 
-        $this->assertFalse($this->dynamicRoutPart->match($routePath), 'Dynamic Route Part should not match if split string is first character of current request path.');
+        self::assertFalse($this->dynamicRoutPart->match($routePath), 'Dynamic Route Part should not match if split string is first character of current request path.');
     }
 
     /**
@@ -198,7 +198,7 @@ class DynamicRoutePartTest extends UnitTestCase
         $this->dynamicRoutPart->setSplitString('_-_');
 
         $routePath = 'foo_-_bar';
-        $this->assertNotFalse($this->dynamicRoutPart->match($routePath), 'Dynamic Route Part with a split string of "_-_" should match request path of "foo_-_bar".');
+        self::assertNotFalse($this->dynamicRoutPart->match($routePath), 'Dynamic Route Part with a split string of "_-_" should match request path of "foo_-_bar".');
     }
 
     /*                                                                        *
@@ -212,7 +212,7 @@ class DynamicRoutePartTest extends UnitTestCase
     {
         $routeValues = ['foo' => 'bar'];
 
-        $this->assertFalse($this->dynamicRoutPart->resolve($routeValues), 'Dynamic Route Part should not resolve if name is not set.');
+        self::assertFalse($this->dynamicRoutPart->resolve($routeValues), 'Dynamic Route Part should not resolve if name is not set.');
     }
 
     /**
@@ -224,7 +224,7 @@ class DynamicRoutePartTest extends UnitTestCase
         $routeValues = ['foo' => 'bar'];
 
         $resolveResult = $this->dynamicRoutPart->resolve($routeValues);
-        $this->assertEquals('bar', $resolveResult->getResolvedValue(), 'Dynamic Route Part should resolve if an element with the same name exists in $routeValues.');
+        self::assertEquals('bar', $resolveResult->getResolvedValue(), 'Dynamic Route Part should resolve if an element with the same name exists in $routeValues.');
     }
 
     /**
@@ -239,7 +239,7 @@ class DynamicRoutePartTest extends UnitTestCase
         $routeValues = ['foo' => 'some \ special öäüß'];
 
         $resolveResult = $this->dynamicRoutPart->resolve($routeValues);
-        $this->assertEquals('some%20%5c%20special%20%c3%b6%c3%a4%c3%bc%c3%9f', $resolveResult->getResolvedValue());
+        self::assertEquals('some%20%5c%20special%20%c3%b6%c3%a4%c3%bc%c3%9f', $resolveResult->getResolvedValue());
     }
 
     /**
@@ -250,7 +250,7 @@ class DynamicRoutePartTest extends UnitTestCase
         $this->dynamicRoutPart->setName('foo');
         $routeValues = [];
 
-        $this->assertFalse($this->dynamicRoutPart->resolve($routeValues), 'Dynamic Route Part should not resolve an empty $routeValues-array.');
+        self::assertFalse($this->dynamicRoutPart->resolve($routeValues), 'Dynamic Route Part should not resolve an empty $routeValues-array.');
     }
 
     /**
@@ -262,7 +262,7 @@ class DynamicRoutePartTest extends UnitTestCase
         $this->dynamicRoutPart->setDefaultValue('defaultValue');
         $routeValues = [];
 
-        $this->assertFalse($this->dynamicRoutPart->resolve($routeValues), 'Dynamic Route Part should not resolve an empty $routeValues-array even if default Value is set.');
+        self::assertFalse($this->dynamicRoutPart->resolve($routeValues), 'Dynamic Route Part should not resolve an empty $routeValues-array even if default Value is set.');
     }
 
     /**
@@ -274,7 +274,7 @@ class DynamicRoutePartTest extends UnitTestCase
         $routeValues = ['Foo' => 'Bar'];
 
         $resolveResult = $this->dynamicRoutPart->resolve($routeValues);
-        $this->assertEquals('bar', $resolveResult->getResolvedValue(), 'By default Dynamic Route Part should lowercase route values.');
+        self::assertEquals('bar', $resolveResult->getResolvedValue(), 'By default Dynamic Route Part should lowercase route values.');
     }
 
     /**
@@ -287,7 +287,7 @@ class DynamicRoutePartTest extends UnitTestCase
         $routeValues = ['Foo' => 'Bar'];
 
         $resolveResult = $this->dynamicRoutPart->resolve($routeValues);
-        $this->assertEquals('Bar', $resolveResult->getResolvedValue(), 'Dynamic Route Part should not change the case of the value if lowerCase is false.');
+        self::assertEquals('Bar', $resolveResult->getResolvedValue(), 'Dynamic Route Part should not change the case of the value if lowerCase is false.');
     }
 
     /**
@@ -298,7 +298,7 @@ class DynamicRoutePartTest extends UnitTestCase
         $this->dynamicRoutPart->setName('foo');
         $routeValues = ['notFoo' => 'bar'];
 
-        $this->assertFalse($this->dynamicRoutPart->resolve($routeValues), 'Dynamic Route Part should not resolve if no element with the same name exists in $routeValues and no default value is set.');
+        self::assertFalse($this->dynamicRoutPart->resolve($routeValues), 'Dynamic Route Part should not resolve if no element with the same name exists in $routeValues and no default value is set.');
     }
 
     /**
@@ -310,8 +310,8 @@ class DynamicRoutePartTest extends UnitTestCase
         $routeValues = ['foo' => 'bar', 'differentString' => 'value2'];
 
         $resolveResult = $this->dynamicRoutPart->resolve($routeValues);
-        $this->assertNotFalse($resolveResult);
-        $this->assertEquals(['differentString' => 'value2'], $routeValues, 'Dynamic Route Part should unset matching element from $routeValues on successful resolve.');
+        self::assertNotFalse($resolveResult);
+        self::assertEquals(['differentString' => 'value2'], $routeValues, 'Dynamic Route Part should unset matching element from $routeValues on successful resolve.');
     }
 
     /**
@@ -323,8 +323,8 @@ class DynamicRoutePartTest extends UnitTestCase
         $routeValues = ['foo' => ['bar' => ['baz' => 'should be removed', 'otherKey' => 'should stay']], 'differentString' => 'value2'];
 
         $resolveResult = $this->dynamicRoutPart->resolve($routeValues);
-        $this->assertNotFalse($resolveResult);
-        $this->assertEquals(['foo' => ['bar' => ['otherKey' => 'should stay']], 'differentString' => 'value2'], $routeValues);
+        self::assertNotFalse($resolveResult);
+        self::assertEquals(['foo' => ['bar' => ['otherKey' => 'should stay']], 'differentString' => 'value2'], $routeValues);
     }
 
     /**
@@ -335,8 +335,8 @@ class DynamicRoutePartTest extends UnitTestCase
         $this->dynamicRoutPart->setName('foo');
         $routeValues = ['differentString' => 'bar'];
 
-        $this->assertFalse($this->dynamicRoutPart->resolve($routeValues));
-        $this->assertEquals(['differentString' => 'bar'], $routeValues, 'Dynamic Route Part should not change $routeValues on unsuccessful resolve.');
+        self::assertFalse($this->dynamicRoutPart->resolve($routeValues));
+        self::assertEquals(['differentString' => 'bar'], $routeValues, 'Dynamic Route Part should not change $routeValues on unsuccessful resolve.');
     }
 
     /**
@@ -348,7 +348,7 @@ class DynamicRoutePartTest extends UnitTestCase
         $this->mockPersistenceManager->expects($this->once())->method('getIdentifierByObject')->with($object)->will($this->returnValue('TheIdentifier'));
         /** @var ResolveResult $resolveResult */
         $resolveResult = $this->dynamicRoutPart->_call('resolveValue', $object);
-        $this->assertSame('theidentifier', $resolveResult->getResolvedValue());
+        self::assertSame('theidentifier', $resolveResult->getResolvedValue());
     }
 
     /**
@@ -361,7 +361,7 @@ class DynamicRoutePartTest extends UnitTestCase
         $this->dynamicRoutPart->setLowerCase(false);
         /** @var ResolveResult $resolveResult */
         $resolveResult = $this->dynamicRoutPart->_call('resolveValue', $object);
-        $this->assertSame('TheIdentifier', $resolveResult->getResolvedValue());
+        self::assertSame('TheIdentifier', $resolveResult->getResolvedValue());
     }
 
     /**
@@ -371,7 +371,7 @@ class DynamicRoutePartTest extends UnitTestCase
     {
         $object = new \stdClass();
         $this->mockPersistenceManager->expects($this->once())->method('getIdentifierByObject')->with($object)->will($this->returnValue(123));
-        $this->assertNotFalse($this->dynamicRoutPart->_call('resolveValue', $object));
+        self::assertNotFalse($this->dynamicRoutPart->_call('resolveValue', $object));
     }
 
     /**
@@ -381,7 +381,7 @@ class DynamicRoutePartTest extends UnitTestCase
     {
         $object = new \stdClass();
         $this->mockPersistenceManager->expects($this->once())->method('getIdentifierByObject')->with($object)->will($this->returnValue(['foo' => 'Foo', 'bar' => 'Bar']));
-        $this->assertFalse($this->dynamicRoutPart->_call('resolveValue', $object));
+        self::assertFalse($this->dynamicRoutPart->_call('resolveValue', $object));
     }
 
     /**
@@ -393,7 +393,7 @@ class DynamicRoutePartTest extends UnitTestCase
     {
         $object = new \stdClass();
         $this->mockPersistenceManager->expects($this->once())->method('getIdentifierByObject')->with($object)->will($this->returnValue(null));
-        $this->assertFalse($this->dynamicRoutPart->_call('resolveValue', $object));
+        self::assertFalse($this->dynamicRoutPart->_call('resolveValue', $object));
     }
 
     /**
@@ -405,11 +405,11 @@ class DynamicRoutePartTest extends UnitTestCase
         $routeValues = ['foo' => 'bar'];
 
         $resolveResult = $this->dynamicRoutPart->resolve($routeValues);
-        $this->assertNotFalse($resolveResult);
+        self::assertNotFalse($resolveResult);
 
         $routeValues = [];
         $resolveResult = $this->dynamicRoutPart->resolve($routeValues);
-        $this->assertFalse($resolveResult);
-        $this->assertNull($this->dynamicRoutPart->getValue(), 'Dynamic Route Part value should be NULL when call to resolve() was not successful.');
+        self::assertFalse($resolveResult);
+        self::assertNull($this->dynamicRoutPart->getValue(), 'Dynamic Route Part value should be NULL when call to resolve() was not successful.');
     }
 }

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/IdentityRoutePartTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/IdentityRoutePartTest.php
@@ -76,7 +76,7 @@ class IdentityRoutePartTest extends UnitTestCase
     public function getUriPatternReturnsTheSpecifiedUriPatternIfItsNotEmpty()
     {
         $this->identityRoutePart->setUriPattern('SomeUriPattern');
-        $this->assertSame('SomeUriPattern', $this->identityRoutePart->getUriPattern());
+        self::assertSame('SomeUriPattern', $this->identityRoutePart->getUriPattern());
     }
 
     /**
@@ -87,7 +87,7 @@ class IdentityRoutePartTest extends UnitTestCase
         $this->mockClassSchema->expects($this->once())->method('getIdentityProperties')->will($this->returnValue([]));
 
         $this->identityRoutePart->setObjectType('SomeObjectType');
-        $this->assertSame('', $this->identityRoutePart->getUriPattern());
+        self::assertSame('', $this->identityRoutePart->getUriPattern());
     }
 
     /**
@@ -97,7 +97,7 @@ class IdentityRoutePartTest extends UnitTestCase
     {
         $this->mockClassSchema->expects($this->once())->method('getIdentityProperties')->will($this->returnValue(['property1' => 'string', 'property2' => 'integer', 'property3' => 'DateTime']));
         $this->identityRoutePart->setObjectType('SomeObjectType');
-        $this->assertSame('{property1}/{property2}/{property3}', $this->identityRoutePart->getUriPattern());
+        self::assertSame('{property1}/{property2}/{property3}', $this->identityRoutePart->getUriPattern());
     }
 
     /**
@@ -105,8 +105,8 @@ class IdentityRoutePartTest extends UnitTestCase
      */
     public function matchValueReturnsFalseIfTheGivenValueIsEmptyOrNull()
     {
-        $this->assertFalse($this->identityRoutePart->_call('matchValue', ''));
-        $this->assertFalse($this->identityRoutePart->_call('matchValue', null));
+        self::assertFalse($this->identityRoutePart->_call('matchValue', ''));
+        self::assertFalse($this->identityRoutePart->_call('matchValue', null));
     }
 
     /**
@@ -117,7 +117,7 @@ class IdentityRoutePartTest extends UnitTestCase
         $this->mockObjectPathMappingRepository->expects($this->once())->method('findOneByObjectTypeUriPatternAndPathSegment')->with('SomeObjectType', 'SomeUriPattern', 'TheRoutePath', false)->will($this->returnValue(null));
         $this->identityRoutePart->setObjectType('SomeObjectType');
         $this->identityRoutePart->setUriPattern('SomeUriPattern');
-        $this->assertFalse($this->identityRoutePart->_call('matchValue', 'TheRoutePath'));
+        self::assertFalse($this->identityRoutePart->_call('matchValue', 'TheRoutePath'));
     }
 
     /**
@@ -131,10 +131,10 @@ class IdentityRoutePartTest extends UnitTestCase
         $this->identityRoutePart->setObjectType('SomeObjectType');
         $this->identityRoutePart->setUriPattern('SomeUriPattern');
 
-        $this->assertTrue($this->identityRoutePart->_call('matchValue', 'TheRoutePath'));
+        self::assertTrue($this->identityRoutePart->_call('matchValue', 'TheRoutePath'));
         $expectedResult = ['__identity' => 'TheIdentifier'];
         $actualResult = $this->identityRoutePart->getValue();
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -150,10 +150,10 @@ class IdentityRoutePartTest extends UnitTestCase
 
         $this->identityRoutePart->setObjectType('stdClass');
 
-        $this->assertTrue($this->identityRoutePart->_call('matchValue', 'The%20Identifier'));
+        self::assertTrue($this->identityRoutePart->_call('matchValue', 'The%20Identifier'));
         $expectedResult = ['__identity' => 'The Identifier'];
         $actualResult = $this->identityRoutePart->getValue();
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -174,9 +174,9 @@ class IdentityRoutePartTest extends UnitTestCase
      */
     public function findValueToMatchReturnsAnEmptyStringIfTheRoutePathIsEmpty()
     {
-        $this->assertSame('', $this->identityRoutePart->_call('findValueToMatch', null));
-        $this->assertSame('', $this->identityRoutePart->_call('findValueToMatch', ''));
-        $this->assertSame('', $this->identityRoutePart->_call('findValueToMatch', '/'));
+        self::assertSame('', $this->identityRoutePart->_call('findValueToMatch', null));
+        self::assertSame('', $this->identityRoutePart->_call('findValueToMatch', ''));
+        self::assertSame('', $this->identityRoutePart->_call('findValueToMatch', '/'));
     }
 
     /**
@@ -186,7 +186,7 @@ class IdentityRoutePartTest extends UnitTestCase
     {
         $this->identityRoutePart->setUriPattern('');
         $this->identityRoutePart->setSplitString('SplitStringThatIsNotInTheCurrentRoutePath');
-        $this->assertSame('', $this->identityRoutePart->_call('findValueToMatch', 'The/Complete/RoutPath'));
+        self::assertSame('', $this->identityRoutePart->_call('findValueToMatch', 'The/Complete/RoutPath'));
     }
 
     /**
@@ -196,7 +196,7 @@ class IdentityRoutePartTest extends UnitTestCase
     {
         $this->identityRoutePart->setUriPattern('');
         $this->identityRoutePart->setSplitString('TheSplitString');
-        $this->assertSame('', $this->identityRoutePart->_call('findValueToMatch', 'First/Part/Of/The/Complete/RoutPath/TheSplitString/SomeThingElse'));
+        self::assertSame('', $this->identityRoutePart->_call('findValueToMatch', 'First/Part/Of/The/Complete/RoutPath/TheSplitString/SomeThingElse'));
     }
 
     /**
@@ -232,7 +232,7 @@ class IdentityRoutePartTest extends UnitTestCase
     {
         $this->identityRoutePart->setUriPattern($uriPattern);
         $this->identityRoutePart->setSplitString($splitString);
-        $this->assertSame($expectedResult, $this->identityRoutePart->_call('findValueToMatch', $routePath));
+        self::assertSame($expectedResult, $this->identityRoutePart->_call('findValueToMatch', $routePath));
     }
 
     /**
@@ -248,8 +248,8 @@ class IdentityRoutePartTest extends UnitTestCase
 
         $this->identityRoutePart->setObjectType('stdClass');
         $this->identityRoutePart->setUriPattern('SomeUriPattern');
-        $this->assertTrue($this->identityRoutePart->_call('resolveValue', $value));
-        $this->assertSame('thepathsegment', $this->identityRoutePart->getValue());
+        self::assertTrue($this->identityRoutePart->_call('resolveValue', $value));
+        self::assertSame('thepathsegment', $this->identityRoutePart->getValue());
     }
 
     /**
@@ -262,7 +262,7 @@ class IdentityRoutePartTest extends UnitTestCase
 
         $this->identityRoutePart->setObjectType('stdClass');
         $this->identityRoutePart->setUriPattern('SomeUriPattern');
-        $this->assertFalse($this->identityRoutePart->_call('resolveValue', $value));
+        self::assertFalse($this->identityRoutePart->_call('resolveValue', $value));
     }
 
     /**
@@ -281,8 +281,8 @@ class IdentityRoutePartTest extends UnitTestCase
         $this->identityRoutePart->setObjectType('stdClass');
 
         $this->identityRoutePart->_call('resolveValue', $value);
-        $this->assertSame('Some%20Identifier', $this->identityRoutePart->getValue());
-        $this->assertNotSame('Some+Identifier', $this->identityRoutePart->getValue());
+        self::assertSame('Some%20Identifier', $this->identityRoutePart->getValue());
+        self::assertNotSame('Some+Identifier', $this->identityRoutePart->getValue());
     }
 
     /**
@@ -300,7 +300,7 @@ class IdentityRoutePartTest extends UnitTestCase
         $this->identityRoutePart->setLowerCase(true);
 
         $this->identityRoutePart->_call('resolveValue', $value);
-        $this->assertSame('thepathsegment', $this->identityRoutePart->getValue());
+        self::assertSame('thepathsegment', $this->identityRoutePart->getValue());
     }
 
     /**
@@ -318,7 +318,7 @@ class IdentityRoutePartTest extends UnitTestCase
         $this->identityRoutePart->setLowerCase(false);
 
         $this->identityRoutePart->_call('resolveValue', $value);
-        $this->assertSame('ThePathSegment', $this->identityRoutePart->getValue());
+        self::assertSame('ThePathSegment', $this->identityRoutePart->getValue());
     }
 
     /**
@@ -327,7 +327,7 @@ class IdentityRoutePartTest extends UnitTestCase
     public function resolveValueReturnsFalseIfTheGivenValueIsNotOfTheSpecifiedType()
     {
         $this->identityRoutePart->setObjectType('SomeObjectType');
-        $this->assertFalse($this->identityRoutePart->_call('resolveValue', new \stdClass()));
+        self::assertFalse($this->identityRoutePart->_call('resolveValue', new \stdClass()));
     }
 
     /**
@@ -343,8 +343,8 @@ class IdentityRoutePartTest extends UnitTestCase
 
         $this->identityRoutePart->setObjectType('stdClass');
         $this->identityRoutePart->setUriPattern('SomeUriPattern');
-        $this->assertTrue($this->identityRoutePart->_call('resolveValue', $object));
-        $this->assertSame('thepathsegment', $this->identityRoutePart->getValue());
+        self::assertTrue($this->identityRoutePart->_call('resolveValue', $object));
+        self::assertSame('thepathsegment', $this->identityRoutePart->getValue());
     }
 
     /**
@@ -370,8 +370,8 @@ class IdentityRoutePartTest extends UnitTestCase
 
         $this->identityRoutePart->setObjectType('stdClass');
         $this->identityRoutePart->setUriPattern('SomeUriPattern');
-        $this->assertTrue($this->identityRoutePart->_call('resolveValue', $object));
-        $this->assertSame('the/path/segment', $this->identityRoutePart->getValue());
+        self::assertTrue($this->identityRoutePart->_call('resolveValue', $object));
+        self::assertSame('the/path/segment', $this->identityRoutePart->getValue());
     }
 
     /**
@@ -405,8 +405,8 @@ class IdentityRoutePartTest extends UnitTestCase
 
         $this->identityRoutePart->setObjectType('stdClass');
         $this->identityRoutePart->setUriPattern('SomeUriPattern');
-        $this->assertTrue($this->identityRoutePart->_call('resolveValue', $object));
-        $this->assertSame('the/path/segment-2', $this->identityRoutePart->getValue());
+        self::assertTrue($this->identityRoutePart->_call('resolveValue', $object));
+        self::assertSame('the/path/segment-2', $this->identityRoutePart->getValue());
     }
 
     /**
@@ -440,8 +440,8 @@ class IdentityRoutePartTest extends UnitTestCase
         $this->identityRoutePart->setObjectType('stdClass');
         $this->identityRoutePart->setUriPattern('SomeUriPattern');
         $this->identityRoutePart->setLowerCase(false);
-        $this->assertTrue($this->identityRoutePart->_call('resolveValue', $object));
-        $this->assertSame('The/Path/Segment-1', $this->identityRoutePart->getValue());
+        self::assertTrue($this->identityRoutePart->_call('resolveValue', $object));
+        self::assertSame('The/Path/Segment-1', $this->identityRoutePart->getValue());
     }
 
     /**
@@ -467,8 +467,8 @@ class IdentityRoutePartTest extends UnitTestCase
 
         $this->identityRoutePart->setObjectType('stdClass');
         $this->identityRoutePart->setUriPattern('SomeUriPattern');
-        $this->assertTrue($this->identityRoutePart->_call('resolveValue', $object));
-        $this->assertSame('-1', $this->identityRoutePart->getValue());
+        self::assertTrue($this->identityRoutePart->_call('resolveValue', $object));
+        self::assertSame('-1', $this->identityRoutePart->getValue());
     }
 
     /**
@@ -536,7 +536,7 @@ class IdentityRoutePartTest extends UnitTestCase
         $identityRoutePart = $this->getAccessibleMock(IdentityRoutePart::class, ['dummy']);
         $identityRoutePart->setUriPattern($uriPattern);
         $actualResult = $identityRoutePart->_call('createPathSegmentForObject', $object);
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/RouteTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/RouteTest.php
@@ -98,7 +98,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setName('SomeName');
 
-        $this->assertEquals('SomeName', $this->route->getName());
+        self::assertEquals('SomeName', $this->route->getName());
     }
 
     /**
@@ -106,13 +106,13 @@ class RouteTest extends UnitTestCase
      */
     public function httpMethodConstraintsCanBeSetAndRetrieved()
     {
-        $this->assertFalse($this->route->hasHttpMethodConstraints(), 'hasHttpMethodConstraints should be false by default');
+        self::assertFalse($this->route->hasHttpMethodConstraints(), 'hasHttpMethodConstraints should be false by default');
         $httpMethods = ['POST', 'PUT'];
         $this->route->setHttpMethods($httpMethods);
-        $this->assertTrue($this->route->hasHttpMethodConstraints(), 'hasHttpMethodConstraints should be true if httpMethods are set');
-        $this->assertEquals($httpMethods, $this->route->getHttpMethods());
+        self::assertTrue($this->route->hasHttpMethodConstraints(), 'hasHttpMethodConstraints should be true if httpMethods are set');
+        self::assertEquals($httpMethods, $this->route->getHttpMethods());
         $this->route->setHttpMethods([]);
-        $this->assertFalse($this->route->hasHttpMethodConstraints(), 'hasHttpMethodConstraints should be false if httpMethods is empty');
+        self::assertFalse($this->route->hasHttpMethodConstraints(), 'hasHttpMethodConstraints should be false if httpMethods is empty');
     }
 
     /**
@@ -123,7 +123,7 @@ class RouteTest extends UnitTestCase
         $this->route->_set('isParsed', true);
         $this->route->setUriPattern('foo/{key3}/foo');
 
-        $this->assertFalse($this->route->_get('isParsed'));
+        self::assertFalse($this->route->_get('isParsed'));
     }
 
     /**
@@ -181,8 +181,8 @@ class RouteTest extends UnitTestCase
 
         $this->route->parse();
         $identityRoutePart = current($this->route->_get('routeParts'));
-        $this->assertInstanceOf(Routing\IdentityRoutePart::class, $identityRoutePart);
-        $this->assertSame('SomeObjectType', $identityRoutePart->getObjectType());
+        self::assertInstanceOf(Routing\IdentityRoutePart::class, $identityRoutePart);
+        self::assertSame('SomeObjectType', $identityRoutePart->getObjectType());
     }
 
     /**
@@ -202,7 +202,7 @@ class RouteTest extends UnitTestCase
 
         $this->route->parse();
         $identityRoutePart = current($this->route->_get('routeParts'));
-        $this->assertSame('SomeUriPattern', $identityRoutePart->getUriPattern());
+        self::assertSame('SomeUriPattern', $identityRoutePart->getUriPattern());
     }
 
     /**
@@ -274,7 +274,7 @@ class RouteTest extends UnitTestCase
      */
     public function routeDoesNotMatchEmptyRequestPathIfUriPatternIsNotSet()
     {
-        $this->assertFalse($this->routeMatchesPath(''), 'Route should not match if no URI Pattern is set.');
+        self::assertFalse($this->routeMatchesPath(''), 'Route should not match if no URI Pattern is set.');
     }
 
     /**
@@ -284,7 +284,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('foo/bar');
 
-        $this->assertFalse($this->routeMatchesPath('bar/foo'), '"foo/bar"-Route should not match "bar/foo"-request.');
+        self::assertFalse($this->routeMatchesPath('bar/foo'), '"foo/bar"-Route should not match "bar/foo"-request.');
     }
 
     /**
@@ -294,7 +294,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('foo/{bar}');
 
-        $this->assertFalse($this->routeMatchesPath('bar/someValue'), '"foo/{bar}"-Route should not match "bar/someValue"-request.');
+        self::assertFalse($this->routeMatchesPath('bar/someValue'), '"foo/{bar}"-Route should not match "bar/someValue"-request.');
     }
 
     /**
@@ -304,7 +304,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('');
 
-        $this->assertTrue($this->routeMatchesPath(''), 'Route should match if URI Pattern and RequestPath are empty.');
+        self::assertTrue($this->routeMatchesPath(''), 'Route should match if URI Pattern and RequestPath are empty.');
     }
 
     /**
@@ -314,7 +314,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('foo/bar');
 
-        $this->assertTrue($this->routeMatchesPath('foo/bar'), '"foo/bar"-Route should match "foo/bar"-request.');
+        self::assertTrue($this->routeMatchesPath('foo/bar'), '"foo/bar"-Route should match "foo/bar"-request.');
     }
 
     /**
@@ -324,7 +324,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('required1/required2');
 
-        $this->assertFalse($this->routeMatchesPath('required1required2'));
+        self::assertFalse($this->routeMatchesPath('required1required2'));
     }
 
     /**
@@ -334,7 +334,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('foo/{bar}');
 
-        $this->assertTrue($this->routeMatchesPath('foo/someValue'), '"foo/{bar}"-Route should match "foo/someValue"-request.');
+        self::assertTrue($this->routeMatchesPath('foo/someValue'), '"foo/{bar}"-Route should match "foo/someValue"-request.');
     }
 
     /**
@@ -345,7 +345,7 @@ class RouteTest extends UnitTestCase
         $this->route->setUriPattern('foo/{bar}');
         $this->routeMatchesPath('foo/someValue');
 
-        $this->assertEquals(['bar' => 'someValue'], $this->route->getMatchResults(), 'Route match results should be set correctly on successful match');
+        self::assertEquals(['bar' => 'someValue'], $this->route->getMatchResults(), 'Route match results should be set correctly on successful match');
     }
 
     /**
@@ -355,9 +355,9 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('{key1}/foo/{key2}/bar');
 
-        $this->assertFalse($this->routeMatchesPath('value1/foo/value2/foo'), '"{key1}/foo/{key2}/bar"-Route should not match "value1/foo/value2/foo"-request.');
-        $this->assertTrue($this->routeMatchesPath('value1/foo/value2/bar'), '"{key1}/foo/{key2}/bar"-Route should match "value1/foo/value2/bar"-request.');
-        $this->assertEquals(['key1' => 'value1', 'key2' => 'value2'], $this->route->getMatchResults(), 'Route match results should be set correctly on successful match');
+        self::assertFalse($this->routeMatchesPath('value1/foo/value2/foo'), '"{key1}/foo/{key2}/bar"-Route should not match "value1/foo/value2/foo"-request.');
+        self::assertTrue($this->routeMatchesPath('value1/foo/value2/bar'), '"{key1}/foo/{key2}/bar"-Route should match "value1/foo/value2/bar"-request.');
+        self::assertEquals(['key1' => 'value1', 'key2' => 'value2'], $this->route->getMatchResults(), 'Route match results should be set correctly on successful match');
     }
 
     /**
@@ -367,9 +367,9 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('user/{firstName}-{lastName}');
 
-        $this->assertFalse($this->routeMatchesPath('user/johndoe'), '"user/{firstName}-{lastName}"-Route should not match "user/johndoe"-request.');
-        $this->assertTrue($this->routeMatchesPath('user/john-doe'), '"user/{firstName}-{lastName}"-Route should match "user/john-doe"-request.');
-        $this->assertEquals(['firstName' => 'john', 'lastName' => 'doe'], $this->route->getMatchResults(), 'Route match results should be set correctly on successful match');
+        self::assertFalse($this->routeMatchesPath('user/johndoe'), '"user/{firstName}-{lastName}"-Route should not match "user/johndoe"-request.');
+        self::assertTrue($this->routeMatchesPath('user/john-doe'), '"user/{firstName}-{lastName}"-Route should match "user/john-doe"-request.');
+        self::assertEquals(['firstName' => 'john', 'lastName' => 'doe'], $this->route->getMatchResults(), 'Route match results should be set correctly on successful match');
     }
 
     /**
@@ -379,9 +379,9 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('{key1}-{key2}/{key3}.{key4}.{@format}');
 
-        $this->assertFalse($this->routeMatchesPath('value1-value2/value3.value4value5'), '"{key1}-{key2}/{key3}.{key4}.{@format}"-Route should not match "value1-value2/value3.value4value5"-request.');
-        $this->assertTrue($this->routeMatchesPath('value1-value2/value3.value4.value5'), '"{key1}-{key2}/{key3}.{key4}.{@format}"-Route should match "value1-value2/value3.value4.value5"-request.');
-        $this->assertEquals(['key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3', 'key4' => 'value4', '@format' => 'value5'], $this->route->getMatchResults(), 'Route match results should be set correctly on successful match');
+        self::assertFalse($this->routeMatchesPath('value1-value2/value3.value4value5'), '"{key1}-{key2}/{key3}.{key4}.{@format}"-Route should not match "value1-value2/value3.value4value5"-request.');
+        self::assertTrue($this->routeMatchesPath('value1-value2/value3.value4.value5'), '"{key1}-{key2}/{key3}.{key4}.{@format}"-Route should match "value1-value2/value3.value4.value5"-request.');
+        self::assertEquals(['key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3', 'key4' => 'value4', '@format' => 'value5'], $this->route->getMatchResults(), 'Route match results should be set correctly on successful match');
     }
 
     /**
@@ -392,7 +392,7 @@ class RouteTest extends UnitTestCase
         $this->route->setUriPattern('{foo}');
         $this->route->setDefaults(['foo' => 'bar']);
 
-        $this->assertFalse($this->routeMatchesPath(''), 'Route should not match if required Route Part does not match.');
+        self::assertFalse($this->routeMatchesPath(''), 'Route should not match if required Route Part does not match.');
     }
 
     /**
@@ -412,8 +412,8 @@ class RouteTest extends UnitTestCase
         $this->routeMatchesPath('SomePackage');
         $matchResults = $this->route->getMatchResults();
 
-        $this->assertEquals($defaults['@controller'], $matchResults{'@controller'});
-        $this->assertEquals($defaults['@action'], $matchResults['@action']);
+        self::assertEquals($defaults['@controller'], $matchResults{'@controller'});
+        self::assertEquals($defaults['@action'], $matchResults['@action']);
     }
 
     /**
@@ -433,7 +433,7 @@ class RouteTest extends UnitTestCase
         $this->mockObjectManager->expects($this->once())->method('get')->with(MockRoutePartHandler::class)->will($this->returnValue($mockRoutePartHandler));
         $this->routeMatchesPath('foo/bar');
 
-        $this->assertEquals(['key1' => '_match_invoked_', 'key2' => 'bar'], $this->route->getMatchResults());
+        self::assertEquals(['key1' => '_match_invoked_', 'key2' => 'bar'], $this->route->getMatchResults());
     }
 
     /**
@@ -501,7 +501,7 @@ class RouteTest extends UnitTestCase
 
         $expectedResult = ['firstLevel' => ['secondLevel' => ['routePart1' => 'foo', 'routePart2' => 'baz']], 'someOtherRoutePart' => 'bar'];
         $actualResult = $this->route->getMatchResults();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /*                                                                        *
@@ -515,7 +515,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('(optional)');
 
-        $this->assertTrue($this->routeMatchesPath(''));
+        self::assertTrue($this->routeMatchesPath(''));
     }
 
     /**
@@ -525,7 +525,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('required(optional)');
 
-        $this->assertTrue($this->routeMatchesPath('requiredoptional'));
+        self::assertTrue($this->routeMatchesPath('requiredoptional'));
     }
 
     /**
@@ -535,7 +535,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('required(optional)');
 
-        $this->assertTrue($this->routeMatchesPath('required'));
+        self::assertTrue($this->routeMatchesPath('required'));
     }
 
     /**
@@ -545,7 +545,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('(optional)required');
 
-        $this->assertTrue($this->routeMatchesPath('required'));
+        self::assertTrue($this->routeMatchesPath('required'));
     }
 
     /**
@@ -555,7 +555,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('(optional)required(optional2)');
 
-        $this->assertTrue($this->routeMatchesPath('required'));
+        self::assertTrue($this->routeMatchesPath('required'));
     }
 
     /**
@@ -565,7 +565,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('(optional)required(optional2)');
 
-        $this->assertTrue($this->routeMatchesPath('optionalrequiredoptional2'));
+        self::assertTrue($this->routeMatchesPath('optionalrequiredoptional2'));
     }
 
     /**
@@ -576,7 +576,7 @@ class RouteTest extends UnitTestCase
         $this->expectException(InvalidRouteSetupException::class);
         $this->route->setUriPattern('({optional})');
 
-        $this->assertFalse($this->routeMatchesPath(''));
+        self::assertFalse($this->routeMatchesPath(''));
     }
 
     /**
@@ -587,7 +587,7 @@ class RouteTest extends UnitTestCase
         $this->route->setUriPattern('({optional})');
         $this->route->setDefaults(['optional' => 'defaultValue']);
 
-        $this->assertTrue($this->routeMatchesPath(''));
+        self::assertTrue($this->routeMatchesPath(''));
     }
 
     /**
@@ -598,7 +598,7 @@ class RouteTest extends UnitTestCase
         $this->route->setUriPattern('page(.{@format})');
         $this->route->setDefaults(['@format' => 'html']);
 
-        $this->assertFalse($this->routeMatchesPath('page.'));
+        self::assertFalse($this->routeMatchesPath('page.'));
     }
 
     /**
@@ -609,7 +609,7 @@ class RouteTest extends UnitTestCase
         $this->route->setUriPattern('page(.{@format})');
         $this->route->setDefaults(['@format' => 'html']);
 
-        $this->assertTrue($this->routeMatchesPath('page'));
+        self::assertTrue($this->routeMatchesPath('page'));
     }
 
     /**
@@ -620,7 +620,7 @@ class RouteTest extends UnitTestCase
         $this->route->setUriPattern('page(.{@format})');
         $this->route->setDefaults(['@format' => 'html']);
 
-        $this->assertTrue($this->routeMatchesPath('page.html'));
+        self::assertTrue($this->routeMatchesPath('page.html'));
     }
 
     /**
@@ -630,7 +630,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('required(/optional1/optional2)');
 
-        $this->assertTrue($this->routeMatchesPath('required'));
+        self::assertTrue($this->routeMatchesPath('required'));
     }
 
     /**
@@ -640,7 +640,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('required(/optional1/optional2)');
 
-        $this->assertFalse($this->routeMatchesPath('required/optional1'));
+        self::assertFalse($this->routeMatchesPath('required/optional1'));
     }
 
     /**
@@ -650,7 +650,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('required(/optional1/optional2)');
 
-        $this->assertTrue($this->routeMatchesPath('required/optional1/optional2'));
+        self::assertTrue($this->routeMatchesPath('required/optional1/optional2'));
     }
 
     /**
@@ -660,7 +660,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('required1(/optional1/optional2)/required2');
 
-        $this->assertTrue($this->routeMatchesPath('required1/required2'));
+        self::assertTrue($this->routeMatchesPath('required1/required2'));
     }
 
     /**
@@ -670,7 +670,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('required1/(optional1/optional2/)required2');
 
-        $this->assertFalse($this->routeMatchesPath('required1/optional1/required2'));
+        self::assertFalse($this->routeMatchesPath('required1/optional1/required2'));
     }
 
     /**
@@ -680,7 +680,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('required1/(optional1/optional2/)required2');
 
-        $this->assertTrue($this->routeMatchesPath('required1/optional1/optional2/required2'));
+        self::assertTrue($this->routeMatchesPath('required1/optional1/optional2/required2'));
     }
 
     /**
@@ -690,7 +690,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('(optional1/optional2/)required1/required2');
 
-        $this->assertTrue($this->routeMatchesPath('required1/required2'));
+        self::assertTrue($this->routeMatchesPath('required1/required2'));
     }
 
     /**
@@ -700,7 +700,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('(optional1/optional2/)required1/required2');
 
-        $this->assertFalse($this->routeMatchesPath('optional1/required1/required2'));
+        self::assertFalse($this->routeMatchesPath('optional1/required1/required2'));
     }
 
     /**
@@ -710,7 +710,7 @@ class RouteTest extends UnitTestCase
     {
         $this->route->setUriPattern('(optional1/optional2/)required1/required2');
 
-        $this->assertTrue($this->routeMatchesPath('optional1/optional2/required1/required2'));
+        self::assertTrue($this->routeMatchesPath('optional1/optional2/required1/required2'));
     }
 
     /**
@@ -721,7 +721,7 @@ class RouteTest extends UnitTestCase
         $this->route->setUriPattern('({foo})');
         $this->route->setDefaults(['foo' => 'bar']);
 
-        $this->assertTrue($this->routeMatchesPath(''), 'Route should match if optional Route Part has a default value.');
+        self::assertTrue($this->routeMatchesPath(''), 'Route should match if optional Route Part has a default value.');
     }
 
     /**
@@ -740,7 +740,7 @@ class RouteTest extends UnitTestCase
         $this->route->setDefaults($defaults);
         $this->routeMatchesPath('foo-/.bar.xml');
 
-        $this->assertEquals(['key1' => 'foo', 'key2' => 'defaultValue2', 'key3' => 'defaultValue3', 'key4' => 'bar', '@format' => 'xml'], $this->route->getMatchResults(), 'Route match results should be set correctly on successful match');
+        self::assertEquals(['key1' => 'foo', 'key2' => 'defaultValue2', 'key3' => 'defaultValue3', 'key4' => 'bar', '@format' => 'xml'], $this->route->getMatchResults(), 'Route match results should be set correctly on successful match');
     }
 
     /**
@@ -763,7 +763,7 @@ class RouteTest extends UnitTestCase
         $mockHttpRequest->expects($this->any())->method('getBaseUri')->will($this->returnValue($mockBaseUri));
 
         $mockHttpRequest->expects($this->atLeastOnce())->method('getMethod')->will($this->returnValue('GET'));
-        $this->assertFalse($this->route->matches(new RouteContext($mockHttpRequest, RouteParameters::createEmpty())), 'Route must not match GET requests if only POST or PUT requests are accepted.');
+        self::assertFalse($this->route->matches(new RouteContext($mockHttpRequest, RouteParameters::createEmpty())), 'Route must not match GET requests if only POST or PUT requests are accepted.');
     }
 
     /**
@@ -787,7 +787,7 @@ class RouteTest extends UnitTestCase
 
         $mockHttpRequest->expects($this->atLeastOnce())->method('getMethod')->will($this->returnValue('PUT'));
 
-        $this->assertTrue($this->route->matches(new RouteContext($mockHttpRequest, RouteParameters::createEmpty())), 'Route should match PUT requests if POST and PUT requests are accepted.');
+        self::assertTrue($this->route->matches(new RouteContext($mockHttpRequest, RouteParameters::createEmpty())), 'Route should match PUT requests if POST and PUT requests are accepted.');
     }
 
     /*                                                                        *
@@ -804,8 +804,8 @@ class RouteTest extends UnitTestCase
         $this->route->setDefaults(['@format' => 'xml']);
         $this->routeValues = ['key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3', 'key4' => 'value4'];
 
-        $this->assertTrue($this->route->resolves($this->routeValues));
-        $this->assertEquals('value1-value2/value3.value4.xml', $this->route->getResolvedUriConstraints()->getPathConstraint());
+        self::assertTrue($this->route->resolves($this->routeValues));
+        self::assertEquals('value1-value2/value3.value4.xml', $this->route->getResolvedUriConstraints()->getPathConstraint());
     }
 
     /**
@@ -817,7 +817,7 @@ class RouteTest extends UnitTestCase
         $this->route->setDefaults(['@format' => 'xml']);
         $this->routeValues = ['key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3', 'key4' => 'value4', 'nonexistingkey' => 'foo'];
 
-        $this->assertFalse($this->route->resolves($this->routeValues));
+        self::assertFalse($this->route->resolves($this->routeValues));
     }
 
     /**
@@ -829,8 +829,8 @@ class RouteTest extends UnitTestCase
         $this->route->setDefaults(['@format' => 'xml']);
         $this->routeValues = ['key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3', 'key4' => 'value4', '__someInternalArgument' => 'someValue'];
 
-        $this->assertTrue($this->route->resolves($this->routeValues));
-        $this->assertEquals('value1-value2/value3.value4.xml?__someInternalArgument=someValue', $this->route->getResolvedUriConstraints()->getPathConstraint());
+        self::assertTrue($this->route->resolves($this->routeValues));
+        self::assertEquals('value1-value2/value3.value4.xml?__someInternalArgument=someValue', $this->route->getResolvedUriConstraints()->getPathConstraint());
     }
 
     /**
@@ -842,8 +842,8 @@ class RouteTest extends UnitTestCase
         $this->route->setDefaults(['@format' => 'xml']);
         $this->routeValues = ['key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3', 'key4' => 'value4', '--subRequest' => ['__someInternalArgument' => 'someValue']];
 
-        $this->assertTrue($this->route->resolves($this->routeValues));
-        $this->assertEquals('value1-value2/value3.value4.xml?--subRequest%5B__someInternalArgument%5D=someValue', $this->route->getResolvedUriConstraints()->getPathConstraint());
+        self::assertTrue($this->route->resolves($this->routeValues));
+        self::assertEquals('value1-value2/value3.value4.xml?--subRequest%5B__someInternalArgument%5D=someValue', $this->route->getResolvedUriConstraints()->getPathConstraint());
     }
 
     /**
@@ -855,7 +855,7 @@ class RouteTest extends UnitTestCase
         $this->route->setDefaults(['@format' => 'xml']);
         $this->routeValues = ['key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3', 'key4' => 'value4', 'someArgument' => ['__identity' => 'someUuid']];
 
-        $this->assertFalse($this->route->resolves($this->routeValues));
+        self::assertFalse($this->route->resolves($this->routeValues));
     }
 
     /**
@@ -868,8 +868,8 @@ class RouteTest extends UnitTestCase
         $this->routeValues = ['key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3', 'key4' => 'value4', '__someInternalArgument' => 'someValue', 'nonexistingkey' => 'foo'];
         $this->route->setAppendExceedingArguments(true);
 
-        $this->assertTrue($this->route->resolves($this->routeValues));
-        $this->assertEquals('value1-value2/value3.value4.xml?__someInternalArgument=someValue&nonexistingkey=foo', $this->route->getResolvedUriConstraints()->getPathConstraint());
+        self::assertTrue($this->route->resolves($this->routeValues));
+        self::assertEquals('value1-value2/value3.value4.xml?__someInternalArgument=someValue&nonexistingkey=foo', $this->route->getResolvedUriConstraints()->getPathConstraint());
     }
 
     /**
@@ -881,7 +881,7 @@ class RouteTest extends UnitTestCase
         $this->route->setDefaults(['key1' => 'value1', 'key2' => 'value2']);
         $this->routeValues = ['key1' => 'value1'];
 
-        $this->assertTrue($this->route->resolves($this->routeValues));
+        self::assertTrue($this->route->resolves($this->routeValues));
     }
 
     /**
@@ -893,8 +893,8 @@ class RouteTest extends UnitTestCase
         $this->route->setDefaults(['key1' => ['key1a' => 'key1aValue', 'key1b' => 'key1bValue'], 'key2' => ['key2a' => 'key2aValue', 'key2b' => 'key2bValue']]);
         $this->routeValues = ['key1' => ['key1a' => 'key1aValue', 'key1b' => 'key1bValue'], 'key2' => ['key2a' => 'key2aValue']];
 
-        $this->assertTrue($this->route->resolves($this->routeValues));
-        $this->assertEquals('key2bValue', $this->route->getResolvedUriConstraints()->getPathConstraint());
+        self::assertTrue($this->route->resolves($this->routeValues));
+        self::assertEquals('key2bValue', $this->route->getResolvedUriConstraints()->getPathConstraint());
     }
 
     /**
@@ -909,7 +909,7 @@ class RouteTest extends UnitTestCase
         $this->route->resolves($this->routeValues);
         $expectedResult = 'foo/barDefaultValue/bazvalue';
         $actualResult = $this->route->getResolvedUriConstraints()->getPathConstraint();
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -920,8 +920,8 @@ class RouteTest extends UnitTestCase
         $this->route->setUriPattern('CamelCase/{someKey}');
         $this->routeValues = ['someKey' => 'CamelCase'];
 
-        $this->assertTrue($this->route->resolves($this->routeValues));
-        $this->assertEquals('camelcase/camelcase', $this->route->getResolvedUriConstraints()->getPathConstraint());
+        self::assertTrue($this->route->resolves($this->routeValues));
+        self::assertEquals('camelcase/camelcase', $this->route->getResolvedUriConstraints()->getPathConstraint());
     }
 
     /**
@@ -933,8 +933,8 @@ class RouteTest extends UnitTestCase
         $this->route->setLowerCase(false);
         $this->routeValues = ['someKey' => 'CamelCase'];
 
-        $this->assertTrue($this->route->resolves($this->routeValues));
-        $this->assertEquals('CamelCase/CamelCase', $this->route->getResolvedUriConstraints()->getPathConstraint());
+        self::assertTrue($this->route->resolves($this->routeValues));
+        self::assertEquals('CamelCase/CamelCase', $this->route->getResolvedUriConstraints()->getPathConstraint());
     }
 
     /**
@@ -946,7 +946,7 @@ class RouteTest extends UnitTestCase
         $this->route->setDefaults(['key1' => 'value1', 'key2' => 'value2']);
         $this->routeValues = ['key2' => 'differentValue'];
 
-        $this->assertFalse($this->route->resolves($this->routeValues));
+        self::assertFalse($this->route->resolves($this->routeValues));
     }
 
     /**
@@ -959,11 +959,11 @@ class RouteTest extends UnitTestCase
         $this->route->setUriPattern('{key1}');
         $this->routeValues = ['key1' => 'value1'];
 
-        $this->assertTrue($this->route->resolves($this->routeValues));
+        self::assertTrue($this->route->resolves($this->routeValues));
 
         $this->routeValues = ['differentKey' => 'value1'];
-        $this->assertFalse($this->route->resolves($this->routeValues));
-        $this->assertNull($this->route->getResolvedUriConstraints()->getPathConstraint());
+        self::assertFalse($this->route->resolves($this->routeValues));
+        self::assertNull($this->route->getResolvedUriConstraints()->getPathConstraint());
     }
 
     /**
@@ -984,7 +984,7 @@ class RouteTest extends UnitTestCase
         $this->mockObjectManager->expects($this->once())->method('get')->with(MockRoutePartHandler::class)->will($this->returnValue($mockRoutePartHandler));
         $this->route->resolves($this->routeValues);
 
-        $this->assertEquals('_resolve_invoked_/value2', $this->route->getResolvedUriConstraints()->getPathConstraint());
+        self::assertEquals('_resolve_invoked_/value2', $this->route->getResolvedUriConstraints()->getPathConstraint());
     }
 
     /**
@@ -995,7 +995,7 @@ class RouteTest extends UnitTestCase
         $this->route->setUriPattern('foo');
         $this->route->_set('isParsed', true);
         $routeValues = ['foo' => 'bar', 'baz' => ['foo2' => 'bar2']];
-        $this->assertFalse($this->route->resolves($routeValues));
+        self::assertFalse($this->route->resolves($routeValues));
     }
 
     /**
@@ -1012,7 +1012,7 @@ class RouteTest extends UnitTestCase
         $actualResult = $this->route->getResolvedUriConstraints()->getPathConstraint();
         $expectedResult = '?foo=bar&baz%5Bfoo2%5D=bar2';
 
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -1039,7 +1039,7 @@ class RouteTest extends UnitTestCase
         $actualResult = $this->route->getResolvedUriConstraints()->getPathConstraint();
         $expectedResult = '?foo=bar&someObject%5B__identity%5D=x&baz%5BsomeOtherObject%5D%5B__identity%5D=y';
 
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -1051,7 +1051,7 @@ class RouteTest extends UnitTestCase
         $this->route->setDefaults(['@package' => 'SomePackage', '@controller' => 'SomeExistingController']);
         $this->routeValues = ['@subpackage' => 'Some\Subpackage'];
 
-        $this->assertTrue($this->route->resolves($this->routeValues));
+        self::assertTrue($this->route->resolves($this->routeValues));
     }
 
     /**
@@ -1112,7 +1112,7 @@ class RouteTest extends UnitTestCase
 
         $route->expects($this->once())->method('compareAndRemoveMatchingDefaultValues')->with($defaultValues, $routeValues)->will($this->returnValue(true));
 
-        $this->assertTrue($route->resolves($routeValues));
+        self::assertTrue($route->resolves($routeValues));
     }
 
     /**
@@ -1197,9 +1197,9 @@ class RouteTest extends UnitTestCase
     public function compareAndRemoveMatchingDefaultValuesTests(array $defaults, array $routeValues, $expectedModifiedRouteValues, $expectedResult)
     {
         $actualResult = $this->route->_callRef('compareAndRemoveMatchingDefaultValues', $defaults, $routeValues);
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
         if ($expectedResult === true) {
-            $this->assertEquals($expectedModifiedRouteValues, $routeValues);
+            self::assertEquals($expectedModifiedRouteValues, $routeValues);
         }
     }
 

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/RouterCachingServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/RouterCachingServiceTest.php
@@ -204,7 +204,7 @@ class RouterCachingServiceTest extends UnitTestCase
     public function containsObjectDetectsObjectsInVariousSituations($expectedResult, $subject)
     {
         $actualResult = $this->routerCachingService->_call('containsObject', $subject);
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -217,7 +217,7 @@ class RouterCachingServiceTest extends UnitTestCase
         $this->mockRouteCache->expects($this->once())->method('get')->with($cacheIdentifier)->will($this->returnValue($expectedResult));
 
         $actualResult = $this->routerCachingService->getCachedMatchResults(new RouteContext($this->mockHttpRequest, RouteParameters::createEmpty()));
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -230,7 +230,7 @@ class RouterCachingServiceTest extends UnitTestCase
         $this->mockRouteCache->expects($this->once())->method('get')->with($cacheIdentifier)->will($this->returnValue(false));
 
         $actualResult = $this->routerCachingService->getCachedMatchResults(new RouteContext($this->mockHttpRequest, RouteParameters::createEmpty()));
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -271,7 +271,7 @@ class RouterCachingServiceTest extends UnitTestCase
         $this->mockResolveCache->expects($this->once())->method('get')->will($this->returnValue($expectedResult));
 
         $actualResult = $this->routerCachingService->getCachedResolvedUriConstraints(new ResolveContext($this->mockUri, $routeValues, false));
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/RouterTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/RouterTest.php
@@ -133,20 +133,20 @@ class RouterTest extends UnitTestCase
         /** @var Route[] $createdRoutes */
         $createdRoutes = $this->router->_get('routes');
 
-        $this->assertEquals('number1', $createdRoutes[0]->getUriPattern());
-        $this->assertTrue($createdRoutes[0]->isLowerCase());
-        $this->assertFalse($createdRoutes[0]->getAppendExceedingArguments());
-        $this->assertEquals('number2', $createdRoutes[1]->getUriPattern());
-        $this->assertFalse($createdRoutes[1]->hasHttpMethodConstraints());
-        $this->assertEquals([], $createdRoutes[1]->getHttpMethods());
-        $this->assertEquals('route3', $createdRoutes[2]->getName());
-        $this->assertEquals(['foodefault'], $createdRoutes[2]->getDefaults());
-        $this->assertEquals(['fooroutepart'], $createdRoutes[2]->getRoutePartsConfiguration());
-        $this->assertEquals('number3', $createdRoutes[2]->getUriPattern());
-        $this->assertFalse($createdRoutes[2]->isLowerCase());
-        $this->assertTrue($createdRoutes[2]->getAppendExceedingArguments());
-        $this->assertTrue($createdRoutes[2]->hasHttpMethodConstraints());
-        $this->assertEquals(['POST', 'PUT'], $createdRoutes[2]->getHttpMethods());
+        self::assertEquals('number1', $createdRoutes[0]->getUriPattern());
+        self::assertTrue($createdRoutes[0]->isLowerCase());
+        self::assertFalse($createdRoutes[0]->getAppendExceedingArguments());
+        self::assertEquals('number2', $createdRoutes[1]->getUriPattern());
+        self::assertFalse($createdRoutes[1]->hasHttpMethodConstraints());
+        self::assertEquals([], $createdRoutes[1]->getHttpMethods());
+        self::assertEquals('route3', $createdRoutes[2]->getName());
+        self::assertEquals(['foodefault'], $createdRoutes[2]->getDefaults());
+        self::assertEquals(['fooroutepart'], $createdRoutes[2]->getRoutePartsConfiguration());
+        self::assertEquals('number3', $createdRoutes[2]->getUriPattern());
+        self::assertFalse($createdRoutes[2]->isLowerCase());
+        self::assertTrue($createdRoutes[2]->getAppendExceedingArguments());
+        self::assertTrue($createdRoutes[2]->hasHttpMethodConstraints());
+        self::assertEquals(['POST', 'PUT'], $createdRoutes[2]->getHttpMethods());
     }
 
     /**
@@ -196,7 +196,7 @@ class RouterTest extends UnitTestCase
         $router->_set('routes', $mockRoutes);
 
         $resolvedUri = $router->resolve(new ResolveContext($this->mockBaseUri, $routeValues, false));
-        $this->assertSame('route2', $resolvedUri->getPath());
+        self::assertSame('route2', $resolvedUri->getPath());
     }
 
     /**
@@ -228,7 +228,7 @@ class RouterTest extends UnitTestCase
      */
     public function getLastResolvedRouteReturnsNullByDefault()
     {
-        $this->assertNull($this->router->getLastResolvedRoute());
+        self::assertNull($this->router->getLastResolvedRoute());
     }
 
     /**
@@ -254,7 +254,7 @@ class RouterTest extends UnitTestCase
 
         $router->resolve($resolveContext);
 
-        $this->assertSame($mockRoute2, $router->getLastResolvedRoute());
+        self::assertSame($mockRoute2, $router->getLastResolvedRoute());
     }
 
     /**
@@ -277,7 +277,7 @@ class RouterTest extends UnitTestCase
         $router->_set('routerCachingService', $mockRouterCachingService);
 
         $router->expects($this->never())->method('createRoutesFromConfiguration');
-        $this->assertSame('cached/path', (string)$router->resolve($resolveContext));
+        self::assertSame('cached/path', (string)$router->resolve($resolveContext));
     }
 
     /**
@@ -303,7 +303,7 @@ class RouterTest extends UnitTestCase
         $router->_set('routes', [$mockRoute1, $mockRoute2]);
 
         $this->mockRouterCachingService->expects($this->once())->method('storeResolvedUriConstraints')->with($resolveContext, $mockResolvedUriConstraints);
-        $this->assertSame('resolved/path', (string)$router->resolve($resolveContext));
+        self::assertSame('resolved/path', (string)$router->resolve($resolveContext));
     }
 
     /**
@@ -324,7 +324,7 @@ class RouterTest extends UnitTestCase
 
         $router->expects($this->never())->method('createRoutesFromConfiguration');
 
-        $this->assertSame($cachedMatchResults, $router->route($routeContext));
+        self::assertSame($cachedMatchResults, $router->route($routeContext));
     }
 
     /**
@@ -350,7 +350,7 @@ class RouterTest extends UnitTestCase
 
         $this->mockRouterCachingService->expects($this->once())->method('storeMatchResults')->with($routeContext, $matchResults);
 
-        $this->assertSame($matchResults, $router->route($routeContext));
+        self::assertSame($matchResults, $router->route($routeContext));
     }
 
     /**
@@ -358,7 +358,7 @@ class RouterTest extends UnitTestCase
      */
     public function getLastMatchedRouteReturnsNullByDefault()
     {
-        $this->assertNull($this->router->getLastMatchedRoute());
+        self::assertNull($this->router->getLastMatchedRoute());
     }
 
     /**
@@ -383,7 +383,7 @@ class RouterTest extends UnitTestCase
 
         $router->route($routeContext);
 
-        $this->assertSame($mockRoute2, $router->getLastMatchedRoute());
+        self::assertSame($mockRoute2, $router->getLastMatchedRoute());
     }
 
     /**
@@ -417,7 +417,7 @@ class RouterTest extends UnitTestCase
 
         $routes = $router->getRoutes();
         $firstRoute = reset($routes);
-        $this->assertSame('some/uri/pattern', $firstRoute->getUriPattern());
+        self::assertSame('some/uri/pattern', $firstRoute->getUriPattern());
     }
 
     /**
@@ -452,6 +452,6 @@ class RouterTest extends UnitTestCase
 
         $routes = $router->getRoutes();
         $firstRoute = reset($routes);
-        $this->assertSame('some/uri/pattern', $firstRoute->getUriPattern());
+        self::assertSame('some/uri/pattern', $firstRoute->getUriPattern());
     }
 }

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/StaticRoutePartTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/StaticRoutePartTest.php
@@ -32,10 +32,10 @@ class StaticRoutePartTest extends UnitTestCase
         $routePart->setName('foo');
 
         $routePath = null;
-        $this->assertFalse($routePart->match($routePath), 'Static Route Part should never match if $routePath is NULL.');
+        self::assertFalse($routePart->match($routePath), 'Static Route Part should never match if $routePath is NULL.');
 
         $routePath = '';
-        $this->assertFalse($routePart->match($routePath), 'Static Route Part should never match if $routePath is empty.');
+        self::assertFalse($routePart->match($routePath), 'Static Route Part should never match if $routePath is empty.');
     }
 
     /**
@@ -48,7 +48,7 @@ class StaticRoutePartTest extends UnitTestCase
         $routePart->setDefaultValue('bar');
 
         $routePath = '';
-        $this->assertFalse($routePart->match($routePath), 'Static Route Part should never match if $routePath is empty.');
+        self::assertFalse($routePart->match($routePath), 'Static Route Part should never match if $routePath is empty.');
     }
 
     /**
@@ -58,7 +58,7 @@ class StaticRoutePartTest extends UnitTestCase
     {
         $routePart = new Mvc\Routing\StaticRoutePart();
         $routePath = 'foo/bar';
-        $this->assertFalse($routePart->match($routePath), 'Static Route Part should not match if name is not set.');
+        self::assertFalse($routePart->match($routePath), 'Static Route Part should not match if name is not set.');
     }
 
     /**
@@ -70,7 +70,7 @@ class StaticRoutePartTest extends UnitTestCase
         $routePart->setName('foo');
         $routePath = 'bar/foo';
 
-        $this->assertFalse($routePart->match($routePath), 'Static Route Part should not match if name is not equal to beginning of request path.');
+        self::assertFalse($routePart->match($routePath), 'Static Route Part should not match if name is not equal to beginning of request path.');
     }
 
     /**
@@ -82,7 +82,7 @@ class StaticRoutePartTest extends UnitTestCase
         $routePart->setName('foo');
         $routePath = 'foo/bar';
 
-        $this->assertTrue($routePart->match($routePath), 'Static Route Part should match if name equals beginning of request path.');
+        self::assertTrue($routePart->match($routePath), 'Static Route Part should match if name equals beginning of request path.');
     }
 
     /**
@@ -94,7 +94,7 @@ class StaticRoutePartTest extends UnitTestCase
         $routePart->setName('SomeName');
         $routePath = 'somename';
 
-        $this->assertFalse($routePart->match($routePath), 'Static Route Part should not match if case of name is not equal to case of request path.');
+        self::assertFalse($routePart->match($routePath), 'Static Route Part should not match if case of name is not equal to case of request path.');
     }
 
     /**
@@ -106,11 +106,11 @@ class StaticRoutePartTest extends UnitTestCase
         $routePart->setName('foo');
 
         $routePath = 'foo/bar';
-        $this->assertTrue($routePart->match($routePath));
+        self::assertTrue($routePart->match($routePath));
 
         $routePath = 'bar/foo';
-        $this->assertFalse($routePart->match($routePath));
-        $this->assertNull($routePart->getValue(), 'Static Route Part value should be NULL after unsuccessful match.');
+        self::assertFalse($routePart->match($routePath));
+        self::assertNull($routePart->getValue(), 'Static Route Part value should be NULL after unsuccessful match.');
     }
 
     /**
@@ -122,8 +122,8 @@ class StaticRoutePartTest extends UnitTestCase
         $routePart->setName('bar');
 
         $routePath = 'foo/bar';
-        $this->assertFalse($routePart->match($routePath));
-        $this->assertSame('foo/bar', $routePath, 'Static Route Part should not change $routePath on unsuccessful match.');
+        self::assertFalse($routePart->match($routePath));
+        self::assertSame('foo/bar', $routePath, 'Static Route Part should not change $routePath on unsuccessful match.');
     }
 
     /**
@@ -135,8 +135,8 @@ class StaticRoutePartTest extends UnitTestCase
         $routePart->setName('bar/');
         $routePath = 'bar/foo/test';
 
-        $this->assertTrue($routePart->match($routePath));
-        $this->assertSame('foo/test', $routePath, 'Static Route Part should shorten $routePath by matching substring on successful match.');
+        self::assertTrue($routePart->match($routePath));
+        self::assertSame('foo/test', $routePath, 'Static Route Part should shorten $routePath by matching substring on successful match.');
     }
 
     /**
@@ -148,11 +148,11 @@ class StaticRoutePartTest extends UnitTestCase
         $routePart->setName('foo');
         $routeValues = [];
         $routePart->resolve($routeValues);
-        $this->assertSame('foo', $routePart->getValue());
+        self::assertSame('foo', $routePart->getValue());
 
         $routePath = 'foo';
         $routePart->match($routePath);
-        $this->assertNull($routePart->getValue(), 'Static Route Part must reset their value to NULL.');
+        self::assertNull($routePart->getValue(), 'Static Route Part must reset their value to NULL.');
     }
 
     /*                                                                        *
@@ -168,8 +168,8 @@ class StaticRoutePartTest extends UnitTestCase
         $routePart->setName('foo');
         $routeValues = [];
 
-        $this->assertTrue($routePart->resolve($routeValues));
-        $this->assertEquals('foo', $routePart->getValue(), 'Static Route Part should resolve empty routeValues-array');
+        self::assertTrue($routePart->resolve($routeValues));
+        self::assertEquals('foo', $routePart->getValue(), 'Static Route Part should resolve empty routeValues-array');
     }
 
     /**
@@ -181,8 +181,8 @@ class StaticRoutePartTest extends UnitTestCase
         $routePart->setName('foo');
         $routeValues = ['@controller' => 'foo', '@action' => 'bar'];
 
-        $this->assertTrue($routePart->resolve($routeValues));
-        $this->assertEquals('foo', $routePart->getValue(), 'Static Route Part should resolve non-empty routeValues-array');
+        self::assertTrue($routePart->resolve($routeValues));
+        self::assertEquals('foo', $routePart->getValue(), 'Static Route Part should resolve non-empty routeValues-array');
     }
 
     /**
@@ -192,7 +192,7 @@ class StaticRoutePartTest extends UnitTestCase
     {
         $routePart = new Mvc\Routing\StaticRoutePart();
         $routeValues = [];
-        $this->assertFalse($routePart->resolve($routeValues), 'Static Route Part should not resolve if name is not set');
+        self::assertFalse($routePart->resolve($routeValues), 'Static Route Part should not resolve if name is not set');
     }
 
     /**
@@ -204,8 +204,8 @@ class StaticRoutePartTest extends UnitTestCase
         $routePart->setName('foo');
         $routeValues = ['@controller' => 'foo', '@action' => 'bar'];
 
-        $this->assertTrue($routePart->resolve($routeValues));
-        $this->assertEquals(['@controller' => 'foo', '@action' => 'bar'], $routeValues, 'when resolve() is called on Static Route Part, specified routeValues-array should never be changed');
+        self::assertTrue($routePart->resolve($routeValues));
+        self::assertEquals(['@controller' => 'foo', '@action' => 'bar'], $routeValues, 'when resolve() is called on Static Route Part, specified routeValues-array should never be changed');
     }
 
     /**
@@ -218,7 +218,7 @@ class StaticRoutePartTest extends UnitTestCase
         $routeValues = [];
 
         $routePart->resolve($routeValues);
-        $this->assertEquals('somename', $routePart->getValue(), 'Static Route Part should lowercase the value if lowerCase is true');
+        self::assertEquals('somename', $routePart->getValue(), 'Static Route Part should lowercase the value if lowerCase is true');
     }
 
     /**
@@ -232,6 +232,6 @@ class StaticRoutePartTest extends UnitTestCase
         $routeValues = [];
 
         $routePart->resolve($routeValues);
-        $this->assertEquals('SomeName', $routePart->getValue(), 'By default Static Route Part should not alter the case of name');
+        self::assertEquals('SomeName', $routePart->getValue(), 'By default Static Route Part should not alter the case of name');
     }
 }

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/UriBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/UriBuilderTest.php
@@ -115,12 +115,12 @@ class UriBuilderTest extends UnitTestCase
             ->setAddQueryString(true)
             ->setArgumentsToBeExcludedFromQueryString(['test' => 'addQueryStringExcludeArguments']);
 
-        $this->assertEquals(['test' => 'arguments'], $this->uriBuilder->getArguments());
-        $this->assertEquals('testSection', $this->uriBuilder->getSection());
-        $this->assertEquals('testformat', $this->uriBuilder->getFormat());
-        $this->assertEquals(true, $this->uriBuilder->getCreateAbsoluteUri());
-        $this->assertEquals(true, $this->uriBuilder->getAddQueryString());
-        $this->assertEquals(['test' => 'addQueryStringExcludeArguments'], $this->uriBuilder->getArgumentsToBeExcludedFromQueryString());
+        self::assertEquals(['test' => 'arguments'], $this->uriBuilder->getArguments());
+        self::assertEquals('testSection', $this->uriBuilder->getSection());
+        self::assertEquals('testformat', $this->uriBuilder->getFormat());
+        self::assertEquals(true, $this->uriBuilder->getCreateAbsoluteUri());
+        self::assertEquals(true, $this->uriBuilder->getAddQueryString());
+        self::assertEquals(['test' => 'addQueryStringExcludeArguments'], $this->uriBuilder->getArgumentsToBeExcludedFromQueryString());
     }
 
     /**
@@ -134,7 +134,7 @@ class UriBuilderTest extends UnitTestCase
 
         $this->uriBuilder->setArguments($arguments);
         $this->uriBuilder->uriFor('index', $controllerArguments, 'SomeController', 'SomePackage');
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -156,7 +156,7 @@ class UriBuilderTest extends UnitTestCase
         $expectedArguments = ['@action' => 'index', '@controller' => 'somecontrollerfromrequest', '@package' => 'somepackage'];
 
         $this->uriBuilder->uriFor('index', [], null, 'SomePackage');
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -169,7 +169,7 @@ class UriBuilderTest extends UnitTestCase
         $expectedArguments = ['@action' => 'index', '@controller' => 'somecontroller', '@package' => 'somepackagekeyfromrequest'];
 
         $this->uriBuilder->uriFor('index', [], 'SomeController', null);
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -183,7 +183,7 @@ class UriBuilderTest extends UnitTestCase
         $expectedArguments = ['@action' => 'index', '@controller' => 'somecontroller', '@package' => 'somepackage', '@subpackage' => 'somesubpackagekeyfromrequest'];
 
         $this->uriBuilder->uriFor('index', [], 'SomeController');
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -194,7 +194,7 @@ class UriBuilderTest extends UnitTestCase
         $expectedArguments = ['@action' => 'index', '@controller' => 'somecontroller', '@package' => 'somepackage'];
 
         $this->uriBuilder->uriFor('index', [], 'SomeController', 'SomePackage');
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -216,7 +216,7 @@ class UriBuilderTest extends UnitTestCase
         $expectedArguments = ['@action' => 'show', '@controller' => 'somecontroller', '@package' => 'somepackage', '@subpackage' => ''];
 
         $this->uriBuilder->uriFor('show', null, 'SomeController', 'SomePackage', '');
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -228,7 +228,7 @@ class UriBuilderTest extends UnitTestCase
 
         $this->uriBuilder->setFormat('SomeFormat');
         $this->uriBuilder->uriFor('index', [], 'SomeController', 'SomePackage');
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -243,7 +243,7 @@ class UriBuilderTest extends UnitTestCase
 
         $this->uriBuilder->setRequest($this->mockSubRequest);
         $this->uriBuilder->uriFor('SomeAction', ['arg1' => 'val1'], 'SomeController', 'SomePackage');
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -276,7 +276,7 @@ class UriBuilderTest extends UnitTestCase
 
         $this->uriBuilder->setRequest($this->mockSubSubRequest);
         $this->uriBuilder->uriFor('SomeAction', ['arg1' => 'val1'], 'SomeController', 'SomePackage');
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -294,7 +294,7 @@ class UriBuilderTest extends UnitTestCase
         $this->uriBuilder->setRequest($this->mockSubSubRequest);
         $this->uriBuilder->uriFor('SomeAction', ['arg1' => 'val1'], 'SomeController', 'SomePackage');
 
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -308,7 +308,7 @@ class UriBuilderTest extends UnitTestCase
         $this->uriBuilder->setArguments(['Foo' => 'Bar']);
         $this->uriBuilder->build();
 
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -320,7 +320,7 @@ class UriBuilderTest extends UnitTestCase
         $this->mockMainRequest->expects($this->once())->method('getArguments')->will($this->returnValue(['Some' => ['Arguments' => 'From Request'], 'Foo' => 'Bar']));
 
         $this->mockRouter->expects($this->once())->method('resolve')->willReturnCallback(function (ResolveContext $resolveContext) use ($expectedArguments) {
-            $this->assertSame($expectedArguments, $resolveContext->getRouteValues());
+            self::assertSame($expectedArguments, $resolveContext->getRouteValues());
             return $this->getMockBuilder(UriInterface::class)->getMock();
         });
 
@@ -328,7 +328,7 @@ class UriBuilderTest extends UnitTestCase
         $this->uriBuilder->setArguments(['Foo' => 'Overruled']);
 
         $this->uriBuilder->build();
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -340,7 +340,7 @@ class UriBuilderTest extends UnitTestCase
         $this->mockMainRequest->expects($this->once())->method('getArguments')->will($this->returnValue(['SubNamespace' => ['Some' => ['Arguments' => 'From Request'], 'Foo' => 'Bar']]));
 
         $this->mockRouter->expects($this->once())->method('resolve')->willReturnCallback(function (ResolveContext $resolveContext) use ($expectedArguments) {
-            $this->assertSame($expectedArguments, $resolveContext->getRouteValues());
+            self::assertSame($expectedArguments, $resolveContext->getRouteValues());
             return $this->getMockBuilder(UriInterface::class)->getMock();
         });
 
@@ -350,7 +350,7 @@ class UriBuilderTest extends UnitTestCase
 
         $this->uriBuilder->build();
 
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -362,7 +362,7 @@ class UriBuilderTest extends UnitTestCase
         $this->mockMainRequest->expects($this->once())->method('getArguments')->will($this->returnValue(['Some' => ['Arguments' => 'From Request'], 'Foo' => 'Bar']));
 
         $this->mockRouter->expects($this->once())->method('resolve')->willReturnCallback(function (ResolveContext $resolveContext) use ($expectedArguments) {
-            $this->assertSame($expectedArguments, $resolveContext->getRouteValues());
+            self::assertSame($expectedArguments, $resolveContext->getRouteValues());
             return $this->getMockBuilder(UriInterface::class)->getMock();
         });
 
@@ -392,7 +392,7 @@ class UriBuilderTest extends UnitTestCase
             ->will($this->returnValue(['Some' => ['Arguments' => 'From Request']]));
 
         $this->mockRouter->expects($this->once())->method('resolve')->willReturnCallback(function (ResolveContext $resolveContext) use ($expectedArguments) {
-            $this->assertSame($expectedArguments, $resolveContext->getRouteValues());
+            self::assertSame($expectedArguments, $resolveContext->getRouteValues());
             return $this->getMockBuilder(UriInterface::class)->getMock();
         });
 
@@ -425,7 +425,7 @@ class UriBuilderTest extends UnitTestCase
             'Foo' => 'Overruled',
             'Some' => 'Other Argument From Request'
         ];
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -445,7 +445,7 @@ class UriBuilderTest extends UnitTestCase
         $expectedArguments = [
             'Foo' => 'Bar'
         ];
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -466,7 +466,7 @@ class UriBuilderTest extends UnitTestCase
             'SubNamespace' => ['Sub' => 'Argument'],
             'Foo' => 'Bar'
         ];
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -495,7 +495,7 @@ class UriBuilderTest extends UnitTestCase
             ],
             'Foo' => 'Bar'
         ];
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -527,7 +527,7 @@ class UriBuilderTest extends UnitTestCase
             ],
             'Foo' => 'Bar'
         ];
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -553,7 +553,7 @@ class UriBuilderTest extends UnitTestCase
         $this->uriBuilder->setArguments(['SubNamespace' => ['Foo' => 'Overruled']]);
         $this->uriBuilder->build();
 
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -583,7 +583,7 @@ class UriBuilderTest extends UnitTestCase
         $this->uriBuilder->setArguments(['SubNamespace' => ['SubSubNamespace' => ['Foo' => 'Overruled']]]);
         $this->uriBuilder->build();
 
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -616,7 +616,7 @@ class UriBuilderTest extends UnitTestCase
         $this->uriBuilder->setArguments(['SubNamespace' => ['SubSubNamespace' => ['Foo' => 'Overruled']]]);
         $this->uriBuilder->build();
 
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -650,7 +650,7 @@ class UriBuilderTest extends UnitTestCase
         $this->uriBuilder->setAddQueryString(true);
         $this->uriBuilder->build();
 
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
 
@@ -666,7 +666,7 @@ class UriBuilderTest extends UnitTestCase
         $this->uriBuilder->setRequest($this->mockSubRequest);
         $this->uriBuilder->build();
 
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -681,7 +681,7 @@ class UriBuilderTest extends UnitTestCase
         $this->uriBuilder->setRequest($this->mockSubRequest);
         $this->uriBuilder->build();
 
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -696,7 +696,7 @@ class UriBuilderTest extends UnitTestCase
         $this->uriBuilder->setRequest($this->mockSubRequest);
         $this->uriBuilder->build();
 
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -711,7 +711,7 @@ class UriBuilderTest extends UnitTestCase
         $this->uriBuilder->setRequest($this->mockSubRequest);
         $this->uriBuilder->build();
 
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -722,7 +722,7 @@ class UriBuilderTest extends UnitTestCase
         $this->mockHttpRequest->expects($this->atLeastOnce())->method('getBaseUri')->will($this->returnValue($this->mockBaseUri));
 
         $this->mockRouter->expects($this->once())->method('resolve')->willReturnCallback(function (ResolveContext $resolveContext) {
-            $this->assertSame($this->mockBaseUri, $resolveContext->getBaseUri());
+            self::assertSame($this->mockBaseUri, $resolveContext->getBaseUri());
             return $this->getMockBuilder(UriInterface::class)->getMock();
         });
 
@@ -750,7 +750,7 @@ class UriBuilderTest extends UnitTestCase
     {
         $this->mockHttpRequest->expects($this->atLeastOnce())->method('getScriptRequestPath')->will($this->returnValue('/document-root/'));
         $this->mockRouter->expects($this->once())->method('resolve')->willReturnCallback(function (ResolveContext $resolveContext) {
-            $this->assertFalse($resolveContext->isForceAbsoluteUri());
+            self::assertFalse($resolveContext->isForceAbsoluteUri());
             return $this->getMockBuilder(UriInterface::class)->getMock();
         });
 
@@ -764,7 +764,7 @@ class UriBuilderTest extends UnitTestCase
     {
         $this->mockHttpRequest->expects($this->atLeastOnce())->method('getScriptRequestPath')->will($this->returnValue('/document-root/'));
         $this->mockRouter->expects($this->once())->method('resolve')->willReturnCallback(function (ResolveContext $resolveContext) {
-            $this->assertTrue($resolveContext->isForceAbsoluteUri());
+            self::assertTrue($resolveContext->isForceAbsoluteUri());
             return $this->getMockBuilder(UriInterface::class)->getMock();
         });
 
@@ -780,7 +780,7 @@ class UriBuilderTest extends UnitTestCase
     {
         $this->mockHttpRequest->expects($this->atLeastOnce())->method('getScriptRequestPath')->will($this->returnValue('/document-root/'));
         $this->mockRouter->expects($this->once())->method('resolve')->willReturnCallback(function (ResolveContext $resolveContext) {
-            $this->assertSame('/document-root/', $resolveContext->getUriPathPrefix());
+            self::assertSame('/document-root/', $resolveContext->getUriPathPrefix());
             return $this->getMockBuilder(UriInterface::class)->getMock();
         });
 
@@ -798,7 +798,7 @@ class UriBuilderTest extends UnitTestCase
         $this->inject($this->uriBuilder, 'environment', $mockEnvironment);
 
         $this->mockRouter->expects($this->once())->method('resolve')->willReturnCallback(function (ResolveContext $resolveContext) {
-            $this->assertSame('index.php/', $resolveContext->getUriPathPrefix());
+            self::assertSame('index.php/', $resolveContext->getUriPathPrefix());
             return $this->getMockBuilder(UriInterface::class)->getMock();
         });
 
@@ -822,12 +822,12 @@ class UriBuilderTest extends UnitTestCase
 
         $this->uriBuilder->reset();
 
-        $this->assertEquals([], $this->uriBuilder->getArguments());
-        $this->assertEquals('', $this->uriBuilder->getSection());
-        $this->assertEquals('', $this->uriBuilder->getFormat());
-        $this->assertEquals(false, $this->uriBuilder->getCreateAbsoluteUri());
-        $this->assertEquals(false, $this->uriBuilder->getAddQueryString());
-        $this->assertEquals([], $this->uriBuilder->getArgumentsToBeExcludedFromQueryString());
+        self::assertEquals([], $this->uriBuilder->getArguments());
+        self::assertEquals('', $this->uriBuilder->getSection());
+        self::assertEquals('', $this->uriBuilder->getFormat());
+        self::assertEquals(false, $this->uriBuilder->getCreateAbsoluteUri());
+        self::assertEquals(false, $this->uriBuilder->getAddQueryString());
+        self::assertEquals([], $this->uriBuilder->getArgumentsToBeExcludedFromQueryString());
     }
 
     /**
@@ -854,7 +854,7 @@ class UriBuilderTest extends UnitTestCase
         ];
         $this->uriBuilder->setArguments($arguments);
         $expectedResult = $arguments;
-        $this->assertEquals($expectedResult, $this->uriBuilder->getArguments());
+        self::assertEquals($expectedResult, $this->uriBuilder->getArguments());
     }
 
     /**
@@ -871,7 +871,7 @@ class UriBuilderTest extends UnitTestCase
         $this->uriBuilder->setRequest($this->mockSubRequest);
         $this->uriBuilder->uriFor('SomeAction', [], 'SomeController', 'SomePackage');
 
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 
     /**
@@ -889,6 +889,6 @@ class UriBuilderTest extends UnitTestCase
         $this->uriBuilder->setFormat('inner');
         $this->uriBuilder->uriFor('SomeAction', [], 'SomeController', 'SomePackage');
 
-        $this->assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
+        self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 }

--- a/Neos.Flow/Tests/Unit/Mvc/View/AbstractViewTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/View/AbstractViewTest.php
@@ -31,7 +31,7 @@ class AbstractViewTest extends UnitTestCase
 
         $expectedResult = ['foo' => 'FooValue', 'bar' => 'BarValue'];
         $actualResult = $view->_get('variables');
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -45,7 +45,7 @@ class AbstractViewTest extends UnitTestCase
 
         $expectedResult = ['foo' => 'FooValueOverridden'];
         $actualResult = $view->_get('variables');
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -60,7 +60,7 @@ class AbstractViewTest extends UnitTestCase
 
         $expectedResult = ['foo' => 'FooValue', 'bar' => 'BarValue', 'baz' => 'BazValue'];
         $actualResult = $view->_get('variables');
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -74,6 +74,6 @@ class AbstractViewTest extends UnitTestCase
 
         $expectedResult = ['foo' => 'FooValueOverridden', 'bar' => 'BarValue'];
         $actualResult = $view->_get('variables');
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 }

--- a/Neos.Flow/Tests/Unit/Mvc/View/JsonViewTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/View/JsonViewTest.php
@@ -156,7 +156,7 @@ class JsonViewTest extends UnitTestCase
 
         $actual = $jsonView->_call('transformValue', $object, $configuration);
 
-        $this->assertEquals($expected, $actual, $description);
+        self::assertEquals($expected, $actual, $description);
     }
 
     /**
@@ -203,7 +203,7 @@ class JsonViewTest extends UnitTestCase
 
         $actual = $jsonView->_call('transformValue', $object, $configuration);
 
-        $this->assertEquals($expected, $actual, $description);
+        self::assertEquals($expected, $actual, $description);
     }
 
     /**
@@ -258,7 +258,7 @@ class JsonViewTest extends UnitTestCase
 
         $jsonView = $this->getAccessibleMock(Mvc\View\JsonView::class, ['dummy'], [], '', false);
         $actual = $jsonView->_call('transformValue', $object, $configuration);
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -282,7 +282,7 @@ class JsonViewTest extends UnitTestCase
 
         $expectedResult = '{"foo":"Foo"}';
         $actualResult = $this->view->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -295,7 +295,7 @@ class JsonViewTest extends UnitTestCase
 
         $expectedResult = '{"foo":"Foo","bar":"Bar"}';
         $actualResult = $this->view->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -308,7 +308,7 @@ class JsonViewTest extends UnitTestCase
 
         $expectedResult = '"Foo"';
         $actualResult = $this->view->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -321,7 +321,7 @@ class JsonViewTest extends UnitTestCase
 
         $expectedResult = 'null';
         $actualResult = $this->view->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -335,7 +335,7 @@ class JsonViewTest extends UnitTestCase
 
         $expectedResult = '"Value"';
         $actualResult = $this->view->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -349,7 +349,7 @@ class JsonViewTest extends UnitTestCase
 
         $expectedResult = '"Foo"';
         $actualResult = $this->view->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -365,7 +365,7 @@ class JsonViewTest extends UnitTestCase
 
         $expectedResult = '{"value":"Value1","secondValue":"Value2"}';
         $actualResult = $this->view->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -385,7 +385,7 @@ class JsonViewTest extends UnitTestCase
 
         $expectedResult = '{"array":{"foo":{"bar":"Baz"}},"object":{"foo":"Foo"}}';
         $actualResult = $this->view->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -406,7 +406,7 @@ class JsonViewTest extends UnitTestCase
 
         $expectedResult = '[{"name":"Foo"},{"name":"Bar"}]';
         $actualResult = $this->view->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -427,7 +427,7 @@ class JsonViewTest extends UnitTestCase
 
         $expectedResult = '[{"name":"Foo","secret":true},{"name":"Bar","secret":true}]';
         $actualResult = $this->view->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -447,7 +447,7 @@ class JsonViewTest extends UnitTestCase
 
         $expectedResult = '{"name":"Foo"}';
         $actualResult = $this->view->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -464,9 +464,9 @@ class JsonViewTest extends UnitTestCase
         $expectedResult = json_encode($array, JSON_PRETTY_PRINT);
 
         $actualResult = $this->view->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
 
         $unexpectedResult = json_encode($array);
-        $this->assertNotEquals($unexpectedResult, $actualResult);
+        self::assertNotEquals($unexpectedResult, $actualResult);
     }
 }

--- a/Neos.Flow/Tests/Unit/Mvc/ViewConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/ViewConfigurationManagerTest.php
@@ -93,7 +93,7 @@ class ViewConfigurationManagerTest extends \Neos\Flow\Tests\UnitTestCase
         $this->mockConfigurationManager->expects($this->any())->method('getConfiguration')->with('Views')->will($this->returnValue($viewConfigurations));
         $calculatedConfiguration = $this->viewConfigurationManager->getViewConfiguration($this->mockActionRequest);
 
-        $this->assertEquals($calculatedConfiguration, $matchingConfiguration);
+        self::assertEquals($calculatedConfiguration, $matchingConfiguration);
     }
 
     /**
@@ -121,7 +121,7 @@ class ViewConfigurationManagerTest extends \Neos\Flow\Tests\UnitTestCase
         $this->mockConfigurationManager->expects($this->any())->method('getConfiguration')->with('Views')->will($this->returnValue($viewConfigurations));
         $calculatedConfiguration = $this->viewConfigurationManager->getViewConfiguration($this->mockActionRequest);
 
-        $this->assertEquals($calculatedConfiguration, $matchingConfigurationTwo);
+        self::assertEquals($calculatedConfiguration, $matchingConfigurationTwo);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/ObjectManagement/CompileTimeObjectManagerTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/CompileTimeObjectManagerTest.php
@@ -69,8 +69,8 @@ class CompileTimeObjectManagerTest extends UnitTestCase
 
         $objectManagementEnabledClasses = $this->compileTimeObjectManager->_call('registerClassFiles', ['Vendor.TestPackage' => $testPackage]);
         // Count is at least 1 as '' => 'DateTime' is hardcoded
-        $this->assertCount(2, $objectManagementEnabledClasses);
-        $this->assertArrayHasKey('Vendor.TestPackage', $objectManagementEnabledClasses);
+        self::assertCount(2, $objectManagementEnabledClasses);
+        self::assertArrayHasKey('Vendor.TestPackage', $objectManagementEnabledClasses);
     }
 
     /**
@@ -87,7 +87,7 @@ class CompileTimeObjectManagerTest extends UnitTestCase
 
         $objectManagementEnabledClasses = $this->compileTimeObjectManager->_call('registerClassFiles', ['NonFlow.TestPackage' => $testPackage]);
         // Count is at least 1 as '' => 'DateTime' is hardcoded
-        $this->assertCount(1, $objectManagementEnabledClasses);
+        self::assertCount(1, $objectManagementEnabledClasses);
     }
 
     /**
@@ -104,8 +104,8 @@ class CompileTimeObjectManagerTest extends UnitTestCase
 
         $objectManagementEnabledClasses = $this->compileTimeObjectManager->_call('registerClassFiles', ['NonFlow.IncludeAllClasses' => $testPackage]);
         // Count is at least 1 as '' => 'DateTime' is hardcoded
-        $this->assertCount(2, $objectManagementEnabledClasses);
-        $this->assertArrayHasKey('NonFlow.IncludeAllClasses', $objectManagementEnabledClasses);
+        self::assertCount(2, $objectManagementEnabledClasses);
+        self::assertArrayHasKey('NonFlow.IncludeAllClasses', $objectManagementEnabledClasses);
     }
 
     /**
@@ -122,7 +122,7 @@ class CompileTimeObjectManagerTest extends UnitTestCase
 
         $objectManagementEnabledClasses = $this->compileTimeObjectManager->_call('registerClassFiles', ['NonFlow.IncludeAndExclude' => $testPackage]);
         // Count is at least 1 as '' => 'DateTime' is hardcoded
-        $this->assertCount(1, $objectManagementEnabledClasses);
+        self::assertCount(1, $objectManagementEnabledClasses);
     }
 
     /**
@@ -139,6 +139,6 @@ class CompileTimeObjectManagerTest extends UnitTestCase
 
         $objectManagementEnabledClasses = $this->compileTimeObjectManager->_call('registerClassFiles', ['Vendor.AnotherPackage' => $testPackage]);
         // Count is at least 1 as '' => 'DateTime' is hardcoded
-        $this->assertCount(1, $objectManagementEnabledClasses);
+        self::assertCount(1, $objectManagementEnabledClasses);
     }
 }

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationBuilderTest.php
@@ -56,7 +56,7 @@ class ConfigurationBuilderTest extends UnitTestCase
 
         $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy']);
         $builtObjectConfiguration = $configurationBuilder->_call('parseConfigurationArray', 'TestObject', $configurationArray, __CLASS__);
-        $this->assertEquals($objectConfiguration, $builtObjectConfiguration, 'The manually created and the built object configuration don\'t match.');
+        self::assertEquals($objectConfiguration, $builtObjectConfiguration, 'The manually created and the built object configuration don\'t match.');
     }
 
     /**
@@ -76,7 +76,7 @@ class ConfigurationBuilderTest extends UnitTestCase
 
         $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy']);
         $builtObjectConfiguration = $configurationBuilder->_call('parseConfigurationArray', 'TestObject', $configurationArray, __CLASS__);
-        $this->assertEquals($objectConfiguration, $builtObjectConfiguration);
+        self::assertEquals($objectConfiguration, $builtObjectConfiguration);
     }
 
     /**
@@ -96,7 +96,7 @@ class ConfigurationBuilderTest extends UnitTestCase
 
         $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy']);
         $builtObjectConfiguration = $configurationBuilder->_call('parseConfigurationArray', 'TestObject', $configurationArray, __CLASS__);
-        $this->assertEquals($objectConfiguration, $builtObjectConfiguration);
+        self::assertEquals($objectConfiguration, $builtObjectConfiguration);
     }
 
     /**
@@ -114,7 +114,7 @@ class ConfigurationBuilderTest extends UnitTestCase
 
         $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy']);
         $builtObjectConfiguration = $configurationBuilder->_call('parseConfigurationArray', 'TestObject', $configurationArray, __CLASS__);
-        $this->assertEquals($objectConfiguration, $builtObjectConfiguration);
+        self::assertEquals($objectConfiguration, $builtObjectConfiguration);
     }
 
     /**
@@ -188,7 +188,7 @@ class ConfigurationBuilderTest extends UnitTestCase
         $builtObjectConfiguration = $configurationBuilder->_call('parseConfigurationArray', 'TestObject', $configurationArray, __CLASS__);
 
         $expectedConfigurationProperty = new ConfigurationProperty('someProperty', ['type' => ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'path' => 'Neos.Foo.Bar'], ConfigurationProperty::PROPERTY_TYPES_CONFIGURATION);
-        $this->assertEquals($expectedConfigurationProperty, $builtObjectConfiguration->getProperties()['someProperty']);
+        self::assertEquals($expectedConfigurationProperty, $builtObjectConfiguration->getProperties()['someProperty']);
     }
 
     /**
@@ -205,6 +205,6 @@ class ConfigurationBuilderTest extends UnitTestCase
         $builtObjectConfiguration = $configurationBuilder->_call('parseConfigurationArray', 'TestObject', $configurationArray, __CLASS__);
 
         $expectedConfigurationArgument = new ConfigurationArgument(1, 'Neos.Foo.Bar', ConfigurationArgument::ARGUMENT_TYPES_SETTING);
-        $this->assertEquals($expectedConfigurationArgument, $builtObjectConfiguration->getArguments()[1]);
+        self::assertEquals($expectedConfigurationArgument, $builtObjectConfiguration->getArguments()[1]);
     }
 }

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationTest.php
@@ -60,10 +60,10 @@ class ConfigurationTest extends UnitTestCase
             'prop2' => new Configuration\ConfigurationProperty('prop2', 'another string')
         ];
         $this->objectConfiguration->setProperties($someProperties);
-        $this->assertEquals($someProperties, $this->objectConfiguration->getProperties(), 'The set properties could not be retrieved again.');
+        self::assertEquals($someProperties, $this->objectConfiguration->getProperties(), 'The set properties could not be retrieved again.');
 
         $this->objectConfiguration->setProperties([]);
-        $this->assertEquals([], $this->objectConfiguration->getProperties(), 'The properties have not been cleared.');
+        self::assertEquals([], $this->objectConfiguration->getProperties(), 'The properties have not been cleared.');
     }
 
     /**
@@ -92,10 +92,10 @@ class ConfigurationTest extends UnitTestCase
             2 => new Configuration\ConfigurationArgument(2, 'another string')
         ];
         $this->objectConfiguration->setArguments($someArguments);
-        $this->assertEquals($someArguments, $this->objectConfiguration->getArguments(), 'The set arguments could not be retrieved again.');
+        self::assertEquals($someArguments, $this->objectConfiguration->getArguments(), 'The set arguments could not be retrieved again.');
 
         $this->objectConfiguration->setArguments([]);
-        $this->assertEquals([], $this->objectConfiguration->getArguments(), 'The constructor arguments have not been cleared.');
+        self::assertEquals([], $this->objectConfiguration->getArguments(), 'The constructor arguments have not been cleared.');
     }
 
     /**
@@ -104,7 +104,7 @@ class ConfigurationTest extends UnitTestCase
     public function setFactoryObjectNameAcceptsValidClassNames()
     {
         $this->objectConfiguration->setFactoryObjectName(__CLASS__);
-        $this->assertSame(__CLASS__, $this->objectConfiguration->getFactoryObjectName());
+        self::assertSame(__CLASS__, $this->objectConfiguration->getFactoryObjectName());
     }
 
     /**
@@ -113,7 +113,7 @@ class ConfigurationTest extends UnitTestCase
     public function setFactoryMethodNameAcceptsValidStrings()
     {
         $this->objectConfiguration->setFactoryMethodName('someMethodName');
-        $this->assertSame('someMethodName', $this->objectConfiguration->getFactoryMethodName());
+        self::assertSame('someMethodName', $this->objectConfiguration->getFactoryMethodName());
     }
 
     /**
@@ -130,6 +130,6 @@ class ConfigurationTest extends UnitTestCase
      */
     public function theDefaultFactoryMethodNameIsCreate()
     {
-        $this->assertSame('create', $this->objectConfiguration->getFactoryMethodName());
+        self::assertSame('create', $this->objectConfiguration->getFactoryMethodName());
     }
 }

--- a/Neos.Flow/Tests/Unit/ObjectManagement/DependencyInjection/DependencyProxyTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/DependencyInjection/DependencyProxyTest.php
@@ -23,6 +23,6 @@ class DependencyProxyTest extends UnitTestCase
     {
         $proxy = new DependencyProxy('SomeClass', function () {
         });
-        $this->assertSame('SomeClass', $proxy->_getClassName());
+        self::assertSame('SomeClass', $proxy->_getClassName());
     }
 }

--- a/Neos.Flow/Tests/Unit/ObjectManagement/ObjectManagerTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/ObjectManagerTest.php
@@ -64,9 +64,9 @@ class ObjectManagerTest extends UnitTestCase
         $object2 = $objectManager->get(BasicClass::class);
 
         if ($scope == ObjectConfiguration::SCOPE_PROTOTYPE) {
-            $this->assertNotSame($object1, $object2);
+            self::assertNotSame($object1, $object2);
         } else {
-            $this->assertSame($object1, $object2);
+            self::assertSame($object1, $object2);
         }
     }
 }

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/CompilerTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/CompilerTest.php
@@ -101,7 +101,7 @@ class CompilerTest extends UnitTestCase
      */
     public function renderAnnotationRendersCorrectly($annotation, $expectedString)
     {
-        $this->assertEquals($expectedString, Compiler::renderAnnotation($annotation));
+        self::assertEquals($expectedString, Compiler::renderAnnotation($annotation));
     }
 
     /**
@@ -138,6 +138,6 @@ class CompilerTest extends UnitTestCase
     public function stripOpeningPhpTagCorrectlyStripsPhpTagTests($classCode, $expectedResult)
     {
         $actualResult = $this->compiler->_call('stripOpeningPhpTag', $classCode);
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 }

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyClassTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyClassTest.php
@@ -86,6 +86,6 @@ class ProxyClassTest extends UnitTestCase
 
         $proxyCode = $mockProxyClass->render();
 
-        $this->assertEquals($expectedProxyCode, $proxyCode);
+        self::assertEquals($expectedProxyCode, $proxyCode);
     }
 }

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyMethodTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyMethodTest.php
@@ -48,7 +48,7 @@ class ProxyMethodTest extends \Neos\Flow\Tests\UnitTestCase
             '     * @\Neos\Flow\Annotations\Validate(type="bar2", argumentName="foo2")' . chr(10) .
             '     * @\Neos\Flow\Annotations\SkipCsrfProtection' . chr(10) .
             '     */' . chr(10);
-        $this->assertEquals($expected, $methodDocumentation);
+        self::assertEquals($expected, $methodDocumentation);
     }
 
     /**
@@ -134,7 +134,7 @@ class ProxyMethodTest extends \Neos\Flow\Tests\UnitTestCase
         $builder->injectReflectionService($mockReflectionService);
 
         $actualCode = $builder->buildMethodParametersCode($className, 'foo', true);
-        $this->assertSame($expectedCode, $actualCode);
+        self::assertSame($expectedCode, $actualCode);
     }
 
     /**
@@ -164,7 +164,7 @@ class ProxyMethodTest extends \Neos\Flow\Tests\UnitTestCase
         $builder->injectReflectionService($mockReflectionService);
 
         $actualCode = $builder->buildMethodParametersCode($className, 'foo', false);
-        $this->assertSame($expectedCode, $actualCode);
+        self::assertSame($expectedCode, $actualCode);
     }
 
     /**
@@ -175,6 +175,6 @@ class ProxyMethodTest extends \Neos\Flow\Tests\UnitTestCase
         $builder = $this->getMockBuilder(ProxyMethod::class)->disableOriginalConstructor()->setMethods(['dummy'])->getMock();
 
         $actualCode = $builder->buildMethodParametersCode(null, 'foo', true);
-        $this->assertSame('', $actualCode);
+        self::assertSame('', $actualCode);
     }
 }

--- a/Neos.Flow/Tests/Unit/Package/PackageFactoryTest.php
+++ b/Neos.Flow/Tests/Unit/Package/PackageFactoryTest.php
@@ -103,7 +103,7 @@ class PackageFactoryTest extends UnitTestCase
         require($packageFilePath);
 
         $package = $this->packageFactory->create('vfs://Packages/', 'Some/Path/Some.Package/', 'Some.Package', 'some/package');
-        $this->assertSame('Neos\Flow\Fixtures\CustomPackage2', get_class($package));
+        self::assertSame('Neos\Flow\Fixtures\CustomPackage2', get_class($package));
     }
 
     /**
@@ -122,7 +122,7 @@ class PackageFactoryTest extends UnitTestCase
         require($packageFilePath);
 
         $package = $this->packageFactory->create('vfs://Packages/', 'Some/Path/Some.Package/', 'Some.Package', 'some/package', $composerManifest['autoload']);
-        $this->assertSame('Neos\Flow\Fixtures\CustomPackage3', get_class($package));
+        self::assertSame('Neos\Flow\Fixtures\CustomPackage3', get_class($package));
     }
 
     /**
@@ -135,6 +135,6 @@ class PackageFactoryTest extends UnitTestCase
         file_put_contents($packagePath . 'composer.json', '{"name": "some/package", "type": "neos-test"}');
 
         $package = $this->packageFactory->create('vfs://Packages/', 'Some/Path/Some.Package/', 'Some.Package', 'some/package');
-        $this->assertSame(Package::class, get_class($package));
+        self::assertSame(Package::class, get_class($package));
     }
 }

--- a/Neos.Flow/Tests/Unit/Package/PackageManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Package/PackageManagerTest.php
@@ -98,7 +98,7 @@ class PackageManagerTest extends UnitTestCase
         $this->packageManager->createPackage('Some.Test.Package', [], 'vfs://Test/Packages/Application');
 
         $package = $this->packageManager->getPackage('Some.Test.Package');
-        $this->assertInstanceOf(PackageInterface::class, $package, 'The result of getPackage() was no valid package object.');
+        self::assertInstanceOf(PackageInterface::class, $package, 'The result of getPackage() was no valid package object.');
     }
 
     /**
@@ -141,7 +141,7 @@ class PackageManagerTest extends UnitTestCase
     {
         $packageManager = $this->getAccessibleMock(PackageManager::class, ['dummy'], ['', '']);
         $packageManager->_set('packageKeys', ['acme.testpackage' => 'Acme.TestPackage']);
-        $this->assertEquals('Acme.TestPackage', $packageManager->getCaseSensitivePackageKey('acme.testpackage'));
+        self::assertEquals('Acme.TestPackage', $packageManager->getCaseSensitivePackageKey('acme.testpackage'));
     }
 
     /**
@@ -174,7 +174,7 @@ class PackageManagerTest extends UnitTestCase
 
         $packageStates = require('vfs://Test/Configuration/PackageStates.php');
         $actualPackageKeys = array_keys($packageStates['packages']);
-        $this->assertEquals(sort($expectedPackageKeys), sort($actualPackageKeys));
+        self::assertEquals(sort($expectedPackageKeys), sort($actualPackageKeys));
     }
 
     /**
@@ -218,7 +218,7 @@ class PackageManagerTest extends UnitTestCase
             ];
         }
 
-        $this->assertEquals($expectedPackageStatesConfiguration, $actualPackageStatesConfiguration['packages']);
+        self::assertEquals($expectedPackageStatesConfiguration, $actualPackageStatesConfiguration['packages']);
     }
 
     /**
@@ -243,10 +243,10 @@ class PackageManagerTest extends UnitTestCase
         $actualPackage = $this->packageManager->createPackage($packageKey, [], 'vfs://Test/Packages/Application');
         $actualPackagePath = $actualPackage->getPackagePath();
 
-        $this->assertEquals($expectedPackagePath, $actualPackagePath);
-        $this->assertTrue(is_dir($actualPackagePath), 'Package path should exist after createPackage()');
-        $this->assertEquals($packageKey, $actualPackage->getPackageKey());
-        $this->assertTrue($this->packageManager->isPackageAvailable($packageKey));
+        self::assertEquals($expectedPackagePath, $actualPackagePath);
+        self::assertTrue(is_dir($actualPackagePath), 'Package path should exist after createPackage()');
+        self::assertEquals($packageKey, $actualPackage->getPackageKey());
+        self::assertTrue($this->packageManager->isPackageAvailable($packageKey));
     }
 
     /**
@@ -268,8 +268,8 @@ class PackageManagerTest extends UnitTestCase
         $json = file_get_contents($package->getPackagePath() . '/composer.json');
         $composerManifest = json_decode($json);
 
-        $this->assertEquals('acme/yetanothertestpackage', $composerManifest->name);
-        $this->assertEquals('Yet Another Test Package', $composerManifest->description);
+        self::assertEquals('acme/yetanothertestpackage', $composerManifest->name);
+        self::assertEquals('Yet Another Test Package', $composerManifest->description);
     }
 
     /**
@@ -293,7 +293,7 @@ class PackageManagerTest extends UnitTestCase
         $json = file_get_contents($package->getPackagePath() . '/composer.json');
         $composerManifest = json_decode($json);
 
-        $this->assertEquals('flow-custom-package', $composerManifest->type);
+        self::assertEquals('flow-custom-package', $composerManifest->type);
     }
 
 
@@ -307,7 +307,7 @@ class PackageManagerTest extends UnitTestCase
         $json = file_get_contents($package->getPackagePath() . '/composer.json');
         $composerManifest = json_decode($json);
 
-        $this->assertEquals('neos-package', $composerManifest->type);
+        self::assertEquals('neos-package', $composerManifest->type);
     }
 
     /**
@@ -320,11 +320,11 @@ class PackageManagerTest extends UnitTestCase
         $package = $this->packageManager->createPackage('Acme.YetAnotherTestPackage', [], 'vfs://Test/Packages/Application');
         $packagePath = $package->getPackagePath();
 
-        $this->assertTrue(is_dir($packagePath . FlowPackageInterface::DIRECTORY_CLASSES), 'Classes directory was not created');
-        $this->assertTrue(is_dir($packagePath . FlowPackageInterface::DIRECTORY_CONFIGURATION), 'Configuration directory was not created');
-        $this->assertTrue(is_dir($packagePath . FlowPackageInterface::DIRECTORY_RESOURCES), 'Resources directory was not created');
-        $this->assertTrue(is_dir($packagePath . FlowPackageInterface::DIRECTORY_TESTS_UNIT), 'Tests/Unit directory was not created');
-        $this->assertTrue(is_dir($packagePath . FlowPackageInterface::DIRECTORY_TESTS_FUNCTIONAL), 'Tests/Functional directory was not created');
+        self::assertTrue(is_dir($packagePath . FlowPackageInterface::DIRECTORY_CLASSES), 'Classes directory was not created');
+        self::assertTrue(is_dir($packagePath . FlowPackageInterface::DIRECTORY_CONFIGURATION), 'Configuration directory was not created');
+        self::assertTrue(is_dir($packagePath . FlowPackageInterface::DIRECTORY_RESOURCES), 'Resources directory was not created');
+        self::assertTrue(is_dir($packagePath . FlowPackageInterface::DIRECTORY_TESTS_UNIT), 'Tests/Unit directory was not created');
+        self::assertTrue(is_dir($packagePath . FlowPackageInterface::DIRECTORY_TESTS_FUNCTIONAL), 'Tests/Functional directory was not created');
     }
 
     /**
@@ -338,7 +338,7 @@ class PackageManagerTest extends UnitTestCase
             $this->packageManager->createPackage('Invalid_PackageKey', [], 'vfs://Test/Packages/Application');
         } catch (InvalidPackageKeyException $exception) {
         }
-        $this->assertFalse(is_dir('vfs://Test/Packages/Application/Invalid_PackageKey'), 'Package folder with invalid package key was created');
+        self::assertFalse(is_dir('vfs://Test/Packages/Application/Invalid_PackageKey'), 'Package folder with invalid package key was created');
     }
 
     /**
@@ -359,7 +359,7 @@ class PackageManagerTest extends UnitTestCase
     public function createPackageMakesTheNewlyCreatedPackageAvailable()
     {
         $this->packageManager->createPackage('Acme.YetAnotherTestPackage', [], 'vfs://Test/Packages/Application');
-        $this->assertTrue($this->packageManager->isPackageAvailable('Acme.YetAnotherTestPackage'));
+        self::assertTrue($this->packageManager->isPackageAvailable('Acme.YetAnotherTestPackage'));
     }
 
     /**
@@ -397,7 +397,7 @@ class PackageManagerTest extends UnitTestCase
         $packageManager = $this->getAccessibleMock(PackageManager::class, ['resolvePackageDependencies'], ['', '']);
         $packageManager->_set('packageStatesConfiguration', $packageStatesConfiguration);
 
-        $this->assertEquals($packageKey, $packageManager->_call('getPackageKeyFromComposerName', $composerName));
+        self::assertEquals($packageKey, $packageManager->_call('getPackageKeyFromComposerName', $composerName));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Package/PackageOrderResolverTest.php
+++ b/Neos.Flow/Tests/Unit/Package/PackageOrderResolverTest.php
@@ -360,6 +360,6 @@ class PackageOrderResolverTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $orderResolver = new PackageOrderResolver($packages, $packages);
         $sortedPackages = $orderResolver->sort();
-        $this->assertEquals($expectedPackageOrder, array_keys($sortedPackages), 'The packages have not been ordered according to their require!');
+        self::assertEquals($expectedPackageOrder, array_keys($sortedPackages), 'The packages have not been ordered according to their require!');
     }
 }

--- a/Neos.Flow/Tests/Unit/Package/PackageTest.php
+++ b/Neos.Flow/Tests/Unit/Package/PackageTest.php
@@ -66,8 +66,8 @@ class PackageTest extends UnitTestCase
 
         $package = new Package('Acme.MyPackage', 'acme/mypackage', $packagePath, $composerManifest['autoload']);
         foreach ($package->getClassFiles() as $className => $classPath) {
-            $this->assertArrayHasKey($className, $expectedClassFilesArray);
-            $this->assertEquals($expectedClassFilesArray[$className], $classPath);
+            self::assertArrayHasKey($className, $expectedClassFilesArray);
+            self::assertEquals($expectedClassFilesArray[$className], $classPath);
         }
     }
 
@@ -83,7 +83,7 @@ class PackageTest extends UnitTestCase
         $package = new Package('Acme.MyPackage', 'acme/mypackage', $packagePath, ['psr-0' => ['acme\\MyPackage' => 'Classes/']]);
 
         $packageType = $package->getComposerManifest('type');
-        $this->assertEquals('flow-test', $packageType);
+        self::assertEquals('flow-test', $packageType);
     }
 
     /**
@@ -107,6 +107,6 @@ class PackageTest extends UnitTestCase
         $package = $this->getMockBuilder(\Neos\Flow\Package\Package::class)->setMethods(['getComposerManifest'])->setConstructorArgs(['Some.Package', 'some/package', 'vfs://Packages/Some/Path/Some.Package/', []])->getMock();
         $package->method('getComposerManifest')->willReturn('1.2.3');
 
-        $this->assertEquals('1.2.3', $package->getInstalledVersion('some/package'));
+        self::assertEquals('1.2.3', $package->getInstalledVersion('some/package'));
     }
 }

--- a/Neos.Flow/Tests/Unit/Persistence/AbstractPersistenceManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/AbstractPersistenceManagerTest.php
@@ -40,7 +40,7 @@ class AbstractPersistenceManagerTest extends UnitTestCase
 
         $expectedResult = ['__identity' => 123];
         $actualResult = $this->abstractPersistenceManager->convertObjectToIdentityArray($someObject);
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -69,7 +69,7 @@ class AbstractPersistenceManagerTest extends UnitTestCase
         $expectedResult = ['foo' => 'bar', 'object1' => ['__identity' => 'identifier1'], 'baz' => ['object2' => ['__identity' => 'identifier2']]];
 
         $actualResult = $this->abstractPersistenceManager->convertObjectsToIdentityArrays($originalArray);
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -86,6 +86,6 @@ class AbstractPersistenceManagerTest extends UnitTestCase
         $expectedResult = ['foo' => 'bar', 'object1' => ['__identity' => 'identifier1'], 'baz' => ['object2' => ['__identity' => 'identifier2']]];
 
         $actualResult = $this->abstractPersistenceManager->convertObjectsToIdentityArrays($originalArray);
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 }

--- a/Neos.Flow/Tests/Unit/Persistence/Aspect/PersistenceMagicAspectTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Aspect/PersistenceMagicAspectTest.php
@@ -59,7 +59,7 @@ class PersistenceMagicAspectTest extends UnitTestCase
         $this->mockJoinPoint->expects($this->any())->method('getProxy')->will($this->returnValue($object));
 
         $this->persistenceMagicAspect->cloneObject($this->mockJoinPoint);
-        $this->assertTrue($object->Flow_Persistence_clone);
+        self::assertTrue($object->Flow_Persistence_clone);
     }
 
     /**
@@ -76,6 +76,6 @@ class PersistenceMagicAspectTest extends UnitTestCase
         $this->mockPersistenceManager->expects($this->atLeastOnce())->method('registerNewObject')->with($object);
         $this->persistenceMagicAspect->generateUuid($this->mockJoinPoint);
 
-        $this->assertEquals(36, strlen($object->Persistence_Object_Identifier));
+        self::assertEquals(36, strlen($object->Persistence_Object_Identifier));
     }
 }

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/DataTypes/JsonArrayTypeTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/DataTypes/JsonArrayTypeTest.php
@@ -45,7 +45,7 @@ class JsonArrayTypeTest extends UnitTestCase
     public function jsonConversionReturnsNullIfArrayIsNull()
     {
         $json = $this->jsonArrayTypeMock->convertToDatabaseValue(null, $this->abstractPlatformMock);
-        $this->assertEquals(null, $json);
+        self::assertEquals(null, $json);
     }
 
     /**
@@ -54,6 +54,6 @@ class JsonArrayTypeTest extends UnitTestCase
     public function passSimpleArrayAndConvertToJson()
     {
         $json = $this->jsonArrayTypeMock->convertToDatabaseValue(['simplestring',1,['nestedArray']], $this->abstractPlatformMock);
-        $this->assertEquals("{\n    \"0\": \"simplestring\",\n    \"1\": 1,\n    \"2\": {\n        \"0\": \"nestedArray\"\n    }\n}", $json);
+        self::assertEquals("{\n    \"0\": \"simplestring\",\n    \"1\": 1,\n    \"2\": {\n        \"0\": \"nestedArray\"\n    }\n}", $json);
     }
 }

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/EntityManagerConfigurationTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/EntityManagerConfigurationTest.php
@@ -25,8 +25,8 @@ class EntityManagerConfigurationTest extends UnitTestCase
     {
         $configuration = $this->buildAndPrepareDqlCustomStringConfiguration();
 
-        $this->assertEquals('Some\Foo\StringClass', $configuration->getCustomStringFunction('FOOSTRING'));
-        $this->assertEquals('Some\Bar\StringClass', $configuration->getCustomStringFunction('BARSTRING'));
+        self::assertEquals('Some\Foo\StringClass', $configuration->getCustomStringFunction('FOOSTRING'));
+        self::assertEquals('Some\Bar\StringClass', $configuration->getCustomStringFunction('BARSTRING'));
     }
 
     /**
@@ -36,8 +36,8 @@ class EntityManagerConfigurationTest extends UnitTestCase
     {
         $configuration = $this->buildAndPrepareDqlCustomStringConfiguration();
 
-        $this->assertEquals('Some\Foo\NumericClass', $configuration->getCustomNumericFunction('FOONUMERIC'));
-        $this->assertEquals('Some\Bar\NumericClass', $configuration->getCustomNumericFunction('BARNUMERIC'));
+        self::assertEquals('Some\Foo\NumericClass', $configuration->getCustomNumericFunction('FOONUMERIC'));
+        self::assertEquals('Some\Bar\NumericClass', $configuration->getCustomNumericFunction('BARNUMERIC'));
     }
 
     /**
@@ -47,8 +47,8 @@ class EntityManagerConfigurationTest extends UnitTestCase
     {
         $configuration = $this->buildAndPrepareDqlCustomStringConfiguration();
 
-        $this->assertEquals('Some\Foo\DateTimeClass', $configuration->getCustomDatetimeFunction('FOODATETIME'));
-        $this->assertEquals('Some\Bar\DateTimeClass', $configuration->getCustomDatetimeFunction('BARDATETIME'));
+        self::assertEquals('Some\Foo\DateTimeClass', $configuration->getCustomDatetimeFunction('FOODATETIME'));
+        self::assertEquals('Some\Bar\DateTimeClass', $configuration->getCustomDatetimeFunction('BARDATETIME'));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriverTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriverTest.php
@@ -44,7 +44,7 @@ class FlowAnnotationDriverTest extends UnitTestCase
     {
         $driver = $this->getAccessibleMock(FlowAnnotationDriver::class, ['getMaxIdentifierLength']);
         $driver->expects($this->any())->method('getMaxIdentifierLength')->will($this->returnValue(64));
-        $this->assertEquals($tableName, $driver->inferTableNameFromClassName($className));
+        self::assertEquals($tableName, $driver->inferTableNameFromClassName($className));
     }
 
     /**
@@ -75,8 +75,8 @@ class FlowAnnotationDriverTest extends UnitTestCase
         $driver->expects($this->any())->method('getMaxIdentifierLength')->will($this->returnValue($maxIdentifierLength));
 
         $actualTableName = $driver->_call('inferJoinTableNameFromClassAndPropertyName', $className, $propertyName);
-        $this->assertEquals($expectedTableName, $actualTableName);
-        $this->assertTrue(strlen($actualTableName) <= $maxIdentifierLength);
+        self::assertEquals($expectedTableName, $actualTableName);
+        self::assertTrue(strlen($actualTableName) <= $maxIdentifierLength);
     }
 
     /**
@@ -93,6 +93,6 @@ class FlowAnnotationDriverTest extends UnitTestCase
 
         $driver = $this->getAccessibleMock(FlowAnnotationDriver::class, ['dummy']);
         $driver->_set('entityManager', $mockEntityManager);
-        $this->assertEquals(2048, $driver->_call('getMaxIdentifierLength'));
+        self::assertEquals(2048, $driver->_call('getMaxIdentifierLength'));
     }
 }

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/PersistenceManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/PersistenceManagerTest.php
@@ -91,7 +91,7 @@ class PersistenceManagerTest extends UnitTestCase
         $this->mockEntityManager->expects($this->any())->method('contains')->with($entity)->willReturn(true);
         $this->mockUnitOfWork->expects($this->any())->method('getEntityIdentifier')->with($entity)->willReturn(['SomeIdentifier']);
 
-        $this->assertEquals('SomeIdentifier', $this->persistenceManager->getIdentifierByObject($entity));
+        self::assertEquals('SomeIdentifier', $this->persistenceManager->getIdentifierByObject($entity));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/QueryResultTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/QueryResultTest.php
@@ -47,7 +47,7 @@ class QueryResultTest extends UnitTestCase
      */
     public function getQueryReturnsQueryObject()
     {
-        $this->assertInstanceOf(QueryInterface::class, $this->queryResult->getQuery());
+        self::assertInstanceOf(QueryInterface::class, $this->queryResult->getQuery());
     }
 
     /**
@@ -55,7 +55,7 @@ class QueryResultTest extends UnitTestCase
      */
     public function getQueryReturnsAClone()
     {
-        $this->assertNotSame($this->query, $this->queryResult->getQuery());
+        self::assertNotSame($this->query, $this->queryResult->getQuery());
     }
 
     /**
@@ -63,7 +63,7 @@ class QueryResultTest extends UnitTestCase
      */
     public function offsetGetReturnsNullIfOffsetDoesNotExist()
     {
-        $this->assertNull($this->queryResult->offsetGet('foo'));
+        self::assertNull($this->queryResult->offsetGet('foo'));
     }
 
     /**
@@ -72,7 +72,7 @@ class QueryResultTest extends UnitTestCase
     public function countCallsCountOnTheQuery()
     {
         $this->query->expects($this->once())->method('count')->will($this->returnValue(123));
-        $this->assertEquals(123, $this->queryResult->count());
+        self::assertEquals(123, $this->queryResult->count());
     }
 
     /**
@@ -82,7 +82,7 @@ class QueryResultTest extends UnitTestCase
     {
         $this->query->expects($this->never())->method('count');
         $this->queryResult->toArray();
-        $this->assertEquals(3, $this->queryResult->count());
+        self::assertEquals(3, $this->queryResult->count());
     }
 
     /**
@@ -92,6 +92,6 @@ class QueryResultTest extends UnitTestCase
     {
         $this->query->expects($this->once())->method('count')->will($this->returnValue(321));
         $this->queryResult->count();
-        $this->assertEquals(321, $this->queryResult->count());
+        self::assertEquals(321, $this->queryResult->count());
     }
 }

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/RepositoryTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/RepositoryTest.php
@@ -66,6 +66,6 @@ class RepositoryTest extends UnitTestCase
 
         /** @var Repository $repository */
         $repository = new $mockClassName($this->mockEntityManager);
-        $this->assertEquals($modelClassName, $repository->getEntityClassName());
+        self::assertEquals($modelClassName, $repository->getEntityClassName());
     }
 }

--- a/Neos.Flow/Tests/Unit/Persistence/Generic/Backend/AbstractBackendTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Generic/Backend/AbstractBackendTest.php
@@ -95,7 +95,7 @@ class AbstractBackendTest extends UnitTestCase
     public function getTypeNormalizesDoubleToFloat()
     {
         $backend = $this->getAccessibleMockForAbstractClass(Persistence\Generic\Backend\AbstractBackend::class);
-        $this->assertEquals('float', $backend->_call('getType', 1.234));
+        self::assertEquals('float', $backend->_call('getType', 1.234));
     }
 
     /**
@@ -104,7 +104,7 @@ class AbstractBackendTest extends UnitTestCase
     public function getTypeReturnsClassNameForObjects()
     {
         $backend = $this->getAccessibleMockForAbstractClass(Persistence\Generic\Backend\AbstractBackend::class);
-        $this->assertEquals('stdClass', $backend->_call('getType', new \stdClass()));
+        self::assertEquals('stdClass', $backend->_call('getType', new \stdClass()));
     }
 
     /**
@@ -119,7 +119,7 @@ class AbstractBackendTest extends UnitTestCase
         $backend = $this->getAccessibleMockForAbstractClass(Persistence\Generic\Backend\AbstractBackend::class);
         $backend->injectPersistenceSession($mockSession);
 
-        $this->assertTrue($backend->_call('arrayContainsObject', [$object], $object, 'fakeUuid'));
+        self::assertTrue($backend->_call('arrayContainsObject', [$object], $object, 'fakeUuid'));
     }
 
     /**
@@ -133,7 +133,7 @@ class AbstractBackendTest extends UnitTestCase
         $backend = $this->getAccessibleMockForAbstractClass(Persistence\Generic\Backend\AbstractBackend::class);
         $backend->injectPersistenceSession($mockSession);
 
-        $this->assertFalse($backend->_call('arrayContainsObject', [new \stdClass()], new \stdClass(), 'uuid1'));
+        self::assertFalse($backend->_call('arrayContainsObject', [new \stdClass()], new \stdClass(), 'uuid1'));
     }
 
     /**
@@ -150,6 +150,6 @@ class AbstractBackendTest extends UnitTestCase
         $backend = $this->getAccessibleMockForAbstractClass(Persistence\Generic\Backend\AbstractBackend::class);
         $backend->injectPersistenceSession($mockSession);
 
-        $this->assertFalse($backend->_call('arrayContainsObject', [$object], $clone, 'clonedFakeUuid'));
+        self::assertFalse($backend->_call('arrayContainsObject', [$object], $clone, 'clonedFakeUuid'));
     }
 }

--- a/Neos.Flow/Tests/Unit/Persistence/Generic/DataMapperTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Generic/DataMapperTest.php
@@ -142,10 +142,10 @@ class DataMapperTest extends UnitTestCase
         $dataMapper = $this->getAccessibleMock(Persistence\Generic\DataMapper::class, ['dummy']);
         $dataMapper->injectReflectionService($mockReflectionService);
         $dataMapper->_call('thawProperties', $object, 1234, $objectData);
-        $this->assertEquals('firstValue', ObjectAccess::getProperty($object, 'firstProperty'));
-        $this->assertEquals(1234, ObjectAccess::getProperty($object, 'secondProperty'));
-        $this->assertEquals(1.234, ObjectAccess::getProperty($object, 'thirdProperty'));
-        $this->assertEquals(false, ObjectAccess::getProperty($object, 'fourthProperty'));
+        self::assertEquals('firstValue', ObjectAccess::getProperty($object, 'firstProperty'));
+        self::assertEquals(1234, ObjectAccess::getProperty($object, 'secondProperty'));
+        self::assertEquals(1.234, ObjectAccess::getProperty($object, 'thirdProperty'));
+        self::assertEquals(false, ObjectAccess::getProperty($object, 'fourthProperty'));
     }
 
     /**
@@ -175,7 +175,7 @@ class DataMapperTest extends UnitTestCase
         $dataMapper->injectReflectionService($mockReflectionService);
         $dataMapper->_call('thawProperties', $object, $objectData['identifier'], $objectData);
 
-        $this->assertEquals('c254d2e0-825a-11de-8a39-0800200c9a66', ObjectAccess::getProperty($object, 'Persistence_Object_Identifier'));
+        self::assertEquals('c254d2e0-825a-11de-8a39-0800200c9a66', ObjectAccess::getProperty($object, 'Persistence_Object_Identifier'));
     }
 
     /**
@@ -278,7 +278,7 @@ class DataMapperTest extends UnitTestCase
 
         // the order of setting those is important, but cannot be tested for now (static setProperty)
         $expected = [['secondProperty' => 'secondValue'],['firstProperty' => 'firstValue'],['thirdProperty' => 'thirdValue'],['Persistence_Object_Identifier' => '1234']];
-        $this->assertSame($expected, ObjectAccess::getProperty($object, 'properties', true));
+        self::assertSame($expected, ObjectAccess::getProperty($object, 'properties', true));
     }
 
     /**
@@ -326,7 +326,7 @@ class DataMapperTest extends UnitTestCase
         $dataMapper->injectReflectionService($mockReflectionService);
         $dataMapper->_call('thawProperties', $object, 1234, $objectData);
 
-        $this->assertObjectNotHasAttribute('secondProperty', $object);
+        self::assertObjectNotHasAttribute('secondProperty', $object);
     }
 
     /**
@@ -357,7 +357,7 @@ class DataMapperTest extends UnitTestCase
         $dataMapper->injectReflectionService($mockReflectionService);
         $dataMapper->_call('thawProperties', $object, $objectData['identifier'], $objectData);
 
-        $this->assertEquals(['My_Metadata' => 'Test'], ObjectAccess::getProperty($object, 'Flow_Persistence_Metadata'));
+        self::assertEquals(['My_Metadata' => 'Test'], ObjectAccess::getProperty($object, 'Flow_Persistence_Metadata'));
     }
 
     /**
@@ -386,7 +386,7 @@ class DataMapperTest extends UnitTestCase
     {
         $expected = new \DateTime();
         $dataMapper = $this->getAccessibleMock(Persistence\Generic\DataMapper::class, ['dummy']);
-        $this->assertEquals($dataMapper->_call('mapDateTime', $expected->getTimestamp())->format(\DateTime::W3C), $expected->format(\DateTime::W3C));
+        self::assertEquals($dataMapper->_call('mapDateTime', $expected->getTimestamp())->format(\DateTime::W3C), $expected->format(\DateTime::W3C));
     }
 
     /**
@@ -450,7 +450,7 @@ class DataMapperTest extends UnitTestCase
         $dataMapper->expects($this->once())->method('mapDateTime')->with($arrayValues['five']['value'])->will($this->returnValue($dateTime));
         $dataMapper->expects($this->once())->method('mapToObject')->with($arrayValues['six']['value'])->will($this->returnValue($object));
         $dataMapper->expects($this->once())->method('mapSplObjectStorage')->with($arrayValues['seven']['value'])->will($this->returnValue($splObjectStorage));
-        $this->assertEquals($dataMapper->_call('mapArray', $arrayValues), $expected);
+        self::assertEquals($dataMapper->_call('mapArray', $arrayValues), $expected);
     }
 
 
@@ -481,6 +481,6 @@ class DataMapperTest extends UnitTestCase
         $expected = ['foo' => ['bar' => 'baz', 'quux' => null]];
 
         $dataMapper = $this->getAccessibleMock(Persistence\Generic\DataMapper::class, ['dummy']);
-        $this->assertEquals($expected, $dataMapper->_call('mapArray', $arrayValues));
+        self::assertEquals($expected, $dataMapper->_call('mapArray', $arrayValues));
     }
 }

--- a/Neos.Flow/Tests/Unit/Persistence/Generic/PersistenceManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Generic/PersistenceManagerTest.php
@@ -77,7 +77,7 @@ class PersistenceManagerTest extends UnitTestCase
         $manager = new Generic\PersistenceManager();
         $manager->injectPersistenceSession($mockSession);
 
-        $this->assertEquals($manager->getIdentifierByObject($object), $fakeUuid);
+        self::assertEquals($manager->getIdentifierByObject($object), $fakeUuid);
     }
 
     /**
@@ -95,7 +95,7 @@ class PersistenceManagerTest extends UnitTestCase
         $manager = new Generic\PersistenceManager();
         $manager->injectPersistenceSession($mockSession);
 
-        $this->assertEquals($manager->getObjectByIdentifier($fakeUuid), $object);
+        self::assertEquals($manager->getObjectByIdentifier($fakeUuid), $object);
     }
 
     /**
@@ -120,7 +120,7 @@ class PersistenceManagerTest extends UnitTestCase
         $manager->injectBackend($mockBackend);
         $manager->injectDataMapper($mockDataMapper);
 
-        $this->assertEquals($manager->getObjectByIdentifier($fakeUuid), $object);
+        self::assertEquals($manager->getObjectByIdentifier($fakeUuid), $object);
     }
 
     /**
@@ -140,7 +140,7 @@ class PersistenceManagerTest extends UnitTestCase
         $manager->injectPersistenceSession($mockSession);
         $manager->injectBackend($mockBackend);
 
-        $this->assertNull($manager->getObjectByIdentifier($fakeUuid));
+        self::assertNull($manager->getObjectByIdentifier($fakeUuid));
     }
 
     /**
@@ -152,7 +152,7 @@ class PersistenceManagerTest extends UnitTestCase
         $persistenceManager = new Generic\PersistenceManager();
         $persistenceManager->add($someObject);
 
-        $this->assertContains($someObject, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
+        self::assertContains($someObject, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
     }
 
     /**
@@ -171,9 +171,9 @@ class PersistenceManagerTest extends UnitTestCase
 
         $persistenceManager->remove($object2);
 
-        $this->assertContains($object1, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
-        $this->assertNotContains($object2, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
-        $this->assertContains($object3, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
+        self::assertContains($object1, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
+        self::assertNotContains($object2, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
+        self::assertContains($object3, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
     }
 
     /**
@@ -195,9 +195,9 @@ class PersistenceManagerTest extends UnitTestCase
 
         $persistenceManager->remove($object2);
 
-        $this->assertContains($object1, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
-        $this->assertNotContains($object2, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
-        $this->assertContains($object3, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
+        self::assertContains($object1, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
+        self::assertNotContains($object2, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
+        self::assertContains($object3, ObjectAccess::getProperty($persistenceManager, 'addedObjects', true));
     }
 
     /**
@@ -212,7 +212,7 @@ class PersistenceManagerTest extends UnitTestCase
         $persistenceManager = new Generic\PersistenceManager();
         $persistenceManager->remove($object);
 
-        $this->assertContains($object, ObjectAccess::getProperty($persistenceManager, 'removedObjects', true));
+        self::assertContains($object, ObjectAccess::getProperty($persistenceManager, 'removedObjects', true));
     }
 
     /**
@@ -224,9 +224,9 @@ class PersistenceManagerTest extends UnitTestCase
         $persistenceManager = $this->getMockBuilder(\Neos\Flow\Persistence\Generic\PersistenceManager::class)->setMethods(['isNewObject'])->getMock();
         $persistenceManager->expects($this->any())->method('isNewObject')->willReturn(false);
 
-        $this->assertNotContains($object, ObjectAccess::getProperty($persistenceManager, 'changedObjects', true));
+        self::assertNotContains($object, ObjectAccess::getProperty($persistenceManager, 'changedObjects', true));
         $persistenceManager->update($object);
-        $this->assertContains($object, ObjectAccess::getProperty($persistenceManager, 'changedObjects', true));
+        self::assertContains($object, ObjectAccess::getProperty($persistenceManager, 'changedObjects', true));
     }
 
     /**
@@ -250,7 +250,7 @@ class PersistenceManagerTest extends UnitTestCase
         $persistenceManager->clearState();
 
         $object = $persistenceManager->getObjectByIdentifier('abcdefg');
-        $this->assertNull($object);
+        self::assertNull($object);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Persistence/Generic/QueryResultTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Generic/QueryResultTest.php
@@ -70,7 +70,7 @@ class QueryResultTest extends UnitTestCase
      */
     public function getQueryReturnsQueryObject()
     {
-        $this->assertInstanceOf(QueryInterface::class, $this->queryResult->getQuery());
+        self::assertInstanceOf(QueryInterface::class, $this->queryResult->getQuery());
     }
 
     /**
@@ -78,7 +78,7 @@ class QueryResultTest extends UnitTestCase
      */
     public function getQueryReturnsAClone()
     {
-        $this->assertNotSame($this->query, $this->queryResult->getQuery());
+        self::assertNotSame($this->query, $this->queryResult->getQuery());
     }
 
     /**
@@ -86,9 +86,9 @@ class QueryResultTest extends UnitTestCase
      */
     public function offsetExistsWorksAsExpected()
     {
-        $this->assertTrue($this->queryResult->offsetExists(0));
-        $this->assertFalse($this->queryResult->offsetExists(2));
-        $this->assertFalse($this->queryResult->offsetExists('foo'));
+        self::assertTrue($this->queryResult->offsetExists(0));
+        self::assertFalse($this->queryResult->offsetExists(2));
+        self::assertFalse($this->queryResult->offsetExists('foo'));
     }
 
     /**
@@ -96,9 +96,9 @@ class QueryResultTest extends UnitTestCase
      */
     public function offsetGetWorksAsExpected()
     {
-        $this->assertEquals(['foo' => 'Foo1', 'bar' => 'Bar1'], $this->queryResult->offsetGet(0));
-        $this->assertNull($this->queryResult->offsetGet(2));
-        $this->assertNull($this->queryResult->offsetGet('foo'));
+        self::assertEquals(['foo' => 'Foo1', 'bar' => 'Bar1'], $this->queryResult->offsetGet(0));
+        self::assertNull($this->queryResult->offsetGet(2));
+        self::assertNull($this->queryResult->offsetGet('foo'));
     }
 
     /**
@@ -107,7 +107,7 @@ class QueryResultTest extends UnitTestCase
     public function offsetSetWorksAsExpected()
     {
         $this->queryResult->offsetSet(0, ['foo' => 'FooOverridden', 'bar' => 'BarOverridden']);
-        $this->assertEquals(['foo' => 'FooOverridden', 'bar' => 'BarOverridden'], $this->queryResult->offsetGet(0));
+        self::assertEquals(['foo' => 'FooOverridden', 'bar' => 'BarOverridden'], $this->queryResult->offsetGet(0));
     }
 
     /**
@@ -116,7 +116,7 @@ class QueryResultTest extends UnitTestCase
     public function offsetUnsetWorksAsExpected()
     {
         $this->queryResult->offsetUnset(0);
-        $this->assertFalse($this->queryResult->offsetExists(0));
+        self::assertFalse($this->queryResult->offsetExists(0));
     }
 
     /**
@@ -136,7 +136,7 @@ class QueryResultTest extends UnitTestCase
     public function countCallsGetObjectCountByQueryOnPersistenceManager()
     {
         $this->persistenceManager->expects($this->once())->method('getObjectCountByQuery')->will($this->returnValue(2));
-        $this->assertEquals(2, $this->queryResult->count());
+        self::assertEquals(2, $this->queryResult->count());
     }
 
     /**
@@ -146,7 +146,7 @@ class QueryResultTest extends UnitTestCase
     {
         $this->persistenceManager->expects($this->never())->method('getObjectCountByQuery');
         $this->queryResult->toArray();
-        $this->assertEquals(2, $this->queryResult->count());
+        self::assertEquals(2, $this->queryResult->count());
     }
 
     /**
@@ -156,7 +156,7 @@ class QueryResultTest extends UnitTestCase
     {
         $this->persistenceManager->expects($this->once())->method('getObjectCountByQuery')->will($this->returnValue(2));
         $this->queryResult->count();
-        $this->assertEquals(2, $this->queryResult->count());
+        self::assertEquals(2, $this->queryResult->count());
     }
 
     /**
@@ -166,19 +166,19 @@ class QueryResultTest extends UnitTestCase
     {
         $array1 = ['foo' => 'Foo1', 'bar' => 'Bar1'];
         $array2 = ['foo' => 'Foo2', 'bar' => 'Bar2'];
-        $this->assertEquals($array1, $this->queryResult->current());
-        $this->assertTrue($this->queryResult->valid());
+        self::assertEquals($array1, $this->queryResult->current());
+        self::assertTrue($this->queryResult->valid());
         $this->queryResult->next();
-        $this->assertEquals($array2, $this->queryResult->current());
-        $this->assertTrue($this->queryResult->valid());
-        $this->assertEquals(1, $this->queryResult->key());
+        self::assertEquals($array2, $this->queryResult->current());
+        self::assertTrue($this->queryResult->valid());
+        self::assertEquals(1, $this->queryResult->key());
         $this->queryResult->next();
-        $this->assertFalse($this->queryResult->current());
-        $this->assertFalse($this->queryResult->valid());
-        $this->assertNull($this->queryResult->key());
+        self::assertFalse($this->queryResult->current());
+        self::assertFalse($this->queryResult->valid());
+        self::assertNull($this->queryResult->key());
         $this->queryResult->rewind();
-        $this->assertEquals(0, $this->queryResult->key());
-        $this->assertEquals($array1, $this->queryResult->current());
+        self::assertEquals(0, $this->queryResult->key());
+        self::assertEquals($array1, $this->queryResult->current());
     }
 
     /**
@@ -207,7 +207,7 @@ class QueryResultTest extends UnitTestCase
 
         $expectedResult = $initializedQueryResult[0];
         $actualResult = $queryResult->getFirst();
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -219,7 +219,7 @@ class QueryResultTest extends UnitTestCase
         $queryResult = $this->getAccessibleMock(QueryResult::class, ['dummy'], [$this->query]);
         $queryResult->_set('queryResult', $initializedQueryResult);
 
-        $this->assertNull($queryResult->getFirst());
+        self::assertNull($queryResult->getFirst());
     }
 
     /**
@@ -242,7 +242,7 @@ class QueryResultTest extends UnitTestCase
 
         $expectedResult = $initializedQueryResult[0];
         $actualResult = $queryResult->getFirst();
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -260,6 +260,6 @@ class QueryResultTest extends UnitTestCase
         $mockDataMapper->expects($this->once())->method('mapToObjects')->with(['one', 'two'])->will($this->returnValue($initializedQueryResult));
         $queryResult->injectDataMapper($mockDataMapper);
 
-        $this->assertNull($queryResult->getFirst());
+        self::assertNull($queryResult->getFirst());
     }
 }

--- a/Neos.Flow/Tests/Unit/Persistence/Generic/QueryTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Generic/QueryTest.php
@@ -54,7 +54,7 @@ class QueryTest extends UnitTestCase
     public function executeReturnsQueryResultInstance()
     {
         $result = $this->query->execute();
-        $this->assertInstanceOf(Persistence\Generic\QueryResult::class, $result);
+        self::assertInstanceOf(Persistence\Generic\QueryResult::class, $result);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Persistence/Generic/SessionTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Generic/SessionTest.php
@@ -31,7 +31,7 @@ class SessionTest extends UnitTestCase
         $session->registerReconstitutedEntity($someObject, ['identifier' => 'fakeUuid']);
 
         $ReconstitutedEntities = $session->getReconstitutedEntities();
-        $this->assertTrue($ReconstitutedEntities->contains($someObject));
+        self::assertTrue($ReconstitutedEntities->contains($someObject));
     }
 
     /**
@@ -46,7 +46,7 @@ class SessionTest extends UnitTestCase
         $session->unregisterReconstitutedEntity($someObject);
 
         $ReconstitutedEntities = $session->getReconstitutedEntities();
-        $this->assertFalse($ReconstitutedEntities->contains($someObject));
+        self::assertFalse($ReconstitutedEntities->contains($someObject));
     }
 
     /**
@@ -59,8 +59,8 @@ class SessionTest extends UnitTestCase
         $session = new Persistence\Generic\Session();
         $session->registerObject($object1, 12345);
 
-        $this->assertTrue($session->hasObject($object1), 'Session claims it does not have registered object.');
-        $this->assertFalse($session->hasObject($object2), 'Session claims it does have unregistered object.');
+        self::assertTrue($session->hasObject($object1), 'Session claims it does not have registered object.');
+        self::assertFalse($session->hasObject($object2), 'Session claims it does have unregistered object.');
     }
 
     /**
@@ -71,8 +71,8 @@ class SessionTest extends UnitTestCase
         $session = new Persistence\Generic\Session();
         $session->registerObject(new \stdClass(), 12345);
 
-        $this->assertTrue($session->hasIdentifier('12345'), 'Session claims it does not have registered object.');
-        $this->assertFalse($session->hasIdentifier('67890'), 'Session claims it does have unregistered object.');
+        self::assertTrue($session->hasIdentifier('12345'), 'Session claims it does not have registered object.');
+        self::assertFalse($session->hasIdentifier('67890'), 'Session claims it does have unregistered object.');
     }
 
     /**
@@ -84,7 +84,7 @@ class SessionTest extends UnitTestCase
         $session = new Persistence\Generic\Session();
         $session->registerObject($object, 12345);
 
-        $this->assertEquals($session->getIdentifierByObject($object), 12345, 'Did not get UUID registered for object.');
+        self::assertEquals($session->getIdentifierByObject($object), 12345, 'Did not get UUID registered for object.');
     }
 
     /**
@@ -96,7 +96,7 @@ class SessionTest extends UnitTestCase
         $session = new Persistence\Generic\Session();
         $session->registerObject($object, 12345);
 
-        $this->assertSame($session->getObjectByIdentifier('12345'), $object, 'Did not get object registered for UUID.');
+        self::assertSame($session->getObjectByIdentifier('12345'), $object, 'Did not get object registered for UUID.');
     }
 
     /**
@@ -110,17 +110,17 @@ class SessionTest extends UnitTestCase
         $session->registerObject($object1, 12345);
         $session->registerObject($object2, 67890);
 
-        $this->assertTrue($session->hasObject($object1), 'Session claims it does not have registered object.');
-        $this->assertTrue($session->hasIdentifier('12345'), 'Session claims it does not have registered object.');
-        $this->assertTrue($session->hasObject($object1), 'Session claims it does not have registered object.');
-        $this->assertTrue($session->hasIdentifier('67890'), 'Session claims it does not have registered object.');
+        self::assertTrue($session->hasObject($object1), 'Session claims it does not have registered object.');
+        self::assertTrue($session->hasIdentifier('12345'), 'Session claims it does not have registered object.');
+        self::assertTrue($session->hasObject($object1), 'Session claims it does not have registered object.');
+        self::assertTrue($session->hasIdentifier('67890'), 'Session claims it does not have registered object.');
 
         $session->unregisterObject($object1);
 
-        $this->assertFalse($session->hasObject($object1), 'Session claims it does have unregistered object.');
-        $this->assertFalse($session->hasIdentifier('12345'), 'Session claims it does not have registered object.');
-        $this->assertTrue($session->hasObject($object2), 'Session claims it does not have registered object.');
-        $this->assertTrue($session->hasIdentifier('67890'), 'Session claims it does not have registered object.');
+        self::assertFalse($session->hasObject($object1), 'Session claims it does have unregistered object.');
+        self::assertFalse($session->hasIdentifier('12345'), 'Session claims it does not have registered object.');
+        self::assertTrue($session->hasObject($object2), 'Session claims it does not have registered object.');
+        self::assertTrue($session->hasIdentifier('67890'), 'Session claims it does not have registered object.');
     }
 
     /**
@@ -129,7 +129,7 @@ class SessionTest extends UnitTestCase
     public function newObjectsAreConsideredDirty()
     {
         $session = new Persistence\Generic\Session();
-        $this->assertTrue($session->isDirty(new \stdClass(), 'foo'));
+        self::assertTrue($session->isDirty(new \stdClass(), 'foo'));
     }
 
     /**
@@ -139,7 +139,7 @@ class SessionTest extends UnitTestCase
     {
         $session = $this->getMockBuilder(Persistence\Generic\Session::class)->setMethods(['isReconstitutedEntity'])->getMock();
         $session->expects($this->once())->method('isReconstitutedEntity')->will($this->returnValue(false));
-        $this->assertTrue($session->isDirty(new \stdClass(), 'foo'));
+        self::assertTrue($session->isDirty(new \stdClass(), 'foo'));
     }
 
     /**
@@ -155,7 +155,7 @@ class SessionTest extends UnitTestCase
         $session->registerReconstitutedEntity($object, ['identifier' => 'fakeUuid']);
         $session->expects($this->once())->method('getIdentifierByObject')->will($this->returnValue('fakeUuid'));
 
-        $this->assertFalse($session->isDirty($object, 'foo'));
+        self::assertFalse($session->isDirty($object, 'foo'));
     }
 
     /**
@@ -183,7 +183,7 @@ class SessionTest extends UnitTestCase
         $session->expects($this->once())->method('getIdentifierByObject')->will($this->returnValue('fakeUuid'));
         $session->expects($this->once())->method('isSingleValuedPropertyDirty')->with('string', 'bar', 'different')->will($this->returnValue(true));
 
-        $this->assertTrue($session->isDirty($object, 'foo'));
+        self::assertTrue($session->isDirty($object, 'foo'));
     }
 
     /**
@@ -198,7 +198,7 @@ class SessionTest extends UnitTestCase
 
         $session = $this->getMockBuilder(Persistence\Generic\Session::class)->setMethods(['dummy'])->getMock();
         $session->registerReconstitutedEntity($object, ['identifier' => 'fakeUuid']);
-        $this->assertFalse($session->isDirty($object, 'foo'));
+        self::assertFalse($session->isDirty($object, 'foo'));
     }
 
     /**
@@ -225,7 +225,7 @@ class SessionTest extends UnitTestCase
         $session->registerReconstitutedEntity($object, $cleanData);
         $session->expects($this->once())->method('getIdentifierByObject')->will($this->returnValue('fakeUuid'));
 
-        $this->assertTrue($session->isDirty($object, 'foo'));
+        self::assertTrue($session->isDirty($object, 'foo'));
     }
 
     /**
@@ -259,7 +259,7 @@ class SessionTest extends UnitTestCase
         $session->registerReconstitutedEntity($object, $cleanData);
         $session->expects($this->once())->method('getIdentifierByObject')->will($this->returnValue('fakeUuid'));
 
-        $this->assertTrue($session->isDirty($object, 'foo'));
+        self::assertTrue($session->isDirty($object, 'foo'));
     }
 
     /**
@@ -294,7 +294,7 @@ class SessionTest extends UnitTestCase
         $session->registerReconstitutedEntity($parent, $cleanData);
         $session->expects($this->atLeastOnce())->method('getIdentifierByObject')->will($this->returnValue('fakeUuid'));
 
-        $this->assertTrue($session->isDirty($parent, 'splObjectStorage'));
+        self::assertTrue($session->isDirty($parent, 'splObjectStorage'));
     }
 
     /**
@@ -332,7 +332,7 @@ class SessionTest extends UnitTestCase
         $session->expects($this->once())->method('getIdentifierByObject')->will($this->returnValue('fakeUuid'));
         $session->expects($this->once())->method('isSingleValuedPropertyDirty')->will($this->returnValue(true));
 
-        $this->assertTrue($session->isDirty($parent, 'array'));
+        self::assertTrue($session->isDirty($parent, 'array'));
     }
 
     /**
@@ -370,7 +370,7 @@ class SessionTest extends UnitTestCase
         $session->expects($this->once())->method('getIdentifierByObject')->will($this->returnValue('fakeUuid'));
         $session->expects($this->once())->method('isSingleValuedPropertyDirty')->with('Some\Object', ['identifier' => 'cleanHash'], $object)->will($this->returnValue(false));
 
-        $this->assertFalse($session->isDirty($parent, 'array'));
+        self::assertFalse($session->isDirty($parent, 'array'));
     }
 
     /**
@@ -413,7 +413,7 @@ class SessionTest extends UnitTestCase
         $session->expects($this->once())->method('getIdentifierByObject')->will($this->returnValue('fakeUuid'));
         $session->expects($this->once())->method('isSingleValuedPropertyDirty')->will($this->returnValue(false));
 
-        $this->assertFalse($session->isDirty($parent, 'array'));
+        self::assertFalse($session->isDirty($parent, 'array'));
     }
 
     /**
@@ -450,7 +450,7 @@ class SessionTest extends UnitTestCase
         $session->registerReconstitutedEntity($parent, $cleanData);
         $session->expects($this->once())->method('getIdentifierByObject')->will($this->returnValue('fakeUuid'));
 
-        $this->assertTrue($session->isDirty($parent, 'array'));
+        self::assertTrue($session->isDirty($parent, 'array'));
     }
 
     /**
@@ -488,7 +488,7 @@ class SessionTest extends UnitTestCase
     public function isSingleValuedPropertyDirtyWorksAsExpected($type, $current, $clean, $expected)
     {
         $session = $this->getAccessibleMock(Persistence\Generic\Session::class, ['getIdentifierByObject']);
-        $this->assertEquals($session->_call('isSingleValuedPropertyDirty', $type, $clean, $current), $expected);
+        self::assertEquals($session->_call('isSingleValuedPropertyDirty', $type, $clean, $current), $expected);
     }
 
     /**
@@ -513,7 +513,7 @@ class SessionTest extends UnitTestCase
         $session->expects($this->any())->method('getIdentifierByObject')->with($entity)->will($this->returnValue('abc'));
 
         $state = $session->getCleanStateOfProperty($entity, 'bar');
-        $this->assertNull($state);
+        self::assertNull($state);
     }
 
     /**
@@ -528,7 +528,7 @@ class SessionTest extends UnitTestCase
         $session->expects($this->any())->method('isReconstitutedEntity')->with($entity)->will($this->returnValue(false));
 
         $state = $session->getCleanStateOfProperty($entity, 'bar');
-        $this->assertNull($state);
+        self::assertNull($state);
     }
 
     /**
@@ -553,7 +553,7 @@ class SessionTest extends UnitTestCase
         $session->expects($this->any())->method('getIdentifierByObject')->with($entity)->will($this->returnValue('abc'));
 
         $state = $session->getCleanStateOfProperty($entity, 'foo');
-        $this->assertEquals(['type' => 'string'], $state);
+        self::assertEquals(['type' => 'string'], $state);
     }
 
     /**
@@ -569,7 +569,7 @@ class SessionTest extends UnitTestCase
         $session = new Persistence\Generic\Session();
         $session->registerObject($knownObject, $fakeUUID);
 
-        $this->assertEquals($fakeUUID, $session->getIdentifierByObject($knownObject));
+        self::assertEquals($fakeUUID, $session->getIdentifierByObject($knownObject));
     }
 
     /**
@@ -589,7 +589,7 @@ class SessionTest extends UnitTestCase
         $session = new Persistence\Generic\Session();
         $session->injectReflectionService($mockReflectionService);
 
-        $this->assertEquals('fakeUuid', $session->getIdentifierByObject($knownObject));
+        self::assertEquals('fakeUuid', $session->getIdentifierByObject($knownObject));
     }
 
     /**
@@ -609,7 +609,7 @@ class SessionTest extends UnitTestCase
         $session = new Persistence\Generic\Session();
         $session->injectReflectionService($mockReflectionService);
 
-        $this->assertEquals('fakeHash', $session->getIdentifierByObject($knownObject));
+        self::assertEquals('fakeHash', $session->getIdentifierByObject($knownObject));
     }
 
     /**
@@ -628,7 +628,7 @@ class SessionTest extends UnitTestCase
         $session = new Persistence\Generic\Session();
         $session->injectReflectionService($mockReflectionService);
 
-        $this->assertNull($session->getIdentifierByObject($unknownObject));
+        self::assertNull($session->getIdentifierByObject($unknownObject));
     }
 
     /**
@@ -646,6 +646,6 @@ class SessionTest extends UnitTestCase
         $session = new Persistence\Generic\Session();
         $session->injectReflectionService($mockReflectionService);
 
-        $this->assertEquals('customId', $session->getIdentifierByObject($object));
+        self::assertEquals('customId', $session->getIdentifierByObject($object));
     }
 }

--- a/Neos.Flow/Tests/Unit/Persistence/RepositoryTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/RepositoryTest.php
@@ -28,7 +28,7 @@ class RepositoryTest extends UnitTestCase
     public function abstractRepositoryImplementsRepositoryInterface()
     {
         $repository = $this->createMock(Persistence\Repository::class);
-        $this->assertTrue($repository instanceof Persistence\RepositoryInterface);
+        self::assertTrue($repository instanceof Persistence\RepositoryInterface);
     }
 
     /**
@@ -54,7 +54,7 @@ class RepositoryTest extends UnitTestCase
         eval('namespace ' . $repositoryNamespace . '; class ' . $repositoryClassName . ' extends \Neos\Flow\Persistence\Repository {}');
 
         $repository = new $mockClassName();
-        $this->assertEquals($modelClassName, $repository->getEntityClassName());
+        self::assertEquals($modelClassName, $repository->getEntityClassName());
     }
 
     /**
@@ -68,7 +68,7 @@ class RepositoryTest extends UnitTestCase
         $fullRepositoryClassName = $repositoryNamespace . '\\' . $repositoryClassName;
 
         $repository = new $fullRepositoryClassName();
-        $this->assertEquals($modelClassName, $repository->getEntityClassName());
+        self::assertEquals($modelClassName, $repository->getEntityClassName());
     }
 
     /**
@@ -120,7 +120,7 @@ class RepositoryTest extends UnitTestCase
         $repository = $this->getMockBuilder(Persistence\Repository::class)->setMethods(['createQuery'])->getMock();
         $repository->expects($this->once())->method('createQuery')->will($this->returnValue($mockQuery));
 
-        $this->assertSame($expectedResult, $repository->findAll());
+        self::assertSame($expectedResult, $repository->findAll());
     }
 
     /**
@@ -138,7 +138,7 @@ class RepositoryTest extends UnitTestCase
         $this->inject($repository, 'persistenceManager', $mockPersistenceManager);
         $repository->_set('entityClassName', 'stdClass');
 
-        $this->assertSame($object, $repository->findByIdentifier($identifier));
+        self::assertSame($object, $repository->findByIdentifier($identifier));
     }
 
     /**
@@ -197,7 +197,7 @@ class RepositoryTest extends UnitTestCase
         $repository = $this->getMockBuilder(Persistence\Repository::class)->setMethods(['createQuery'])->getMock();
         $repository->expects($this->once())->method('createQuery')->will($this->returnValue($mockQuery));
 
-        $this->assertSame($mockQueryResult, $repository->findByFoo('bar'));
+        self::assertSame($mockQueryResult, $repository->findByFoo('bar'));
     }
 
     /**
@@ -216,7 +216,7 @@ class RepositoryTest extends UnitTestCase
         $repository = $this->getMockBuilder(Persistence\Repository::class)->setMethods(['createQuery'])->getMock();
         $repository->expects($this->once())->method('createQuery')->will($this->returnValue($mockQuery));
 
-        $this->assertSame($object, $repository->findOneByFoo('bar'));
+        self::assertSame($object, $repository->findOneByFoo('bar'));
     }
 
     /**
@@ -232,7 +232,7 @@ class RepositoryTest extends UnitTestCase
         $repository = $this->getMockBuilder(Persistence\Repository::class)->setMethods(['createQuery'])->getMock();
         $repository->expects($this->once())->method('createQuery')->will($this->returnValue($mockQuery));
 
-        $this->assertSame(2, $repository->countByFoo('bar'));
+        self::assertSame(2, $repository->countByFoo('bar'));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Property/PropertyMapperTest.php
+++ b/Neos.Flow/Tests/Unit/Property/PropertyMapperTest.php
@@ -65,7 +65,7 @@ class PropertyMapperTest extends UnitTestCase
     public function sourceTypeCanBeCorrectlyDetermined($source, $sourceTypes)
     {
         $propertyMapper = $this->getAccessibleMock(PropertyMapper::class, ['dummy']);
-        $this->assertEquals($sourceTypes, $propertyMapper->_call('determineSourceTypes', $source));
+        self::assertEquals($sourceTypes, $propertyMapper->_call('determineSourceTypes', $source));
     }
 
     /**
@@ -117,7 +117,7 @@ class PropertyMapperTest extends UnitTestCase
         $this->mockConfiguration->expects($this->any())->method('getTypeConverter')->will($this->returnValue($mockTypeConverter));
 
         $propertyMapper = $this->getAccessibleMock(PropertyMapper::class, ['dummy']);
-        $this->assertSame($mockTypeConverter, $propertyMapper->_call('findTypeConverter', 'someSource', 'someTargetType', $this->mockConfiguration));
+        self::assertSame($mockTypeConverter, $propertyMapper->_call('findTypeConverter', 'someSource', 'someTargetType', $this->mockConfiguration));
     }
 
     /**
@@ -171,7 +171,7 @@ class PropertyMapperTest extends UnitTestCase
         $propertyMapper = $this->getAccessibleMock(PropertyMapper::class, ['dummy']);
         $propertyMapper->_set('typeConverters', $typeConverters);
         $actualTypeConverter = $propertyMapper->_call('findTypeConverter', $source, $targetType, $this->mockConfiguration);
-        $this->assertSame($expectedTypeConverter, $actualTypeConverter->_name);
+        self::assertSame($expectedTypeConverter, $actualTypeConverter->_name);
     }
 
     /**
@@ -190,7 +190,7 @@ class PropertyMapperTest extends UnitTestCase
             $internalTypeConverter1,
             $internalTypeConverter2,
         ];
-        $this->assertNull($propertyMapper->_call('findEligibleConverterWithHighestPriority', $mockTypeConverters, 'foo', 'string'));
+        self::assertNull($propertyMapper->_call('findEligibleConverterWithHighestPriority', $mockTypeConverters, 'foo', 'string'));
     }
 
     /**
@@ -361,12 +361,12 @@ class PropertyMapperTest extends UnitTestCase
             if ($shouldFailWithException) {
                 $this->fail('Expected exception ' . $shouldFailWithException . ' which was not thrown.');
             }
-            $this->assertSame($expectedTypeConverter, $actualTypeConverter->_name);
+            self::assertSame($expectedTypeConverter, $actualTypeConverter->_name);
         } catch (\Exception $e) {
             if ($shouldFailWithException === false) {
                 throw $e;
             }
-            $this->assertInstanceOf($shouldFailWithException, $e);
+            self::assertInstanceOf($shouldFailWithException, $e);
         }
     }
 
@@ -385,7 +385,7 @@ class PropertyMapperTest extends UnitTestCase
         ];
 
         $propertyMapper->_set('typeConverters', $typeConverters);
-        $this->assertEquals('string2string', $propertyMapper->convert('source', 'string'));
+        self::assertEquals('string2string', $propertyMapper->convert('source', 'string'));
     }
 
     /**
@@ -406,7 +406,7 @@ class PropertyMapperTest extends UnitTestCase
     public function findFirstEligibleTypeConverterInObjectHierarchyShouldReturnNullIfSourceTypeIsUnknown()
     {
         $propertyMapper = $this->getAccessibleMock(PropertyMapper::class, ['dummy']);
-        $this->assertNull($propertyMapper->_call('findFirstEligibleTypeConverterInObjectHierarchy', 'source', 'unknownSourceType', Bootstrap::class));
+        self::assertNull($propertyMapper->_call('findFirstEligibleTypeConverterInObjectHierarchy', 'source', 'unknownSourceType', Bootstrap::class));
     }
 
     /**
@@ -418,7 +418,7 @@ class PropertyMapperTest extends UnitTestCase
         $targetType = 'ArrayObject';
         $propertyPath = '';
         $propertyMapper = $this->getAccessibleMock(PropertyMapper::class, ['dummy']);
-        $this->assertSame($source, $propertyMapper->_callRef('doMapping', $source, $targetType, $this->mockConfiguration, $propertyPath));
+        self::assertSame($source, $propertyMapper->_callRef('doMapping', $source, $targetType, $this->mockConfiguration, $propertyPath));
     }
 
     /**
@@ -430,7 +430,7 @@ class PropertyMapperTest extends UnitTestCase
         $targetType = 'ArrayObject<SomeEntity>';
         $propertyPath = '';
         $propertyMapper = $this->getAccessibleMock(PropertyMapper::class, ['dummy']);
-        $this->assertSame($source, $propertyMapper->_callRef('doMapping', $source, $targetType, $this->mockConfiguration, $propertyPath));
+        self::assertSame($source, $propertyMapper->_callRef('doMapping', $source, $targetType, $this->mockConfiguration, $propertyPath));
     }
 
     /**
@@ -561,6 +561,6 @@ class PropertyMapperTest extends UnitTestCase
         $propertyMapper = $this->getAccessibleMock(PropertyMapper::class, ['dummy']);
 
         $mockConfiguration = $this->getMockBuilder(PropertyMappingConfiguration::class)->disableOriginalConstructor()->getMock();
-        $this->assertEquals(null, $propertyMapper->convert($source, $fullTargetType, $mockConfiguration));
+        self::assertEquals(null, $propertyMapper->convert($source, $fullTargetType, $mockConfiguration));
     }
 }

--- a/Neos.Flow/Tests/Unit/Property/PropertyMappingConfigurationTest.php
+++ b/Neos.Flow/Tests/Unit/Property/PropertyMappingConfigurationTest.php
@@ -43,8 +43,8 @@ class PropertyMappingConfigurationTest extends UnitTestCase
      */
     public function getTargetPropertyNameShouldReturnTheUnmodifiedPropertyNameWithoutConfiguration()
     {
-        $this->assertEquals('someSourceProperty', $this->propertyMappingConfiguration->getTargetPropertyName('someSourceProperty'));
-        $this->assertEquals('someOtherSourceProperty', $this->propertyMappingConfiguration->getTargetPropertyName('someOtherSourceProperty'));
+        self::assertEquals('someSourceProperty', $this->propertyMappingConfiguration->getTargetPropertyName('someSourceProperty'));
+        self::assertEquals('someOtherSourceProperty', $this->propertyMappingConfiguration->getTargetPropertyName('someOtherSourceProperty'));
     }
 
     /**
@@ -53,8 +53,8 @@ class PropertyMappingConfigurationTest extends UnitTestCase
      */
     public function shouldMapReturnsFalseByDefault()
     {
-        $this->assertFalse($this->propertyMappingConfiguration->shouldMap('someSourceProperty'));
-        $this->assertFalse($this->propertyMappingConfiguration->shouldMap('someOtherSourceProperty'));
+        self::assertFalse($this->propertyMappingConfiguration->shouldMap('someSourceProperty'));
+        self::assertFalse($this->propertyMappingConfiguration->shouldMap('someOtherSourceProperty'));
     }
 
     /**
@@ -64,8 +64,8 @@ class PropertyMappingConfigurationTest extends UnitTestCase
     public function shouldMapReturnsTrueIfConfigured()
     {
         $this->propertyMappingConfiguration->allowAllProperties();
-        $this->assertTrue($this->propertyMappingConfiguration->shouldMap('someSourceProperty'));
-        $this->assertTrue($this->propertyMappingConfiguration->shouldMap('someOtherSourceProperty'));
+        self::assertTrue($this->propertyMappingConfiguration->shouldMap('someSourceProperty'));
+        self::assertTrue($this->propertyMappingConfiguration->shouldMap('someOtherSourceProperty'));
     }
 
     /**
@@ -75,8 +75,8 @@ class PropertyMappingConfigurationTest extends UnitTestCase
     public function shouldMapReturnsTrueForAllowedProperties()
     {
         $this->propertyMappingConfiguration->allowProperties('someSourceProperty', 'someOtherProperty');
-        $this->assertTrue($this->propertyMappingConfiguration->shouldMap('someSourceProperty'));
-        $this->assertTrue($this->propertyMappingConfiguration->shouldMap('someOtherProperty'));
+        self::assertTrue($this->propertyMappingConfiguration->shouldMap('someSourceProperty'));
+        self::assertTrue($this->propertyMappingConfiguration->shouldMap('someOtherProperty'));
     }
 
     /**
@@ -86,10 +86,10 @@ class PropertyMappingConfigurationTest extends UnitTestCase
     public function shouldMapReturnsFalseForBlacklistedProperties()
     {
         $this->propertyMappingConfiguration->allowAllPropertiesExcept('someSourceProperty', 'someOtherProperty');
-        $this->assertFalse($this->propertyMappingConfiguration->shouldMap('someSourceProperty'));
-        $this->assertFalse($this->propertyMappingConfiguration->shouldMap('someOtherProperty'));
+        self::assertFalse($this->propertyMappingConfiguration->shouldMap('someSourceProperty'));
+        self::assertFalse($this->propertyMappingConfiguration->shouldMap('someOtherProperty'));
 
-        $this->assertTrue($this->propertyMappingConfiguration->shouldMap('someOtherPropertyWhichHasNotBeenConfigured'));
+        self::assertTrue($this->propertyMappingConfiguration->shouldMap('someOtherPropertyWhichHasNotBeenConfigured'));
     }
 
     /**
@@ -98,8 +98,8 @@ class PropertyMappingConfigurationTest extends UnitTestCase
      */
     public function shouldSkipReturnsFalseByDefault()
     {
-        $this->assertFalse($this->propertyMappingConfiguration->shouldSkip('someSourceProperty'));
-        $this->assertFalse($this->propertyMappingConfiguration->shouldSkip('someOtherSourceProperty'));
+        self::assertFalse($this->propertyMappingConfiguration->shouldSkip('someSourceProperty'));
+        self::assertFalse($this->propertyMappingConfiguration->shouldSkip('someOtherSourceProperty'));
     }
 
     /**
@@ -109,8 +109,8 @@ class PropertyMappingConfigurationTest extends UnitTestCase
     public function shouldSkipReturnsTrueIfConfigured()
     {
         $this->propertyMappingConfiguration->skipProperties('someSourceProperty', 'someOtherSourceProperty');
-        $this->assertTrue($this->propertyMappingConfiguration->shouldSkip('someSourceProperty'));
-        $this->assertTrue($this->propertyMappingConfiguration->shouldSkip('someOtherSourceProperty'));
+        self::assertTrue($this->propertyMappingConfiguration->shouldSkip('someSourceProperty'));
+        self::assertTrue($this->propertyMappingConfiguration->shouldSkip('someOtherSourceProperty'));
     }
 
     /**
@@ -121,8 +121,8 @@ class PropertyMappingConfigurationTest extends UnitTestCase
         $mockTypeConverterClass = $this->getMockClass(TypeConverterInterface::class);
 
         $this->propertyMappingConfiguration->setTypeConverterOptions($mockTypeConverterClass, ['k1' => 'v1', 'k2' => 'v2']);
-        $this->assertEquals('v1', $this->propertyMappingConfiguration->getConfigurationValue($mockTypeConverterClass, 'k1'));
-        $this->assertEquals('v2', $this->propertyMappingConfiguration->getConfigurationValue($mockTypeConverterClass, 'k2'));
+        self::assertEquals('v1', $this->propertyMappingConfiguration->getConfigurationValue($mockTypeConverterClass, 'k1'));
+        self::assertEquals('v2', $this->propertyMappingConfiguration->getConfigurationValue($mockTypeConverterClass, 'k2'));
     }
 
     /**
@@ -130,7 +130,7 @@ class PropertyMappingConfigurationTest extends UnitTestCase
      */
     public function nonexistentTypeConverterOptionsReturnNull()
     {
-        $this->assertNull($this->propertyMappingConfiguration->getConfigurationValue('foo', 'bar'));
+        self::assertNull($this->propertyMappingConfiguration->getConfigurationValue('foo', 'bar'));
     }
 
     /**
@@ -142,8 +142,8 @@ class PropertyMappingConfigurationTest extends UnitTestCase
         $this->propertyMappingConfiguration->setTypeConverterOptions($mockTypeConverterClass, ['k1' => 'v1', 'k2' => 'v2']);
         $this->propertyMappingConfiguration->setTypeConverterOptions($mockTypeConverterClass, ['k3' => 'v3']);
 
-        $this->assertEquals('v3', $this->propertyMappingConfiguration->getConfigurationValue($mockTypeConverterClass, 'k3'));
-        $this->assertNull($this->propertyMappingConfiguration->getConfigurationValue($mockTypeConverterClass, 'k2'));
+        self::assertEquals('v3', $this->propertyMappingConfiguration->getConfigurationValue($mockTypeConverterClass, 'k3'));
+        self::assertNull($this->propertyMappingConfiguration->getConfigurationValue($mockTypeConverterClass, 'k2'));
     }
 
     /**
@@ -155,8 +155,8 @@ class PropertyMappingConfigurationTest extends UnitTestCase
         $this->propertyMappingConfiguration->setTypeConverterOptions($mockTypeConverterClass, ['k1' => 'v1', 'k2' => 'v2']);
         $this->propertyMappingConfiguration->setTypeConverterOption($mockTypeConverterClass, 'k1', 'v3');
 
-        $this->assertEquals('v3', $this->propertyMappingConfiguration->getConfigurationValue($mockTypeConverterClass, 'k1'));
-        $this->assertEquals('v2', $this->propertyMappingConfiguration->getConfigurationValue($mockTypeConverterClass, 'k2'));
+        self::assertEquals('v3', $this->propertyMappingConfiguration->getConfigurationValue($mockTypeConverterClass, 'k1'));
+        self::assertEquals('v2', $this->propertyMappingConfiguration->getConfigurationValue($mockTypeConverterClass, 'k2'));
     }
 
     /**
@@ -164,7 +164,7 @@ class PropertyMappingConfigurationTest extends UnitTestCase
      */
     public function getTypeConverterReturnsNullIfNoTypeConverterSet()
     {
-        $this->assertNull($this->propertyMappingConfiguration->getTypeConverter());
+        self::assertNull($this->propertyMappingConfiguration->getTypeConverter());
     }
 
     /**
@@ -174,7 +174,7 @@ class PropertyMappingConfigurationTest extends UnitTestCase
     {
         $mockTypeConverter = $this->createMock(TypeConverterInterface::class);
         $this->propertyMappingConfiguration->setTypeConverter($mockTypeConverter);
-        $this->assertSame($mockTypeConverter, $this->propertyMappingConfiguration->getTypeConverter());
+        self::assertSame($mockTypeConverter, $this->propertyMappingConfiguration->getTypeConverter());
     }
 
     /**
@@ -194,8 +194,8 @@ class PropertyMappingConfigurationTest extends UnitTestCase
     public function getTargetPropertyNameShouldRespectMapping()
     {
         $this->propertyMappingConfiguration->setMapping('k1', 'k1a');
-        $this->assertEquals('k1a', $this->propertyMappingConfiguration->getTargetPropertyName('k1'));
-        $this->assertEquals('k2', $this->propertyMappingConfiguration->getTargetPropertyName('k2'));
+        self::assertEquals('k1a', $this->propertyMappingConfiguration->getTargetPropertyName('k1'));
+        self::assertEquals('k2', $this->propertyMappingConfiguration->getTargetPropertyName('k2'));
     }
 
     /**
@@ -223,7 +223,7 @@ class PropertyMappingConfigurationTest extends UnitTestCase
     public function respectiveMethodsProvideFluentInterface($methodToTestForFluentInterface, array $argumentsForMethod = [])
     {
         $actualResult = call_user_func_array([$this->propertyMappingConfiguration, $methodToTestForFluentInterface], $argumentsForMethod);
-        $this->assertSame($this->propertyMappingConfiguration, $actualResult);
+        self::assertSame($this->propertyMappingConfiguration, $actualResult);
     }
 
     /**
@@ -235,7 +235,7 @@ class PropertyMappingConfigurationTest extends UnitTestCase
         $this->propertyMappingConfiguration->forProperty('items.*')->setTypeConverterOptions('stdClass', ['k1' => 'v1']);
 
         $configuration = $this->propertyMappingConfiguration->getConfigurationFor('items')->getConfigurationFor('6');
-        $this->assertSame('v1', $configuration->getConfigurationValue(\stdClass::class, 'k1'));
+        self::assertSame('v1', $configuration->getConfigurationValue(\stdClass::class, 'k1'));
     }
 
     /**
@@ -247,7 +247,7 @@ class PropertyMappingConfigurationTest extends UnitTestCase
         $this->propertyMappingConfiguration->forProperty('items.*.foo')->setTypeConverterOptions('stdClass', ['k1' => 'v1']);
 
         $configuration = $this->propertyMappingConfiguration->forProperty('items.6.foo');
-        $this->assertSame('v1', $configuration->getConfigurationValue(\stdClass::class, 'k1'));
+        self::assertSame('v1', $configuration->getConfigurationValue(\stdClass::class, 'k1'));
     }
 
     /**
@@ -258,6 +258,6 @@ class PropertyMappingConfigurationTest extends UnitTestCase
         $this->propertyMappingConfiguration->forProperty('items.*')->setTypeConverterOptions('stdClass', ['k1' => 'v1']);
 
         $configuration = $this->propertyMappingConfiguration->forProperty('items');
-        $this->assertTrue($configuration->shouldMap(6));
+        self::assertTrue($configuration->shouldMap(6));
     }
 }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/ArrayConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/ArrayConverterTest.php
@@ -36,9 +36,9 @@ class ArrayConverterTest extends UnitTestCase
      */
     public function checkMetadata()
     {
-        $this->assertEquals(['array', 'string', PersistentResource::class], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
-        $this->assertEquals('array', $this->converter->getSupportedTargetType(), 'Target type does not match');
-        $this->assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
+        self::assertEquals(['array', 'string', PersistentResource::class], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
+        self::assertEquals('array', $this->converter->getSupportedTargetType(), 'Target type does not match');
+        self::assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
     }
 
     /**
@@ -47,7 +47,7 @@ class ArrayConverterTest extends UnitTestCase
     public function convertFromDoesNotModifyTheSourceArray()
     {
         $sourceArray = ['Foo' => 'Bar', 'Baz'];
-        $this->assertEquals($sourceArray, $this->converter->convertFrom($sourceArray, 'array'));
+        self::assertEquals($sourceArray, $this->converter->convertFrom($sourceArray, 'array'));
     }
 
     public function stringToArrayDataProvider()
@@ -79,6 +79,6 @@ class ArrayConverterTest extends UnitTestCase
             ->method('getConfigurationValue')
             ->will($this->returnValueMap($configurationValueMap));
 
-        $this->assertEquals($expectedResult, $this->converter->convertFrom($source, 'array', [], $propertyMappingConfiguration));
+        self::assertEquals($expectedResult, $this->converter->convertFrom($source, 'array', [], $propertyMappingConfiguration));
     }
 }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/ArrayFromObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/ArrayFromObjectConverterTest.php
@@ -35,9 +35,9 @@ class ArrayFromObjectConverterTest extends UnitTestCase
      */
     public function checkMetadata()
     {
-        $this->assertEquals(['object'], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
-        $this->assertEquals('array', $this->converter->getSupportedTargetType(), 'Target type does not match');
-        $this->assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
+        self::assertEquals(['object'], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
+        self::assertEquals('array', $this->converter->getSupportedTargetType(), 'Target type does not match');
+        self::assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
     }
 
     /**
@@ -48,7 +48,7 @@ class ArrayFromObjectConverterTest extends UnitTestCase
         $source = new \stdClass();
         $source->first = 'Foo';
         $source->second = new \stdClass();
-        $this->assertEquals(['second' => new \stdClass()], $this->converter->getSourceChildPropertiesToBeConverted($source));
+        self::assertEquals(['second' => new \stdClass()], $this->converter->getSourceChildPropertiesToBeConverted($source));
     }
 
     public function objectToArrayDataProvider()
@@ -73,6 +73,6 @@ class ArrayFromObjectConverterTest extends UnitTestCase
         $convertedChildProperties = array_map(function ($value) {
             return $this->converter->convertFrom($value, 'array', [], null);
         }, $this->converter->getSourceChildPropertiesToBeConverted($source));
-        $this->assertEquals($expectedResult, $this->converter->convertFrom($source, 'array', $convertedChildProperties, null));
+        self::assertEquals($expectedResult, $this->converter->convertFrom($source, 'array', $convertedChildProperties, null));
     }
 }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/BooleanConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/BooleanConverterTest.php
@@ -34,9 +34,9 @@ class BooleanConverterTest extends UnitTestCase
      */
     public function checkMetadata()
     {
-        $this->assertEquals(['boolean', 'string', 'integer', 'float'], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
-        $this->assertEquals('boolean', $this->converter->getSupportedTargetType(), 'Target type does not match');
-        $this->assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
+        self::assertEquals(['boolean', 'string', 'integer', 'float'], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
+        self::assertEquals('boolean', $this->converter->getSupportedTargetType(), 'Target type does not match');
+        self::assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
     }
 
     /**
@@ -45,7 +45,7 @@ class BooleanConverterTest extends UnitTestCase
     public function convertFromDoesNotModifyTheBooleanSource()
     {
         $source = true;
-        $this->assertSame($source, $this->converter->convertFrom($source, 'boolean'));
+        self::assertSame($source, $this->converter->convertFrom($source, 'boolean'));
     }
 
     /**
@@ -54,7 +54,7 @@ class BooleanConverterTest extends UnitTestCase
     public function convertFromCastsSourceStringToBoolean()
     {
         $source = 'true';
-        $this->assertTrue($this->converter->convertFrom($source, 'boolean'));
+        self::assertTrue($this->converter->convertFrom($source, 'boolean'));
     }
 
     /**
@@ -63,7 +63,7 @@ class BooleanConverterTest extends UnitTestCase
     public function convertFromCastsNumericSourceStringToBoolean()
     {
         $source = '1';
-        $this->assertTrue($this->converter->convertFrom($source, 'boolean'));
+        self::assertTrue($this->converter->convertFrom($source, 'boolean'));
     }
 
     public function convertFromDataProvider()
@@ -98,6 +98,6 @@ class BooleanConverterTest extends UnitTestCase
      */
     public function convertFromTests($source, $expected)
     {
-        $this->assertSame($expected, $this->converter->convertFrom($source, 'boolean'));
+        self::assertSame($expected, $this->converter->convertFrom($source, 'boolean'));
     }
 }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/CollectionConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/CollectionConverterTest.php
@@ -35,9 +35,9 @@ class CollectionConverterTest extends UnitTestCase
      */
     public function checkMetadata()
     {
-        $this->assertEquals(['string', 'array'], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
-        $this->assertEquals('Doctrine\Common\Collections\Collection', $this->converter->getSupportedTargetType(), 'Target type does not match');
-        $this->assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
+        self::assertEquals(['string', 'array'], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
+        self::assertEquals('Doctrine\Common\Collections\Collection', $this->converter->getSupportedTargetType(), 'Target type does not match');
+        self::assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
     }
 
     /**
@@ -45,7 +45,7 @@ class CollectionConverterTest extends UnitTestCase
      */
     public function getTypeOfChildPropertyReturnsElementTypeFromTargetTypeIfGiven()
     {
-        $this->assertEquals('FooBar', $this->converter->getTypeOfChildProperty('array<FooBar>', '', $this->createMock(PropertyMappingConfigurationInterface::class)));
+        self::assertEquals('FooBar', $this->converter->getTypeOfChildProperty('array<FooBar>', '', $this->createMock(PropertyMappingConfigurationInterface::class)));
     }
 
     /**
@@ -53,6 +53,6 @@ class CollectionConverterTest extends UnitTestCase
      */
     public function getTypeOfChildPropertyReturnsEmptyStringForElementTypeIfNotGivenInTargetType()
     {
-        $this->assertEquals('', $this->converter->getTypeOfChildProperty('array', '', $this->createMock(PropertyMappingConfigurationInterface::class)));
+        self::assertEquals('', $this->converter->getTypeOfChildProperty('array', '', $this->createMock(PropertyMappingConfigurationInterface::class)));
     }
 }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/DateTimeConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/DateTimeConverterTest.php
@@ -40,9 +40,9 @@ class DateTimeConverterTest extends UnitTestCase
      */
     public function checkMetadata()
     {
-        $this->assertEquals(['string', 'integer', 'array'], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
-        $this->assertEquals(\DateTimeInterface::class, $this->converter->getSupportedTargetType(), 'Target type does not match');
-        $this->assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
+        self::assertEquals(['string', 'integer', 'array'], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
+        self::assertEquals(\DateTimeInterface::class, $this->converter->getSupportedTargetType(), 'Target type does not match');
+        self::assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
     }
 
 
@@ -53,7 +53,7 @@ class DateTimeConverterTest extends UnitTestCase
      */
     public function canConvertFromReturnsFalseIfTargetTypeIsNotDateTime()
     {
-        $this->assertFalse($this->converter->canConvertFrom('Foo', 'SomeOtherType'));
+        self::assertFalse($this->converter->canConvertFrom('Foo', 'SomeOtherType'));
     }
 
     /**
@@ -61,7 +61,7 @@ class DateTimeConverterTest extends UnitTestCase
      */
     public function canConvertFromReturnsTrueIfSourceTypeIsAString()
     {
-        $this->assertTrue($this->converter->canConvertFrom('Foo', 'DateTime'));
+        self::assertTrue($this->converter->canConvertFrom('Foo', 'DateTime'));
     }
 
     /**
@@ -69,7 +69,7 @@ class DateTimeConverterTest extends UnitTestCase
      */
     public function canConvertFromReturnsTrueIfSourceTypeIsAnEmptyString()
     {
-        $this->assertTrue($this->converter->canConvertFrom('', 'DateTime'));
+        self::assertTrue($this->converter->canConvertFrom('', 'DateTime'));
     }
 
     /**
@@ -77,7 +77,7 @@ class DateTimeConverterTest extends UnitTestCase
      */
     public function canConvertFromReturnsTrueITargetTypeIsADateTimeImmutable()
     {
-        $this->assertTrue($this->converter->canConvertFrom('', \DateTimeImmutable::class));
+        self::assertTrue($this->converter->canConvertFrom('', \DateTimeImmutable::class));
     }
 
     /**
@@ -86,7 +86,7 @@ class DateTimeConverterTest extends UnitTestCase
     public function convertFromReturnsErrorIfGivenStringCantBeConverted()
     {
         $error = $this->converter->convertFrom('1980-12-13', 'DateTime');
-        $this->assertInstanceOf(FlowError::class, $error);
+        self::assertInstanceOf(FlowError::class, $error);
     }
 
     /**
@@ -97,7 +97,7 @@ class DateTimeConverterTest extends UnitTestCase
         $expectedResult = '1980-12-13T20:15:07+01:23';
         $date = $this->converter->convertFrom($expectedResult, 'DateTime');
         $actualResult = $date->format('Y-m-d\TH:i:sP');
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -107,7 +107,7 @@ class DateTimeConverterTest extends UnitTestCase
     {
         $expectedResult = '1980-12-13T20:15:07+01:23';
         $date = $this->converter->convertFrom($expectedResult, \DateTimeImmutable::class);
-        $this->assertInstanceOf(\DateTimeImmutable::class, $date);
+        self::assertInstanceOf(\DateTimeImmutable::class, $date);
     }
 
     /**
@@ -125,7 +125,7 @@ class DateTimeConverterTest extends UnitTestCase
 
         $date = $this->converter->convertFrom($expectedResult, 'DateTime', [], $mockMappingConfiguration);
         $actualResult = $date->format(DateTimeConverter::DEFAULT_DATE_FORMAT);
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -134,7 +134,7 @@ class DateTimeConverterTest extends UnitTestCase
     public function convertFromEmptyStringReturnsNull()
     {
         $date = $this->converter->convertFrom('', 'DateTime', [], null);
-        $this->assertNull($date);
+        self::assertNull($date);
     }
 
     /**
@@ -176,15 +176,15 @@ class DateTimeConverterTest extends UnitTestCase
         }
         $date = $this->converter->convertFrom($source, 'DateTime', [], $mockMappingConfiguration);
         if ($isValid !== true) {
-            $this->assertInstanceOf(FlowError::class, $date);
+            self::assertInstanceOf(FlowError::class, $date);
             return;
         }
-        $this->assertInstanceOf(\DateTime::class, $date);
+        self::assertInstanceOf(\DateTime::class, $date);
 
         if ($dateFormat === null) {
             $dateFormat = DateTimeConverter::DEFAULT_DATE_FORMAT;
         }
-        $this->assertSame($source, $date->format($dateFormat));
+        self::assertSame($source, $date->format($dateFormat));
     }
 
     /**
@@ -208,8 +208,8 @@ class DateTimeConverterTest extends UnitTestCase
     public function convertFromIntegerOrDigitStringWithoutConfigurationTests($source)
     {
         $date = $this->converter->convertFrom($source, 'DateTime', [], null);
-        $this->assertInstanceOf(\DateTime::class, $date);
-        $this->assertSame(strval($source), $date->format('U'));
+        self::assertInstanceOf(\DateTime::class, $date);
+        self::assertSame(strval($source), $date->format('U'));
     }
 
     /**
@@ -240,8 +240,8 @@ class DateTimeConverterTest extends UnitTestCase
             ->will($this->returnValue(null));
 
         $date = $this->converter->convertFrom($source, 'DateTime', [], $mockMappingConfiguration);
-        $this->assertInstanceOf(\DateTime::class, $date);
-        $this->assertSame(strval($source), $date->format('U'));
+        self::assertInstanceOf(\DateTime::class, $date);
+        self::assertSame(strval($source), $date->format('U'));
     }
 
     /** Array to DateTime testcases  **/
@@ -254,8 +254,8 @@ class DateTimeConverterTest extends UnitTestCase
     public function convertFromIntegerOrDigitStringInArrayWithoutConfigurationTests($source)
     {
         $date = $this->converter->convertFrom(['date' => $source], 'DateTime', [], null);
-        $this->assertInstanceOf(\DateTime::class, $date);
-        $this->assertSame(strval($source), $date->format('U'));
+        self::assertInstanceOf(\DateTime::class, $date);
+        self::assertSame(strval($source), $date->format('U'));
     }
 
     /**
@@ -263,7 +263,7 @@ class DateTimeConverterTest extends UnitTestCase
      */
     public function canConvertFromReturnsTrueIfSourceTypeIsAnArray()
     {
-        $this->assertTrue($this->converter->canConvertFrom([], 'DateTime'));
+        self::assertTrue($this->converter->canConvertFrom([], 'DateTime'));
     }
 
     /**
@@ -272,7 +272,7 @@ class DateTimeConverterTest extends UnitTestCase
     public function convertFromReturnsErrorIfGivenArrayCantBeConverted()
     {
         $error = $this->converter->convertFrom(['date' => '1980-12-13'], 'DateTime');
-        $this->assertInstanceOf(FlowError::class, $error);
+        self::assertInstanceOf(FlowError::class, $error);
     }
 
     /**
@@ -292,7 +292,7 @@ class DateTimeConverterTest extends UnitTestCase
         $expectedResult = '1980-12-13T20:15:07+01:23';
         $date = $this->converter->convertFrom(['date' => $expectedResult], 'DateTime');
         $actualResult = $date->format('Y-m-d\TH:i:sP');
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -336,7 +336,7 @@ class DateTimeConverterTest extends UnitTestCase
 
         $date = $this->converter->convertFrom($source, 'DateTime', [], $mappingConfiguration);
         $actualResult = $date->format('Y-m-d');
-        $this->assertSame('2010-10-13', $actualResult);
+        self::assertSame('2010-10-13', $actualResult);
     }
 
     /**
@@ -352,10 +352,10 @@ class DateTimeConverterTest extends UnitTestCase
             'second' => '59',
         ];
         $date = $this->converter->convertFrom($source, 'DateTime');
-        $this->assertSame('2011-06-16', $date->format('Y-m-d'));
-        $this->assertSame('12', $date->format('H'));
-        $this->assertSame('30', $date->format('i'));
-        $this->assertSame('59', $date->format('s'));
+        self::assertSame('2011-06-16', $date->format('Y-m-d'));
+        self::assertSame('12', $date->format('H'));
+        self::assertSame('30', $date->format('i'));
+        self::assertSame('59', $date->format('s'));
     }
 
     /**
@@ -371,10 +371,10 @@ class DateTimeConverterTest extends UnitTestCase
             'second' => '59',
         ];
         $date = $this->converter->convertFrom($source, \DateTimeImmutable::class);
-        $this->assertSame('2011-06-16', $date->format('Y-m-d'));
-        $this->assertSame('12', $date->format('H'));
-        $this->assertSame('30', $date->format('i'));
-        $this->assertSame('59', $date->format('s'));
+        self::assertSame('2011-06-16', $date->format('Y-m-d'));
+        self::assertSame('12', $date->format('H'));
+        self::assertSame('30', $date->format('i'));
+        self::assertSame('59', $date->format('s'));
     }
 
     /**
@@ -388,11 +388,11 @@ class DateTimeConverterTest extends UnitTestCase
             'timezone' => 'Atlantic/Reykjavik',
         ];
         $date = $this->converter->convertFrom($source, 'DateTime');
-        $this->assertSame('2011-06-16', $date->format('Y-m-d'));
-        $this->assertSame('12', $date->format('H'));
-        $this->assertSame('30', $date->format('i'));
-        $this->assertSame('59', $date->format('s'));
-        $this->assertSame('Atlantic/Reykjavik', $date->getTimezone()->getName());
+        self::assertSame('2011-06-16', $date->format('Y-m-d'));
+        self::assertSame('12', $date->format('H'));
+        self::assertSame('30', $date->format('i'));
+        self::assertSame('59', $date->format('s'));
+        self::assertSame('Atlantic/Reykjavik', $date->getTimezone()->getName());
     }
 
     /**
@@ -406,11 +406,11 @@ class DateTimeConverterTest extends UnitTestCase
             'timezone' => 'Atlantic/Reykjavik',
         ];
         $date = $this->converter->convertFrom($source, \DateTimeImmutable::class);
-        $this->assertSame('2011-06-16', $date->format('Y-m-d'));
-        $this->assertSame('12', $date->format('H'));
-        $this->assertSame('30', $date->format('i'));
-        $this->assertSame('59', $date->format('s'));
-        $this->assertSame('Atlantic/Reykjavik', $date->getTimezone()->getName());
+        self::assertSame('2011-06-16', $date->format('Y-m-d'));
+        self::assertSame('12', $date->format('H'));
+        self::assertSame('30', $date->format('i'));
+        self::assertSame('59', $date->format('s'));
+        self::assertSame('Atlantic/Reykjavik', $date->getTimezone()->getName());
     }
 
     /**
@@ -441,7 +441,7 @@ class DateTimeConverterTest extends UnitTestCase
      */
     public function convertFromArrayReturnsNullForEmptyDate()
     {
-        $this->assertNull($this->converter->convertFrom(['date' => ''], 'DateTime', [], null));
+        self::assertNull($this->converter->convertFrom(['date' => ''], 'DateTime', [], null));
     }
 
     /**
@@ -486,11 +486,11 @@ class DateTimeConverterTest extends UnitTestCase
         $date = $this->converter->convertFrom($source, 'DateTime', [], $mockMappingConfiguration);
 
         if ($isValid !== true) {
-            $this->assertInstanceOf(FlowError::class, $date);
+            self::assertInstanceOf(FlowError::class, $date);
             return;
         }
 
-        $this->assertInstanceOf(\DateTime::class, $date);
+        self::assertInstanceOf(\DateTime::class, $date);
         $dateAsString = isset($source['date']) ? strval($source['date']) : '';
         if ($dateFormat === null) {
             if (ctype_digit($dateAsString)) {
@@ -499,7 +499,7 @@ class DateTimeConverterTest extends UnitTestCase
                 $dateFormat = DateTimeConverter::DEFAULT_DATE_FORMAT;
             }
         }
-        $this->assertSame($dateAsString, $date->format($dateFormat));
+        self::assertSame($dateAsString, $date->format($dateFormat));
     }
 
     /**
@@ -529,8 +529,8 @@ class DateTimeConverterTest extends UnitTestCase
         }
         $date = $this->converter->convertFrom('2005-08-15T15:52:01+00:00', $className);
 
-        $this->assertInstanceOf($className, $date);
-        $this->assertSame('Bar', $date->foo());
+        self::assertInstanceOf($className, $date);
+        self::assertSame('Bar', $date->foo());
     }
 
     /**
@@ -542,7 +542,7 @@ class DateTimeConverterTest extends UnitTestCase
         // Serialize to an array with json_decode from an json_encoded string
         $source = json_decode(json_encode($sourceDate), true);
         $convertedDate = $this->converter->convertFrom($source, 'DateTime');
-        $this->assertInstanceOf('DateTime', $convertedDate);
-        $this->assertSame($sourceDate->getTimestamp(), $convertedDate->getTimestamp());
+        self::assertInstanceOf('DateTime', $convertedDate);
+        self::assertSame($sourceDate->getTimestamp(), $convertedDate->getTimestamp());
     }
 }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/FloatConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/FloatConverterTest.php
@@ -38,9 +38,9 @@ class FloatConverterTest extends UnitTestCase
      */
     public function checkMetadata()
     {
-        $this->assertEquals(['float', 'integer', 'string'], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
-        $this->assertEquals('float', $this->converter->getSupportedTargetType(), 'Target type does not match');
-        $this->assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
+        self::assertEquals(['float', 'integer', 'string'], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
+        self::assertEquals('float', $this->converter->getSupportedTargetType(), 'Target type does not match');
+        self::assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
     }
 
     /**
@@ -48,7 +48,7 @@ class FloatConverterTest extends UnitTestCase
      */
     public function convertFromShouldCastTheStringToFloat()
     {
-        $this->assertSame(1.5, $this->converter->convertFrom('1.5', 'float'));
+        self::assertSame(1.5, $this->converter->convertFrom('1.5', 'float'));
     }
 
     /**
@@ -56,7 +56,7 @@ class FloatConverterTest extends UnitTestCase
      */
     public function convertFromReturnsNullIfEmptyStringSpecified()
     {
-        $this->assertNull($this->converter->convertFrom('', 'float'));
+        self::assertNull($this->converter->convertFrom('', 'float'));
     }
 
     /**
@@ -64,7 +64,7 @@ class FloatConverterTest extends UnitTestCase
      */
     public function convertFromShouldAcceptIntegers()
     {
-        $this->assertSame((float)123, $this->converter->convertFrom(123, 'float'));
+        self::assertSame((float)123, $this->converter->convertFrom(123, 'float'));
     }
 
     /**
@@ -72,7 +72,7 @@ class FloatConverterTest extends UnitTestCase
      */
     public function convertFromReturnsAnErrorIfSpecifiedStringIsNotNumeric()
     {
-        $this->assertInstanceOf(Error\Error::class, $this->converter->convertFrom('not numeric', 'float'));
+        self::assertInstanceOf(Error\Error::class, $this->converter->convertFrom('not numeric', 'float'));
     }
 
     /**
@@ -80,7 +80,7 @@ class FloatConverterTest extends UnitTestCase
      */
     public function canConvertFromShouldReturnTrue()
     {
-        $this->assertTrue($this->converter->canConvertFrom('1.5', 'float'));
+        self::assertTrue($this->converter->canConvertFrom('1.5', 'float'));
     }
 
     /**
@@ -88,7 +88,7 @@ class FloatConverterTest extends UnitTestCase
      */
     public function canConvertFromShouldReturnTrueForAnEmptyValue()
     {
-        $this->assertTrue($this->converter->canConvertFrom('', 'integer'));
+        self::assertTrue($this->converter->canConvertFrom('', 'integer'));
     }
 
     /**
@@ -96,7 +96,7 @@ class FloatConverterTest extends UnitTestCase
      */
     public function canConvertFromShouldReturnTrueForANullValue()
     {
-        $this->assertTrue($this->converter->canConvertFrom(null, 'integer'));
+        self::assertTrue($this->converter->canConvertFrom(null, 'integer'));
     }
 
     /**
@@ -104,6 +104,6 @@ class FloatConverterTest extends UnitTestCase
      */
     public function getSourceChildPropertiesToBeConvertedShouldReturnEmptyArray()
     {
-        $this->assertEquals([], $this->converter->getSourceChildPropertiesToBeConverted('myString'));
+        self::assertEquals([], $this->converter->getSourceChildPropertiesToBeConverted('myString'));
     }
 }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/IntegerConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/IntegerConverterTest.php
@@ -38,9 +38,9 @@ class IntegerConverterTest extends UnitTestCase
      */
     public function checkMetadata()
     {
-        $this->assertEquals(['integer', 'string', 'DateTime'], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
-        $this->assertEquals('integer', $this->converter->getSupportedTargetType(), 'Target type does not match');
-        $this->assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
+        self::assertEquals(['integer', 'string', 'DateTime'], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
+        self::assertEquals('integer', $this->converter->getSupportedTargetType(), 'Target type does not match');
+        self::assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
     }
 
     /**
@@ -48,7 +48,7 @@ class IntegerConverterTest extends UnitTestCase
      */
     public function convertFromCastsStringToInteger()
     {
-        $this->assertSame(15, $this->converter->convertFrom('15', 'integer'));
+        self::assertSame(15, $this->converter->convertFrom('15', 'integer'));
     }
 
     /**
@@ -57,7 +57,7 @@ class IntegerConverterTest extends UnitTestCase
     public function convertFromCastsDateTimeToInteger()
     {
         $dateTime = new \DateTime();
-        $this->assertSame($dateTime->format('U'), $this->converter->convertFrom($dateTime, 'integer'));
+        self::assertSame($dateTime->format('U'), $this->converter->convertFrom($dateTime, 'integer'));
     }
 
     /**
@@ -66,7 +66,7 @@ class IntegerConverterTest extends UnitTestCase
     public function convertFromDoesNotModifyIntegers()
     {
         $source = 123;
-        $this->assertSame($source, $this->converter->convertFrom($source, 'integer'));
+        self::assertSame($source, $this->converter->convertFrom($source, 'integer'));
     }
 
     /**
@@ -74,7 +74,7 @@ class IntegerConverterTest extends UnitTestCase
      */
     public function convertFromReturnsNullIfEmptyStringSpecified()
     {
-        $this->assertNull($this->converter->convertFrom('', 'integer'));
+        self::assertNull($this->converter->convertFrom('', 'integer'));
     }
 
     /**
@@ -82,7 +82,7 @@ class IntegerConverterTest extends UnitTestCase
      */
     public function convertFromReturnsAnErrorIfSpecifiedStringIsNotNumeric()
     {
-        $this->assertInstanceOf(FlowError\Error::class, $this->converter->convertFrom('not numeric', 'integer'));
+        self::assertInstanceOf(FlowError\Error::class, $this->converter->convertFrom('not numeric', 'integer'));
     }
 
     /**
@@ -90,7 +90,7 @@ class IntegerConverterTest extends UnitTestCase
      */
     public function canConvertFromShouldReturnTrueForANumericStringSource()
     {
-        $this->assertTrue($this->converter->canConvertFrom('15', 'integer'));
+        self::assertTrue($this->converter->canConvertFrom('15', 'integer'));
     }
 
     /**
@@ -98,7 +98,7 @@ class IntegerConverterTest extends UnitTestCase
      */
     public function canConvertFromShouldReturnTrueForAnIntegerSource()
     {
-        $this->assertTrue($this->converter->canConvertFrom(123, 'integer'));
+        self::assertTrue($this->converter->canConvertFrom(123, 'integer'));
     }
 
     /**
@@ -106,7 +106,7 @@ class IntegerConverterTest extends UnitTestCase
      */
     public function canConvertFromShouldReturnTrueForAnEmptyValue()
     {
-        $this->assertTrue($this->converter->canConvertFrom('', 'integer'));
+        self::assertTrue($this->converter->canConvertFrom('', 'integer'));
     }
 
     /**
@@ -114,7 +114,7 @@ class IntegerConverterTest extends UnitTestCase
      */
     public function canConvertFromShouldReturnTrueForANullValue()
     {
-        $this->assertTrue($this->converter->canConvertFrom(null, 'integer'));
+        self::assertTrue($this->converter->canConvertFrom(null, 'integer'));
     }
 
     /**
@@ -122,7 +122,7 @@ class IntegerConverterTest extends UnitTestCase
      */
     public function canConvertFromShouldReturnTrueForADateTimeValue()
     {
-        $this->assertTrue($this->converter->canConvertFrom(new \DateTime(), 'integer'));
+        self::assertTrue($this->converter->canConvertFrom(new \DateTime(), 'integer'));
     }
 
     /**
@@ -130,6 +130,6 @@ class IntegerConverterTest extends UnitTestCase
      */
     public function getSourceChildPropertiesToBeConvertedShouldReturnEmptyArray()
     {
-        $this->assertEquals([], $this->converter->getSourceChildPropertiesToBeConverted('myString'));
+        self::assertEquals([], $this->converter->getSourceChildPropertiesToBeConverted('myString'));
     }
 }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/MediaTypeConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/MediaTypeConverterTest.php
@@ -48,7 +48,7 @@ class MediaTypeConverterTest extends UnitTestCase
     {
         $actualResult = $this->mediaTypeConverter->convertFrom('{"jsonArgument":"jsonValue"}', 'array');
         $expectedResult = ['jsonArgument' => 'jsonValue'];
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -58,7 +58,7 @@ class MediaTypeConverterTest extends UnitTestCase
     {
         $actualResult = $this->mediaTypeConverter->convertFrom('<root><xmlArgument>xmlValue</xmlArgument></root>', 'array');
         $expectedResult = [];
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -70,7 +70,7 @@ class MediaTypeConverterTest extends UnitTestCase
 
         $actualResult = $this->mediaTypeConverter->convertFrom('{"jsonArgument":"jsonValue"}', 'array', [], $this->mockPropertyMappingConfiguration);
         $expectedResult = [];
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -105,6 +105,6 @@ class MediaTypeConverterTest extends UnitTestCase
         $this->mockPropertyMappingConfiguration->expects($this->atLeastOnce())->method('getConfigurationValue')->with(MediaTypeConverterInterface::class, MediaTypeConverterInterface::CONFIGURATION_MEDIA_TYPE)->will($this->returnValue($mediaType));
 
         $actualResult = $this->mediaTypeConverter->convertFrom($requestBody, 'array', [], $this->mockPropertyMappingConfiguration);
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/ObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/ObjectConverterTest.php
@@ -55,9 +55,9 @@ class ObjectConverterTest extends UnitTestCase
      */
     public function checkMetadata()
     {
-        $this->assertEquals(['array'], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
-        $this->assertEquals('object', $this->converter->getSupportedTargetType(), 'Target type does not match');
-        $this->assertEquals(0, $this->converter->getPriority(), 'Priority does not match');
+        self::assertEquals(['array'], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
+        self::assertEquals('object', $this->converter->getSupportedTargetType(), 'Target type does not match');
+        self::assertEquals(0, $this->converter->getPriority(), 'Priority does not match');
     }
 
     public function dataProviderForCanConvert()
@@ -82,7 +82,7 @@ class ObjectConverterTest extends UnitTestCase
             $this->mockReflectionService->expects($this->at(1))->method('isClassAnnotatedWith')->with('TheTargetType', Flow\ValueObject::class)->will($this->returnValue($isValueObject));
         }
 
-        $this->assertEquals($expected, $this->converter->canConvertFrom('myInputData', 'TheTargetType'));
+        self::assertEquals($expected, $this->converter->canConvertFrom('myInputData', 'TheTargetType'));
     }
 
     /**
@@ -99,7 +99,7 @@ class ObjectConverterTest extends UnitTestCase
         ]));
         $configuration = new PropertyMappingConfiguration();
         $configuration->setTypeConverterOptions(ObjectConverter::class, []);
-        $this->assertEquals('TheTypeOfSubObject', $this->converter->getTypeOfChildProperty('TheTargetType', 'thePropertyName', $configuration));
+        self::assertEquals('TheTypeOfSubObject', $this->converter->getTypeOfChildProperty('TheTargetType', 'thePropertyName', $configuration));
     }
 
     /**
@@ -117,6 +117,6 @@ class ObjectConverterTest extends UnitTestCase
         ]));
         $configuration = new PropertyMappingConfiguration();
         $configuration->setTypeConverterOptions(ObjectConverter::class, []);
-        $this->assertEquals('TheTypeOfSubObject', $this->converter->getTypeOfChildProperty('TheTargetType', 'thePropertyName', $configuration));
+        self::assertEquals('TheTypeOfSubObject', $this->converter->getTypeOfChildProperty('TheTargetType', 'thePropertyName', $configuration));
     }
 }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/PersistentObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/PersistentObjectConverterTest.php
@@ -74,9 +74,9 @@ class PersistentObjectConverterTest extends UnitTestCase
      */
     public function checkMetadata()
     {
-        $this->assertEquals(['string', 'array'], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
-        $this->assertEquals('object', $this->converter->getSupportedTargetType(), 'Target type does not match');
-        $this->assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
+        self::assertEquals(['string', 'array'], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
+        self::assertEquals('object', $this->converter->getSupportedTargetType(), 'Target type does not match');
+        self::assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
     }
 
     /**
@@ -107,7 +107,7 @@ class PersistentObjectConverterTest extends UnitTestCase
             $this->mockReflectionService->expects($this->at(1))->method('isClassAnnotatedWith')->with('TheTargetType', Flow\ValueObject::class)->will($this->returnValue($isValueObject));
         }
 
-        $this->assertEquals($expected, $this->converter->canConvertFrom('myInputData', 'TheTargetType'));
+        self::assertEquals($expected, $this->converter->canConvertFrom('myInputData', 'TheTargetType'));
     }
 
     /**
@@ -124,7 +124,7 @@ class PersistentObjectConverterTest extends UnitTestCase
             'k1' => 'v1',
             'k2' => 'v2'
         ];
-        $this->assertEquals($expected, $this->converter->getSourceChildPropertiesToBeConverted($source));
+        self::assertEquals($expected, $this->converter->getSourceChildPropertiesToBeConverted($source));
     }
 
     /**
@@ -141,7 +141,7 @@ class PersistentObjectConverterTest extends UnitTestCase
             'elementType' => null
         ]));
         $configuration = $this->buildConfiguration([]);
-        $this->assertEquals('TheTypeOfSubObject', $this->converter->getTypeOfChildProperty('TheTargetType', 'thePropertyName', $configuration));
+        self::assertEquals('TheTypeOfSubObject', $this->converter->getTypeOfChildProperty('TheTargetType', 'thePropertyName', $configuration));
     }
 
     /**
@@ -153,7 +153,7 @@ class PersistentObjectConverterTest extends UnitTestCase
 
         $configuration = $this->buildConfiguration([]);
         $configuration->forProperty('thePropertyName')->setTypeConverterOption(PersistentObjectConverter::class, PersistentObjectConverter::CONFIGURATION_TARGET_TYPE, 'Foo\Bar');
-        $this->assertEquals('Foo\Bar', $this->converter->getTypeOfChildProperty('foo', 'thePropertyName', $configuration));
+        self::assertEquals('Foo\Bar', $this->converter->getTypeOfChildProperty('foo', 'thePropertyName', $configuration));
     }
 
     /**
@@ -184,7 +184,7 @@ class PersistentObjectConverterTest extends UnitTestCase
                 ['type' => 'TheTypeOfSubObject']
             ]));
         $configuration = $this->buildConfiguration([]);
-        $this->assertEquals('TheTypeOfSubObject', $this->converter->getTypeOfChildProperty('TheTargetType', 'virtualPropertyName', $configuration));
+        self::assertEquals('TheTypeOfSubObject', $this->converter->getTypeOfChildProperty('TheTargetType', 'virtualPropertyName', $configuration));
     }
 
     /**
@@ -203,7 +203,7 @@ class PersistentObjectConverterTest extends UnitTestCase
             ]));
 
         $configuration = $this->buildConfiguration([]);
-        $this->assertEquals('string', $this->converter->getTypeOfChildProperty('TheTargetType', 'anotherProperty', $configuration));
+        self::assertEquals('string', $this->converter->getTypeOfChildProperty('TheTargetType', 'anotherProperty', $configuration));
     }
 
 
@@ -216,7 +216,7 @@ class PersistentObjectConverterTest extends UnitTestCase
         $object = new \stdClass();
 
         $this->mockPersistenceManager->expects($this->once())->method('getObjectByIdentifier')->with($identifier)->will($this->returnValue($object));
-        $this->assertSame($object, $this->converter->convertFrom($identifier, 'MySpecialType'));
+        self::assertSame($object, $this->converter->convertFrom($identifier, 'MySpecialType'));
     }
 
     /**
@@ -228,7 +228,7 @@ class PersistentObjectConverterTest extends UnitTestCase
         $object = new \stdClass();
 
         $this->mockPersistenceManager->expects($this->once())->method('getObjectByIdentifier')->with($identifier)->will($this->returnValue($object));
-        $this->assertSame($object, $this->converter->convertFrom($identifier, 'MySpecialType'));
+        self::assertSame($object, $this->converter->convertFrom($identifier, 'MySpecialType'));
     }
 
     /**
@@ -243,7 +243,7 @@ class PersistentObjectConverterTest extends UnitTestCase
             '__identity' => $identifier
         ];
         $this->mockPersistenceManager->expects($this->once())->method('getObjectByIdentifier')->with($identifier)->will($this->returnValue($object));
-        $this->assertSame($object, $this->converter->convertFrom($source, 'MySpecialType'));
+        self::assertSame($object, $this->converter->convertFrom($source, 'MySpecialType'));
     }
 
     /**
@@ -280,7 +280,7 @@ class PersistentObjectConverterTest extends UnitTestCase
         $this->mockPersistenceManager->expects($this->once())->method('getObjectByIdentifier')->with($identifier)->will($this->returnValue(null));
         $actualResult = $this->converter->convertFrom($source, 'MySpecialType', ['foo' => 'bar']);
 
-        $this->assertInstanceOf(TargetNotFoundError::class, $actualResult);
+        self::assertInstanceOf(TargetNotFoundError::class, $actualResult);
     }
 
     /**
@@ -332,7 +332,7 @@ class PersistentObjectConverterTest extends UnitTestCase
             '__identity' => ['key1' => 'value1', 'key2' => 'value2']
         ];
         $actual = $this->converter->convertFrom($source, 'SomeType');
-        $this->assertSame($mockObject, $actual);
+        self::assertSame($mockObject, $actual);
     }
 
     /**
@@ -346,7 +346,7 @@ class PersistentObjectConverterTest extends UnitTestCase
             '__identity' => ['key1' => 'value1', 'key2' => 'value2']
         ];
         $actual = $this->converter->convertFrom($source, 'SomeType');
-        $this->assertInstanceOf(TargetNotFoundError::class, $actual);
+        self::assertInstanceOf(TargetNotFoundError::class, $actual);
     }
 
     /**
@@ -405,7 +405,7 @@ class PersistentObjectConverterTest extends UnitTestCase
         $this->mockObjectManager->expects($this->once())->method('getClassNameByObjectName')->with(ClassWithSetters::class)->will($this->returnValue(ClassWithSetters::class));
         $configuration = $this->buildConfiguration([PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED => true]);
         $result = $this->converter->convertFrom($source, ClassWithSetters::class, $convertedChildProperties, $configuration);
-        $this->assertEquals($expectedObject, $result);
+        self::assertEquals($expectedObject, $result);
     }
 
     /**
@@ -426,7 +426,7 @@ class PersistentObjectConverterTest extends UnitTestCase
         $this->mockObjectManager->expects($this->once())->method('getClassNameByObjectName')->with(ClassWithSetters::class)->will($this->returnValue(ClassWithSetters::class));
         $configuration = $this->buildConfiguration([PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED => true]);
         $result = $this->converter->convertFrom($source, ClassWithSetters::class, $convertedChildProperties, $configuration);
-        $this->assertSame($object, $result);
+        self::assertSame($object, $result);
     }
 
     /**
@@ -451,8 +451,8 @@ class PersistentObjectConverterTest extends UnitTestCase
         $this->mockObjectManager->expects($this->once())->method('getClassNameByObjectName')->with(ClassWithSettersAndConstructor::class)->will($this->returnValue(ClassWithSettersAndConstructor::class));
         $configuration = $this->buildConfiguration([PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED => true]);
         $result = $this->converter->convertFrom($source, ClassWithSettersAndConstructor::class, $convertedChildProperties, $configuration);
-        $this->assertEquals($expectedObject, $result);
-        $this->assertEquals('bar', $expectedObject->getProperty2());
+        self::assertEquals($expectedObject, $result);
+        self::assertEquals('bar', $expectedObject->getProperty2());
     }
 
     /**
@@ -472,7 +472,7 @@ class PersistentObjectConverterTest extends UnitTestCase
         $this->mockObjectManager->expects($this->once())->method('getClassNameByObjectName')->with(ClassWithSettersAndConstructor::class)->will($this->returnValue(ClassWithSettersAndConstructor::class));
         $configuration = $this->buildConfiguration([PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED => true]);
         $result = $this->converter->convertFrom($source, ClassWithSettersAndConstructor::class, [], $configuration);
-        $this->assertEquals($expectedObject, $result);
+        self::assertEquals($expectedObject, $result);
     }
 
     /**
@@ -496,7 +496,7 @@ class PersistentObjectConverterTest extends UnitTestCase
         $this->mockObjectManager->expects($this->once())->method('getClassNameByObjectName')->with(ClassWithSettersAndConstructor::class)->will($this->returnValue(ClassWithSettersAndConstructor::class));
         $configuration = $this->buildConfiguration([PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED => true]);
         $result = $this->converter->convertFrom($source, ClassWithSettersAndConstructor::class, $convertedChildProperties, $configuration);
-        $this->assertSame($object, $result);
+        self::assertSame($object, $result);
     }
 
     /**
@@ -506,6 +506,6 @@ class PersistentObjectConverterTest extends UnitTestCase
     {
         $source = '';
         $result = $this->converter->convertFrom($source, ClassWithSettersAndConstructor::class);
-        $this->assertNull($result);
+        self::assertNull($result);
     }
 }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/ScalarTypeToObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/ScalarTypeToObjectConverterTest.php
@@ -52,7 +52,7 @@ class ScalarTypeToObjectConverterTest extends UnitTestCase
     {
         $converter = new ScalarTypeToObjectConverter();
         $valueObject = $converter->convertFrom('Hello World!', ClassWithStringConstructor::class);
-        $this->assertEquals('Hello World!', $valueObject->value);
+        self::assertEquals('Hello World!', $valueObject->value);
     }
 
     /**
@@ -62,7 +62,7 @@ class ScalarTypeToObjectConverterTest extends UnitTestCase
     {
         $converter = new ScalarTypeToObjectConverter();
         $valueObject = $converter->convertFrom(42, ClassWithIntegerConstructor::class);
-        $this->assertSame(42, $valueObject->value);
+        self::assertSame(42, $valueObject->value);
     }
 
     /**
@@ -72,7 +72,7 @@ class ScalarTypeToObjectConverterTest extends UnitTestCase
     {
         $converter = new ScalarTypeToObjectConverter();
         $valueObject = $converter->convertFrom(true, ClassWithBoolConstructor::class);
-        $this->assertSame(true, $valueObject->value);
+        self::assertSame(true, $valueObject->value);
     }
 
     /**
@@ -89,7 +89,7 @@ class ScalarTypeToObjectConverterTest extends UnitTestCase
             ]]);
         $this->inject($converter, 'reflectionService', $this->reflectionMock);
         $canConvert = $converter->canConvertFrom(true, ClassWithBoolConstructor::class);
-        $this->assertTrue($canConvert);
+        self::assertTrue($canConvert);
     }
 
     /**
@@ -106,6 +106,6 @@ class ScalarTypeToObjectConverterTest extends UnitTestCase
             ]]);
         $this->inject($converter, 'reflectionService', $this->reflectionMock);
         $canConvert = $converter->canConvertFrom(42, ClassWithIntegerConstructor::class);
-        $this->assertTrue($canConvert);
+        self::assertTrue($canConvert);
     }
 }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/StringConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/StringConverterTest.php
@@ -37,9 +37,9 @@ class StringConverterTest extends UnitTestCase
      */
     public function checkMetadata()
     {
-        $this->assertEquals(['string', 'integer', 'float', 'boolean', 'array', \DateTimeInterface::class], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
-        $this->assertEquals('string', $this->converter->getSupportedTargetType(), 'Target type does not match');
-        $this->assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
+        self::assertEquals(['string', 'integer', 'float', 'boolean', 'array', \DateTimeInterface::class], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
+        self::assertEquals('string', $this->converter->getSupportedTargetType(), 'Target type does not match');
+        self::assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
     }
 
     /**
@@ -47,7 +47,7 @@ class StringConverterTest extends UnitTestCase
      */
     public function convertFromShouldReturnSourceString()
     {
-        $this->assertEquals('myString', $this->converter->convertFrom('myString', 'string'));
+        self::assertEquals('myString', $this->converter->convertFrom('myString', 'string'));
     }
 
     /**
@@ -58,7 +58,7 @@ class StringConverterTest extends UnitTestCase
         $date = new \DateTime('1980-12-13');
         $propertyMappingConfiguration = new PropertyMappingConfiguration();
         $propertyMappingConfiguration->setTypeConverterOption(StringConverter::class, StringConverter::CONFIGURATION_DATE_FORMAT, 'd.m.Y');
-        $this->assertEquals('13.12.1980', $this->converter->convertFrom($date, 'string', [], $propertyMappingConfiguration));
+        self::assertEquals('13.12.1980', $this->converter->convertFrom($date, 'string', [], $propertyMappingConfiguration));
     }
 
     /**
@@ -69,7 +69,7 @@ class StringConverterTest extends UnitTestCase
         $date = new \DateTimeImmutable('1980-12-13');
         $propertyMappingConfiguration = new PropertyMappingConfiguration();
         $propertyMappingConfiguration->setTypeConverterOption(StringConverter::class, StringConverter::CONFIGURATION_DATE_FORMAT, 'd.m.Y');
-        $this->assertEquals('13.12.1980', $this->converter->convertFrom($date, 'string', [], $propertyMappingConfiguration));
+        self::assertEquals('13.12.1980', $this->converter->convertFrom($date, 'string', [], $propertyMappingConfiguration));
     }
 
 
@@ -78,7 +78,7 @@ class StringConverterTest extends UnitTestCase
      */
     public function canConvertFromShouldReturnTrue()
     {
-        $this->assertTrue($this->converter->canConvertFrom('myString', 'string'));
+        self::assertTrue($this->converter->canConvertFrom('myString', 'string'));
     }
 
     /**
@@ -86,7 +86,7 @@ class StringConverterTest extends UnitTestCase
      */
     public function getSourceChildPropertiesToBeConvertedShouldReturnEmptyArray()
     {
-        $this->assertEquals([], $this->converter->getSourceChildPropertiesToBeConverted('myString'));
+        self::assertEquals([], $this->converter->getSourceChildPropertiesToBeConverted('myString'));
     }
 
 
@@ -119,6 +119,6 @@ class StringConverterTest extends UnitTestCase
             ->method('getConfigurationValue')
             ->will($this->returnValueMap($configurationValueMap));
 
-        $this->assertEquals($expectedResult, $this->converter->convertFrom($source, 'array', [], $propertyMappingConfiguration));
+        self::assertEquals($expectedResult, $this->converter->convertFrom($source, 'array', [], $propertyMappingConfiguration));
     }
 }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/TypedArrayConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/TypedArrayConverterTest.php
@@ -35,9 +35,9 @@ class TypedArrayConverterTest extends UnitTestCase
      */
     public function checkMetadata()
     {
-        $this->assertEquals(['array'], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
-        $this->assertEquals('array', $this->converter->getSupportedTargetType(), 'Target type does not match');
-        $this->assertEquals(2, $this->converter->getPriority(), 'Priority does not match');
+        self::assertEquals(['array'], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
+        self::assertEquals('array', $this->converter->getSupportedTargetType(), 'Target type does not match');
+        self::assertEquals(2, $this->converter->getPriority(), 'Priority does not match');
     }
 
     /**
@@ -63,9 +63,9 @@ class TypedArrayConverterTest extends UnitTestCase
     {
         $actualResult = $this->converter->canConvertFrom([], $targetType);
         if ($expectedResult === true) {
-            $this->assertTrue($actualResult);
+            self::assertTrue($actualResult);
         } else {
-            $this->assertFalse($actualResult);
+            self::assertFalse($actualResult);
         }
     }
 
@@ -74,6 +74,6 @@ class TypedArrayConverterTest extends UnitTestCase
      */
     public function getSourceChildPropertiesToBeConvertedShouldReturnEmptyArray()
     {
-        $this->assertEquals([], $this->converter->getSourceChildPropertiesToBeConverted(''));
+        self::assertEquals([], $this->converter->getSourceChildPropertiesToBeConverted(''));
     }
 }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/UriTypeConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/UriTypeConverterTest.php
@@ -40,8 +40,8 @@ class UriTypeConverterTest extends UnitTestCase
     public function sourceTypeIsStringOnly()
     {
         $sourceTypes = $this->typeConverter->getSupportedSourceTypes();
-        $this->assertCount(1, $sourceTypes);
-        $this->assertSame('string', $sourceTypes[0]);
+        self::assertCount(1, $sourceTypes);
+        self::assertSame('string', $sourceTypes[0]);
     }
 
     /**
@@ -49,7 +49,7 @@ class UriTypeConverterTest extends UnitTestCase
      */
     public function targetTypeIsUri()
     {
-        $this->assertSame(Http\Uri::class, $this->typeConverter->getSupportedTargetType());
+        self::assertSame(Http\Uri::class, $this->typeConverter->getSupportedTargetType());
     }
 
     /**
@@ -57,7 +57,7 @@ class UriTypeConverterTest extends UnitTestCase
      */
     public function typeConverterReturnsUriOnValidUri()
     {
-        $this->assertInstanceOf(Http\Uri::class, $this->typeConverter->convertFrom('http://localhost/foo', Http\Uri::class));
+        self::assertInstanceOf(Http\Uri::class, $this->typeConverter->convertFrom('http://localhost/foo', Http\Uri::class));
     }
 
     /**
@@ -66,6 +66,6 @@ class UriTypeConverterTest extends UnitTestCase
     public function typeConverterReturnsErrorOnMalformedUri()
     {
         $actual = $this->typeConverter->convertFrom('http:////localhost', Http\Uri::class);
-        $this->assertInstanceOf(FlowError\Error::class, $actual);
+        self::assertInstanceOf(FlowError\Error::class, $actual);
     }
 }

--- a/Neos.Flow/Tests/Unit/Reflection/ClassReflectionTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/ClassReflectionTest.php
@@ -43,8 +43,8 @@ class ClassReflectionTest extends UnitTestCase implements Fixture\DummyInterface
         $class = new ClassReflection(__CLASS__);
         $properties = $class->getProperties();
 
-        $this->assertTrue(is_array($properties), 'The returned value is no array.');
-        $this->assertInstanceOf(PropertyReflection::class, array_pop($properties), 'The returned properties are not of type \Neos\Flow\Reflection\PropertyReflection.');
+        self::assertTrue(is_array($properties), 'The returned value is no array.');
+        self::assertInstanceOf(PropertyReflection::class, array_pop($properties), 'The returned properties are not of type \Neos\Flow\Reflection\PropertyReflection.');
     }
 
     /**
@@ -53,8 +53,8 @@ class ClassReflectionTest extends UnitTestCase implements Fixture\DummyInterface
     public function getPropertyReturnsFlowsPropertyReflection()
     {
         $class = new ClassReflection(__CLASS__);
-        $this->assertInstanceOf(PropertyReflection::class, $class->getProperty('someProperty'), 'The returned property is not of type \Neos\Flow\Reflection\PropertyReflection.');
-        $this->assertEquals('someProperty', $class->getProperty('someProperty')->getName(), 'The returned property seems not to be the right one.');
+        self::assertInstanceOf(PropertyReflection::class, $class->getProperty('someProperty'), 'The returned property is not of type \Neos\Flow\Reflection\PropertyReflection.');
+        self::assertEquals('someProperty', $class->getProperty('someProperty')->getName(), 'The returned property seems not to be the right one.');
     }
 
     /**
@@ -65,7 +65,7 @@ class ClassReflectionTest extends UnitTestCase implements Fixture\DummyInterface
         $class = new ClassReflection(__CLASS__);
         $methods = $class->getMethods();
         foreach ($methods as $method) {
-            $this->assertInstanceOf(MethodReflection::class, $method, 'The returned methods are not of type \Neos\Flow\Reflection\MethodReflection.');
+            self::assertInstanceOf(MethodReflection::class, $method, 'The returned methods are not of type \Neos\Flow\Reflection\MethodReflection.');
         }
     }
 
@@ -88,7 +88,7 @@ class ClassReflectionTest extends UnitTestCase implements Fixture\DummyInterface
     {
         $class = new ClassReflection(__CLASS__);
         $method = $class->getMethod('getMethodReturnsFlowsMethodReflection');
-        $this->assertInstanceOf(MethodReflection::class, $method, 'The returned method is not of type \Neos\Flow\Reflection\MethodReflection.');
+        self::assertInstanceOf(MethodReflection::class, $method, 'The returned method is not of type \Neos\Flow\Reflection\MethodReflection.');
     }
 
     /**
@@ -98,7 +98,7 @@ class ClassReflectionTest extends UnitTestCase implements Fixture\DummyInterface
     {
         $class = new ClassReflection(__CLASS__);
         $constructor = $class->getConstructor();
-        $this->assertInstanceOf(MethodReflection::class, $constructor, 'The returned method is not of type \Neos\Flow\Reflection\MethodReflection.');
+        self::assertInstanceOf(MethodReflection::class, $constructor, 'The returned method is not of type \Neos\Flow\Reflection\MethodReflection.');
     }
 
     /**
@@ -109,7 +109,7 @@ class ClassReflectionTest extends UnitTestCase implements Fixture\DummyInterface
         $class = new ClassReflection(__CLASS__);
         $interfaces = $class->getInterfaces();
         foreach ($interfaces as $interface) {
-            $this->assertInstanceOf(ClassReflection::class, $interface);
+            self::assertInstanceOf(ClassReflection::class, $interface);
         }
     }
 
@@ -120,6 +120,6 @@ class ClassReflectionTest extends UnitTestCase implements Fixture\DummyInterface
     {
         $class = new ClassReflection(__CLASS__);
         $parentClass = $class->getParentClass();
-        $this->assertInstanceOf(ClassReflection::class, $parentClass);
+        self::assertInstanceOf(ClassReflection::class, $parentClass);
     }
 }

--- a/Neos.Flow/Tests/Unit/Reflection/ClassSchemaTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/ClassSchemaTest.php
@@ -32,9 +32,9 @@ class ClassSchemaTest extends UnitTestCase
         $classSchema->addProperty('a', 'string');
         $classSchema->addProperty('b', 'integer');
 
-        $this->assertTrue($classSchema->hasProperty('a'));
-        $this->assertTrue($classSchema->hasProperty('b'));
-        $this->assertFalse($classSchema->hasProperty('c'));
+        self::assertTrue($classSchema->hasProperty('a'));
+        self::assertTrue($classSchema->hasProperty('b'));
+        self::assertFalse($classSchema->hasProperty('c'));
     }
 
     /**
@@ -53,7 +53,7 @@ class ClassSchemaTest extends UnitTestCase
         $classSchema->addProperty('b', 'Neos\Flow\SomeObject', true);
         $classSchema->addProperty('c', 'Neos\Flow\SomeOtherObject', true, true);
 
-        $this->assertSame($expectedProperties, $classSchema->getProperties());
+        self::assertSame($expectedProperties, $classSchema->getProperties());
     }
 
     /**
@@ -65,8 +65,8 @@ class ClassSchemaTest extends UnitTestCase
         $classSchema->addProperty('a', 'Neos\Flow\SomeObject');
         $classSchema->addProperty('b', 'Neos\Flow\SomeObject', true);
 
-        $this->assertFalse($classSchema->isPropertyLazy('a'));
-        $this->assertTrue($classSchema->isPropertyLazy('b'));
+        self::assertFalse($classSchema->isPropertyLazy('a'));
+        self::assertTrue($classSchema->isPropertyLazy('b'));
     }
 
     /**
@@ -78,8 +78,8 @@ class ClassSchemaTest extends UnitTestCase
         $classSchema->addProperty('a', 'Neos\Flow\SomeObject');
         $classSchema->addProperty('b', 'Neos\Flow\SomeObject', false, true);
 
-        $this->assertFalse($classSchema->isPropertyTransient('a'));
-        $this->assertTrue($classSchema->isPropertyTransient('b'));
+        self::assertFalse($classSchema->isPropertyTransient('a'));
+        self::assertTrue($classSchema->isPropertyTransient('b'));
     }
 
     /**
@@ -116,7 +116,7 @@ class ClassSchemaTest extends UnitTestCase
 
         $classSchema->markAsIdentityProperty('a');
 
-        $this->assertSame(['a' => 'string'], $classSchema->getIdentityProperties());
+        self::assertSame(['a' => 'string'], $classSchema->getIdentityProperties());
     }
 
     /**
@@ -188,8 +188,8 @@ class ClassSchemaTest extends UnitTestCase
         $classSchema->addProperty('a', 'array<\Neos\Flow\Foo>');
 
         $properties = $classSchema->getProperties();
-        $this->assertEquals('array', $properties['a']['type']);
-        $this->assertEquals('Neos\Flow\Foo', $properties['a']['elementType']);
+        self::assertEquals('array', $properties['a']['type']);
+        self::assertEquals('Neos\Flow\Foo', $properties['a']['elementType']);
     }
 
     /**
@@ -214,12 +214,12 @@ class ClassSchemaTest extends UnitTestCase
         $classSchema->addProperty('bar', 'string');
         $classSchema->markAsIdentityProperty('bar');
         $classSchema->setRepositoryClassName('Some\Repository');
-        $this->assertSame(['bar' => 'string'], $classSchema->getIdentityProperties());
+        self::assertSame(['bar' => 'string'], $classSchema->getIdentityProperties());
 
         $classSchema->setModelType(ClassSchema::MODELTYPE_VALUEOBJECT);
 
-        $this->assertSame([], $classSchema->getIdentityProperties());
-        $this->assertFalse($classSchema->isAggregateRoot());
+        self::assertSame([], $classSchema->getIdentityProperties());
+        self::assertFalse($classSchema->isAggregateRoot());
     }
 
     /**
@@ -244,6 +244,6 @@ class ClassSchemaTest extends UnitTestCase
     {
         $classSchema = new ClassSchema('SomeClass');
         $classSchema->addProperty('testProperty', $type);
-        $this->assertTrue($classSchema->isMultiValuedProperty('testProperty'));
+        self::assertTrue($classSchema->isMultiValuedProperty('testProperty'));
     }
 }

--- a/Neos.Flow/Tests/Unit/Reflection/DocCommentParserTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/DocCommentParserTest.php
@@ -26,7 +26,7 @@ class DocCommentParserTest extends UnitTestCase
     {
         $parser = new DocCommentParser();
         $parser->parseDocComment('/**' . chr(10) . ' * Testcase for DocCommentParser' . chr(10) . ' */');
-        $this->assertEquals('Testcase for DocCommentParser', $parser->getDescription());
+        self::assertEquals('Testcase for DocCommentParser', $parser->getDescription());
     }
 
     /**
@@ -36,6 +36,6 @@ class DocCommentParserTest extends UnitTestCase
     {
         $parser = new DocCommentParser();
         $parser->parseDocComment('/**' . chr(10) . ' * @var $foo integer' . chr(13) . chr(10) . ' * @var $bar string' . chr(10) . ' */');
-        $this->assertEquals(['$foo integer', '$bar string'], $parser->getTagValues('var'));
+        self::assertEquals(['$foo integer', '$bar string'], $parser->getTagValues('var'));
     }
 }

--- a/Neos.Flow/Tests/Unit/Reflection/MethodReflectionTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/MethodReflectionTest.php
@@ -30,7 +30,7 @@ class MethodReflectionTest extends UnitTestCase
     public function getDeclaringClassReturnsFlowsClassReflection()
     {
         $method = new Reflection\MethodReflection(__CLASS__, __FUNCTION__);
-        $this->assertInstanceOf(Reflection\ClassReflection::class, $method->getDeclaringClass());
+        self::assertInstanceOf(Reflection\ClassReflection::class, $method->getDeclaringClass());
     }
 
     /**
@@ -40,8 +40,8 @@ class MethodReflectionTest extends UnitTestCase
     {
         $method = new Reflection\MethodReflection(__CLASS__, __FUNCTION__);
         foreach ($method->getParameters() as $parameter) {
-            $this->assertInstanceOf(Reflection\ParameterReflection::class, $parameter);
-            $this->assertEquals(__CLASS__, $parameter->getDeclaringClass()->getName());
+            self::assertInstanceOf(Reflection\ParameterReflection::class, $parameter);
+            self::assertEquals(__CLASS__, $parameter->getDeclaringClass()->getName());
         }
     }
 }

--- a/Neos.Flow/Tests/Unit/Reflection/ParameterReflectionTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/ParameterReflectionTest.php
@@ -26,7 +26,7 @@ class ParameterReflectionTest extends UnitTestCase
     public function getDeclaringClassReturnsFlowsClassReflection($dummy = null)
     {
         $parameter = new ParameterReflection([__CLASS__, 'fixtureMethod'], 'arg2');
-        $this->assertInstanceOf(ClassReflection::class, $parameter->getDeclaringClass());
+        self::assertInstanceOf(ClassReflection::class, $parameter->getDeclaringClass());
     }
 
     /**
@@ -35,7 +35,7 @@ class ParameterReflectionTest extends UnitTestCase
     public function getClassReturnsFlowsClassReflection($dummy = null)
     {
         $parameter = new ParameterReflection([__CLASS__, 'fixtureMethod'], 'arg1');
-        $this->assertInstanceOf(ClassReflection::class, $parameter->getClass());
+        self::assertInstanceOf(ClassReflection::class, $parameter->getClass());
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Reflection/PropertyReflectionTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/PropertyReflectionTest.php
@@ -50,7 +50,7 @@ class PropertyReflectionTest extends UnitTestCase
     public function getValueReturnsValueOfAPublicProperty()
     {
         $reflectionProperty = new Reflection\PropertyReflection(__CLASS__, 'publicProperty');
-        $this->assertEquals('I\'m public', $reflectionProperty->getValue($this), 'ReflectionProperty->getValue($this) did not return the value of a public property.');
+        self::assertEquals('I\'m public', $reflectionProperty->getValue($this), 'ReflectionProperty->getValue($this) did not return the value of a public property.');
     }
 
     /**
@@ -59,10 +59,10 @@ class PropertyReflectionTest extends UnitTestCase
     public function getValueEvenReturnsValueOfAProtectedProperty()
     {
         $reflectionProperty = new Reflection\PropertyReflection(__CLASS__, 'protectedProperty');
-        $this->assertEquals('abc', $reflectionProperty->getValue($this), 'ReflectionProperty->getValue($this) did not return the value of a protected property.');
+        self::assertEquals('abc', $reflectionProperty->getValue($this), 'ReflectionProperty->getValue($this) did not return the value of a protected property.');
 
         $this->protectedProperty = 'def';
-        $this->assertEquals('def', $reflectionProperty->getValue($this), 'ReflectionProperty->getValue($this) did not return "def".');
+        self::assertEquals('def', $reflectionProperty->getValue($this), 'ReflectionProperty->getValue($this) did not return "def".');
     }
 
     /**
@@ -72,10 +72,10 @@ class PropertyReflectionTest extends UnitTestCase
     {
         $reflectionProperty = new Reflection\PropertyReflection(__CLASS__, 'protectedProperty');
         $this->protectedProperty = new \ArrayObject(['1', '2', '3']);
-        $this->assertEquals($this->protectedProperty, $reflectionProperty->getValue($this), 'ReflectionProperty->getValue($this) did not return the object of our protected property.');
+        self::assertEquals($this->protectedProperty, $reflectionProperty->getValue($this), 'ReflectionProperty->getValue($this) did not return the object of our protected property.');
 
         $this->protectedProperty = $this;
-        $this->assertSame($this, $reflectionProperty->getValue($this), 'ReflectionProperty->getValue($this) did not return the reference to $this.');
+        self::assertSame($this, $reflectionProperty->getValue($this), 'ReflectionProperty->getValue($this) did not return the reference to $this.');
     }
 
     /**
@@ -85,7 +85,7 @@ class PropertyReflectionTest extends UnitTestCase
     {
         $reflectionProperty = new Reflection\PropertyReflection(__CLASS__, 'publicProperty');
         $reflectionProperty->setValue($this, 'modified');
-        $this->assertEquals('modified', $this->publicProperty, 'ReflectionProperty->setValue() did not successfully set the value of a public property.');
+        self::assertEquals('modified', $this->publicProperty, 'ReflectionProperty->setValue() did not successfully set the value of a public property.');
     }
 
     /**
@@ -94,10 +94,10 @@ class PropertyReflectionTest extends UnitTestCase
     public function getValueEvenReturnsValueOfAPrivateProperty()
     {
         $reflectionProperty = new Reflection\PropertyReflection(__CLASS__, 'privateProperty');
-        $this->assertEquals('123', $reflectionProperty->getValue($this), 'ReflectionProperty->getValue($this) did not return the value of a private property.');
+        self::assertEquals('123', $reflectionProperty->getValue($this), 'ReflectionProperty->getValue($this) did not return the value of a private property.');
 
         $this->privateProperty = '456';
-        $this->assertEquals('456', $reflectionProperty->getValue($this), 'ReflectionProperty->getValue($this) did not return "456".');
+        self::assertEquals('456', $reflectionProperty->getValue($this), 'ReflectionProperty->getValue($this) did not return "456".');
     }
 
     /**
@@ -107,9 +107,9 @@ class PropertyReflectionTest extends UnitTestCase
     {
         $reflectionProperty = new Reflection\PropertyReflection(__CLASS__, 'privateProperty');
         $this->protectedProperty = new \ArrayObject(['1', '2', '3']);
-        $this->assertEquals($this->privateProperty, $reflectionProperty->getValue($this), 'ReflectionProperty->getValue($this) did not return the object of our private property.');
+        self::assertEquals($this->privateProperty, $reflectionProperty->getValue($this), 'ReflectionProperty->getValue($this) did not return the object of our private property.');
 
         $this->privateProperty = $this;
-        $this->assertSame($this, $reflectionProperty->getValue($this), 'ReflectionProperty->getValue($this) did not return the reference to $this.');
+        self::assertSame($this, $reflectionProperty->getValue($this), 'ReflectionProperty->getValue($this) did not return the reference to $this.');
     }
 }

--- a/Neos.Flow/Tests/Unit/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/ReflectionServiceTest.php
@@ -76,7 +76,7 @@ class ReflectionServiceTest extends UnitTestCase
         $settings = ['reflection' => ['ignoredTags' => ['ignored' => true]]];
         $this->reflectionService->injectSettings($settings);
 
-        $this->assertTrue($this->reflectionService->_call('isTagIgnored', 'ignored'));
+        self::assertTrue($this->reflectionService->_call('isTagIgnored', 'ignored'));
     }
 
     /**
@@ -87,7 +87,7 @@ class ReflectionServiceTest extends UnitTestCase
         $settings = ['reflection' => ['ignoredTags' => ['notignored' => false]]];
         $this->reflectionService->injectSettings($settings);
 
-        $this->assertFalse($this->reflectionService->_call('isTagIgnored', 'notignored'));
+        self::assertFalse($this->reflectionService->_call('isTagIgnored', 'notignored'));
     }
 
     /**
@@ -98,7 +98,7 @@ class ReflectionServiceTest extends UnitTestCase
         $settings = ['reflection' => ['ignoredTags' => ['ignored' => true, 'notignored' => false]]];
         $this->reflectionService->injectSettings($settings);
 
-        $this->assertFalse($this->reflectionService->_call('isTagIgnored', 'notconfigured'));
+        self::assertFalse($this->reflectionService->_call('isTagIgnored', 'notconfigured'));
     }
 
     /**
@@ -109,7 +109,7 @@ class ReflectionServiceTest extends UnitTestCase
         $settings = ['reflection' => ['ignoredTags' => ['ignored']]];
         $this->reflectionService->injectSettings($settings);
 
-        $this->assertTrue($this->reflectionService->_call('isTagIgnored', 'ignored'));
-        $this->assertFalse($this->reflectionService->_call('isTagIgnored', 'notignored'));
+        self::assertTrue($this->reflectionService->_call('isTagIgnored', 'ignored'));
+        self::assertFalse($this->reflectionService->_call('isTagIgnored', 'notignored'));
     }
 }

--- a/Neos.Flow/Tests/Unit/ResourceManagement/PersistentResourceTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/PersistentResourceTest.php
@@ -26,8 +26,8 @@ class PersistentResourceTest extends UnitTestCase
     {
         $resource = new PersistentResource();
         $resource->setFilename('Something.Jpeg');
-        $this->assertSame('jpeg', $resource->getFileExtension());
-        $this->assertSame('Something.jpeg', $resource->getFilename());
+        self::assertSame('jpeg', $resource->getFileExtension());
+        self::assertSame('Something.jpeg', $resource->getFilename());
     }
 
     /**
@@ -38,13 +38,13 @@ class PersistentResourceTest extends UnitTestCase
         $resource = new PersistentResource();
 
         $resource->setFilename('Something.jpg');
-        $this->assertSame('image/jpeg', $resource->getMediaType());
+        self::assertSame('image/jpeg', $resource->getMediaType());
 
         $resource->setFilename('Something.png');
-        $this->assertSame('image/png', $resource->getMediaType());
+        self::assertSame('image/png', $resource->getMediaType());
 
         $resource->setFilename('Something.Jpeg');
-        $this->assertSame('image/jpeg', $resource->getMediaType());
+        self::assertSame('image/jpeg', $resource->getMediaType());
     }
 
     /**
@@ -54,8 +54,8 @@ class PersistentResourceTest extends UnitTestCase
     {
         $resource = new PersistentResource();
         $resource->setFilename('FileWithoutExtension');
-        $this->assertSame('', $resource->getFileExtension());
-        $this->assertSame('FileWithoutExtension', $resource->getFilename());
+        self::assertSame('', $resource->getFileExtension());
+        self::assertSame('FileWithoutExtension', $resource->getFilename());
     }
 
     /**
@@ -65,15 +65,15 @@ class PersistentResourceTest extends UnitTestCase
     {
         $resource = new PersistentResource();
         $resource->setFilename('file.jpg');
-        $this->assertSame('image/jpeg', $resource->getMediaType());
+        self::assertSame('image/jpeg', $resource->getMediaType());
 
         $resource = new PersistentResource();
         $resource->setFilename('file.zip');
-        $this->assertSame('application/zip', $resource->getMediaType());
+        self::assertSame('application/zip', $resource->getMediaType());
 
         $resource = new PersistentResource();
         $resource->setFilename('file.someunknownextension');
-        $this->assertSame('application/octet-stream', $resource->getMediaType());
+        self::assertSame('application/octet-stream', $resource->getMediaType());
     }
 
     /**
@@ -99,7 +99,7 @@ class PersistentResourceTest extends UnitTestCase
         $this->expectException(\InvalidArgumentException::class);
         $resource = new PersistentResource();
         $resource->setSha1($invalidValue);
-        $this->assertSame('d0be2dc421be4fcd0172e5afceea3970e2f3d940', $resource->getSha1());
+        self::assertSame('d0be2dc421be4fcd0172e5afceea3970e2f3d940', $resource->getSha1());
     }
 
     /**
@@ -109,6 +109,6 @@ class PersistentResourceTest extends UnitTestCase
     {
         $resource = new PersistentResource();
         $resource->setSha1('D0BE2DC421BE4fCD0172E5AFCEEA3970E2f3d940');
-        $this->assertSame('d0be2dc421be4fcd0172e5afceea3970e2f3d940', $resource->getSha1());
+        self::assertSame('d0be2dc421be4fcd0172e5afceea3970e2f3d940', $resource->getSha1());
     }
 }

--- a/Neos.Flow/Tests/Unit/ResourceManagement/ResourceTypeConverterTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/ResourceTypeConverterTest.php
@@ -57,9 +57,9 @@ class ResourceTypeConverterTest extends UnitTestCase
      */
     public function checkMetadata()
     {
-        $this->assertEquals(['string', 'array', UploadedFileInterface::class], $this->resourceTypeConverter->getSupportedSourceTypes(), 'Source types do not match');
-        $this->assertEquals(PersistentResource::class, $this->resourceTypeConverter->getSupportedTargetType(), 'Target type does not match');
-        $this->assertEquals(1, $this->resourceTypeConverter->getPriority(), 'Priority does not match');
+        self::assertEquals(['string', 'array', UploadedFileInterface::class], $this->resourceTypeConverter->getSupportedSourceTypes(), 'Source types do not match');
+        self::assertEquals(PersistentResource::class, $this->resourceTypeConverter->getSupportedTargetType(), 'Target type does not match');
+        self::assertEquals(1, $this->resourceTypeConverter->getPriority(), 'Priority does not match');
     }
 
     /**
@@ -67,7 +67,7 @@ class ResourceTypeConverterTest extends UnitTestCase
      */
     public function canConvertFromReturnsTrueIfSourceTypeIsAnArrayWithErrorSet()
     {
-        $this->assertTrue($this->resourceTypeConverter->canConvertFrom(['error' => \UPLOAD_ERR_OK], PersistentResource::class));
+        self::assertTrue($this->resourceTypeConverter->canConvertFrom(['error' => \UPLOAD_ERR_OK], PersistentResource::class));
     }
 
     /**
@@ -75,7 +75,7 @@ class ResourceTypeConverterTest extends UnitTestCase
      */
     public function canConvertFromReturnsTrueIfSourceTypeIsAnArrayWithOriginallySubmittedResourceSet()
     {
-        $this->assertTrue($this->resourceTypeConverter->canConvertFrom(['originallySubmittedResource' => 'SomeResource'], PersistentResource::class));
+        self::assertTrue($this->resourceTypeConverter->canConvertFrom(['originallySubmittedResource' => 'SomeResource'], PersistentResource::class));
     }
 
     /**
@@ -83,7 +83,7 @@ class ResourceTypeConverterTest extends UnitTestCase
      */
     public function convertFromReturnsNullIfSourceArrayIsEmpty()
     {
-        $this->assertNull($this->resourceTypeConverter->convertFrom([], PersistentResource::class));
+        self::assertNull($this->resourceTypeConverter->convertFrom([], PersistentResource::class));
     }
 
     /**
@@ -92,7 +92,7 @@ class ResourceTypeConverterTest extends UnitTestCase
     public function convertFromReturnsNullIfNoFileWasUploaded()
     {
         $source = ['error' => \UPLOAD_ERR_NO_FILE];
-        $this->assertNull($this->resourceTypeConverter->convertFrom($source, PersistentResource::class));
+        self::assertNull($this->resourceTypeConverter->convertFrom($source, PersistentResource::class));
     }
 
     /**
@@ -101,7 +101,7 @@ class ResourceTypeConverterTest extends UnitTestCase
     public function convertFromReturnsNullIfNoFileWasUploadedAndEmptyHashIsSet()
     {
         $source = ['error' => \UPLOAD_ERR_NO_FILE, 'hash' => ''];
-        $this->assertNull($this->resourceTypeConverter->convertFrom($source, PersistentResource::class));
+        self::assertNull($this->resourceTypeConverter->convertFrom($source, PersistentResource::class));
     }
 
     /**
@@ -122,8 +122,8 @@ class ResourceTypeConverterTest extends UnitTestCase
 
         $actualResource = $this->resourceTypeConverter->convertFrom($source, PersistentResource::class);
 
-        $this->assertInstanceOf(PersistentResource::class, $actualResource);
-        $this->assertSame($expectedResource, $actualResource);
+        self::assertInstanceOf(PersistentResource::class, $actualResource);
+        self::assertSame($expectedResource, $actualResource);
     }
 
     /**
@@ -143,7 +143,7 @@ class ResourceTypeConverterTest extends UnitTestCase
 
         $actualResource = $this->resourceTypeConverter->convertFrom($source, PersistentResource::class);
 
-        $this->assertNull($actualResource);
+        self::assertNull($actualResource);
     }
 
     /**
@@ -156,7 +156,7 @@ class ResourceTypeConverterTest extends UnitTestCase
         ];
 
         $actualResult = $this->resourceTypeConverter->convertFrom($source, PersistentResource::class);
-        $this->assertInstanceOf(FlowError\Error::class, $actualResult);
+        self::assertInstanceOf(FlowError\Error::class, $actualResult);
     }
 
     /**
@@ -188,7 +188,7 @@ class ResourceTypeConverterTest extends UnitTestCase
         $this->mockResourceManager->expects($this->once())->method('importUploadedResource')->with($source)->will($this->returnValue($mockResource));
 
         $actualResult = $this->resourceTypeConverter->convertFrom($source, PersistentResource::class);
-        $this->assertSame($mockResource, $actualResult);
+        self::assertSame($mockResource, $actualResult);
     }
 
     /**
@@ -205,6 +205,6 @@ class ResourceTypeConverterTest extends UnitTestCase
         $this->mockResourceManager->expects($this->once())->method('importUploadedResource')->with($source)->will($this->throwException(new Exception()));
 
         $actualResult = $this->resourceTypeConverter->convertFrom($source, PersistentResource::class);
-        $this->assertInstanceOf(FlowError\Error::class, $actualResult);
+        self::assertInstanceOf(FlowError\Error::class, $actualResult);
     }
 }

--- a/Neos.Flow/Tests/Unit/ResourceManagement/Storage/WritableFileSystemStorageTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/Storage/WritableFileSystemStorageTest.php
@@ -76,6 +76,6 @@ class WritableFileSystemStorageTest extends UnitTestCase
 
         $this->writableFileSystemStorage->_call('importTemporaryFile', $mockTempFile->url(), 'default');
 
-        $this->assertSame('existing file', file_get_contents($finalTargetPathAndFilename));
+        self::assertSame('existing file', file_get_contents($finalTargetPathAndFilename));
     }
 }

--- a/Neos.Flow/Tests/Unit/ResourceManagement/Streams/ResourceStreamWrapperTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/Streams/ResourceStreamWrapperTest.php
@@ -78,8 +78,8 @@ class ResourceStreamWrapperTest extends UnitTestCase
         $this->mockResourceManager->expects($this->once())->method('getStreamByResource')->with($mockResource)->will($this->returnValue($tempFile));
 
         $openedPathAndFilename = '';
-        $this->assertTrue($this->resourceStreamWrapper->open('resource://' . $sha1Hash, 'r', 0, $openedPathAndFilename));
-        $this->assertSame($tempFile, ObjectAccess::getProperty($this->resourceStreamWrapper, 'handle', true));
+        self::assertTrue($this->resourceStreamWrapper->open('resource://' . $sha1Hash, 'r', 0, $openedPathAndFilename));
+        self::assertSame($tempFile, ObjectAccess::getProperty($this->resourceStreamWrapper, 'handle', true));
     }
 
     /**
@@ -96,8 +96,8 @@ class ResourceStreamWrapperTest extends UnitTestCase
         $this->mockResourceManager->expects($this->once())->method('getStreamByResource')->with($mockResource)->will($this->returnValue($tempFile));
 
         $openedPathAndFilename = '';
-        $this->assertTrue($this->resourceStreamWrapper->open('resource://' . $sha1Hash, 'r', 0, $openedPathAndFilename));
-        $this->assertSame($tempFile, ObjectAccess::getProperty($this->resourceStreamWrapper, 'handle', true));
+        self::assertTrue($this->resourceStreamWrapper->open('resource://' . $sha1Hash, 'r', 0, $openedPathAndFilename));
+        self::assertSame($tempFile, ObjectAccess::getProperty($this->resourceStreamWrapper, 'handle', true));
     }
 
     /**
@@ -127,8 +127,8 @@ class ResourceStreamWrapperTest extends UnitTestCase
         $this->mockPackageManager->expects($this->once())->method('getPackage')->with($packageKey)->will($this->returnValue($mockPackage));
 
         $openedPathAndFilename = '';
-        $this->assertTrue($this->resourceStreamWrapper->open('resource://' . $packageKey . '/Some/Path', 'r', 0, $openedPathAndFilename));
-        $this->assertSame($openedPathAndFilename, 'vfs://Foo/Some/Path');
+        self::assertTrue($this->resourceStreamWrapper->open('resource://' . $packageKey . '/Some/Path', 'r', 0, $openedPathAndFilename));
+        self::assertSame($openedPathAndFilename, 'vfs://Foo/Some/Path');
     }
 
     /**
@@ -139,13 +139,13 @@ class ResourceStreamWrapperTest extends UnitTestCase
         $packageKey = 'Some.PackageKey.Containing.40.Characters';
         mkdir('vfs://Foo/Some/');
         file_put_contents('vfs://Foo/Some/Path', 'fixture');
-        
+
         $mockPackage = $this->createMock(FlowPackageInterface::class);
         $mockPackage->expects($this->any())->method('getResourcesPath')->will($this->returnValue('vfs://Foo'));
         $this->mockPackageManager->expects($this->once())->method('getPackage')->with($packageKey)->will($this->returnValue($mockPackage));
 
         $openedPathAndFilename = '';
-        $this->assertTrue($this->resourceStreamWrapper->open('resource://' . $packageKey . '/Some/Path', 'r', 0, $openedPathAndFilename));
-        $this->assertSame($openedPathAndFilename, 'vfs://Foo/Some/Path');
+        self::assertTrue($this->resourceStreamWrapper->open('resource://' . $packageKey . '/Some/Path', 'r', 0, $openedPathAndFilename));
+        self::assertSame($openedPathAndFilename, 'vfs://Foo/Some/Path');
     }
 }

--- a/Neos.Flow/Tests/Unit/ResourceManagement/Streams/StreamWrapperAdapterTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/Streams/StreamWrapperAdapterTest.php
@@ -51,8 +51,8 @@ class StreamWrapperAdapterTest extends UnitTestCase
         StreamWrapperAdapter::registerStreamWrapper('mockScheme2', $mockStreamWrapper2ClassName);
 
         $registeredStreamWrappers = StreamWrapperAdapter::getRegisteredStreamWrappers();
-        $this->assertSame($mockStreamWrapper1ClassName, $registeredStreamWrappers['mockScheme1']);
-        $this->assertSame($mockStreamWrapper2ClassName, $registeredStreamWrappers['mockScheme2']);
+        self::assertSame($mockStreamWrapper1ClassName, $registeredStreamWrappers['mockScheme1']);
+        self::assertSame($mockStreamWrapper2ClassName, $registeredStreamWrappers['mockScheme2']);
     }
 
     /**
@@ -61,7 +61,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
     public function dir_closedirTest()
     {
         $this->mockStreamWrapper->expects($this->once())->method('closeDirectory')->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->dir_closedir());
+        self::assertTrue($this->streamWrapperAdapter->dir_closedir());
     }
 
     /**
@@ -74,7 +74,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
 
         $this->streamWrapperAdapter->expects($this->once())->method('createStreamWrapper')->with($path);
         $this->mockStreamWrapper->expects($this->once())->method('openDirectory')->with($path, $options)->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->dir_opendir($path, $options));
+        self::assertTrue($this->streamWrapperAdapter->dir_opendir($path, $options));
     }
 
     /**
@@ -83,7 +83,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
     public function dir_readdirTest()
     {
         $this->mockStreamWrapper->expects($this->once())->method('readDirectory')->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->dir_readdir());
+        self::assertTrue($this->streamWrapperAdapter->dir_readdir());
     }
 
     /**
@@ -92,7 +92,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
     public function dir_rewinddirTest()
     {
         $this->mockStreamWrapper->expects($this->once())->method('rewindDirectory')->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->dir_rewinddir());
+        self::assertTrue($this->streamWrapperAdapter->dir_rewinddir());
     }
 
     /**
@@ -106,7 +106,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
 
         $this->streamWrapperAdapter->expects($this->once())->method('createStreamWrapper')->with($path);
         $this->mockStreamWrapper->expects($this->once())->method('makeDirectory')->with($path, $mode, $options)->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->mkdir($path, $mode, $options));
+        self::assertTrue($this->streamWrapperAdapter->mkdir($path, $mode, $options));
     }
 
     /**
@@ -119,7 +119,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
 
         $this->streamWrapperAdapter->expects($this->once())->method('createStreamWrapper')->with($fromPath);
         $this->mockStreamWrapper->expects($this->once())->method('rename')->with($fromPath, $toPath)->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->rename($fromPath, $toPath));
+        self::assertTrue($this->streamWrapperAdapter->rename($fromPath, $toPath));
     }
 
     /**
@@ -132,7 +132,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
 
         $this->streamWrapperAdapter->expects($this->once())->method('createStreamWrapper')->with($path);
         $this->mockStreamWrapper->expects($this->once())->method('removeDirectory')->with($path, $options)->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->rmdir($path, $options));
+        self::assertTrue($this->streamWrapperAdapter->rmdir($path, $options));
     }
 
     /**
@@ -146,7 +146,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
         $castAs = STREAM_CAST_FOR_SELECT;
 
         $this->mockStreamWrapper->expects($this->once())->method('cast')->with($castAs)->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->stream_cast($castAs));
+        self::assertTrue($this->streamWrapperAdapter->stream_cast($castAs));
     }
 
     /**
@@ -164,7 +164,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
     public function stream_eofTest()
     {
         $this->mockStreamWrapper->expects($this->once())->method('isAtEof')->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->stream_eof());
+        self::assertTrue($this->streamWrapperAdapter->stream_eof());
     }
 
     /**
@@ -173,7 +173,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
     public function stream_flushTest()
     {
         $this->mockStreamWrapper->expects($this->once())->method('flush')->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->stream_flush());
+        self::assertTrue($this->streamWrapperAdapter->stream_flush());
     }
 
     /**
@@ -184,7 +184,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
         $operation = LOCK_SH;
 
         $this->mockStreamWrapper->expects($this->once())->method('lock')->with($operation)->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->stream_lock($operation));
+        self::assertTrue($this->streamWrapperAdapter->stream_lock($operation));
     }
 
     /**
@@ -195,7 +195,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
         $operation = LOCK_UN;
 
         $this->mockStreamWrapper->expects($this->once())->method('unlock')->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->stream_lock($operation));
+        self::assertTrue($this->streamWrapperAdapter->stream_lock($operation));
     }
 
     /**
@@ -210,7 +210,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
 
         $this->streamWrapperAdapter->expects($this->once())->method('createStreamWrapper')->with($path);
         $this->mockStreamWrapper->expects($this->once())->method('open')->with($path, $mode, $options, $openedPath)->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->stream_open($path, $mode, $options, $openedPath));
+        self::assertTrue($this->streamWrapperAdapter->stream_open($path, $mode, $options, $openedPath));
     }
 
     /**
@@ -221,7 +221,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
         $count = 123;
 
         $this->mockStreamWrapper->expects($this->once())->method('read')->with($count)->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->stream_read($count));
+        self::assertTrue($this->streamWrapperAdapter->stream_read($count));
     }
 
     /**
@@ -232,7 +232,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
         $offset = 123;
 
         $this->mockStreamWrapper->expects($this->once())->method('seek')->with($offset, SEEK_SET)->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->stream_seek($offset));
+        self::assertTrue($this->streamWrapperAdapter->stream_seek($offset));
     }
 
     /**
@@ -244,7 +244,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
         $whence = SEEK_END;
 
         $this->mockStreamWrapper->expects($this->once())->method('seek')->with($offset, $whence)->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->stream_seek($offset, $whence));
+        self::assertTrue($this->streamWrapperAdapter->stream_seek($offset, $whence));
     }
 
     /**
@@ -260,7 +260,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
         $arg2 = 123000000;
 
         $this->mockStreamWrapper->expects($this->once())->method('setOption')->with($option, $arg1, $arg2)->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->stream_set_option($option, $arg1, $arg2));
+        self::assertTrue($this->streamWrapperAdapter->stream_set_option($option, $arg1, $arg2));
     }
 
     /**
@@ -269,7 +269,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
     public function stream_statTest()
     {
         $this->mockStreamWrapper->expects($this->once())->method('resourceStat')->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->stream_stat());
+        self::assertTrue($this->streamWrapperAdapter->stream_stat());
     }
 
     /**
@@ -278,7 +278,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
     public function stream_tellTest()
     {
         $this->mockStreamWrapper->expects($this->once())->method('tell')->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->stream_tell());
+        self::assertTrue($this->streamWrapperAdapter->stream_tell());
     }
 
     /**
@@ -289,7 +289,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
         $data = 'foo bar';
 
         $this->mockStreamWrapper->expects($this->once())->method('write')->with($data)->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->stream_write($data));
+        self::assertTrue($this->streamWrapperAdapter->stream_write($data));
     }
 
     /**
@@ -301,7 +301,7 @@ class StreamWrapperAdapterTest extends UnitTestCase
 
         $this->streamWrapperAdapter->expects($this->once())->method('createStreamWrapper')->with($path);
         $this->mockStreamWrapper->expects($this->once())->method('unlink')->with($path)->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->unlink($path));
+        self::assertTrue($this->streamWrapperAdapter->unlink($path));
     }
 
     /**
@@ -314,6 +314,6 @@ class StreamWrapperAdapterTest extends UnitTestCase
 
         $this->streamWrapperAdapter->expects($this->once())->method('createStreamWrapper')->with($path);
         $this->mockStreamWrapper->expects($this->once())->method('pathStat')->with($path, $flags)->will($this->returnValue(true));
-        $this->assertTrue($this->streamWrapperAdapter->url_stat($path, $flags));
+        self::assertTrue($this->streamWrapperAdapter->url_stat($path, $flags));
     }
 }

--- a/Neos.Flow/Tests/Unit/ResourceManagement/Target/FileSystemTargetTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/Target/FileSystemTargetTest.php
@@ -73,7 +73,7 @@ class FileSystemTargetTest extends UnitTestCase
      */
     public function getNameReturnsTargetName()
     {
-        $this->assertSame('test', $this->fileSystemTarget->getName());
+        self::assertSame('test', $this->fileSystemTarget->getName());
     }
 
     /**
@@ -100,7 +100,7 @@ class FileSystemTargetTest extends UnitTestCase
     public function getPublicStaticResourceUriTests($baseUri, $relativePathAndFilename, $expectedResult)
     {
         $this->inject($this->fileSystemTarget, 'baseUri', $baseUri);
-        $this->assertSame($expectedResult, $this->fileSystemTarget->getPublicStaticResourceUri($relativePathAndFilename));
+        self::assertSame($expectedResult, $this->fileSystemTarget->getPublicStaticResourceUri($relativePathAndFilename));
     }
 
     /**
@@ -114,7 +114,7 @@ class FileSystemTargetTest extends UnitTestCase
         $this->inject($this->fileSystemTarget, 'bootstrap', $mockBootstrap);
         $this->inject($this->fileSystemTarget, 'httpBaseUri', 'http://configured/http/base/uri/');
 
-        $this->assertStringStartsWith('http://configured/http/base/uri/', $this->fileSystemTarget->getPublicStaticResourceUri('some/path/SomeFilename.jpg'));
+        self::assertStringStartsWith('http://configured/http/base/uri/', $this->fileSystemTarget->getPublicStaticResourceUri('some/path/SomeFilename.jpg'));
     }
 
     /**
@@ -165,7 +165,7 @@ class FileSystemTargetTest extends UnitTestCase
         $mockResource->expects($this->any())->method('getFilename')->will($this->returnValue($filename));
         $mockResource->expects($this->any())->method('getSha1')->will($this->returnValue($sha1));
 
-        $this->assertSame($expectedResult, $this->fileSystemTarget->getPublicPersistentResourceUri($mockResource));
+        self::assertSame($expectedResult, $this->fileSystemTarget->getPublicPersistentResourceUri($mockResource));
     }
 
     /**
@@ -182,7 +182,7 @@ class FileSystemTargetTest extends UnitTestCase
         /** @var PersistentResource|\PHPUnit_Framework_MockObject_MockObject $mockResource */
         $mockResource = $this->getMockBuilder(PersistentResource::class)->disableOriginalConstructor()->getMock();
 
-        $this->assertStringStartsWith('http://configured/http/base/uri/', $this->fileSystemTarget->getPublicPersistentResourceUri($mockResource));
+        self::assertStringStartsWith('http://configured/http/base/uri/', $this->fileSystemTarget->getPublicPersistentResourceUri($mockResource));
     }
 
     /**
@@ -233,6 +233,6 @@ class FileSystemTargetTest extends UnitTestCase
         $fileSystemTarget->injectLogger($mockSystemLogger);
         $fileSystemTarget->publishCollection($staticCollection, $_publicationCallback);
 
-        $this->assertTrue($oneResourcePublished);
+        self::assertTrue($oneResourcePublished);
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/AccountTest.php
+++ b/Neos.Flow/Tests/Unit/Security/AccountTest.php
@@ -79,7 +79,7 @@ class AccountTest extends UnitTestCase
     {
         $this->account->setRoles([$this->administratorRole]);
         $this->account->addRole($this->customerRole);
-        $this->assertCount(2, $this->account->getRoles());
+        self::assertCount(2, $this->account->getRoles());
     }
 
     /**
@@ -90,7 +90,7 @@ class AccountTest extends UnitTestCase
         $this->account->setRoles([$this->administratorRole]);
         $this->account->addRole($this->administratorRole);
 
-        $this->assertCount(1, $this->account->getRoles());
+        self::assertCount(1, $this->account->getRoles());
     }
 
     /**
@@ -101,7 +101,7 @@ class AccountTest extends UnitTestCase
         $this->account->setRoles([$this->administratorRole, $this->customerRole]);
         $this->account->removeRole($this->customerRole);
 
-        $this->assertCount(1, $this->account->getRoles());
+        self::assertCount(1, $this->account->getRoles());
     }
 
     /**
@@ -112,7 +112,7 @@ class AccountTest extends UnitTestCase
         $this->account->setRoles([$this->administratorRole]);
         $this->account->removeRole($this->customerRole);
 
-        $this->assertCount(1, $this->account->getRoles());
+        self::assertCount(1, $this->account->getRoles());
     }
 
     /**
@@ -122,8 +122,8 @@ class AccountTest extends UnitTestCase
     {
         $this->account->setRoles([$this->administratorRole]);
 
-        $this->assertTrue($this->account->hasRole($this->administratorRole));
-        $this->assertFalse($this->account->hasRole($this->customerRole));
+        self::assertTrue($this->account->hasRole($this->administratorRole));
+        self::assertFalse($this->account->hasRole($this->customerRole));
     }
 
     /**
@@ -134,8 +134,8 @@ class AccountTest extends UnitTestCase
         $this->inject($this->account, 'roleIdentifiers', ['Acme.Demo:NoLongerThere', $this->administratorRole->getIdentifier()]);
 
         $roles = $this->account->getRoles();
-        $this->assertCount(1, $roles);
-        $this->assertArrayHasKey($this->administratorRole->getIdentifier(), $roles);
+        self::assertCount(1, $roles);
+        self::assertArrayHasKey($this->administratorRole->getIdentifier(), $roles);
     }
 
     /**
@@ -145,8 +145,8 @@ class AccountTest extends UnitTestCase
     {
         $this->inject($this->account, 'roleIdentifiers', ['Acme.Demo:NoLongerThere', $this->administratorRole->getIdentifier()]);
 
-        $this->assertTrue($this->account->hasRole($this->administratorRole));
-        $this->assertFalse($this->account->hasRole(new Role('Acme.Demo:NoLongerThere')));
+        self::assertTrue($this->account->hasRole($this->administratorRole));
+        self::assertFalse($this->account->hasRole(new Role('Acme.Demo:NoLongerThere')));
     }
 
     /**
@@ -158,7 +158,7 @@ class AccountTest extends UnitTestCase
         $expectedRoles = [$this->administratorRole->getIdentifier() => $this->administratorRole, $this->customerRole->getIdentifier() => $this->customerRole];
         $this->account->setRoles($roles);
 
-        $this->assertSame($expectedRoles, $this->account->getRoles());
+        self::assertSame($expectedRoles, $this->account->getRoles());
     }
 
     /**
@@ -169,7 +169,7 @@ class AccountTest extends UnitTestCase
         $this->account->setExpirationDate(new \DateTime());
         $this->account->setExpirationDate(null);
 
-        $this->assertEquals(null, $this->account->getExpirationDate());
+        self::assertEquals(null, $this->account->getExpirationDate());
     }
 
     /**
@@ -178,7 +178,7 @@ class AccountTest extends UnitTestCase
     public function isActiveReturnsTrueIfTheAccountHasNoExpirationDate()
     {
         $this->account->setExpirationDate(null);
-        $this->assertTrue($this->account->isActive());
+        self::assertTrue($this->account->isActive());
     }
 
     /**
@@ -189,7 +189,7 @@ class AccountTest extends UnitTestCase
         $this->inject($this->account, 'now', new \DateTime());
 
         $this->account->setExpirationDate(new \DateTime('tomorrow'));
-        $this->assertTrue($this->account->isActive());
+        self::assertTrue($this->account->isActive());
     }
 
     /**
@@ -200,6 +200,6 @@ class AccountTest extends UnitTestCase
         $this->inject($this->account, 'now', new \DateTime());
 
         $this->account->setExpirationDate(new \DateTime('yesterday'));
-        $this->assertFalse($this->account->isActive());
+        self::assertFalse($this->account->isActive());
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/Aspect/PolicyEnforcementAspectTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Aspect/PolicyEnforcementAspectTest.php
@@ -144,7 +144,7 @@ class PolicyEnforcementAspectTest extends UnitTestCase
         $this->mockAdviceChain->expects($this->once())->method('proceed')->will($this->returnValue($someResult));
         // $this->mockAfterInvocationInterceptor->expects($this->once())->method('invoke')->will($this->returnValue($someResult));
 
-        $this->assertEquals($someResult, $this->policyEnforcementAspect->enforcePolicy($this->mockJoinPoint));
+        self::assertEquals($someResult, $this->policyEnforcementAspect->enforcePolicy($this->mockJoinPoint));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderManagerTest.php
@@ -203,7 +203,7 @@ class AuthenticationProviderManagerTest extends UnitTestCase
 
         $this->mockSecurityContext->expects($this->once())->method('getAuthenticationTokens')->will($this->returnValue([$mockToken]));
 
-        $this->assertTrue($this->authenticationProviderManager->isAuthenticated());
+        self::assertTrue($this->authenticationProviderManager->isAuthenticated());
     }
 
     /**
@@ -220,7 +220,7 @@ class AuthenticationProviderManagerTest extends UnitTestCase
 
         $this->mockSecurityContext->expects($this->atLeastOnce())->method('getAuthenticationTokens')->will($this->returnValue($authenticationTokens));
 
-        $this->assertFalse($this->authenticationProviderManager->isAuthenticated());
+        self::assertFalse($this->authenticationProviderManager->isAuthenticated());
     }
 
     /**
@@ -237,7 +237,7 @@ class AuthenticationProviderManagerTest extends UnitTestCase
 
         $this->mockSecurityContext->expects($this->atLeastOnce())->method('getAuthenticationTokens')->will($this->returnValue($authenticationTokens));
 
-        $this->assertTrue($this->authenticationProviderManager->isAuthenticated());
+        self::assertTrue($this->authenticationProviderManager->isAuthenticated());
     }
 
     /**
@@ -255,7 +255,7 @@ class AuthenticationProviderManagerTest extends UnitTestCase
         $this->mockSecurityContext->expects($this->any())->method('getAuthenticationStrategy')->will($this->returnValue(Context::AUTHENTICATE_ANY_TOKEN));
         $this->mockSecurityContext->expects($this->atLeastOnce())->method('getAuthenticationTokens')->will($this->returnValue($authenticationTokens));
 
-        $this->assertFalse($this->authenticationProviderManager->isAuthenticated());
+        self::assertFalse($this->authenticationProviderManager->isAuthenticated());
     }
 
     /**
@@ -273,7 +273,7 @@ class AuthenticationProviderManagerTest extends UnitTestCase
         $this->mockSecurityContext->expects($this->any())->method('getAuthenticationStrategy')->will($this->returnValue(Context::AUTHENTICATE_ANY_TOKEN));
         $this->mockSecurityContext->expects($this->atLeastOnce())->method('getAuthenticationTokens')->will($this->returnValue($authenticationTokens));
 
-        $this->assertTrue($this->authenticationProviderManager->isAuthenticated());
+        self::assertTrue($this->authenticationProviderManager->isAuthenticated());
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderResolverTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderResolverTest.php
@@ -58,7 +58,7 @@ class AuthenticationProviderResolverTest extends UnitTestCase
         $providerResolver = new AuthenticationProviderResolver($mockObjectManager);
         $providerClass = $providerResolver->resolveProviderClass('ValidShortName');
 
-        $this->assertEquals($longClassNameForTest, $providerClass, 'The wrong classname has been resolved');
+        self::assertEquals($longClassNameForTest, $providerClass, 'The wrong classname has been resolved');
     }
 
     /**
@@ -72,6 +72,6 @@ class AuthenticationProviderResolverTest extends UnitTestCase
         $providerResolver = new AuthenticationProviderResolver($mockObjectManager);
         $providerClass = $providerResolver->resolveProviderClass('existingProviderClass');
 
-        $this->assertEquals('existingProviderClass', $providerClass, 'The wrong classname has been resolved');
+        self::assertEquals('existingProviderClass', $providerClass, 'The wrong classname has been resolved');
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/Authentication/EntryPoint/HttpBasicTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/EntryPoint/HttpBasicTest.php
@@ -38,6 +38,6 @@ class HttpBasicTest extends UnitTestCase
 
         $entryPoint->startAuthentication($mockHttpRequest, $mockResponse);
 
-        $this->assertEquals(['realm' => 'realm string'], $entryPoint->getOptions());
+        self::assertEquals(['realm' => 'realm string'], $entryPoint->getOptions());
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/Authentication/EntryPoint/WebRedirectTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/EntryPoint/WebRedirectTest.php
@@ -52,8 +52,8 @@ class WebRedirectTest extends UnitTestCase
 
         $entryPoint->startAuthentication($request, $response);
 
-        $this->assertEquals('303', substr($response->getStatus(), 0, 3));
-        $this->assertEquals('http://robertlemke.com/some/page', $response->getHeader('Location'));
+        self::assertEquals('303', substr($response->getStatus(), 0, 3));
+        self::assertEquals('http://robertlemke.com/some/page', $response->getHeader('Location'));
     }
 
     /**
@@ -69,7 +69,7 @@ class WebRedirectTest extends UnitTestCase
 
         $entryPoint->startAuthentication($request, $response);
 
-        $this->assertEquals('http://some.abs/olute/url', $response->getHeader('Location'));
+        self::assertEquals('http://some.abs/olute/url', $response->getHeader('Location'));
     }
 
     /**
@@ -112,7 +112,7 @@ class WebRedirectTest extends UnitTestCase
 
         $entryPoint->startAuthentication($request, $response);
 
-        $this->assertEquals('303', substr($response->getStatus(), 0, 3));
-        $this->assertEquals('http://resolved/redirect/uri', $response->getHeader('Location'));
+        self::assertEquals('303', substr($response->getStatus(), 0, 3));
+        self::assertEquals('http://resolved/redirect/uri', $response->getHeader('Location'));
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Provider/FileBasedSimpleKeyProviderTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Provider/FileBasedSimpleKeyProviderTest.php
@@ -116,7 +116,7 @@ class FileBasedSimpleKeyProviderTest extends UnitTestCase
         $authenticationProvider->authenticate($this->mockToken);
 
         $authenticatedRoles = $this->mockToken->getAccount()->getRoles();
-        $this->assertTrue(in_array('Neos.Flow:TestRoleIdentifier', array_keys($authenticatedRoles)));
+        self::assertTrue(in_array('Neos.Flow:TestRoleIdentifier', array_keys($authenticatedRoles)));
     }
 
     /**
@@ -157,7 +157,7 @@ class FileBasedSimpleKeyProviderTest extends UnitTestCase
     public function getTokenClassNameReturnsCorrectClassNames()
     {
         $authenticationProvider = FileBasedSimpleKeyProvider::create('myProvider', []);
-        $this->assertSame($authenticationProvider->getTokenClassNames(), [PasswordToken::class]);
+        self::assertSame($authenticationProvider->getTokenClassNames(), [PasswordToken::class]);
     }
 
     /**
@@ -185,7 +185,7 @@ class FileBasedSimpleKeyProviderTest extends UnitTestCase
 
         $authenticationProvider = FileBasedSimpleKeyProvider::create('myProvider', []);
 
-        $this->assertTrue($authenticationProvider->canAuthenticate($mockToken1));
-        $this->assertFalse($authenticationProvider->canAuthenticate($mockToken2));
+        self::assertTrue($authenticationProvider->canAuthenticate($mockToken1));
+        self::assertFalse($authenticationProvider->canAuthenticate($mockToken2));
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
@@ -151,7 +151,7 @@ class PersistedUsernamePasswordProviderTest extends UnitTestCase
 
         $usernamePasswordProvider = Security\Authentication\Provider\PersistedUsernamePasswordProvider::create('myProvider', []);
 
-        $this->assertTrue($usernamePasswordProvider->canAuthenticate($mockToken1));
-        $this->assertFalse($usernamePasswordProvider->canAuthenticate($mockToken2));
+        self::assertTrue($usernamePasswordProvider->canAuthenticate($mockToken1));
+        self::assertFalse($usernamePasswordProvider->canAuthenticate($mockToken2));
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Token/AbstractTokenTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Token/AbstractTokenTest.php
@@ -40,7 +40,7 @@ class AbstractTokenTest extends UnitTestCase
     public function authenticationProviderNameCanBeSetAndRetrieved()
     {
         $this->token->setAuthenticationProviderName('My Cool Provider');
-        $this->assertEquals('My Cool Provider', $this->token->getAuthenticationProviderName());
+        self::assertEquals('My Cool Provider', $this->token->getAuthenticationProviderName());
     }
 
     /**
@@ -50,7 +50,7 @@ class AbstractTokenTest extends UnitTestCase
     {
         $entryPoint = new WebRedirect();
         $this->token->setAuthenticationEntryPoint($entryPoint);
-        $this->assertSame($entryPoint, $this->token->getAuthenticationEntryPoint());
+        self::assertSame($entryPoint, $this->token->getAuthenticationEntryPoint());
     }
 
     /**
@@ -58,7 +58,7 @@ class AbstractTokenTest extends UnitTestCase
      */
     public function theAuthenticationStatusIsCorrectlyInitialized()
     {
-        $this->assertSame(TokenInterface::NO_CREDENTIALS_GIVEN, $this->token->getAuthenticationStatus());
+        self::assertSame(TokenInterface::NO_CREDENTIALS_GIVEN, $this->token->getAuthenticationStatus());
     }
 
     /**
@@ -81,13 +81,13 @@ class AbstractTokenTest extends UnitTestCase
     public function isAuthenticatedReturnsTheCorrectValueForAGivenStatus($status, $isAuthenticated)
     {
         $this->token->setAuthenticationStatus($status);
-        $this->assertEquals($isAuthenticated, $this->token->isAuthenticated());
+        self::assertEquals($isAuthenticated, $this->token->isAuthenticated());
         $this->token->setAuthenticationStatus($status);
-        $this->assertEquals($isAuthenticated, $this->token->isAuthenticated());
+        self::assertEquals($isAuthenticated, $this->token->isAuthenticated());
         $this->token->setAuthenticationStatus($status);
-        $this->assertEquals($isAuthenticated, $this->token->isAuthenticated());
+        self::assertEquals($isAuthenticated, $this->token->isAuthenticated());
         $this->token->setAuthenticationStatus($status);
-        $this->assertEquals($isAuthenticated, $this->token->isAuthenticated());
+        self::assertEquals($isAuthenticated, $this->token->isAuthenticated());
     }
 
     /**
@@ -104,13 +104,13 @@ class AbstractTokenTest extends UnitTestCase
      */
     public function requestPatternsCanBeSetRetrievedAndChecked()
     {
-        $this->assertFalse($this->token->hasRequestPatterns());
+        self::assertFalse($this->token->hasRequestPatterns());
 
         $uriRequestPattern = new UriRequestPattern(['uriPattern' => 'http://mydomain.com/some/path/pattern']);
         $this->token->setRequestPatterns([$uriRequestPattern]);
 
-        $this->assertTrue($this->token->hasRequestPatterns());
-        $this->assertEquals([$uriRequestPattern], $this->token->getRequestPatterns());
+        self::assertTrue($this->token->hasRequestPatterns());
+        self::assertEquals([$uriRequestPattern], $this->token->getRequestPatterns());
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Token/PasswordTokenTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Token/PasswordTokenTest.php
@@ -64,7 +64,7 @@ class PasswordTokenTest extends UnitTestCase
         $this->token->updateCredentials($this->mockActionRequest);
 
         $expectedCredentials = ['password' => 'verysecurepassword'];
-        $this->assertEquals($expectedCredentials, $this->token->getCredentials(), 'The credentials have not been extracted correctly from the POST arguments');
+        self::assertEquals($expectedCredentials, $this->token->getCredentials(), 'The credentials have not been extracted correctly from the POST arguments');
     }
 
     /**
@@ -80,7 +80,7 @@ class PasswordTokenTest extends UnitTestCase
 
         $this->token->updateCredentials($this->mockActionRequest);
 
-        $this->assertSame(TokenInterface::AUTHENTICATION_NEEDED, $this->token->getAuthenticationStatus());
+        self::assertSame(TokenInterface::AUTHENTICATION_NEEDED, $this->token->getAuthenticationStatus());
     }
 
     /**
@@ -95,7 +95,7 @@ class PasswordTokenTest extends UnitTestCase
         $this->mockActionRequest->expects($this->atLeastOnce())->method('getInternalArguments')->will($this->returnValue($arguments));
 
         $this->token->updateCredentials($this->mockActionRequest);
-        $this->assertEquals(['password' => 'verysecurepassword'], $this->token->getCredentials());
+        self::assertEquals(['password' => 'verysecurepassword'], $this->token->getCredentials());
 
         $secondToken = new PasswordToken();
         $secondMockActionRequest = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->getMock();
@@ -104,6 +104,6 @@ class PasswordTokenTest extends UnitTestCase
         $secondMockActionRequest->expects($this->any())->method('getHttpRequest')->will($this->returnValue($secondMockHttpRequest));
         $secondMockHttpRequest->expects($this->atLeastOnce())->method('getMethod')->will($this->returnValue('GET'));
         $secondToken->updateCredentials($secondMockActionRequest);
-        $this->assertEquals(['password' => ''], $secondToken->getCredentials());
+        self::assertEquals(['password' => ''], $secondToken->getCredentials());
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Token/UsernamePasswordHttpBasicTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Token/UsernamePasswordHttpBasicTest.php
@@ -54,8 +54,8 @@ class UsernamePasswordHttpBasicTest extends UnitTestCase
         $this->token->updateCredentials($mockActionRequest);
 
         $expectedCredentials = ['username' => 'robert', 'password' => 'mysecretpassword, containing a : colon ;-)'];
-        $this->assertEquals($expectedCredentials, $this->token->getCredentials());
-        $this->assertSame(TokenInterface::AUTHENTICATION_NEEDED, $this->token->getAuthenticationStatus());
+        self::assertEquals($expectedCredentials, $this->token->getCredentials());
+        self::assertSame(TokenInterface::AUTHENTICATION_NEEDED, $this->token->getAuthenticationStatus());
     }
 
     /**
@@ -74,8 +74,8 @@ class UsernamePasswordHttpBasicTest extends UnitTestCase
         $mockActionRequest->expects($this->atLeastOnce())->method('getHttpRequest')->will($this->returnValue($httpRequest));
         $this->token->updateCredentials($mockActionRequest);
 
-        $this->assertEquals($expectedCredentials, $this->token->getCredentials());
-        $this->assertSame(TokenInterface::AUTHENTICATION_NEEDED, $this->token->getAuthenticationStatus());
+        self::assertEquals($expectedCredentials, $this->token->getCredentials());
+        self::assertSame(TokenInterface::AUTHENTICATION_NEEDED, $this->token->getAuthenticationStatus());
     }
 
     /**
@@ -88,6 +88,6 @@ class UsernamePasswordHttpBasicTest extends UnitTestCase
         $mockActionRequest->expects($this->atLeastOnce())->method('getHttpRequest')->will($this->returnValue($httpRequest));
         $this->token->updateCredentials($mockActionRequest);
 
-        $this->assertSame(TokenInterface::NO_CREDENTIALS_GIVEN, $this->token->getAuthenticationStatus());
+        self::assertSame(TokenInterface::NO_CREDENTIALS_GIVEN, $this->token->getAuthenticationStatus());
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Token/UsernamePasswordTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Token/UsernamePasswordTest.php
@@ -66,7 +66,7 @@ class UsernamePasswordTest extends UnitTestCase
         $this->token->updateCredentials($this->mockActionRequest);
 
         $expectedCredentials = ['username' => 'johndoe', 'password' => 'verysecurepassword'];
-        $this->assertEquals($expectedCredentials, $this->token->getCredentials(), 'The credentials have not been extracted correctly from the POST arguments');
+        self::assertEquals($expectedCredentials, $this->token->getCredentials(), 'The credentials have not been extracted correctly from the POST arguments');
     }
 
     /**
@@ -83,7 +83,7 @@ class UsernamePasswordTest extends UnitTestCase
 
         $this->token->updateCredentials($this->mockActionRequest);
 
-        $this->assertSame(TokenInterface::AUTHENTICATION_NEEDED, $this->token->getAuthenticationStatus());
+        self::assertSame(TokenInterface::AUTHENTICATION_NEEDED, $this->token->getAuthenticationStatus());
     }
 
     /**
@@ -99,7 +99,7 @@ class UsernamePasswordTest extends UnitTestCase
         $this->mockActionRequest->expects($this->atLeastOnce())->method('getInternalArguments')->will($this->returnValue($arguments));
 
         $this->token->updateCredentials($this->mockActionRequest);
-        $this->assertEquals(['username' => 'Neos.Flow', 'password' => 'verysecurepassword'], $this->token->getCredentials());
+        self::assertEquals(['username' => 'Neos.Flow', 'password' => 'verysecurepassword'], $this->token->getCredentials());
 
         $secondToken = new UsernamePassword();
         $secondMockActionRequest = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->getMock();
@@ -109,7 +109,7 @@ class UsernamePasswordTest extends UnitTestCase
         $secondMockActionRequest->expects($this->any())->method('getHttpRequest')->will($this->returnValue($secondMockHttpRequest));
         $secondMockHttpRequest->expects($this->atLeastOnce())->method('getMethod')->will($this->returnValue('GET'));
         $secondToken->updateCredentials($secondMockActionRequest);
-        $this->assertEquals(['username' => '', 'password' => ''], $secondToken->getCredentials());
+        self::assertEquals(['username' => '', 'password' => ''], $secondToken->getCredentials());
     }
 
     /**
@@ -126,6 +126,6 @@ class UsernamePasswordTest extends UnitTestCase
 
         $this->token->updateCredentials($this->mockActionRequest);
 
-        $this->assertEquals('Username: "Neos.Flow"', (string)$this->token);
+        self::assertEquals('Username: "Neos.Flow"', (string)$this->token);
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/Authentication/TokenAndProviderFactoryTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/TokenAndProviderFactoryTest.php
@@ -32,8 +32,8 @@ class TokenAndProviderFactoryTest extends UnitTestCase
 
         $tokenAndProviderFactory = new TokenAndProviderFactory($mockProviderResolver, $mockRequestPatternResolver);
 
-        $this->assertEquals([], $tokenAndProviderFactory->getProviders(), 'The array of providers should be empty.');
-        $this->assertEquals([], $tokenAndProviderFactory->getTokens(), 'The array of tokens should be empty.');
+        self::assertEquals([], $tokenAndProviderFactory->getProviders(), 'The array of providers should be empty.');
+        self::assertEquals([], $tokenAndProviderFactory->getTokens(), 'The array of tokens should be empty.');
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Security/Authorization/FilterFirewallTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authorization/FilterFirewallTest.php
@@ -64,10 +64,10 @@ class FilterFirewallTest extends UnitTestCase
             $args = func_get_args();
 
             if ($args[0] === 'mockPatternURI') {
-                $this->assertSame(['uriPattern' => '/some/url/.*'], $args[1]);
+                self::assertSame(['uriPattern' => '/some/url/.*'], $args[1]);
                 return $mockRequestPattern1;
             } elseif ($args[0] === 'mockPatternTest') {
-                $this->assertSame(['uriPattern' => '/some/url/blocked.*'], $args[1]);
+                self::assertSame(['uriPattern' => '/some/url/blocked.*'], $args[1]);
                 return $mockRequestPattern2;
             } elseif ($args[0] === 'mockInterceptorAccessGrant') {
                 return $accessGrant;

--- a/Neos.Flow/Tests/Unit/Security/Authorization/Interceptor/AfterInvocationTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authorization/Interceptor/AfterInvocationTest.php
@@ -31,6 +31,6 @@ class AfterInvocationTest extends UnitTestCase
 
         $interceptor = new Security\Authorization\Interceptor\AfterInvocation($mockSecurityContext, $mockAfterInvocationManager);
         $interceptor->setResult($theResult);
-        $this->assertSame($theResult, $interceptor->invoke());
+        self::assertSame($theResult, $interceptor->invoke());
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/Authorization/InterceptorResolverTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authorization/InterceptorResolverTest.php
@@ -58,7 +58,7 @@ class InterceptorResolverTest extends UnitTestCase
         $interceptorResolver = new Security\Authorization\InterceptorResolver($mockObjectManager);
         $interceptorClass = $interceptorResolver->resolveInterceptorClass('ValidShortName');
 
-        $this->assertEquals($longClassNameForTest, $interceptorClass, 'The wrong classname has been resolved');
+        self::assertEquals($longClassNameForTest, $interceptorClass, 'The wrong classname has been resolved');
     }
 
     /**
@@ -72,6 +72,6 @@ class InterceptorResolverTest extends UnitTestCase
         $interceptorResolver = new Security\Authorization\InterceptorResolver($mockObjectManager);
         $interceptorClass = $interceptorResolver->resolveInterceptorClass('ExistingInterceptorClass');
 
-        $this->assertEquals('ExistingInterceptorClass', $interceptorClass, 'The wrong classname has been resolved');
+        self::assertEquals('ExistingInterceptorClass', $interceptorClass, 'The wrong classname has been resolved');
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/Authorization/PrivilegeManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authorization/PrivilegeManagerTest.php
@@ -113,7 +113,7 @@ class PrivilegeManagerTest extends UnitTestCase
 
         $this->mockSecurityContext->expects($this->once())->method('getRoles')->will($this->returnValue([$mockRoleAdministrator, $mockRoleCustomer]));
 
-        $this->assertTrue($this->privilegeManager->isGranted(MethodPrivilegeInterface::class, $this->mockJoinPoint));
+        self::assertTrue($this->privilegeManager->isGranted(MethodPrivilegeInterface::class, $this->mockJoinPoint));
     }
 
     /**
@@ -123,7 +123,7 @@ class PrivilegeManagerTest extends UnitTestCase
     {
         $this->mockSecurityContext->expects($this->once())->method('getRoles')->will($this->returnValue([]));
 
-        $this->assertTrue($this->privilegeManager->isGranted(MethodPrivilegeInterface::class, $this->mockJoinPoint));
+        self::assertTrue($this->privilegeManager->isGranted(MethodPrivilegeInterface::class, $this->mockJoinPoint));
     }
 
     /**
@@ -136,7 +136,7 @@ class PrivilegeManagerTest extends UnitTestCase
 
         $this->mockSecurityContext->expects($this->once())->method('getRoles')->will($this->returnValue([$testRole1]));
 
-        $this->assertTrue($this->privilegeManager->isGranted(MethodPrivilegeInterface::class, $this->mockJoinPoint));
+        self::assertTrue($this->privilegeManager->isGranted(MethodPrivilegeInterface::class, $this->mockJoinPoint));
     }
 
     /**
@@ -155,7 +155,7 @@ class PrivilegeManagerTest extends UnitTestCase
 
         $this->mockSecurityContext->expects($this->once())->method('getRoles')->will($this->returnValue([$mockRoleAdministrator, $mockRoleCustomer]));
 
-        $this->assertFalse($this->privilegeManager->isGranted(MethodPrivilegeInterface::class, new MethodPrivilegeSubject($this->mockJoinPoint)));
+        self::assertFalse($this->privilegeManager->isGranted(MethodPrivilegeInterface::class, new MethodPrivilegeSubject($this->mockJoinPoint)));
     }
 
     /**
@@ -174,7 +174,7 @@ class PrivilegeManagerTest extends UnitTestCase
 
         $this->mockSecurityContext->expects($this->once())->method('getRoles')->will($this->returnValue([$mockRoleAdministrator, $mockRoleCustomer]));
 
-        $this->assertTrue($this->privilegeManager->isGranted(MethodPrivilegeInterface::class, new MethodPrivilegeSubject($this->mockJoinPoint)));
+        self::assertTrue($this->privilegeManager->isGranted(MethodPrivilegeInterface::class, new MethodPrivilegeSubject($this->mockJoinPoint)));
     }
 
     /**
@@ -191,7 +191,7 @@ class PrivilegeManagerTest extends UnitTestCase
 
         $this->mockSecurityContext->expects($this->any())->method('getRoles')->will($this->returnValue([$mockRole1, $mockRole2, $mockRole3]));
 
-        $this->assertFalse($this->privilegeManager->isPrivilegeTargetGranted('somePrivilegeTargetIdentifier'));
+        self::assertFalse($this->privilegeManager->isPrivilegeTargetGranted('somePrivilegeTargetIdentifier'));
     }
 
     /**
@@ -208,7 +208,7 @@ class PrivilegeManagerTest extends UnitTestCase
 
         $this->mockSecurityContext->expects($this->any())->method('getRoles')->will($this->returnValue([$mockRole1, $mockRole2, $mockRole3]));
 
-        $this->assertFalse($this->privilegeManager->isPrivilegeTargetGranted('somePrivilegeTargetIdentifier'));
+        self::assertFalse($this->privilegeManager->isPrivilegeTargetGranted('somePrivilegeTargetIdentifier'));
     }
 
     /**
@@ -227,7 +227,7 @@ class PrivilegeManagerTest extends UnitTestCase
 
         $this->mockSecurityContext->expects($this->any())->method('getRoles')->will($this->returnValue([$mockRole1, $mockRole2, $mockRole3]));
 
-        $this->assertTrue($this->privilegeManager->isPrivilegeTargetGranted('somePrivilegeTargetIdentifier'));
+        self::assertTrue($this->privilegeManager->isPrivilegeTargetGranted('somePrivilegeTargetIdentifier'));
     }
 
     /**
@@ -244,6 +244,6 @@ class PrivilegeManagerTest extends UnitTestCase
 
         $this->mockSecurityContext->expects($this->any())->method('getRoles')->will($this->returnValue([$mockRole1, $mockRole2, $mockRole3]));
 
-        $this->assertTrue($this->privilegeManager->isPrivilegeTargetGranted('somePrivilegeTargetIdentifier'));
+        self::assertTrue($this->privilegeManager->isPrivilegeTargetGranted('somePrivilegeTargetIdentifier'));
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/Authorization/RequestFilterTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authorization/RequestFilterTest.php
@@ -64,7 +64,7 @@ class RequestFilterTest extends UnitTestCase
         $requestPattern->expects($this->once())->method('matchRequest')->will($this->returnValue(true));
 
         $requestFilter = new Security\Authorization\RequestFilter($requestPattern, $interceptor);
-        $this->assertTrue($requestFilter->filterRequest($request));
+        self::assertTrue($requestFilter->filterRequest($request));
     }
 
     /**
@@ -79,6 +79,6 @@ class RequestFilterTest extends UnitTestCase
         $requestPattern->expects($this->once())->method('matchRequest')->will($this->returnValue(false));
 
         $requestFilter = new Security\Authorization\RequestFilter($requestPattern, $interceptor);
-        $this->assertFalse($requestFilter->filterRequest($request));
+        self::assertFalse($requestFilter->filterRequest($request));
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/ContextTest.php
+++ b/Neos.Flow/Tests/Unit/Security/ContextTest.php
@@ -86,7 +86,7 @@ class ContextTest extends UnitTestCase
     public function currentRequestIsSetInTheSecurityContext()
     {
         $this->securityContext->initialize();
-        $this->assertSame($this->mockActionRequest, $this->securityContext->_get('request'));
+        self::assertSame($this->mockActionRequest, $this->securityContext->_get('request'));
     }
 
     /**
@@ -94,9 +94,9 @@ class ContextTest extends UnitTestCase
      */
     public function securityContextIsSetToInitialized()
     {
-        $this->assertFalse($this->securityContext->isInitialized());
+        self::assertFalse($this->securityContext->isInitialized());
         $this->securityContext->initialize();
-        $this->assertTrue($this->securityContext->isInitialized());
+        self::assertTrue($this->securityContext->isInitialized());
     }
 
     /**
@@ -202,8 +202,8 @@ class ContextTest extends UnitTestCase
         $securityContext->_set('tokens', [$token1, $token3, $token4]);
         $securityContext->initialize();
 
-        $this->assertEquals([$token1, $token2, $token4], array_values($securityContext->_get('activeTokens')));
-        $this->assertEquals([$token3, $token5], array_values($securityContext->_get('inactiveTokens')));
+        self::assertEquals([$token1, $token2, $token4], array_values($securityContext->_get('activeTokens')));
+        self::assertEquals([$token3, $token5], array_values($securityContext->_get('inactiveTokens')));
     }
 
     /**
@@ -351,9 +351,9 @@ class ContextTest extends UnitTestCase
 
         $this->securityContext->initialize();
         if ($expectedActive) {
-            $this->assertContains($mockToken, $this->securityContext->_get('activeTokens'));
+            self::assertContains($mockToken, $this->securityContext->_get('activeTokens'));
         } else {
-            $this->assertContains($mockToken, $this->securityContext->_get('inactiveTokens'));
+            self::assertContains($mockToken, $this->securityContext->_get('inactiveTokens'));
         }
     }
 
@@ -417,7 +417,7 @@ class ContextTest extends UnitTestCase
 //        $securityContext->_call('initialize');
 
         $expectedMergedTokens = [$token1Clone, $token2Clone, $token3];
-        $this->assertEquals($expectedMergedTokens, array_values($securityContext->_get('activeTokens')));
+        self::assertEquals($expectedMergedTokens, array_values($securityContext->_get('activeTokens')));
     }
 
     /**
@@ -483,7 +483,7 @@ class ContextTest extends UnitTestCase
         $this->inject($securityContext, 'objectManager', $this->mockObjectManager);
         $securityContext->injectSettings($settings);
 
-        $this->assertEquals($expectedAuthenticationStrategy, $securityContext->getAuthenticationStrategy());
+        self::assertEquals($expectedAuthenticationStrategy, $securityContext->getAuthenticationStrategy());
     }
 
     /**
@@ -528,7 +528,7 @@ class ContextTest extends UnitTestCase
         $this->inject($securityContext, 'objectManager', $this->mockObjectManager);
         $securityContext->injectSettings($settings);
 
-        $this->assertEquals($expectedCsrfProtectionStrategy, $securityContext->_get('csrfProtectionStrategy'));
+        self::assertEquals($expectedCsrfProtectionStrategy, $securityContext->_get('csrfProtectionStrategy'));
     }
 
     /**
@@ -581,7 +581,7 @@ class ContextTest extends UnitTestCase
         $securityContext->_set('policyService', $mockPolicyService);
 
         $expectedResult = ['Neos.Flow:Everybody' => $everybodyRole, 'Neos.Flow:AuthenticatedUser' => $authenticatedUserRole, 'Acme.Demo:TestRole' => $testRole];
-        $this->assertEquals($expectedResult, $securityContext->getRoles());
+        self::assertEquals($expectedResult, $securityContext->getRoles());
     }
 
     /**
@@ -672,7 +672,7 @@ class ContextTest extends UnitTestCase
         ksort($expectedResult);
         ksort($result);
 
-        $this->assertSame(array_keys($expectedResult), array_keys($result));
+        self::assertSame(array_keys($expectedResult), array_keys($result));
     }
 
     /**
@@ -690,8 +690,8 @@ class ContextTest extends UnitTestCase
         $securityContext->_set('policyService', $mockPolicyService);
 
         $result = $securityContext->getRoles();
-        $this->assertInstanceOf(Policy\Role::class, $result['Neos.Flow:Everybody']);
-        $this->assertEquals('Neos.Flow:Everybody', $result['Neos.Flow:Everybody']->getIdentifier());
+        self::assertInstanceOf(Policy\Role::class, $result['Neos.Flow:Everybody']);
+        self::assertEquals('Neos.Flow:Everybody', $result['Neos.Flow:Everybody']->getIdentifier());
     }
 
     /**
@@ -709,8 +709,8 @@ class ContextTest extends UnitTestCase
         $securityContext->_set('policyService', $mockPolicyService);
 
         $result = $securityContext->getRoles();
-        $this->assertInstanceOf(Policy\Role::class, $result['Neos.Flow:Anonymous']);
-        $this->assertEquals('Neos.Flow:Anonymous', (string)($result['Neos.Flow:Anonymous']));
+        self::assertInstanceOf(Policy\Role::class, $result['Neos.Flow:Anonymous']);
+        self::assertEquals('Neos.Flow:Anonymous', (string)($result['Neos.Flow:Anonymous']));
     }
 
     /**
@@ -731,8 +731,8 @@ class ContextTest extends UnitTestCase
         $securityContext->_set('policyService', $mockPolicyService);
 
         $result = $securityContext->getRoles();
-        $this->assertInstanceOf(Policy\Role::class, $result['Neos.Flow:AuthenticatedUser']);
-        $this->assertEquals('Neos.Flow:AuthenticatedUser', (string)($result['Neos.Flow:AuthenticatedUser']));
+        self::assertInstanceOf(Policy\Role::class, $result['Neos.Flow:AuthenticatedUser']);
+        self::assertEquals('Neos.Flow:AuthenticatedUser', (string)($result['Neos.Flow:AuthenticatedUser']));
     }
 
     /**
@@ -750,7 +750,7 @@ class ContextTest extends UnitTestCase
         $this->inject($securityContext, 'objectManager', $this->mockObjectManager);
         $securityContext->_set('policyService', $mockPolicyService);
 
-        $this->assertTrue($securityContext->hasRole('Neos.Flow:Everybody'));
+        self::assertTrue($securityContext->hasRole('Neos.Flow:Everybody'));
     }
 
     /**
@@ -772,7 +772,7 @@ class ContextTest extends UnitTestCase
         $this->inject($securityContext, 'objectManager', $this->mockObjectManager);
         $securityContext->_set('policyService', $mockPolicyService);
 
-        $this->assertTrue($securityContext->hasRole('Neos.Flow:Anonymous'));
+        self::assertTrue($securityContext->hasRole('Neos.Flow:Anonymous'));
     }
 
     /**
@@ -794,7 +794,7 @@ class ContextTest extends UnitTestCase
         $this->inject($securityContext, 'objectManager', $this->mockObjectManager);
         $this->inject($securityContext, 'policyService', $mockPolicyService);
 
-        $this->assertFalse($securityContext->hasRole('Neos.Flow:Anonymous'));
+        self::assertFalse($securityContext->hasRole('Neos.Flow:Anonymous'));
     }
 
     /**
@@ -829,8 +829,8 @@ class ContextTest extends UnitTestCase
         $securityContext->_set('activeTokens', [$mockToken]);
         $securityContext->_set('policyService', $mockPolicyService);
 
-        $this->assertTrue($securityContext->hasRole('Acme.Demo:TestRole'));
-        $this->assertFalse($securityContext->hasRole('Foo.Bar:Baz'));
+        self::assertTrue($securityContext->hasRole('Acme.Demo:TestRole'));
+        self::assertFalse($securityContext->hasRole('Foo.Bar:Baz'));
     }
 
     /**
@@ -877,7 +877,7 @@ class ContextTest extends UnitTestCase
         $securityContext->_set('activeTokens', [$mockToken]);
         $securityContext->_set('policyService', $mockPolicyService);
 
-        $this->assertTrue($securityContext->hasRole('Acme.Demo:TestRole2'));
+        self::assertTrue($securityContext->hasRole('Acme.Demo:TestRole2'));
     }
 
     /**
@@ -905,7 +905,7 @@ class ContextTest extends UnitTestCase
         $securityContext->_set('initialized', true);
         $securityContext->expects($this->once())->method('getAuthenticationTokens')->will($this->returnValue([$token1, $token2, $token3]));
 
-        $this->assertEquals($mockAccount, $securityContext->getAccount());
+        self::assertEquals($mockAccount, $securityContext->getAccount());
     }
 
     /**
@@ -934,7 +934,7 @@ class ContextTest extends UnitTestCase
         $securityContext->_set('activeTokens', ['SomeOhterProvider' => $token1, 'SecondProvider' => $token2, 'MatchingProvider' => $token3]);
         $securityContext->_set('initialized', true);
 
-        $this->assertSame($mockAccount2, $securityContext->getAccountByAuthenticationProviderName('MatchingProvider'));
+        self::assertSame($mockAccount2, $securityContext->getAccountByAuthenticationProviderName('MatchingProvider'));
     }
 
     /**
@@ -949,7 +949,7 @@ class ContextTest extends UnitTestCase
         $securityContext->_set('activeTokens', []);
         $securityContext->_set('initialized', true);
 
-        $this->assertSame(null, $securityContext->getAccountByAuthenticationProviderName('UnknownProvider'));
+        self::assertSame(null, $securityContext->getAccountByAuthenticationProviderName('UnknownProvider'));
     }
 
     /**
@@ -964,7 +964,7 @@ class ContextTest extends UnitTestCase
         $securityContext->_set('csrfTokens', []);
         $securityContext->_set('initialized', true);
 
-        $this->assertNotEmpty($securityContext->getCsrfProtectionToken());
+        self::assertNotEmpty($securityContext->getCsrfProtectionToken());
     }
 
     /**
@@ -979,7 +979,7 @@ class ContextTest extends UnitTestCase
         $this->securityContext->_set('csrfTokens', $existingTokens);
         $this->securityContext->_set('csrfStrategy', Context::CSRF_ONE_PER_URI);
 
-        $this->assertFalse(array_key_exists($this->securityContext->getCsrfProtectionToken(), $existingTokens));
+        self::assertFalse(array_key_exists($this->securityContext->getCsrfProtectionToken(), $existingTokens));
     }
 
     /**
@@ -995,8 +995,8 @@ class ContextTest extends UnitTestCase
         $this->securityContext->_set('objectManager', $this->mockObjectManager);
         $this->securityContext->_set('csrfProtectionTokens', $existingTokens);
 
-        $this->assertTrue($this->securityContext->isCsrfProtectionTokenValid('csrfToken12345'));
-        $this->assertFalse($this->securityContext->isCsrfProtectionTokenValid('csrfToken'));
+        self::assertTrue($this->securityContext->isCsrfProtectionTokenValid('csrfToken12345'));
+        self::assertFalse($this->securityContext->isCsrfProtectionTokenValid('csrfToken'));
     }
 
     /**
@@ -1018,8 +1018,8 @@ class ContextTest extends UnitTestCase
         $this->securityContext->_set('initialized', true);
         $this->securityContext->_set('csrfProtectionStrategy', Context::CSRF_ONE_PER_URI);
 
-        $this->assertTrue($this->securityContext->isCsrfProtectionTokenValid('csrfToken12345'));
-        $this->assertFalse($this->securityContext->isCsrfProtectionTokenValid('csrfToken12345'));
+        self::assertTrue($this->securityContext->isCsrfProtectionTokenValid('csrfToken12345'));
+        self::assertFalse($this->securityContext->isCsrfProtectionTokenValid('csrfToken12345'));
     }
 
     /**
@@ -1028,7 +1028,7 @@ class ContextTest extends UnitTestCase
     public function authorizationChecksAreEnabledByDefault()
     {
         $securityContext = $this->getAccessibleMock(Context::class, ['initialize']);
-        $this->assertFalse($securityContext->areAuthorizationChecksDisabled());
+        self::assertFalse($securityContext->areAuthorizationChecksDisabled());
     }
 
     /**
@@ -1052,7 +1052,7 @@ class ContextTest extends UnitTestCase
         $securityContext = $this->getAccessibleMock(Context::class, ['initialize']);
         $securityContext->withoutAuthorizationChecks(function () {
         });
-        $this->assertFalse($securityContext->areAuthorizationChecksDisabled());
+        self::assertFalse($securityContext->areAuthorizationChecksDisabled());
     }
 
     /**
@@ -1068,7 +1068,7 @@ class ContextTest extends UnitTestCase
             });
         } catch (\Exception $exception) {
         }
-        $this->assertFalse($securityContext->areAuthorizationChecksDisabled());
+        self::assertFalse($securityContext->areAuthorizationChecksDisabled());
     }
 
     /**
@@ -1085,7 +1085,7 @@ class ContextTest extends UnitTestCase
             });
             $self->assertTrue($securityContext->areAuthorizationChecksDisabled());
         });
-        $this->assertFalse($securityContext->areAuthorizationChecksDisabled());
+        self::assertFalse($securityContext->areAuthorizationChecksDisabled());
     }
 
     /**
@@ -1128,7 +1128,7 @@ class ContextTest extends UnitTestCase
         $securityContext->expects($this->atLeastOnce())->method('getRoles')->will($this->returnValue($mockRoles));
 
         $expectedHash = md5(implode('|', array_keys($mockRoles)));
-        $this->assertSame($expectedHash, $securityContext->getContextHash());
+        self::assertSame($expectedHash, $securityContext->getContextHash());
     }
 
     /**
@@ -1140,7 +1140,7 @@ class ContextTest extends UnitTestCase
         $securityContext = $this->getAccessibleMock(Context::class, ['initialize', 'canBeInitialized']);
         $securityContext->expects($this->atLeastOnce())->method('canBeInitialized')->will($this->returnValue(false));
         $securityContext->expects($this->never())->method('initialize');
-        $this->assertSame(Context::CONTEXT_HASH_UNINITIALIZED, $securityContext->getContextHash());
+        self::assertSame(Context::CONTEXT_HASH_UNINITIALIZED, $securityContext->getContextHash());
     }
 
     /**
@@ -1153,7 +1153,7 @@ class ContextTest extends UnitTestCase
         $account2 = $this->createMock(Account::class);
         $account2->expects($this->any())->method('getAccountIdentifier')->willReturn('Account2');
 
-        $this->assertNotSame($this->securityContext->getSessionTagForAccount($account1), $this->securityContext->getSessionTagForAccount($account2));
+        self::assertNotSame($this->securityContext->getSessionTagForAccount($account1), $this->securityContext->getSessionTagForAccount($account2));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Security/Cryptography/AlgorithmsTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Cryptography/AlgorithmsTest.php
@@ -46,6 +46,6 @@ class AlgorithmsTest extends UnitTestCase
     public function pbkdf2TestVectorsAreCorrect($password, $salt, $iterationCount, $derivedKeyLength, $output)
     {
         $result = Algorithms::pbkdf2($password, $salt, $iterationCount, $derivedKeyLength, 'sha1');
-        $this->assertEquals(unpack('H*', pack('H*', $output)), unpack('H*', $result));
+        self::assertEquals(unpack('H*', pack('H*', $output)), unpack('H*', $result));
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/Cryptography/BCryptHashingStrategyTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Cryptography/BCryptHashingStrategyTest.php
@@ -25,10 +25,10 @@ class BCryptHashingStrategyTest extends UnitTestCase
      */
     public function systemSupportsBlowfishCryptMethod()
     {
-        $this->assertTrue(\CRYPT_BLOWFISH === 1);
+        self::assertTrue(\CRYPT_BLOWFISH === 1);
 
         $cryptResult = crypt('rasmuslerdorf', '$2a$07$usesomesillystringforsalt$');
-        $this->assertEquals('$2a$07$usesomesillystringfore2uDLvp1Ii2e./U9C8sBjqp8I90dH6hi', $cryptResult);
+        self::assertEquals('$2a$07$usesomesillystringfore2uDLvp1Ii2e./U9C8sBjqp8I90dH6hi', $cryptResult);
     }
 
     /**
@@ -39,8 +39,8 @@ class BCryptHashingStrategyTest extends UnitTestCase
         $strategy = new BCryptHashingStrategy(10);
         $derivedKeyWithSalt = $strategy->hashPassword('password');
 
-        $this->assertTrue($strategy->validatePassword('password', $derivedKeyWithSalt));
-        $this->assertFalse($strategy->validatePassword('pass', $derivedKeyWithSalt));
+        self::assertTrue($strategy->validatePassword('password', $derivedKeyWithSalt));
+        self::assertFalse($strategy->validatePassword('pass', $derivedKeyWithSalt));
     }
 
     /**
@@ -51,7 +51,7 @@ class BCryptHashingStrategyTest extends UnitTestCase
         $strategy = new BCryptHashingStrategy(10);
         $derivedKeyWithSalt = $strategy->hashPassword('password');
 
-        $this->assertFalse($strategy->validatePassword('pass', $derivedKeyWithSalt), 'Different password should not match');
+        self::assertFalse($strategy->validatePassword('pass', $derivedKeyWithSalt), 'Different password should not match');
     }
 
     /**
@@ -64,7 +64,7 @@ class BCryptHashingStrategyTest extends UnitTestCase
         $otherStrategy = new BCryptHashingStrategy(6);
         $derivedKeyWithSalt = $otherStrategy->hashPassword('password');
 
-        $this->assertTrue($strategy->validatePassword('password', $derivedKeyWithSalt), 'Hashing strategy should validate password with different cost');
+        self::assertTrue($strategy->validatePassword('password', $derivedKeyWithSalt), 'Hashing strategy should validate password with different cost');
     }
 
     /**
@@ -74,8 +74,8 @@ class BCryptHashingStrategyTest extends UnitTestCase
     {
         $strategy = new BCryptHashingStrategy(10);
 
-        $this->assertFalse($strategy->validatePassword('password', ''));
-        $this->assertFalse($strategy->validatePassword('password', '$1$abc'));
-        $this->assertFalse($strategy->validatePassword('password', '$2x$01$012345678901234567890123456789'));
+        self::assertFalse($strategy->validatePassword('password', ''));
+        self::assertFalse($strategy->validatePassword('password', '$1$abc'));
+        self::assertFalse($strategy->validatePassword('password', '$2x$01$012345678901234567890123456789'));
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/Cryptography/HashServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Cryptography/HashServiceTest.php
@@ -81,7 +81,7 @@ class HashServiceTest extends UnitTestCase
     public function generateHmacReturnsHashStringIfStringIsGiven()
     {
         $hash = $this->hashService->generateHmac('asdf');
-        $this->assertTrue(is_string($hash));
+        self::assertTrue(is_string($hash));
     }
 
     /**
@@ -90,7 +90,7 @@ class HashServiceTest extends UnitTestCase
     public function generateHmacReturnsHashStringWhichContainsSomeSalt()
     {
         $hash = $this->hashService->generateHmac('asdf');
-        $this->assertNotEquals(sha1('asdf'), $hash);
+        self::assertNotEquals(sha1('asdf'), $hash);
     }
 
     /**
@@ -100,7 +100,7 @@ class HashServiceTest extends UnitTestCase
     {
         $hash1 = $this->hashService->generateHmac('asdf');
         $hash2 = $this->hashService->generateHmac('blubb');
-        $this->assertNotEquals($hash1, $hash2);
+        self::assertNotEquals($hash1, $hash2);
     }
 
     /**
@@ -119,7 +119,7 @@ class HashServiceTest extends UnitTestCase
     {
         $string = 'asdf';
         $hash = $this->hashService->generateHmac($string);
-        $this->assertTrue($this->hashService->validateHmac($string, $hash));
+        self::assertTrue($this->hashService->validateHmac($string, $hash));
     }
 
     /**
@@ -129,7 +129,7 @@ class HashServiceTest extends UnitTestCase
     {
         $string = 'asdf';
         $hash = 'myhash';
-        $this->assertFalse($this->hashService->validateHmac($string, $hash));
+        self::assertFalse($this->hashService->validateHmac($string, $hash));
     }
 
     /**
@@ -168,7 +168,7 @@ class HashServiceTest extends UnitTestCase
         $this->mockObjectManager->expects($this->any())->method('get')->will($this->returnValue($mockStrategy));
 
         $result = $this->hashService->hashPassword('myTestPassword', 'TestStrategy');
-        $this->assertEquals('TestStrategy=>---hashed-password---', $result);
+        self::assertEquals('TestStrategy=>---hashed-password---', $result);
     }
 
     /**
@@ -211,7 +211,7 @@ class HashServiceTest extends UnitTestCase
         $mockStrategy->expects($this->atLeastOnce())->method('validatePassword')->with('myTestPassword', '---hashed-password---')->will($this->returnValue(true));
 
         $result = $this->hashService->validatePassword('myTestPassword', 'TestStrategy=>---hashed-password---');
-        $this->assertEquals(true, $result);
+        self::assertEquals(true, $result);
     }
 
     /**
@@ -220,7 +220,7 @@ class HashServiceTest extends UnitTestCase
     public function generatedHashReturnsAHashOf40Characters()
     {
         $hash = $this->hashService->generateHmac('asdf');
-        $this->assertSame(40, strlen($hash));
+        self::assertSame(40, strlen($hash));
     }
 
     /**
@@ -239,7 +239,7 @@ class HashServiceTest extends UnitTestCase
     {
         $string = 'This is some arbitrary string ';
         $hashedString = $this->hashService->appendHmac($string);
-        $this->assertSame($string, substr($hashedString, 0, -40));
+        self::assertSame($string, substr($hashedString, 0, -40));
     }
 
     /**
@@ -286,6 +286,6 @@ class HashServiceTest extends UnitTestCase
         $string = ' Some arbitrary string with special characters: öäüß!"§$ ';
         $hashedString = $this->hashService->appendHmac($string);
         $actualResult = $this->hashService->validateAndStripHmac($hashedString);
-        $this->assertSame($string, $actualResult);
+        self::assertSame($string, $actualResult);
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/Cryptography/Pbkdf2HashingStrategyTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Cryptography/Pbkdf2HashingStrategyTest.php
@@ -27,9 +27,9 @@ class Pbkdf2HashingStrategyTest extends UnitTestCase
         $strategy = new Pbkdf2HashingStrategy(8, 1000, 64, 'sha256');
         $derivedKeyWithSalt = $strategy->hashPassword('password', 'MyStaticSalt');
 
-        $this->assertTrue($strategy->validatePassword('password', $derivedKeyWithSalt, 'MyStaticSalt'));
-        $this->assertFalse($strategy->validatePassword('pass', $derivedKeyWithSalt, 'MyStaticSalt'));
-        $this->assertFalse($strategy->validatePassword('password', $derivedKeyWithSalt, 'SomeSalt'));
+        self::assertTrue($strategy->validatePassword('password', $derivedKeyWithSalt, 'MyStaticSalt'));
+        self::assertFalse($strategy->validatePassword('pass', $derivedKeyWithSalt, 'MyStaticSalt'));
+        self::assertFalse($strategy->validatePassword('password', $derivedKeyWithSalt, 'SomeSalt'));
     }
 
     /**
@@ -40,10 +40,10 @@ class Pbkdf2HashingStrategyTest extends UnitTestCase
         $strategy = new Pbkdf2HashingStrategy(8, 1000, 64, 'sha256');
         $derivedKeyWithSalt = $strategy->hashPassword('password', 'MyStaticSalt');
 
-        $this->assertFalse($strategy->validatePassword('pass', $derivedKeyWithSalt, 'MyStaticSalt'), 'Different password should not match');
-        $this->assertFalse($strategy->validatePassword('password', $derivedKeyWithSalt, 'SomeSalt'), 'Different static salt should not match');
+        self::assertFalse($strategy->validatePassword('pass', $derivedKeyWithSalt, 'MyStaticSalt'), 'Different password should not match');
+        self::assertFalse($strategy->validatePassword('password', $derivedKeyWithSalt, 'SomeSalt'), 'Different static salt should not match');
 
         $strategy = new Pbkdf2HashingStrategy(8, 99, 64, 'sha256');
-        $this->assertFalse($strategy->validatePassword('password', $derivedKeyWithSalt, 'MyStaticSalt'), 'Different iteration should not match');
+        self::assertFalse($strategy->validatePassword('password', $derivedKeyWithSalt, 'MyStaticSalt'), 'Different iteration should not match');
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/Cryptography/RsaWalletServicePhpTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Cryptography/RsaWalletServicePhpTest.php
@@ -62,8 +62,8 @@ class RsaWalletServicePhpTest extends UnitTestCase
         $plaintext = 'some very sensitive data!';
         $ciphertext = $this->rsaWalletService->encryptWithPublicKey($plaintext, $this->keyPairUuid);
 
-        $this->assertNotEquals($ciphertext, $plaintext);
-        $this->assertEquals($plaintext, $this->rsaWalletService->decrypt($ciphertext, $this->keyPairUuid));
+        self::assertNotEquals($ciphertext, $plaintext);
+        self::assertEquals($plaintext, $this->rsaWalletService->decrypt($ciphertext, $this->keyPairUuid));
     }
 
     /**
@@ -74,8 +74,8 @@ class RsaWalletServicePhpTest extends UnitTestCase
         $plaintext = 'trustworthy data!';
         $signature = $this->rsaWalletService->sign($plaintext, $this->keyPairUuid);
 
-        $this->assertTrue($this->rsaWalletService->verifySignature($plaintext, $signature, $this->keyPairUuid));
-        $this->assertFalse($this->rsaWalletService->verifySignature('modified data!', $signature, $this->keyPairUuid));
+        self::assertTrue($this->rsaWalletService->verifySignature($plaintext, $signature, $this->keyPairUuid));
+        self::assertFalse($this->rsaWalletService->verifySignature('modified data!', $signature, $this->keyPairUuid));
     }
 
     /**
@@ -88,7 +88,7 @@ class RsaWalletServicePhpTest extends UnitTestCase
         $passwordHash = 'af1e8a52451786a6b3bf78838e03a0a2';
         $salt = 'a709157e66e0197cafa0c2ba99f6e252';
 
-        $this->assertTrue($this->rsaWalletService->checkRSAEncryptedPassword($encryptedPassword, $passwordHash, $salt, $this->keyPairUuid));
+        self::assertTrue($this->rsaWalletService->checkRSAEncryptedPassword($encryptedPassword, $passwordHash, $salt, $this->keyPairUuid));
     }
 
     /**
@@ -101,7 +101,7 @@ class RsaWalletServicePhpTest extends UnitTestCase
         $passwordHash = 'af1e8a52451786a6b3bf78838e03a0a2';
         $salt = 'a709157e66e0197cafa0c2ba99f6e252';
 
-        $this->assertFalse($this->rsaWalletService->checkRSAEncryptedPassword($encryptedPassword, $passwordHash, $salt, $this->keyPairUuid));
+        self::assertFalse($this->rsaWalletService->checkRSAEncryptedPassword($encryptedPassword, $passwordHash, $salt, $this->keyPairUuid));
     }
 
     /**
@@ -119,11 +119,11 @@ class RsaWalletServicePhpTest extends UnitTestCase
      */
     public function shutdownSavesKeysToKeystoreFileIfKeysWereModified()
     {
-        $this->assertFalse(file_exists('vfs://Foo/EncryptionKey'));
+        self::assertFalse(file_exists('vfs://Foo/EncryptionKey'));
         $keyPairUuid = $this->rsaWalletService->generateNewKeypair(true);
         $this->rsaWalletService->shutdownObject();
 
-        $this->assertTrue(file_exists('vfs://Foo/EncryptionKey'));
+        self::assertTrue(file_exists('vfs://Foo/EncryptionKey'));
 
         $this->rsaWalletService->destroyKeypair($keyPairUuid);
         $this->rsaWalletService->initializeObject();
@@ -136,10 +136,10 @@ class RsaWalletServicePhpTest extends UnitTestCase
      */
     public function shutdownDoesNotSavesKeysToKeystoreFileIfKeysWereNotModified()
     {
-        $this->assertFalse(file_exists('vfs://Foo/EncryptionKey'));
+        self::assertFalse(file_exists('vfs://Foo/EncryptionKey'));
         $keyPairUuid = $this->rsaWalletService->generateNewKeypair(true);
         $this->rsaWalletService->shutdownObject();
-        $this->assertTrue(file_exists('vfs://Foo/EncryptionKey'));
+        self::assertTrue(file_exists('vfs://Foo/EncryptionKey'));
 
         $this->rsaWalletService->initializeObject();
         $this->rsaWalletService->getPublicKey($keyPairUuid);
@@ -148,7 +148,7 @@ class RsaWalletServicePhpTest extends UnitTestCase
         unlink('vfs://Foo/EncryptionKey');
 
         $this->rsaWalletService->shutdownObject();
-        $this->assertFalse(file_exists('vfs://Foo/EncryptionKey'));
+        self::assertFalse(file_exists('vfs://Foo/EncryptionKey'));
     }
 
     /**
@@ -163,7 +163,7 @@ HofCDIScx7AMgIB7hRB9ZMDEyWN/1vgSm8+4K4jUcD6OGLJYTSAlaQ7e2ZGaAY5h
 p2P76gIh+wUlPjsr/QIDAQAB
 -----END PUBLIC KEY-----';
 
-        $this->assertEquals('cfa6879e3dfcf709db4cfd8e61fdd782', $this->rsaWalletService->getFingerprintByPublicKey($keyString));
+        self::assertEquals('cfa6879e3dfcf709db4cfd8e61fdd782', $this->rsaWalletService->getFingerprintByPublicKey($keyString));
     }
 
     /**
@@ -178,6 +178,6 @@ HofCDIScx7AMgIB7hRB9ZMDEyWN/1vgSm8+4K4jUcD6OGLJYTSAlaQ7e2ZGaAY5h
 p2P76gIh+wUlPjsr/QIDAQAB
 -----END PUBLIC KEY-----';
 
-        $this->assertEquals('cfa6879e3dfcf709db4cfd8e61fdd782', $this->rsaWalletService->registerPublicKeyFromString($keyString));
+        self::assertEquals('cfa6879e3dfcf709db4cfd8e61fdd782', $this->rsaWalletService->registerPublicKeyFromString($keyString));
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/Policy/PolicyServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Policy/PolicyServiceTest.php
@@ -71,7 +71,7 @@ class PolicyServiceTest extends UnitTestCase
      */
     public function hasRoleReturnsFalseIfTheSpecifiedRoleIsNotConfigured()
     {
-        $this->assertFalse($this->policyService->hasRole('Non.Existing:Role'));
+        self::assertFalse($this->policyService->hasRole('Non.Existing:Role'));
     }
 
     /**
@@ -84,7 +84,7 @@ class PolicyServiceTest extends UnitTestCase
                 'Some.Package:SomeRole' => [],
             ],
         ];
-        $this->assertTrue($this->policyService->hasRole('Some.Package:SomeRole'));
+        self::assertTrue($this->policyService->hasRole('Some.Package:SomeRole'));
     }
 
     /**
@@ -112,9 +112,9 @@ class PolicyServiceTest extends UnitTestCase
             ],
         ];
         $role = $this->policyService->getRole('Some.Package:SomeOtherRole');
-        $this->assertInstanceOf(Role::class, $role);
-        $this->assertSame('Some.Package:SomeOtherRole', $role->getIdentifier());
-        $this->assertSame('Some.Package:SomeRole', $role->getParentRoles()['Some.Package:SomeRole']->getIdentifier());
+        self::assertInstanceOf(Role::class, $role);
+        self::assertSame('Some.Package:SomeOtherRole', $role->getIdentifier());
+        self::assertSame('Some.Package:SomeRole', $role->getParentRoles()['Some.Package:SomeRole']->getIdentifier());
     }
 
     /**
@@ -133,7 +133,7 @@ class PolicyServiceTest extends UnitTestCase
             ],
         ];
         $roles = $this->policyService->getRoles();
-        $this->assertSame(['Some.Package:SomeOtherRole'], array_keys($roles));
+        self::assertSame(['Some.Package:SomeOtherRole'], array_keys($roles));
     }
 
     /**
@@ -152,7 +152,7 @@ class PolicyServiceTest extends UnitTestCase
             ],
         ];
         $roles = $this->policyService->getRoles(true);
-        $this->assertSame(['Some.Package:SomeRole', 'Some.Package:SomeOtherRole', 'Neos.Flow:Everybody'], array_keys($roles));
+        self::assertSame(['Some.Package:SomeRole', 'Some.Package:SomeOtherRole', 'Neos.Flow:Everybody'], array_keys($roles));
     }
 
     /**
@@ -160,7 +160,7 @@ class PolicyServiceTest extends UnitTestCase
      */
     public function getAllPrivilegesByTypeReturnsAnEmptyArrayIfNoMatchingPrivilegesAreConfigured()
     {
-        $this->assertSame([], $this->policyService->getAllPrivilegesByType('SomeNonExistingPrivilegeType'));
+        self::assertSame([], $this->policyService->getAllPrivilegesByType('SomeNonExistingPrivilegeType'));
     }
 
     /**
@@ -178,9 +178,9 @@ class PolicyServiceTest extends UnitTestCase
                 ],
             ],
         ];
-        $this->assertCount(1, $this->policyService->getAllPrivilegesByType($mockPrivilegeClassName));
+        self::assertCount(1, $this->policyService->getAllPrivilegesByType($mockPrivilegeClassName));
         $returnedPrivilege = current($this->policyService->getAllPrivilegesByType($mockPrivilegeClassName));
-        $this->assertInstanceOf($mockPrivilegeClassName, $this->mockPrivilege, get_class($returnedPrivilege));
+        self::assertInstanceOf($mockPrivilegeClassName, $this->mockPrivilege, get_class($returnedPrivilege));
     }
 
     /**
@@ -188,7 +188,7 @@ class PolicyServiceTest extends UnitTestCase
      */
     public function getPrivilegeTargetsReturnsAnEmptyArrayIfNoPrivilegeTargetsAreConfigured()
     {
-        $this->assertSame([], $this->policyService->getPrivilegeTargets());
+        self::assertSame([], $this->policyService->getPrivilegeTargets());
     }
 
     /**
@@ -206,8 +206,8 @@ class PolicyServiceTest extends UnitTestCase
                 ],
             ],
         ];
-        $this->assertCount(1, $this->policyService->getPrivilegeTargets());
-        $this->assertSame('Some.PrivilegeTarget:Identifier', $this->policyService->getPrivilegeTargets()['Some.PrivilegeTarget:Identifier']->getIdentifier());
+        self::assertCount(1, $this->policyService->getPrivilegeTargets());
+        self::assertSame('Some.PrivilegeTarget:Identifier', $this->policyService->getPrivilegeTargets()['Some.PrivilegeTarget:Identifier']->getIdentifier());
     }
 
     /**
@@ -215,7 +215,7 @@ class PolicyServiceTest extends UnitTestCase
      */
     public function getPrivilegeTargetByIdentifierReturnsAnNullIfNoPrivilegeTargetIsConfigured()
     {
-        $this->assertNull($this->policyService->getPrivilegeTargetByIdentifier('SomeNonExistingPrivilegeTarget'));
+        self::assertNull($this->policyService->getPrivilegeTargetByIdentifier('SomeNonExistingPrivilegeTarget'));
     }
 
     /**
@@ -235,8 +235,8 @@ class PolicyServiceTest extends UnitTestCase
         ];
 
         $privilegeTarget = $this->policyService->getPrivilegeTargetByIdentifier('Some.PrivilegeTarget:Identifier');
-        $this->assertInstanceOf(PrivilegeTarget::class, $privilegeTarget);
-        $this->assertSame('Some.PrivilegeTarget:Identifier', $privilegeTarget->getIdentifier());
+        self::assertInstanceOf(PrivilegeTarget::class, $privilegeTarget);
+        self::assertSame('Some.PrivilegeTarget:Identifier', $privilegeTarget->getIdentifier());
     }
 
     /**
@@ -259,9 +259,9 @@ class PolicyServiceTest extends UnitTestCase
         ];
 
         $everybodyRole = $this->policyService->getRole('Neos.Flow:Everybody');
-        $this->assertCount(2, $everybodyRole->getPrivileges());
-        $this->assertTrue($everybodyRole->getPrivilegeForTarget('Some.PrivilegeTarget:Identifier')->isAbstained());
-        $this->assertTrue($everybodyRole->getPrivilegeForTarget('Some.OtherPrivilegeTarget:Identifier')->isAbstained());
+        self::assertCount(2, $everybodyRole->getPrivileges());
+        self::assertTrue($everybodyRole->getPrivilegeForTarget('Some.PrivilegeTarget:Identifier')->isAbstained());
+        self::assertTrue($everybodyRole->getPrivilegeForTarget('Some.OtherPrivilegeTarget:Identifier')->isAbstained());
     }
 
     /**
@@ -302,7 +302,7 @@ class PolicyServiceTest extends UnitTestCase
         ];
 
         $everybodyRole = $this->policyService->getRole('Neos.Flow:Everybody');
-        $this->assertTrue($everybodyRole->getPrivilegeForTarget('Some.PrivilegeTarget:Identifier')->isGranted());
+        self::assertTrue($everybodyRole->getPrivilegeForTarget('Some.PrivilegeTarget:Identifier')->isGranted());
     }
 
     /**
@@ -343,6 +343,6 @@ class PolicyServiceTest extends UnitTestCase
         ];
 
         $everybodyRole = $this->policyService->getRole('Neos.Flow:Everybody');
-        $this->assertTrue($everybodyRole->getPrivilegeForTarget('Some.PrivilegeTarget:Identifier')->isDenied());
+        self::assertTrue($everybodyRole->getPrivilegeForTarget('Some.PrivilegeTarget:Identifier')->isDenied());
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/Policy/RoleTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Policy/RoleTest.php
@@ -41,8 +41,8 @@ class RoleTest extends UnitTestCase
     {
         $role = new Role($roleIdentifier);
 
-        $this->assertEquals($name, $role->getName());
-        $this->assertEquals($packageKey, $role->getPackageKey());
+        self::assertEquals($name, $role->getName());
+        self::assertEquals($packageKey, $role->getPackageKey());
     }
 
     /**
@@ -66,7 +66,7 @@ class RoleTest extends UnitTestCase
             'Acme.Demo:Parent2' => $parentRole2
         ];
 
-        $this->assertEquals(2, count($role->getParentRoles()));
-        $this->assertEquals($expectedParentRoles, $role->getParentRoles());
+        self::assertEquals(2, count($role->getParentRoles()));
+        self::assertEquals($expectedParentRoles, $role->getParentRoles());
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/RequestPattern/ControllerObjectNameTest.php
+++ b/Neos.Flow/Tests/Unit/Security/RequestPattern/ControllerObjectNameTest.php
@@ -31,7 +31,7 @@ class ControllerObjectNameTest extends UnitTestCase
 
         $requestPattern = new ControllerObjectName(['controllerObjectNamePattern' => 'Neos\Flow\Security\.*']);
 
-        $this->assertTrue($requestPattern->matchRequest($request));
+        self::assertTrue($requestPattern->matchRequest($request));
     }
 
     /**
@@ -44,6 +44,6 @@ class ControllerObjectNameTest extends UnitTestCase
 
         $requestPattern = new ControllerObjectName(['controllerObjectNamePattern' => 'Neos\Flow\Security\.*']);
 
-        $this->assertFalse($requestPattern->matchRequest($request));
+        self::assertFalse($requestPattern->matchRequest($request));
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/RequestPattern/CsrfProtectionTest.php
+++ b/Neos.Flow/Tests/Unit/Security/RequestPattern/CsrfProtectionTest.php
@@ -88,7 +88,7 @@ class CsrfProtectionTest extends UnitTestCase
         $mockCsrfProtectionPattern->_set('securityContext', $mockSecurityContext);
         $mockCsrfProtectionPattern->_set('logger', $this->mockSystemLogger);
 
-        $this->assertFalse($mockCsrfProtectionPattern->matchRequest($this->mockActionRequest));
+        self::assertFalse($mockCsrfProtectionPattern->matchRequest($this->mockActionRequest));
     }
 
     /**
@@ -123,7 +123,7 @@ class CsrfProtectionTest extends UnitTestCase
         $mockCsrfProtectionPattern->_set('securityContext', $mockSecurityContext);
         $mockCsrfProtectionPattern->_set('logger', $this->mockSystemLogger);
 
-        $this->assertFalse($mockCsrfProtectionPattern->matchRequest($this->mockActionRequest));
+        self::assertFalse($mockCsrfProtectionPattern->matchRequest($this->mockActionRequest));
     }
 
     /**
@@ -167,7 +167,7 @@ class CsrfProtectionTest extends UnitTestCase
         $mockCsrfProtectionPattern->_set('securityContext', $mockSecurityContext);
         $mockCsrfProtectionPattern->_set('logger', $this->mockSystemLogger);
 
-        $this->assertTrue($mockCsrfProtectionPattern->matchRequest($this->mockActionRequest));
+        self::assertTrue($mockCsrfProtectionPattern->matchRequest($this->mockActionRequest));
     }
 
     /**
@@ -213,7 +213,7 @@ class CsrfProtectionTest extends UnitTestCase
         $mockCsrfProtectionPattern->_set('securityContext', $mockSecurityContext);
         $mockCsrfProtectionPattern->_set('logger', $this->mockSystemLogger);
 
-        $this->assertTrue($mockCsrfProtectionPattern->matchRequest($this->mockActionRequest));
+        self::assertTrue($mockCsrfProtectionPattern->matchRequest($this->mockActionRequest));
     }
 
     /**
@@ -259,7 +259,7 @@ class CsrfProtectionTest extends UnitTestCase
         $mockCsrfProtectionPattern->_set('securityContext', $mockSecurityContext);
         $mockCsrfProtectionPattern->_set('logger', $this->mockSystemLogger);
 
-        $this->assertFalse($mockCsrfProtectionPattern->matchRequest($this->mockActionRequest));
+        self::assertFalse($mockCsrfProtectionPattern->matchRequest($this->mockActionRequest));
     }
 
     /**
@@ -306,7 +306,7 @@ class CsrfProtectionTest extends UnitTestCase
         $mockCsrfProtectionPattern->_set('securityContext', $mockSecurityContext);
         $mockCsrfProtectionPattern->_set('logger', $this->mockSystemLogger);
 
-        $this->assertFalse($mockCsrfProtectionPattern->matchRequest($this->mockActionRequest));
+        self::assertFalse($mockCsrfProtectionPattern->matchRequest($this->mockActionRequest));
     }
 
     /**
@@ -325,7 +325,7 @@ class CsrfProtectionTest extends UnitTestCase
         $mockCsrfProtectionPattern->_set('authenticationManager', $mockAuthenticationManager);
         $mockCsrfProtectionPattern->_set('logger', $this->mockSystemLogger);
 
-        $this->assertFalse($mockCsrfProtectionPattern->matchRequest($this->mockActionRequest));
+        self::assertFalse($mockCsrfProtectionPattern->matchRequest($this->mockActionRequest));
     }
 
     /**
@@ -340,7 +340,7 @@ class CsrfProtectionTest extends UnitTestCase
         $mockCsrfProtectionPattern = $this->getAccessibleMock(Security\RequestPattern\CsrfProtection::class, ['dummy']);
         $mockCsrfProtectionPattern->_set('logger', $this->mockSystemLogger);
 
-        $this->assertFalse($mockCsrfProtectionPattern->matchRequest($this->mockActionRequest));
+        self::assertFalse($mockCsrfProtectionPattern->matchRequest($this->mockActionRequest));
     }
 
     /**
@@ -353,7 +353,7 @@ class CsrfProtectionTest extends UnitTestCase
         $mockCsrfProtectionPattern = $this->getAccessibleMock(Security\RequestPattern\CsrfProtection::class, ['dummy']);
         $mockCsrfProtectionPattern->_set('logger', $this->mockSystemLogger);
 
-        $this->assertFalse($mockCsrfProtectionPattern->matchRequest($mockRequest));
+        self::assertFalse($mockCsrfProtectionPattern->matchRequest($mockRequest));
     }
 
     /**
@@ -376,6 +376,6 @@ class CsrfProtectionTest extends UnitTestCase
         $mockCsrfProtectionPattern->_set('logger', $this->mockSystemLogger);
         $mockCsrfProtectionPattern->_set('securityContext', $mockSecurityContext);
 
-        $this->assertFalse($mockCsrfProtectionPattern->matchRequest($this->mockActionRequest));
+        self::assertFalse($mockCsrfProtectionPattern->matchRequest($this->mockActionRequest));
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/RequestPattern/HostTest.php
+++ b/Neos.Flow/Tests/Unit/Security/RequestPattern/HostTest.php
@@ -47,6 +47,6 @@ class HostTest extends UnitTestCase
 
         $requestPattern = new Host(['hostPattern' => $pattern]);
 
-        $this->assertEquals($expected, $requestPattern->matchRequest($request), $message);
+        self::assertEquals($expected, $requestPattern->matchRequest($request), $message);
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/RequestPattern/IpTest.php
+++ b/Neos.Flow/Tests/Unit/Security/RequestPattern/IpTest.php
@@ -55,6 +55,6 @@ class IpTest extends UnitTestCase
 
         $requestPattern = new Ip(['cidrPattern' => $pattern]);
 
-        $this->assertEquals($expected, $requestPattern->matchRequest($actionRequestMock));
+        self::assertEquals($expected, $requestPattern->matchRequest($actionRequestMock));
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/RequestPattern/UriTest.php
+++ b/Neos.Flow/Tests/Unit/Security/RequestPattern/UriTest.php
@@ -51,9 +51,9 @@ class UriTest extends UnitTestCase
         $requestPattern = new UriPattern(['uriPattern' => $pattern]);
 
         if ($shouldMatch) {
-            $this->assertTrue($requestPattern->matchRequest($mockActionRequest));
+            self::assertTrue($requestPattern->matchRequest($mockActionRequest));
         } else {
-            $this->assertFalse($requestPattern->matchRequest($mockActionRequest));
+            self::assertFalse($requestPattern->matchRequest($mockActionRequest));
         }
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/RequestPatternResolverTest.php
+++ b/Neos.Flow/Tests/Unit/Security/RequestPatternResolverTest.php
@@ -58,7 +58,7 @@ class RequestPatternResolverTest extends UnitTestCase
         $requestPatternResolver = new RequestPatternResolver($mockObjectManager);
         $requestPatternClass = $requestPatternResolver->resolveRequestPatternClass('ValidShortName');
 
-        $this->assertEquals($longNameForTest, $requestPatternClass, 'The wrong classname has been resolved');
+        self::assertEquals($longNameForTest, $requestPatternClass, 'The wrong classname has been resolved');
     }
 
     /**
@@ -72,6 +72,6 @@ class RequestPatternResolverTest extends UnitTestCase
         $requestPatternResolver = new RequestPatternResolver($mockObjectManager);
         $requestPatternClass = $requestPatternResolver->resolveRequestPatternClass('ExistingRequestPatternClass');
 
-        $this->assertEquals('ExistingRequestPatternClass', $requestPatternClass, 'The wrong classname has been resolved');
+        self::assertEquals('ExistingRequestPatternClass', $requestPatternClass, 'The wrong classname has been resolved');
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/SessionDataContainerTest.php
+++ b/Neos.Flow/Tests/Unit/Security/SessionDataContainerTest.php
@@ -55,9 +55,9 @@ class SessionDataContainerTest extends UnitTestCase
 
         $this->sessionDataContainer->reset();
 
-        $this->assertSame([], $this->sessionDataContainer->getCsrfProtectionTokens());
-        $this->assertNull($this->sessionDataContainer->getInterceptedRequest());
-        $this->assertSame([], $this->sessionDataContainer->getSecurityTokens());
+        self::assertSame([], $this->sessionDataContainer->getCsrfProtectionTokens());
+        self::assertNull($this->sessionDataContainer->getInterceptedRequest());
+        self::assertSame([], $this->sessionDataContainer->getSecurityTokens());
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Session/Aspect/SessionObjectMethodsPointcutFilterTest.php
+++ b/Neos.Flow/Tests/Unit/Session/Aspect/SessionObjectMethodsPointcutFilterTest.php
@@ -53,6 +53,6 @@ class SessionObjectMethodsPointcutFilterTest extends UnitTestCase
 
         $result = $sessionObjectMethodsPointcutFilter->reduceTargetClassNames($availableClassNamesIndex);
 
-        $this->assertEquals($expectedClassNamesIndex, $result, 'The wrong class names have been filtered');
+        self::assertEquals($expectedClassNamesIndex, $result, 'The wrong class names have been filtered');
     }
 }

--- a/Neos.Flow/Tests/Unit/Session/SessionTest.php
+++ b/Neos.Flow/Tests/Unit/Session/SessionTest.php
@@ -113,10 +113,10 @@ class SessionTest extends UnitTestCase
     {
         $storageIdentifier = '6e988eaa-7010-4ee8-bfb8-96ea4b40ec16';
         $session = new Session('ZPjPj3A0Opd7JeDoe7rzUQYCoDMcxscb', $storageIdentifier, 1354293259);
-        $this->assertTrue($session->isRemote());
+        self::assertTrue($session->isRemote());
 
         $session = new Session();
-        $this->assertFalse($session->isRemote());
+        self::assertFalse($session->isRemote());
     }
 
     /**
@@ -143,13 +143,13 @@ class SessionTest extends UnitTestCase
         $this->inject($session, 'storageCache', $storageCache);
         $session->initializeObject();
 
-        $this->assertFalse($session->hasKey('some key'));
+        self::assertFalse($session->hasKey('some key'));
         $session->putData('some key', 'some value');
 
-        $this->assertEquals('some value', $session->getData('some key'));
-        $this->assertTrue($session->hasKey('some key'));
+        self::assertEquals('some value', $session->getData('some key'));
+        self::assertTrue($session->hasKey('some key'));
 
-        $this->assertTrue($storageCache->has($storageIdentifier . md5('some key')));
+        self::assertTrue($storageCache->has($storageIdentifier . md5('some key')));
     }
 
     /**
@@ -158,7 +158,7 @@ class SessionTest extends UnitTestCase
     public function canBeResumedReturnsFalseIfNoSessionCookieExists()
     {
         $session = new Session();
-        $this->assertFalse($session->canBeResumed());
+        self::assertFalse($session->canBeResumed());
     }
 
     /**
@@ -174,7 +174,7 @@ class SessionTest extends UnitTestCase
 
         $session->start();
 
-        $this->assertFalse($session->canBeResumed());
+        self::assertFalse($session->canBeResumed());
     }
 
     /**
@@ -196,12 +196,12 @@ class SessionTest extends UnitTestCase
         $sessionIdentifier = $session->getId();
         $session->close();
 
-        $this->assertTrue($session->canBeResumed());
+        self::assertTrue($session->canBeResumed());
 
         $sessionInfo = $metaDataCache->get($sessionIdentifier);
         $sessionInfo['lastActivityTimestamp'] = time() - 4000;
         $metaDataCache->set($sessionIdentifier, $sessionInfo, [$sessionInfo['storageIdentifier'], 'session'], 0);
-        $this->assertFalse($session->canBeResumed());
+        self::assertFalse($session->canBeResumed());
     }
 
     /**
@@ -210,7 +210,7 @@ class SessionTest extends UnitTestCase
     public function isStartedReturnsFalseByDefault()
     {
         $session = new Session();
-        $this->assertFalse($session->isStarted());
+        self::assertFalse($session->isStarted());
     }
 
     /**
@@ -224,7 +224,7 @@ class SessionTest extends UnitTestCase
         $this->inject($session, 'storageCache', $this->createCache('Storage'));
         $session->initializeObject();
         $session->start();
-        $this->assertTrue($session->isStarted());
+        self::assertTrue($session->isStarted());
     }
 
     /**
@@ -246,8 +246,8 @@ class SessionTest extends UnitTestCase
 
         $session->resume();
 
-        $this->assertNotNull($session->getSessionCookie());
-        $this->assertEquals($sessionIdentifier, $session->getSessionCookie()->getValue());
+        self::assertNotNull($session->getSessionCookie());
+        self::assertEquals($sessionIdentifier, $session->getSessionCookie()->getValue());
     }
 
     /**
@@ -267,7 +267,7 @@ class SessionTest extends UnitTestCase
 
         $session->resume();
 
-        $this->assertTrue(true);
+        self::assertTrue(true);
     }
 
     /**
@@ -283,8 +283,8 @@ class SessionTest extends UnitTestCase
 
         $session->start();
 
-        $this->assertNotNull($session->getSessionCookie());
-        $this->assertEquals($session->getId(), $session->getSessionCookie()->getValue());
+        self::assertNotNull($session->getSessionCookie());
+        self::assertEquals($session->getId(), $session->getSessionCookie()->getValue());
     }
 
     /**
@@ -303,7 +303,7 @@ class SessionTest extends UnitTestCase
             $this->fail('No exception thrown although the session was not started yet.');
         } catch (SessionNotStartedException $e) {
             $session->start();
-            $this->assertEquals(32, strlen($session->getId()));
+            self::assertEquals(32, strlen($session->getId()));
         }
     }
 
@@ -322,7 +322,7 @@ class SessionTest extends UnitTestCase
         $oldSessionId = $session->getId();
         $session->renewId();
         $newSessionId = $session->getId();
-        $this->assertNotEquals($oldSessionId, $newSessionId);
+        self::assertNotEquals($oldSessionId, $newSessionId);
     }
 
     /**
@@ -385,7 +385,7 @@ class SessionTest extends UnitTestCase
 
         $session->resume();
 
-        $this->assertEquals('bar', $session->getData('foo'));
+        self::assertEquals('bar', $session->getData('foo'));
     }
 
     /**
@@ -438,10 +438,10 @@ class SessionTest extends UnitTestCase
 
         $session->start();
 
-        $this->assertFalse($session->hasKey('some key'));
+        self::assertFalse($session->hasKey('some key'));
         $session->putData('some key', 'some value');
-        $this->assertEquals('some value', $session->getData('some key'));
-        $this->assertTrue($session->hasKey('some key'));
+        self::assertEquals('some value', $session->getData('some key'));
+        self::assertTrue($session->hasKey('some key'));
     }
 
     /**
@@ -479,8 +479,8 @@ class SessionTest extends UnitTestCase
         $session1->putData('foo', 'bar');
         $session2->putData('foo', 'baz');
 
-        $this->assertEquals('bar', $session1->getData('foo'));
-        $this->assertEquals('baz', $session2->getData('foo'));
+        self::assertEquals('bar', $session1->getData('foo'));
+        self::assertEquals('baz', $session2->getData('foo'));
     }
 
     /**
@@ -513,12 +513,12 @@ class SessionTest extends UnitTestCase
 
         $session->start();
         $sessionIdentifier = $session->getId();
-        $this->assertEquals($now, $session->getLastActivityTimestamp());
+        self::assertEquals($now, $session->getLastActivityTimestamp());
 
         $session->close();
 
         $sessionInfo = $metaDataCache->get($sessionIdentifier);
-        $this->assertEquals($now, $sessionInfo['lastActivityTimestamp']);
+        self::assertEquals($now, $sessionInfo['lastActivityTimestamp']);
     }
 
     /**
@@ -586,8 +586,8 @@ class SessionTest extends UnitTestCase
         $this->inject($sessionManager, 'metaDataCache', $metaDataCache);
 
         $retrievedSessions = $sessionManager->getSessionsByTag('SampleTag');
-        $this->assertSame($taggedSessionId, $retrievedSessions[0]->getId());
-        $this->assertEquals(['SampleTag', 'AnotherTag'], $retrievedSessions[0]->getTags());
+        self::assertSame($taggedSessionId, $retrievedSessions[0]->getId());
+        self::assertEquals(['SampleTag', 'AnotherTag'], $retrievedSessions[0]->getTags());
     }
 
     /**
@@ -618,13 +618,13 @@ class SessionTest extends UnitTestCase
 
         $activeSessions = $sessionManager->getActiveSessions();
 
-        $this->assertCount(5, $activeSessions);
+        self::assertCount(5, $activeSessions);
 
         /* @var $randomActiveSession Session */
         $randomActiveSession = $activeSessions[array_rand($activeSessions)];
         $randomActiveSession->resume();
 
-        $this->assertContains($randomActiveSession->getId(), $sessionIDs);
+        self::assertContains($randomActiveSession->getId(), $sessionIDs);
     }
 
     /**
@@ -657,9 +657,9 @@ class SessionTest extends UnitTestCase
         $this->inject($session, 'metaDataCache', $metaDataCache);
         $this->inject($session, 'storageCache', $storageCache);
         $session->initializeObject();
-        $this->assertNotNull($session->resume(), 'The session was not properly resumed.');
+        self::assertNotNull($session->resume(), 'The session was not properly resumed.');
 
-        $this->assertEquals(['SampleTag', 'AnotherTag'], $session->getTags());
+        self::assertEquals(['SampleTag', 'AnotherTag'], $session->getTags());
     }
 
     /**
@@ -703,7 +703,7 @@ class SessionTest extends UnitTestCase
 
         $taggedSession->removeTag('DoesntExistButDoesNotAnyHarm');
 
-        $this->assertEquals(['AnotherTag', 'YetAnotherTag'], array_values($taggedSession->getTags()));
+        self::assertEquals(['AnotherTag', 'YetAnotherTag'], array_values($taggedSession->getTags()));
     }
 
     /**
@@ -736,8 +736,8 @@ class SessionTest extends UnitTestCase
         $session->touch();
 
         $sessionInfo = $metaDataCache->get('ZPjPj3A0Opd7JeDoe7rzUQYCoDMcxscb');
-        $this->assertEquals(2220000000, $sessionInfo['lastActivityTimestamp']);
-        $this->assertEquals($storageIdentifier, $sessionInfo['storageIdentifier']);
+        self::assertEquals(2220000000, $sessionInfo['lastActivityTimestamp']);
+        self::assertEquals($storageIdentifier, $sessionInfo['storageIdentifier']);
     }
 
     /**
@@ -753,10 +753,10 @@ class SessionTest extends UnitTestCase
         $session->initializeObject();
 
         $session->start();
-        $this->assertTrue($session->isStarted());
+        self::assertTrue($session->isStarted());
 
         $session->close();
-        $this->assertFalse($session->isStarted());
+        self::assertFalse($session->isStarted());
     }
 
     /**
@@ -773,10 +773,10 @@ class SessionTest extends UnitTestCase
         $session->initializeObject();
 
         $session->start();
-        $this->assertTrue($session->isStarted());
+        self::assertTrue($session->isStarted());
 
         $session->close();
-        $this->assertTrue($session->isStarted());
+        self::assertTrue($session->isStarted());
     }
 
     /**
@@ -808,7 +808,7 @@ class SessionTest extends UnitTestCase
         $session->close();
 
         $session->resume();
-        $this->assertEquals(['MyProvider:admin'], $session->getData('Neos_Flow_Security_Accounts'));
+        self::assertEquals(['MyProvider:admin'], $session->getData('Neos_Flow_Security_Accounts'));
     }
 
     /**
@@ -843,7 +843,7 @@ class SessionTest extends UnitTestCase
         $remoteSession->initializeObject();
 
         // Resume the local session and add more data:
-        $this->assertTrue($metaDataCache->has($sessionIdentifier));
+        self::assertTrue($metaDataCache->has($sessionIdentifier));
         $session->resume();
         $session->putData('baz', 'quux');
 
@@ -853,7 +853,7 @@ class SessionTest extends UnitTestCase
         // Close the local session – this must not write any data because the session doesn't exist anymore:
         $session->close();
 
-        $this->assertFalse($metaDataCache->has($sessionIdentifier));
+        self::assertFalse($metaDataCache->has($sessionIdentifier));
     }
 
     /**
@@ -897,9 +897,9 @@ class SessionTest extends UnitTestCase
 
         $this->inject($session1, 'started', true);
         $this->inject($session2, 'started', true);
-        $this->assertFalse($session1->hasKey('session 1 key 1'));
-        $this->assertFalse($session1->hasKey('session 1 key 2'));
-        $this->assertTrue($session2->hasKey('session 2 key'), 'Entry in session was also removed.');
+        self::assertFalse($session1->hasKey('session 1 key 1'));
+        self::assertFalse($session1->hasKey('session 1 key 2'));
+        self::assertTrue($session2->hasKey('session 2 key'), 'Entry in session was also removed.');
     }
 
     /**
@@ -923,8 +923,8 @@ class SessionTest extends UnitTestCase
         $session->destroy(__METHOD__);
 
         $this->inject($session, 'started', true);
-        $this->assertFalse($session->hasKey('session 1 key 1'));
-        $this->assertFalse($session->hasKey('session 1 key 2'));
+        self::assertFalse($session->hasKey('session 1 key 1'));
+        self::assertFalse($session->hasKey('session 1 key 2'));
     }
 
     /**
@@ -951,8 +951,8 @@ class SessionTest extends UnitTestCase
         $session->putData('session 1 key 1', 'some value');
         $session->putData('session 1 key 2', 'some other value');
 
-        $this->assertTrue($storageCache->has($storageIdentifier . md5('session 1 key 1')));
-        $this->assertTrue($storageCache->has($storageIdentifier . md5('session 1 key 2')));
+        self::assertTrue($storageCache->has($storageIdentifier . md5('session 1 key 1')));
+        self::assertTrue($storageCache->has($storageIdentifier . md5('session 1 key 2')));
 
         $session->close();
 
@@ -961,10 +961,10 @@ class SessionTest extends UnitTestCase
         $metaDataCache->set($sessionIdentifier, $sessionInfo, [$storageIdentifier, 'session'], 0);
 
         // canBeResumed implicitly calls autoExpire():
-        $this->assertFalse($session->canBeResumed(), 'canBeResumed');
+        self::assertFalse($session->canBeResumed(), 'canBeResumed');
 
-        $this->assertFalse($storageCache->has($storageIdentifier . md5('session 1 key 1')));
-        $this->assertFalse($storageCache->has($storageIdentifier . md5('session 1 key 2')));
+        self::assertFalse($storageCache->has($storageIdentifier . md5('session 1 key 1')));
+        self::assertFalse($storageCache->has($storageIdentifier . md5('session 1 key 2')));
     }
 
     /**
@@ -995,8 +995,8 @@ class SessionTest extends UnitTestCase
         $session->close();
 
         $session->resume();
-        $this->assertTrue($session->isStarted());
-        $this->assertTrue($metaDataCache->has($sessionIdentifier1), 'session 1 meta entry doesnt exist');
+        self::assertTrue($session->isStarted());
+        self::assertTrue($metaDataCache->has($sessionIdentifier1), 'session 1 meta entry doesnt exist');
         $session->close();
 
         $sessionInfo1 = $metaDataCache->get($sessionIdentifier1);
@@ -1029,11 +1029,11 @@ class SessionTest extends UnitTestCase
         $sessionInfo2 = $metaDataCache->get($sessionIdentifier2);
 
         // Check how the cache looks like - data of session 1 should be gone:
-        $this->assertFalse($metaDataCache->has($sessionIdentifier1), 'session 1 meta entry still there');
-        $this->assertFalse($storageCache->has($sessionInfo1['storageIdentifier'] . md5('session 1 key 1')), 'session 1 key 1 still there');
-        $this->assertFalse($storageCache->has($sessionInfo1['storageIdentifier'] . md5('session 1 key 2')), 'session 1 key 2 still there');
-        $this->assertTrue($storageCache->has($sessionInfo2['storageIdentifier'] . md5('session 2 key 1')), 'session 2 key 1 not there');
-        $this->assertTrue($storageCache->has($sessionInfo2['storageIdentifier'] . md5('session 2 key 2')), 'session 2 key 2 not there');
+        self::assertFalse($metaDataCache->has($sessionIdentifier1), 'session 1 meta entry still there');
+        self::assertFalse($storageCache->has($sessionInfo1['storageIdentifier'] . md5('session 1 key 1')), 'session 1 key 1 still there');
+        self::assertFalse($storageCache->has($sessionInfo1['storageIdentifier'] . md5('session 1 key 2')), 'session 1 key 2 still there');
+        self::assertTrue($storageCache->has($sessionInfo2['storageIdentifier'] . md5('session 2 key 1')), 'session 2 key 1 not there');
+        self::assertTrue($storageCache->has($sessionInfo2['storageIdentifier'] . md5('session 2 key 2')), 'session 2 key 2 not there');
     }
 
     /**
@@ -1054,7 +1054,7 @@ class SessionTest extends UnitTestCase
         $session->injectSettings($settings);
         $session->initializeObject();
 
-        $this->assertSame(0, $session->collectGarbage());
+        self::assertSame(0, $session->collectGarbage());
     }
 
     /**
@@ -1077,12 +1077,12 @@ class SessionTest extends UnitTestCase
         $session->initializeObject();
 
         // No sessions need to be removed:
-        $this->assertSame(0, $session->collectGarbage());
+        self::assertSame(0, $session->collectGarbage());
 
         $metaDataCache->set('_garbage-collection-running', true, [], 120);
 
         // Session garbage collection is omitted:
-        $this->assertFalse($session->collectGarbage());
+        self::assertFalse($session->collectGarbage());
     }
 
     /**
@@ -1117,7 +1117,7 @@ class SessionTest extends UnitTestCase
             $metaDataCache->set($sessionIdentifier, $sessionInfo, ['session'], 0);
         }
 
-        $this->assertLessThanOrEqual(5, $session->collectGarbage());
+        self::assertLessThanOrEqual(5, $session->collectGarbage());
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Session/TransientSessionTest.php
+++ b/Neos.Flow/Tests/Unit/Session/TransientSessionTest.php
@@ -25,7 +25,7 @@ class TransientSessionTest extends UnitTestCase
     public function theTransientSessionImplementsTheSessionInterface()
     {
         $session = new Session\TransientSession();
-        $this->assertInstanceOf(Session\SessionInterface::class, $session);
+        self::assertInstanceOf(Session\SessionInterface::class, $session);
     }
 
     /**
@@ -35,7 +35,7 @@ class TransientSessionTest extends UnitTestCase
     {
         $session = new Session\TransientSession();
         $session->start();
-        $this->assertTrue(strlen($session->getId()) == 13);
+        self::assertTrue(strlen($session->getId()) == 13);
     }
 
     /**
@@ -56,7 +56,7 @@ class TransientSessionTest extends UnitTestCase
         $session = new Session\TransientSession();
         $session->start();
         $session->putData('theKey', 'some data');
-        $this->assertEquals('some data', $session->getData('theKey'));
+        self::assertEquals('some data', $session->getData('theKey'));
     }
 
     /**
@@ -69,7 +69,7 @@ class TransientSessionTest extends UnitTestCase
         $session->putData('theKey', 'some data');
         $session->destroy();
         $session->start();
-        $this->assertNull($session->getData('theKey'));
+        self::assertNull($session->getData('theKey'));
     }
 
     /**
@@ -80,7 +80,7 @@ class TransientSessionTest extends UnitTestCase
         $session = new Session\TransientSession();
         $session->start();
         $session->putData('theKey', 'some data');
-        $this->assertTrue($session->hasKey('theKey'));
-        $this->assertFalse($session->hasKey('noKey'));
+        self::assertTrue($session->hasKey('theKey'));
+        self::assertFalse($session->hasKey('noKey'));
     }
 }

--- a/Neos.Flow/Tests/Unit/SignalSlot/DispatcherTest.php
+++ b/Neos.Flow/Tests/Unit/SignalSlot/DispatcherTest.php
@@ -35,7 +35,7 @@ class DispatcherTest extends UnitTestCase
         $expectedSlots = [
             ['class' => get_class($mockSlot), 'method' => 'someSlotMethod', 'object' => null, 'passSignalInformation' => false]
         ];
-        $this->assertSame($expectedSlots, $dispatcher->getSlots(get_class($mockSignal), 'someSignal'));
+        self::assertSame($expectedSlots, $dispatcher->getSlots(get_class($mockSignal), 'someSignal'));
     }
 
     /**
@@ -52,7 +52,7 @@ class DispatcherTest extends UnitTestCase
         $expectedSlots = [
             ['class' => null, 'method' => 'someSlotMethod', 'object' => $mockSlot, 'passSignalInformation' => false]
         ];
-        $this->assertSame($expectedSlots, $dispatcher->getSlots(get_class($mockSignal), 'someSignal'));
+        self::assertSame($expectedSlots, $dispatcher->getSlots(get_class($mockSignal), 'someSignal'));
     }
 
     /**
@@ -70,7 +70,7 @@ class DispatcherTest extends UnitTestCase
         $expectedSlots = [
             ['class' => null, 'method' => '__invoke', 'object' => $mockSlot, 'passSignalInformation' => false]
         ];
-        $this->assertSame($expectedSlots, $dispatcher->getSlots(get_class($mockSignal), 'someSignal'));
+        self::assertSame($expectedSlots, $dispatcher->getSlots(get_class($mockSignal), 'someSignal'));
     }
 
     /**
@@ -90,7 +90,7 @@ class DispatcherTest extends UnitTestCase
         $dispatcher->injectObjectManager($mockObjectManager);
 
         $dispatcher->dispatch('Foo', 'bar', ['foo' => 'bar', 'baz' => 'quux']);
-        $this->assertSame(['bar', 'quux'], $arguments);
+        self::assertSame(['bar', 'quux'], $arguments);
     }
 
     /**
@@ -106,7 +106,7 @@ class DispatcherTest extends UnitTestCase
         $dispatcher->injectObjectManager($mockObjectManager);
 
         $dispatcher->dispatch('Foo', 'bar', ['foo' => 'bar', 'baz' => 'quux']);
-        $this->assertSame(['bar', 'quux'], self::$arguments);
+        self::assertSame(['bar', 'quux'], self::$arguments);
     }
 
     /**
@@ -118,7 +118,7 @@ class DispatcherTest extends UnitTestCase
         $dispatcher->connect('Foo', 'bar', get_class($this), '::staticSlot', false);
 
         $dispatcher->dispatch('Foo', 'bar', ['no' => 'object', 'manager' => 'exists']);
-        $this->assertSame(['object', 'exists'], self::$arguments);
+        self::assertSame(['object', 'exists'], self::$arguments);
     }
 
     /**
@@ -155,7 +155,7 @@ class DispatcherTest extends UnitTestCase
         $dispatcher->connect('Foo', 'bar', $slotClassName, 'slot', false);
 
         $dispatcher->dispatch('Foo', 'bar', ['foo' => 'bar', 'baz' => 'quux']);
-        $this->assertSame($mockSlot->arguments, ['bar', 'quux']);
+        self::assertSame($mockSlot->arguments, ['bar', 'quux']);
     }
 
     /**
@@ -192,7 +192,7 @@ class DispatcherTest extends UnitTestCase
         $dispatcher->connect('Foo', 'bar', $slotClassName, 'unknownMethodName', true);
 
         $dispatcher->dispatch('Foo', 'bar', ['foo' => 'bar', 'baz' => 'quux']);
-        $this->assertSame($mockSlot->arguments, ['bar', 'quux']);
+        self::assertSame($mockSlot->arguments, ['bar', 'quux']);
     }
 
     /**
@@ -212,7 +212,7 @@ class DispatcherTest extends UnitTestCase
         $dispatcher->injectObjectManager($mockObjectManager);
 
         $dispatcher->dispatch('SignalClassName', 'methodName', ['foo' => 'bar', 'baz' => 'quux']);
-        $this->assertSame(['bar', 'quux', 'SignalClassName::methodName'], $arguments);
+        self::assertSame(['bar', 'quux', 'SignalClassName::methodName'], $arguments);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Utility/AlgorithmsTest.php
+++ b/Neos.Flow/Tests/Unit/Utility/AlgorithmsTest.php
@@ -25,7 +25,7 @@ class AlgorithmsTest extends UnitTestCase
      */
     public function generateUUIDGeneratesUuidLikeString()
     {
-        $this->assertRegExp('/^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}$/', Algorithms::generateUUID());
+        self::assertRegExp('/^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}$/', Algorithms::generateUUID());
     }
 
     /**
@@ -34,7 +34,7 @@ class AlgorithmsTest extends UnitTestCase
     public function generateUUIDGeneratesLowercaseString()
     {
         $uuid = Algorithms::generateUUID();
-        $this->assertSame(strtolower($uuid), $uuid);
+        self::assertSame(strtolower($uuid), $uuid);
     }
 
     /**
@@ -42,7 +42,7 @@ class AlgorithmsTest extends UnitTestCase
      */
     public function generateUUIDGeneratesAtLeastNotTheSameUuidOnSubsequentCalls()
     {
-        $this->assertNotEquals(Algorithms::generateUUID(), Algorithms::generateUUID());
+        self::assertNotEquals(Algorithms::generateUUID(), Algorithms::generateUUID());
     }
 
     /**
@@ -50,7 +50,7 @@ class AlgorithmsTest extends UnitTestCase
      */
     public function generateRandomBytesGeneratesRandomBytes()
     {
-        $this->assertEquals(20, strlen(Algorithms::generateRandomBytes(20)));
+        self::assertEquals(20, strlen(Algorithms::generateRandomBytes(20)));
     }
 
     /**
@@ -58,7 +58,7 @@ class AlgorithmsTest extends UnitTestCase
      */
     public function generateRandomTokenGeneratesRandomToken()
     {
-        $this->assertRegExp('/^[[:xdigit:]]{64}$/', Algorithms::generateRandomToken(32));
+        self::assertRegExp('/^[[:xdigit:]]{64}$/', Algorithms::generateRandomToken(32));
     }
 
     /**
@@ -66,7 +66,7 @@ class AlgorithmsTest extends UnitTestCase
      */
     public function generateRandomStringGeneratesAlnumCharactersPerDefault()
     {
-        $this->assertRegExp('/^[a-z0-9]{64}$/i', Algorithms::generateRandomString(64));
+        self::assertRegExp('/^[a-z0-9]{64}$/i', Algorithms::generateRandomString(64));
     }
 
     /**
@@ -86,6 +86,6 @@ class AlgorithmsTest extends UnitTestCase
      */
     public function generateRandomStringGeneratesOnlyDefinedCharactersRange($regularExpression, $charactersClass)
     {
-        $this->assertRegExp($regularExpression, Algorithms::generateRandomString(64, $charactersClass));
+        self::assertRegExp($regularExpression, Algorithms::generateRandomString(64, $charactersClass));
     }
 }

--- a/Neos.Flow/Tests/Unit/Utility/EnvironmentTest.php
+++ b/Neos.Flow/Tests/Unit/Utility/EnvironmentTest.php
@@ -29,7 +29,7 @@ class EnvironmentTest extends UnitTestCase
         $environment = new Environment(new ApplicationContext('Testing'));
         $environment->setTemporaryDirectoryBase(Files::concatenatePaths([sys_get_temp_dir(), 'FlowEnvironmentTest']));
         $path = $environment->getPathToTemporaryDirectory();
-        $this->assertEquals('/', substr($path, -1, 1), 'The temporary path did not end with slash.');
+        self::assertEquals('/', substr($path, -1, 1), 'The temporary path did not end with slash.');
     }
 
     /**
@@ -41,7 +41,7 @@ class EnvironmentTest extends UnitTestCase
         $environment->setTemporaryDirectoryBase(Files::concatenatePaths([sys_get_temp_dir(), 'FlowEnvironmentTest']));
 
         $path = $environment->getPathToTemporaryDirectory();
-        $this->assertTrue(file_exists($path), 'The temporary path does not exist.');
+        self::assertTrue(file_exists($path), 'The temporary path does not exist.');
     }
 
     /**
@@ -54,6 +54,6 @@ class EnvironmentTest extends UnitTestCase
         if ((integer)$expectedValue <= 0) {
             $this->fail('The PHP Constant PHP_MAXPATHLEN is not available on your system! Please file a PHP bug report.');
         }
-        $this->assertEquals($expectedValue, $environment->getMaximumPathLength());
+        self::assertEquals($expectedValue, $environment->getMaximumPathLength());
     }
 }

--- a/Neos.Flow/Tests/Unit/Utility/IpTest.php
+++ b/Neos.Flow/Tests/Unit/Utility/IpTest.php
@@ -46,6 +46,6 @@ class IpTest extends \Neos\Flow\Tests\UnitTestCase
      */
     public function cidrMatchCorrectlyMatchesIpRanges($range, $ip, $expected)
     {
-        $this->assertEquals($expected, Ip::cidrMatch($ip, $range));
+        self::assertEquals($expected, Ip::cidrMatch($ip, $range));
     }
 }

--- a/Neos.Flow/Tests/Unit/Utility/PhpAnalyzerTest.php
+++ b/Neos.Flow/Tests/Unit/Utility/PhpAnalyzerTest.php
@@ -48,7 +48,7 @@ class PhpAnalyzerTest extends UnitTestCase
     public function extractNamespaceTests($phpCode, $namespace)
     {
         $phpAnalyzer = new PhpAnalyzer($phpCode);
-        $this->assertSame($namespace, $phpAnalyzer->extractNamespace());
+        self::assertSame($namespace, $phpAnalyzer->extractNamespace());
     }
 
     /**
@@ -61,7 +61,7 @@ class PhpAnalyzerTest extends UnitTestCase
     public function extractClassNameTests($phpCode, $namespace, $className)
     {
         $phpAnalyzer = new PhpAnalyzer($phpCode);
-        $this->assertSame($className, $phpAnalyzer->extractClassName());
+        self::assertSame($className, $phpAnalyzer->extractClassName());
     }
 
     /**
@@ -75,6 +75,6 @@ class PhpAnalyzerTest extends UnitTestCase
     public function extractFullyQualifiedClassNameTests($phpCode, $namespace, $className, $fqn)
     {
         $phpAnalyzer = new PhpAnalyzer($phpCode);
-        $this->assertSame($fqn, $phpAnalyzer->extractFullyQualifiedClassName());
+        self::assertSame($fqn, $phpAnalyzer->extractFullyQualifiedClassName());
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/AbstractValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/AbstractValidatorTest.php
@@ -39,7 +39,7 @@ class AbstractValidatorTest extends UnitTestCase
     {
         $this->validator->__construct(['thirdPlaceHolder' => 'dummy']);
 
-        $this->assertInstanceOf(AbstractValidator::class, $this->validator);
+        self::assertInstanceOf(AbstractValidator::class, $this->validator);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Validation/Validator/AlphanumericValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/AlphanumericValidatorTest.php
@@ -28,7 +28,7 @@ class AlphanumericValidatorTest extends AbstractValidatorTestcase
      */
     public function alphanumericValidatorShouldReturnNoErrorsIfTheGivenValueIsNull()
     {
-        $this->assertFalse($this->validator->validate(null)->hasErrors());
+        self::assertFalse($this->validator->validate(null)->hasErrors());
     }
 
     /**
@@ -36,7 +36,7 @@ class AlphanumericValidatorTest extends AbstractValidatorTestcase
      */
     public function alphanumericValidatorShouldReturnNoErrorsIfTheGivenStringIsEmpty()
     {
-        $this->assertFalse($this->validator->validate('')->hasErrors());
+        self::assertFalse($this->validator->validate('')->hasErrors());
     }
 
     /**
@@ -44,7 +44,7 @@ class AlphanumericValidatorTest extends AbstractValidatorTestcase
      */
     public function alphanumericValidatorShouldReturnNoErrorsForAnAlphanumericString()
     {
-        $this->assertFalse($this->validator->validate('12ssDF34daweidf')->hasErrors());
+        self::assertFalse($this->validator->validate('12ssDF34daweidf')->hasErrors());
     }
 
     /**
@@ -52,7 +52,7 @@ class AlphanumericValidatorTest extends AbstractValidatorTestcase
      */
     public function alphanumericValidatorShouldReturnNoErrorsForAnAlphanumericStringWithUmlauts()
     {
-        $this->assertFalse($this->validator->validate('12ssDF34daweidfäøüößØLīgaestevimīlojuņščļœøÅ')->hasErrors());
+        self::assertFalse($this->validator->validate('12ssDF34daweidfäøüößØLīgaestevimīlojuņščļœøÅ')->hasErrors());
     }
 
     /**
@@ -60,7 +60,7 @@ class AlphanumericValidatorTest extends AbstractValidatorTestcase
      */
     public function alphanumericValidatorReturnsErrorsForAStringWithSpecialCharacters()
     {
-        $this->assertTrue($this->validator->validate('adsf%&/$jklsfdö')->hasErrors());
+        self::assertTrue($this->validator->validate('adsf%&/$jklsfdö')->hasErrors());
     }
 
     /**
@@ -68,6 +68,6 @@ class AlphanumericValidatorTest extends AbstractValidatorTestcase
      */
     public function alphanumericValidatorCreatesTheCorrectErrorForAnInvalidSubject()
     {
-        $this->assertEquals(1, count($this->validator->validate('adsf%&/$jklsfdö')->getErrors()));
+        self::assertEquals(1, count($this->validator->validate('adsf%&/$jklsfdö')->getErrors()));
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/BooleanValueValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/BooleanValueValidatorTest.php
@@ -27,7 +27,7 @@ class BooleanValueValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsAnEmptyString()
     {
-        $this->assertFalse($this->validator->validate('')->hasErrors());
+        self::assertFalse($this->validator->validate('')->hasErrors());
     }
 
     /**
@@ -35,7 +35,7 @@ class BooleanValueValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsNull()
     {
-        $this->assertFalse($this->validator->validate(null)->hasErrors());
+        self::assertFalse($this->validator->validate(null)->hasErrors());
     }
 
     /**
@@ -43,7 +43,7 @@ class BooleanValueValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsTrueAndNoOptionIsSet()
     {
-        $this->assertFalse($this->validator->validate(true)->hasErrors());
+        self::assertFalse($this->validator->validate(true)->hasErrors());
     }
 
     /**
@@ -52,7 +52,7 @@ class BooleanValueValidatorTest extends AbstractValidatorTestcase
     public function validateReturnsNoErrorIfTheGivenValueIsFalseAndExpectedValueIsFalse()
     {
         $this->validatorOptions(['expectedValue' => false]);
-        $this->assertFalse($this->validator->validate(false)->hasErrors());
+        self::assertFalse($this->validator->validate(false)->hasErrors());
     }
 
     /**
@@ -60,7 +60,7 @@ class BooleanValueValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsErrorIfTheGivenValueIsAString()
     {
-        $this->assertTrue($this->validator->validate('1')->hasErrors());
+        self::assertTrue($this->validator->validate('1')->hasErrors());
     }
 
     /**
@@ -68,7 +68,7 @@ class BooleanValueValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsErrorIfTheGivenValueIsFalse()
     {
-        $this->assertTrue($this->validator->validate(false)->hasErrors());
+        self::assertTrue($this->validator->validate(false)->hasErrors());
     }
 
     /**
@@ -76,6 +76,6 @@ class BooleanValueValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsErrorIfTheGivenValueIsAnInteger()
     {
-        $this->assertTrue($this->validator->validate(1)->hasErrors());
+        self::assertTrue($this->validator->validate(1)->hasErrors());
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/CollectionValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/CollectionValidatorTest.php
@@ -42,7 +42,7 @@ class CollectionValidatorTest extends AbstractValidatorTestcase
      */
     public function collectionValidatorReturnsNoErrorsForANullValue()
     {
-        $this->assertFalse($this->validator->validate(null)->hasErrors());
+        self::assertFalse($this->validator->validate(null)->hasErrors());
     }
 
     /**
@@ -50,7 +50,7 @@ class CollectionValidatorTest extends AbstractValidatorTestcase
      */
     public function collectionValidatorFailsForAValueNotBeingACollection()
     {
-        $this->assertTrue($this->validator->validate(new \StdClass())->hasErrors());
+        self::assertTrue($this->validator->validate(new \StdClass())->hasErrors());
     }
 
     /**
@@ -70,8 +70,8 @@ class CollectionValidatorTest extends AbstractValidatorTestcase
 
         $result = $this->validator->validate($arrayOfEmailAddresses);
 
-        $this->assertTrue($result->hasErrors());
-        $this->assertEquals(2, count($result->getFlattenedErrors()));
+        self::assertTrue($result->hasErrors());
+        self::assertEquals(2, count($result->getFlattenedErrors()));
     }
 
     /**
@@ -102,7 +102,7 @@ class CollectionValidatorTest extends AbstractValidatorTestcase
         $aValidator->addPropertyValidator('integer', $integerValidator);
 
         $result = $aValidator->validate($A)->getFlattenedErrors();
-        $this->assertEquals('A valid integer number is expected.', $result['b.0'][0]->getMessage());
+        self::assertEquals('A valid integer number is expected.', $result['b.0'][0]->getMessage());
     }
 
     /**
@@ -130,6 +130,6 @@ class CollectionValidatorTest extends AbstractValidatorTestcase
 
         $result = $this->validator->validate([5, 6, 1]);
 
-        $this->assertCount(1, $result->getFlattenedErrors());
+        self::assertCount(1, $result->getFlattenedErrors());
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/ConjunctionValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/ConjunctionValidatorTest.php
@@ -32,7 +32,7 @@ class ConjunctionValidatorTest extends UnitTestCase
 
         $mockValidator = $this->createMock(ValidatorInterface::class);
         $conjunctionValidator->addValidator($mockValidator);
-        $this->assertTrue($conjunctionValidator->_get('validators')->contains($mockValidator));
+        self::assertTrue($conjunctionValidator->_get('validators')->contains($mockValidator));
     }
 
     /**
@@ -74,7 +74,7 @@ class ConjunctionValidatorTest extends UnitTestCase
         $validatorConjunction->addValidator($validatorObject);
         $validatorConjunction->addValidator($secondValidatorObject);
 
-        $this->assertFalse($validatorConjunction->validate('some subject')->hasErrors());
+        self::assertFalse($validatorConjunction->validate('some subject')->hasErrors());
     }
 
     /**
@@ -92,7 +92,7 @@ class ConjunctionValidatorTest extends UnitTestCase
 
         $validatorConjunction->addValidator($validatorObject);
 
-        $this->assertTrue($validatorConjunction->validate('some subject')->hasErrors());
+        self::assertTrue($validatorConjunction->validate('some subject')->hasErrors());
     }
 
     /**
@@ -110,8 +110,8 @@ class ConjunctionValidatorTest extends UnitTestCase
 
         $validatorConjunction->removeValidator($validator1);
 
-        $this->assertFalse($validatorConjunction->_get('validators')->contains($validator1));
-        $this->assertTrue($validatorConjunction->_get('validators')->contains($validator2));
+        self::assertFalse($validatorConjunction->_get('validators')->contains($validator1));
+        self::assertTrue($validatorConjunction->_get('validators')->contains($validator2));
     }
 
     /**
@@ -135,11 +135,11 @@ class ConjunctionValidatorTest extends UnitTestCase
         $validator1 = $this->createMock(ValidatorInterface::class);
         $validator2 = $this->createMock(ValidatorInterface::class);
 
-        $this->assertSame(0, count($validatorConjunction));
+        self::assertSame(0, count($validatorConjunction));
 
         $validatorConjunction->addValidator($validator1);
         $validatorConjunction->addValidator($validator2);
 
-        $this->assertSame(2, count($validatorConjunction));
+        self::assertSame(2, count($validatorConjunction));
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/CountValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/CountValidatorTest.php
@@ -29,7 +29,7 @@ class CountValidatorTest extends AbstractValidatorTestcase
     public function countValidatorReturnsNoErrorsIfTheGivenValueIsNull()
     {
         $this->validatorOptions(['minimum' => 1, 'maximum' => 10]);
-        $this->assertFalse($this->validator->validate(null)->hasErrors());
+        self::assertFalse($this->validator->validate(null)->hasErrors());
     }
 
     /**
@@ -38,7 +38,7 @@ class CountValidatorTest extends AbstractValidatorTestcase
     public function countValidatorReturnsNoErrorsIfTheGivenStringIsEmpty()
     {
         $this->validatorOptions(['minimum' => 1, 'maximum' => 10]);
-        $this->assertFalse($this->validator->validate('')->hasErrors());
+        self::assertFalse($this->validator->validate('')->hasErrors());
     }
 
     /**
@@ -62,7 +62,7 @@ class CountValidatorTest extends AbstractValidatorTestcase
     public function countValidatorReturnsNoErrorsForValidCountables($countable)
     {
         $this->validatorOptions(['minimum' => 1, 'maximum' => 10]);
-        $this->assertFalse($this->validator->validate($countable)->hasErrors());
+        self::assertFalse($this->validator->validate($countable)->hasErrors());
     }
 
     /**
@@ -72,7 +72,7 @@ class CountValidatorTest extends AbstractValidatorTestcase
     public function countValidatorReturnsErrorsForInvalidCountables($countable)
     {
         $this->validatorOptions(['minimum' => 5, 'maximum' => 10]);
-        $this->assertTrue($this->validator->validate($countable)->hasErrors());
+        self::assertTrue($this->validator->validate($countable)->hasErrors());
     }
 
     /**
@@ -94,6 +94,6 @@ class CountValidatorTest extends AbstractValidatorTestcase
      */
     public function countValidatorReturnsErrorsForNonCountables($nonCountable)
     {
-        $this->assertTrue($this->validator->validate($nonCountable)->hasErrors());
+        self::assertTrue($this->validator->validate($nonCountable)->hasErrors());
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/DateTimeRangeValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/DateTimeRangeValidatorTest.php
@@ -45,7 +45,7 @@ class DateTimeRangeValidatorTest extends AbstractValidatorTestcase
     public function parseReferenceDateReturnsInstanceOfDateTime()
     {
         $testResult = $this->accessibleValidator->_call('parseReferenceDate', '2007-03-01T13:00:00Z/P1Y2M10DT2H30M');
-        $this->assertTrue($testResult instanceof \DateTime);
+        self::assertTrue($testResult instanceof \DateTime);
     }
 
     /**
@@ -54,7 +54,7 @@ class DateTimeRangeValidatorTest extends AbstractValidatorTestcase
     public function parseReferenceDateReturnsTimeWithoutCalculationCorrectly()
     {
         $testResult = $this->accessibleValidator->_call('parseReferenceDate', '2007-03-01T13:00:00Z');
-        $this->assertEquals('2007-03-01 13:00', $testResult->format('Y-m-d H:i'));
+        self::assertEquals('2007-03-01 13:00', $testResult->format('Y-m-d H:i'));
     }
 
     /**
@@ -63,7 +63,7 @@ class DateTimeRangeValidatorTest extends AbstractValidatorTestcase
     public function parseReferenceDateAddsTimeIntervalCorrectlyUsingOnlyHourAndMinute()
     {
         $testResult = $this->accessibleValidator->_call('parseReferenceDate', '2007-03-01T13:00:00Z/PT2H30M');
-        $this->assertEquals('2007-03-01 15:30', $testResult->format('Y-m-d H:i'));
+        self::assertEquals('2007-03-01 15:30', $testResult->format('Y-m-d H:i'));
     }
 
     /**
@@ -72,7 +72,7 @@ class DateTimeRangeValidatorTest extends AbstractValidatorTestcase
     public function parseReferenceDateSubstractsTimeIntervalCorrectlyUsingMonthAndMinuteForcingYearSwap()
     {
         $testResult = $this->accessibleValidator->_call('parseReferenceDate', 'P4MT15M/2013-02-01T13:00:00Z');
-        $this->assertEquals('2012-10-01 12:45', $testResult->format('Y-m-d H:i'));
+        self::assertEquals('2012-10-01 12:45', $testResult->format('Y-m-d H:i'));
     }
 
     /**
@@ -81,7 +81,7 @@ class DateTimeRangeValidatorTest extends AbstractValidatorTestcase
     public function validateReturnsNoErrorIfTheGivenValueIsNull()
     {
         $this->validatorOptions(['earliestDate' => '2007-03-01T13:00:00Z']);
-        $this->assertFalse($this->validator->validate(null)->hasErrors());
+        self::assertFalse($this->validator->validate(null)->hasErrors());
     }
 
     /**
@@ -90,7 +90,7 @@ class DateTimeRangeValidatorTest extends AbstractValidatorTestcase
     public function validateReturnsNoErrorIfTheGivenValueIsAnEmptyString()
     {
         $this->validatorOptions(['earliestDate' => '2007-03-01T13:00:00Z']);
-        $this->assertFalse($this->validator->validate('')->hasErrors());
+        self::assertFalse($this->validator->validate('')->hasErrors());
     }
 
     /**
@@ -101,7 +101,7 @@ class DateTimeRangeValidatorTest extends AbstractValidatorTestcase
         $this->validatorOptions(['earliestDate' => '2007-03-01T13:00:00Z']);
 
         $errors = $this->validator->validate('no DateTime object')->getErrors();
-        $this->assertSame(1, count($errors));
+        self::assertSame(1, count($errors));
     }
 
     /**
@@ -111,7 +111,7 @@ class DateTimeRangeValidatorTest extends AbstractValidatorTestcase
     {
         $this->validatorOptions(['earliestDate' => '2007-03-01T13:00:00Z']);
 
-        $this->assertFalse($this->validator->validate(new \DateTime('2009-03-01T13:00:00Z'))->hasErrors());
+        self::assertFalse($this->validator->validate(new \DateTime('2009-03-01T13:00:00Z'))->hasErrors());
     }
 
     /**
@@ -121,7 +121,7 @@ class DateTimeRangeValidatorTest extends AbstractValidatorTestcase
     {
         $this->validatorOptions(['earliestDate' => '2007-03-01T13:00:00Z']);
 
-        $this->assertTrue($this->validator->validate(new \DateTime('2007-02-01T13:00:00Z'))->hasErrors());
+        self::assertTrue($this->validator->validate(new \DateTime('2007-02-01T13:00:00Z'))->hasErrors());
     }
 
     /**
@@ -131,7 +131,7 @@ class DateTimeRangeValidatorTest extends AbstractValidatorTestcase
     {
         $this->validatorOptions(['earliestDate' => '2007-03-01T13:00:00Z/P1Y2M10DT2H30M']);
 
-        $this->assertFalse($this->validator->validate(new \DateTime('2009-03-01T13:00:00Z'))->hasErrors());
+        self::assertFalse($this->validator->validate(new \DateTime('2009-03-01T13:00:00Z'))->hasErrors());
     }
 
     /**
@@ -141,7 +141,7 @@ class DateTimeRangeValidatorTest extends AbstractValidatorTestcase
     {
         $this->validatorOptions(['earliestDate' => 'P2M10DT2H30M/2011-03-01T13:00:00Z']);
 
-        $this->assertTrue($this->validator->validate(new \DateTime('2009-03-01T13:00:00Z'))->hasErrors());
+        self::assertTrue($this->validator->validate(new \DateTime('2009-03-01T13:00:00Z'))->hasErrors());
     }
 
     /**
@@ -151,7 +151,7 @@ class DateTimeRangeValidatorTest extends AbstractValidatorTestcase
     {
         $this->validatorOptions(['latestDate' => '2007-03-01T13:00:00Z/P1Y2M10DT2H30M']);
 
-        $this->assertFalse($this->validator->validate(new \DateTime('2008-03-01T13:00:00Z'))->hasErrors());
+        self::assertFalse($this->validator->validate(new \DateTime('2008-03-01T13:00:00Z'))->hasErrors());
     }
 
     /**
@@ -161,7 +161,7 @@ class DateTimeRangeValidatorTest extends AbstractValidatorTestcase
     {
         $this->validatorOptions(['latestDate' => 'P2M10DT2H30M/2011-03-01T13:00:00Z']);
 
-        $this->assertTrue($this->validator->validate(new \DateTime('2011-02-01T13:00:00Z'))->hasErrors());
+        self::assertTrue($this->validator->validate(new \DateTime('2011-02-01T13:00:00Z'))->hasErrors());
     }
 
     /**
@@ -174,7 +174,7 @@ class DateTimeRangeValidatorTest extends AbstractValidatorTestcase
             'latestDate' => '2011-03-01T13:00:00Z'
         ]);
 
-        $this->assertTrue($this->validator->validate(new \DateTime('2011-04-01T13:00:00Z'))->hasErrors());
+        self::assertTrue($this->validator->validate(new \DateTime('2011-04-01T13:00:00Z'))->hasErrors());
     }
 
     /**
@@ -187,7 +187,7 @@ class DateTimeRangeValidatorTest extends AbstractValidatorTestcase
             'latestDate' => '2011-03-01T13:00:00Z'
         ]);
 
-        $this->assertFalse($this->validator->validate(new \DateTime('2011-02-01T13:00:00Z'))->hasErrors());
+        self::assertFalse($this->validator->validate(new \DateTime('2011-02-01T13:00:00Z'))->hasErrors());
     }
 
     /**
@@ -199,7 +199,7 @@ class DateTimeRangeValidatorTest extends AbstractValidatorTestcase
             'earliestDate' => '2011-01-01T13:00:00Z',
         ]);
 
-        $this->assertFalse($this->validator->validate(new \DateTime('2011-01-01T13:00:00Z'))->hasErrors());
+        self::assertFalse($this->validator->validate(new \DateTime('2011-01-01T13:00:00Z'))->hasErrors());
     }
 
     /**
@@ -211,6 +211,6 @@ class DateTimeRangeValidatorTest extends AbstractValidatorTestcase
             'latestDate' => '2011-01-01T13:00:00Z',
         ]);
 
-        $this->assertFalse($this->validator->validate(new \DateTime('2011-01-01T13:00:00Z'))->hasErrors());
+        self::assertFalse($this->validator->validate(new \DateTime('2011-01-01T13:00:00Z'))->hasErrors());
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/DateTimeValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/DateTimeValidatorTest.php
@@ -50,7 +50,7 @@ class DateTimeValidatorTest extends AbstractValidatorTestcase
     {
         $this->validatorOptions([]);
         $this->inject($this->validator, 'datetimeParser', $this->mockDatetimeParser);
-        $this->assertFalse($this->validator->validate(null)->hasErrors());
+        self::assertFalse($this->validator->validate(null)->hasErrors());
     }
 
     /**
@@ -60,7 +60,7 @@ class DateTimeValidatorTest extends AbstractValidatorTestcase
     {
         $this->validatorOptions([]);
         $this->inject($this->validator, 'datetimeParser', $this->mockDatetimeParser);
-        $this->assertFalse($this->validator->validate('')->hasErrors());
+        self::assertFalse($this->validator->validate('')->hasErrors());
     }
 
     /**
@@ -70,7 +70,7 @@ class DateTimeValidatorTest extends AbstractValidatorTestcase
     {
         $this->validatorOptions([]);
         $this->inject($this->validator, 'datetimeParser', $this->mockDatetimeParser);
-        $this->assertFalse($this->validator->validate(new \DateTime())->hasErrors());
+        self::assertFalse($this->validator->validate(new \DateTime())->hasErrors());
     }
 
     /**
@@ -84,7 +84,7 @@ class DateTimeValidatorTest extends AbstractValidatorTestcase
         $this->validatorOptions(['locale' => 'en_GB', 'formatLength' => I18n\Cldr\Reader\DatesReader::FORMAT_LENGTH_DEFAULT, 'formatType' => I18n\Cldr\Reader\DatesReader::FORMAT_TYPE_TIME]);
         $this->inject($this->validator, 'datetimeParser', $this->mockDatetimeParser);
 
-        $this->assertTrue($this->validator->validate($sampleInvalidTime)->hasErrors());
+        self::assertTrue($this->validator->validate($sampleInvalidTime)->hasErrors());
     }
 
     /**
@@ -98,6 +98,6 @@ class DateTimeValidatorTest extends AbstractValidatorTestcase
         $this->validatorOptions(['locale' => 'en_GB', 'formatLength' => I18n\Cldr\Reader\DatesReader::FORMAT_LENGTH_FULL, 'formatType' => I18n\Cldr\Reader\DatesReader::FORMAT_TYPE_DATETIME]);
         $this->inject($this->validator, 'datetimeParser', $this->mockDatetimeParser);
 
-        $this->assertFalse($this->validator->validate($sampleValidDateTime)->hasErrors());
+        self::assertFalse($this->validator->validate($sampleValidDateTime)->hasErrors());
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/DisjunctionValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/DisjunctionValidatorTest.php
@@ -39,7 +39,7 @@ class DisjunctionValidatorTest extends UnitTestCase
         $validatorDisjunction->addValidator($validatorObject);
         $validatorDisjunction->addValidator($secondValidatorObject);
 
-        $this->assertFalse($validatorDisjunction->validate('some subject')->hasErrors());
+        self::assertFalse($validatorDisjunction->validate('some subject')->hasErrors());
     }
 
     /**
@@ -65,6 +65,6 @@ class DisjunctionValidatorTest extends UnitTestCase
         $validatorDisjunction->addValidator($validatorObject);
         $validatorDisjunction->addValidator($secondValidatorObject);
 
-        $this->assertEquals([$error1, $error2], $validatorDisjunction->validate('some subject')->getErrors());
+        self::assertEquals([$error1, $error2], $validatorDisjunction->validate('some subject')->getErrors());
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/EmailAddressValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/EmailAddressValidatorTest.php
@@ -28,7 +28,7 @@ class EmailAddressValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsNull()
     {
-        $this->assertFalse($this->validator->validate(null)->hasErrors());
+        self::assertFalse($this->validator->validate(null)->hasErrors());
     }
 
     /**
@@ -36,7 +36,7 @@ class EmailAddressValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsAnEmptyString()
     {
-        $this->assertFalse($this->validator->validate('')->hasErrors());
+        self::assertFalse($this->validator->validate('')->hasErrors());
     }
 
     /**
@@ -61,7 +61,7 @@ class EmailAddressValidatorTest extends AbstractValidatorTestcase
      */
     public function emailAddressValidatorReturnsNoErrorsForAValidEmailAddress($address)
     {
-        $this->assertFalse($this->validator->validate($address)->hasErrors());
+        self::assertFalse($this->validator->validate($address)->hasErrors());
     }
 
     /**
@@ -90,7 +90,7 @@ class EmailAddressValidatorTest extends AbstractValidatorTestcase
      */
     public function emailAddressValidatorReturnsFalseForAnInvalidEmailAddress($address)
     {
-        $this->assertTrue($this->validator->validate($address)->hasErrors());
+        self::assertTrue($this->validator->validate($address)->hasErrors());
     }
 
     /**
@@ -98,6 +98,6 @@ class EmailAddressValidatorTest extends AbstractValidatorTestcase
      */
     public function emailValidatorCreatesTheCorrectErrorForAnInvalidEmailAddress()
     {
-        $this->assertEquals(1, count($this->validator->validate('notAValidMail@Address')->getErrors()));
+        self::assertEquals(1, count($this->validator->validate('notAValidMail@Address')->getErrors()));
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/FloatValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/FloatValidatorTest.php
@@ -28,7 +28,7 @@ class FloatValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsNull()
     {
-        $this->assertFalse($this->validator->validate(null)->hasErrors());
+        self::assertFalse($this->validator->validate(null)->hasErrors());
     }
 
     /**
@@ -36,7 +36,7 @@ class FloatValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsAnEmptyString()
     {
-        $this->assertFalse($this->validator->validate('')->hasErrors());
+        self::assertFalse($this->validator->validate('')->hasErrors());
     }
 
     /**
@@ -62,7 +62,7 @@ class FloatValidatorTest extends AbstractValidatorTestcase
      */
     public function floatValidatorReturnsNoErrorsForAValidFloat($float)
     {
-        $this->assertFalse($this->validator->validate($float)->hasErrors());
+        self::assertFalse($this->validator->validate($float)->hasErrors());
     }
 
     /**
@@ -86,7 +86,7 @@ class FloatValidatorTest extends AbstractValidatorTestcase
      */
     public function floatValidatorReturnsErrorForAnInvalidFloat($float)
     {
-        $this->assertTrue($this->validator->validate($float)->hasErrors());
+        self::assertTrue($this->validator->validate($float)->hasErrors());
     }
 
     /**
@@ -94,6 +94,6 @@ class FloatValidatorTest extends AbstractValidatorTestcase
      */
     public function floatValidatorCreatesTheCorrectErrorForAnInvalidSubject()
     {
-        $this->assertEquals(1, count($this->validator->validate(123456)->getErrors()));
+        self::assertEquals(1, count($this->validator->validate(123456)->getErrors()));
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/GenericObjectValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/GenericObjectValidatorTest.php
@@ -31,7 +31,7 @@ class GenericObjectValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsAnEmptyString()
     {
-        $this->assertFalse($this->validator->validate('')->hasErrors());
+        self::assertFalse($this->validator->validate('')->hasErrors());
     }
 
     /**
@@ -39,7 +39,7 @@ class GenericObjectValidatorTest extends AbstractValidatorTestcase
      */
     public function validatorShouldReturnErrorsIfTheValueIsNoObjectAndNotNull()
     {
-        $this->assertTrue($this->validator->validate('foo')->hasErrors());
+        self::assertTrue($this->validator->validate('foo')->hasErrors());
     }
 
     /**
@@ -47,7 +47,7 @@ class GenericObjectValidatorTest extends AbstractValidatorTestcase
      */
     public function validatorShouldReturnNoErrorsIfTheValueIsNull()
     {
-        $this->assertFalse($this->validator->validate(null)->hasErrors());
+        self::assertFalse($this->validator->validate(null)->hasErrors());
     }
 
     /**
@@ -94,7 +94,7 @@ class GenericObjectValidatorTest extends AbstractValidatorTestcase
 
         $this->validator->addPropertyValidator('foo', $validatorForFoo);
         $this->validator->addPropertyValidator('bar', $validatorForBar);
-        $this->assertEquals($errors, $this->validator->validate($mockObject)->getFlattenedErrors());
+        self::assertEquals($errors, $this->validator->validate($mockObject)->getFlattenedErrors());
     }
 
     /**
@@ -116,7 +116,7 @@ class GenericObjectValidatorTest extends AbstractValidatorTestcase
         $aValidator->addPropertyValidator('b', $bValidator);
         $bValidator->addPropertyValidator('a', $aValidator);
 
-        $this->assertFalse($aValidator->validate($A)->hasErrors());
+        self::assertFalse($aValidator->validate($A)->hasErrors());
     }
 
     /**
@@ -146,7 +146,7 @@ class GenericObjectValidatorTest extends AbstractValidatorTestcase
         $mockUuidValidator->expects($this->any())->method('validate')->with(0xF)->will($this->returnValue($result));
         $bValidator->addPropertyValidator('uuid', $mockUuidValidator);
 
-        $this->assertSame(['b.uuid' => [$error]], $aValidator->validate($A)->getFlattenedErrors());
+        self::assertSame(['b.uuid' => [$error]], $aValidator->validate($A)->getFlattenedErrors());
     }
 
     /**
@@ -177,7 +177,7 @@ class GenericObjectValidatorTest extends AbstractValidatorTestcase
         $aValidator->addPropertyValidator('uuid', $mockUuidValidator);
         $bValidator->addPropertyValidator('uuid', $mockUuidValidator);
 
-        $this->assertSame(['b.uuid' => [$error1], 'uuid' => [$error1]], $aValidator->validate($A)->getFlattenedErrors());
+        self::assertSame(['b.uuid' => [$error1], 'uuid' => [$error1]], $aValidator->validate($A)->getFlattenedErrors());
     }
 
     /**
@@ -200,6 +200,6 @@ class GenericObjectValidatorTest extends AbstractValidatorTestcase
         $validator->validate($object);
         $validator->validate($object);
 
-        $this->assertEquals(1, $matcher->getInvocationCount());
+        self::assertEquals(1, $matcher->getInvocationCount());
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/IntegerValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/IntegerValidatorTest.php
@@ -28,7 +28,7 @@ class IntegerValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsNull()
     {
-        $this->assertFalse($this->validator->validate(null)->hasErrors());
+        self::assertFalse($this->validator->validate(null)->hasErrors());
     }
 
     /**
@@ -36,7 +36,7 @@ class IntegerValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsAnEmptyString()
     {
-        $this->assertFalse($this->validator->validate('')->hasErrors());
+        self::assertFalse($this->validator->validate('')->hasErrors());
     }
 
     /**
@@ -60,7 +60,7 @@ class IntegerValidatorTest extends AbstractValidatorTestcase
      */
     public function integerValidatorReturnsNoErrorsForAValidInteger($integer)
     {
-        $this->assertFalse($this->validator->validate($integer)->hasErrors());
+        self::assertFalse($this->validator->validate($integer)->hasErrors());
     }
 
     /**
@@ -83,7 +83,7 @@ class IntegerValidatorTest extends AbstractValidatorTestcase
      */
     public function integerValidatorReturnsErrorForAnInvalidInteger($invalidInteger)
     {
-        $this->assertTrue($this->validator->validate($invalidInteger)->hasErrors());
+        self::assertTrue($this->validator->validate($invalidInteger)->hasErrors());
     }
 
     /**
@@ -91,6 +91,6 @@ class IntegerValidatorTest extends AbstractValidatorTestcase
      */
     public function integerValidatorCreatesTheCorrectErrorForAnInvalidSubject()
     {
-        $this->assertEquals(1, count($this->validator->validate('not a number')->getErrors()));
+        self::assertEquals(1, count($this->validator->validate('not a number')->getErrors()));
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/LabelValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/LabelValidatorTest.php
@@ -28,7 +28,7 @@ class LabelValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsNull()
     {
-        $this->assertFalse($this->validator->validate(null)->hasErrors());
+        self::assertFalse($this->validator->validate(null)->hasErrors());
     }
 
     /**
@@ -36,7 +36,7 @@ class LabelValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsAnEmptyString()
     {
-        $this->assertFalse($this->validator->validate('')->hasErrors());
+        self::assertFalse($this->validator->validate('')->hasErrors());
     }
 
     /**
@@ -80,7 +80,7 @@ class LabelValidatorTest extends AbstractValidatorTestcase
      */
     public function labelValidatorReturnsNoErrorForValidLabels($label)
     {
-        $this->assertFalse($this->validator->validate($label)->hasErrors());
+        self::assertFalse($this->validator->validate($label)->hasErrors());
     }
 
     /**
@@ -89,6 +89,6 @@ class LabelValidatorTest extends AbstractValidatorTestcase
      */
     public function labelValidatorReturnsErrorsForInvalidLabels($label)
     {
-        $this->assertTrue($this->validator->validate($label)->hasErrors());
+        self::assertTrue($this->validator->validate($label)->hasErrors());
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/LocaleIdentifierValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/LocaleIdentifierValidatorTest.php
@@ -28,8 +28,8 @@ class LocaleIdentifierValidatorTest extends AbstractValidatorTestcase
      */
     public function localeIdentifierReturnsNoErrorIfLocaleIsEmpty()
     {
-        $this->assertFalse($this->validator->validate('')->hasErrors());
-        $this->assertFalse($this->validator->validate(null)->hasErrors());
+        self::assertFalse($this->validator->validate('')->hasErrors());
+        self::assertFalse($this->validator->validate(null)->hasErrors());
     }
 
     /**
@@ -37,10 +37,10 @@ class LocaleIdentifierValidatorTest extends AbstractValidatorTestcase
      */
     public function localeIdentifierReturnsNoErrorIfLocaleIsValid()
     {
-        $this->assertFalse($this->validator->validate('de_DE')->hasErrors());
-        $this->assertFalse($this->validator->validate('en_Latn_US')->hasErrors());
-        $this->assertFalse($this->validator->validate('de')->hasErrors());
-        $this->assertFalse($this->validator->validate('AR-arab_ae')->hasErrors());
+        self::assertFalse($this->validator->validate('de_DE')->hasErrors());
+        self::assertFalse($this->validator->validate('en_Latn_US')->hasErrors());
+        self::assertFalse($this->validator->validate('de')->hasErrors());
+        self::assertFalse($this->validator->validate('AR-arab_ae')->hasErrors());
     }
 
     /**
@@ -48,6 +48,6 @@ class LocaleIdentifierValidatorTest extends AbstractValidatorTestcase
      */
     public function localeIdentifierReturnsErrorIfLocaleIsInvalid()
     {
-        $this->assertTrue($this->validator->validate('ThisIsOfCourseNoValidLocaleIdentifier')->hasErrors());
+        self::assertTrue($this->validator->validate('ThisIsOfCourseNoValidLocaleIdentifier')->hasErrors());
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/NotEmptyValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/NotEmptyValidatorTest.php
@@ -28,7 +28,7 @@ class NotEmptyValidatorTest extends AbstractValidatorTestcase
      */
     public function notEmptyValidatorReturnsNoErrorForASimpleString()
     {
-        $this->assertFalse($this->validator->validate('a not empty string')->hasErrors());
+        self::assertFalse($this->validator->validate('a not empty string')->hasErrors());
     }
 
     /**
@@ -36,7 +36,7 @@ class NotEmptyValidatorTest extends AbstractValidatorTestcase
      */
     public function notEmptyValidatorReturnsErrorForAnEmptyString()
     {
-        $this->assertTrue($this->validator->validate('')->hasErrors());
+        self::assertTrue($this->validator->validate('')->hasErrors());
     }
 
     /**
@@ -44,7 +44,7 @@ class NotEmptyValidatorTest extends AbstractValidatorTestcase
      */
     public function notEmptyValidatorReturnsErrorForANullValue()
     {
-        $this->assertTrue($this->validator->validate(null)->hasErrors());
+        self::assertTrue($this->validator->validate(null)->hasErrors());
     }
 
     /**
@@ -52,7 +52,7 @@ class NotEmptyValidatorTest extends AbstractValidatorTestcase
      */
     public function notEmptyValidatorReturnsErrorForAnEmptyArray()
     {
-        $this->assertTrue($this->validator->validate([])->hasErrors());
+        self::assertTrue($this->validator->validate([])->hasErrors());
     }
 
     /**
@@ -60,7 +60,7 @@ class NotEmptyValidatorTest extends AbstractValidatorTestcase
      */
     public function notEmptyValidatorReturnsErrorForAnEmptyCountableObject()
     {
-        $this->assertTrue($this->validator->validate(new \SplObjectStorage())->hasErrors());
+        self::assertTrue($this->validator->validate(new \SplObjectStorage())->hasErrors());
     }
 
     /**
@@ -68,7 +68,7 @@ class NotEmptyValidatorTest extends AbstractValidatorTestcase
      */
     public function notEmptyValidatorCreatesTheCorrectErrorForAnEmptySubject()
     {
-        $this->assertEquals(1, count($this->validator->validate('')->getErrors()));
+        self::assertEquals(1, count($this->validator->validate('')->getErrors()));
     }
 
     /**
@@ -76,6 +76,6 @@ class NotEmptyValidatorTest extends AbstractValidatorTestcase
      */
     public function notEmptyValidatorCreatesTheCorrectErrorForANullValue()
     {
-        $this->assertEquals(1, count($this->validator->validate(null)->getErrors()));
+        self::assertEquals(1, count($this->validator->validate(null)->getErrors()));
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/NumberRangeValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/NumberRangeValidatorTest.php
@@ -27,7 +27,7 @@ class NumberRangeValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsNull()
     {
-        $this->assertFalse($this->validator->validate(null)->hasErrors());
+        self::assertFalse($this->validator->validate(null)->hasErrors());
     }
 
     /**
@@ -35,7 +35,7 @@ class NumberRangeValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsAnEmptyString()
     {
-        $this->assertFalse($this->validator->validate('')->hasErrors());
+        self::assertFalse($this->validator->validate('')->hasErrors());
     }
 
     /**
@@ -45,7 +45,7 @@ class NumberRangeValidatorTest extends AbstractValidatorTestcase
     {
         $this->validatorOptions(['minimum' => 0, 'maximum' => 1000]);
 
-        $this->assertFalse($this->validator->validate(10.5)->hasErrors());
+        self::assertFalse($this->validator->validate(10.5)->hasErrors());
     }
 
     /**
@@ -54,7 +54,7 @@ class NumberRangeValidatorTest extends AbstractValidatorTestcase
     public function numberRangeValidatorReturnsErrorForANumberOutOfRange()
     {
         $this->validatorOptions(['minimum' => 0, 'maximum' => 1000]);
-        $this->assertTrue($this->validator->validate(1000.1)->hasErrors());
+        self::assertTrue($this->validator->validate(1000.1)->hasErrors());
     }
 
     /**
@@ -63,7 +63,7 @@ class NumberRangeValidatorTest extends AbstractValidatorTestcase
     public function numberRangeValidatorReturnsNoErrorForANumberInReversedRange()
     {
         $this->validatorOptions(['minimum' => 1000, 'maximum' => 0]);
-        $this->assertFalse($this->validator->validate(100)->hasErrors());
+        self::assertFalse($this->validator->validate(100)->hasErrors());
     }
 
     /**
@@ -72,6 +72,6 @@ class NumberRangeValidatorTest extends AbstractValidatorTestcase
     public function numberRangeValidatorReturnsErrorForAString()
     {
         $this->validatorOptions(['minimum' => 0, 'maximum' => 1000]);
-        $this->assertTrue($this->validator->validate('not a number')->hasErrors());
+        self::assertTrue($this->validator->validate('not a number')->hasErrors());
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/NumberValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/NumberValidatorTest.php
@@ -48,7 +48,7 @@ class NumberValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsNull()
     {
-        $this->assertFalse($this->validator->validate(null)->hasErrors());
+        self::assertFalse($this->validator->validate(null)->hasErrors());
     }
 
     /**
@@ -56,7 +56,7 @@ class NumberValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsAnEmptyString()
     {
-        $this->assertFalse($this->validator->validate('')->hasErrors());
+        self::assertFalse($this->validator->validate('')->hasErrors());
     }
 
     /**
@@ -71,7 +71,7 @@ class NumberValidatorTest extends AbstractValidatorTestcase
         $this->validatorOptions(['locale' => $this->sampleLocale]);
         $this->inject($this->validator, 'numberParser', $this->mockNumberParser);
 
-        $this->assertEquals(1, count($this->validator->validate($sampleInvalidNumber)->getErrors()));
+        self::assertEquals(1, count($this->validator->validate($sampleInvalidNumber)->getErrors()));
     }
 
     /**
@@ -86,6 +86,6 @@ class NumberValidatorTest extends AbstractValidatorTestcase
         $this->validatorOptions(['locale' => 'en_GB', 'formatLength' => NumbersReader::FORMAT_LENGTH_DEFAULT, 'formatType' => NumbersReader::FORMAT_TYPE_PERCENT]);
         $this->inject($this->validator, 'numberParser', $this->mockNumberParser);
 
-        $this->assertEquals(1, count($this->validator->validate($sampleInvalidNumber)->getErrors()));
+        self::assertEquals(1, count($this->validator->validate($sampleInvalidNumber)->getErrors()));
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/RawValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/RawValidatorTest.php
@@ -29,10 +29,10 @@ class RawValidatorTest extends AbstractValidatorTestcase
     {
         $rawValidator = new RawValidator([]);
 
-        $this->assertFalse($rawValidator->validate('simple1expression')->hasErrors());
-        $this->assertFalse($rawValidator->validate('')->hasErrors());
-        $this->assertFalse($rawValidator->validate(null)->hasErrors());
-        $this->assertFalse($rawValidator->validate(false)->hasErrors());
-        $this->assertFalse($rawValidator->validate(new \ArrayObject())->hasErrors());
+        self::assertFalse($rawValidator->validate('simple1expression')->hasErrors());
+        self::assertFalse($rawValidator->validate('')->hasErrors());
+        self::assertFalse($rawValidator->validate(null)->hasErrors());
+        self::assertFalse($rawValidator->validate(false)->hasErrors());
+        self::assertFalse($rawValidator->validate(new \ArrayObject())->hasErrors());
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/RegularExpressionValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/RegularExpressionValidatorTest.php
@@ -47,7 +47,7 @@ class RegularExpressionValidatorTest extends AbstractValidatorTestcase
     public function validateReturnsNoErrorIfTheGivenValueIsNull()
     {
         $this->validatorOptions(['regularExpression' => '/^.*$/']);
-        $this->assertFalse($this->validator->validate(null)->hasErrors());
+        self::assertFalse($this->validator->validate(null)->hasErrors());
     }
 
     /**
@@ -56,7 +56,7 @@ class RegularExpressionValidatorTest extends AbstractValidatorTestcase
     public function validateReturnsNoErrorIfTheGivenValueIsAnEmptyString()
     {
         $this->validatorOptions(['regularExpression' => '/^.*$/']);
-        $this->assertFalse($this->validator->validate('')->hasErrors());
+        self::assertFalse($this->validator->validate('')->hasErrors());
     }
 
     /**
@@ -66,8 +66,8 @@ class RegularExpressionValidatorTest extends AbstractValidatorTestcase
     {
         $this->validatorOptions(['regularExpression' => '/^simple[0-9]expression$/']);
 
-        $this->assertFalse($this->validator->validate('simple1expression')->hasErrors());
-        $this->assertTrue($this->validator->validate('simple1expressions')->hasErrors());
+        self::assertFalse($this->validator->validate('simple1expression')->hasErrors());
+        self::assertTrue($this->validator->validate('simple1expressions')->hasErrors());
     }
 
     /**
@@ -78,6 +78,6 @@ class RegularExpressionValidatorTest extends AbstractValidatorTestcase
         $this->validatorOptions(['regularExpression' => '/^simple[0-9]expression$/']);
         $subject = 'some subject that will not match';
         $errors = $this->validator->validate($subject)->getErrors();
-        $this->assertEquals([new Validation\Error('The given subject did not match the pattern. Got: %1$s', 1221565130, [$subject])], $errors);
+        self::assertEquals([new Validation\Error('The given subject did not match the pattern. Got: %1$s', 1221565130, [$subject])], $errors);
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/StringLengthValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/StringLengthValidatorTest.php
@@ -34,7 +34,7 @@ class StringLengthValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsNull()
     {
-        $this->assertFalse($this->validator->validate(null)->hasErrors());
+        self::assertFalse($this->validator->validate(null)->hasErrors());
     }
 
     /**
@@ -42,7 +42,7 @@ class StringLengthValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsAnEmptyString()
     {
-        $this->assertFalse($this->validator->validate('')->hasErrors());
+        self::assertFalse($this->validator->validate('')->hasErrors());
     }
 
     /**
@@ -51,7 +51,7 @@ class StringLengthValidatorTest extends AbstractValidatorTestcase
     public function stringLengthValidatorReturnsNoErrorForAStringShorterThanMaxLengthAndLongerThanMinLength()
     {
         $this->validatorOptions(['minimum' => 0, 'maximum' => 50]);
-        $this->assertFalse($this->validator->validate('this is a very simple string')->hasErrors());
+        self::assertFalse($this->validator->validate('this is a very simple string')->hasErrors());
     }
 
     /**
@@ -60,7 +60,7 @@ class StringLengthValidatorTest extends AbstractValidatorTestcase
     public function stringLengthValidatorReturnsErrorForAStringShorterThanThanMinLength()
     {
         $this->validatorOptions(['minimum' => 50, 'maximum' => 100]);
-        $this->assertTrue($this->validator->validate('this is a very short string')->hasErrors());
+        self::assertTrue($this->validator->validate('this is a very short string')->hasErrors());
     }
 
     /**
@@ -69,7 +69,7 @@ class StringLengthValidatorTest extends AbstractValidatorTestcase
     public function stringLengthValidatorReturnsErrorsForAStringLongerThanThanMaxLength()
     {
         $this->validatorOptions(['minimum' => 5, 'maximum' => 10]);
-        $this->assertTrue($this->validator->validate('this is a very short string')->hasErrors());
+        self::assertTrue($this->validator->validate('this is a very short string')->hasErrors());
     }
 
     /**
@@ -78,7 +78,7 @@ class StringLengthValidatorTest extends AbstractValidatorTestcase
     public function stringLengthValidatorReturnsNoErrorsForAStringLongerThanThanMinLengthAndMaxLengthNotSpecified()
     {
         $this->validatorOptions(['minimum' => 5]);
-        $this->assertFalse($this->validator->validate('this is a very short string')->hasErrors());
+        self::assertFalse($this->validator->validate('this is a very short string')->hasErrors());
     }
 
     /**
@@ -87,7 +87,7 @@ class StringLengthValidatorTest extends AbstractValidatorTestcase
     public function stringLengthValidatorReturnsNoErrorsForAStringShorterThanThanMaxLengthAndMinLengthNotSpecified()
     {
         $this->validatorOptions(['maximum' => 100]);
-        $this->assertFalse($this->validator->validate('this is a very short string')->hasErrors());
+        self::assertFalse($this->validator->validate('this is a very short string')->hasErrors());
     }
 
     /**
@@ -96,7 +96,7 @@ class StringLengthValidatorTest extends AbstractValidatorTestcase
     public function stringLengthValidatorReturnsNoErrorsForAStringLengthEqualToMaxLengthAndMinLengthNotSpecified()
     {
         $this->validatorOptions(['maximum' => 10]);
-        $this->assertFalse($this->validator->validate('1234567890')->hasErrors());
+        self::assertFalse($this->validator->validate('1234567890')->hasErrors());
     }
 
     /**
@@ -105,7 +105,7 @@ class StringLengthValidatorTest extends AbstractValidatorTestcase
     public function stringLengthValidatorReturnsNoErrorForAStringLengthEqualToMinLengthAndMaxLengthNotSpecified()
     {
         $this->validatorOptions(['minimum' => 10]);
-        $this->assertFalse($this->validator->validate('1234567890')->hasErrors());
+        self::assertFalse($this->validator->validate('1234567890')->hasErrors());
     }
 
     /**
@@ -114,7 +114,7 @@ class StringLengthValidatorTest extends AbstractValidatorTestcase
     public function stringLengthValidatorReturnsNoErrorIfMinLengthAndMaxLengthAreEqualAndTheGivenStringMatchesThisValue()
     {
         $this->validatorOptions(['minimum' => 10, 'maximum' => 10]);
-        $this->assertFalse($this->validator->validate('1234567890')->hasErrors());
+        self::assertFalse($this->validator->validate('1234567890')->hasErrors());
     }
 
     /**
@@ -123,7 +123,7 @@ class StringLengthValidatorTest extends AbstractValidatorTestcase
     public function stringLengthValidatorReturnsNoErrorsfTheStringLengthIsEqualToMaxLength()
     {
         $this->validatorOptions(['minimum' => 1, 'maximum' => 10]);
-        $this->assertFalse($this->validator->validate('1234567890')->hasErrors());
+        self::assertFalse($this->validator->validate('1234567890')->hasErrors());
     }
 
     /**
@@ -132,7 +132,7 @@ class StringLengthValidatorTest extends AbstractValidatorTestcase
     public function stringLengthValidatorReturnsNoErrorIfTheStringLengthIsEqualToMinLength()
     {
         $this->validatorOptions(['minimum' => 10, 'maximum' => 100]);
-        $this->assertFalse($this->validator->validate('1234567890')->hasErrors());
+        self::assertFalse($this->validator->validate('1234567890')->hasErrors());
     }
 
     /**
@@ -153,7 +153,7 @@ class StringLengthValidatorTest extends AbstractValidatorTestcase
     {
         $this->validatorOptions(['minimum' => 50, 'maximum' => 100]);
 
-        $this->assertEquals(1, count($this->validator->validate('this is a very short string')->getErrors()));
+        self::assertEquals(1, count($this->validator->validate('this is a very short string')->getErrors()));
     }
 
     /**
@@ -175,7 +175,7 @@ class StringLengthValidatorTest extends AbstractValidatorTestcase
 		');
 
         $object = new $className();
-        $this->assertFalse($this->validator->validate($object)->hasErrors());
+        self::assertFalse($this->validator->validate($object)->hasErrors());
     }
 
     /**
@@ -195,7 +195,7 @@ class StringLengthValidatorTest extends AbstractValidatorTestcase
 		');
 
         $object = new $className();
-        $this->assertTrue($this->validator->validate($object)->hasErrors());
+        self::assertTrue($this->validator->validate($object)->hasErrors());
     }
 
     /**
@@ -204,6 +204,6 @@ class StringLengthValidatorTest extends AbstractValidatorTestcase
     public function validateRegardsMultibyteStringsCorrectly()
     {
         $this->validatorOptions(['maximum' => 8]);
-        $this->assertFalse($this->validator->validate('überlang')->hasErrors());
+        self::assertFalse($this->validator->validate('überlang')->hasErrors());
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/StringValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/StringValidatorTest.php
@@ -27,7 +27,7 @@ class StringValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsNull()
     {
-        $this->assertFalse($this->validator->validate(null)->hasErrors());
+        self::assertFalse($this->validator->validate(null)->hasErrors());
     }
 
     /**
@@ -35,7 +35,7 @@ class StringValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsAnEmptyString()
     {
-        $this->assertFalse($this->validator->validate('')->hasErrors());
+        self::assertFalse($this->validator->validate('')->hasErrors());
     }
 
     /**
@@ -43,7 +43,7 @@ class StringValidatorTest extends AbstractValidatorTestcase
      */
     public function stringValidatorShouldValidateString()
     {
-        $this->assertFalse($this->validator->validate('Hello World')->hasErrors());
+        self::assertFalse($this->validator->validate('Hello World')->hasErrors());
     }
 
     /**
@@ -51,7 +51,7 @@ class StringValidatorTest extends AbstractValidatorTestcase
      */
     public function stringValidatorShouldReturnErrorIfNumberIsGiven()
     {
-        $this->assertTrue($this->validator->validate(42)->hasErrors());
+        self::assertTrue($this->validator->validate(42)->hasErrors());
     }
 
     /**
@@ -69,6 +69,6 @@ class StringValidatorTest extends AbstractValidatorTestcase
 			}
 		');
         $object = new $className();
-        $this->assertTrue($this->validator->validate($object)->hasErrors());
+        self::assertTrue($this->validator->validate($object)->hasErrors());
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/TextValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/TextValidatorTest.php
@@ -29,7 +29,7 @@ class TextValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsNull()
     {
-        $this->assertFalse($this->validator->validate(null)->hasErrors());
+        self::assertFalse($this->validator->validate(null)->hasErrors());
     }
 
     /**
@@ -38,7 +38,7 @@ class TextValidatorTest extends AbstractValidatorTestcase
      */
     public function validateReturnsNoErrorIfTheGivenValueIsAnEmptyString()
     {
-        $this->assertFalse($this->validator->validate('')->hasErrors());
+        self::assertFalse($this->validator->validate('')->hasErrors());
     }
 
     /**
@@ -46,7 +46,7 @@ class TextValidatorTest extends AbstractValidatorTestcase
      */
     public function textValidatorReturnsNoErrorForASimpleString()
     {
-        $this->assertFalse($this->validator->validate('this is a very simple string')->hasErrors());
+        self::assertFalse($this->validator->validate('this is a very simple string')->hasErrors());
     }
 
     /**
@@ -69,7 +69,7 @@ class TextValidatorTest extends AbstractValidatorTestcase
     public function textValidatorAcceptsValidInput($input)
     {
         $textValidator = new TextValidator();
-        $this->assertFalse($textValidator->validate($input)->hasErrors());
+        self::assertFalse($textValidator->validate($input)->hasErrors());
     }
 
     /**
@@ -90,7 +90,7 @@ class TextValidatorTest extends AbstractValidatorTestcase
      */
     public function textValidatorRejectsInvalidInput($input)
     {
-        $this->assertTrue($this->validator->validate($input)->hasErrors());
+        self::assertTrue($this->validator->validate($input)->hasErrors());
     }
 
     /**
@@ -99,6 +99,6 @@ class TextValidatorTest extends AbstractValidatorTestcase
     public function textValidatorCreatesTheCorrectErrorIfTheSubjectContainsHtmlEntities()
     {
         $expected = [new Validation\Error('Valid text without any XML tags is expected.', 1221565786)];
-        $this->assertEquals($expected, $this->validator->validate('<span style="color: #BBBBBB;">a nice text</span>')->getErrors());
+        self::assertEquals($expected, $this->validator->validate('<span style="color: #BBBBBB;">a nice text</span>')->getErrors());
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/Validator/UuidValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/UuidValidatorTest.php
@@ -29,8 +29,8 @@ class UuidValidatorTest extends AbstractValidatorTestcase
      */
     public function validatorAcceptsCorrectUUIDs()
     {
-        $this->assertFalse($this->validator->validate('e104e469-9030-4b98-babf-3990f07dd3f1')->hasErrors());
-        $this->assertFalse($this->validator->validate('533548ca-8914-4a19-9404-ef390a6ce387')->hasErrors());
+        self::assertFalse($this->validator->validate('e104e469-9030-4b98-babf-3990f07dd3f1')->hasErrors());
+        self::assertFalse($this->validator->validate('533548ca-8914-4a19-9404-ef390a6ce387')->hasErrors());
     }
 
     /**
@@ -38,7 +38,7 @@ class UuidValidatorTest extends AbstractValidatorTestcase
      */
     public function tooShortUUIDIsRejected()
     {
-        $this->assertTrue($this->validator->validate('e104e469-9030-4b98-babf-3990f07')->hasErrors());
+        self::assertTrue($this->validator->validate('e104e469-9030-4b98-babf-3990f07')->hasErrors());
     }
 
     /**
@@ -46,8 +46,8 @@ class UuidValidatorTest extends AbstractValidatorTestcase
      */
     public function tooLongButValidUUIDIsRejected()
     {
-        $this->assertTrue($this->validator->validate('e104e469-9030-4b98-babf-3990f07dd3f1-3990f07dd3f1')->hasErrors());
-        $this->assertTrue($this->validator->validate('abcde-533548ca-8914-4a19-9404-ef390a6ce387-xyz')->hasErrors());
+        self::assertTrue($this->validator->validate('e104e469-9030-4b98-babf-3990f07dd3f1-3990f07dd3f1')->hasErrors());
+        self::assertTrue($this->validator->validate('abcde-533548ca-8914-4a19-9404-ef390a6ce387-xyz')->hasErrors());
     }
 
     /**
@@ -55,7 +55,7 @@ class UuidValidatorTest extends AbstractValidatorTestcase
      */
     public function UUIDWithOtherThanHexValuesIsRejected()
     {
-        $this->assertTrue($this->validator->validate('e104e469-9030-4g98-babf-3990f07dd3f1')->hasErrors());
+        self::assertTrue($this->validator->validate('e104e469-9030-4g98-babf-3990f07dd3f1')->hasErrors());
     }
 
     /**
@@ -64,6 +64,6 @@ class UuidValidatorTest extends AbstractValidatorTestcase
     public function UUIDValidatorCreatesTheCorrectErrorIfTheSubjectIsInvalid()
     {
         $expected = [new Validation\Error('The given subject was not a valid UUID.', 1221565853)];
-        $this->assertEquals($expected, $this->validator->validate('e104e469-9030-4b98-babf-3990f07')->getErrors());
+        self::assertEquals($expected, $this->validator->validate('e104e469-9030-4b98-babf-3990f07')->getErrors());
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/ValidatorResolverTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/ValidatorResolverTest.php
@@ -68,7 +68,7 @@ class ValidatorResolverTest extends UnitTestCase
         $this->mockObjectManager->expects($this->at(1))->method('isRegistered')->with('Foo')->will($this->returnValue(false));
         $this->mockObjectManager->expects($this->at(2))->method('isRegistered')->with('Neos\Flow\Validation\Validator\FooValidator')->will($this->returnValue(false));
 
-        $this->assertSame(false, $this->validatorResolver->_call('resolveValidatorObjectName', 'Foo'));
+        self::assertSame(false, $this->validatorResolver->_call('resolveValidatorObjectName', 'Foo'));
     }
 
     /**
@@ -80,7 +80,7 @@ class ValidatorResolverTest extends UnitTestCase
         $this->mockObjectManager->expects($this->any())->method('isRegistered')->with('Foo')->will($this->returnValue(true));
         $this->mockReflectionService->expects($this->any())->method('getAllImplementationClassNamesForInterface')->with(ValidatorInterface::class)->will($this->returnValue(['Foo']));
 
-        $this->assertSame('Foo', $this->validatorResolver->_call('resolveValidatorObjectName', 'Foo'));
+        self::assertSame('Foo', $this->validatorResolver->_call('resolveValidatorObjectName', 'Foo'));
     }
 
     /**
@@ -93,7 +93,7 @@ class ValidatorResolverTest extends UnitTestCase
         $this->mockObjectManager->expects($this->at(2))->method('isRegistered')->with('Neos\Flow\Validation\Validator\FooValidator')->will($this->returnValue(false));
         $this->mockReflectionService->expects($this->any())->method('getAllImplementationClassNamesForInterface')->with(ValidatorInterface::class)->will($this->returnValue(['Bar']));
 
-        $this->assertFalse($this->validatorResolver->_call('resolveValidatorObjectName', 'Foo'));
+        self::assertFalse($this->validatorResolver->_call('resolveValidatorObjectName', 'Foo'));
     }
 
     /**
@@ -106,7 +106,7 @@ class ValidatorResolverTest extends UnitTestCase
         $this->mockObjectManager->expects($this->at(2))->method('isRegistered')->with(DateTimeValidator::class)->will($this->returnValue(true));
         $this->mockReflectionService->expects($this->any())->method('getAllImplementationClassNamesForInterface')->with(ValidatorInterface::class)->will($this->returnValue([DateTimeValidator::class]));
 
-        $this->assertSame(DateTimeValidator::class, $this->validatorResolver->_call('resolveValidatorObjectName', 'DateTime'));
+        self::assertSame(DateTimeValidator::class, $this->validatorResolver->_call('resolveValidatorObjectName', 'DateTime'));
     }
 
     /**
@@ -118,7 +118,7 @@ class ValidatorResolverTest extends UnitTestCase
         $this->mockObjectManager->expects($this->any())->method('isRegistered')->with('Foo\Bar')->will($this->returnValue(true));
         $this->mockReflectionService->expects($this->any())->method('getAllImplementationClassNamesForInterface')->with(ValidatorInterface::class)->will($this->returnValue(['Foo\Bar']));
 
-        $this->assertSame('Foo\Bar', $this->validatorResolver->_call('resolveValidatorObjectName', '\Foo\Bar'));
+        self::assertSame('Foo\Bar', $this->validatorResolver->_call('resolveValidatorObjectName', '\Foo\Bar'));
     }
 
     /**
@@ -132,7 +132,7 @@ class ValidatorResolverTest extends UnitTestCase
 
         $this->mockReflectionService->expects($this->any())->method('getAllImplementationClassNamesForInterface')->with(ValidatorInterface::class)->will($this->returnValue(['Mypkg\Validation\Validator\MyValidator']));
 
-        $this->assertSame('Mypkg\Validation\Validator\MyValidator', $this->validatorResolver->_call('resolveValidatorObjectName', 'Mypkg:My'));
+        self::assertSame('Mypkg\Validation\Validator\MyValidator', $this->validatorResolver->_call('resolveValidatorObjectName', 'Mypkg:My'));
     }
 
     /**
@@ -146,7 +146,7 @@ class ValidatorResolverTest extends UnitTestCase
 
         $this->mockReflectionService->expects($this->any())->method('getAllImplementationClassNamesForInterface')->with(ValidatorInterface::class)->will($this->returnValue(['Mypkg\Foo\Validation\Validator\MyValidator']));
 
-        $this->assertSame('Mypkg\Foo\Validation\Validator\MyValidator', $this->validatorResolver->_call('resolveValidatorObjectName', 'Mypkg.Foo:My'));
+        self::assertSame('Mypkg\Foo\Validation\Validator\MyValidator', $this->validatorResolver->_call('resolveValidatorObjectName', 'Mypkg.Foo:My'));
     }
 
     /**
@@ -158,7 +158,7 @@ class ValidatorResolverTest extends UnitTestCase
         $this->mockObjectManager->expects($this->at(1))->method('isRegistered')->with('Foo')->will($this->returnValue(false));
         $this->mockObjectManager->expects($this->at(2))->method('isRegistered')->with('Neos\Flow\Validation\Validator\FooValidator')->will($this->returnValue(true));
         $this->mockReflectionService->expects($this->any())->method('getAllImplementationClassNamesForInterface')->with(ValidatorInterface::class)->will($this->returnValue(['Neos\Flow\Validation\Validator\FooValidator']));
-        $this->assertSame('Neos\Flow\Validation\Validator\FooValidator', $this->validatorResolver->_call('resolveValidatorObjectName', 'Foo'));
+        self::assertSame('Neos\Flow\Validation\Validator\FooValidator', $this->validatorResolver->_call('resolveValidatorObjectName', 'Foo'));
     }
 
     /**
@@ -199,8 +199,8 @@ class ValidatorResolverTest extends UnitTestCase
         $validatorResolver->_set('objectManager', $mockObjectManager);
         $validatorResolver->expects($this->once())->method('resolveValidatorObjectName')->with($className)->will($this->returnValue($className));
         $validator = $validatorResolver->createValidator($className, ['foo' => 'bar']);
-        $this->assertInstanceOf($className, $validator);
-        $this->assertEquals(['foo' => 'bar'], $validator->getOptions());
+        self::assertInstanceOf($className, $validator);
+        self::assertEquals(['foo' => 'bar'], $validator->getOptions());
     }
 
     /**
@@ -211,7 +211,7 @@ class ValidatorResolverTest extends UnitTestCase
         $validatorResolver = $this->getMockBuilder(ValidatorResolver::class)->setMethods(['resolveValidatorObjectName'])->getMock();
         $validatorResolver->expects($this->once())->method('resolveValidatorObjectName')->with('Foo')->will($this->returnValue(false));
         $validator = $validatorResolver->createValidator('Foo', ['foo' => 'bar']);
-        $this->assertNull($validator);
+        self::assertNull($validator);
     }
 
     /**
@@ -243,10 +243,10 @@ class ValidatorResolverTest extends UnitTestCase
         $this->validatorResolver->_set('reflectionService', $mockReflectionService);
 
         $result1 = $this->validatorResolver->getBaseValidatorConjunction('TYPO3\Virtual\Foo');
-        $this->assertInstanceOf(ConjunctionValidator::class, $result1, '#1');
+        self::assertInstanceOf(ConjunctionValidator::class, $result1, '#1');
 
         $result2 = $this->validatorResolver->getBaseValidatorConjunction('TYPO3\Virtual\Foo');
-        $this->assertSame($result1, $result2, '#2');
+        self::assertSame($result1, $result2, '#2');
     }
 
     /**
@@ -263,7 +263,7 @@ class ValidatorResolverTest extends UnitTestCase
         $this->validatorResolver->_set('reflectionService', $mockReflectionService);
 
         $result = $this->validatorResolver->buildMethodArgumentsValidatorConjunctions(get_class($mockController), 'fooAction');
-        $this->assertSame([], $result);
+        self::assertSame([], $result);
     }
 
     /**
@@ -329,7 +329,7 @@ class ValidatorResolverTest extends UnitTestCase
         $validatorResolver->_set('reflectionService', $mockReflectionService);
 
         $result = $validatorResolver->buildMethodArgumentsValidatorConjunctions(get_class($mockObject), 'fooAction');
-        $this->assertEquals(['arg1' => $conjunction1, 'arg2' => $conjunction2], $result);
+        self::assertEquals(['arg1' => $conjunction1, 'arg2' => $conjunction2], $result);
     }
 
     /**
@@ -423,8 +423,8 @@ class ValidatorResolverTest extends UnitTestCase
         $validatorResolver->_call('buildBaseValidatorConjunction', $modelClassName, $modelClassName, ['Default']);
         $builtValidators = $validatorResolver->_get('baseValidatorConjunctions');
 
-        $this->assertFalse($builtValidators[$modelClassName]->validate('foo@example.com')->hasErrors());
-        $this->assertTrue($builtValidators[$modelClassName]->validate('foo')->hasErrors());
+        self::assertFalse($builtValidators[$modelClassName]->validate('foo@example.com')->hasErrors());
+        self::assertTrue($builtValidators[$modelClassName]->validate('foo')->hasErrors());
     }
 
     /**
@@ -536,7 +536,7 @@ class ValidatorResolverTest extends UnitTestCase
         $validatorResolver->_set('objectManager', $mockObjectManager);
         $validatorResolver->_set('reflectionService', $mockReflectionService);
 
-        $this->assertNull($validatorResolver->_call('buildBaseValidatorConjunction', 'NonExistingClassName', 'NonExistingClassName', ['Default']));
+        self::assertNull($validatorResolver->_call('buildBaseValidatorConjunction', 'NonExistingClassName', 'NonExistingClassName', ['Default']));
     }
 
     /**
@@ -608,7 +608,7 @@ class ValidatorResolverTest extends UnitTestCase
 
         $validatorResolver->_call('buildBaseValidatorConjunction', $className . 'Default', $className, ['Default']);
         $builtValidators = $validatorResolver->_get('baseValidatorConjunctions');
-        $this->assertInstanceOf(ConjunctionValidator::class, $builtValidators[$className . 'Default']);
+        self::assertInstanceOf(ConjunctionValidator::class, $builtValidators[$className . 'Default']);
     }
 
     /**
@@ -657,19 +657,19 @@ class ValidatorResolverTest extends UnitTestCase
         /* @var $validatorChain ConjunctionValidator */
         $validatorChain = $validatorResolver->getBaseValidatorConjunction($fooClassName);
         $fooValidators = $validatorChain->getValidators();
-        $this->assertGreaterThan(0, $fooValidators->count());
+        self::assertGreaterThan(0, $fooValidators->count());
 
         // ugh, it's so cumbersome to work with SplObjectStorage outside of iterations...
         $fooValidators->rewind();
         $barValidators = $fooValidators->current()->getPropertyValidators('bar');
-        $this->assertGreaterThan(0, $barValidators->count());
+        self::assertGreaterThan(0, $barValidators->count());
 
         $barValidators->rewind();
         $barValidators = $barValidators->current()->getValidators();
-        $this->assertGreaterThan(0, $barValidators->count());
+        self::assertGreaterThan(0, $barValidators->count());
         $barValidators->rewind();
 
-        $this->assertGreaterThan(0, $barValidators->current()->getPropertyValidators('foo')->count());
+        self::assertGreaterThan(0, $barValidators->current()->getPropertyValidators('foo')->count());
     }
 
     /**
@@ -681,16 +681,16 @@ class ValidatorResolverTest extends UnitTestCase
         $validatorResolver = $this->getAccessibleMock(ValidatorResolver::class, ['dummy']);
         $validatorResolver->_set('objectManager', $mockObjectManager);
 
-        $this->assertEquals('Integer', $validatorResolver->_call('getValidatorType', 'integer'));
-        $this->assertEquals('Integer', $validatorResolver->_call('getValidatorType', 'int'));
-        $this->assertEquals('String', $validatorResolver->_call('getValidatorType', 'string'));
-        $this->assertEquals('Array', $validatorResolver->_call('getValidatorType', 'array'));
-        $this->assertEquals('Float', $validatorResolver->_call('getValidatorType', 'float'));
-        $this->assertEquals('Float', $validatorResolver->_call('getValidatorType', 'double'));
-        $this->assertEquals('Boolean', $validatorResolver->_call('getValidatorType', 'boolean'));
-        $this->assertEquals('Boolean', $validatorResolver->_call('getValidatorType', 'bool'));
-        $this->assertEquals('Number', $validatorResolver->_call('getValidatorType', 'number'));
-        $this->assertEquals('Number', $validatorResolver->_call('getValidatorType', 'numeric'));
+        self::assertEquals('Integer', $validatorResolver->_call('getValidatorType', 'integer'));
+        self::assertEquals('Integer', $validatorResolver->_call('getValidatorType', 'int'));
+        self::assertEquals('String', $validatorResolver->_call('getValidatorType', 'string'));
+        self::assertEquals('Array', $validatorResolver->_call('getValidatorType', 'array'));
+        self::assertEquals('Float', $validatorResolver->_call('getValidatorType', 'float'));
+        self::assertEquals('Float', $validatorResolver->_call('getValidatorType', 'double'));
+        self::assertEquals('Boolean', $validatorResolver->_call('getValidatorType', 'boolean'));
+        self::assertEquals('Boolean', $validatorResolver->_call('getValidatorType', 'bool'));
+        self::assertEquals('Number', $validatorResolver->_call('getValidatorType', 'number'));
+        self::assertEquals('Number', $validatorResolver->_call('getValidatorType', 'numeric'));
     }
 
     /**
@@ -701,7 +701,7 @@ class ValidatorResolverTest extends UnitTestCase
         $mockObjectManager = $this->createMock(ObjectManagerInterface::class);
         $validatorResolver = $this->getAccessibleMock(ValidatorResolver::class, ['dummy']);
         $validatorResolver->_set('objectManager', $mockObjectManager);
-        $this->assertEquals('Raw', $validatorResolver->_call('getValidatorType', 'mixed'));
+        self::assertEquals('Raw', $validatorResolver->_call('getValidatorType', 'mixed'));
     }
 
     /**
@@ -714,6 +714,6 @@ class ValidatorResolverTest extends UnitTestCase
         $validatorResolver->_set('baseValidatorConjunctions', ['SomeId##' => $mockConjunctionValidator]);
 
         $validatorResolver->reset();
-        $this->assertEmpty($validatorResolver->_get('baseValidatorConjunctions'));
+        self::assertEmpty($validatorResolver->_get('baseValidatorConjunctions'));
     }
 }

--- a/Neos.FluidAdaptor/Tests/Functional/Core/WidgetTest.php
+++ b/Neos.FluidAdaptor/Tests/Functional/Core/WidgetTest.php
@@ -51,7 +51,7 @@ class WidgetTest extends FunctionalTestCase
     {
         $response = $this->browser->request('http://localhost/test/widget/ajaxtest');
         [$confirmation,] = explode(chr(10), $response->getContent());
-        $this->assertSame('SomeAjaxController::indexAction()', $confirmation);
+        self::assertSame('SomeAjaxController::indexAction()', $confirmation);
     }
 
     /**
@@ -70,7 +70,7 @@ class WidgetTest extends FunctionalTestCase
         [, $ajaxWidgetUri] = explode(chr(10), $response->getContent());
 
         $response = $this->browser->request('http://localhost/' . $ajaxWidgetUri);
-        $this->assertSame('SomeAjaxController::ajaxAction("value1", "value2")', trim($response->getContent()));
+        self::assertSame('SomeAjaxController::ajaxAction("value1", "value2")', trim($response->getContent()));
     }
 
     /**
@@ -82,7 +82,7 @@ class WidgetTest extends FunctionalTestCase
         $redirectTriggerUri = $this->browser->getCrawler()->filterXPath('//*[@id="redirect-no-delay-no-param"]')->attr('href');
 
         $response = $this->browser->request($redirectTriggerUri);
-        $this->assertSame('<div id="parameter"></div>', trim($response->getContent()));
+        self::assertSame('<div id="parameter"></div>', trim($response->getContent()));
     }
 
     /**
@@ -94,7 +94,7 @@ class WidgetTest extends FunctionalTestCase
         $redirectTriggerUri = $this->browser->getCrawler()->filterXPath('//*[@id="redirect-no-delay-with-param"]')->attr('href');
 
         $response = $this->browser->request($redirectTriggerUri);
-        $this->assertSame('<div id="parameter">foo, via redirect</div>', trim($response->getContent()));
+        self::assertSame('<div id="parameter">foo, via redirect</div>', trim($response->getContent()));
     }
 
     /**
@@ -109,11 +109,11 @@ class WidgetTest extends FunctionalTestCase
         $this->browser->request($redirectTriggerUri);
         $this->browser->setFollowRedirects(true);
         $redirectHeader = $this->browser->getCrawler()->filterXPath('//meta[@http-equiv="refresh"]')->attr('content');
-        $this->assertSame('2;url=', substr($redirectHeader, 0, 6));
+        self::assertSame('2;url=', substr($redirectHeader, 0, 6));
 
         $redirectTargetUri = substr($redirectHeader, 6);
         $response = $this->browser->request($redirectTargetUri);
-        $this->assertSame('<div id="parameter"></div>', trim($response->getContent()));
+        self::assertSame('<div id="parameter"></div>', trim($response->getContent()));
     }
 
     /**
@@ -128,11 +128,11 @@ class WidgetTest extends FunctionalTestCase
         $this->browser->request($redirectTriggerUri);
         $this->browser->setFollowRedirects(true);
         $redirectHeader = $this->browser->getCrawler()->filterXPath('//meta[@http-equiv="refresh"]')->attr('content');
-        $this->assertSame('2;url=', substr($redirectHeader, 0, 6));
+        self::assertSame('2;url=', substr($redirectHeader, 0, 6));
 
         $redirectTargetUri = substr($redirectHeader, 6);
         $response = $this->browser->request($redirectTargetUri);
-        $this->assertSame('<div id="parameter">bar, via redirect</div>', trim($response->getContent()));
+        self::assertSame('<div id="parameter">bar, via redirect</div>', trim($response->getContent()));
     }
 
     /**
@@ -144,8 +144,8 @@ class WidgetTest extends FunctionalTestCase
         $redirectTriggerUri = $this->browser->getCrawler()->filterXPath('//*[@id="redirect-other-controller"]')->attr('href');
 
         $response = $this->browser->request($redirectTriggerUri);
-        $this->assertSame(500, $response->getStatusCode());
-        $this->assertSame(1380284579, $response->getHeader('X-Flow-ExceptionCode'));
+        self::assertSame(500, $response->getStatusCode());
+        self::assertSame(1380284579, $response->getHeader('X-Flow-ExceptionCode'));
     }
 
     /**
@@ -157,7 +157,7 @@ class WidgetTest extends FunctionalTestCase
         $redirectTriggerUri = $this->browser->getCrawler()->filterXPath('//*[@id="forward-no-param"]')->attr('href');
 
         $response = $this->browser->request($redirectTriggerUri);
-        $this->assertSame('<div id="parameter"></div>', trim($response->getContent()));
+        self::assertSame('<div id="parameter"></div>', trim($response->getContent()));
     }
 
     /**
@@ -169,7 +169,7 @@ class WidgetTest extends FunctionalTestCase
         $redirectTriggerUri = $this->browser->getCrawler()->filterXPath('//*[@id="forward-with-param"]')->attr('href');
 
         $response = $this->browser->request($redirectTriggerUri);
-        $this->assertSame('<div id="parameter">baz, via forward</div>', trim($response->getContent()));
+        self::assertSame('<div id="parameter">baz, via forward</div>', trim($response->getContent()));
     }
 
     /**
@@ -181,7 +181,7 @@ class WidgetTest extends FunctionalTestCase
         $redirectTriggerUri = $this->browser->getCrawler()->filterXPath('//*[@id="forward-other-controller"]')->attr('href');
 
         $response = $this->browser->request($redirectTriggerUri);
-        $this->assertSame(500, $response->getStatusCode());
-        $this->assertSame(1380284579, $response->getHeader('X-Flow-ExceptionCode'));
+        self::assertSame(500, $response->getStatusCode());
+        self::assertSame(1380284579, $response->getHeader('X-Flow-ExceptionCode'));
     }
 }

--- a/Neos.FluidAdaptor/Tests/Functional/Form/FormObjectsTest.php
+++ b/Neos.FluidAdaptor/Tests/Functional/Form/FormObjectsTest.php
@@ -60,7 +60,7 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
         $form['post']['author']['emailAddress']->setValue('hello@neos.io');
 
         $response = $this->browser->submit($form);
-        $this->assertSame('Neos Team|hello@neos.io', $response->getContent());
+        self::assertSame('Neos Team|hello@neos.io', $response->getContent());
     }
 
     /**
@@ -72,8 +72,8 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
 
         $this->browser->request('http://localhost/test/fluid/formobjects/edit?fooPost=' . $postIdentifier);
         $form = $this->browser->getForm();
-        $this->assertFalse(isset($form['post']['tags']['__identity']), 'Post tags identities not set.');
-        $this->assertFalse(isset($form['tags']['__identity']), 'Tags identities not set.');
+        self::assertFalse(isset($form['post']['tags']['__identity']), 'Post tags identities not set.');
+        self::assertFalse(isset($form['tags']['__identity']), 'Tags identities not set.');
     }
 
     /**
@@ -85,7 +85,7 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
 
         $this->browser->request('http://localhost/test/fluid/formobjects/edit?fooPost=' . $postIdentifier);
         $form = $this->browser->getForm();
-        $this->assertFalse(isset($form['post']['author']['location']['__identity']));
+        self::assertFalse(isset($form['post']['author']['location']['__identity']));
     }
 
     /**
@@ -101,14 +101,14 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
 
         $this->browser->submit($form);
         $form = $this->browser->getForm();
-        $this->assertSame('Neos Team', $form['post']['name']->getValue());
-        $this->assertSame('test_noValidEmail', $form['post']['author']['emailAddress']->getValue());
-        $this->assertSame('f3-form-error', $this->browser->getCrawler()->filterXPath('//*[@id="email"]')->attr('class'));
+        self::assertSame('Neos Team', $form['post']['name']->getValue());
+        self::assertSame('test_noValidEmail', $form['post']['author']['emailAddress']->getValue());
+        self::assertSame('f3-form-error', $this->browser->getCrawler()->filterXPath('//*[@id="email"]')->attr('class'));
 
         $form['post']['author']['emailAddress']->setValue('another@email.org');
 
         $response = $this->browser->submit($form);
-        $this->assertSame('Neos Team|another@email.org', $response->getContent());
+        self::assertSame('Neos Team|another@email.org', $response->getContent());
     }
 
     /**
@@ -126,14 +126,14 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
 
         $this->browser->submit($form);
         $form = $this->browser->getForm();
-        $this->assertSame('Egon Olsen', $form['post']['name']->getValue());
-        $this->assertSame('test_noValidEmail', $form['post']['author']['emailAddress']->getValue());
-        $this->assertSame('f3-form-error', $this->browser->getCrawler()->filterXPath('//*[@id="email"]')->attr('class'));
+        self::assertSame('Egon Olsen', $form['post']['name']->getValue());
+        self::assertSame('test_noValidEmail', $form['post']['author']['emailAddress']->getValue());
+        self::assertSame('f3-form-error', $this->browser->getCrawler()->filterXPath('//*[@id="email"]')->attr('class'));
 
         $form['post']['author']['emailAddress']->setValue('another@email.org');
 
         $response = $this->browser->submit($form);
-        $this->assertSame('Egon Olsen|another@email.org', $response->getContent());
+        self::assertSame('Egon Olsen|another@email.org', $response->getContent());
     }
 
     /**
@@ -149,7 +149,7 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
         $this->browser->submit($form);
 
         $form = $this->browser->getForm();
-        $this->assertSame('f3-form-error', $this->browser->getCrawler()->filterXPath('//*[@id="email"]')->attr('class'));
+        self::assertSame('f3-form-error', $this->browser->getCrawler()->filterXPath('//*[@id="email"]')->attr('class'));
     }
 
     /**
@@ -165,7 +165,7 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
         $this->browser->submit($form);
 
         $form = $this->browser->getForm();
-        $this->assertSame('test_noValidEmail', $form['email']->getValue());
+        self::assertSame('test_noValidEmail', $form['email']->getValue());
     }
 
     /**
@@ -179,7 +179,7 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
         $form['__trustedProperties']->setValue($form['__trustedProperties']->getValue() . 'a');
         $this->browser->submit($form);
 
-        $this->assertSame('500 Internal Server Error', $this->browser->getLastResponse()->getStatus());
+        self::assertSame('500 Internal Server Error', $this->browser->getLastResponse()->getStatus());
     }
 
     /**
@@ -196,7 +196,7 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
 
         $this->browser->submit($form);
 
-        $this->assertSame('500 Internal Server Error', $this->browser->getLastResponse()->getStatus());
+        self::assertSame('500 Internal Server Error', $this->browser->getLastResponse()->getStatus());
     }
 
     /**
@@ -212,7 +212,7 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
 
         $this->browser->submit($form);
 
-        $this->assertSame('500 Internal Server Error', $this->browser->getLastResponse()->getStatus());
+        self::assertSame('500 Internal Server Error', $this->browser->getLastResponse()->getStatus());
     }
 
     /**
@@ -226,7 +226,7 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
         unset($form['__trustedProperties']);
         $this->browser->submit($form);
 
-        $this->assertSame('500 Internal Server Error', $this->browser->getLastResponse()->getStatus());
+        self::assertSame('500 Internal Server Error', $this->browser->getLastResponse()->getStatus());
     }
 
     /**
@@ -242,11 +242,11 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
         $form['post']['author']['emailAddress']->setValue('test_noValidEmail');
 
         $response = $this->browser->submit($form);
-        $this->assertNotSame('Hello World|test_noValidEmail', $response->getContent());
+        self::assertNotSame('Hello World|test_noValidEmail', $response->getContent());
 
         $this->persistenceManager->clearState();
         $post = $this->persistenceManager->getObjectByIdentifier($postIdentifier, \Neos\FluidAdaptor\Tests\Functional\Form\Fixtures\Domain\Model\Post::class);
-        $this->assertNotSame('test_noValidEmail', $post->getAuthor()->getEmailAddress(), 'The invalid email address "' . $post->getAuthor()->getEmailAddress() . '" was persisted!');
+        self::assertNotSame('test_noValidEmail', $post->getAuthor()->getEmailAddress(), 'The invalid email address "' . $post->getAuthor()->getEmailAddress() . '" was persisted!');
     }
 
     /**
@@ -263,15 +263,15 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
 
         $this->browser->submit($form);
 
-        $this->assertSame($postIdentifier, $this->browser->getCrawler()->filterXPath('//input[@name="post[__identity]"]')->attr('value'));
+        self::assertSame($postIdentifier, $this->browser->getCrawler()->filterXPath('//input[@name="post[__identity]"]')->attr('value'));
 
         $form['post']['name']->setValue('Hello World');
         $form['post']['author']['emailAddress']->setValue('foo@bar.org');
         $response = $this->browser->submit($form);
-        $this->assertSame('Hello World|foo@bar.org', $response->getContent());
+        self::assertSame('Hello World|foo@bar.org', $response->getContent());
 
         $post = $this->persistenceManager->getObjectByIdentifier($postIdentifier, \Neos\FluidAdaptor\Tests\Functional\Form\Fixtures\Domain\Model\Post::class);
-        $this->assertSame('foo@bar.org', $post->getAuthor()->getEmailAddress());
+        self::assertSame('foo@bar.org', $post->getAuthor()->getEmailAddress());
     }
 
     /**
@@ -284,11 +284,11 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
         $this->browser->request('http://localhost/test/fluid/formobjects/edit?fooPost=' . $postIdentifier);
         $form = $this->browser->getForm();
 
-        $this->assertSame('myName', $form['post']['name']->getValue());
+        self::assertSame('myName', $form['post']['name']->getValue());
 
         $form['post']['name']->setValue('Hello World');
         $response = $this->browser->submit($form);
-        $this->assertSame('Hello World|foo@bar.org', $response->getContent());
+        self::assertSame('Hello World|foo@bar.org', $response->getContent());
     }
 
     /**
@@ -304,7 +304,7 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
         $form['__trustedProperties']->setValue($form['__trustedProperties']->getValue() . 'a');
         $this->browser->submit($form);
 
-        $this->assertSame('500 Internal Server Error', $this->browser->getLastResponse()->getStatus());
+        self::assertSame('500 Internal Server Error', $this->browser->getLastResponse()->getStatus());
     }
 
     /**
@@ -320,7 +320,7 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
 
         $this->browser->submit($form);
 
-        $this->assertSame('500 Internal Server Error', $this->browser->getLastResponse()->getStatus());
+        self::assertSame('500 Internal Server Error', $this->browser->getLastResponse()->getStatus());
     }
 
     /**
@@ -338,7 +338,7 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
 
         $this->browser->submit($form);
 
-        $this->assertSame('500 Internal Server Error', $this->browser->getLastResponse()->getStatus());
+        self::assertSame('500 Internal Server Error', $this->browser->getLastResponse()->getStatus());
     }
 
     /**
@@ -354,7 +354,7 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
         unset($form['__trustedProperties']);
         $this->browser->submit($form);
 
-        $this->assertSame('500 Internal Server Error', $this->browser->getLastResponse()->getStatus());
+        self::assertSame('500 Internal Server Error', $this->browser->getLastResponse()->getStatus());
     }
 
     /**
@@ -393,11 +393,11 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
         $form['post']['private']->setValue(false);
 
         $this->browser->submit($form);
-        $this->assertEmpty($this->browser->getCrawler()->filterXPath('//input[@id="private"]')->attr('checked'));
+        self::assertEmpty($this->browser->getCrawler()->filterXPath('//input[@id="private"]')->attr('checked'));
 
         $form['post']['private']->setValue(true);
         $this->browser->submit($form);
-        $this->assertNotNull($this->browser->getCrawler()->filterXPath('//input[@id="private"]')->attr('checked'));
+        self::assertNotNull($this->browser->getCrawler()->filterXPath('//input[@id="private"]')->attr('checked'));
     }
 
     /**
@@ -414,20 +414,20 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
 
         $this->browser->submit($form);
 
-        $this->assertNull($this->browser->getCrawler()->filterXPath('//input[@id="category_foo"]')->attr('checked'));
-        $this->assertNotNull($this->browser->getCrawler()->filterXPath('//input[@id="category_bar"]')->attr('checked'));
-        $this->assertNull($this->browser->getCrawler()->filterXPath('//input[@id="subCategory_foo"]')->attr('checked'));
-        $this->assertNotNull($this->browser->getCrawler()->filterXPath('//input[@id="subCategory_bar"]')->attr('checked'));
+        self::assertNull($this->browser->getCrawler()->filterXPath('//input[@id="category_foo"]')->attr('checked'));
+        self::assertNotNull($this->browser->getCrawler()->filterXPath('//input[@id="category_bar"]')->attr('checked'));
+        self::assertNull($this->browser->getCrawler()->filterXPath('//input[@id="subCategory_foo"]')->attr('checked'));
+        self::assertNotNull($this->browser->getCrawler()->filterXPath('//input[@id="subCategory_bar"]')->attr('checked'));
 
         $form['post']['category']->setValue('foo');
         $form['post']['subCategory']->setValue('foo');
 
         $this->browser->submit($form);
 
-        $this->assertNotNull($this->browser->getCrawler()->filterXPath('//input[@id="category_foo"]')->attr('checked'));
-        $this->assertNull($this->browser->getCrawler()->filterXPath('//input[@id="category_bar"]')->attr('checked'));
-        $this->assertNotNull($this->browser->getCrawler()->filterXPath('//input[@id="subCategory_foo"]')->attr('checked'));
-        $this->assertNull($this->browser->getCrawler()->filterXPath('//input[@id="subCategory_bar"]')->attr('checked'));
+        self::assertNotNull($this->browser->getCrawler()->filterXPath('//input[@id="category_foo"]')->attr('checked'));
+        self::assertNull($this->browser->getCrawler()->filterXPath('//input[@id="category_bar"]')->attr('checked'));
+        self::assertNotNull($this->browser->getCrawler()->filterXPath('//input[@id="subCategory_foo"]')->attr('checked'));
+        self::assertNull($this->browser->getCrawler()->filterXPath('//input[@id="subCategory_bar"]')->attr('checked'));
     }
 
     /**
@@ -437,12 +437,12 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
     {
         $postIdentifier = $this->setupDummyPost();
         $post = $this->persistenceManager->getObjectByIdentifier($postIdentifier, \Neos\FluidAdaptor\Tests\Functional\Form\Fixtures\Domain\Model\Post::class);
-        $this->assertEquals(true, $post->getPrivate());
+        self::assertEquals(true, $post->getPrivate());
 
         $this->browser->request('http://localhost/test/fluid/formobjects/edit?fooPost=' . $postIdentifier);
         $checkboxDisabled = $this->browser->getCrawler()->filterXPath('//*[@id="private"]')->attr('disabled');
-        $this->assertNotNull($checkboxDisabled, 'Private checkbox was not disabled.');
-        $this->assertEquals($checkboxDisabled, $this->browser->getCrawler()->filterXPath('//input[@type="hidden" and contains(@name,"private")]')->attr('disabled'), 'The hidden checkbox field is not disabled like the connected checkbox.');
+        self::assertNotNull($checkboxDisabled, 'Private checkbox was not disabled.');
+        self::assertEquals($checkboxDisabled, $this->browser->getCrawler()->filterXPath('//input[@type="hidden" and contains(@name,"private")]')->attr('disabled'), 'The hidden checkbox field is not disabled like the connected checkbox.');
 
         $form = $this->browser->getForm();
         $this->browser->submit($form);
@@ -451,6 +451,6 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
         $post = $this->persistenceManager->getObjectByIdentifier($postIdentifier, \Neos\FluidAdaptor\Tests\Functional\Form\Fixtures\Domain\Model\Post::class);
         // This will currently never fail, because DomCrawler\Form does not handle hidden checkbox fields correctly!
         // Hence this test currently only relies on the correctly set "disabled" attribute on the hidden field.
-        $this->assertEquals(true, $post->getPrivate(), 'The value for the checkbox field "private" was lost on form submit!');
+        self::assertEquals(true, $post->getPrivate(), 'The value for the checkbox field "private" was lost on form submit!');
     }
 }

--- a/Neos.FluidAdaptor/Tests/Functional/View/StandaloneViewTest.php
+++ b/Neos.FluidAdaptor/Tests/Functional/View/StandaloneViewTest.php
@@ -60,7 +60,7 @@ class StandaloneViewTest extends FunctionalTestCase
 
         $expected = 'This is my cool bar template!';
         $actual = $standaloneView->render();
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -77,7 +77,7 @@ class StandaloneViewTest extends FunctionalTestCase
 
         $expected = 'test bar';
         $actual = $standaloneView->renderSection('innerSection');
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -150,7 +150,7 @@ class StandaloneViewTest extends FunctionalTestCase
 
         $expected = 'This is a test template. Hello Robert.';
         $actual = $standaloneView->render();
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -164,7 +164,7 @@ class StandaloneViewTest extends FunctionalTestCase
 
         $expected = 'Hello Sebastian &lt;script&gt;alert(&quot;dangerous&quot;);&lt;/script&gt;.';
         $actual = $standaloneView->render();
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -178,7 +178,7 @@ class StandaloneViewTest extends FunctionalTestCase
 
         $expected = 'Hello Sebastian <script>alert("dangerous");</script>.';
         $actual = $standaloneView->render();
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -195,7 +195,7 @@ class StandaloneViewTest extends FunctionalTestCase
 
         $expected = 'This is a test template. Hello Robert.';
         $actual = $standaloneView->render();
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -213,7 +213,7 @@ class StandaloneViewTest extends FunctionalTestCase
 
         $expected = 'This is a test template. Hello Karsten.';
         $actual = $standaloneView->render();
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -230,7 +230,7 @@ class StandaloneViewTest extends FunctionalTestCase
 
         $expected = 'Hey HEY HO';
         $actual = $standaloneView->render();
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -247,7 +247,7 @@ class StandaloneViewTest extends FunctionalTestCase
 
         $expected = 'Hey -- overridden -- HEY HO';
         $actual = $standaloneView->render();
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -280,7 +280,7 @@ class StandaloneViewTest extends FunctionalTestCase
 
         $expected = '<foo:bar /><bar:foo></bar:foo><foo.bar:baz />foobar';
         $actual = $standaloneView->render();
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -303,7 +303,7 @@ class StandaloneViewTest extends FunctionalTestCase
 
         $expected = 'Christian uses &lt;h1&gt;HACK&lt;/h1&gt;';
         $actual = trim($standaloneView->renderSection('test'));
-        $this->assertSame($expected, $actual, 'First rendering was not escaped.');
+        self::assertSame($expected, $actual, 'First rendering was not escaped.');
 
         $partialCacheIdentifier = $standaloneView->getTemplatePaths()->getPartialIdentifier('Test');
         $templateCache = $this->objectManager->get(CacheManager::class)->getCache('Fluid_TemplateCache');
@@ -315,7 +315,7 @@ class StandaloneViewTest extends FunctionalTestCase
 
         $expected = 'Christian uses &lt;h1&gt;HACK&lt;/h1&gt;';
         $actual = trim($standaloneView->renderSection('test'));
-        $this->assertSame($expected, $actual, 'Second rendering was not escaped.');
+        self::assertSame($expected, $actual, 'Second rendering was not escaped.');
     }
 
     /**
@@ -327,8 +327,8 @@ class StandaloneViewTest extends FunctionalTestCase
         $standaloneView = new StandaloneView();
         $standaloneView->setFormat($formatToBeSet);
 
-        $this->assertSame($formatToBeSet, $standaloneView->getFormat());
-        $this->assertSame($formatToBeSet, $standaloneView->getRenderingContext()->getTemplatePaths()->getFormat());
+        self::assertSame($formatToBeSet, $standaloneView->getFormat());
+        self::assertSame($formatToBeSet, $standaloneView->getRenderingContext()->getTemplatePaths()->getFormat());
     }
 
     /**
@@ -340,7 +340,7 @@ class StandaloneViewTest extends FunctionalTestCase
         $standaloneView = new StandaloneView();
         $standaloneView->setTemplatePathAndFilename($templatePathAndFilename);
 
-        $this->assertSame($templatePathAndFilename, $standaloneView->getTemplatePathAndFilename());
+        self::assertSame($templatePathAndFilename, $standaloneView->getTemplatePathAndFilename());
     }
 
     /**
@@ -358,6 +358,6 @@ class StandaloneViewTest extends FunctionalTestCase
 
         $expected = 'This is a test template.<input type="checkbox" name="checkbox-outside" value="1" />';
         $actual = $standaloneView->render();
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Parser/Interceptor/ResourceInterceptorTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Parser/Interceptor/ResourceInterceptorTest.php
@@ -42,15 +42,15 @@ class ResourceInterceptorTest extends UnitTestCase
 			}';
         $originalText = $originalText1 . $originalText2 . $originalText3;
         $mockTextNode = $this->getMockBuilder(TextNode::class)->setMethods(['evaluateChildNodes'])->setConstructorArgs([$originalText])->getMock();
-        $this->assertEquals($originalText, $mockTextNode->evaluate($this->createMock(RenderingContextInterface::class)));
+        self::assertEquals($originalText, $mockTextNode->evaluate($this->createMock(RenderingContextInterface::class)));
 
         $interceptor = new ResourceInterceptor();
         $resultingNodeTree = $interceptor->process($mockTextNode, InterceptorInterface::INTERCEPT_TEXT, $this->createMock(ParsingState::class));
-        $this->assertInstanceOf(RootNode::class, $resultingNodeTree);
-        $this->assertCount(3, $resultingNodeTree->getChildNodes());
+        self::assertInstanceOf(RootNode::class, $resultingNodeTree);
+        self::assertCount(3, $resultingNodeTree->getChildNodes());
         foreach ($resultingNodeTree->getChildNodes() as $parserNode) {
             if ($parserNode instanceof ResourceUriNode) {
-                $this->assertEquals([
+                self::assertEquals([
                     'path' => $path
                 ], $parserNode->getArguments());
             }
@@ -112,17 +112,17 @@ class ResourceInterceptorTest extends UnitTestCase
     {
         $originalText = $part1 . $part2 . $part3;
         $mockTextNode = $this->getMockBuilder(TextNode::class)->setMethods(['evaluateChildNodes'])->setConstructorArgs([$originalText])->getMock();
-        $this->assertEquals($originalText, $mockTextNode->evaluate($this->createMock(RenderingContextInterface::class)));
+        self::assertEquals($originalText, $mockTextNode->evaluate($this->createMock(RenderingContextInterface::class)));
 
         $interceptor = new ResourceInterceptor();
         $interceptor->setDefaultPackageKey('Acme.Demo');
         $resultingNodeTree = $interceptor->process($mockTextNode, InterceptorInterface::INTERCEPT_TEXT, $this->createMock(ParsingState::class));
 
-        $this->assertInstanceOf(RootNode::class, $resultingNodeTree);
-        $this->assertCount(3, $resultingNodeTree->getChildNodes());
+        self::assertInstanceOf(RootNode::class, $resultingNodeTree);
+        self::assertCount(3, $resultingNodeTree->getChildNodes());
         foreach ($resultingNodeTree->getChildNodes() as $parserNode) {
             if ($parserNode instanceof ResourceUriNode) {
-                $this->assertEquals([
+                self::assertEquals([
                     'path' => $expectedPath,
                     'package' => $expectedPackageKey
                 ], $parserNode->getArguments());

--- a/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractConditionViewHelperTest.php
@@ -45,7 +45,7 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->any())->method('renderChildren')->will($this->returnValue('foo'));
 
         $actualResult = $this->viewHelper->_call('renderThenChild');
-        $this->assertEquals('foo', $actualResult);
+        self::assertEquals('foo', $actualResult);
     }
 
     /**
@@ -59,7 +59,7 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
 
         $this->viewHelper->setChildNodes([$mockThenViewHelperNode]);
         $actualResult = $this->viewHelper->_call('renderThenChild');
-        $this->assertEquals('ThenViewHelperResults', $actualResult);
+        self::assertEquals('ThenViewHelperResults', $actualResult);
     }
 
     /**
@@ -72,7 +72,7 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
 
         $actualResult = $this->viewHelper->_call('renderThenChild');
-        $this->assertEquals('ThenArgument', $actualResult);
+        self::assertEquals('ThenArgument', $actualResult);
     }
 
     /**
@@ -86,7 +86,7 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->never())->method('renderChildren')->will($this->returnValue('Child nodes'));
 
         $actualResult = $this->viewHelper->_call('renderThenChild');
-        $this->assertEquals('', $actualResult);
+        self::assertEquals('', $actualResult);
     }
 
     /**
@@ -95,7 +95,7 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
     public function renderElseChildReturnsEmptyStringIfConditionIsFalseAndNoElseViewHelperChildExists()
     {
         $actualResult = $this->viewHelper->_call('renderElseChild');
-        $this->assertEquals('', $actualResult);
+        self::assertEquals('', $actualResult);
     }
 
     /**
@@ -109,7 +109,7 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
 
         $this->viewHelper->setChildNodes([$mockElseViewHelperNode]);
         $actualResult = $this->viewHelper->_call('renderElseChild');
-        $this->assertEquals('ElseViewHelperResults', $actualResult);
+        self::assertEquals('ElseViewHelperResults', $actualResult);
     }
 
     /**
@@ -128,7 +128,7 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
 
         $actualResult = $this->viewHelper->_call('renderThenChild');
-        $this->assertEquals('ThenArgument', $actualResult);
+        self::assertEquals('ThenArgument', $actualResult);
     }
 
     /**
@@ -141,7 +141,7 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
 
         $actualResult = $this->viewHelper->_call('renderElseChild');
-        $this->assertEquals('ElseArgument', $actualResult);
+        self::assertEquals('ElseArgument', $actualResult);
     }
 
     /**
@@ -160,6 +160,6 @@ class AbstractConditionViewHelperTest extends ViewHelperBaseTestcase
         $this->injectDependenciesIntoViewHelper($this->viewHelper);
 
         $actualResult = $this->viewHelper->_call('renderElseChild');
-        $this->assertEquals('ElseArgument', $actualResult);
+        self::assertEquals('ElseArgument', $actualResult);
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -102,7 +102,7 @@ class AbstractViewHelperTest extends UnitTestCase
         $expected = new ArgumentDefinition($name, $type, $description, $isRequired);
 
         $viewHelper->_call('registerArgument', $name, $type, $description, $isRequired);
-        $this->assertEquals([$name => $expected], $viewHelper->prepareArguments(), 'Argument definitions not returned correctly.');
+        self::assertEquals([$name => $expected], $viewHelper->prepareArguments(), 'Argument definitions not returned correctly.');
     }
 
     /**
@@ -142,7 +142,7 @@ class AbstractViewHelperTest extends UnitTestCase
 
         $viewHelper->_call('registerArgument', $name, $type, $description, $isRequired);
         $viewHelper->_call('overrideArgument', $name, $overriddenType, $overriddenDescription, $isRequired);
-        $this->assertEquals($viewHelper->prepareArguments(), [$name => $expected], 'Argument definitions not returned correctly. The original ArgumentDefinition could not be overridden.');
+        self::assertEquals($viewHelper->prepareArguments(), [$name => $expected], 'Argument definitions not returned correctly. The original ArgumentDefinition could not be overridden.');
     }
 
     /**
@@ -244,7 +244,7 @@ class AbstractViewHelperTest extends UnitTestCase
 
         $expectedOutput = 'Output';
         $actualOutput = $viewHelper->initializeArgumentsAndRender(['argument1' => 'value1']);
-        $this->assertEquals($expectedOutput, $actualOutput);
+        self::assertEquals($expectedOutput, $actualOutput);
     }
 
     /**
@@ -266,8 +266,8 @@ class AbstractViewHelperTest extends UnitTestCase
 
         $viewHelper->setRenderingContext($renderingContext);
 
-        $this->assertSame($viewHelper->_get('templateVariableContainer'), $templateVariableContainer);
-        $this->assertSame($viewHelper->_get('viewHelperVariableContainer'), $viewHelperVariableContainer);
-        $this->assertSame($viewHelper->_get('controllerContext'), $controllerContext);
+        self::assertSame($viewHelper->_get('templateVariableContainer'), $templateVariableContainer);
+        self::assertSame($viewHelper->_get('viewHelperVariableContainer'), $viewHelperVariableContainer);
+        self::assertSame($viewHelper->_get('controllerContext'), $controllerContext);
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetControllerTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetControllerTest.php
@@ -63,6 +63,6 @@ class AbstractWidgetControllerTest extends UnitTestCase
         $abstractWidgetController->processRequest($mockActionRequest, $mockResponse);
 
         $actualWidgetConfiguration = $abstractWidgetController->_get('widgetConfiguration');
-        $this->assertEquals($expectedWidgetConfiguration, $actualWidgetConfiguration);
+        self::assertEquals($expectedWidgetConfiguration, $actualWidgetConfiguration);
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetViewHelperTest.php
@@ -123,7 +123,7 @@ class AbstractWidgetViewHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $this->viewHelper->expects($this->once())->method('initialize');
         $this->viewHelper->expects($this->once())->method('callRenderMethod')->will($this->returnValue('renderedResult'));
         $output = $this->viewHelper->initializeArgumentsAndRender(['arg1' => 'val1']);
-        $this->assertEquals('renderedResult', $output);
+        self::assertEquals('renderedResult', $output);
     }
 
     /**
@@ -148,7 +148,7 @@ class AbstractWidgetViewHelperTest extends \Neos\Flow\Tests\UnitTestCase
 
         $this->viewHelper->setChildNodes([$node1, $node2, $node3]);
 
-        $this->assertEquals($rootNode, $this->widgetContext->getViewHelperChildNodes());
+        self::assertEquals($rootNode, $this->widgetContext->getViewHelperChildNodes());
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AjaxWidgetComponentTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AjaxWidgetComponentTest.php
@@ -248,6 +248,6 @@ class AjaxWidgetComponentTest extends UnitTestCase
         $this->mockHashService->expects($this->atLeastOnce())->method('validateAndStripHmac')->with($mockSerializedWidgetContextWithHmac)->will($this->returnValue($mockSerializedWidgetContext));
 
         $actualResult = $ajaxWidgetComponent->_call('extractWidgetContext', $this->mockHttpRequest);
-        $this->assertEquals($mockWidgetContext, $actualResult);
+        self::assertEquals($mockWidgetContext, $actualResult);
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AjaxWidgetContextHolderTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AjaxWidgetContextHolderTest.php
@@ -31,7 +31,7 @@ class AjaxWidgetContextHolderTest extends \Neos\Flow\Tests\UnitTestCase
         $widgetContext->expects($this->once())->method('setAjaxWidgetIdentifier')->with(123);
 
         $ajaxWidgetContextHolder->store($widgetContext);
-        $this->assertEquals(124, $ajaxWidgetContextHolder->_get('nextFreeAjaxWidgetId'));
+        self::assertEquals(124, $ajaxWidgetContextHolder->_get('nextFreeAjaxWidgetId'));
     }
 
     /**
@@ -45,7 +45,7 @@ class AjaxWidgetContextHolderTest extends \Neos\Flow\Tests\UnitTestCase
         $widgetContext = $this->createMock(\Neos\FluidAdaptor\Core\Widget\WidgetContext::class, ['setAjaxWidgetIdentifier']);
         $ajaxWidgetContextHolder->store($widgetContext);
 
-        $this->assertSame($widgetContext, $ajaxWidgetContextHolder->get('123'));
+        self::assertSame($widgetContext, $ajaxWidgetContextHolder->get('123'));
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/WidgetContextTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/WidgetContextTest.php
@@ -37,7 +37,7 @@ class WidgetContextTest extends \Neos\Flow\Tests\UnitTestCase
     public function widgetIdentifierCanBeReadAgain()
     {
         $this->widgetContext->setWidgetIdentifier('myWidgetIdentifier');
-        $this->assertEquals('myWidgetIdentifier', $this->widgetContext->getWidgetIdentifier());
+        self::assertEquals('myWidgetIdentifier', $this->widgetContext->getWidgetIdentifier());
     }
 
     /**
@@ -46,7 +46,7 @@ class WidgetContextTest extends \Neos\Flow\Tests\UnitTestCase
     public function ajaxWidgetIdentifierCanBeReadAgain()
     {
         $this->widgetContext->setAjaxWidgetIdentifier(42);
-        $this->assertEquals(42, $this->widgetContext->getAjaxWidgetIdentifier());
+        self::assertEquals(42, $this->widgetContext->getAjaxWidgetIdentifier());
     }
 
     /**
@@ -56,7 +56,7 @@ class WidgetContextTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $this->widgetContext->setNonAjaxWidgetConfiguration(['key' => 'value']);
         $this->widgetContext->setAjaxWidgetConfiguration(['keyAjax' => 'valueAjax']);
-        $this->assertEquals(['key' => 'value'], $this->widgetContext->getWidgetConfiguration());
+        self::assertEquals(['key' => 'value'], $this->widgetContext->getWidgetConfiguration());
     }
 
     /**
@@ -68,7 +68,7 @@ class WidgetContextTest extends \Neos\Flow\Tests\UnitTestCase
         $this->widgetContext->setAjaxWidgetConfiguration(['keyAjax' => 'valueAjax']);
         $this->widgetContext = serialize($this->widgetContext);
         $this->widgetContext = unserialize($this->widgetContext);
-        $this->assertEquals(['keyAjax' => 'valueAjax'], $this->widgetContext->getWidgetConfiguration());
+        self::assertEquals(['keyAjax' => 'valueAjax'], $this->widgetContext->getWidgetConfiguration());
     }
 
     /**
@@ -77,7 +77,7 @@ class WidgetContextTest extends \Neos\Flow\Tests\UnitTestCase
     public function controllerObjectNameCanBeReadAgain()
     {
         $this->widgetContext->setControllerObjectName('TYPO3\My\Object\Name');
-        $this->assertEquals('TYPO3\My\Object\Name', $this->widgetContext->getControllerObjectName());
+        self::assertEquals('TYPO3\My\Object\Name', $this->widgetContext->getControllerObjectName());
     }
 
     /**
@@ -89,7 +89,7 @@ class WidgetContextTest extends \Neos\Flow\Tests\UnitTestCase
         $renderingContext = $this->createMock(RenderingContextInterface::class);
 
         $this->widgetContext->setViewHelperChildNodes($viewHelperChildNodes, $renderingContext);
-        $this->assertSame($viewHelperChildNodes, $this->widgetContext->getViewHelperChildNodes());
-        $this->assertSame($renderingContext, $this->widgetContext->getViewHelperChildNodeRenderingContext());
+        self::assertSame($viewHelperChildNodes, $this->widgetContext->getViewHelperChildNodes());
+        self::assertSame($renderingContext, $this->widgetContext->getViewHelperChildNodeRenderingContext());
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/View/TemplatePathsTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/View/TemplatePathsTest.php
@@ -486,7 +486,7 @@ class TemplatePathsTest extends UnitTestCase
         ];
 
         $actualResult = $templatePaths->_call('expandGenericPathPattern', $pattern, $patternReplacementVariables, $bubbleControllerAndSubpackage, $formatIsOptional);
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -507,7 +507,7 @@ class TemplatePathsTest extends UnitTestCase
             'controllerName' => 'My',
             'format' => 'html'
         ], false, false);
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -531,7 +531,7 @@ class TemplatePathsTest extends UnitTestCase
         $expected = [
             'Resources/Private/Templates/MySubPackage/My/@action.html'
         ];
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -556,7 +556,7 @@ class TemplatePathsTest extends UnitTestCase
             'Resources/Private/Templates/MySubPackage/My/@action.html',
             'Resources/Private/Templates/MySubPackage/My/@action'
         ];
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -585,7 +585,7 @@ class TemplatePathsTest extends UnitTestCase
             'Resources/Private/Templates/@action.html',
             'Resources/Private/Templates/@action'
         ];
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -608,7 +608,7 @@ class TemplatePathsTest extends UnitTestCase
         ]], '', true);
         $templatePaths->expects($this->once())->method('expandGenericPathPattern')->with('@partialRoot/@subpackage/@partial.@format', ['partial' => 'SomePartial', 'format' => 'html'], true, true)->will($this->returnValue($paths));
 
-        $this->assertSame('contentsOfSomePartial', $templatePaths->getPartialSource('SomePartial'));
+        self::assertSame('contentsOfSomePartial', $templatePaths->getPartialSource('SomePartial'));
     }
 
     /**
@@ -638,7 +638,7 @@ class TemplatePathsTest extends UnitTestCase
             'format' => 'html'
         ], false, false)->will($this->returnValue($paths));
 
-        $this->assertSame('contentsOfMyCoolAction', $templatePaths->getTemplateSource('', 'myCoolAction'));
+        self::assertSame('contentsOfMyCoolAction', $templatePaths->getTemplateSource('', 'myCoolAction'));
     }
 
     /**
@@ -707,7 +707,7 @@ class TemplatePathsTest extends UnitTestCase
 
         $templatePaths = $this->getAccessibleMock(TemplatePaths::class, ['dummy'], [['templatePathAndFilename' => 'vfs://MyTemplates/MyCoolAction.html']]);
 
-        $this->assertSame('contentsOfMyCoolAction', $templatePaths->_call('getTemplateSource'));
+        self::assertSame('contentsOfMyCoolAction', $templatePaths->_call('getTemplateSource'));
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Unit/View/TemplateViewTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/View/TemplateViewTest.php
@@ -63,7 +63,7 @@ class TemplateViewTest extends UnitTestCase
         $templateView->setOption('templateRootPaths', $templateRootPaths);
 
         $actual = $templateView->getTemplatePaths()->getTemplateRootPaths();
-        $this->assertEquals($templateRootPaths, $actual, 'A set template root path was not returned correctly.');
+        self::assertEquals($templateRootPaths, $actual, 'A set template root path was not returned correctly.');
     }
 
     /**
@@ -77,7 +77,7 @@ class TemplateViewTest extends UnitTestCase
         $templateView->setOption('partialRootPaths', $partialRootPaths);
 
         $actual = $templateView->getTemplatePaths()->getPartialRootPaths();
-        $this->assertEquals($partialRootPaths, $actual, 'A set partial root path was not returned correctly.');
+        self::assertEquals($partialRootPaths, $actual, 'A set partial root path was not returned correctly.');
     }
 
     /**
@@ -91,6 +91,6 @@ class TemplateViewTest extends UnitTestCase
         $templateView->setOption('layoutRootPaths', $layoutRootPaths);
 
         $actual = $templateView->getTemplatePaths()->getLayoutRootPaths();
-        $this->assertEquals($layoutRootPaths, $actual, 'A set layout root path was not returned correctly.');
+        self::assertEquals($layoutRootPaths, $actual, 'A set layout root path was not returned correctly.');
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/FlashMessagesViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/FlashMessagesViewHelperTest.php
@@ -59,7 +59,7 @@ class FlashMessagesViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelp
     {
         $this->mockFlashMessageContainer->expects($this->once())->method('getMessagesAndFlush')->will($this->returnValue([]));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
-        $this->assertEmpty($this->viewHelper->render());
+        self::assertEmpty($this->viewHelper->render());
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/AbstractFormFieldViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/AbstractFormFieldViewHelperTest.php
@@ -48,8 +48,8 @@ class AbstractFormFieldViewHelperTest extends FormFieldViewHelperBaseTestcase
         $formViewHelper->_set('arguments', $arguments);
         $formViewHelper->expects($this->any())->method('isObjectAccessorMode')->willReturn(false);
 
-        $this->assertSame('foo[__identity]', $formViewHelper->_call('getName'));
-        $this->assertSame('6f487e40-4483-11de-8a39-0800200c9a66', $formViewHelper->_call('getValueAttribute'));
+        self::assertSame('foo[__identity]', $formViewHelper->_call('getName'));
+        self::assertSame('6f487e40-4483-11de-8a39-0800200c9a66', $formViewHelper->_call('getValueAttribute'));
     }
 
     /**
@@ -73,7 +73,7 @@ class AbstractFormFieldViewHelperTest extends FormFieldViewHelperBaseTestcase
         $formViewHelper->_set('arguments', $arguments);
         $expected = 'formPrefix[myObjectName][bla]';
         $actual = $formViewHelper->_call('getName');
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -97,7 +97,7 @@ class AbstractFormFieldViewHelperTest extends FormFieldViewHelperBaseTestcase
         $formViewHelper->_set('arguments', $arguments);
         $expected = 'formPrefix[myObjectName][bla][blubb]';
         $actual = $formViewHelper->_call('getName');
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -120,7 +120,7 @@ class AbstractFormFieldViewHelperTest extends FormFieldViewHelperBaseTestcase
         $formViewHelper->_set('arguments', $arguments);
         $expected = 'formPrefix[bla]';
         $actual = $formViewHelper->_call('getName');
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -143,7 +143,7 @@ class AbstractFormFieldViewHelperTest extends FormFieldViewHelperBaseTestcase
         $formViewHelper->_set('arguments', $arguments);
         $expected = 'formPrefix[some][property][path]';
         $actual = $formViewHelper->_call('getName');
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -165,7 +165,7 @@ class AbstractFormFieldViewHelperTest extends FormFieldViewHelperBaseTestcase
         $formViewHelper->_set('arguments', $arguments);
         $expected = 'formPrefix[fieldName]';
         $actual = $formViewHelper->_call('getName');
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
 
@@ -212,7 +212,7 @@ class AbstractFormFieldViewHelperTest extends FormFieldViewHelperBaseTestcase
         $formViewHelper->_set('arguments', $arguments);
         $expected = 'MyString';
         $actual = $formViewHelper->_call('getValueAttribute');
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -227,7 +227,7 @@ class AbstractFormFieldViewHelperTest extends FormFieldViewHelperBaseTestcase
         $mockArguments = [];
         $formViewHelper->_set('arguments', $mockArguments);
 
-        $this->assertNull($formViewHelper->_call('getValueAttribute'));
+        self::assertNull($formViewHelper->_call('getValueAttribute'));
     }
 
     /**
@@ -242,7 +242,7 @@ class AbstractFormFieldViewHelperTest extends FormFieldViewHelperBaseTestcase
         $mockArguments = ['value' => 'someValue'];
         $formViewHelper->_set('arguments', $mockArguments);
 
-        $this->assertEquals('someValue', $formViewHelper->_call('getValueAttribute'));
+        self::assertEquals('someValue', $formViewHelper->_call('getValueAttribute'));
     }
 
     /**
@@ -263,7 +263,7 @@ class AbstractFormFieldViewHelperTest extends FormFieldViewHelperBaseTestcase
         $mockArguments = ['value' => $mockObject];
         $formViewHelper->_set('arguments', $mockArguments);
 
-        $this->assertSame('6f487e40-4483-11de-8a39-0800200c9a66', $formViewHelper->_call('getValueAttribute'));
+        self::assertSame('6f487e40-4483-11de-8a39-0800200c9a66', $formViewHelper->_call('getValueAttribute'));
     }
 
     /**
@@ -284,7 +284,7 @@ class AbstractFormFieldViewHelperTest extends FormFieldViewHelperBaseTestcase
         $mockArguments = ['value' => $mockObject];
         $formViewHelper->_set('arguments', $mockArguments);
 
-        $this->assertSame($mockObject, $formViewHelper->_call('getValueAttribute'));
+        self::assertSame($mockObject, $formViewHelper->_call('getValueAttribute'));
     }
 
     /**
@@ -302,10 +302,10 @@ class AbstractFormFieldViewHelperTest extends FormFieldViewHelperBaseTestcase
         ];
 
         $formViewHelper->_set('arguments', ['name' => null, 'value' => null, 'property' => 'bla']);
-        $this->assertTrue($formViewHelper->_call('isObjectAccessorMode'));
+        self::assertTrue($formViewHelper->_call('isObjectAccessorMode'));
 
         $formViewHelper->_set('arguments', ['name' => null, 'value' => null, 'property' => null]);
-        $this->assertFalse($formViewHelper->_call('isObjectAccessorMode'));
+        self::assertFalse($formViewHelper->_call('isObjectAccessorMode'));
     }
 
     /**
@@ -332,7 +332,7 @@ class AbstractFormFieldViewHelperTest extends FormFieldViewHelperBaseTestcase
         $this->request->expects($this->once())->method('getInternalArgument')->with('__submittedArgumentValidationResults')->willReturn($mockFormResult);
 
         $actualResult = $formViewHelper->_call('getMappingResultsForProperty');
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -359,7 +359,7 @@ class AbstractFormFieldViewHelperTest extends FormFieldViewHelperBaseTestcase
 
         $formViewHelper = $this->prepareArguments($formViewHelper, ['property' => 'bar']);
         $actualResult = $formViewHelper->_call('getMappingResultsForProperty');
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -372,7 +372,7 @@ class AbstractFormFieldViewHelperTest extends FormFieldViewHelperBaseTestcase
         $formViewHelper->expects($this->any())->method('isObjectAccessorMode')->willReturn(true);
 
         $actualResult = $formViewHelper->_call('getMappingResultsForProperty');
-        $this->assertEmpty($actualResult->getFlattenedErrors());
+        self::assertEmpty($actualResult->getFlattenedErrors());
     }
 
     /**
@@ -385,7 +385,7 @@ class AbstractFormFieldViewHelperTest extends FormFieldViewHelperBaseTestcase
         $formViewHelper->expects($this->any())->method('isObjectAccessorMode')->willReturn(false);
 
         $actualResult = $formViewHelper->_call('getMappingResultsForProperty');
-        $this->assertEmpty($actualResult->getFlattenedErrors());
+        self::assertEmpty($actualResult->getFlattenedErrors());
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/AbstractFormViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/AbstractFormViewHelperTest.php
@@ -41,7 +41,7 @@ class AbstractFormViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpe
         $viewHelper->_set('persistenceManager', $mockPersistenceManager);
 
         $actualResult = $viewHelper->_call('renderHiddenIdentityField', $object, 'theName');
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -66,7 +66,7 @@ class AbstractFormViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpe
         $viewHelper->_set('persistenceManager', $mockPersistenceManager);
 
         $actualResult = $viewHelper->_call('renderHiddenIdentityField', $object, 'theName');
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -90,7 +90,7 @@ class AbstractFormViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpe
         $viewHelper->_set('persistenceManager', $mockPersistenceManager);
 
         $actualResult = $viewHelper->_call('renderHiddenIdentityField', $object, 'theName');
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -101,7 +101,7 @@ class AbstractFormViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpe
         $viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\ViewHelpers\Form\AbstractFormViewHelper::class, ['dummy'], [], '', false);
         $this->injectDependenciesIntoViewHelper($viewHelper);
 
-        $this->assertSame('', $viewHelper->_call('prefixFieldName', null));
+        self::assertSame('', $viewHelper->_call('prefixFieldName', null));
     }
 
     /**
@@ -112,7 +112,7 @@ class AbstractFormViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpe
         $viewHelper = $this->getAccessibleMock(\Neos\FluidAdaptor\ViewHelpers\Form\AbstractFormViewHelper::class, ['dummy'], [], '', false);
         $this->injectDependenciesIntoViewHelper($viewHelper);
 
-        $this->assertSame('', $viewHelper->_call('prefixFieldName', ''));
+        self::assertSame('', $viewHelper->_call('prefixFieldName', ''));
     }
 
     /**
@@ -128,7 +128,7 @@ class AbstractFormViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpe
             ]
         ];
 
-        $this->assertSame('someFieldName', $viewHelper->_call('prefixFieldName', 'someFieldName'));
+        self::assertSame('someFieldName', $viewHelper->_call('prefixFieldName', 'someFieldName'));
     }
 
     /**
@@ -144,7 +144,7 @@ class AbstractFormViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpe
             ]
         ];
 
-        $this->assertSame('somePrefix[someFieldName]', $viewHelper->_call('prefixFieldName', 'someFieldName'));
+        self::assertSame('somePrefix[someFieldName]', $viewHelper->_call('prefixFieldName', 'someFieldName'));
     }
 
     /**
@@ -160,6 +160,6 @@ class AbstractFormViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpe
             ]
         ];
 
-        $this->assertSame('somePrefix[foo][someFieldName][bar]', $viewHelper->_call('prefixFieldName', 'someFieldName[bar]'));
+        self::assertSame('somePrefix[foo][someFieldName][bar]', $viewHelper->_call('prefixFieldName', 'someFieldName[bar]'));
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/SelectViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/SelectViewHelperTest.php
@@ -169,7 +169,7 @@ class SelectViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\For
             '<option value="value2">label2</option>' . chr(10) .
             '<option value="value3" selected="selected">label3</option>' . chr(10) .
             '</select>';
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     /**
@@ -211,7 +211,7 @@ class SelectViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\For
             '<option value="value2">label2</option>' . chr(10) .
             '<option value="value3" selected="selected">label3</option>' . chr(10) .
             '</select>';
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     /**
@@ -281,7 +281,7 @@ class SelectViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\For
             '<option value="2">Kurfuerst</option>' . chr(10) .
             '<option value="3" selected="selected">Lemke</option>' . chr(10) .
             '</select>';
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -321,7 +321,7 @@ class SelectViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\For
             '<option value="2">Kurfuerst</option>' . chr(10) .
             '<option value="3" selected="selected">Lemke</option>' . chr(10) .
             '</select>';
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -624,7 +624,7 @@ class SelectViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\For
         $this->inject($this->viewHelper, 'translator', $mockTranslator);
 
         $actualResult = $this->viewHelper->_call('getTranslatedLabel', 'someValue', 'Some label');
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/UploadViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/UploadViewHelperTest.php
@@ -104,7 +104,7 @@ class UploadViewHelperTest extends FormFieldViewHelperBaseTestcase
         $expectedResult = '';
         $this->viewHelper->initialize();
         $actualResult = $this->viewHelper->render();
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -125,7 +125,7 @@ class UploadViewHelperTest extends FormFieldViewHelperBaseTestcase
         $expectedResult = '<input type="hidden" name="[foo][originallySubmittedResource][__identity]" value="79ecda60-1a27-69ca-17bf-a5d9e80e6c39" />';
         $actualResult = $this->viewHelper->render();
 
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -166,7 +166,7 @@ class UploadViewHelperTest extends FormFieldViewHelperBaseTestcase
         $expectedResult = '<input type="hidden" name="foo[bar][originallySubmittedResource][__identity]" value="' . $mockResourceUuid . '" />';
         $this->viewHelper->initialize();
         $actualResult = $this->viewHelper->render();
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -200,7 +200,7 @@ class UploadViewHelperTest extends FormFieldViewHelperBaseTestcase
 
         $expectedResult = '<input type="hidden" name="someObject[foo][originallySubmittedResource][__identity]" value="' . $mockValueResourceUuid . '" />';
         $actualResult = $this->viewHelper->render();
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -233,6 +233,6 @@ class UploadViewHelperTest extends FormFieldViewHelperBaseTestcase
 
         $expectedResult = '<input type="hidden" name="someObject[foo][originallySubmittedResource][__identity]" value="' . $mockResourceUuid . '" />';
         $actualResult = $this->viewHelper->render();
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/FormViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/FormViewHelperTest.php
@@ -334,7 +334,7 @@ class FormViewHelperTest extends ViewHelperBaseTestcase
         $expected = chr(10) . '<input type="hidden" name="object1[object2][__identity]" value="42" />' . chr(10) .
             '<input type="hidden" name="object1[object2][subobject][__identity]" value="21" />';
         $actual = $viewHelper->_call('renderAdditionalIdentityFields');
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -357,7 +357,7 @@ class FormViewHelperTest extends ViewHelperBaseTestcase
             '<input type="hidden" name="__referrer[@controller]" value="controllerName" />' . chr(10) .
             '<input type="hidden" name="__referrer[@action]" value="controllerActionName" />' . chr(10) .
             '<input type="hidden" name="__referrer[arguments]" value="" />' . chr(10);
-        $this->assertEquals($expectedResult, $hiddenFields);
+        self::assertEquals($expectedResult, $hiddenFields);
     }
 
     /**
@@ -400,7 +400,7 @@ class FormViewHelperTest extends ViewHelperBaseTestcase
             '<input type="hidden" name="__referrer[@action]" value="controllerActionName" />' . chr(10) .
             '<input type="hidden" name="__referrer[arguments]" value="" />' . chr(10);
 
-        $this->assertEquals($expectedResult, $hiddenFields);
+        self::assertEquals($expectedResult, $hiddenFields);
     }
 
     /**
@@ -488,7 +488,7 @@ class FormViewHelperTest extends ViewHelperBaseTestcase
         $this->injectDependenciesIntoViewHelper($viewHelper);
         $expected = '';
         $actual = $viewHelper->_call('renderEmptyHiddenFields');
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -507,7 +507,7 @@ class FormViewHelperTest extends ViewHelperBaseTestcase
 
         $expected = '<input type="hidden" name="fieldName1" value="" />' . chr(10) . '<input type="hidden" name="fieldName2" value="" />' . chr(10);
         $actual = $viewHelper->_call('renderEmptyHiddenFields');
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -526,7 +526,7 @@ class FormViewHelperTest extends ViewHelperBaseTestcase
         ];
 
         $viewHelper->render('index');
-        $this->assertNull($viewHelper->_get('formActionUri'));
+        self::assertNull($viewHelper->_get('formActionUri'));
     }
 
     /**
@@ -600,7 +600,7 @@ class FormViewHelperTest extends ViewHelperBaseTestcase
         $this->injectDependenciesIntoViewHelper($viewHelper);
         $this->securityContext->expects($this->never())->method('getCsrfProtectionToken');
 
-        $this->assertEquals('', $viewHelper->_call('renderCsrfTokenField'));
+        self::assertEquals('', $viewHelper->_call('renderCsrfTokenField'));
     }
 
     /**
@@ -615,7 +615,7 @@ class FormViewHelperTest extends ViewHelperBaseTestcase
         $this->mockAuthenticationManager->expects($this->any())->method('isAuthenticated')->will($this->returnValue(true));
         $this->securityContext->expects($this->never())->method('getCsrfProtectionToken');
 
-        $this->assertEquals('', $viewHelper->_call('renderCsrfTokenField'));
+        self::assertEquals('', $viewHelper->_call('renderCsrfTokenField'));
     }
 
     /**
@@ -630,7 +630,7 @@ class FormViewHelperTest extends ViewHelperBaseTestcase
         $this->mockAuthenticationManager->expects($this->atLeastOnce())->method('isAuthenticated')->will($this->returnValue(false));
         $this->securityContext->expects($this->never())->method('getCsrfProtectionToken');
 
-        $this->assertEquals('', $viewHelper->_call('renderCsrfTokenField'));
+        self::assertEquals('', $viewHelper->_call('renderCsrfTokenField'));
     }
 
     /**
@@ -646,6 +646,6 @@ class FormViewHelperTest extends ViewHelperBaseTestcase
 
         $this->securityContext->expects($this->atLeastOnce())->method('getCsrfProtectionToken')->will($this->returnValue('CSRFTOKEN'));
 
-        $this->assertEquals('<input type="hidden" name="__csrfToken" value="CSRFTOKEN" />' . chr(10), $viewHelper->_call('renderCsrfTokenField'));
+        self::assertEquals('<input type="hidden" name="__csrfToken" value="CSRFTOKEN" />' . chr(10), $viewHelper->_call('renderCsrfTokenField'));
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/BytesViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/BytesViewHelperTest.php
@@ -129,7 +129,7 @@ class BytesViewHelperTest extends ViewHelperBaseTestcase
     {
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $value, 'decimals' => $decimals, 'decimalSeparator' => $decimalSeparator, 'thousandsSeparator' => $thousandsSeparator]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals($expected, $actualResult);
+        self::assertEquals($expected, $actualResult);
     }
 
     /**
@@ -140,6 +140,6 @@ class BytesViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(12345));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('12 KB', $actualResult);
+        self::assertEquals('12 KB', $actualResult);
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CaseViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CaseViewHelperTest.php
@@ -68,7 +68,7 @@ class CaseViewHelperTest extends ViewHelperBaseTestcase
         });
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
         $result = $this->viewHelper->render();
-        $this->assertEquals(strtoupper($testString), $result);
+        self::assertEquals(strtoupper($testString), $result);
     }
 
     /**
@@ -91,7 +91,7 @@ class CaseViewHelperTest extends ViewHelperBaseTestcase
     {
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $testString]);
         $result = $this->viewHelper->render();
-        $this->assertEquals($expected, $result);
+        self::assertEquals($expected, $result);
     }
 
     /**
@@ -112,7 +112,7 @@ class CaseViewHelperTest extends ViewHelperBaseTestcase
         mb_internal_encoding('ASCII');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => 'dummy']);
         $this->viewHelper->render();
-        $this->assertEquals('ASCII', mb_internal_encoding());
+        self::assertEquals('ASCII', mb_internal_encoding());
     }
 
     /**
@@ -124,7 +124,7 @@ class CaseViewHelperTest extends ViewHelperBaseTestcase
         mb_internal_encoding('ASCII');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => 'dummy', 'mode' => 'incorrectModeResultingInException']);
         $this->viewHelper->render();
-        $this->assertEquals('ASCII', mb_internal_encoding());
+        self::assertEquals('ASCII', mb_internal_encoding());
     }
 
     /**
@@ -133,7 +133,7 @@ class CaseViewHelperTest extends ViewHelperBaseTestcase
     public function viewHelperConvertsUppercasePerDefault()
     {
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => 'FooB4r']);
-        $this->assertSame('FOOB4R', $this->viewHelper->render());
+        self::assertSame('FOOB4R', $this->viewHelper->render());
     }
 
     /**
@@ -162,6 +162,6 @@ class CaseViewHelperTest extends ViewHelperBaseTestcase
     public function viewHelperConvertsCorrectly($input, $mode, $expected)
     {
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $input, 'mode' => $mode]);
-        $this->assertSame($expected, $this->viewHelper->render(), sprintf('The conversion with mode "%s" did not perform as expected.', $mode));
+        self::assertSame($expected, $this->viewHelper->render(), sprintf('The conversion with mode "%s" did not perform as expected.', $mode));
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CropViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CropViewHelperTest.php
@@ -40,7 +40,7 @@ class CropViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('some text'));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['maxCharacters' => 50]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('some text', $actualResult);
+        self::assertEquals('some text', $actualResult);
     }
 
     /**
@@ -51,7 +51,7 @@ class CropViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('some text'));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['maxCharacters' => 5]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('some ...', $actualResult);
+        self::assertEquals('some ...', $actualResult);
     }
 
     /**
@@ -62,7 +62,7 @@ class CropViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('some text'));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['maxCharacters' => 3, 'append' => '[custom suffix]']);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('som[custom suffix]', $actualResult);
+        self::assertEquals('som[custom suffix]', $actualResult);
     }
 
     /**
@@ -73,7 +73,7 @@ class CropViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('some text'));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['maxCharacters' => 8]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('some tex...', $actualResult);
+        self::assertEquals('some tex...', $actualResult);
     }
 
     /**
@@ -84,7 +84,7 @@ class CropViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->never())->method('renderChildren');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['maxCharacters' => 8, 'append' => '...', 'value' => 'some text']);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('some tex...', $actualResult);
+        self::assertEquals('some tex...', $actualResult);
     }
 
     /**
@@ -95,7 +95,7 @@ class CropViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->never())->method('renderChildren');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['maxCharacters' => 8, 'append' => '...', 'value' => '']);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('', $actualResult);
+        self::assertEquals('', $actualResult);
     }
 
     /**
@@ -106,6 +106,6 @@ class CropViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->never())->method('renderChildren');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['maxCharacters' => 3, 'append' => '...', 'value' => 'Äßütest']);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('Äßü...', $actualResult);
+        self::assertEquals('Äßü...', $actualResult);
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CurrencyViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CurrencyViewHelperTest.php
@@ -37,7 +37,7 @@ class CurrencyViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(123.456));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('123,46', $actualResult);
+        self::assertEquals('123,46', $actualResult);
     }
 
     /**
@@ -48,7 +48,7 @@ class CurrencyViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(123));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['currencySign' => 'foo']);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('123,00 foo', $actualResult);
+        self::assertEquals('123,00 foo', $actualResult);
     }
 
     /**
@@ -59,7 +59,7 @@ class CurrencyViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(12345));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['currencySign' => '', 'decimalSeparator' => '|']);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('12.345|00', $actualResult);
+        self::assertEquals('12.345|00', $actualResult);
     }
 
     /**
@@ -70,7 +70,7 @@ class CurrencyViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(12345));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['currencySign' => '', 'decimalSeparator' => ',', 'thousandsSeparator' => '|']);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('12|345,00', $actualResult);
+        self::assertEquals('12|345,00', $actualResult);
     }
 
     /**
@@ -81,7 +81,7 @@ class CurrencyViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(null));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('0,00', $actualResult);
+        self::assertEquals('0,00', $actualResult);
     }
 
     /**
@@ -92,7 +92,7 @@ class CurrencyViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(-123.456));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('-123,46', $actualResult);
+        self::assertEquals('-123,46', $actualResult);
     }
 
     /**
@@ -175,7 +175,7 @@ class CurrencyViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(12345));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['currencySign' => '€', 'decimalSeparator' => ',', 'thousandsSeparator' => '.', 'prependCurrency' => true]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('€ 12.345,00', $actualResult);
+        self::assertEquals('€ 12.345,00', $actualResult);
     }
 
     /**
@@ -186,7 +186,7 @@ class CurrencyViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(12345));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['currencySign' => '€', 'decimalSeparator' => ',', 'thousandsSeparator' => '.', 'prependCurrency' => false, 'separateCurrency' => false]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('12.345,00€', $actualResult);
+        self::assertEquals('12.345,00€', $actualResult);
     }
 
     /**
@@ -197,7 +197,7 @@ class CurrencyViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(12345));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['currencySign' => '€', 'decimalSeparator' => ',', 'thousandsSeparator' => '.', 'prependCurrency' => false, 'separateCurrency' => true, 'decimals' => 4]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('12.345,0000 €', $actualResult);
+        self::assertEquals('12.345,0000 €', $actualResult);
     }
 
     /**
@@ -208,6 +208,6 @@ class CurrencyViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(12345));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['currencySign' => '', 'decimalSeparator' => ',', 'thousandsSeparator' => '.', 'prependCurrency' => false, 'separateCurrency' => true, 'decimals' => 2]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('12.345,00', $actualResult);
+        self::assertEquals('12.345,00', $actualResult);
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/DateViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/DateViewHelperTest.php
@@ -36,7 +36,7 @@ class DateViewHelperTest extends ViewHelperBaseTestcase
     {
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['date' => new \DateTime('1980-12-13')]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('1980-12-13', $actualResult);
+        self::assertEquals('1980-12-13', $actualResult);
     }
 
     /**
@@ -46,7 +46,7 @@ class DateViewHelperTest extends ViewHelperBaseTestcase
     {
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['date' => '1980-12-13']);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('1980-12-13', $actualResult);
+        self::assertEquals('1980-12-13', $actualResult);
     }
 
     /**
@@ -56,7 +56,7 @@ class DateViewHelperTest extends ViewHelperBaseTestcase
     {
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['date' => new \DateTime('1980-02-01'), 'format' => 'd.m.Y']);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('01.02.1980', $actualResult);
+        self::assertEquals('01.02.1980', $actualResult);
     }
 
     /**
@@ -67,7 +67,7 @@ class DateViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(null));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('', $actualResult);
+        self::assertEquals('', $actualResult);
     }
 
     /**
@@ -88,7 +88,7 @@ class DateViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(new \DateTime('1980-12-13')));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('1980-12-13', $actualResult);
+        self::assertEquals('1980-12-13', $actualResult);
     }
 
     /**
@@ -99,7 +99,7 @@ class DateViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->never())->method('renderChildren');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['date' => '1980-12-12']);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('1980-12-12', $actualResult);
+        self::assertEquals('1980-12-12', $actualResult);
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/HtmlentitiesDecodeViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/HtmlentitiesDecodeViewHelperTest.php
@@ -41,7 +41,7 @@ class HtmlentitiesDecodeViewHelperTest extends ViewHelperBaseTestcase
      */
     public function viewHelperDeactivatesEscapingInterceptor()
     {
-        $this->assertFalse($this->viewHelper->isEscapingInterceptorEnabled());
+        self::assertFalse($this->viewHelper->isEscapingInterceptorEnabled());
     }
 
     /**
@@ -52,7 +52,7 @@ class HtmlentitiesDecodeViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->never())->method('renderChildren');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => 'Some string']);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('Some string', $actualResult);
+        self::assertEquals('Some string', $actualResult);
     }
 
     /**
@@ -63,7 +63,7 @@ class HtmlentitiesDecodeViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->atLeastOnce())->method('renderChildren')->will($this->returnValue('Some string'));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('Some string', $actualResult);
+        self::assertEquals('Some string', $actualResult);
     }
 
     /**
@@ -74,7 +74,7 @@ class HtmlentitiesDecodeViewHelperTest extends ViewHelperBaseTestcase
         $source = 'This is a sample text without special characters. <> &©"\'';
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $source]);
         $actualResult = $this->viewHelper->render();
-        $this->assertSame($source, $actualResult);
+        self::assertSame($source, $actualResult);
     }
 
     /**
@@ -86,7 +86,7 @@ class HtmlentitiesDecodeViewHelperTest extends ViewHelperBaseTestcase
         $expectedResult = 'Some special characters: & " \' < > *';
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $source]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -98,7 +98,7 @@ class HtmlentitiesDecodeViewHelperTest extends ViewHelperBaseTestcase
         $expectedResult = 'Some special characters: & &quot; \' < > *';
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $source, 'keepQuotes' => true]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -110,7 +110,7 @@ class HtmlentitiesDecodeViewHelperTest extends ViewHelperBaseTestcase
         $expectedResult = 'Some special characters: & " \' < > *';
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $source, 'keepQuotes' => false, 'encoding' => 'ISO-8859-1']);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -121,7 +121,7 @@ class HtmlentitiesDecodeViewHelperTest extends ViewHelperBaseTestcase
         $source = 123.45;
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $source]);
         $actualResult = $this->viewHelper->render();
-        $this->assertSame($source, $actualResult);
+        self::assertSame($source, $actualResult);
     }
 
     /**
@@ -133,7 +133,7 @@ class HtmlentitiesDecodeViewHelperTest extends ViewHelperBaseTestcase
         $expectedResult = 'Xaver <b>Cross-Site</b>';
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $user]);
         $actualResult = $this->viewHelper->render();
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/HtmlentitiesViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/HtmlentitiesViewHelperTest.php
@@ -41,7 +41,7 @@ class HtmlentitiesViewHelperTest extends ViewHelperBaseTestcase
      */
     public function viewHelperDeactivatesEscapingInterceptor()
     {
-        $this->assertFalse($this->viewHelper->isEscapingInterceptorEnabled());
+        self::assertFalse($this->viewHelper->isEscapingInterceptorEnabled());
     }
 
     /**
@@ -52,7 +52,7 @@ class HtmlentitiesViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->never())->method('renderChildren');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => 'Some string']);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('Some string', $actualResult);
+        self::assertEquals('Some string', $actualResult);
     }
 
     /**
@@ -63,7 +63,7 @@ class HtmlentitiesViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->atLeastOnce())->method('renderChildren')->will($this->returnValue('Some string'));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('Some string', $actualResult);
+        self::assertEquals('Some string', $actualResult);
     }
 
     /**
@@ -74,7 +74,7 @@ class HtmlentitiesViewHelperTest extends ViewHelperBaseTestcase
         $source = 'This is a sample text without special characters.';
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $source]);
         $actualResult = $this->viewHelper->render();
-        $this->assertSame($source, $actualResult);
+        self::assertSame($source, $actualResult);
     }
 
     /**
@@ -86,7 +86,7 @@ class HtmlentitiesViewHelperTest extends ViewHelperBaseTestcase
         $expectedResult = 'Some special characters: &amp;&copy;&quot;\'';
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $source]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -98,7 +98,7 @@ class HtmlentitiesViewHelperTest extends ViewHelperBaseTestcase
         $expectedResult = 'Some special characters: &amp;&copy;"\'';
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $source, 'keepQuotes' => true]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -110,7 +110,7 @@ class HtmlentitiesViewHelperTest extends ViewHelperBaseTestcase
         $expectedResult = 'Some special characters: &amp;&copy;&quot;\'';
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $source, 'keepQuotes' => false, 'encoding' => 'ISO-8859-1']);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -122,7 +122,7 @@ class HtmlentitiesViewHelperTest extends ViewHelperBaseTestcase
         $expectedResult = 'already &amp;quot;encoded&amp;quot;';
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $source]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -134,7 +134,7 @@ class HtmlentitiesViewHelperTest extends ViewHelperBaseTestcase
         $expectedResult = 'already &quot;encoded&quot;';
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $source, 'keepQuotes' => false, 'encoding' => 'UTF-8', 'doubleEncode' => false]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -145,7 +145,7 @@ class HtmlentitiesViewHelperTest extends ViewHelperBaseTestcase
         $source = 123.45;
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $source]);
         $actualResult = $this->viewHelper->render();
-        $this->assertSame($source, $actualResult);
+        self::assertSame($source, $actualResult);
     }
 
     /**
@@ -157,7 +157,7 @@ class HtmlentitiesViewHelperTest extends ViewHelperBaseTestcase
         $expectedResult = 'Xaver &lt;b&gt;Cross-Site&lt;/b&gt;';
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $user]);
         $actualResult = $this->viewHelper->render();
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/IdentifierViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/IdentifierViewHelperTest.php
@@ -59,7 +59,7 @@ class IdentifierViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $object]);
         $actualResult = $this->viewHelper->render();
 
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -80,7 +80,7 @@ class IdentifierViewHelperTest extends ViewHelperBaseTestcase
             ->will($this->returnValue('b59292c5-1a28-4b36-8615-10d3c5b3a4d8'));
 
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
-        $this->assertEquals('b59292c5-1a28-4b36-8615-10d3c5b3a4d8', $this->viewHelper->render());
+        self::assertEquals('b59292c5-1a28-4b36-8615-10d3c5b3a4d8', $this->viewHelper->render());
     }
 
     /**
@@ -94,7 +94,7 @@ class IdentifierViewHelperTest extends ViewHelperBaseTestcase
             ->will($this->returnValue(null));
 
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
-        $this->assertEquals(null, $this->viewHelper->render());
+        self::assertEquals(null, $this->viewHelper->render());
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/JsonViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/JsonViewHelperTest.php
@@ -44,7 +44,7 @@ class JsonViewHelperTest extends ViewHelperBaseTestcase
 
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('{"foo":"bar"}', $actualResult);
+        self::assertEquals('{"foo":"bar"}', $actualResult);
     }
 
     /**
@@ -58,7 +58,7 @@ class JsonViewHelperTest extends ViewHelperBaseTestcase
 
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => ['foo' => 'bar']]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('{"foo":"bar"}', $actualResult);
+        self::assertEquals('{"foo":"bar"}', $actualResult);
     }
 
     /**
@@ -71,10 +71,10 @@ class JsonViewHelperTest extends ViewHelperBaseTestcase
                 ->method('renderChildren')
                 ->will($this->returnValue(['foo', 'bar', 42]));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
-        $this->assertEquals('["foo","bar",42]', $this->viewHelper->render());
+        self::assertEquals('["foo","bar",42]', $this->viewHelper->render());
 
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => null, 'forceObject' => true]);
-        $this->assertEquals('{"0":"foo","1":"bar","2":42}', $this->viewHelper->render());
+        self::assertEquals('{"0":"foo","1":"bar","2":42}', $this->viewHelper->render());
     }
 
     /**
@@ -83,8 +83,8 @@ class JsonViewHelperTest extends ViewHelperBaseTestcase
     public function viewHelperEscapesGreaterThanLowerThanCharacters()
     {
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => ['<foo>', 'bar', 'elephant > mouse']]);
-        $this->assertEquals('["\u003Cfoo\u003E","bar","elephant \u003E mouse"]', $this->viewHelper->render());
+        self::assertEquals('["\u003Cfoo\u003E","bar","elephant \u003E mouse"]', $this->viewHelper->render());
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => ['<foo>', 'bar', 'elephant > mouse'], 'forceObject' => true]);
-        $this->assertEquals('{"0":"\u003Cfoo\u003E","1":"bar","2":"elephant \u003E mouse"}', $this->viewHelper->render());
+        self::assertEquals('{"0":"\u003Cfoo\u003E","1":"bar","2":"elephant \u003E mouse"}', $this->viewHelper->render());
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/Nl2brViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/Nl2brViewHelperTest.php
@@ -40,7 +40,7 @@ class Nl2brViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('<p class="bodytext">Some Text without line breaks</p>'));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('<p class="bodytext">Some Text without line breaks</p>', $actualResult);
+        self::assertEquals('<p class="bodytext">Some Text without line breaks</p>', $actualResult);
     }
 
     /**
@@ -51,7 +51,7 @@ class Nl2brViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('Line 1' . chr(10) . 'Line 2'));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('Line 1<br />' . chr(10) . 'Line 2', $actualResult);
+        self::assertEquals('Line 1<br />' . chr(10) . 'Line 2', $actualResult);
     }
 
     /**
@@ -62,6 +62,6 @@ class Nl2brViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('Line 1' . chr(13) . chr(10) . 'Line 2'));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('Line 1<br />' . chr(13) . chr(10) . 'Line 2', $actualResult);
+        self::assertEquals('Line 1<br />' . chr(13) . chr(10) . 'Line 2', $actualResult);
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/NumberViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/NumberViewHelperTest.php
@@ -38,7 +38,7 @@ class NumberViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(10000.0 / 3.0));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('3,333.33', $actualResult);
+        self::assertEquals('3,333.33', $actualResult);
     }
 
     /**
@@ -49,7 +49,7 @@ class NumberViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(10000.0 / 3.0));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['decimals' => 3, 'decimalSeparator' => ',', 'thousandsSeparator' => '.']);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('3.333,333', $actualResult);
+        self::assertEquals('3.333,333', $actualResult);
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/PaddingViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/PaddingViewHelperTest.php
@@ -40,7 +40,7 @@ class PaddingViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('foo'));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['padLength' => 10]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('foo       ', $actualResult);
+        self::assertEquals('foo       ', $actualResult);
     }
 
     /**
@@ -51,7 +51,7 @@ class PaddingViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('foo'));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['padLength' => 10, 'padString' => '-=']);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('foo-=-=-=-', $actualResult);
+        self::assertEquals('foo-=-=-=-', $actualResult);
     }
 
     /**
@@ -62,7 +62,7 @@ class PaddingViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('some long string'));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['padLength' => 5]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('some long string', $actualResult);
+        self::assertEquals('some long string', $actualResult);
     }
 
     /**
@@ -73,6 +73,6 @@ class PaddingViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue(123));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['padLength' => 5, 'padString' => '0']);
         $actualResult = $this->viewHelper->render(5, '0');
-        $this->assertEquals('12300', $actualResult);
+        self::assertEquals('12300', $actualResult);
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/StripTagsViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/StripTagsViewHelperTest.php
@@ -41,7 +41,7 @@ class StripTagsViewHelperTest extends ViewHelperBaseTestcase
      */
     public function viewHelperDeactivatesEscapingInterceptor()
     {
-        $this->assertFalse($this->viewHelper->isEscapingInterceptorEnabled());
+        self::assertFalse($this->viewHelper->isEscapingInterceptorEnabled());
     }
 
     /**
@@ -55,7 +55,7 @@ class StripTagsViewHelperTest extends ViewHelperBaseTestcase
         });
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $string]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals($string, $actualResult);
+        self::assertEquals($string, $actualResult);
     }
 
     /**
@@ -67,7 +67,7 @@ class StripTagsViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->willReturn($string);
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals($string, $actualResult);
+        self::assertEquals($string, $actualResult);
     }
 
     /**
@@ -95,7 +95,7 @@ class StripTagsViewHelperTest extends ViewHelperBaseTestcase
         });
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $source]);
         $actualResult = $this->viewHelper->render();
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -109,7 +109,7 @@ class StripTagsViewHelperTest extends ViewHelperBaseTestcase
         });
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $source]);
         $actualResult = $this->viewHelper->render();
-        $this->assertSame($source, $actualResult);
+        self::assertSame($source, $actualResult);
     }
 
     /**
@@ -124,7 +124,7 @@ class StripTagsViewHelperTest extends ViewHelperBaseTestcase
         });
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $user]);
         $actualResult = $this->viewHelper->render();
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/UrlencodeViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/UrlencodeViewHelperTest.php
@@ -39,7 +39,7 @@ class UrlencodeViewHelperTest extends ViewHelperBaseTestcase
      */
     public function viewHelperDeactivatesEscapingInterceptor()
     {
-        $this->assertFalse($this->viewHelper->isEscapingInterceptorEnabled());
+        self::assertFalse($this->viewHelper->isEscapingInterceptorEnabled());
     }
 
     /**
@@ -50,7 +50,7 @@ class UrlencodeViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->never())->method('renderChildren');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => 'Source']);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('Source', $actualResult);
+        self::assertEquals('Source', $actualResult);
     }
 
     /**
@@ -61,7 +61,7 @@ class UrlencodeViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->atLeastOnce())->method('renderChildren')->will($this->returnValue('Source'));
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('Source', $actualResult);
+        self::assertEquals('Source', $actualResult);
     }
 
     /**
@@ -72,7 +72,7 @@ class UrlencodeViewHelperTest extends ViewHelperBaseTestcase
         $source = 'StringWithoutSpecialCharacters';
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $source]);
         $actualResult = $this->viewHelper->render();
-        $this->assertSame($source, $actualResult);
+        self::assertSame($source, $actualResult);
     }
 
     /**
@@ -84,7 +84,7 @@ class UrlencodeViewHelperTest extends ViewHelperBaseTestcase
         $expectedResult = 'Foo%20%40%2B%25%2F%20%22';
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $source]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -106,6 +106,6 @@ class UrlencodeViewHelperTest extends ViewHelperBaseTestcase
         $source = new Uri('http://typo3.com/foo&bar=1');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['value' => $source]);
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals(urlencode('http://typo3.com/foo&bar=1'), $actualResult);
+        self::assertEquals(urlencode('http://typo3.com/foo&bar=1'), $actualResult);
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/ActionViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Link/ActionViewHelperTest.php
@@ -93,7 +93,7 @@ class ActionViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Vie
             $this->viewHelper->render();
         } catch (\Neos\FluidAdaptor\Core\ViewHelper\Exception $exception) {
         }
-        $this->assertEquals(12345, $exception->getPrevious()->getCode());
+        self::assertEquals(12345, $exception->getPrevious()->getCode());
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/RenderChildrenViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/RenderChildrenViewHelperTest.php
@@ -59,7 +59,7 @@ class RenderChildrenViewHelperTest extends ViewHelperBaseTestcase
 
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['k1' => 'v1', 'k2' => 'v2']);
         $output = $this->viewHelper->render();
-        $this->assertEquals('Rendered Results', $output);
+        self::assertEquals('Rendered Results', $output);
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Security/CsrfTokenViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Security/CsrfTokenViewHelperTest.php
@@ -53,6 +53,6 @@ class CsrfTokenViewHelperTest extends ViewHelperBaseTestcase
         $this->objectManagerMock->expects(self::any())->method('get')->willReturn($mockSecurityContext);
 
         $actualResult = $this->viewHelper->render();
-        $this->assertEquals('TheCsrfToken', $actualResult);
+        self::assertEquals('TheCsrfToken', $actualResult);
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Security/IfAccessViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Security/IfAccessViewHelperTest.php
@@ -67,7 +67,7 @@ class IfAccessViewHelperTest extends ViewHelperBaseTestcase
         ];
         $this->ifAccessViewHelper->setArguments($arguments);
         $actualResult = $this->ifAccessViewHelper->render();
-        $this->assertEquals('foo', $actualResult);
+        self::assertEquals('foo', $actualResult);
     }
 
     /**
@@ -84,6 +84,6 @@ class IfAccessViewHelperTest extends ViewHelperBaseTestcase
         ];
         $this->ifAccessViewHelper->setArguments($arguments);
         $actualResult = $this->ifAccessViewHelper->render();
-        $this->assertEquals('ElseViewHelperResults', $actualResult);
+        self::assertEquals('ElseViewHelperResults', $actualResult);
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Security/IfHasRoleViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Security/IfHasRoleViewHelperTest.php
@@ -117,7 +117,7 @@ class IfHasRoleViewHelperTest extends ViewHelperBaseTestcase
         ];
         $this->mockViewHelper = $this->prepareArguments($this->mockViewHelper, $arguments);
         $actualResult = $this->mockViewHelper->render();
-        $this->assertEquals('then-child', $actualResult);
+        self::assertEquals('then-child', $actualResult);
     }
 
     /**
@@ -143,7 +143,7 @@ class IfHasRoleViewHelperTest extends ViewHelperBaseTestcase
         ];
         $this->mockViewHelper = $this->prepareArguments($this->mockViewHelper, $arguments);
         $actualResult = $this->mockViewHelper->render();
-        $this->assertEquals('true', $actualResult, 'Full role identifier in role argument is accepted');
+        self::assertEquals('true', $actualResult, 'Full role identifier in role argument is accepted');
 
         $arguments = [
             'role' => new Role('Neos.FluidAdaptor:User'),
@@ -152,7 +152,7 @@ class IfHasRoleViewHelperTest extends ViewHelperBaseTestcase
         ];
         $this->mockViewHelper = $this->prepareArguments($this->mockViewHelper, $arguments);
         $actualResult = $this->mockViewHelper->render();
-        $this->assertEquals('false', $actualResult);
+        self::assertEquals('false', $actualResult);
     }
 
     /**
@@ -178,6 +178,6 @@ class IfHasRoleViewHelperTest extends ViewHelperBaseTestcase
         ];
         $this->mockViewHelper = $this->prepareArguments($this->mockViewHelper, $arguments);
         $actualResult = $this->mockViewHelper->render();
-        $this->assertEquals('true', $actualResult, 'Full role identifier in role argument is accepted');
+        self::assertEquals('true', $actualResult, 'Full role identifier in role argument is accepted');
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/TranslateViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/TranslateViewHelperTest.php
@@ -64,7 +64,7 @@ class TranslateViewHelperTest extends ViewHelperBaseTestcase
         $this->translateViewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('Untranslated Label'));
         $this->translateViewHelper = $this->prepareArguments($this->translateViewHelper, ['id' => null, 'value' => null, 'arguments' => [], 'source' => 'Main', 'package' => null, 'quantity' => null, 'locale' => 'de_DE']);
         $result = $this->translateViewHelper->render();
-        $this->assertEquals('Translated Label', $result);
+        self::assertEquals('Translated Label', $result);
     }
 
     /**
@@ -76,7 +76,7 @@ class TranslateViewHelperTest extends ViewHelperBaseTestcase
 
         $this->translateViewHelper = $this->prepareArguments($this->translateViewHelper, ['id' => 'some.label', 'value' => null, 'arguments' => [], 'source' => 'Main', 'package' => null, 'quantity' => null, 'locale' => 'de_DE']);
         $result = $this->translateViewHelper->render();
-        $this->assertEquals('Translated Label', $result);
+        self::assertEquals('Translated Label', $result);
     }
 
     /**
@@ -88,7 +88,7 @@ class TranslateViewHelperTest extends ViewHelperBaseTestcase
 
         $this->translateViewHelper = $this->prepareArguments($this->translateViewHelper, ['id' => 'some.label', 'value' => 'Default from value', 'arguments' => [], 'source' => 'Main', 'package' => null, 'quantity' => null, 'locale' => 'de_DE']);
         $result = $this->translateViewHelper->render();
-        $this->assertEquals('Default from value', $result);
+        self::assertEquals('Default from value', $result);
     }
 
     /**
@@ -100,7 +100,7 @@ class TranslateViewHelperTest extends ViewHelperBaseTestcase
 
         $this->translateViewHelper = $this->prepareArguments($this->translateViewHelper, ['id' => 'some.label', 'value' => null, 'arguments' => [], 'source' => 'Main', 'package' => null, 'quantity' => null, 'locale' => 'de_DE']);
         $result = $this->translateViewHelper->render();
-        $this->assertEquals('Default from renderChildren', $result);
+        self::assertEquals('Default from renderChildren', $result);
     }
 
     /**
@@ -114,7 +114,7 @@ class TranslateViewHelperTest extends ViewHelperBaseTestcase
 
         $this->translateViewHelper = $this->prepareArguments($this->translateViewHelper, ['id' => 'some.label', 'value' => null, 'arguments' => [], 'source' => 'Main', 'package' => null, 'quantity' => null, 'locale' => 'de_DE']);
         $result = $this->translateViewHelper->render();
-        $this->assertEquals('some.label', $result);
+        self::assertEquals('some.label', $result);
     }
 
     /**
@@ -195,6 +195,6 @@ class TranslateViewHelperTest extends ViewHelperBaseTestcase
 
         $this->translateViewHelper = $this->prepareArguments($this->translateViewHelper, ['id' => $id, 'value' => $value]);
         $actualResult = $this->translateViewHelper->render();
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ActionViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ActionViewHelperTest.php
@@ -43,7 +43,7 @@ class ActionViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Vie
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['action' => 'index']);
         $actualResult = $this->viewHelper->render();
 
-        $this->assertEquals('some/uri', $actualResult);
+        self::assertEquals('some/uri', $actualResult);
     }
 
     /**
@@ -92,7 +92,7 @@ class ActionViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Vie
             $this->viewHelper->render();
         } catch (\Neos\FluidAdaptor\Core\ViewHelper\Exception $exception) {
         }
-        $this->assertEquals(12345, $exception->getPrevious()->getCode());
+        self::assertEquals(12345, $exception->getPrevious()->getCode());
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/EmailViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/EmailViewHelperTest.php
@@ -38,6 +38,6 @@ class EmailViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\View
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['email' => 'some@email.tld']);
         $actualResult = $this->viewHelper->render();
 
-        $this->assertEquals('mailto:some@email.tld', $actualResult);
+        self::assertEquals('mailto:some@email.tld', $actualResult);
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ExternalViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ExternalViewHelperTest.php
@@ -39,7 +39,7 @@ class ExternalViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\V
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['uri' => 'http://www.some-domain.tld']);
         $actualResult = $this->viewHelper->render();
 
-        $this->assertEquals('http://www.some-domain.tld', $actualResult);
+        self::assertEquals('http://www.some-domain.tld', $actualResult);
     }
 
     /**
@@ -50,7 +50,7 @@ class ExternalViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\V
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['uri' => 'www.some-domain.tld']);
         $actualResult = $this->viewHelper->render();
 
-        $this->assertEquals('http://www.some-domain.tld', $actualResult);
+        self::assertEquals('http://www.some-domain.tld', $actualResult);
     }
 
     /**
@@ -61,7 +61,7 @@ class ExternalViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\V
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['uri' => 'some-domain.tld', 'defaultScheme' => 'ftp']);
         $actualResult = $this->viewHelper->render();
 
-        $this->assertEquals('ftp://some-domain.tld', $actualResult);
+        self::assertEquals('ftp://some-domain.tld', $actualResult);
     }
 
     /**
@@ -72,6 +72,6 @@ class ExternalViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\V
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['uri' => 'some-domain.tld', 'defaultScheme' => '']);
         $actualResult = $this->viewHelper->render();
 
-        $this->assertEquals('some-domain.tld', $actualResult);
+        self::assertEquals('some-domain.tld', $actualResult);
     }
 }

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ResourceViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Uri/ResourceViewHelperTest.php
@@ -76,7 +76,7 @@ class ResourceViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\V
             'localize' => false
         ]);
         $resourceUri = $this->viewHelper->render();
-        $this->assertEquals('TheCorrectResourceUri', $resourceUri);
+        self::assertEquals('TheCorrectResourceUri', $resourceUri);
     }
 
     /**
@@ -92,7 +92,7 @@ class ResourceViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\V
             'localize' => false
         ]);
         $resourceUri = $this->viewHelper->render();
-        $this->assertEquals('TheCorrectResourceUri', $resourceUri);
+        self::assertEquals('TheCorrectResourceUri', $resourceUri);
     }
 
     /**
@@ -109,7 +109,7 @@ class ResourceViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\V
             'localize' => false
         ]);
         $resourceUri = $this->viewHelper->render();
-        $this->assertEquals('TheCorrectResourceUri', $resourceUri);
+        self::assertEquals('TheCorrectResourceUri', $resourceUri);
     }
 
     /**
@@ -126,7 +126,7 @@ class ResourceViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\V
             'localize' => false
         ]);
         $resourceUri = $this->viewHelper->render();
-        $this->assertEquals('404-Resource-Not-Found', $resourceUri);
+        self::assertEquals('404-Resource-Not-Found', $resourceUri);
     }
 
     /**
@@ -141,7 +141,7 @@ class ResourceViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\V
             'package' => 'ThePackageKey'
         ]);
         $resourceUri = $this->viewHelper->render();
-        $this->assertEquals('TheCorrectResourceUri', $resourceUri);
+        self::assertEquals('TheCorrectResourceUri', $resourceUri);
     }
 
     /**
@@ -167,7 +167,7 @@ class ResourceViewHelperTest extends \Neos\FluidAdaptor\Tests\Unit\ViewHelpers\V
             'localize' => true
         ]);
         $resourceUri = $this->viewHelper->render();
-        $this->assertEquals('TheCorrectResourceUri', $resourceUri);
+        self::assertEquals('TheCorrectResourceUri', $resourceUri);
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Validation/IfHasErrorsViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Validation/IfHasErrorsViewHelperTest.php
@@ -46,7 +46,7 @@ class IfHasErrorsViewHelperTest extends ViewHelperBaseTestcase
 
         $this->request->expects($this->once())->method('getInternalArgument')->with('__submittedArgumentValidationResults')->will($this->returnValue($result));
         $this->viewHelper->expects($this->once())->method('renderThenChild')->will($this->returnValue('ThenChild'));
-        $this->assertEquals('ThenChild', $this->viewHelper->render());
+        self::assertEquals('ThenChild', $this->viewHelper->render());
     }
 
     /**
@@ -55,7 +55,7 @@ class IfHasErrorsViewHelperTest extends ViewHelperBaseTestcase
     public function returnsAndRendersElseChildIfNoValidationResultsArePresentAtAll()
     {
         $this->viewHelper->expects($this->once())->method('renderElseChild')->will($this->returnValue('ElseChild'));
-        $this->assertEquals('ElseChild', $this->viewHelper->render());
+        self::assertEquals('ElseChild', $this->viewHelper->render());
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Validation/ResultsViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Validation/ResultsViewHelperTest.php
@@ -45,7 +45,7 @@ class ResultsViewHelperTest extends ViewHelperBaseTestcase
         $this->viewHelper->expects($this->once())->method('renderChildren')->will($this->returnValue('child nodes'));
 
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
-        $this->assertSame('child nodes', $this->viewHelper->render());
+        self::assertSame('child nodes', $this->viewHelper->render());
     }
 
     /**

--- a/Neos.Kickstarter/Tests/Unit/Service/GeneratorServiceTest.php
+++ b/Neos.Kickstarter/Tests/Unit/Service/GeneratorServiceTest.php
@@ -29,7 +29,7 @@ class GeneratorServiceTest extends \Neos\Flow\Tests\UnitTestCase
             )
         );
         $normalizedFieldDefinitions = $service->_call('normalizeFieldDefinitions', $fieldDefinitions);
-        $this->assertEquals('boolean', $normalizedFieldDefinitions['field']['type']);
+        self::assertEquals('boolean', $normalizedFieldDefinitions['field']['type']);
     }
 
     /**
@@ -44,7 +44,7 @@ class GeneratorServiceTest extends \Neos\Flow\Tests\UnitTestCase
             )
         );
         $normalizedFieldDefinitions = $service->_call('normalizeFieldDefinitions', $fieldDefinitions);
-        $this->assertEquals('\DateTime', $normalizedFieldDefinitions['field']['type']);
+        self::assertEquals('\DateTime', $normalizedFieldDefinitions['field']['type']);
     }
 
     /**
@@ -60,6 +60,6 @@ class GeneratorServiceTest extends \Neos\Flow\Tests\UnitTestCase
             )
         );
         $normalizedFieldDefinitions = $service->_call('normalizeFieldDefinitions', $fieldDefinitions, 'TYPO3\Testing\Domain\Model');
-        $this->assertEquals('\TYPO3\Testing\Domain\Model\\' . $uniqueClassName, $normalizedFieldDefinitions['field']['type']);
+        self::assertEquals('\TYPO3\Testing\Domain\Model\\' . $uniqueClassName, $normalizedFieldDefinitions['field']['type']);
     }
 }

--- a/Neos.Kickstarter/Tests/Unit/Utility/InflectorTest.php
+++ b/Neos.Kickstarter/Tests/Unit/Utility/InflectorTest.php
@@ -26,7 +26,7 @@ class InflectorTest extends \Neos\Flow\Tests\UnitTestCase
     {
         $inflector = new \Neos\Kickstarter\Utility\Inflector();
         $humanized = $inflector->humanizeCamelCase('BlogAuthor');
-        $this->assertEquals('Blog author', $humanized);
+        self::assertEquals('Blog author', $humanized);
     }
 
     /**
@@ -35,7 +35,7 @@ class InflectorTest extends \Neos\Flow\Tests\UnitTestCase
     public function pluralizePluralizesWords()
     {
         $inflector = new \Neos\Kickstarter\Utility\Inflector();
-        $this->assertEquals('boxes', $inflector->pluralize('box'));
-        $this->assertEquals('foos', $inflector->pluralize('foo'));
+        self::assertEquals('boxes', $inflector->pluralize('box'));
+        self::assertEquals('foos', $inflector->pluralize('foo'));
     }
 }

--- a/Neos.Utility.Arrays/Tests/Unit/ArraysTest.php
+++ b/Neos.Utility.Arrays/Tests/Unit/ArraysTest.php
@@ -23,7 +23,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
      */
     public function containsMultipleTypesReturnsFalseOnEmptyArray()
     {
-        $this->assertFalse(Arrays::containsMultipleTypes([]), 'An empty array was seen as containing multiple types');
+        self::assertFalse(Arrays::containsMultipleTypes([]), 'An empty array was seen as containing multiple types');
     }
 
     /**
@@ -31,7 +31,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
      */
     public function containsMultipleTypesReturnsFalseOnArrayWithIntegers()
     {
-        $this->assertFalse(Arrays::containsMultipleTypes([1, 2, 3]), 'An array with only integers was seen as containing multiple types');
+        self::assertFalse(Arrays::containsMultipleTypes([1, 2, 3]), 'An array with only integers was seen as containing multiple types');
     }
 
     /**
@@ -39,7 +39,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
      */
     public function containsMultipleTypesReturnsFalseOnArrayWithObjects()
     {
-        $this->assertFalse(Arrays::containsMultipleTypes([new \stdClass(), new \stdClass(), new \stdClass()]), 'An array with only \stdClass was seen as containing multiple types');
+        self::assertFalse(Arrays::containsMultipleTypes([new \stdClass(), new \stdClass(), new \stdClass()]), 'An array with only \stdClass was seen as containing multiple types');
     }
 
     /**
@@ -47,7 +47,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
      */
     public function containsMultipleTypesReturnsTrueOnMixedArray()
     {
-        $this->assertTrue(Arrays::containsMultipleTypes([1, 'string', 1.25, new \stdClass()]), 'An array with mixed contents was not seen as containing multiple types');
+        self::assertTrue(Arrays::containsMultipleTypes([1, 'string', 1.25, new \stdClass()]), 'An array with mixed contents was not seen as containing multiple types');
     }
 
     /**
@@ -56,7 +56,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
     public function getValueByPathReturnsTheValueOfANestedArrayByFollowingTheGivenSimplePath()
     {
         $array = ['Foo' => 'the value'];
-        $this->assertSame('the value', Arrays::getValueByPath($array, ['Foo']));
+        self::assertSame('the value', Arrays::getValueByPath($array, ['Foo']));
     }
 
     /**
@@ -65,7 +65,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
     public function getValueByPathReturnsTheValueOfANestedArrayByFollowingTheGivenPath()
     {
         $array = ['Foo' => ['Bar' => ['Baz' => [2 => 'the value']]]];
-        $this->assertSame('the value', Arrays::getValueByPath($array, ['Foo', 'Bar', 'Baz', 2]));
+        self::assertSame('the value', Arrays::getValueByPath($array, ['Foo', 'Bar', 'Baz', 2]));
     }
 
     /**
@@ -77,7 +77,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
         $array = ['Foo' => ['Bar' => ['Baz' => [2 => 'the value']]]];
         $expectedResult = 'the value';
         $actualResult = Arrays::getValueByPath($array, $path);
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -96,7 +96,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
     public function getValueByPathReturnsNullIfTheSegementsOfThePathDontExist()
     {
         $array = ['Foo' => ['Bar' => ['Baz' => [2 => 'the value']]]];
-        $this->assertNULL(Arrays::getValueByPath($array, ['Foo', 'Bar', 'Bax', 2]));
+        self::assertNull(Arrays::getValueByPath($array, ['Foo', 'Bar', 'Bax', 2]));
     }
 
     /**
@@ -105,7 +105,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
     public function getValueByPathReturnsNullIfThePathHasMoreSegmentsThanTheGivenArray()
     {
         $array = ['Foo' => ['Bar' => ['Baz' => 'the value']]];
-        $this->assertNULL(Arrays::getValueByPath($array, ['Foo', 'Bar', 'Baz', 'Bux']));
+        self::assertNull(Arrays::getValueByPath($array, ['Foo', 'Bar', 'Baz', 'Bux']));
     }
 
     /**
@@ -133,7 +133,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
             ]
         ];
 
-        $this->assertEquals($expected, $array);
+        self::assertEquals($expected, $array);
     }
 
     /**
@@ -145,7 +145,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
         $path = ['foo', 'bar', 'baz'];
         $expectedValue = ['foo' => ['bar' => ['baz' => 'The Value']]];
         $actualValue = Arrays::setValueByPath($array, $path, 'The Value');
-        $this->assertEquals($expectedValue, $actualValue);
+        self::assertEquals($expectedValue, $actualValue);
     }
 
     /**
@@ -157,7 +157,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
         $path = 'foo.bar.baz';
         $expectedValue = ['foo' => ['bar' => ['baz' => 'The Value']]];
         $actualValue = Arrays::setValueByPath($array, $path, 'The Value');
-        $this->assertEquals($expectedValue, $actualValue);
+        self::assertEquals($expectedValue, $actualValue);
     }
 
     /**
@@ -169,7 +169,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
         $path = ['foo', 'bar', 'baz'];
         $expectedValue = ['foo' => ['bar' => ['baz' => 'The Value']], 'bar' => 'Baz'];
         $actualValue = Arrays::setValueByPath($array, $path, 'The Value');
-        $this->assertEquals($expectedValue, $actualValue);
+        self::assertEquals($expectedValue, $actualValue);
     }
 
     /**
@@ -209,7 +209,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
     {
         $subject = $subjectBackup = ['foo' => 'bar'];
         Arrays::setValueByPath($subject, 'foo', 'baz');
-        $this->assertEquals($subject, $subjectBackup);
+        self::assertEquals($subject, $subjectBackup);
     }
 
     /**
@@ -221,7 +221,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
         $path = ['foo', 'bar', 'nonExistingKey'];
         $expectedValue = $array;
         $actualValue = Arrays::unsetValueByPath($array, $path);
-        $this->assertEquals($expectedValue, $actualValue);
+        self::assertEquals($expectedValue, $actualValue);
     }
 
     /**
@@ -234,7 +234,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
         $expectedValue = ['foo' => ['bar' => []], 'bar' => 'Baz'];
         ;
         $actualValue = Arrays::unsetValueByPath($array, $path);
-        $this->assertEquals($expectedValue, $actualValue);
+        self::assertEquals($expectedValue, $actualValue);
     }
 
     /**
@@ -247,7 +247,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
         $expectedValue = ['foo' => ['bar' => []], 'bar' => 'Baz'];
         ;
         $actualValue = Arrays::unsetValueByPath($array, $path);
-        $this->assertEquals($expectedValue, $actualValue);
+        self::assertEquals($expectedValue, $actualValue);
     }
 
     /**
@@ -260,7 +260,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
         $expectedValue = ['bar' => 'Baz'];
         ;
         $actualValue = Arrays::unsetValueByPath($array, $path);
-        $this->assertEquals($expectedValue, $actualValue);
+        self::assertEquals($expectedValue, $actualValue);
     }
 
     /**
@@ -281,7 +281,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
         $array = ['EmptyElement' => null, 'Foo' => ['Bar' => ['Baz' => ['NotNull' => '', 'AnotherEmptyElement' => null]]]];
         $expectedResult = ['Foo' => ['Bar' => ['Baz' => ['NotNull' => '']]]];
         $actualResult = Arrays::removeEmptyElementsRecursively($array);
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     /**
@@ -292,7 +292,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
         $array = ['EmptyElement' => [], 'Foo' => ['Bar' => ['Baz' => ['AnotherEmptyElement' => null]]], 'NotNull' => 123];
         $expectedResult = ['NotNull' => 123];
         $actualResult = Arrays::removeEmptyElementsRecursively($array);
-        $this->assertEquals($expectedResult, $actualResult);
+        self::assertEquals($expectedResult, $actualResult);
     }
 
     public function arrayMergeRecursiveOverruleData()
@@ -504,7 +504,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
     public function arrayMergeRecursiveOverruleMergesSimpleArrays(array $inputArray1, array $inputArray2, bool $dontAddNewKeys, bool $emptyValuesOverride, array $expected)
     {
         $actual = Arrays::arrayMergeRecursiveOverrule($inputArray1, $inputArray2, $dontAddNewKeys, $emptyValuesOverride);
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -534,7 +534,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
         $actual = Arrays::arrayMergeRecursiveOverruleWithCallback($inputArray1, $inputArray2, function ($simpleType) {
             return ['__convertedValue' => $simpleType];
         });
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -570,7 +570,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
             }
             return ['__convertedValue' => $simpleType];
         });
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
@@ -609,6 +609,6 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
             }
         );
 
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 }

--- a/Neos.Utility.Arrays/Tests/Unit/PositionalArraySorterTest.php
+++ b/Neos.Utility.Arrays/Tests/Unit/PositionalArraySorterTest.php
@@ -29,7 +29,7 @@ class PositionalArraySorterTest extends \PHPUnit\Framework\TestCase
 
         $positionalArraySorter = new PositionalArraySorter($array);
         $sortedArray = $positionalArraySorter->toArray();
-        $this->assertSame($expectedResult, $sortedArray);
+        self::assertSame($expectedResult, $sortedArray);
     }
 
     /**
@@ -165,7 +165,7 @@ class PositionalArraySorterTest extends \PHPUnit\Framework\TestCase
         $positionalArraySorter = new PositionalArraySorter($subject, $positionPropertyPath);
         $result = $positionalArraySorter->toArray();
 
-        $this->assertSame($expectedKeyOrder, array_keys($result), $message);
+        self::assertSame($expectedKeyOrder, array_keys($result), $message);
     }
 
     /**
@@ -182,6 +182,6 @@ class PositionalArraySorterTest extends \PHPUnit\Framework\TestCase
         $positionalArraySorter = new PositionalArraySorter($subject, $positionPropertyPath);
         $result = $positionalArraySorter->getSortedKeys();
 
-        $this->assertSame($expectedKeyOrder, $result, $message);
+        self::assertSame($expectedKeyOrder, $result, $message);
     }
 }

--- a/Neos.Utility.Files/Tests/Unit/FilesTest.php
+++ b/Neos.Utility.Files/Tests/Unit/FilesTest.php
@@ -66,7 +66,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
     public function getUnixStylePathWorksForPathWithoutSlashes()
     {
         $path = 'foobar';
-        $this->assertEquals('foobar', Files::getUnixStylePath($path));
+        self::assertEquals('foobar', Files::getUnixStylePath($path));
     }
 
     /**
@@ -75,7 +75,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
     public function getUnixStylePathWorksForPathWithForwardSlashes()
     {
         $path = 'foo/bar/test/';
-        $this->assertEquals('foo/bar/test/', Files::getUnixStylePath($path));
+        self::assertEquals('foo/bar/test/', Files::getUnixStylePath($path));
     }
 
     /**
@@ -84,7 +84,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
     public function getUnixStylePathWorksForPathWithBackwardSlashes()
     {
         $path = 'foo\\bar\\test\\';
-        $this->assertEquals('foo/bar/test/', Files::getUnixStylePath($path));
+        self::assertEquals('foo/bar/test/', Files::getUnixStylePath($path));
     }
 
     /**
@@ -93,7 +93,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
     public function getUnixStylePathWorksForPathWithForwardAndBackwardSlashes()
     {
         $path = 'foo/bar\\test/';
-        $this->assertEquals('foo/bar/test/', Files::getUnixStylePath($path));
+        self::assertEquals('foo/bar/test/', Files::getUnixStylePath($path));
     }
 
     /**
@@ -101,7 +101,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
      */
     public function concatenatePathsWorksForEmptyPath()
     {
-        $this->assertEquals('', Files::concatenatePaths([]));
+        self::assertEquals('', Files::concatenatePaths([]));
     }
 
     /**
@@ -109,7 +109,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
      */
     public function concatenatePathsWorksForOnePath()
     {
-        $this->assertEquals('foo', Files::concatenatePaths(['foo']));
+        self::assertEquals('foo', Files::concatenatePaths(['foo']));
     }
 
     /**
@@ -117,7 +117,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
      */
     public function concatenatePathsWorksForTwoPath()
     {
-        $this->assertEquals('foo/bar', Files::concatenatePaths(['foo', 'bar']));
+        self::assertEquals('foo/bar', Files::concatenatePaths(['foo', 'bar']));
     }
 
     /**
@@ -125,7 +125,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
      */
     public function concatenatePathsWorksForPathsWithLeadingSlash()
     {
-        $this->assertEquals('/foo/bar', Files::concatenatePaths(['/foo', 'bar']));
+        self::assertEquals('/foo/bar', Files::concatenatePaths(['/foo', 'bar']));
     }
 
     /**
@@ -133,7 +133,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
      */
     public function concatenatePathsWorksForPathsWithTrailingSlash()
     {
-        $this->assertEquals('foo/bar', Files::concatenatePaths(['foo', 'bar/']));
+        self::assertEquals('foo/bar', Files::concatenatePaths(['foo', 'bar/']));
     }
 
     /**
@@ -141,7 +141,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
      */
     public function concatenatePathsWorksForPathsWithLeadingAndTrailingSlash()
     {
-        $this->assertEquals('/foo/bar/bar/foo', Files::concatenatePaths(['/foo/bar/', '/bar/foo/']));
+        self::assertEquals('/foo/bar/bar/foo', Files::concatenatePaths(['/foo/bar/', '/bar/foo/']));
     }
 
     /**
@@ -149,7 +149,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
      */
     public function concatenatePathsWorksForBrokenPaths()
     {
-        $this->assertEquals('/foo/bar/bar', Files::concatenatePaths(['\\foo/bar\\', '\\bar']));
+        self::assertEquals('/foo/bar/bar', Files::concatenatePaths(['\\foo/bar\\', '\\bar']));
     }
 
     /**
@@ -157,7 +157,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
      */
     public function concatenatePathsWorksForEmptyPathArrayElements()
     {
-        $this->assertEquals('foo/bar', Files::concatenatePaths(['foo', '', 'bar']));
+        self::assertEquals('foo/bar', Files::concatenatePaths(['foo', '', 'bar']));
     }
 
     /**
@@ -166,7 +166,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
     public function getUnixStylePathWorksForPathWithDriveLetterAndBackwardSlashes()
     {
         $path = 'c:\\foo\\bar\\test\\';
-        $this->assertEquals('c:/foo/bar/test/', Files::getUnixStylePath($path));
+        self::assertEquals('c:/foo/bar/test/', Files::getUnixStylePath($path));
     }
 
     /**
@@ -188,7 +188,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
      */
     public function getUnixStylePathWorksForPathWithProtocol($path, $expected)
     {
-        $this->assertEquals($expected, Files::getUnixStylePath($path));
+        self::assertEquals($expected, Files::getUnixStylePath($path));
     }
 
     /**
@@ -196,7 +196,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
      */
     public function is_linkReturnsFalseForNonExistingFiles()
     {
-        $this->assertFalse(Files::is_link('NonExistingPath'));
+        self::assertFalse(Files::is_link('NonExistingPath'));
     }
 
     /**
@@ -206,7 +206,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
     {
         $targetPathAndFilename = tempnam($this->temporaryDirectory, 'FlowFilesTestFile');
         file_put_contents($targetPathAndFilename, 'some data');
-        $this->assertFalse(Files::is_link($targetPathAndFilename));
+        self::assertFalse(Files::is_link($targetPathAndFilename));
     }
 
     /**
@@ -221,7 +221,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
             @unlink($linkPathAndFilename);
         }
         $this->trySymlink($targetPathAndFilename, $linkPathAndFilename);
-        $this->assertTrue(Files::is_link($linkPathAndFilename));
+        self::assertTrue(Files::is_link($linkPathAndFilename));
     }
 
     /**
@@ -233,7 +233,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
         if (!is_dir($targetPath)) {
             Files::createDirectoryRecursively($targetPath);
         }
-        $this->assertFalse(Files::is_link($targetPath));
+        self::assertFalse(Files::is_link($targetPath));
     }
 
     /**
@@ -250,7 +250,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
             Files::removeDirectoryRecursively($linkPath);
         }
         $this->trySymlink($targetPath, $linkPath);
-        $this->assertTrue(Files::is_link($linkPath));
+        self::assertTrue(Files::is_link($linkPath));
     }
 
     /**
@@ -262,7 +262,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
         if (!is_dir($targetPath)) {
             Files::createDirectoryRecursively($targetPath);
         }
-        $this->assertFalse(Files::is_link($targetPath));
+        self::assertFalse(Files::is_link($targetPath));
     }
 
     /**
@@ -290,7 +290,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
     {
         Files::createDirectoryRecursively('vfs://Foo/Bar/Baz/Quux');
         Files::removeEmptyDirectoriesOnPath('vfs://Foo/Bar/Baz/Quux');
-        $this->assertFalse(file_exists('vfs://Foo'));
+        self::assertFalse(file_exists('vfs://Foo'));
     }
 
     /**
@@ -301,8 +301,8 @@ class FilesTest extends \PHPUnit\Framework\TestCase
         Files::createDirectoryRecursively('vfs://Foo/Bar/Baz/Quux');
         file_put_contents('vfs://Foo/Bar/someFile.txt', 'x');
         Files::removeEmptyDirectoriesOnPath('vfs://Foo/Bar/Baz/Quux');
-        $this->assertTrue(file_exists('vfs://Foo/Bar/someFile.txt'));
-        $this->assertFalse(file_exists('vfs://Foo/Bar/Baz'));
+        self::assertTrue(file_exists('vfs://Foo/Bar/someFile.txt'));
+        self::assertFalse(file_exists('vfs://Foo/Bar/Baz'));
     }
 
     /**
@@ -313,7 +313,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
         Files::createDirectoryRecursively('vfs://Foo/Bar/Baz/Quux');
         file_put_contents('vfs://Foo/Bar/Baz/Quux/someFile.txt', 'x');
         Files::removeEmptyDirectoriesOnPath('vfs://Foo/Bar/Baz/Quux');
-        $this->assertTrue(file_exists('vfs://Foo/Bar/Baz/Quux/someFile.txt'));
+        self::assertTrue(file_exists('vfs://Foo/Bar/Baz/Quux/someFile.txt'));
     }
 
     /**
@@ -325,8 +325,8 @@ class FilesTest extends \PHPUnit\Framework\TestCase
         file_put_contents('vfs://Foo/Bar/someFile.txt', 'x');
         file_put_contents('vfs://Foo/Bar/Baz/.DS_Store', 'x');
         Files::removeEmptyDirectoriesOnPath('vfs://Foo/Bar/Baz/Quux');
-        $this->assertTrue(file_exists('vfs://Foo/Bar/someFile.txt'));
-        $this->assertFalse(file_exists('vfs://Foo/Bar/Baz'));
+        self::assertTrue(file_exists('vfs://Foo/Bar/someFile.txt'));
+        self::assertFalse(file_exists('vfs://Foo/Bar/Baz'));
     }
 
     /**
@@ -336,13 +336,13 @@ class FilesTest extends \PHPUnit\Framework\TestCase
     {
         Files::createDirectoryRecursively('vfs://Foo/Bar/Baz/Quux');
         Files::removeEmptyDirectoriesOnPath('vfs://Foo/Bar/Baz/Quux', 'vfs://Foo/Bar');
-        $this->assertFalse(file_exists('vfs://Foo/Bar/Baz'));
-        $this->assertTrue(file_exists('vfs://Foo/Bar'));
+        self::assertFalse(file_exists('vfs://Foo/Bar/Baz'));
+        self::assertTrue(file_exists('vfs://Foo/Bar'));
 
         Files::createDirectoryRecursively('vfs://Foo/Bar/Baz/Quux');
         Files::removeEmptyDirectoriesOnPath('vfs://Foo/Bar/Baz/Quux', 'vfs://Foo/Bar/');
-        $this->assertFalse(file_exists('vfs://Foo/Bar/Baz'));
-        $this->assertTrue(file_exists('vfs://Foo/Bar'));
+        self::assertFalse(file_exists('vfs://Foo/Bar/Baz'));
+        self::assertTrue(file_exists('vfs://Foo/Bar'));
     }
 
     /**
@@ -367,9 +367,9 @@ class FilesTest extends \PHPUnit\Framework\TestCase
             @unlink($linkPathAndFilename);
         }
         $this->trySymlink($targetPathAndFilename, $linkPathAndFilename);
-        $this->assertTrue(Files::unlink($linkPathAndFilename));
-        $this->assertTrue(file_exists($targetPathAndFilename));
-        $this->assertFalse(file_exists($linkPathAndFilename));
+        self::assertTrue(Files::unlink($linkPathAndFilename));
+        self::assertTrue(file_exists($targetPathAndFilename));
+        self::assertFalse(file_exists($linkPathAndFilename));
     }
 
     /**
@@ -386,9 +386,9 @@ class FilesTest extends \PHPUnit\Framework\TestCase
             Files::removeDirectoryRecursively($linkPath);
         }
         $this->trySymlink($targetPath, $linkPath);
-        $this->assertTrue(Files::unlink($linkPath));
-        $this->assertTrue(file_exists($targetPath));
-        $this->assertFalse(file_exists($linkPath));
+        self::assertTrue(Files::unlink($linkPath));
+        self::assertTrue(file_exists($targetPath));
+        self::assertFalse(file_exists($linkPath));
     }
 
     /**
@@ -398,7 +398,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
      */
     public function unlinkReturnsTrueIfSpecifiedPathDoesNotExist()
     {
-        $this->assertTrue(Files::unlink('NonExistingPath'));
+        self::assertTrue(Files::unlink('NonExistingPath'));
     }
 
     /**
@@ -411,9 +411,9 @@ class FilesTest extends \PHPUnit\Framework\TestCase
 
         Files::copyDirectoryRecursively('vfs://Foo/source', 'vfs://Foo/target');
 
-        $this->assertTrue(is_dir('vfs://Foo/target/bar/baz'));
-        $this->assertTrue(is_file('vfs://Foo/target/bar/baz/file.txt'));
-        $this->assertEquals('source content', file_get_contents('vfs://Foo/target/bar/baz/file.txt'));
+        self::assertTrue(is_dir('vfs://Foo/target/bar/baz'));
+        self::assertTrue(is_file('vfs://Foo/target/bar/baz/file.txt'));
+        self::assertEquals('source content', file_get_contents('vfs://Foo/target/bar/baz/file.txt'));
     }
 
     /**
@@ -426,9 +426,9 @@ class FilesTest extends \PHPUnit\Framework\TestCase
 
         Files::copyDirectoryRecursively('vfs://Foo/source', 'vfs://Foo/target', false, true);
 
-        $this->assertTrue(is_dir('vfs://Foo/target/bar/baz'));
-        $this->assertTrue(is_file('vfs://Foo/target/bar/baz/.file.txt'));
-        $this->assertEquals('source content', file_get_contents('vfs://Foo/target/bar/baz/.file.txt'));
+        self::assertTrue(is_dir('vfs://Foo/target/bar/baz'));
+        self::assertTrue(is_file('vfs://Foo/target/bar/baz/.file.txt'));
+        self::assertEquals('source content', file_get_contents('vfs://Foo/target/bar/baz/.file.txt'));
     }
 
     /**
@@ -443,7 +443,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
         file_put_contents('vfs://Foo/target/bar/baz/file.txt', 'target content');
 
         Files::copyDirectoryRecursively('vfs://Foo/source', 'vfs://Foo/target');
-        $this->assertEquals('source content', file_get_contents('vfs://Foo/target/bar/baz/file.txt'));
+        self::assertEquals('source content', file_get_contents('vfs://Foo/target/bar/baz/file.txt'));
     }
 
     /**
@@ -458,7 +458,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
         file_put_contents('vfs://Foo/target/bar/baz/file.txt', 'target content');
 
         Files::copyDirectoryRecursively('vfs://Foo/source', 'vfs://Foo/target', true);
-        $this->assertEquals('target content', file_get_contents('vfs://Foo/target/bar/baz/file.txt'));
+        self::assertEquals('target content', file_get_contents('vfs://Foo/target/bar/baz/file.txt'));
     }
 
     /**
@@ -577,7 +577,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
     public function bytesToSizeStringTests($bytes, $decimals, $decimalSeparator, $thousandsSeparator, $expected)
     {
         $actualResult = Files::bytesToSizeString($bytes, $decimals, $decimalSeparator, $thousandsSeparator);
-        $this->assertSame($expected, $actualResult);
+        self::assertSame($expected, $actualResult);
     }
 
     /**
@@ -650,7 +650,7 @@ class FilesTest extends \PHPUnit\Framework\TestCase
     public function sizeStringToBytesTests($sizeString, $expected)
     {
         $actualResult = Files::sizeStringToBytes($sizeString);
-        $this->assertSame($expected, $actualResult);
+        self::assertSame($expected, $actualResult);
     }
 
     /**

--- a/Neos.Utility.Lock/Tests/Unit/LockTest.php
+++ b/Neos.Utility.Lock/Tests/Unit/LockTest.php
@@ -62,7 +62,7 @@ class LockTest extends \PHPUnit\Framework\TestCase
             $this->fail('Lock could not be acquired after it was released');
         }
 
-        $this->assertTrue($lock->release());
+        self::assertTrue($lock->release());
     }
 
     /**
@@ -72,11 +72,11 @@ class LockTest extends \PHPUnit\Framework\TestCase
     {
         $lock = new Lock('testLock');
         $this->assertExclusivelyLocked('Failed to exclusively lock file.');
-        $this->assertTrue($lock->release());
+        self::assertTrue($lock->release());
 
         $lock = new Lock('testLock');
         $this->assertExclusivelyLocked('Failed to exclusively lock file.');
-        $this->assertTrue($lock->release());
+        self::assertTrue($lock->release());
     }
 
     /**
@@ -87,8 +87,8 @@ class LockTest extends \PHPUnit\Framework\TestCase
         $lock1 = new Lock('testLock', false);
         $lock2 = new Lock('testLock', false);
 
-        $this->assertTrue($lock1->release(), 'Lock 1 could not be released');
-        $this->assertTrue($lock2->release(), 'Lock 2 could not be released');
+        self::assertTrue($lock1->release(), 'Lock 1 could not be released');
+        self::assertTrue($lock2->release(), 'Lock 2 could not be released');
     }
 
     /**
@@ -97,7 +97,7 @@ class LockTest extends \PHPUnit\Framework\TestCase
     protected function assertExclusivelyLocked(string $message = '')
     {
         $lockFilePointer = fopen($this->lockFileName, 'w');
-        $this->assertFalse(flock($lockFilePointer, LOCK_EX | LOCK_NB), $message);
+        self::assertFalse(flock($lockFilePointer, LOCK_EX | LOCK_NB), $message);
         fclose($lockFilePointer);
     }
 }

--- a/Neos.Utility.MediaTypes/Tests/Unit/MediaTypesTest.php
+++ b/Neos.Utility.MediaTypes/Tests/Unit/MediaTypesTest.php
@@ -42,7 +42,7 @@ class MediaTypesTest extends \PHPUnit\Framework\TestCase
      */
     public function getMediaTypeFromFilenameMapsFilenameOrExtensionToMediaType(string $filename, string $expectedMediaType)
     {
-        $this->assertSame($expectedMediaType, MediaTypes::getMediaTypeFromFilename($filename));
+        self::assertSame($expectedMediaType, MediaTypes::getMediaTypeFromFilename($filename));
     }
 
     /**
@@ -65,7 +65,7 @@ class MediaTypesTest extends \PHPUnit\Framework\TestCase
     {
         $filePath = __DIR__ . '/Fixtures/' . $filename;
         $fileContent = is_file($filePath) ? file_get_contents($filePath) : '';
-        $this->assertSame($expectedMediaType, MediaTypes::getMediaTypeFromFileContent($fileContent));
+        self::assertSame($expectedMediaType, MediaTypes::getMediaTypeFromFileContent($fileContent));
     }
 
     /**
@@ -87,7 +87,7 @@ class MediaTypesTest extends \PHPUnit\Framework\TestCase
      */
     public function getFilenameExtensionFromMediaTypeReturnsFirstFileExtensionFoundForThatMediaType(string $mediaType, array $filenameExtensions)
     {
-        $this->assertSame(($filenameExtensions === [] ? '' : $filenameExtensions[0]), MediaTypes::getFilenameExtensionFromMediaType($mediaType));
+        self::assertSame(($filenameExtensions === [] ? '' : $filenameExtensions[0]), MediaTypes::getFilenameExtensionFromMediaType($mediaType));
     }
 
     /**
@@ -96,7 +96,7 @@ class MediaTypesTest extends \PHPUnit\Framework\TestCase
      */
     public function getFilenameExtensionsFromMediaTypeReturnsAllFileExtensionForThatMediaType(string $mediaType, array $filenameExtensions)
     {
-        $this->assertSame($filenameExtensions, MediaTypes::getFilenameExtensionsFromMediaType($mediaType));
+        self::assertSame($filenameExtensions, MediaTypes::getFilenameExtensionsFromMediaType($mediaType));
     }
 
 
@@ -119,7 +119,7 @@ class MediaTypesTest extends \PHPUnit\Framework\TestCase
     public function parseMediaTypeReturnsAssociativeArrayWithIndividualPartsOfTheMediaType(string $mediaType, array $expectedPieces)
     {
         $actualPieces = MediaTypes::parseMediaType($mediaType);
-        $this->assertSame($expectedPieces, $actualPieces);
+        self::assertSame($expectedPieces, $actualPieces);
     }
 
     /**
@@ -149,7 +149,7 @@ class MediaTypesTest extends \PHPUnit\Framework\TestCase
     public function mediaRangeMatchesChecksIfTheGivenMediaRangeMatchesTheGivenMediaType(string $mediaRange, string $mediaType, bool $expectedResult)
     {
         $actualResult = MediaTypes::mediaRangeMatches($mediaRange, $mediaType);
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**
@@ -173,6 +173,6 @@ class MediaTypesTest extends \PHPUnit\Framework\TestCase
     public function trimMediaTypeReturnsJustTheTypeAndSubTypeWithoutParameters(string $mediaType, string $expectedResult = null)
     {
         $actualResult = MediaTypes::trimMediaType($mediaType);
-        $this->assertSame($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
     }
 }

--- a/Neos.Utility.ObjectHandling/Tests/Unit/ObjectAccessTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/ObjectAccessTest.php
@@ -49,7 +49,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
     public function getPropertyReturnsExpectedValueForGetterProperty()
     {
         $property = ObjectAccess::getProperty($this->dummyObject, 'property');
-        $this->assertEquals($property, 'string1');
+        self::assertEquals($property, 'string1');
     }
 
     /**
@@ -58,7 +58,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
     public function getPropertyReturnsExpectedValueForPublicProperty()
     {
         $property = ObjectAccess::getProperty($this->dummyObject, 'publicProperty2');
-        $this->assertEquals($property, 42, 'A property of a given object was not returned correctly.');
+        self::assertEquals($property, 42, 'A property of a given object was not returned correctly.');
     }
 
     /**
@@ -67,7 +67,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
     public function getPropertyReturnsExpectedValueForUnexposedPropertyIfForceDirectAccessIsTrue()
     {
         $property = ObjectAccess::getProperty($this->dummyObject, 'unexposedProperty', true);
-        $this->assertEquals($property, 'unexposed', 'A property of a given object was not returned correctly.');
+        self::assertEquals($property, 'unexposed', 'A property of a given object was not returned correctly.');
     }
 
     /**
@@ -77,7 +77,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
     {
         $this->dummyObject->unknownProperty = 'unknown';
         $property = ObjectAccess::getProperty($this->dummyObject, 'unknownProperty', true);
-        $this->assertEquals($property, 'unknown', 'A property of a given object was not returned correctly.');
+        self::assertEquals($property, 'unknown', 'A property of a given object was not returned correctly.');
     }
 
     /**
@@ -113,7 +113,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
     public function getPropertyTriesToCallABooleanIsGetterMethodIfItExists()
     {
         $property = ObjectAccess::getProperty($this->dummyObject, 'booleanProperty');
-        $this->assertSame('method called 1', $property);
+        self::assertSame('method called 1', $property);
     }
 
     /**
@@ -122,11 +122,11 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
     public function getPropertyTriesToCallABooleanHasGetterMethodIfItExists()
     {
         $property = ObjectAccess::getProperty($this->dummyObject, 'anotherBooleanProperty');
-        $this->assertSame(false, $property);
+        self::assertSame(false, $property);
 
         $this->dummyObject->setAnotherBooleanProperty(true);
         $property = ObjectAccess::getProperty($this->dummyObject, 'anotherBooleanProperty');
-        $this->assertSame(true, $property);
+        self::assertSame(true, $property);
     }
 
     /**
@@ -154,7 +154,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
     {
         $array = new \ArrayObject();
         ObjectAccess::setProperty($array, 42, 'Test');
-        $this->assertSame('Test', $array[42]);
+        self::assertSame('Test', $array[42]);
     }
 
     /**
@@ -162,7 +162,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
      */
     public function setPropertyReturnsFalseIfPropertyIsNotAccessible()
     {
-        $this->assertFalse(ObjectAccess::setProperty($this->dummyObject, 'protectedProperty', 42));
+        self::assertFalse(ObjectAccess::setProperty($this->dummyObject, 'protectedProperty', 42));
     }
 
     /**
@@ -170,11 +170,11 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
      */
     public function setPropertySetsValueIfPropertyIsNotAccessibleWhenForceDirectAccessIsTrue()
     {
-        $this->assertTrue(ObjectAccess::setProperty($this->dummyObject, 'unexposedProperty', 'was set anyway', true));
+        self::assertTrue(ObjectAccess::setProperty($this->dummyObject, 'unexposedProperty', 'was set anyway', true));
         $className = TypeHandling::getTypeForValue($this->dummyObject);
         $propertyReflection = new \ReflectionProperty($className, 'unexposedProperty');
         $propertyReflection->setAccessible(true);
-        $this->assertEquals('was set anyway', $propertyReflection->getValue($this->dummyObject));
+        self::assertEquals('was set anyway', $propertyReflection->getValue($this->dummyObject));
     }
 
     /**
@@ -182,8 +182,8 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
      */
     public function setPropertySetsValueIfPropertyDoesNotExistWhenForceDirectAccessIsTrue()
     {
-        $this->assertTrue(ObjectAccess::setProperty($this->dummyObject, 'unknownProperty', 'was set anyway', true));
-        $this->assertEquals('was set anyway', $this->dummyObject->unknownProperty);
+        self::assertTrue(ObjectAccess::setProperty($this->dummyObject, 'unknownProperty', 'was set anyway', true));
+        self::assertEquals('was set anyway', $this->dummyObject->unknownProperty);
     }
 
     /**
@@ -192,7 +192,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
     public function setPropertyCallsASetterMethodToSetThePropertyValueIfOneIsAvailable()
     {
         ObjectAccess::setProperty($this->dummyObject, 'property', 4242);
-        $this->assertEquals($this->dummyObject->getProperty(), 4242, 'setProperty does not work with setter.');
+        self::assertEquals($this->dummyObject->getProperty(), 4242, 'setProperty does not work with setter.');
     }
 
     /**
@@ -201,7 +201,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
     public function setPropertyWorksWithPublicProperty()
     {
         ObjectAccess::setProperty($this->dummyObject, 'publicProperty', 4242);
-        $this->assertEquals($this->dummyObject->publicProperty, 4242, 'setProperty does not work with public property.');
+        self::assertEquals($this->dummyObject->publicProperty, 4242, 'setProperty does not work with public property.');
     }
 
     /**
@@ -215,8 +215,8 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
         ObjectAccess::setProperty($arrayObject, 'publicProperty', 4242);
         ObjectAccess::setProperty($array, 'key', 'value');
 
-        $this->assertEquals(4242, $arrayObject['publicProperty']);
-        $this->assertEquals('value', $array['key']);
+        self::assertEquals(4242, $arrayObject['publicProperty']);
+        self::assertEquals('value', $array['key']);
     }
 
     /**
@@ -227,7 +227,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
         $arrayObject = new \ArrayObject(['key' => 'value']);
         $expectedResult = 'value';
         $actualResult = ObjectAccess::getProperty($arrayObject, 'key');
-        $this->assertEquals($expectedResult, $actualResult, 'getProperty does not work with ArrayObject property.');
+        self::assertEquals($expectedResult, $actualResult, 'getProperty does not work with ArrayObject property.');
     }
 
     /**
@@ -238,7 +238,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
         $arrayObject = new \ArrayObject();
         $expectedResult = 'ArrayIterator';
         $actualResult = ObjectAccess::getProperty($arrayObject, 'iteratorClass');
-        $this->assertEquals($expectedResult, $actualResult, 'getProperty does not call existing getter of object implementing ArrayAccess.');
+        self::assertEquals($expectedResult, $actualResult, 'getProperty does not call existing getter of object implementing ArrayAccess.');
     }
 
     /**
@@ -249,7 +249,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
         $arrayObject = new \ArrayObject(['iteratorClass' => 'This should be ignored']);
         $expectedResult = 'ArrayIterator';
         $actualResult = ObjectAccess::getProperty($arrayObject, 'iteratorClass');
-        $this->assertEquals($expectedResult, $actualResult, 'getProperty does not call existing getter of object implementing ArrayAccess.');
+        self::assertEquals($expectedResult, $actualResult, 'getProperty does not call existing getter of object implementing ArrayAccess.');
     }
 
     /**
@@ -280,7 +280,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
         $arrayAccessInstance = new ArrayAccessClass(['key' => 'value']);
         $expectedResult = 'value';
         $actualResult = ObjectAccess::getProperty($arrayAccessInstance, 'key');
-        $this->assertEquals($expectedResult, $actualResult, 'getPropertyPath does not work with Array Access property.');
+        self::assertEquals($expectedResult, $actualResult, 'getPropertyPath does not work with Array Access property.');
     }
 
     /**
@@ -290,7 +290,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
     {
         $arrayAccessInstance = new ArrayAccessClass(['key' => 'value']);
         $actualResult = ObjectAccess::getProperty($arrayAccessInstance, 'internalProperty', true);
-        $this->assertEquals('access through forceDirectAccess', $actualResult, 'getPropertyPath does not respect ForceDirectAccess for ArrayAccess implementations.');
+        self::assertEquals('access through forceDirectAccess', $actualResult, 'getPropertyPath does not respect ForceDirectAccess for ArrayAccess implementations.');
     }
 
     /**
@@ -300,7 +300,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
     {
         $array = ['key' => 'value'];
         $actualResult = ObjectAccess::getProperty($array, 'key');
-        $this->assertEquals('value', $actualResult, 'getProperty does not work with Array property.');
+        self::assertEquals('value', $actualResult, 'getProperty does not work with Array property.');
     }
 
     /**
@@ -310,7 +310,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
     {
         $array = ['key' => null];
         $actualResult = ObjectAccess::getProperty($array, 'key');
-        $this->assertNull($actualResult, 'getProperty should allow access to NULL properties.');
+        self::assertNull($actualResult, 'getProperty should allow access to NULL properties.');
     }
 
     /**
@@ -320,7 +320,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
     {
         $array = ['parent' => ['key' => 'value']];
         $actualResult = ObjectAccess::getPropertyPath($array, 'parent.key');
-        $this->assertEquals('value', $actualResult, 'getPropertyPath does not work with Array property.');
+        self::assertEquals('value', $actualResult, 'getPropertyPath does not work with Array property.');
     }
 
     /**
@@ -330,7 +330,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
     {
         $array = ['parent' => new \ArrayObject(['key' => 'value'])];
         $actualResult = ObjectAccess::getPropertyPath($array, 'parent.key');
-        $this->assertEquals('value', $actualResult, 'getPropertyPath does not work with Array Access property.');
+        self::assertEquals('value', $actualResult, 'getPropertyPath does not work with Array Access property.');
     }
 
     /**
@@ -340,7 +340,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
     {
         $expectedPropertyNames = ['anotherBooleanProperty', 'anotherProperty', 'booleanProperty', 'property', 'property2', 'publicProperty', 'publicProperty2'];
         $actualPropertyNames = ObjectAccess::getGettablePropertyNames($this->dummyObject);
-        $this->assertEquals($expectedPropertyNames, $actualPropertyNames, 'getGettablePropertyNames returns not all gettable properties.');
+        self::assertEquals($expectedPropertyNames, $actualPropertyNames, 'getGettablePropertyNames returns not all gettable properties.');
     }
 
     /**
@@ -350,7 +350,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
     {
         $expectedPropertyNames = ['anotherBooleanProperty', 'anotherProperty', 'property', 'property2', 'publicProperty', 'publicProperty2', 'writeOnlyMagicProperty'];
         $actualPropertyNames = ObjectAccess::getSettablePropertyNames($this->dummyObject);
-        $this->assertEquals($expectedPropertyNames, $actualPropertyNames, 'getSettablePropertyNames returns not all settable properties.');
+        self::assertEquals($expectedPropertyNames, $actualPropertyNames, 'getSettablePropertyNames returns not all settable properties.');
     }
 
     /**
@@ -364,7 +364,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
 
         $expectedPropertyNames = ['property', 'property2'];
         $actualPropertyNames = ObjectAccess::getSettablePropertyNames($stdClassObject);
-        $this->assertEquals($expectedPropertyNames, $actualPropertyNames, 'getSettablePropertyNames returns not all settable properties.');
+        self::assertEquals($expectedPropertyNames, $actualPropertyNames, 'getSettablePropertyNames returns not all settable properties.');
     }
 
     /**
@@ -382,7 +382,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
             'publicProperty2' => 42
         ];
         $actualProperties = ObjectAccess::getGettableProperties($this->dummyObject);
-        $this->assertEquals($expectedProperties, $actualProperties, 'expectedProperties did not return the right values for the properties.');
+        self::assertEquals($expectedProperties, $actualProperties, 'expectedProperties did not return the right values for the properties.');
     }
 
     /**
@@ -400,7 +400,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
             'publicProperty2' => 42
         ];
         $actualProperties = ObjectAccess::getGettableProperties($stdClassObject);
-        $this->assertEquals($expectedProperties, $actualProperties, 'expectedProperties did not return the right values for the properties.');
+        self::assertEquals($expectedProperties, $actualProperties, 'expectedProperties did not return the right values for the properties.');
     }
 
     /**
@@ -412,7 +412,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
 
         $expectedProperties = [];
         $actualProperties = ObjectAccess::getGettableProperties($proxyObject);
-        $this->assertEquals($expectedProperties, $actualProperties, 'expectedProperties did not return the right values for the properties.');
+        self::assertEquals($expectedProperties, $actualProperties, 'expectedProperties did not return the right values for the properties.');
     }
 
     /**
@@ -420,12 +420,12 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
      */
     public function isPropertySettableTellsIfAPropertyCanBeSet()
     {
-        $this->assertTrue(ObjectAccess::isPropertySettable($this->dummyObject, 'writeOnlyMagicProperty'));
-        $this->assertTrue(ObjectAccess::isPropertySettable($this->dummyObject, 'publicProperty'));
-        $this->assertTrue(ObjectAccess::isPropertySettable($this->dummyObject, 'property'));
+        self::assertTrue(ObjectAccess::isPropertySettable($this->dummyObject, 'writeOnlyMagicProperty'));
+        self::assertTrue(ObjectAccess::isPropertySettable($this->dummyObject, 'publicProperty'));
+        self::assertTrue(ObjectAccess::isPropertySettable($this->dummyObject, 'property'));
 
-        $this->assertFalse(ObjectAccess::isPropertySettable($this->dummyObject, 'privateProperty'));
-        $this->assertFalse(ObjectAccess::isPropertySettable($this->dummyObject, 'shouldNotBePickedUp'));
+        self::assertFalse(ObjectAccess::isPropertySettable($this->dummyObject, 'privateProperty'));
+        self::assertFalse(ObjectAccess::isPropertySettable($this->dummyObject, 'shouldNotBePickedUp'));
     }
 
     /**
@@ -436,9 +436,9 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
         $stdClassObject = new \stdClass();
         $stdClassObject->property = 'foo';
 
-        $this->assertTrue(ObjectAccess::isPropertySettable($stdClassObject, 'property'));
+        self::assertTrue(ObjectAccess::isPropertySettable($stdClassObject, 'property'));
 
-        $this->assertFalse(ObjectAccess::isPropertySettable($stdClassObject, 'undefinedProperty'));
+        self::assertFalse(ObjectAccess::isPropertySettable($stdClassObject, 'undefinedProperty'));
     }
 
     /**
@@ -446,14 +446,14 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
      */
     public function isPropertyGettableTellsIfAPropertyCanBeRetrieved()
     {
-        $this->assertTrue(ObjectAccess::isPropertyGettable($this->dummyObject, 'publicProperty'));
-        $this->assertTrue(ObjectAccess::isPropertyGettable($this->dummyObject, 'property'));
-        $this->assertTrue(ObjectAccess::isPropertyGettable($this->dummyObject, 'booleanProperty'));
-        $this->assertTrue(ObjectAccess::isPropertyGettable($this->dummyObject, 'anotherBooleanProperty'));
+        self::assertTrue(ObjectAccess::isPropertyGettable($this->dummyObject, 'publicProperty'));
+        self::assertTrue(ObjectAccess::isPropertyGettable($this->dummyObject, 'property'));
+        self::assertTrue(ObjectAccess::isPropertyGettable($this->dummyObject, 'booleanProperty'));
+        self::assertTrue(ObjectAccess::isPropertyGettable($this->dummyObject, 'anotherBooleanProperty'));
 
-        $this->assertFalse(ObjectAccess::isPropertyGettable($this->dummyObject, 'privateProperty'));
-        $this->assertFalse(ObjectAccess::isPropertyGettable($this->dummyObject, 'writeOnlyMagicProperty'));
-        $this->assertFalse(ObjectAccess::isPropertyGettable($this->dummyObject, 'shouldNotBePickedUp'));
+        self::assertFalse(ObjectAccess::isPropertyGettable($this->dummyObject, 'privateProperty'));
+        self::assertFalse(ObjectAccess::isPropertyGettable($this->dummyObject, 'writeOnlyMagicProperty'));
+        self::assertFalse(ObjectAccess::isPropertyGettable($this->dummyObject, 'shouldNotBePickedUp'));
     }
 
     /**
@@ -464,8 +464,8 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
         $arrayObject = new \ArrayObject();
         $arrayObject['key'] = 'v';
 
-        $this->assertTrue(ObjectAccess::isPropertyGettable($arrayObject, 'key'));
-        $this->assertFalse(ObjectAccess::isPropertyGettable($arrayObject, 'undefinedKey'));
+        self::assertTrue(ObjectAccess::isPropertyGettable($arrayObject, 'key'));
+        self::assertFalse(ObjectAccess::isPropertyGettable($arrayObject, 'undefinedKey'));
     }
 
     /**
@@ -476,9 +476,9 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
         $stdClassObject = new \stdClass();
         $stdClassObject->property = 'foo';
 
-        $this->assertTrue(ObjectAccess::isPropertyGettable($stdClassObject, 'property'));
+        self::assertTrue(ObjectAccess::isPropertyGettable($stdClassObject, 'property'));
 
-        $this->assertFalse(ObjectAccess::isPropertyGettable($stdClassObject, 'undefinedProperty'));
+        self::assertFalse(ObjectAccess::isPropertyGettable($stdClassObject, 'undefinedProperty'));
     }
 
     /**
@@ -492,7 +492,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
 
         $expected = 'test';
         $actual = ObjectAccess::getPropertyPath($this->dummyObject, 'property2.property');
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 
     /**
@@ -504,7 +504,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
         $alternativeObject->setProperty(new \stdClass());
         $this->dummyObject->setProperty2($alternativeObject);
 
-        $this->assertNull(ObjectAccess::getPropertyPath($this->dummyObject, 'property2.property.not.existing'));
+        self::assertNull(ObjectAccess::getPropertyPath($this->dummyObject, 'property2.property.not.existing'));
     }
 
     /**
@@ -514,7 +514,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
     {
         $string = 'Hello world';
 
-        $this->assertNull(ObjectAccess::getPropertyPath($string, 'property2'));
+        self::assertNull(ObjectAccess::getPropertyPath($string, 'property2'));
     }
 
     /**
@@ -525,7 +525,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
         $object = new \stdClass();
         $object->foo = 'Hello World';
 
-        $this->assertNull(ObjectAccess::getPropertyPath($object, 'foo.bar'));
+        self::assertNull(ObjectAccess::getPropertyPath($object, 'foo.bar'));
     }
 
     /**
@@ -538,7 +538,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
         $object1->property = 'booh!';
         $object2 = new \stdClass();
 
-        $this->assertEquals('booh!', ObjectAccess::getProperty($object1, 'property'));
+        self::assertEquals('booh!', ObjectAccess::getProperty($object1, 'property'));
         ObjectAccess::getProperty($object2, 'property');
     }
 }

--- a/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
@@ -70,7 +70,7 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
      */
     public function parseTypeReturnsArrayWithInformation(string $type, array $expectedResult)
     {
-        $this->assertEquals(
+        self::assertEquals(
             $expectedResult,
             TypeHandling::parseType($type),
             'Failed for ' . $type
@@ -107,7 +107,7 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
      */
     public function extractCollectionTypeReturnsOnlyTheMainType(string $type, string $expectedResult)
     {
-        $this->assertEquals(
+        self::assertEquals(
             $expectedResult,
             TypeHandling::truncateElementType($type),
             'Failed for ' . $type
@@ -133,7 +133,7 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
      */
     public function normalizeTypesReturnsNormalizedType(string $type, string $normalized)
     {
-        $this->assertEquals(TypeHandling::normalizeType($type), $normalized);
+        self::assertEquals(TypeHandling::normalizeType($type), $normalized);
     }
 
     /**
@@ -156,7 +156,7 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
      */
     public function isLiteralReturnsFalseForNonLiteralTypes(string $type)
     {
-        $this->assertFalse(TypeHandling::isLiteral($type), 'Failed for ' . $type);
+        self::assertFalse(TypeHandling::isLiteral($type), 'Failed for ' . $type);
     }
 
     /**
@@ -181,7 +181,7 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
      */
     public function isLiteralReturnsTrueForLiteralType(string $type)
     {
-        $this->assertTrue(TypeHandling::isLiteral($type), 'Failed for ' . $type);
+        self::assertTrue(TypeHandling::isLiteral($type), 'Failed for ' . $type);
     }
 
     /**
@@ -212,7 +212,7 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
      */
     public function isCollectionTypeReturnsTrueForCollectionType(string $type, bool $expected)
     {
-        $this->assertSame($expected, TypeHandling::isCollectionType($type), 'Failed for ' . $type);
+        self::assertSame($expected, TypeHandling::isCollectionType($type), 'Failed for ' . $type);
     }
 
     /**
@@ -251,7 +251,7 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
      */
     public function stripNullableTypesReturnsOnlyTheType($type, $expectedResult)
     {
-        $this->assertEquals(
+        self::assertEquals(
             $expectedResult,
             TypeHandling::stripNullableType($type),
             'Failed for ' . $type

--- a/Neos.Utility.Schema/Tests/Unit/SchemaGeneratorTest.php
+++ b/Neos.Utility.Schema/Tests/Unit/SchemaGeneratorTest.php
@@ -50,7 +50,7 @@ class SchemaGeneratorTest extends \PHPUnit\Framework\TestCase
     public function testSchemaGenerationForSimpleTypes($value, array $expectedSchema)
     {
         $schema = $this->configurationGenerator->generate($value);
-        $this->assertEquals($schema, $expectedSchema);
+        self::assertEquals($schema, $expectedSchema);
     }
 
     /**
@@ -72,6 +72,6 @@ class SchemaGeneratorTest extends \PHPUnit\Framework\TestCase
     public function testSchemaGenerationForArrayOfTypes(array $value, array $expectedSchema)
     {
         $schema = $this->configurationGenerator->generate($value);
-        $this->assertEquals($schema, $expectedSchema);
+        self::assertEquals($schema, $expectedSchema);
     }
 }

--- a/Neos.Utility.Schema/Tests/Unit/SchemaValidatorTest.php
+++ b/Neos.Utility.Schema/Tests/Unit/SchemaValidatorTest.php
@@ -39,9 +39,9 @@ class SchemaValidatorTest extends \PHPUnit\Framework\TestCase
     protected function assertError(Error\Result $result, bool $expectError = true)
     {
         if ($expectError === true) {
-            $this->assertTrue($result->hasErrors());
+            self::assertTrue($result->hasErrors());
         } else {
-            $this->assertFalse($result->hasErrors());
+            self::assertFalse($result->hasErrors());
         }
     }
 
@@ -55,9 +55,9 @@ class SchemaValidatorTest extends \PHPUnit\Framework\TestCase
     protected function assertSuccess(Error\Result $result, bool $expectSuccess = true)
     {
         if ($expectSuccess === true) {
-            $this->assertFalse($result->hasErrors());
+            self::assertFalse($result->hasErrors());
         } else {
-            $this->assertTrue($result->hasErrors());
+            self::assertTrue($result->hasErrors());
         }
     }
 
@@ -180,12 +180,12 @@ class SchemaValidatorTest extends \PHPUnit\Framework\TestCase
         $this->assertError($result);
 
         $allErrors = $result->getFlattenedErrors();
-        $this->assertTrue(array_key_exists('foo.bar.baz', $allErrors));
+        self::assertTrue(array_key_exists('foo.bar.baz', $allErrors));
 
         $pathErrors = $result->forProperty('foo.bar.baz')->getErrors();
         $firstPathError = $pathErrors[0];
-        $this->assertEquals($firstPathError->getCode(), 1328557141);
-        $this->assertEquals($firstPathError->getArguments(), ['type=number', 'type=string']);
+        self::assertEquals($firstPathError->getCode(), 1328557141);
+        self::assertEquals($firstPathError->getArguments(), ['type=number', 'type=string']);
     }
 
     /**

--- a/Neos.Utility.Unicode/Tests/Unit/FunctionsTest.php
+++ b/Neos.Utility.Unicode/Tests/Unit/FunctionsTest.php
@@ -26,7 +26,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     public function strtotitleWorksWithLatinCharacters()
     {
         $testString = 'this Is - my TestString.';
-        $this->assertEquals('This Is - My Teststring.', Functions::strtotitle($testString), 'strtotitle() did not return the expected string.');
+        self::assertEquals('This Is - My Teststring.', Functions::strtotitle($testString), 'strtotitle() did not return the expected string.');
     }
 
     /**
@@ -38,7 +38,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     {
         $testString = ' öl Ist nicht das GLEICHE wie øl.';
         $expectedString = ' Öl Ist Nicht Das Gleiche Wie Øl.';
-        $this->assertEquals($expectedString, Functions::strtotitle($testString), 'strtotitle() did not return the expected string for the unicode test.');
+        self::assertEquals($expectedString, Functions::strtotitle($testString), 'strtotitle() did not return the expected string for the unicode test.');
     }
 
     /**
@@ -49,7 +49,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     public function substrWorksWithLatinCharacters()
     {
         $testString = 'I say "hello world".';
-        $this->assertEquals('hello world', Functions::substr($testString, 7, 11), 'substr() with latin characters did not return the expected string.');
+        self::assertEquals('hello world', Functions::substr($testString, 7, 11), 'substr() with latin characters did not return the expected string.');
     }
 
     /**
@@ -60,7 +60,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     public function substrWorksWithUTF8Characters()
     {
         $testString = 'Kasper Skårhøj implemented most versions of TYPO3.';
-        $this->assertEquals('Kasper Skårhøj', Functions::substr($testString, 0, 14), 'substr() with UTF8 characters did not return the expected string.');
+        self::assertEquals('Kasper Skårhøj', Functions::substr($testString, 0, 14), 'substr() with UTF8 characters did not return the expected string.');
     }
 
     /**
@@ -71,7 +71,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     public function substrWorksWithUTF8CharactersSpecifyingNoLength()
     {
         $testString = 'Kasper Skårhøj implemented most versions of TYPO3.';
-        $this->assertEquals('implemented most versions of TYPO3.', Functions::substr($testString, 15), 'substr() with UTF8 characters did not return the expected string after specifying no length.');
+        self::assertEquals('implemented most versions of TYPO3.', Functions::substr($testString, 15), 'substr() with UTF8 characters did not return the expected string after specifying no length.');
     }
 
     /**
@@ -82,7 +82,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     public function strtoupperWorksWithLatinCharacters()
     {
         $testString = 'typo3';
-        $this->assertEquals('TYPO3', Functions::strtoupper($testString), 'strtoupper() with latin characters didn\'t work out.');
+        self::assertEquals('TYPO3', Functions::strtoupper($testString), 'strtoupper() with latin characters didn\'t work out.');
     }
 
     /**
@@ -95,7 +95,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
         $testString = 'Here are some characters: äöüÄÖÜßéèêåÅøØæÆœŒ ...';
         $expectedResult = 'HERE ARE SOME CHARACTERS: ÄÖÜÄÖÜSSÉÈÊÅÅØØÆÆŒŒ ...';
         $result = Functions::strtoupper($testString);
-        $this->assertEquals($expectedResult, $result, 'strtoupper() could not convert our selection of special characters.');
+        self::assertEquals($expectedResult, $result, 'strtoupper() could not convert our selection of special characters.');
     }
 
     /**
@@ -106,7 +106,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     public function strtolowerWorksWithLatinCharacters()
     {
         $testString = 'TYPO3';
-        $this->assertEquals('typo3', Functions::strtolower($testString), 'strtolower() with latin characters didn\'t work out.');
+        self::assertEquals('typo3', Functions::strtolower($testString), 'strtolower() with latin characters didn\'t work out.');
     }
 
     /**
@@ -119,7 +119,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
         $testString = 'HERE ARE SOME CHARACTERS: ÄÖÜÄÖÜßÉÈÊÅÅØØÆÆŒŒ ...';
         $expectedResult = 'here are some characters: äöüäöüßéèêååøøææœœ ...';
         $result = Functions::strtolower($testString);
-        $this->assertEquals($expectedResult, $result, 'strtolower() could not convert our selection of special characters.');
+        self::assertEquals($expectedResult, $result, 'strtolower() could not convert our selection of special characters.');
     }
 
     /**
@@ -130,7 +130,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     public function strlenWorksWithLatinCharacters()
     {
         $testString = 'Feugiat tincidunt duo id, 23 quam delenit vocibus nam eu';
-        $this->assertEquals(56, Functions::strlen($testString), 'strlen() did not return the correct string length for latin character string.');
+        self::assertEquals(56, Functions::strlen($testString), 'strlen() did not return the correct string length for latin character string.');
     }
 
     /**
@@ -141,7 +141,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     public function strlenWorksWithCertainSpecialChars()
     {
         $testString = 'here are some characters: äöüäöüßéèêååøøææœœ“” ...';
-        $this->assertEquals(50, Functions::strlen($testString), 'strlen() did not return the correct string length for unicode string.');
+        self::assertEquals(50, Functions::strlen($testString), 'strlen() did not return the correct string length for unicode string.');
     }
 
     /**
@@ -153,7 +153,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     {
         $testString = 'feugiat tincidunt duo id, 23 quam delenit vocibus nam eu';
         $expectedResult = 'Feugiat tincidunt duo id, 23 quam delenit vocibus nam eu';
-        $this->assertEquals($expectedResult, Functions::ucfirst($testString), 'ucfirst() did not return the correct string for latin string.');
+        self::assertEquals($expectedResult, Functions::ucfirst($testString), 'ucfirst() did not return the correct string for latin string.');
     }
 
     /**
@@ -165,11 +165,11 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     {
         $testString = 'äeugiat tincidunt duo id, 23 quam delenit vocibus nam eu';
         $expectedResult = 'Äeugiat tincidunt duo id, 23 quam delenit vocibus nam eu';
-        $this->assertEquals($expectedResult, Functions::ucfirst($testString), 'ucfirst() did not return the correct string for a umlaut.');
+        self::assertEquals($expectedResult, Functions::ucfirst($testString), 'ucfirst() did not return the correct string for a umlaut.');
 
         $testString = 'åeugiat tincidunt duo id, 23 quam delenit vocibus nam eu';
         $expectedResult = 'Åeugiat tincidunt duo id, 23 quam delenit vocibus nam eu';
-        $this->assertEquals($expectedResult, Functions::ucfirst($testString), 'ucfirst() did not return the correct string for danish a.');
+        self::assertEquals($expectedResult, Functions::ucfirst($testString), 'ucfirst() did not return the correct string for danish a.');
     }
 
     /**
@@ -181,7 +181,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     {
         $testString = 'FEUGIAT TINCIDUNT DUO ID, 23 QUAM DELENIT VOCIBUS NAM EU';
         $expectedResult = 'fEUGIAT TINCIDUNT DUO ID, 23 QUAM DELENIT VOCIBUS NAM EU';
-        $this->assertEquals($expectedResult, Functions::lcfirst($testString), 'lcfirst() did not return the correct string for latin string.');
+        self::assertEquals($expectedResult, Functions::lcfirst($testString), 'lcfirst() did not return the correct string for latin string.');
     }
 
     /**
@@ -193,11 +193,11 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     {
         $testString = 'ÄEUGIAT TINCIDUNT DUO ID, 23 QUAM DELENIT VOCIBUS NAM EU';
         $expectedResult = 'äEUGIAT TINCIDUNT DUO ID, 23 QUAM DELENIT VOCIBUS NAM EU';
-        $this->assertEquals($expectedResult, Functions::lcfirst($testString), 'lcfirst() did not return the correct string for a umlaut.');
+        self::assertEquals($expectedResult, Functions::lcfirst($testString), 'lcfirst() did not return the correct string for a umlaut.');
 
         $testString = 'ÅEUGIAT TINCIDUNT DUO ID, 23 QUAM DELENIT VOCIBUS NAM EU';
         $expectedResult = 'åEUGIAT TINCIDUNT DUO ID, 23 QUAM DELENIT VOCIBUS NAM EU';
-        $this->assertEquals($expectedResult, Functions::lcfirst($testString), 'lcfirst() did not return the correct string for danish a.');
+        self::assertEquals($expectedResult, Functions::lcfirst($testString), 'lcfirst() did not return the correct string for danish a.');
     }
 
     /**
@@ -208,7 +208,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     public function strposWorksWithLatinCharacters()
     {
         $testString = 'Feugiat tincidunt duo id, 23 quam delenit vocibus nam eu';
-        $this->assertEquals(8, strpos($testString, 'tincidunt'), 'strpos() did not return the correct position for a latin character string.');
+        self::assertEquals(8, strpos($testString, 'tincidunt'), 'strpos() did not return the correct position for a latin character string.');
     }
 
     /**
@@ -219,7 +219,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     public function strposWorksWithCertainSpecialChars()
     {
         $testString = 'Åeugiat tincidunt duo id, 23 quam delenit vocibus nam eu';
-        $this->assertEquals(8, Functions::strpos($testString, 'tincidunt'), 'strpos() did not return the correct positions for a unicode string.');
+        self::assertEquals(8, Functions::strpos($testString, 'tincidunt'), 'strpos() did not return the correct positions for a unicode string.');
     }
 
     /**
@@ -233,7 +233,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
             'host' => 'www.mysite.org',
             'path' => '/he/פרויקטים/ByYear.html'
         ];
-        $this->assertEquals($expected, Functions::parse_url($url), 'parse_url() did not return the correct result for a unicode URL.');
+        self::assertEquals($expected, Functions::parse_url($url), 'parse_url() did not return the correct result for a unicode URL.');
     }
 
     /**
@@ -246,7 +246,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
             'scheme' => 'http',
             'host' => '[3b00:f59:1008::212:183:20]'
         ];
-        $this->assertEquals($expected, Functions::parse_url($url), 'parse_url() did not return the correct result for a unicode URL.');
+        self::assertEquals($expected, Functions::parse_url($url), 'parse_url() did not return the correct result for a unicode URL.');
     }
 
     /**
@@ -261,7 +261,7 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
             'port' => 443,
             'path' => '/he/פרויקטים/ByYear.html'
         ];
-        $this->assertEquals($expected, Functions::parse_url($url), 'parse_url() did not return the correct result for a unicode URL.');
+        self::assertEquals($expected, Functions::parse_url($url), 'parse_url() did not return the correct result for a unicode URL.');
     }
 
     /**
@@ -272,9 +272,9 @@ class FunctionsTest extends \PHPUnit\Framework\TestCase
     public function pathinfoWorksWithCertainSpecialChars()
     {
         $testString = 'кириллическийПуть/кириллическоеИмя.расширение';
-        $this->assertEquals('кириллическийПуть', Functions::pathinfo($testString, PATHINFO_DIRNAME), 'pathinfo() did not return the correct dirname for a unicode path.');
-        $this->assertEquals('кириллическоеИмя.расширение', Functions::pathinfo($testString, PATHINFO_BASENAME), 'pathinfo() did not return the correct basename for a unicode path.');
-        $this->assertEquals('расширение', Functions::pathinfo($testString, PATHINFO_EXTENSION), 'pathinfo() did not return the correct extension for a unicode path.');
-        $this->assertEquals('кириллическоеИмя', Functions::pathinfo($testString, PATHINFO_FILENAME), 'pathinfo() did not return the correct filename for a unicode path.');
+        self::assertEquals('кириллическийПуть', Functions::pathinfo($testString, PATHINFO_DIRNAME), 'pathinfo() did not return the correct dirname for a unicode path.');
+        self::assertEquals('кириллическоеИмя.расширение', Functions::pathinfo($testString, PATHINFO_BASENAME), 'pathinfo() did not return the correct basename for a unicode path.');
+        self::assertEquals('расширение', Functions::pathinfo($testString, PATHINFO_EXTENSION), 'pathinfo() did not return the correct extension for a unicode path.');
+        self::assertEquals('кириллическоеИмя', Functions::pathinfo($testString, PATHINFO_FILENAME), 'pathinfo() did not return the correct filename for a unicode path.');
     }
 }

--- a/Neos.Utility.Unicode/Tests/Unit/TextIteratorTest.php
+++ b/Neos.Utility.Unicode/Tests/Unit/TextIteratorTest.php
@@ -27,7 +27,7 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
     public function canCreateIteratorOfDefaultType()
     {
         $iterator = new TextIterator('Some string');
-        $this->assertInstanceOf(TextIterator::class, $iterator);
+        self::assertInstanceOf(TextIterator::class, $iterator);
     }
 
     /**
@@ -38,7 +38,7 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
     public function instantiatingCharacterIteratorWorks()
     {
         $characterIterator = new TextIterator('Some string', TextIterator::CHARACTER);
-        $this->assertInstanceOf(TextIterator::class, $characterIterator);
+        self::assertInstanceOf(TextIterator::class, $characterIterator);
     }
 
     /**
@@ -49,7 +49,7 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
     public function instantiatingWordIteratorWorks()
     {
         $wordIterator = new TextIterator('Some string', TextIterator::WORD);
-        $this->assertInstanceOf(TextIterator::class, $wordIterator);
+        self::assertInstanceOf(TextIterator::class, $wordIterator);
     }
 
 
@@ -61,7 +61,7 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
     public function instantiatingSentenceIteratorWorks()
     {
         $sentenceIterator = new TextIterator('Some string', TextIterator::SENTENCE);
-        $this->assertInstanceOf(TextIterator::class, $sentenceIterator);
+        self::assertInstanceOf(TextIterator::class, $sentenceIterator);
     }
 
     /**
@@ -72,7 +72,7 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
     public function instantiatingLineIteratorWorks()
     {
         $lineIterator = new TextIterator('Some string', TextIterator::LINE);
-        $this->assertInstanceOf(TextIterator::class, $lineIterator);
+        self::assertInstanceOf(TextIterator::class, $lineIterator);
     }
 
 
@@ -87,7 +87,7 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
             new TextIterator('Some string', 948);
             $this->fail('Constructor did not reject invalid TextIterator type.');
         } catch (Unicode\Exception $exception) {
-            $this->assertStringContainsString('Invalid iterator type in TextIterator constructor', $exception->getMessage(), 'Wrong error message.');
+            self::assertStringContainsString('Invalid iterator type in TextIterator constructor', $exception->getMessage(), 'Wrong error message.');
         }
     }
 
@@ -104,7 +104,7 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
         foreach ($iterator as $currentCharacter) {
             $result .= $currentCharacter;
         }
-        $this->assertEquals('This is a test string. Let\'s iterate it by character...', $result, 'Character iteration didn\'t return the right values.');
+        self::assertEquals('This is a test string. Let\'s iterate it by character...', $result, 'Character iteration didn\'t return the right values.');
     }
 
     /**
@@ -120,7 +120,7 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
         foreach ($iterator as $currentWord) {
             $result .= $currentWord;
         }
-        $this->assertEquals('This is a test string. Let\'s iterate it by word...', $result, 'Word iteration didn\'t return the right values.');
+        self::assertEquals('This is a test string. Let\'s iterate it by word...', $result, 'Word iteration didn\'t return the right values.');
     }
 
     /**
@@ -136,7 +136,7 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
         foreach ($iterator as $currentSentence) {
             $result .= $currentSentence;
         }
-        $this->assertEquals('This is a test string. Let\'s iterate it by sentence...', $result, 'Sentence iteration didn\'t return the right values.');
+        self::assertEquals('This is a test string. Let\'s iterate it by sentence...', $result, 'Sentence iteration didn\'t return the right values.');
     }
 
     /**
@@ -152,7 +152,7 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
         foreach ($iterator as $currentLine) {
             $result .= $currentLine;
         }
-        $this->assertEquals("This is a test string. \nLet's iterate \nit by line...", $result, 'Line iteration didn\'t return the right values.');
+        self::assertEquals("This is a test string. \nLet's iterate \nit by line...", $result, 'Line iteration didn\'t return the right values.');
     }
 
     /**
@@ -168,7 +168,7 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
                 break;
             }
         }
-        $this->assertEquals($iterator->offset(), 23, 'Wrong offset returned in character iteration.');
+        self::assertEquals($iterator->offset(), 23, 'Wrong offset returned in character iteration.');
     }
 
     /**
@@ -184,7 +184,7 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
                 break;
             }
         }
-        $this->assertEquals($iterator->offset(), 29, 'Wrong offset returned in word iteration.');
+        self::assertEquals($iterator->offset(), 29, 'Wrong offset returned in word iteration.');
     }
 
     /**
@@ -200,7 +200,7 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
                 break;
             }
         }
-        $this->assertEquals($iterator->offset(), 23, 'Wrong offset returned in sentence iteration.');
+        self::assertEquals($iterator->offset(), 23, 'Wrong offset returned in sentence iteration.');
     }
 
     /**
@@ -212,7 +212,7 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
     {
         $iterator = new TextIterator('This is a test string. Let\'s iterate it by word...', TextIterator::WORD);
         $iterator->next();
-        $this->assertEquals($iterator->first(), 'This', 'Wrong element returned by first().');
+        self::assertEquals($iterator->first(), 'This', 'Wrong element returned by first().');
     }
 
     /**
@@ -224,7 +224,7 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
     {
         $iterator = new TextIterator('This is a test string. Let\'s iterate it by word', TextIterator::WORD);
         $iterator->rewind();
-        $this->assertEquals($iterator->last(), 'word', 'Wrong element returned by last().');
+        self::assertEquals($iterator->last(), 'word', 'Wrong element returned by last().');
     }
 
     /**
@@ -249,7 +249,7 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
             9 => '.',
         ];
 
-        $this->assertEquals($iterator->getAll(), $expectedResult, 'Wrong element returned by getAll().');
+        self::assertEquals($iterator->getAll(), $expectedResult, 'Wrong element returned by getAll().');
     }
 
     /**
@@ -262,7 +262,7 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
         $iterator = new TextIterator('This is a test string. Let\'s iterate it by character', TextIterator::CHARACTER);
         $iterator->rewind();
         while ($iterator->valid()) {
-            $this->assertFalse($iterator->isBoundary(), 'Character iteration has no boundary elements.');
+            self::assertFalse($iterator->isBoundary(), 'Character iteration has no boundary elements.');
             $iterator->next();
         }
     }
@@ -276,10 +276,10 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
     {
         $iterator = new TextIterator('This is a test string. Let\'s iterate it by word', TextIterator::WORD);
         $iterator->rewind();
-        $this->assertFalse($iterator->isBoundary(), 'This element was a boundary element.');
+        self::assertFalse($iterator->isBoundary(), 'This element was a boundary element.');
 
         $iterator->next();
-        $this->assertTrue($iterator->isBoundary(), 'This element was no boundary element.');
+        self::assertTrue($iterator->isBoundary(), 'This element was no boundary element.');
     }
 
     /**
@@ -291,10 +291,10 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
     {
         $iterator = new TextIterator('This is a test string. Let\'s iterate it by sentence', TextIterator::SENTENCE);
         $iterator->rewind();
-        $this->assertFalse($iterator->isBoundary(), 'This element was a boundary element.');
+        self::assertFalse($iterator->isBoundary(), 'This element was a boundary element.');
 
         $iterator->next();
-        $this->assertTrue($iterator->isBoundary(), 'This element was no boundary element.');
+        self::assertTrue($iterator->isBoundary(), 'This element was no boundary element.');
     }
 
     /**
@@ -306,10 +306,10 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
     {
         $iterator = new TextIterator("This is a test string. \nLet\'s iterate \nit by line", TextIterator::LINE);
         $iterator->rewind();
-        $this->assertFalse($iterator->isBoundary(), 'This element was a boundary element.');
+        self::assertFalse($iterator->isBoundary(), 'This element was a boundary element.');
 
         $iterator->next();
-        $this->assertTrue($iterator->isBoundary(), 'This element was no boundary element.');
+        self::assertTrue($iterator->isBoundary(), 'This element was no boundary element.');
     }
 
     /**
@@ -321,7 +321,7 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
     {
         $iterator = new TextIterator('This is a test string. Let\'s iterate it by word', TextIterator::WORD);
 
-        $this->assertEquals($iterator->following(11), 14, 'Wrong offset for the following element returned.');
+        self::assertEquals($iterator->following(11), 14, 'Wrong offset for the following element returned.');
     }
 
     /**
@@ -333,6 +333,6 @@ class TextIteratorTest extends \PHPUnit\Framework\TestCase
     {
         $iterator = new TextIterator('This is a test string. Let\'s iterate it by word', TextIterator::WORD);
 
-        $this->assertEquals($iterator->preceding(11), 10, 'Wrong offset for the preceding element returned.' . $iterator->preceding(11));
+        self::assertEquals($iterator->preceding(11), 10, 'Wrong offset for the preceding element returned.' . $iterator->preceding(11));
     }
 }


### PR DESCRIPTION
The `assert* ` methods are static methods in recent versions of PHPUnit. As calling static methods via `$this->` feels odd, I replaced the method calls with static calls.