### PR TITLE
BUGFIX: Avoid changing REQUEST_TIME in functional tests

### DIFF
--- a/Neos.Flow/Tests/Functional/Http/RequestHandlerTest.php
+++ b/Neos.Flow/Tests/Functional/Http/RequestHandlerTest.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Tests\Functional\Http;
 
 use Neos\Flow\Http\RequestHandler;
 use Neos\Flow\Tests\FunctionalTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Functional tests for the HTTP Request Handler
@@ -47,10 +48,13 @@ class RequestHandlerTest extends FunctionalTestCase
             'REQUEST_URI' => '/neos/flow/test/http/foo',
             'SCRIPT_NAME' => '/index.php',
             'PHP_SELF' => '/index.php',
+            'REQUEST_TIME' => $_SERVER['REQUEST_TIME'] ?? null,
+            'REQUEST_TIME_FLOAT' => $_SERVER['REQUEST_TIME_FLOAT'] ?? null,
         ];
 
+        /** @var MockObject|RequestHandler $requestHandler */
         $requestHandler = $this->getAccessibleMock(RequestHandler::class, ['boot'], [self::$bootstrap]);
-        $requestHandler->exit = function () {
+        $requestHandler->exit = static function () {
         };
         $requestHandler->handleRequest();
 

--- a/Neos.Flow/Tests/FunctionalTestCase.php
+++ b/Neos.Flow/Tests/FunctionalTestCase.php
@@ -410,7 +410,8 @@ abstract class FunctionalTestCase extends \Neos\Flow\Tests\BaseTestCase
             'REQUEST_URI' => '',
             'SCRIPT_NAME' => '/index.php',
             'PHP_SELF' => '/index.php',
-            'REQUEST_TIME' => 1326472534,
+            'REQUEST_TIME' => $_SERVER['REQUEST_TIME'] ?? null,
+            'REQUEST_TIME_FLOAT' => $_SERVER['REQUEST_TIME_FLOAT'] ?? null,
         ];
     }
 

--- a/Neos.Flow/Tests/Unit/Http/Component/TrustedProxiesComponentTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Component/TrustedProxiesComponentTest.php
@@ -107,7 +107,6 @@ class TrustedProxiesComponentTest extends UnitTestCase
             'SERVER_PORT' => '80',
             'REMOTE_ADDR' => '127.0.0.1',
             'REQUEST_URI' => '/posts/2011/11/28/laboriosam-soluta-est-minus-molestiae?getKey1=getValue1&getKey2=getValue2',
-            'REQUEST_TIME' => 1326472534
         ]);
 
         $request = $this->serverRequestFactory->createServerRequest('GET', new Uri('https://dev.blog.rob/foo/bar?baz=quux&coffee=due'), $server);
@@ -132,7 +131,6 @@ class TrustedProxiesComponentTest extends UnitTestCase
             'SERVER_PORT' => '80',
             'REMOTE_ADDR' => '127.0.0.1',
             'REQUEST_URI' => '/posts/2011/11/28/laboriosam-soluta-est-minus-molestiae?getKey1=getValue1&getKey2=getValue2',
-            'REQUEST_TIME' => 1326472534
         ]);
 
         $request = $this->serverRequestFactory->createServerRequest('GET', new Uri('https://[2a00:f48:1008::212:183:10]:2727/foo/bar?baz=quux&coffee=due'), $server);


### PR DESCRIPTION
This fixes two symptoms:

- the time reported for functional tests (used to be years…)
- an error in the RequestHandlerTest caused by the PhpUnit Timer
  complaining about not being able to determine the time
