### PR TITLE
BUGFIX: Allow string for trusted proxies again (env variable use)

### DIFF
--- a/Neos.Flow/Classes/Http/Component/TrustedProxiesComponent.php
+++ b/Neos.Flow/Classes/Http/Component/TrustedProxiesComponent.php
@@ -49,14 +49,17 @@ class TrustedProxiesComponent implements ComponentInterface
 
         if ($this->settings['proxies'] === false) {
             $this->settings['proxies'] = [];
+            return;
         }
 
         if ($this->settings['proxies'] === ['*']) {
             $this->settings['proxies'] = '*';
         }
-        if (is_string($this->settings['proxies'])) {
+
+        if (is_string($this->settings['proxies']) && $this->settings['proxies'] !== '*') {
             $this->settings['proxies'] = array_map('trim', explode(',', $this->settings['proxies']));
         }
+
         if (!is_array($this->settings['proxies']) && $this->settings['proxies'] !== '*') {
             throw new InvalidConfigurationException('The Neos.Flow.http.trustedProxies.proxies setting may only be an array of IP addresses or the single string "*". Got "' . var_export($this->settings['proxies'], true) . '" instead.', 1564659249);
         }

--- a/Neos.Flow/Classes/Http/Component/TrustedProxiesComponent.php
+++ b/Neos.Flow/Classes/Http/Component/TrustedProxiesComponent.php
@@ -54,10 +54,13 @@ class TrustedProxiesComponent implements ComponentInterface
         if ($this->settings['proxies'] === ['*']) {
             $this->settings['proxies'] = '*';
         }
+        if (is_string($this->settings['proxies'])) {
+            $this->settings['proxies'] = array_map('trim', explode(',', $this->settings['proxies']));
+        }
         if (!is_array($this->settings['proxies']) && $this->settings['proxies'] !== '*') {
             throw new InvalidConfigurationException('The Neos.Flow.http.trustedProxies.proxies setting may only be an array of IP addresses or the single string "*". Got "' . var_export($this->settings['proxies'], true) . '" instead.', 1564659249);
         }
-        if (is_array($this->settings['proxies']) && array_search('*', $this->settings['proxies'], true) !== false) {
+        if (is_array($this->settings['proxies']) && in_array('*', $this->settings['proxies'], true)) {
             throw new InvalidConfigurationException('The Neos.Flow.http.trustedProxies.proxies setting is an array of IP addresses but also contains the string "*". Did you intend to allow all proxies? If so set the setting to the explicit string "*".', 1564659250);
         }
     }
@@ -204,12 +207,6 @@ class TrustedProxiesComponent implements ComponentInterface
         $allowedProxies = $this->settings['proxies'];
         if ($allowedProxies === '*') {
             return true;
-        }
-        if (is_string($allowedProxies)) {
-            $allowedProxies = array_map('trim', explode(',', $allowedProxies));
-        }
-        if (!is_array($allowedProxies)) {
-            return false;
         }
         foreach ($allowedProxies as $ipPattern) {
             if (IpUtility::cidrMatch($ipAddress, $ipPattern)) {

--- a/Neos.Flow/Classes/Http/Component/TrustedProxiesComponent.php
+++ b/Neos.Flow/Classes/Http/Component/TrustedProxiesComponent.php
@@ -61,10 +61,10 @@ class TrustedProxiesComponent implements ComponentInterface
         }
 
         if (!is_array($this->settings['proxies']) && $this->settings['proxies'] !== '*') {
-            throw new InvalidConfigurationException('The Neos.Flow.http.trustedProxies.proxies setting may only be an array of IP addresses or the single string "*". Got "' . var_export($this->settings['proxies'], true) . '" instead.', 1564659249);
+            throw new InvalidConfigurationException('The Neos.Flow.http.trustedProxies.proxies setting may only be the single string "*" or a list of IP addresses or address ranges (in CIDR notation) given as an array or comma separated string. Got "' . var_export($this->settings['proxies'], true) . '" instead.', 1564659249);
         }
         if (is_array($this->settings['proxies']) && in_array('*', $this->settings['proxies'], true)) {
-            throw new InvalidConfigurationException('The Neos.Flow.http.trustedProxies.proxies setting is an array of IP addresses but also contains the string "*". Did you intend to allow all proxies? If so set the setting to the explicit string "*".', 1564659250);
+            throw new InvalidConfigurationException('The Neos.Flow.http.trustedProxies.proxies setting is an array of IP addresses or address ranges (in CIDR notation) but also contains the string "*". Did you intend to allow all proxies? If so set the setting to the explicit string "*".', 1564659250);
         }
     }
 


### PR DESCRIPTION
Fixes a regression introduced with #1683
