### PR TITLE
FEATURE: Interceptor return value may influence request filter

### DIFF
--- a/Neos.Flow/Classes/Security/Authorization/RequestFilter.php
+++ b/Neos.Flow/Classes/Security/Authorization/RequestFilter.php
@@ -78,8 +78,7 @@ class RequestFilter
     public function filterRequest(ActionRequest $request): bool
     {
         if ($this->pattern->matchRequest($request)) {
-            $this->securityInterceptor->invoke();
-            return true;
+            return $this->securityInterceptor->invoke() !== false;
         }
         return false;
     }


### PR DESCRIPTION
This checks the return result of the security interceptor in the authentication request filter. If it is false, this will lead to the filter also rejecting the request.
Before, the request filter always returned true, no matter the return value of the interceptor.

Resolves #1515 
