### PR TITLE
BUGFIX: Make ScriptsMock::buildSubprocessCommand signature match parent

### DIFF
--- a/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
+++ b/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
@@ -32,7 +32,7 @@ class ScriptsMock extends Scripts
     {
     }
 
-    public static function buildSubprocessCommand(...$arguments)
+    public static function buildSubprocessCommand(...$arguments): string
     {
         return parent::buildSubprocessCommand(...$arguments);
     }

--- a/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
+++ b/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
@@ -32,9 +32,9 @@ class ScriptsMock extends Scripts
     {
     }
 
-    public static function buildSubprocessCommand(...$arguments): string
+    public static function buildSubprocessCommand($commandIdentifier, array $settings, array $commandArguments = []): string
     {
-        return parent::buildSubprocessCommand(...$arguments);
+        return parent::buildSubprocessCommand($commandIdentifier, $settings, $commandArguments);
     }
 }
 


### PR DESCRIPTION
This prevents a Warning notice in Unit Tests.

Related to #1731