### PR TITLE
TASK: Remove unneeded code section

### DIFF
--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1625,12 +1625,7 @@ class ReflectionService
         }
 
         $declaredType = strtok(trim(current($varTagValues), " \n\t"), " \n\t");
-        try {
-            TypeHandling::parseType($declaredType);
-        } catch (InvalidTypeException $exception) {
-            throw new \InvalidArgumentException(sprintf($exception->getMessage(), 'class "' . $className . '" for property "' . $propertyName . '"'), 1315564475);
-        }
-
+        
         if ($this->isPropertyAnnotatedWith($className, $propertyName, ORM\Id::class)) {
             $skipArtificialIdentity = true;
         }


### PR DESCRIPTION
The call to `TypeHandling::parse` is already done inside `ClassSchema::addProperty` and throws a very similar exception.
As a side effect, this should have a very small performance improvement for class schema building/compile time.
