### PR TITLE
BUGFIX: Handle configuration value "false" for trusted proxies

### DIFF
--- a/Neos.Flow/Classes/Http/Component/TrustedProxiesComponent.php
+++ b/Neos.Flow/Classes/Http/Component/TrustedProxiesComponent.php
@@ -46,6 +46,11 @@ class TrustedProxiesComponent implements ComponentInterface
     public function injectSettings(array $settings)
     {
         $this->settings = $settings['http']['trustedProxies'];
+
+        if ($this->settings['proxies'] === false) {
+            $this->settings['proxies'] = [];
+        }
+
         if ($this->settings['proxies'] === ['*']) {
             $this->settings['proxies'] = '*';
         }


### PR DESCRIPTION
This fixes the case when a configured environment variable (like the default `FLOW_HTTP_TRUSTEDPROXIES`) is not set, in which case the value will be `false`.