### PR TITLE
BUGFIX: Safeguard ob_end_flush() against empty buffer

### DIFF
--- a/Neos.Flow/Classes/Http/RequestHandler.php
+++ b/Neos.Flow/Classes/Http/RequestHandler.php
@@ -167,6 +167,8 @@ class RequestHandler implements HttpRequestHandlerInterface
             header($prepareHeader);
         }
         echo $response->getBody()->getContents();
-        ob_end_flush();
+        while (ob_get_level() > 0) {
+            ob_end_flush();
+        }
     }
 }


### PR DESCRIPTION
Fixes #1753
