### PR TITLE
TASK: Use RequestInterface in Browser and RequestEngineInterface

### DIFF
--- a/Neos.Flow/Classes/Http/Client/CurlEngine.php
+++ b/Neos.Flow/Classes/Http/Client/CurlEngine.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Http\Client;
 
 /*
@@ -11,11 +13,10 @@ namespace Neos\Flow\Http\Client;
  * source code.
  */
 
-use function GuzzleHttp\Psr7\parse_response;
-use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use function GuzzleHttp\Psr7\parse_response;
 
 /**
  * A Request Engine which uses cURL in order to send requests to external
@@ -41,7 +42,7 @@ class CurlEngine implements RequestEngineInterface
      * @param integer $optionName One of the CURLOPT_* constants
      * @param mixed $value The value to set
      */
-    public function setOption($optionName, $value)
+    public function setOption(int $optionName, $value): void
     {
         $this->options[$optionName] = $value;
     }
@@ -49,13 +50,13 @@ class CurlEngine implements RequestEngineInterface
     /**
      * Sends the given HTTP request
      *
-     * @param ServerRequestInterface $request
+     * @param RequestInterface $request
      * @return ResponseInterface The response or false
-     * @api
      * @throws Http\Exception
      * @throws CurlEngineException
+     * @api
      */
