### PR TITLE
TASK: Remove lockStrategyClassName from settings

### DIFF
--- a/Neos.Flow/Configuration/Settings.yaml
+++ b/Neos.Flow/Configuration/Settings.yaml
@@ -11,6 +11,3 @@ Neos:
   Flow:
     # A section for compatibility flags that are deprecated.
     compatibility: []
-
-    utility:
-      lockStrategyClassName: 'Neos\Utility\Lock\FlockLockStrategy'

--- a/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.utility.schema.yaml
+++ b/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.utility.schema.yaml
@@ -1,4 +1,3 @@
 type: dictionary
 additionalProperties: false
-properties:
-
+properties: []

--- a/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.utility.schema.yaml
+++ b/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.utility.schema.yaml
@@ -1,7 +1,4 @@
 type: dictionary
 additionalProperties: false
 properties:
-  'lockStrategyClassName':
-    type: string
-    required: true
-    format: class-name
+


### PR DESCRIPTION
Remove the configuration in flow and the according settings schema, 
as the Lock package was removed already in https://github.com/neos/flow-development-collection/pull/1771