### PR TITLE
BUGFIX: Avoid error when setting up SQLite cache backends

### DIFF
--- a/Neos.Cache/Classes/Backend/PdoBackend.php
+++ b/Neos.Cache/Classes/Backend/PdoBackend.php
@@ -504,6 +504,15 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
     public function setup(): Result
     {
         $result = new Result();
+        try {
+            $this->connect();
+        } catch (Exception $exception) {
+            $result->addError(new Error($exception->getMessage(), $exception->getCode(), [], 'Failed'));
+        }
+        if ($this->pdoDriver === 'sqlite') {
+            $result->addNotice(new Notice('SQLite database tables are created automatically and don\'t need to be set up'));
+            return $result;
+        }
         $result->addNotice(new Notice('Creating database tables "%s" & "%s"...', null, [$this->cacheTableName, $this->tagsTableName]));
         try {
             $this->createCacheTables();


### PR DESCRIPTION
When configuring the `PdoBackend` to use an SQLite database
it will be set up automatically upon connection.

Invoking the `cache:setup` command afterwards leads to an
error:

   General error: 1 table "cache" already exists

With this fix, the creation of cache tables is skipped for
SQLite databases during setup.

Fixes: #1763