-    public function sendRequest(ServerRequestInterface $request): ResponseInterface
+    public function sendRequest(RequestInterface $request): ResponseInterface
     {
         if (!extension_loaded('curl')) {
             throw new Http\Exception('CurlEngine requires the PHP CURL extension to be installed and loaded.', 1346319808);

--- a/Neos.Flow/Classes/Http/Client/RequestEngineInterface.php
+++ b/Neos.Flow/Classes/Http/Client/RequestEngineInterface.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Http\Client;
 
 /*
@@ -12,8 +14,8 @@ namespace Neos\Flow\Http\Client;
  */
 
 use Neos\Flow\Http;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Interface for a Request Engine which can be used by a HTTP Client implementation
@@ -22,11 +24,11 @@ use Psr\Http\Message\ServerRequestInterface;
 interface RequestEngineInterface
 {
     /**
-     * Sends the given HTTP request
+     * Sends the given request
      *
-     * @param ServerRequestInterface $request
+     * @param RequestInterface $request
      * @return ResponseInterface
      * @throws Http\Exception
      */
-    public function sendRequest(ServerRequestInterface $request): ResponseInterface;
+    public function sendRequest(RequestInterface $request): ResponseInterface;
 }

--- a/Neos.Flow/Tests/Functional/Http/Client/BrowserTest.php
+++ b/Neos.Flow/Tests/Functional/Http/Client/BrowserTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Http\Client;
 
 /*
@@ -47,7 +49,7 @@ class BrowserTest extends FunctionalTestCase
      *
      * @test
      */
-    public function redirectsAreFollowed()
+    public function redirectsAreFollowed(): void
     {
         $response = $this->browser->request('http://localhost/test/http/redirecting');
         self::assertEquals('arrived.', $response->getBody()->getContents());
@@ -58,7 +60,7 @@ class BrowserTest extends FunctionalTestCase
      *
      * @test
      */
-    public function redirectsAreNotFollowedIfSwitchedOff()
+    public function redirectsAreNotFollowedIfSwitchedOff(): void
     {
         $this->browser->setFollowRedirects(false);
         $response = $this->browser->request('http://localhost/test/http/redirecting');

--- a/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
@@ -461,7 +461,7 @@ class ActionControllerTest extends FunctionalTestCase
         ];
         $body = json_encode($arguments, JSON_PRETTY_PRINT);
         $this->browser->addAutomaticRequestHeader('Content-Type', 'application/json');
-        $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertestb/mappedrequestbody', 'POST', [], [], [], $body);
+        $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertestb/mappedrequestbody', 'POST', [], [], $body);
 
         $expectedResult = 'Foo-foo@bar.org';
         self::assertEquals($expectedResult, $response->getBody()->getContents());
@@ -478,7 +478,7 @@ class ActionControllerTest extends FunctionalTestCase
         ];
         $body = json_encode($arguments, JSON_PRETTY_PRINT);
         $this->browser->addAutomaticRequestHeader('Content-Type', 'application/json');
-        $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertestb/mappedrequestbodywithoutannotation', 'POST', [], [], [], $body);
+        $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertestb/mappedrequestbodywithoutannotation', 'POST', [], [], $body);
 
         $expectedResult = 'Foo-foo@bar.org';
         self::assertEquals($expectedResult, $response->getBody()->getContents());

--- a/Neos.Flow/Tests/Unit/Http/BrowserTest.php
+++ b/Neos.Flow/Tests/Unit/Http/BrowserTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Unit\Http;
 
 /*
@@ -41,14 +43,14 @@ class BrowserTest extends UnitTestCase
     /**
      * @test
      */
-    public function requestingUriQueriesRequestEngine()
+    public function requestingUriQueriesRequestEngine(): void
     {
         $requestEngine = $this->createMock(Client\RequestEngineInterface::class);
         $requestEngine
             ->expects(self::once())
             ->method('sendRequest')
             ->with($this->isInstanceOf(RequestInterface::class))
-            ->will(self::returnValue(new Response()));
+            ->willReturn(new Response());
         $this->browser->setRequestEngine($requestEngine);
         $this->browser->request('http://localhost/foo');
     }
@@ -56,11 +58,10 @@ class BrowserTest extends UnitTestCase
     /**
      * @test
      */
-    public function automaticHeadersAreSetOnEachRequest()
+    public function automaticHeadersAreSetOnEachRequest(): void
     {
         $requestEngine = $this->createMock(Client\RequestEngineInterface::class);
         $requestEngine
-            ->expects(self::any())
             ->method('sendRequest')
             ->willReturn(new Response());
         $this->browser->setRequestEngine($requestEngine);
@@ -78,13 +79,13 @@ class BrowserTest extends UnitTestCase
      * @test
      * @depends automaticHeadersAreSetOnEachRequest
      */
-    public function automaticHeadersCanBeRemovedAgain()
+    public function automaticHeadersCanBeRemovedAgain(): void
     {
         $requestEngine = $this->createMock(Client\RequestEngineInterface::class);
         $requestEngine
             ->expects(self::once())
             ->method('sendRequest')
-            ->will(self::returnValue(new Response()));
+            ->willReturn(new Response());
         $this->browser->setRequestEngine($requestEngine);
 
         $this->browser->addAutomaticRequestHeader('X-Test-Header', 'Acme');
@@ -96,7 +97,7 @@ class BrowserTest extends UnitTestCase
     /**
      * @test
      */
-    public function browserFollowsRedirectionIfResponseTellsSo()
+    public function browserFollowsRedirectionIfResponseTellsSo(): void
     {
         $initialUri = new Uri('http://localhost/foo');
         $redirectUri = new Uri('http://localhost/goToAnotherFoo');
@@ -108,14 +109,14 @@ class BrowserTest extends UnitTestCase
         $requestEngine
             ->expects(self::at(0))
             ->method('sendRequest')
-            ->with($this->callback(function (RequestInterface $request) use ($initialUri) {
+            ->with($this->callback(static function (RequestInterface $request) use ($initialUri) {
                 return (string)$request->getUri() === (string)$initialUri;
             }))
             ->willReturn($firstResponse);
         $requestEngine
             ->expects(self::at(1))
             ->method('sendRequest')
-            ->with($this->callback(function (RequestInterface $request) use ($redirectUri) {
+            ->with($this->callback(static function (RequestInterface $request) use ($redirectUri) {
                 return (string)$request->getUri() === (string)$redirectUri;
             }))
             ->willReturn($secondResponse);
@@ -128,7 +129,7 @@ class BrowserTest extends UnitTestCase
     /**
      * @test
      */
-    public function browserDoesNotRedirectOnLocationHeaderButNot3xxResponseCode()
+    public function browserDoesNotRedirectOnLocationHeaderButNot3xxResponseCode(): void
     {
         $twoZeroOneResponse = new Response(201, ['Location' => 'http://localhost/createdResource/isHere']);
 
@@ -136,7 +137,7 @@ class BrowserTest extends UnitTestCase
         $requestEngine
             ->expects(self::once())
             ->method('sendRequest')
-            ->will(self::returnValue($twoZeroOneResponse));
+            ->willReturn($twoZeroOneResponse);
 
         $this->browser->setRequestEngine($requestEngine);
         $actual = $this->browser->request('http://localhost/createSomeResource');
@@ -146,7 +147,7 @@ class BrowserTest extends UnitTestCase
     /**
      * @test
      */
-    public function browserHaltsOnAttemptedInfiniteRedirectionLoop()
+    public function browserHaltsOnAttemptedInfiniteRedirectionLoop(): void
     {
         $this->expectException(Client\InfiniteRedirectionException::class);
         $wildResponses = [];
@@ -156,11 +157,11 @@ class BrowserTest extends UnitTestCase
         $wildResponses[3] = new Response(301, ['Location' => 'http://localhost/ahNoPleaseRatherGoThere']);
 
         $requestEngine = $this->createMock(Client\RequestEngineInterface::class);
-        for ($i=0; $i<=3; $i++) {
+        for ($i = 0; $i <= 3; $i++) {
             $requestEngine
                 ->expects(self::at($i))
                 ->method('sendRequest')
-                ->will(self::returnValue($wildResponses[$i]));
+                ->willReturn($wildResponses[$i]);
         }
 
         $this->browser->setRequestEngine($requestEngine);
@@ -170,16 +171,16 @@ class BrowserTest extends UnitTestCase
     /**
      * @test
      */
-    public function browserHaltsOnExceedingMaximumRedirections()
+    public function browserHaltsOnExceedingMaximumRedirections(): void
     {
         $this->expectException(Client\InfiniteRedirectionException::class);
         $requestEngine = $this->createMock(Client\RequestEngineInterface::class);
-        for ($i=0; $i<=10; $i++) {
+        for ($i = 0; $i <= 10; $i++) {
             $response = new Response(301, ['Location' => 'http://localhost/this/willLead/you/knowhere/' . $i]);
             $requestEngine
                 ->expects(self::at($i))
                 ->method('sendRequest')
-                ->will(self::returnValue($response));
+                ->willReturn($response);
         }
 
         $this->browser->setRequestEngine($requestEngine);

--- a/Neos.Flow/Tests/Unit/Http/BrowserTest.php
+++ b/Neos.Flow/Tests/Unit/Http/BrowserTest.php
@@ -15,10 +15,8 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Http\Client;
 use Neos\Flow\Tests\UnitTestCase;
-use Neos\Http\Factories\ServerRequestFactory;
-use Neos\Http\Factories\UriFactory;
+use Neos\Http\Factories\RequestFactory;
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Test case for the Http Cookie class
@@ -37,7 +35,7 @@ class BrowserTest extends UnitTestCase
     {
         parent::setUp();
         $this->browser = new Client\Browser();
-        $this->inject($this->browser, 'serverRequestFactory', new ServerRequestFactory(new UriFactory()));
+        $this->inject($this->browser, 'requestFactory', new RequestFactory());
     }
 
     /**
@@ -110,14 +108,14 @@ class BrowserTest extends UnitTestCase
         $requestEngine
             ->expects(self::at(0))
             ->method('sendRequest')
-            ->with($this->callback(function (ServerRequestInterface $request) use ($initialUri) {
+            ->with($this->callback(function (RequestInterface $request) use ($initialUri) {
                 return (string)$request->getUri() === (string)$initialUri;
             }))
             ->willReturn($firstResponse);
         $requestEngine
             ->expects(self::at(1))
             ->method('sendRequest')
-            ->with($this->callback(function (ServerRequestInterface $request) use ($redirectUri) {
+            ->with($this->callback(function (RequestInterface $request) use ($redirectUri) {
                 return (string)$request->getUri() === (string)$redirectUri;
             }))
             ->willReturn($secondResponse);

--- a/Neos.Http.Factories/Classes/ServerRequestFactory.php
+++ b/Neos.Http.Factories/Classes/ServerRequestFactory.php
@@ -1,7 +1,6 @@
 <?php
 namespace Neos\Http\Factories;
 
-use function GuzzleHttp\Psr7\parse_query;
 use GuzzleHttp\Psr7\ServerRequest;
 use Neos\Flow\Http\Helper\RequestInformationHelper;
 use Psr\Http\Message\ServerRequestFactoryInterface;


### PR DESCRIPTION
Replaces the use of `ServerRequestInterface` in `Browser` and the
`RequestEngineInterface` with `RequestInterface`. The latter is a
request that is sent, while the `ServerRequestInterface` represents
an incoming request.

This is fixed in 6.0 like a bug, since those interfaces were introduced
with 6.0.0 only, and thus this is acceptable as a fix before it
manifests itself into something we can only adjust in a year from now.
