### PR TITLE
!!! FEATURE: Add strict typehints for error message title and code

### DIFF
--- a/Neos.Error.Messages/Classes/Message.php
+++ b/Neos.Error.Messages/Classes/Message.php
@@ -57,15 +57,15 @@ class Message
      * Constructs this error
      *
      * @param string $message An english error message which is used if no other error message can be resolved
-     * @param integer $code A unique error code
+     * @param integer|null $code A unique error code
      * @param array $arguments Array of arguments to be replaced in message
      * @param string $title optional title for the message
      * @api
      */
-    public function __construct(string $message, int $code = 0, array $arguments = [], string $title = '')
+    public function __construct(string $message, ?int $code = null, array $arguments = [], string $title = '')
     {
         $this->message = $message;
-        $this->code = $code;
+        $this->code = $code ?? 0;
         $this->arguments = $arguments;
         $this->title = $title;
     }

--- a/Neos.Error.Messages/Classes/Message.php
+++ b/Neos.Error.Messages/Classes/Message.php
@@ -57,12 +57,12 @@ class Message
      * Constructs this error
      *
      * @param string $message An english error message which is used if no other error message can be resolved
-     * @param integer|null $code A unique error code
+     * @param integer $code A unique error code
      * @param array $arguments Array of arguments to be replaced in message
-     * @param string|null $title optional title for the message
+     * @param string $title optional title for the message
      * @api
      */
-    public function __construct(string $message, int $code = null, array $arguments = [], $title = '')
+    public function __construct(string $message, int $code = 0, array $arguments = [], string $title = '')
     {
         $this->message = $message;
         $this->code = $code;
@@ -87,16 +87,16 @@ class Message
      */
     public function hasCode(): bool
     {
-        return $this->code !== null;
+        return $this->code !== 0;
     }
 
     /**
      * Returns the error code
      *
-     * @return integer|null The error code
+     * @return integer The error code
      * @api
      */
-    public function getCode()
+    public function getCode(): int
     {
         return $this->code;
     }
@@ -116,14 +116,14 @@ class Message
      */
     public function hasTitle(): bool
     {
-        return $this->title !== null && $this->title !== '';
+        return $this->title !== '';
     }
 
     /**
-     * @return string|null
+     * @return string
      * @api
      */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->title;
     }

--- a/Neos.Flow.Log/Tests/Unit/Psr/LoggerTest.php
+++ b/Neos.Flow.Log/Tests/Unit/Psr/LoggerTest.php
@@ -52,7 +52,7 @@ class LoggerTest extends UnitTestCase
     {
         $mockBackend = $this->createMock(BackendInterface::class);
         if (!$willError) {
-            $mockBackend->expects(self::once())->method('append')->with('some message', $legacyLogLevel)->willReturn(null);
+            $mockBackend->expects(self::once())->method('append')->with('some message', $legacyLogLevel);
         }
         $psrLogger = new Logger([$mockBackend]);
 
@@ -75,7 +75,7 @@ class LoggerTest extends UnitTestCase
     public function levelSpecificMethodsAreSupported($psrLogLevel, $legacyLogLevel, $willError)
     {
         $mockBackend = $this->createMock(BackendInterface::class);
-        $mockBackend->expects(self::once())->method('append')->with('some message', $legacyLogLevel)->willReturn(null);
+        $mockBackend->expects(self::once())->method('append')->with('some message', $legacyLogLevel);
 
         $psrLogger = new Logger([$mockBackend]);
 
@@ -94,7 +94,7 @@ class LoggerTest extends UnitTestCase
         $message = 'some message';
         $context = ['something' => 123, 'else' => true];
         $mockBackend = $this->createMock(BackendInterface::class);
-        $mockBackend->expects(self::once())->method('append')->with('some message', LOG_INFO, $context)->willReturn(null);
+        $mockBackend->expects(self::once())->method('append')->with('some message', LOG_INFO, $context);
 
         $psrLogger = new Logger([$mockBackend]);
         $psrLogger->log(LogLevel::INFO, $message, $context);

--- a/Neos.Flow/Classes/ResourceManagement/Publishing/MessageCollector.php
+++ b/Neos.Flow/Classes/ResourceManagement/Publishing/MessageCollector.php
@@ -71,7 +71,7 @@ class MessageCollector
      * @throws Exception
      * @api
      */
-    public function append($message, $severity = Error::SEVERITY_ERROR, $code = null)
+    public function append(string $message, string $severity = Error::SEVERITY_ERROR, int $code = 0): void
     {
         switch ($severity) {
             case Error::SEVERITY_ERROR:
@@ -96,7 +96,7 @@ class MessageCollector
      * @return boolean
      * @api
      */
-    public function hasMessages()
+    public function hasMessages(): bool
     {
         return $this->messages->count() > 0;
     }
@@ -106,7 +106,7 @@ class MessageCollector
      * @return void
      * @api
      */
-    public function flush(callable $callback = null)
+    public function flush(callable $callback = null): void
     {
         foreach ($this->messages as $message) {
             /** @var Message $message */

--- a/Neos.Flow/Classes/ResourceManagement/Publishing/MessageCollector.php
+++ b/Neos.Flow/Classes/ResourceManagement/Publishing/MessageCollector.php
@@ -66,12 +66,12 @@ class MessageCollector
     /**
      * @param string $message The message to log
      * @param string $severity An integer value, one of the Error::SEVERITY_* constants
-     * @param integer $code A unique error code
+     * @param integer|null $code A unique error code
      * @return void
      * @throws Exception
      * @api
      */
-    public function append(string $message, string $severity = Error::SEVERITY_ERROR, int $code = 0): void
+    public function append(string $message, string $severity = Error::SEVERITY_ERROR, ?int $code = null): void
     {
         switch ($severity) {
             case Error::SEVERITY_ERROR:


### PR DESCRIPTION
This is breaking, because the Error messages no longer accept `null` for the `$code` and `$title` constructor arguments.

See https://github.com/neos/flow-development-collection/pull/1046 for the PR that could not yet fix this issue.