### PR TITLE
BUGFIX: Trigger Entry Points of all authenticated tokens

### DIFF
--- a/Neos.Flow/Classes/Http/Component/SecurityEntryPointComponent.php
+++ b/Neos.Flow/Classes/Http/Component/SecurityEntryPointComponent.php
@@ -63,7 +63,7 @@ class SecurityEntryPointComponent implements ComponentInterface
                 $actionRequest = $componentContext->getParameter(DispatchComponent::class, 'actionRequest');
                 $this->securityContext->setInterceptedRequest($actionRequest->getMainRequest());
             }
-            $response = $entryPoint->startAuthentication($componentContext->getHttpRequest(), $componentContext->getHttpResponse());
+            $response = $entryPoint->startAuthentication($componentContext->getHttpRequest(), $response);
         }
         $componentContext->replaceHttpResponse($response);
     }

--- a/Neos.Flow/Classes/Http/Component/SecurityEntryPointComponent.php
+++ b/Neos.Flow/Classes/Http/Component/SecurityEntryPointComponent.php
@@ -1,6 +1,5 @@
 <?php
 declare(strict_types=1);
-
 namespace Neos\Flow\Http\Component;
 
 use Neos\Flow\Annotations as Flow;
@@ -9,15 +8,16 @@ use Neos\Flow\Mvc\DispatchComponent;
 use Neos\Flow\Security\Authentication\Token\SessionlessTokenInterface;
 use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\Context;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 
 /**
- *
+ * A HTTP component that handles authentication exceptions that were thrown by the dispatcher (@see \Neos\Flow\Mvc\Dispatcher::dispatch()) and
+ * * rethrows the exception if not token with Entry Point is authenticated
+ * * or otherwise invokes the Entry Point of all authenticated tokens
  */
 class SecurityEntryPointComponent implements ComponentInterface
 {
-    const AUTHENTICATION_EXCEPTION = 'authenticationException';
+    public const AUTHENTICATION_EXCEPTION = 'authenticationException';
 
     /**
      * @Flow\Inject
@@ -34,46 +34,37 @@ class SecurityEntryPointComponent implements ComponentInterface
     /**
      * @inheritDoc
      */
-    public function handle(ComponentContext $componentContext)
+    public function handle(ComponentContext $componentContext): void
     {
-        $authenticationException = $componentContext->getParameter(SecurityEntryPointComponent::class, SecurityEntryPointComponent::AUTHENTICATION_EXCEPTION);
+        $authenticationException = $componentContext->getParameter(self::class, self::AUTHENTICATION_EXCEPTION);
         if ($authenticationException === null) {
             return;
         }
 
-        $actionRequest = $componentContext->getParameter(DispatchComponent::class, 'actionRequest');
-        $firstTokenWithEntryPoint = $this->getFirstTokenWithEntryPoint();
-        if ($firstTokenWithEntryPoint === null) {
+        /** @var TokenInterface[] $tokensWithEntryPoint */
+        $tokensWithEntryPoint = array_filter($this->securityContext->getAuthenticationTokens(), static function(TokenInterface $token) {
+            return $token->getAuthenticationEntryPoint() !== null;
+        });
+
+        if ($tokensWithEntryPoint === []) {
             $this->securityLogger->notice('No authentication entry point found for active tokens, therefore cannot authenticate or redirect to authentication automatically.');
             throw $authenticationException;
         }
 
-        $entryPoint = $firstTokenWithEntryPoint->getAuthenticationEntryPoint();
-        $this->securityLogger->info(sprintf('Starting authentication with entry point of type "%s"', get_class($entryPoint)), LogEnvironment::fromMethodName(__METHOD__));
+        $response = $componentContext->getHttpResponse();
+        foreach ($tokensWithEntryPoint as $token) {
+            $entryPoint = $token->getAuthenticationEntryPoint();
+            $this->securityLogger->info(sprintf('Starting authentication with entry point of type "%s"', \get_class($entryPoint)), LogEnvironment::fromMethodName(__METHOD__));
 
-        // TODO: We should only prevent storage of intercepted request in the session here, but we don't have a different storage mechanism yet.
-        if (!$firstTokenWithEntryPoint instanceof SessionlessTokenInterface && $componentContext->getHttpRequest()->getMethod() === 'GET') {
-            $this->securityContext->setInterceptedRequest($actionRequest->getMainRequest());
-        }
-
-
-        /** @var ResponseInterface $response */
-        $response = $entryPoint->startAuthentication($componentContext->getHttpRequest(), $componentContext->getHttpResponse());
-        $componentContext->replaceHttpResponse($response);
-    }
-
-    /**
-     * Returns the first authenticated token that has an Authentication Entry Point configured, or NULL if none exists
-     *
-     * @return TokenInterface|null
-     */
-    private function getFirstTokenWithEntryPoint(): ?TokenInterface
-    {
-        foreach ($this->securityContext->getAuthenticationTokens() as $token) {
-            if ($token->getAuthenticationEntryPoint() !== null) {
-                return $token;
+            // Only store the intercepted request if it is a GET request (otherwise it can't be resumed properly)
+            // We also don't store the request for "sessionless authentications" because that would implicitly start a session
+            // TODO: Adjust when a session-independent storing mechanism is possible (see https://github.com/neos/flow-development-collection/issues/1693)
+            if (!$token instanceof SessionlessTokenInterface && $componentContext->getHttpRequest()->getMethod() === 'GET') {
+                $actionRequest = $componentContext->getParameter(DispatchComponent::class, 'actionRequest');
+                $this->securityContext->setInterceptedRequest($actionRequest->getMainRequest());
             }
+            $response = $entryPoint->startAuthentication($componentContext->getHttpRequest(), $componentContext->getHttpResponse());
         }
-        return null;
+        $componentContext->replaceHttpResponse($response);
     }
 }

--- a/Neos.Flow/Classes/Http/Component/SecurityEntryPointComponent.php
+++ b/Neos.Flow/Classes/Http/Component/SecurityEntryPointComponent.php
@@ -42,7 +42,7 @@ class SecurityEntryPointComponent implements ComponentInterface
         }
 
         /** @var TokenInterface[] $tokensWithEntryPoint */
-        $tokensWithEntryPoint = array_filter($this->securityContext->getAuthenticationTokens(), static function(TokenInterface $token) {
+        $tokensWithEntryPoint = array_filter($this->securityContext->getAuthenticationTokens(), static function (TokenInterface $token) {
             return $token->getAuthenticationEntryPoint() !== null;
         });
 

--- a/Neos.Flow/Tests/Unit/Http/Component/SecurityEntryPointComponentTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Component/SecurityEntryPointComponentTest.php
@@ -88,7 +88,7 @@ class SecurityEntryPointComponentTest extends UnitTestCase
         $this->mockComponentContext->method('getHttpResponse')->willReturn($this->mockHttpResponse);
         $this->mockActionRequest = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->getMock();
         $this->mockActionRequest->method('getMainRequest')->willReturn($this->mockActionRequest);
-        $this->mockComponentContext->method('getParameter')->willReturnCallback(function($componentClassName, $parameterName) {
+        $this->mockComponentContext->method('getParameter')->willReturnCallback(function ($componentClassName, $parameterName) {
             if ($componentClassName === SecurityEntryPointComponent::class && $parameterName === SecurityEntryPointComponent::AUTHENTICATION_EXCEPTION) {
                 return $this->mockAuthenticationRequiredException;
             }

--- a/Neos.Flow/Tests/Unit/Http/Component/SecurityEntryPointComponentTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Component/SecurityEntryPointComponentTest.php
@@ -1,0 +1,196 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Http\Component;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Http\Component\ComponentContext;
+use Neos\Flow\Http\Component\SecurityEntryPointComponent;
+use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Mvc\DispatchComponent;
+use Neos\Flow\Security\Authentication\EntryPointInterface;
+use Neos\Flow\Security\Authentication\Token\SessionlessTokenInterface;
+use Neos\Flow\Security\Authentication\TokenInterface;
+use Neos\Flow\Security\Context;
+use Neos\Flow\Security\Exception\AuthenticationRequiredException;
+use Neos\Flow\Tests\UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Test case for the SecurityEntryPointComponent
+ */
+class SecurityEntryPointComponentTest extends UnitTestCase
+{
+    /**
+     * @var SecurityEntryPointComponent
+     */
+    private $securityEntryPointComponent;
+
+    /**
+     * @var Context|MockObject
+     */
+    private $mockSecurityContext;
+
+    /**
+     * @var ComponentContext|MockObject
+     */
+    private $mockComponentContext;
+
+    /**
+     * @var ServerRequestInterface|MockObject
+     */
+    private $mockHttpRequest;
+
+    /**
+     * @var ResponseInterface|MockObject
+     */
+    private $mockHttpResponse;
+
+    /**
+     * @var AuthenticationRequiredException
+     */
+    private $mockAuthenticationRequiredException;
+
+    /**
+     * @var ActionRequest|MockObject
+     */
+    private $mockActionRequest;
+
+    /**
+     * @var TokenInterface|MockObject
+     */
+    private $mockTokenWithEntryPoint;
+
+    protected function setUp(): void
+    {
+        $this->securityEntryPointComponent = new SecurityEntryPointComponent();
+
+        $this->mockSecurityContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
+        $this->inject($this->securityEntryPointComponent, 'securityContext', $this->mockSecurityContext);
+
+        $mockSecurityLogger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+        $this->inject($this->securityEntryPointComponent, 'securityLogger', $mockSecurityLogger);
+
+        $this->mockComponentContext = $this->getMockBuilder(ComponentContext::class)->disableOriginalConstructor()->getMock();
+        $this->mockHttpRequest = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
+        $this->mockComponentContext->method('getHttpRequest')->willReturn($this->mockHttpRequest);
+        $this->mockHttpResponse = $this->getMockBuilder(ResponseInterface::class)->getMock();
+        $this->mockComponentContext->method('getHttpResponse')->willReturn($this->mockHttpResponse);
+        $this->mockActionRequest = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->getMock();
+        $this->mockActionRequest->method('getMainRequest')->willReturn($this->mockActionRequest);
+        $this->mockComponentContext->method('getParameter')->willReturnCallback(function($componentClassName, $parameterName) {
+            if ($componentClassName === SecurityEntryPointComponent::class && $parameterName === SecurityEntryPointComponent::AUTHENTICATION_EXCEPTION) {
+                return $this->mockAuthenticationRequiredException;
+            }
+            if ($componentClassName === DispatchComponent::class && $parameterName === 'actionRequest') {
+                return $this->mockActionRequest;
+            }
+        });
+
+        $this->mockAuthenticationRequiredException = new AuthenticationRequiredException();
+
+        $this->mockTokenWithEntryPoint = $this->getMockBuilder(TokenInterface::class)->getMock();
+        $mockEntryPoint = $this->getMockBuilder(EntryPointInterface::class)->getMock();
+        $this->mockTokenWithEntryPoint->method('getAuthenticationEntryPoint')->willReturn($mockEntryPoint);
+    }
+
+    /**
+     * @test
+     */
+    public function handleReturnsIfNoAuthenticationExceptionWasSet(): void
+    {
+        $this->mockAuthenticationRequiredException = null;
+        $this->mockSecurityContext->expects(self::never())->method('getAuthenticationTokens');
+        $this->securityEntryPointComponent->handle($this->mockComponentContext);
+    }
+
+    /**
+     * @test
+     */
+    public function handleRethrowsAuthenticationRequiredExceptionIfSecurityContextDoesNotContainAnyAuthenticationToken(): void
+    {
+        $this->mockSecurityContext->expects(self::atLeastOnce())->method('getAuthenticationTokens')->willReturn([]);
+
+        $this->expectExceptionObject($this->mockAuthenticationRequiredException);
+        $this->securityEntryPointComponent->handle($this->mockComponentContext);
+    }
+
+    /**
+     * @test
+     */
+    public function handleCallsStartAuthenticationOnAllActiveEntryPoints(): void
+    {
+        $mockAuthenticationToken1 = $this->getMockBuilder(TokenInterface::class)->getMock();
+        $mockEntryPoint1 = $this->getMockBuilder(EntryPointInterface::class)->getMock();
+        $mockAuthenticationToken1->method('getAuthenticationEntryPoint')->willReturn($mockEntryPoint1);
+
+        $mockAuthenticationToken2 = $this->getMockBuilder(TokenInterface::class)->getMock();
+        $mockEntryPoint2 = $this->getMockBuilder(EntryPointInterface::class)->getMock();
+        $mockAuthenticationToken2->method('getAuthenticationEntryPoint')->willReturn($mockEntryPoint2);
+
+        $this->mockSecurityContext->expects(self::atLeastOnce())->method('getAuthenticationTokens')->willReturn([$mockAuthenticationToken1, $mockAuthenticationToken2]);
+
+        $mockEntryPoint1->expects(self::once())->method('startAuthentication')->with($this->mockHttpRequest, $this->mockHttpResponse);
+        $mockEntryPoint2->expects(self::once())->method('startAuthentication')->with($this->mockHttpRequest, $this->mockHttpResponse);
+
+        $this->securityEntryPointComponent->handle($this->mockComponentContext);
+    }
+
+    /**
+     * @test
+     */
+    public function handleSetsInterceptedRequestIfSecurityContextContainsAuthenticationTokensWithEntryPoints(): void
+    {
+        $this->mockSecurityContext->expects(self::atLeastOnce())->method('getAuthenticationTokens')->willReturn([$this->mockTokenWithEntryPoint]);
+        $this->mockSecurityContext->expects(self::atLeastOnce())->method('setInterceptedRequest')->with($this->mockActionRequest);
+
+        $this->mockHttpRequest->method('getMethod')->willReturn('GET');
+
+        $this->securityEntryPointComponent->handle($this->mockComponentContext);
+    }
+
+    /**
+     * @test
+     */
+    public function handleDoesNotSetInterceptedRequestIfRequestMethodIsNotGET(): void
+    {
+        $this->mockSecurityContext->expects(self::atLeastOnce())->method('getAuthenticationTokens')->willReturn([$this->mockTokenWithEntryPoint]);
+        $this->mockSecurityContext->expects(self::never())->method('setInterceptedRequest');
+
+        $this->mockHttpRequest->method('getMethod')->willReturn('POST');
+
+        $this->securityEntryPointComponent->handle($this->mockComponentContext);
+    }
+
+    /**
+     * @test
+     */
+    public function handleDoesNotSetInterceptedRequestIfAllAuthenticatedTokensAreSessionless(): void
+    {
+        $mockAuthenticationToken1 = $this->getMockBuilder([TokenInterface::class, SessionlessTokenInterface::class])->getMock();
+        $mockEntryPoint1 = $this->getMockBuilder(EntryPointInterface::class)->getMock();
+        $mockAuthenticationToken1->method('getAuthenticationEntryPoint')->willReturn($mockEntryPoint1);
+
+        $mockAuthenticationToken2 = $this->getMockBuilder([TokenInterface::class, SessionlessTokenInterface::class])->getMock();
+        $mockEntryPoint2 = $this->getMockBuilder(EntryPointInterface::class)->getMock();
+        $mockAuthenticationToken2->method('getAuthenticationEntryPoint')->willReturn($mockEntryPoint2);
+
+        $this->mockSecurityContext->expects(self::atLeastOnce())->method('getAuthenticationTokens')->willReturn([$mockAuthenticationToken1, $mockAuthenticationToken2]);
+
+        $this->mockHttpRequest->method('getMethod')->willReturn('GET');
+
+        $this->mockSecurityContext->expects(self::never())->method('setInterceptedRequest');
+
+        $this->securityEntryPointComponent->handle($this->mockComponentContext);
+    }
+}

--- a/Neos.Flow/Tests/Unit/Mvc/DispatcherTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/DispatcherTest.php
@@ -24,8 +24,6 @@ use Neos\Flow\Mvc\Exception\ForwardException;
 use Neos\Flow\Mvc\Exception\InfiniteLoopException;
 use Neos\Flow\Mvc\Exception\StopActionException;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Flow\Security\Authentication\EntryPointInterface;
-use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\Authorization\FirewallInterface;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Security\Exception\AccessDeniedException;

--- a/Neos.Flow/Tests/Unit/Mvc/DispatcherTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/DispatcherTest.php
@@ -242,23 +242,6 @@ class DispatcherTest extends UnitTestCase
     }
 
     /**
-     * @test_disabled
-     *
-     * FIXME: move to test class for SecurityEntryPointComponent
-     */
-    public function dispatchRethrowsAuthenticationRequiredExceptionIfSecurityContextDoesNotContainAnyAuthenticationToken()
-    {
-        $this->expectException(AuthenticationRequiredException::class);
-        $this->mockActionRequest->method('isDispatched')->willReturn(true);
-
-        $this->mockSecurityContext->expects(self::atLeastOnce())->method('getAuthenticationTokens')->willReturn([]);
-
-        $this->mockFirewall->expects(self::once())->method('blockIllegalRequests')->will(self::throwException(new AuthenticationRequiredException()));
-
-        $this->dispatcher->dispatch($this->mockActionRequest, $this->actionResponse);
-    }
-
-    /**
      * @test
      */
     public function dispatchSetsAuthenticationExceptions()
@@ -278,82 +261,6 @@ class DispatcherTest extends UnitTestCase
         $this->actionResponse->mergeIntoComponentContext($componentContext);
         self::assertNotNull($componentContext->getAllParametersFor(SecurityEntryPointComponent::class));
         self::assertNotEmpty($componentContext->getParameter(SecurityEntryPointComponent::class, SecurityEntryPointComponent::AUTHENTICATION_EXCEPTION));
-    }
-
-    /**
-     * @test_disabled
-     * FIXME: move to test class for SecurityEntryPointComponent
-     */
-    public function dispatchSetsInterceptedRequestIfSecurityContextContainsAuthenticationTokensWithEntryPoints()
-    {
-        $this->mockActionRequest->method('isDispatched')->willReturn(true);
-
-        $mockEntryPoint = $this->getMockBuilder(EntryPointInterface::class)->getMock();
-
-        $mockAuthenticationToken = $this->getMockBuilder(TokenInterface::class)->getMock();
-        $mockAuthenticationToken->method('getAuthenticationEntryPoint')->willReturn($mockEntryPoint);
-        $this->mockSecurityContext->expects(self::atLeastOnce())->method('getAuthenticationTokens')->willReturn([$mockAuthenticationToken]);
-
-        $this->mockSecurityContext->expects(self::atLeastOnce())->method('setInterceptedRequest')->with($this->mockMainRequest);
-
-        $this->mockFirewall->expects(self::once())->method('blockIllegalRequests')->will(self::throwException(new AuthenticationRequiredException()));
-
-        $this->mockHttpRequest->method('getMethod')->willReturn('GET');
-
-        try {
-            $this->dispatcher->dispatch($this->mockActionRequest, $this->mockHttpResponse);
-        } catch (AuthenticationRequiredException $exception) {
-        }
-    }
-
-    /**
-     * @test
-     */
-    public function dispatchDoesNotSetInterceptedRequestIfRequestMethodIsNotGET()
-    {
-        $this->mockActionRequest->expects(self::any())->method('isDispatched')->will(self::returnValue(true));
-
-        $mockEntryPoint = $this->getMockBuilder(EntryPointInterface::class)->getMock();
-
-        $mockAuthenticationToken = $this->getMockBuilder(TokenInterface::class)->getMock();
-        $mockAuthenticationToken->expects(self::any())->method('getAuthenticationEntryPoint')->will(self::returnValue($mockEntryPoint));
-
-        $this->mockSecurityContext->expects(self::never())->method('setInterceptedRequest');
-        $this->mockHttpRequest->method('getMethod')->willReturn('POST');
-
-        try {
-            $this->dispatcher->dispatch($this->mockActionRequest, $this->actionResponse);
-        } catch (AuthenticationRequiredException $exception) {
-        }
-    }
-
-    /**
-     * @test_disabled
-     * FIXME: move to test class for SecurityEntryPointComponent
-     */
-    public function dispatchCallsStartAuthenticationOnAllActiveEntryPoints()
-    {
-        $this->mockActionRequest->method('isDispatched')->willReturn(true);
-
-        $mockAuthenticationToken1 = $this->getMockBuilder(TokenInterface::class)->getMock();
-        $mockEntryPoint1 = $this->getMockBuilder(EntryPointInterface::class)->getMock();
-        $mockAuthenticationToken1->method('getAuthenticationEntryPoint')->willReturn($mockEntryPoint1);
-
-        $mockAuthenticationToken2 = $this->getMockBuilder(TokenInterface::class)->getMock();
-        $mockEntryPoint2 = $this->getMockBuilder(EntryPointInterface::class)->getMock();
-        $mockAuthenticationToken2->method('getAuthenticationEntryPoint')->willReturn($mockEntryPoint2);
-
-        $this->mockSecurityContext->expects(self::atLeastOnce())->method('getAuthenticationTokens')->willReturn([$mockAuthenticationToken1, $mockAuthenticationToken2]);
-
-        $this->mockFirewall->expects(self::once())->method('blockIllegalRequests')->will(self::throwException(new AuthenticationRequiredException()));
-
-        $mockEntryPoint1->expects(self::once())->method('startAuthentication')->with($this->mockHttpRequest, $this->actionResponse);
-        $mockEntryPoint2->expects(self::once())->method('startAuthentication')->with($this->mockHttpRequest, $this->actionResponse);
-
-        try {
-            $this->dispatcher->dispatch($this->mockActionRequest, $this->actionResponse);
-        } catch (AuthenticationRequiredException $exception) {
-        }
     }
 
     /**


### PR DESCRIPTION
Previously the `Dispatcher` invoked the `startAuthentication()` method
of all authenticated tokens.

That behavior was changed by accident with #1552 and now only the first
Entry Point was triggered.