### PR TITLE
FEATURE: Add cookie support to ActionResponse

### DIFF
--- a/Neos.Flow/Classes/Mvc/ActionResponse.php
+++ b/Neos.Flow/Classes/Mvc/ActionResponse.php
@@ -264,5 +264,4 @@ final class ActionResponse
 
         return $componentContext;
     }
-
 }

--- a/Neos.Flow/Classes/Mvc/ActionResponse.php
+++ b/Neos.Flow/Classes/Mvc/ActionResponse.php
@@ -118,7 +118,7 @@ final class ActionResponse
      */
     public function setCookie(Cookie $cookie): void
     {
-        $this->cookies[$cookie->getName()] = $cookie;
+        $this->cookies[$cookie->getName()] = clone $cookie;
     }
 
     /**

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
@@ -435,7 +435,7 @@ The cookie value can be updated and re-assigned to the response::
 	public function myAction() {
 		$httpRequest = $this->request->getHttpRequest();
 		$counter = $httpRequest->getCookieParams()['myCounter'] ?? 0;
-		$this->view->assign('counter', $cookie->getValue());
+		$this->view->assign('counter', $counter);
 
 		$cookie = new Cookie('myCounter', $counter + 1);
 		$this->response->setCookie($cookie);

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
@@ -407,7 +407,7 @@ Cookies
 -------
 
 The HTTP foundation provides a very convenient way to deal with cookies. Instead of calling the PHP cookie functions
-(like ``setcookie()``), we recommend using the respective methods available in the ``Request`` and ``Response`` classes.
+(like ``setcookie()``), we recommend using the respective methods available in the ``ResponseInterface`` and ``ActionResponse`` classes.
 
 Like requests and responses, a cookie also is represented by a PHP class. Instead of working on arrays with values,
 instances of the ``Cookie`` class are used.
@@ -424,9 +424,9 @@ will send the cookie through the ``Cookie`` header. These headers are parsed aut
 
 	public function myAction() {
 		$httpRequest = $this->request->getHttpRequest();
-		if ($httpRequest->hasCookie('myCounter')) {
-			$cookie = $httpRequest->getCookie('myCounter');
-			$this->view->assign('counter', $cookie->getValue());
+		$cookieParams = $httpRequest->getCookieParams();
+		if (isset($cookieParams['myCounter']) {
+			$this->view->assign('counter', (int)$cookieParams['myCounter']);
 		}
 	}
 
@@ -434,24 +434,17 @@ The cookie value can be updated and re-assigned to the response::
 
 	public function myAction() {
 		$httpRequest = $this->request->getHttpRequest();
-		if ($httpRequest->hasCookie('myCounter')) {
-			$cookie = $httpRequest->getCookie('myCounter');
-		} else {
-			$cookie = new Cookie('myCounter', 1);
-		}
+		$counter = $httpRequest->getCookieParams()['myCounter'] ?? 0;
 		$this->view->assign('counter', $cookie->getValue());
 
-		$cookie->setValue((integer)$cookie->getValue() + 1);
+		$cookie = new Cookie('myCounter', $counter + 1);
 		$this->response->setCookie($cookie);
 	}
 
-Finally, a cookie can be deleted by calling the ``expire()`` method::
+Finally, a cookie can be deleted by calling the ``deleteCookie()`` method::
 
 	public function myAction() {
-		$httpRequest = $this->request->getHttpRequest();
-		$cookie = $httpRequest->getCookie('myCounter');
-		$cookie->expire();
-		$this->response->setCookie($cookie);
+		$this->response->deleteCookie('myCounter');
 	}
 
 Uri


### PR DESCRIPTION
Adds the two convenience methods `ActionResponse::setCookie()`
and `ActionResponse::deleteCookie()` and adjusts the documentation
accordingly.

Resolves: #1722