### PR TITLE
TASK: Loosen typo3fluid/fluid dependency

### DIFF
--- a/Neos.FluidAdaptor/composer.json
+++ b/Neos.FluidAdaptor/composer.json
@@ -8,7 +8,7 @@
 		"neos/cache": "*",
 		"neos/utility-files": "*",
 		"neos/utility-objecthandling": "*",
-		"typo3fluid/fluid": "~2.1.3"
+		"typo3fluid/fluid": ">=2.1.3,<2.5.0"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Adjusts the dependency declared in `neos/fluid-adaptor` to complement https://github.com/neos/flow-development-collection/pull/1638 and thus fix https://github.com/neos/flow-development-collection/pull/1756