### PR TITLE
Revert "TASK: Include TYPO3Fluid for reflection"

### DIFF
--- a/Neos.Flow/Configuration/Settings.yaml
+++ b/Neos.Flow/Configuration/Settings.yaml
@@ -322,8 +322,7 @@ Neos:
       # by specifying corresponding regular expressions that don't match classes to exclude.
       #
       # Note: The previous setting "excludeClasses" has been deprecated with Flow 3.0
-      includeClasses:
-        'typo3fluid.fluid': ['.*']
+      includeClasses: []
 
     package:
 


### PR DESCRIPTION
This reverts commit e5bb869d3d1262080bbe687095e7b4a58789d971.

This is necessary, because the inclusion of Fluid in reflection for 4.3 introduced a regression, due to a wrong annotation in Fluid versions < 2.3.

See https://github.com/TYPO3/Fluid/pull/260

Fixes #1756

NOTE: This revert should not be included in upmerges, since the issue does not exist in Flow 5.0+ as it requires Fluid 2.5 minimum