### PR TITLE
BUGFIX: Check for AbstractLazyCollection instead of PersistentCollect…

### DIFF
--- a/Neos.Flow/Classes/Validation/Validator/CollectionValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/CollectionValidator.php
@@ -50,7 +50,7 @@ class CollectionValidator extends GenericObjectValidator
      */
     protected function isValid($value)
     {
-        if ($value instanceof \Doctrine\ORM\PersistentCollection && !$value->isInitialized()) {
+        if ($value instanceof \Doctrine\Common\Collections\AbstractLazyCollection && !$value->isInitialized()) {
             return;
         } elseif ((is_object($value) && !TypeHandling::isCollectionType(get_class($value))) && !is_array($value)) {
             $this->addError('The given subject was not a collection.', 1317204797);

--- a/Neos.Flow/Tests/Unit/Validation/Validator/CollectionValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/CollectionValidatorTest.php
@@ -122,6 +122,19 @@ class CollectionValidatorTest extends AbstractValidatorTestcase
     /**
      * @test
      */
+    public function collectionValidatorIsValidEarlyReturnsOnUnitializedDoctrineAbstractLazyCollections()
+    {
+        $doctrineArrayCollection = $this->getMockBuilder(\Doctrine\Common\Collections\AbstractLazyCollection::class)->disableOriginalConstructor()->getMock();
+        $doctrineArrayCollection->method('isInitialized')->willReturn(false);
+
+        $this->mockValidatorResolver->expects(self::never())->method('createValidator');
+
+        $this->validator->validate($doctrineArrayCollection);
+    }
+
+    /**
+     * @test
+     */
     public function collectionValidatorTransfersElementValidatorOptionsToTheElementValidator()
     {
         $elementValidatorOptions = ['minimum' => 5];


### PR DESCRIPTION
Use more generic `AbstractLazyCollection` instead of  `PersistentCollection` in `isValid` of `CollectionValidator` to prevent lazy collection of classes extending `AbstractLazyCollection` to get loaded.