### PR TITLE
TASK: Fix documented return type for ViewInterface.render()

### DIFF
--- a/Neos.Flow/Classes/Mvc/View/ViewInterface.php
+++ b/Neos.Flow/Classes/Mvc/View/ViewInterface.php
@@ -63,7 +63,7 @@ interface ViewInterface
     /**
      * Renders the view
      *
-     * @return string|ActionResponse|ResponseInterface|StreamInterface|object The rendered result; object is only handled of __toString() exists!
+     * @return string|ActionResponse|ResponseInterface|StreamInterface|object The rendered result; object is only handled if __toString() exists!
      * @api
      */
     public function render();

--- a/Neos.Flow/Classes/Mvc/View/ViewInterface.php
+++ b/Neos.Flow/Classes/Mvc/View/ViewInterface.php
@@ -63,7 +63,7 @@ interface ViewInterface
     /**
      * Renders the view
      *
-     * @return string|ActionResponse|ResponseInterface|StreamInterface|object The rendered result
+     * @return string|ActionResponse|ResponseInterface|StreamInterface|object The rendered result; object is only handled of __toString() exists!
      * @api
      */
     public function render();

--- a/Neos.Flow/Classes/Mvc/View/ViewInterface.php
+++ b/Neos.Flow/Classes/Mvc/View/ViewInterface.php
@@ -10,7 +10,11 @@ namespace Neos\Flow\Mvc\View;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+
+use Neos\Flow\Mvc\ActionResponse;
 use Neos\Flow\Mvc\Controller\ControllerContext;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * Interface of a view
@@ -59,7 +63,7 @@ interface ViewInterface
     /**
      * Renders the view
      *
-     * @return string The rendered view
+     * @return string|ActionResponse|ResponseInterface|StreamInterface|object The rendered result
      * @api
      */
     public function render();


### PR DESCRIPTION
The `render()` in `ViewInterface` method used to return a string,
but now that is no longer true. This makes the docblock list the
return types that our `ActionController` handles, to lessen the
potential for confusion.