### PR TITLE
TASK: Fix ScriptTest invoking dummy commands

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -713,7 +713,7 @@ class Scripts
             $subRequestEnvironmentVariables = array_merge($subRequestEnvironmentVariables, $settings['core']['subRequestEnvironmentVariables']);
         }
 
-        self::ensureCLISubrequestsUseCurrentlyRunningPhpBinary($settings['core']['phpBinaryPathAndFilename']);
+        static::ensureCLISubrequestsUseCurrentlyRunningPhpBinary($settings['core']['phpBinaryPathAndFilename']);
 
         $command = '';
         foreach ($subRequestEnvironmentVariables as $argumentKey => $argumentValue) {
@@ -739,7 +739,7 @@ class Scripts
             $command .= ' -c ' . escapeshellarg($useIniFile);
         }
 
-        self::ensureWebSubrequestsUseCurrentlyRunningPhpVersion($command);
+        static::ensureWebSubrequestsUseCurrentlyRunningPhpVersion($command);
 
         return $command;
     }

--- a/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
+++ b/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
@@ -23,6 +23,11 @@ class ScriptsMock extends Scripts
     protected static function ensureWebSubrequestsUseCurrentlyRunningPhpVersion($phpCommand)
     {
     }
+    
+    public static function buildSubprocessCommand(...$arguments)
+    {
+        return parent::buildSubprocessCommand(...$arguments);
+    }
 }
 
 /**

--- a/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
+++ b/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
@@ -14,6 +14,14 @@ namespace Neos\Flow\Tests\Unit\Core\Booting;
 use Neos\Flow\Core\Booting\Scripts;
 use Neos\Flow\Tests\UnitTestCase;
 
+/**
+ * This is something that PHPUnit would have to do in order to support stubbing static methods. And
+ * it would only work if those static methods are called with `static::`, otherwise it breaks badly
+ * without a way to work around it. And that's the reason why PHPUnit doesn't support mocking static
+ * classes since ages any more and why you shouldn't use static methods for anything but trivial
+ * methods that do not do any IO. Unfortunately, we do that in the Scripts.
+ * TODO: Refactor Scripts class to be more testable.
+ */
 class ScriptsMock extends Scripts
 {
     protected static function ensureCLISubrequestsUseCurrentlyRunningPhpBinary($phpBinaryPathAndFilename)
@@ -23,7 +31,7 @@ class ScriptsMock extends Scripts
     protected static function ensureWebSubrequestsUseCurrentlyRunningPhpVersion($phpCommand)
     {
     }
-    
+
     public static function buildSubprocessCommand(...$arguments)
     {
         return parent::buildSubprocessCommand(...$arguments);

--- a/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
+++ b/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
@@ -14,24 +14,21 @@ namespace Neos\Flow\Tests\Unit\Core\Booting;
 use Neos\Flow\Core\Booting\Scripts;
 use Neos\Flow\Tests\UnitTestCase;
 
+class ScriptsMock extends Scripts {
+    protected static function ensureCLISubrequestsUseCurrentlyRunningPhpBinary($phpBinaryPathAndFilename)
+    {
+    }
+
+    protected static function ensureWebSubrequestsUseCurrentlyRunningPhpVersion($phpCommand)
+    {
+    }
+}
+
 /**
  * Testcase for the initialization scripts
  */
 class ScriptsTest extends UnitTestCase
 {
-    /**
-     * @var Scripts|\PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $scriptsMock;
-
-    /**
-     */
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->scriptsMock = $this->getAccessibleMock(Scripts::class, ['dummy']);
-    }
-
     /**
      * @test
      */
@@ -43,22 +40,22 @@ class ScriptsTest extends UnitTestCase
         ]];
 
         $message = 'The command must contain the current ini because it is not explicitly set in settings.';
-        $actual = $this->scriptsMock->_call('buildSubprocessCommand', 'flow:foo:identifier', $settings);
+        $actual = ScriptsMock::buildSubprocessCommand('flow:foo:identifier', $settings);
         $this->assertContains(sprintf(' -c %s ', escapeshellarg(php_ini_loaded_file())), $actual, $message);
 
         $settings['core']['subRequestPhpIniPathAndFilename'] = null;
         $message = 'The command must contain the current ini because it is explicitly set, but NULL, in settings.';
-        $actual = $this->scriptsMock->_call('buildSubprocessCommand', 'flow:foo:identifier', $settings);
+        $actual = ScriptsMock::buildSubprocessCommand('flow:foo:identifier', $settings);
         $this->assertContains(sprintf(' -c %s ', escapeshellarg(php_ini_loaded_file())), $actual, $message);
 
         $settings['core']['subRequestPhpIniPathAndFilename'] = '/foo/ini/path';
         $message = 'The command must contain a specified ini file path because it is set in settings.';
-        $actual = $this->scriptsMock->_call('buildSubprocessCommand', 'flow:foo:identifier', $settings);
+        $actual = ScriptsMock::buildSubprocessCommand('flow:foo:identifier', $settings);
         $this->assertContains(sprintf(' -c %s ', escapeshellarg('/foo/ini/path')), $actual, $message);
 
         $settings['core']['subRequestPhpIniPathAndFilename'] = false;
         $message = 'The command must not contain an ini file path because it is set to FALSE in settings.';
-        $actual = $this->scriptsMock->_call('buildSubprocessCommand', 'flow:foo:identifier', $settings);
+        $actual = ScriptsMock::buildSubprocessCommand('flow:foo:identifier', $settings);
         $this->assertNotContains(' -c ', $actual, $message);
     }
 
@@ -72,7 +69,7 @@ class ScriptsTest extends UnitTestCase
             'phpBinaryPathAndFilename' => '/must/be/set/according/to/schema',
             'subRequestIniEntries' => ['someSetting' => 'withValue', 'someFlagSettingWithoutValue' => '']
         ]];
-        $actual = $this->scriptsMock->_call('buildSubprocessCommand', 'flow:foo:identifier', $settings);
+        $actual = ScriptsMock::buildSubprocessCommand('flow:foo:identifier', $settings);
 
         $this->assertContains(sprintf(' -d %s=%s ', escapeshellarg('someSetting'), escapeshellarg('withValue')), $actual);
         $this->assertContains(sprintf(' -d %s ', escapeshellarg('someFlagSettingWithoutValue')), $actual);

--- a/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
+++ b/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
@@ -14,7 +14,8 @@ namespace Neos\Flow\Tests\Unit\Core\Booting;
 use Neos\Flow\Core\Booting\Scripts;
 use Neos\Flow\Tests\UnitTestCase;
 
-class ScriptsMock extends Scripts {
+class ScriptsMock extends Scripts
+{
     protected static function ensureCLISubrequestsUseCurrentlyRunningPhpBinary($phpBinaryPathAndFilename)
     {
     }


### PR DESCRIPTION
Also, the static class does not need to be mocked with PHPUnit, as PHPUnit can not stub static methods anyway.
