### PR TITLE
!!! TASK: Enable `subdivideHashPathSegment` and `relativeSymlinks` by default

### DIFF
--- a/Neos.Flow/Configuration/Settings.Resource.yaml
+++ b/Neos.Flow/Configuration/Settings.Resource.yaml
@@ -76,7 +76,7 @@ Neos:
             extensionBlacklist: *uploadExtensionBlacklist
 
             # If the generated URI path segment containing the sha1 should be divided into multiple segments (recommended if you expect many resources):
-            subdivideHashPathSegment: false
+            subdivideHashPathSegment: true
 
             # If the symlinks should be relative instead of absolute
-            #relativeSymlinks: false
+            relativeSymlinks: true


### PR DESCRIPTION
The old defaults for these settings worked but caused trouble once projects got bigger over time:
- `subdivideHashPathSegment: false` caused having too many symlinks in a single folder for many filesystems 
- `relativeSymlinks: false` did not allow to put the `Web/_Resources` directory into the shared folder for faster deployments

ATTENTION: This alters the default behavior and the published resources will get a url with nested pathes. That is why this is considered a breaking change.

NOTE: After updating you have to empty the `Web/_Resources/Persistent` folder and run `./flow resource:publish`. This us usually all done automatically from the deployment tool you are using.

If you do not want this behavior you can disable the subdivision via configuration for your project with the following configuration.

```
Neos:
  Flow:
    resource:
      targets:
        localWebDirectoryPersistentResourcesTarget:
          targetOptions:
            subdivideHashPathSegment: false
            relativeSymlinks: false
``` 
You probably want to redirect requests to the old urls in your webserver configuration, the following regex search/replace patterns may be used for that:
- searchPattern: `^_Resources\/Persistent\/([a-f0-9]{1})([a-f0-9]{1})([a-f0-9]{1})([a-f0-9]{1})([a-f0-9]{36})\/(.+)$`
- replacePattern: `_Resources/Persistent/$1/$2/$3/$4/$1$2$3$4$5/$6`