### PR TITLE
!!! TASK: Remove deprecated methods

### DIFF
--- a/Neos.Flow/Classes/Http/Helper/UploadedFilesHelper.php
+++ b/Neos.Flow/Classes/Http/Helper/UploadedFilesHelper.php
@@ -111,23 +111,6 @@ abstract class UploadedFilesHelper
      *
      * @param array $structure The array to walk through
      * @param string $firstLevelFieldName
-     * @return array An array of paths (as strings) in the format "key1/key2/key3" ...
-     * @deprecated
-     */
-    protected static function calculateFieldPaths(array $structure, string $firstLevelFieldName = null): array
-    {
-        $fieldPaths = self::calculateFieldPathsAsArray($structure, $firstLevelFieldName);
-        array_walk($fieldPaths, function (&$fieldPath) {
-            $fieldPath = implode('/', $fieldPath);
-        });
-        return $fieldPaths;
-    }
-
-    /**
-     * Returns an array of all possible "field paths" for the given array.
-     *
-     * @param array $structure The array to walk through
-     * @param string $firstLevelFieldName
      * @return array An array of paths (as arrays) in the format ["key1", "key2", "key3"] ...
      */
     protected static function calculateFieldPathsAsArray(array $structure, string $firstLevelFieldName = null): array

--- a/Neos.Flow/Classes/Mvc/Routing/Dto/ResolveContext.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Dto/ResolveContext.php
@@ -75,15 +75,6 @@ final class ResolveContext
 
     /**
      * @return UriInterface
-     * @deprecated This getter has been renamed. @see getBaseUri()
-     */
-    public function getRequestUri(): UriInterface
-    {
-        return $this->getBaseUri();
-    }
-
-    /**
-     * @return UriInterface
      */
     public function getBaseUri(): UriInterface
     {

--- a/Neos.Flow/Classes/Security/Authentication/AuthenticationProviderManager.php
+++ b/Neos.Flow/Classes/Security/Authentication/AuthenticationProviderManager.php
@@ -109,18 +109,6 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
     }
 
     /**
-     * Sets the security context
-     *
-     * @param Context $securityContext The security context of the current request
-     * @return void
-     * @deprecated Just get it injected
-     */
-    public function setSecurityContext(Context $securityContext): void
-    {
-        $this->securityContext = $securityContext;
-    }
-
-    /**
      * Returns the security context
      *
      * @return Context $securityContext The security context of the current request

--- a/Neos.Flow/Classes/Security/Cryptography/SaltedMd5HashingStrategy.php
+++ b/Neos.Flow/Classes/Security/Cryptography/SaltedMd5HashingStrategy.php
@@ -24,6 +24,7 @@ class SaltedMd5HashingStrategy implements PasswordHashingStrategyInterface
      *
      * @param string $clearString The unencrypted string which is the subject to be hashed
      * @return string Salted hash and the salt, separated by a comma ","
+     * @throws \Exception
      */
     public static function generateSaltedMd5($clearString)
     {
@@ -55,6 +56,7 @@ class SaltedMd5HashingStrategy implements PasswordHashingStrategyInterface
      * @param string $password The cleartext password
      * @param string $staticSalt ignored parameter
      * @return string A hashed password with salt
+     * @throws \Exception
      */
     public function hashPassword($password, $staticSalt = null)
     {

--- a/Neos.Flow/Classes/Session/Session.php
+++ b/Neos.Flow/Classes/Session/Session.php
@@ -297,9 +297,10 @@ class Session implements CookieEnabledInterface
      * Starts the session, if it has not been already started
      *
      * @return void
-     * @api
+     * @throws \Exception
      * @deprecated This method is not deprecated, but be aware that from next major a cookie will no longer be auto generated.
      * @see CookieEnabledInterface
+     * @api
      */
     public function start()
     {


### PR DESCRIPTION
- Method `AuthenticationProviderManager::setSecurityContext()` was removed. Just get it injected.
- Method `ResolveContext::getRequestUri()` was removed. Use `getBaseUri()` instead.
- Method `UploadedFilesHelper::calculateFieldPaths()` was removed which was unused.