### PR TITLE
BUGFIX: Don't validate transient properties during persistence

### DIFF
--- a/Neos.Flow/Classes/Validation/ValidatorResolver.php
+++ b/Neos.Flow/Classes/Validation/ValidatorResolver.php
@@ -324,7 +324,7 @@ class ValidatorResolver
                 foreach ($validateAnnotations as $validateAnnotation) {
                     if ($validateAnnotation->type === 'Collection') {
                         $needsCollectionValidator = false;
-                        $validateAnnotation->options = array_merge(['elementType' => $parsedType['elementType'], 'validationGroups' => $validationGroups], $validateAnnotation->options);
+                        $validateAnnotation->options = array_merge(['elementType' => $parsedType['elementType'], 'validationGroups' => $propertyValidationGroups], $validateAnnotation->options);
                     }
                     if (count(array_intersect($validateAnnotation->validationGroups, $propertyValidationGroups)) === 0) {
                         if ($validateAnnotation->type === 'GenericObject') {

--- a/Neos.Flow/Classes/Validation/ValidatorResolver.php
+++ b/Neos.Flow/Classes/Validation/ValidatorResolver.php
@@ -310,7 +310,7 @@ class ValidatorResolver
                     continue;
                 }
 
-                if ($classSchema->isPropertyTransient($classPropertyName)) {
+                if ($classSchema !== null && $classSchema->isPropertyTransient($classPropertyName)) {
                     // Prevent transient properties to be validated for persistence
                     $propertyValidationGroups = array_diff($validationGroups, ['Persistence', 'Default']);
                 } else {


### PR DESCRIPTION
See https://github.com/neos/flow-development-collection/pull/1538#issuecomment-524485959

Currently, this will also prevent the validators for transient properties from running in 'Default' only validation group.