### PR TITLE
!!! TASK: Set $result private, to remove it from the interface

### DIFF
--- a/Neos.Flow/Classes/Validation/Validator/AbstractValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/AbstractValidator.php
@@ -51,10 +51,9 @@ abstract class AbstractValidator implements ValidatorInterface
     protected $options = [];
 
     /**
-     * @deprecated since Flow 4.3. Don't overwrite this and instead use pushResult/popResult
      * @var ErrorResult
      */
-    protected $result;
+    private $result;
 
     /**
      * @var array<ErrorResult>
@@ -133,6 +132,7 @@ abstract class AbstractValidator implements ValidatorInterface
      *
      * @param mixed $value The value that should be validated
      * @return ErrorResult
+     * @throws InvalidValidationOptionsException
      * @api
      */
     public function validate($value)

--- a/Neos.Flow/Classes/Validation/Validator/AbstractValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/AbstractValidator.php
@@ -127,6 +127,18 @@ abstract class AbstractValidator implements ValidatorInterface
     }
 
     /**
+     * Get the current Result for this validation invocation. Use this inside your isValid() implementation
+     * to e.g. merge results together into the current one.
+     *
+     * @since Flow 6.0
+     * @return ErrorResult|null
+     */
+    protected function getResult()
+    {
+        return $this->result;
+    }
+
+    /**
      * Checks if the given value is valid according to the validator, and returns
      * the Error Messages object which occurred.
      *

--- a/Neos.Flow/Classes/Validation/Validator/CollectionValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/CollectionValidator.php
@@ -75,7 +75,7 @@ class CollectionValidator extends GenericObjectValidator
                 $collectionElementValidator->setValidatedInstancesContainer($this->validatedInstancesContainer);
             }
 
-            $this->result->forProperty($index)->merge($collectionElementValidator->validate($collectionElement));
+            $this->getResult()->forProperty($index)->merge($collectionElementValidator->validate($collectionElement));
         }
     }
 }

--- a/Neos.Flow/Classes/Validation/Validator/GenericObjectValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/GenericObjectValidator.php
@@ -62,7 +62,7 @@ class GenericObjectValidator extends AbstractValidator implements ObjectValidato
             $propertyValue = $this->getPropertyValue($object, $propertyName);
             $result = $this->checkProperty($propertyValue, $validators);
             if ($result !== null) {
-                $this->result->forProperty($propertyName)->merge($result);
+                $this->getResult()->forProperty($propertyName)->merge($result);
             }
         }
     }


### PR DESCRIPTION
Don't access `$this->result` inside Validators and instead use pushResult/popResult/getResult.