### PR TITLE
BUGFIX: Authentication: Only intercept GET requests

### DIFF
--- a/Neos.Flow/Classes/Mvc/Dispatcher.php
+++ b/Neos.Flow/Classes/Mvc/Dispatcher.php
@@ -119,9 +119,12 @@ class Dispatcher
                 } else {
                     $securityLogger->log(sprintf('Starting authentication with entry point of type "%s"', get_class($entryPoint)), LOG_INFO);
                 }
-                $securityContext->setInterceptedRequest($request->getMainRequest());
+                $httpRequest = $request->getHttpRequest();
+                if ($httpRequest->getMethod() === 'GET') {
+                    $securityContext->setInterceptedRequest($request->getMainRequest());
+                }
                 /** @var HttpResponse $response */
-                $entryPoint->startAuthentication($request->getHttpRequest(), $response);
+                $entryPoint->startAuthentication($httpRequest, $response);
             }
             if ($entryPointFound === false) {
                 $securityLogger->log('No authentication entry point found for active tokens, therefore cannot authenticate or redirect to authentication automatically.', LOG_NOTICE);

--- a/Neos.Flow/Tests/Unit/Mvc/DispatcherTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/DispatcherTest.php
@@ -302,6 +302,33 @@ class DispatcherTest extends UnitTestCase
 
         $this->mockFirewall->expects($this->once())->method('blockIllegalRequests')->will($this->throwException(new AuthenticationRequiredException()));
 
+        $this->mockHttpRequest->method('getMethod')->willReturn('GET');
+
+        try {
+            $this->dispatcher->dispatch($this->mockActionRequest, $this->mockHttpResponse);
+        } catch (AuthenticationRequiredException $exception) {
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function dispatchDoesNotSetInterceptedRequestIfRequestMethodIsNotGET()
+    {
+        $this->mockActionRequest->expects($this->any())->method('isDispatched')->will($this->returnValue(true));
+
+        $mockEntryPoint = $this->getMockBuilder(EntryPointInterface::class)->getMock();
+
+        $mockAuthenticationToken = $this->getMockBuilder(TokenInterface::class)->getMock();
+        $mockAuthenticationToken->expects($this->any())->method('getAuthenticationEntryPoint')->will($this->returnValue($mockEntryPoint));
+        $this->mockSecurityContext->expects($this->atLeastOnce())->method('getAuthenticationTokens')->will($this->returnValue([$mockAuthenticationToken]));
+
+        $this->mockSecurityContext->expects($this->never())->method('setInterceptedRequest');
+
+        $this->mockFirewall->expects($this->once())->method('blockIllegalRequests')->will($this->throwException(new AuthenticationRequiredException()));
+
+        $this->mockHttpRequest->method('getMethod')->willReturn('POST');
+
         try {
             $this->dispatcher->dispatch($this->mockActionRequest, $this->mockHttpResponse);
         } catch (AuthenticationRequiredException $exception) {


### PR DESCRIPTION
Adjusts the `Dispatcher` so that it only intercepts GET
requests in order to prevent unwanted side effects when
redirecting to an unsafe request.

Fixes: #1694