### PR TITLE
BUGFIX: Allow to return PSR7 streams and PHP resources/file handles from action

### DIFF
--- a/Neos.Flow/Classes/Mvc/Controller/ActionController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ActionController.php
@@ -504,10 +504,8 @@ class ActionController extends AbstractController
 
         if ($actionResult === null && $this->view instanceof ViewInterface) {
             $this->renderView();
-        } elseif (is_string($actionResult) && strlen($actionResult) > 0) {
+        } else {
             $this->response->setContent($actionResult);
-        } elseif (is_object($actionResult) && method_exists($actionResult, '__toString')) {
-            $this->response->setContent((string)$actionResult);
         }
     }
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ModelViewController.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ModelViewController.rst
@@ -194,15 +194,15 @@ referred to simply by its *action name*, in this case ``index``.
 If an action returns a string or an object which can be cast to a string, a PHP resource stream
 like an opened file or a PSR7 stream, it will be set as the content of the response automatically::
 
-		/**
-		 * Stream a file content to the browser
-		 *
-		 * @return resource
-		 */
-		public function exportAction() {
-      $this->response->setContentType('text/csv');
-			return fopen('/path/fo/file', 'r');
-		}
+	/**
+	 * Stream a file content to the browser
+	 *
+	 * @return resource
+	 */
+	public function exportAction() {
+		$this->response->setContentType('text/csv');
+		return fopen('/path/fo/file', 'r');
+	}
 
 .. note::
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ModelViewController.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ModelViewController.rst
@@ -916,7 +916,7 @@ ViewHelper. Please consult the ViewHelper for a full reference.
 Since Flash Messages need to possibly survive over requests until they get displayed, they need
 to be persisted somehow.
 Flash Messages can be stored in different ways, the Framework default is to store them in the session.
-The storage can be configured in Settings.yaml via the following options:
+The storage can be configured in Settings.yaml via the following options::
 
 	Neos:
 	  Flow:

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ModelViewController.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ModelViewController.rst
@@ -191,8 +191,23 @@ requested. An action method name must be camelCased and always end with the suff
 "Action". In the Action Request and other parts of the routing system, it is
 referred to simply by its *action name*, in this case ``index``.
 
-If an action returns a string or an object which can be cast to a string, it will
-be set as the content of the response automatically.
+If an action returns a string or an object which can be cast to a string, a PHP resource stream
+like an opened file or a PSR7 stream, it will be set as the content of the response automatically::
+
+		/**
+		 * Stream a file content to the browser
+		 *
+		 * @return resource
+		 */
+		public function exportAction() {
+      $this->response->setContentType('text/csv');
+			return fopen('/path/fo/file', 'r');
+		}
+
+.. note::
+
+   This also works for large files, in which case the file content will be streamed to the browser.
+
 
 Defining Arguments
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This allows to return PSR7 streams, PHP resources or anything else that guzzle stream_for can deal with from the action.
https://github.com/guzzle/psr7/blob/master/README.md#function-stream_for

With that it is possible to just do this in an action:
```php
return fopen('/path/to/file', 'r');
```

Resolves #1800 