### PR TITLE
!!! TASK: Be more strict with the default accepted clientIP headers

### DIFF
--- a/Neos.Flow/Configuration/Settings.Http.yaml
+++ b/Neos.Flow/Configuration/Settings.Http.yaml
@@ -95,8 +95,7 @@ Neos:
         # Defines request headers which are trusted from proxies to override important request information
         # Each value can be a single header or a comma separated list of headers
         headers:
-          # This is a list mainly for backwards-compatibility. You should only set a single header, e.g. 'X-Forwarded-For'
-          clientIp: 'Client-Ip,X-Forwarded-For,X-Forwarded,X-Cluster-Client-Ip,Forwarded-For,Forwarded'
+          clientIp: 'X-Forwarded-For'
           host: 'X-Forwarded-Host'
           port: 'X-Forwarded-Port'
           proto: 'X-Forwarded-Proto'


### PR DESCRIPTION
This will only accept the `X-Forwarded-For` header to override the client IP address by default to be in line with the other headers.

If you use the clientIp from the Http Request, are behind a reverse proxy and did not explicitly configure which HTTP header you expect to contain the original users IP address, then this might break for you if the first reverse proxy in your chain did not set the `X-Forwarded-For` header.
In that case, make sure which header contains the clients IP address and specify that in the `Neos.Flow.http.trustedProxies.headers.clientIp` Setting.