### PR TITLE
BUGFIX: Undo `dirname` simplification in getScriptRequestPath

### DIFF
--- a/Neos.Flow/Classes/Http/Helper/RequestInformationHelper.php
+++ b/Neos.Flow/Classes/Http/Helper/RequestInformationHelper.php
@@ -51,8 +51,10 @@ abstract class RequestInformationHelper
      */
     public static function getScriptRequestPath(ServerRequestInterface $request): string
     {
-        $requestPath = dirname(self::getScriptRequestPathAndFilename($request));
-        return rtrim($requestPath, '/') . '/';
+        // This is not a simple `dirname()` because on Windows it will end up with backslashes in the URL
+        $requestPathSegments = explode('/', self::getScriptRequestPathAndFilename($request));
+        array_pop($requestPathSegments);
+        return implode('/', $requestPathSegments) . '/';
     }
 
     /**


### PR DESCRIPTION
This was broken in the PSR7 move, by replacing the explode/array_pop/implode logic with a simple dirname. On Windows, you in most cases end up with a single `\` which in turn results in generating URLs like `/\/`. This change simply changes the code back to the pre-PSR state, which worked fine.

Resolves #1785