### PR TITLE
BUGFIX: fix double "//" encoding in some URLs

### DIFF
--- a/Neos.Flow/Classes/Mvc/Routing/Dto/ResolveContext.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Dto/ResolveContext.php
@@ -54,7 +54,7 @@ final class ResolveContext
      * @param UriInterface $baseUri The base URI, retrieved from the current request URI or from configuration, if specified. Required to fill in parts of the result when resolving absolute URIs
      * @param array $routeValues Route values to build the URI, for example ['@action' => 'index', 'someArgument' => 'foo', ...]
      * @param bool $forceAbsoluteUri Whether or not an absolute URI is to be returned
-     * @param string $uriPathPrefix A prefix to be prepended to any resolved URI
+     * @param string $uriPathPrefix A prefix to be prepended to any resolved URI. Not allowed to start with "/".
      */
     public function __construct(UriInterface $baseUri, array $routeValues, bool $forceAbsoluteUri, string $uriPathPrefix = '')
     {
@@ -63,13 +63,8 @@ final class ResolveContext
         $this->forceAbsoluteUri = $forceAbsoluteUri;
         $this->uriPathPrefix = $uriPathPrefix;
 
-        // Only add base uri path for absolute uri, in case of relative uri the uri has to be relative to the given base uri
-        if ($forceAbsoluteUri) {
-            $this->uriPathPrefix = '/' . ltrim($this->uriPathPrefix, '/');
-
-            if ($baseUri->getPath() !== '') {
-                $this->uriPathPrefix = rtrim($baseUri->getPath(), '/') . $this->uriPathPrefix;
-            }
+        if (strpos($this->uriPathPrefix, '/') === 0) {
+            throw new \InvalidArgumentException('UriPathPrefix "' . $uriPathPrefix . '" is not allowed to start with "/".', 1570187176);
         }
     }
 

--- a/Neos.Flow/Classes/Mvc/Routing/Dto/UriConstraints.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Dto/UriConstraints.php
@@ -196,6 +196,11 @@ final class UriConstraints
         if (isset($newConstraints[self::CONSTRAINT_PATH_PREFIX])) {
             $pathPrefix = $append ? $newConstraints[self::CONSTRAINT_PATH_PREFIX] . $pathPrefix : $pathPrefix . $newConstraints[self::CONSTRAINT_PATH_PREFIX];
         }
+
+        if (strpos($pathPrefix, '/') === 0) {
+            throw new \InvalidArgumentException('path prefix is not allowed to start with "/". The passed-in path prefix was "' . $pathPrefix . '", and the computed path prefix (including previously set path prefixes) is "' . $pathPrefix . '". The computed path prefix may never start with "/".', 1570187341);
+        }
+
         $newConstraints[self::CONSTRAINT_PATH_PREFIX] = $pathPrefix;
         return new static($newConstraints);
     }
@@ -237,23 +242,23 @@ final class UriConstraints
      * Applies all constraints of this instance to the given $templateUri and returns a new UriInterface instance
      * satisfying all of the constraints (see example above)
      *
-     * @param UriInterface $templateUri The base URI to transform, usually the current request URI
+     * @param UriInterface $baseUri The base URI to transform, usually the current request's base URI
      * @param bool $forceAbsoluteUri Whether or not to enforce the resulting URI to contain scheme and host (note: some of the constraints force an absolute URI by default)
      * @return UriInterface The transformed URI with all constraints applied
      */
-    public function applyTo(UriInterface $templateUri, bool $forceAbsoluteUri): UriInterface
+    public function applyTo(UriInterface $baseUri, bool $forceAbsoluteUri): UriInterface
     {
         $uri = new Uri('');
-        if (isset($this->constraints[self::CONSTRAINT_SCHEME]) && $this->constraints[self::CONSTRAINT_SCHEME] !== $templateUri->getScheme()) {
+        if (isset($this->constraints[self::CONSTRAINT_SCHEME]) && $this->constraints[self::CONSTRAINT_SCHEME] !== $baseUri->getScheme()) {
             $forceAbsoluteUri = true;
             $uri = $uri->withScheme($this->constraints[self::CONSTRAINT_SCHEME]);
         }
-        if (isset($this->constraints[self::CONSTRAINT_HOST]) && $this->constraints[self::CONSTRAINT_HOST] !== $templateUri->getHost()) {
+        if (isset($this->constraints[self::CONSTRAINT_HOST]) && $this->constraints[self::CONSTRAINT_HOST] !== $baseUri->getHost()) {
             $forceAbsoluteUri = true;
             $uri = $uri->withHost($this->constraints[self::CONSTRAINT_HOST]);
         }
         if (isset($this->constraints[self::CONSTRAINT_HOST_PREFIX])) {
-            $originalHost = $host = !empty($uri->getHost()) ? $uri->getHost() : $templateUri->getHost();
+            $originalHost = $host = !empty($uri->getHost()) ? $uri->getHost() : $baseUri->getHost();
             $prefix = $this->constraints[self::CONSTRAINT_HOST_PREFIX]['prefix'];
             $replacePrefixes = $this->constraints[self::CONSTRAINT_HOST_PREFIX]['replacePrefixes'];
             foreach ($replacePrefixes as $replacePrefix) {
@@ -269,7 +274,7 @@ final class UriConstraints
             }
         }
         if (isset($this->constraints[self::CONSTRAINT_HOST_SUFFIX])) {
-            $originalHost = $host = !empty($uri->getHost()) ? $uri->getHost() : $templateUri->getHost();
+            $originalHost = $host = !empty($uri->getHost()) ? $uri->getHost() : $baseUri->getHost();
             $suffix = $this->constraints[self::CONSTRAINT_HOST_SUFFIX]['suffix'];
             $replaceSuffixes = $this->constraints[self::CONSTRAINT_HOST_SUFFIX]['replaceSuffixes'];
 
@@ -289,12 +294,12 @@ final class UriConstraints
                 $uri = $uri->withHost($host);
             }
         }
-        if (isset($this->constraints[self::CONSTRAINT_PORT]) && $this->constraints[self::CONSTRAINT_PORT] !== $templateUri->getPort()) {
+        if (isset($this->constraints[self::CONSTRAINT_PORT]) && $this->constraints[self::CONSTRAINT_PORT] !== $baseUri->getPort()) {
             $forceAbsoluteUri = true;
             $uri = $uri->withPort($this->constraints[self::CONSTRAINT_PORT]);
         }
 
-        if (isset($this->constraints[self::CONSTRAINT_PATH]) && $this->constraints[self::CONSTRAINT_PATH] !== $templateUri->getPath()) {
+        if (isset($this->constraints[self::CONSTRAINT_PATH]) && $this->constraints[self::CONSTRAINT_PATH] !== $baseUri->getPath()) {
             $uri = $uri->withPath($this->constraints[self::CONSTRAINT_PATH]);
         }
         if (isset($this->constraints[self::CONSTRAINT_PATH_PREFIX])) {
@@ -307,15 +312,19 @@ final class UriConstraints
             $uri = $uri->withQuery($this->constraints[self::CONSTRAINT_QUERY_STRING]);
         }
 
+        if ($baseUri->getPath() !== '' && $baseUri->getPath() !== '/') {
+            $uri = $uri->withPath('/' . trim($baseUri->getPath(), '/') . '/' . ltrim($uri->getPath(), '/'));
+        }
+
         if ($forceAbsoluteUri) {
             if (empty($uri->getScheme())) {
-                $uri = $uri->withScheme($templateUri->getScheme());
+                $uri = $uri->withScheme($baseUri->getScheme());
             }
             if (empty($uri->getHost()) || $uri->getHost() === Uri::HTTP_DEFAULT_HOST) {
-                $uri = $uri->withHost($templateUri->getHost());
+                $uri = $uri->withHost($baseUri->getHost());
             }
             if (empty($uri->getPort()) && !isset($this->constraints[self::CONSTRAINT_PORT])) {
-                $port = $templateUri->getPort() ?? UriHelper::getDefaultPortForScheme($templateUri->getScheme());
+                $port = $baseUri->getPort() ?? UriHelper::getDefaultPortForScheme($baseUri->getScheme());
                 $uri = $uri->withPort($port);
             }
         }

--- a/Neos.Flow/Classes/Mvc/Routing/Dto/UriConstraints.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Dto/UriConstraints.php
@@ -303,7 +303,10 @@ final class UriConstraints
             $uri = $uri->withPath($this->constraints[self::CONSTRAINT_PATH]);
         }
         if (isset($this->constraints[self::CONSTRAINT_PATH_PREFIX])) {
-            $uri = $uri->withPath($this->constraints[self::CONSTRAINT_PATH_PREFIX] . $uri->getPath());
+            // we need to trim the leading "/" from $uri->getPath() (as it is always absolute); so
+            // that the Path Prefix can build strings like <prepended><url>, or
+            // <prepended>/<url>
+            $uri = $uri->withPath($this->constraints[self::CONSTRAINT_PATH_PREFIX] . ltrim($uri->getPath(), '/'));
         }
         if (isset($this->constraints[self::CONSTRAINT_PATH_SUFFIX])) {
             $uri = $uri->withPath($uri->getPath() . $this->constraints[self::CONSTRAINT_PATH_SUFFIX]);

--- a/Neos.Flow/Classes/Mvc/Routing/Dto/UriConstraints.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Dto/UriConstraints.php
@@ -312,8 +312,14 @@ final class UriConstraints
             $uri = $uri->withQuery($this->constraints[self::CONSTRAINT_QUERY_STRING]);
         }
 
+        // In case the base URL contains a path segment, prepend this to the URL (to generate proper host-absolute URLs)
         if ($baseUri->getPath() !== '' && $baseUri->getPath() !== '/') {
-            $uri = $uri->withPath('/' . trim($baseUri->getPath(), '/') . '/' . ltrim($uri->getPath(), '/'));
+            $uri = $uri->withPath(trim($baseUri->getPath(), '/') . '/' . ltrim($uri->getPath(), '/'));
+        }
+
+        // Ensure the URL always starts with "/" if non-empty.
+        if (strlen($uri->getPath()) > 0 && $uri->getPath(){0} !== '/') {
+            $uri = $uri->withPath('/' . $uri->getPath());
         }
 
         if ($forceAbsoluteUri) {

--- a/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
+++ b/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
@@ -358,6 +358,8 @@ class UriBuilder
 
         $uriPathPrefix = $this->environment->isRewriteEnabled() ? '' : 'index.php/';
         $uriPathPrefix = RequestInformationHelper::getScriptRequestPath($httpRequest) . $uriPathPrefix;
+        $uriPathPrefix = ltrim($uriPathPrefix, '/');
+
         $resolveContext = new ResolveContext($this->baseUriProvider->getConfiguredBaseUriOrFallbackToCurrentRequest(), $arguments, $this->createAbsoluteUri, $uriPathPrefix);
         $resolvedUri = $this->router->resolve($resolveContext);
         if ($this->section !== '') {

--- a/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/UriBuilderController.php
+++ b/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/UriBuilderController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\Controller\ActionController;
+
+/**
+ * part of the test fixture for {@see UriBuilderTest}
+ *
+ * @Flow\Scope("singleton")
+ */
+class UriBuilderController extends ActionController
+{
+    /**
+     * @return string
+     */
+    public function differentHostAction()
+    {
+        return $this->uriBuilder
+            ->reset()
+            ->uriFor('target', [
+                'someRoutePart' => 'foo'
+            ], 'UriBuilder', 'Neos.Flow', 'Tests\Functional\Mvc\Fixtures');
+    }
+
+    /**
+     * @return string
+     */
+    public function differentHostWithCreateAbsoluteUriAction()
+    {
+        return $this->uriBuilder
+            ->reset()
+            ->setCreateAbsoluteUri(true)
+            ->uriFor('target', [
+                'someRoutePart' => 'foo'
+            ], 'UriBuilder', 'Neos.Flow', 'Tests\Functional\Mvc\Fixtures');
+    }
+
+    /**
+     * @return string
+     */
+    public function targetAction()
+    {
+    }
+}

--- a/Neos.Flow/Tests/Functional/Mvc/Fixtures/RoutePartHandler/UriBuilderSetDomainAndPathPrefixRoutePartHandler.php
+++ b/Neos.Flow/Tests/Functional/Mvc/Fixtures/RoutePartHandler/UriBuilderSetDomainAndPathPrefixRoutePartHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Neos\Flow\Tests\Functional\Mvc\Fixtures\RoutePartHandler;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\Routing\Dto\ResolveResult;
+use Neos\Flow\Mvc\Routing\Dto\UriConstraints;
+use Neos\Flow\Mvc\Routing\DynamicRoutePart;
+use Neos\Flow\Tests\Functional\Mvc\UriBuilderTest;
+
+/**
+ * part of the test fixture for {@see UriBuilderTest}
+ *
+ * @Flow\Scope("singleton")
+ */
+class UriBuilderSetDomainAndPathPrefixRoutePartHandler extends DynamicRoutePart
+{
+    protected function resolveValue($foo)
+    {
+        $uriConstraints = UriConstraints::create();
+        $uriConstraints = $uriConstraints->withHost('my-host');
+        $uriConstraints = $uriConstraints->withPathPrefix('my-path/');
+
+        return new ResolveResult('my-path', $uriConstraints);
+    }
+}

--- a/Neos.Flow/Tests/Functional/Mvc/Fixtures/RoutePartHandler/UriBuilderSetDomainRoutePartHandler.php
+++ b/Neos.Flow/Tests/Functional/Mvc/Fixtures/RoutePartHandler/UriBuilderSetDomainRoutePartHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Neos\Flow\Tests\Functional\Mvc\Fixtures\RoutePartHandler;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\Routing\Dto\ResolveResult;
+use Neos\Flow\Mvc\Routing\Dto\UriConstraints;
+use Neos\Flow\Mvc\Routing\DynamicRoutePart;
+use Neos\Flow\Tests\Functional\Mvc\UriBuilderTest;
+
+/**
+ * part of the test fixture for {@see UriBuilderTest}
+ *
+ * @Flow\Scope("singleton")
+ */
+class UriBuilderSetDomainRoutePartHandler extends DynamicRoutePart
+{
+    protected function resolveValue($foo)
+    {
+        $uriConstraints = UriConstraints::create();
+        $uriConstraints = $uriConstraints->withHost('my-host');
+
+        return new ResolveResult('my-path', $uriConstraints);
+    }
+}

--- a/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
@@ -243,43 +243,43 @@ class RoutingTest extends FunctionalTestCase
             [
                 'routeValues' => array_merge($defaults, ['dynamic' => 'DynamicDefault']),
                 'expectedResolvedRouteName' => 'dynamic part without default',
-                'expectedResolvedUriPath' => 'neos/flow/test/dynamic/part/without/default/dynamicdefault'
+                'expectedResolvedUriPath' => '/neos/flow/test/dynamic/part/without/default/dynamicdefault'
             ],
             [
                 'routeValues' => array_merge($defaults, ['dynamic' => 'OverwrittenDynamicValue']),
                 'expectedResolvedRouteName' => 'dynamic part without default',
-                'expectedResolvedUriPath' => 'neos/flow/test/dynamic/part/without/default/overwrittendynamicvalue'
+                'expectedResolvedUriPath' => '/neos/flow/test/dynamic/part/without/default/overwrittendynamicvalue'
             ],
 
             // if route value is omitted, only routes with a default value resolve
             [
                 'routeValues' => $defaults,
                 'expectedResolvedRouteName' => 'dynamic part with default',
-                'expectedResolvedUriPath' => 'neos/flow/test/dynamic/part/with/default/DynamicDefault'
+                'expectedResolvedUriPath' => '/neos/flow/test/dynamic/part/with/default/DynamicDefault'
             ],
             [
                 'routeValues' => array_merge($defaults, ['optionalDynamic' => 'OptionalDynamicDefault']),
                 'expectedResolvedRouteName' => 'optional dynamic part with default',
-                'expectedResolvedUriPath' => 'neos/flow/test/optional/dynamic/part/with/default'
+                'expectedResolvedUriPath' => '/neos/flow/test/optional/dynamic/part/with/default'
             ],
 
             // toLowerCase has an effect on generated URIs
             [
                 'routeValues' => array_merge($defaults, ['dynamic1' => 'DynamicRouteValue1', 'dynamic2' => 'DynamicRouteValue2']),
                 'expectedResolvedRouteName' => 'dynamic part case',
-                'expectedResolvedUriPath' => 'neos/flow/test/dynamic/part/case/DynamicRouteValue1/dynamicroutevalue2'
+                'expectedResolvedUriPath' => '/neos/flow/test/dynamic/part/case/DynamicRouteValue1/dynamicroutevalue2'
             ],
 
             // exceeding arguments are appended to resolved URI if appendExceedingArguments is set
             [
                 'routeValues' => array_merge($defaults, ['@action' => 'test1', 'dynamic' => 'DynamicDefault', 'exceedingArgument2' => 'foo', 'exceedingArgument1' => 'bar']),
                 'expectedResolvedRouteName' => 'exceeding arguments 01',
-                'expectedResolvedUriPath' => 'neos/flow/test/exceeding/arguments1?%40action=test1&exceedingArgument2=foo&exceedingArgument1=bar'
+                'expectedResolvedUriPath' => '/neos/flow/test/exceeding/arguments1?%40action=test1&exceedingArgument2=foo&exceedingArgument1=bar'
             ],
             [
                 'routeValues' => array_merge($defaults, ['@action' => 'test1', 'exceedingArgument2' => 'foo', 'exceedingArgument1' => 'bar', 'dynamic' => 'DynamicOther']),
                 'expectedResolvedRouteName' => 'exceeding arguments 02',
-                'expectedResolvedUriPath' => 'neos/flow/test/exceeding/arguments2/dynamicother?%40action=test1&exceedingArgument2=foo&exceedingArgument1=bar'
+                'expectedResolvedUriPath' => '/neos/flow/test/exceeding/arguments2/dynamicother?%40action=test1&exceedingArgument2=foo&exceedingArgument1=bar'
             ],
         ];
     }
@@ -362,7 +362,7 @@ class RoutingTest extends FunctionalTestCase
         $baseUri = new Uri('http://localhost');
         $actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, false));
 
-        self::assertSame('neos/flow/test/http/foo', (string)$actualResult);
+        self::assertSame('/neos/flow/test/http/foo', (string)$actualResult);
     }
 
     /**
@@ -380,7 +380,7 @@ class RoutingTest extends FunctionalTestCase
         $baseUri = new Uri('http://localhost');
         $actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, false, 'index.php/'));
 
-        $this->assertSame('index.php/neos/flow/test/http/foo', (string)$actualResult);
+        $this->assertSame('/index.php/neos/flow/test/http/foo', (string)$actualResult);
     }
 
     /**
@@ -500,7 +500,7 @@ class RoutingTest extends FunctionalTestCase
         $this->router->setRoutesConfiguration($routesConfiguration);
         $baseUri = new Uri('http://localhost');
         $actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, false));
-        self::assertSame('custom/uri/pattern', (string)$actualResult);
+        self::assertSame('/custom/uri/pattern', (string)$actualResult);
 
         // reset router configuration for following tests
         $this->router->setRoutesConfiguration(null);

--- a/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
@@ -434,7 +434,7 @@ class RoutingTest extends FunctionalTestCase
         $baseUri = new Uri('http://localhost/baz');
         $actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, false));
 
-        $this->assertSame('neos/flow/test/http/foo', (string)$actualResult);
+        $this->assertSame('/baz/neos/flow/test/http/foo', (string)$actualResult);
     }
 
     /**
@@ -452,7 +452,7 @@ class RoutingTest extends FunctionalTestCase
         $baseUri = new Uri('http://localhost/baz');
         $actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, false, 'index.php/'));
 
-        $this->assertSame('index.php/neos/flow/test/http/foo', (string)$actualResult);
+        $this->assertSame('/baz/index.php/neos/flow/test/http/foo', (string)$actualResult);
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/Mvc/UriBuilderTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/UriBuilderTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Tests\Functional\Mvc;
  * source code.
  */
 
+use Neos\Flow\Tests\Functional\Mvc\Fixtures\RoutePartHandler\UriBuilderSetDomainAndPathPrefixRoutePartHandler;
 use Neos\Flow\Tests\Functional\Mvc\Fixtures\RoutePartHandler\UriBuilderSetDomainRoutePartHandler;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Psr\Http\Message\ServerRequestFactoryInterface;
@@ -36,6 +37,11 @@ class UriBuilderTest extends FunctionalTestCase
     {
         parent::setUp();
 
+        $this->serverRequestFactory = $this->objectManager->get(ServerRequestFactoryInterface::class);
+    }
+
+    private function registerSingleRoute($routePartHandler): void
+    {
         $route = $this->registerRoute('testa', 'test/mvc/uribuilder/{@action}/{someRoutePart}', [
             '@package' => 'Neos.Flow',
             '@subpackage' => 'Tests\Functional\Mvc\Fixtures',
@@ -45,11 +51,9 @@ class UriBuilderTest extends FunctionalTestCase
         ]);
         $route->setRoutePartsConfiguration([
             'someRoutePart' => [
-                'handler' => UriBuilderSetDomainRoutePartHandler::class
+                'handler' => $routePartHandler
             ]
         ]);
-
-        $this->serverRequestFactory = $this->objectManager->get(ServerRequestFactoryInterface::class);
     }
 
     /**
@@ -59,6 +63,7 @@ class UriBuilderTest extends FunctionalTestCase
      */
     public function whenLinkingToDifferentHostTheUrlIsAsExpectedNotContainingDoubleSlashes()
     {
+        $this->registerSingleRoute(UriBuilderSetDomainRoutePartHandler::class);
         $response = $this->browser->request('http://localhost/test/mvc/uribuilder/differentHost/bla');
         self::assertEquals('http://my-host/test/mvc/uribuilder/target/my-path', $response->getBody()->getContents());
         self::assertEquals(200, $response->getStatusCode());
@@ -71,6 +76,7 @@ class UriBuilderTest extends FunctionalTestCase
      */
     public function whenLinkingToDifferentHostTheUrlIsAsExpectedNotContainingDoubleSlashes_forceAbsoluteUris()
     {
+        $this->registerSingleRoute(UriBuilderSetDomainRoutePartHandler::class);
         $response = $this->browser->request('http://localhost/test/mvc/uribuilder/differentHostWithCreateAbsoluteUri/bla');
         self::assertEquals('http://my-host/test/mvc/uribuilder/target/my-path', $response->getBody()->getContents());
         self::assertEquals(200, $response->getStatusCode());
@@ -83,6 +89,7 @@ class UriBuilderTest extends FunctionalTestCase
      */
     public function whenLinkingToSameHostTheUrlIsAsExpectedNotContainingDoubleSlashes()
     {
+        $this->registerSingleRoute(UriBuilderSetDomainRoutePartHandler::class);
         $response = $this->browser->request('http://my-host/test/mvc/uribuilder/differentHost/bla');
         self::assertEquals('/test/mvc/uribuilder/target/my-path', $response->getBody()->getContents());
         self::assertEquals(200, $response->getStatusCode());
@@ -95,8 +102,61 @@ class UriBuilderTest extends FunctionalTestCase
      */
     public function whenLinkingToSameHostTheUrlIsAsExpectedNotContainingDoubleSlashes_forceAbsoluteUrls()
     {
+        $this->registerSingleRoute(UriBuilderSetDomainRoutePartHandler::class);
         $response = $this->browser->request('http://my-host/test/mvc/uribuilder/differentHostWithCreateAbsoluteUri/bla');
         self::assertEquals('http://my-host/test/mvc/uribuilder/target/my-path', $response->getBody()->getContents());
+        self::assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * Testcase for https://github.com/neos/flow-development-collection/issues/1803
+     *
+     * @test
+     */
+    public function urlPrefix_whenLinkingToDifferentHostTheUrlIsAsExpectedNotContainingDoubleSlashes()
+    {
+        $this->registerSingleRoute(UriBuilderSetDomainAndPathPrefixRoutePartHandler::class);
+        $response = $this->browser->request('http://localhost/test/mvc/uribuilder/differentHost/bla');
+        self::assertEquals('http://my-host/my-path/test/mvc/uribuilder/target/my-path', $response->getBody()->getContents());
+        self::assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * Testcase for https://github.com/neos/flow-development-collection/issues/1803
+     *
+     * @test
+     */
+    public function urlPrefix_whenLinkingToDifferentHostTheUrlIsAsExpectedNotContainingDoubleSlashes_forceAbsoluteUris()
+    {
+        $this->registerSingleRoute(UriBuilderSetDomainAndPathPrefixRoutePartHandler::class);
+        $response = $this->browser->request('http://localhost/test/mvc/uribuilder/differentHostWithCreateAbsoluteUri/bla');
+        self::assertEquals('http://my-host/my-path/test/mvc/uribuilder/target/my-path', $response->getBody()->getContents());
+        self::assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * Testcase for https://github.com/neos/flow-development-collection/issues/1803
+     *
+     * @test
+     */
+    public function urlPrefix_whenLinkingToSameHostTheUrlIsAsExpectedNotContainingDoubleSlashes()
+    {
+        $this->registerSingleRoute(UriBuilderSetDomainAndPathPrefixRoutePartHandler::class);
+        $response = $this->browser->request('http://my-host/test/mvc/uribuilder/differentHost/bla');
+        self::assertEquals('/my-path/test/mvc/uribuilder/target/my-path', $response->getBody()->getContents());
+        self::assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * Testcase for https://github.com/neos/flow-development-collection/issues/1803
+     *
+     * @test
+     */
+    public function urlPrefix_whenLinkingToSameHostTheUrlIsAsExpectedNotContainingDoubleSlashes_forceAbsoluteUrls()
+    {
+        $this->registerSingleRoute(UriBuilderSetDomainAndPathPrefixRoutePartHandler::class);
+        $response = $this->browser->request('http://my-host/test/mvc/uribuilder/differentHostWithCreateAbsoluteUri/bla');
+        self::assertEquals('http://my-host/my-path/test/mvc/uribuilder/target/my-path', $response->getBody()->getContents());
         self::assertEquals(200, $response->getStatusCode());
     }
 }

--- a/Neos.Flow/Tests/Functional/Mvc/UriBuilderTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/UriBuilderTest.php
@@ -1,0 +1,102 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Mvc;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Tests\Functional\Mvc\Fixtures\RoutePartHandler\UriBuilderSetDomainRoutePartHandler;
+use Neos\Flow\Tests\FunctionalTestCase;
+use Psr\Http\Message\ServerRequestFactoryInterface;
+
+/**
+ * Functional tests for the Router
+ *
+ * HINT: The routes used in these tests are defined in the Routes.yaml file in the
+ *       Testing context of the Flow package configuration.
+ */
+class UriBuilderTest extends FunctionalTestCase
+{
+
+    /**
+     * @var ServerRequestFactoryInterface
+     */
+    protected $serverRequestFactory;
+
+    /**
+     * Additional setup: Routes
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $route = $this->registerRoute('testa', 'test/mvc/uribuilder/{@action}/{someRoutePart}', [
+            '@package' => 'Neos.Flow',
+            '@subpackage' => 'Tests\Functional\Mvc\Fixtures',
+            '@controller' => 'UriBuilder',
+            '@action' => 'index',
+            '@format' => 'html'
+        ]);
+        $route->setRoutePartsConfiguration([
+            'someRoutePart' => [
+                'handler' => UriBuilderSetDomainRoutePartHandler::class
+            ]
+        ]);
+
+        $this->serverRequestFactory = $this->objectManager->get(ServerRequestFactoryInterface::class);
+    }
+
+    /**
+     * Testcase for https://github.com/neos/flow-development-collection/issues/1803
+     *
+     * @test
+     */
+    public function whenLinkingToDifferentHostTheUrlIsAsExpectedNotContainingDoubleSlashes()
+    {
+        $response = $this->browser->request('http://localhost/test/mvc/uribuilder/differentHost/bla');
+        self::assertEquals('http://my-host/test/mvc/uribuilder/target/my-path', $response->getBody()->getContents());
+        self::assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * Testcase for https://github.com/neos/flow-development-collection/issues/1803
+     *
+     * @test
+     */
+    public function whenLinkingToDifferentHostTheUrlIsAsExpectedNotContainingDoubleSlashes_forceAbsoluteUris()
+    {
+        $response = $this->browser->request('http://localhost/test/mvc/uribuilder/differentHostWithCreateAbsoluteUri/bla');
+        self::assertEquals('http://my-host/test/mvc/uribuilder/target/my-path', $response->getBody()->getContents());
+        self::assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * Testcase for https://github.com/neos/flow-development-collection/issues/1803
+     *
+     * @test
+     */
+    public function whenLinkingToSameHostTheUrlIsAsExpectedNotContainingDoubleSlashes()
+    {
+        $response = $this->browser->request('http://my-host/test/mvc/uribuilder/differentHost/bla');
+        self::assertEquals('test/mvc/uribuilder/target/my-path', $response->getBody()->getContents());
+        self::assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * Testcase for https://github.com/neos/flow-development-collection/issues/1803
+     *
+     * @test
+     */
+    public function whenLinkingToSameHostTheUrlIsAsExpectedNotContainingDoubleSlashes_forceAbsoluteUrls()
+    {
+        $response = $this->browser->request('http://my-host/test/mvc/uribuilder/differentHostWithCreateAbsoluteUri/bla');
+        self::assertEquals('http://my-host/test/mvc/uribuilder/target/my-path', $response->getBody()->getContents());
+        self::assertEquals(200, $response->getStatusCode());
+    }
+}

--- a/Neos.Flow/Tests/Functional/Mvc/UriBuilderTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/UriBuilderTest.php
@@ -84,7 +84,7 @@ class UriBuilderTest extends FunctionalTestCase
     public function whenLinkingToSameHostTheUrlIsAsExpectedNotContainingDoubleSlashes()
     {
         $response = $this->browser->request('http://my-host/test/mvc/uribuilder/differentHost/bla');
-        self::assertEquals('test/mvc/uribuilder/target/my-path', $response->getBody()->getContents());
+        self::assertEquals('/test/mvc/uribuilder/target/my-path', $response->getBody()->getContents());
         self::assertEquals(200, $response->getStatusCode());
     }
 

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/UriConstraintsTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/UriConstraintsTest.php
@@ -75,10 +75,12 @@ class UriConstraintsTest extends UnitTestCase
             ['constraints' => [UriConstraints::CONSTRAINT_PATH => '/some/path'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => '/some/path'],
             ['constraints' => [UriConstraints::CONSTRAINT_PATH => '/some/path'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => true, 'expectedUri' => 'http://some-domain.tld/some/path'],
 
-            ['constraints' => [UriConstraints::CONSTRAINT_PATH_PREFIX => '/prefix'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => '/prefix'],
-            ['constraints' => [UriConstraints::CONSTRAINT_PATH_PREFIX => '/prefix'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => true, 'expectedUri' => 'http://some-domain.tld/prefix'],
-            ['constraints' => [UriConstraints::CONSTRAINT_PATH_PREFIX => '/prefix', UriConstraints::CONSTRAINT_PATH => '/some/path'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => '/prefix/some/path'],
-            ['constraints' => [UriConstraints::CONSTRAINT_PATH_PREFIX => '/prefix', UriConstraints::CONSTRAINT_PATH => '/some/path'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => true, 'expectedUri' => 'http://some-domain.tld/prefix/some/path'],
+            ['constraints' => [UriConstraints::CONSTRAINT_PATH_PREFIX => 'prefix'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => '/prefix'],
+            ['constraints' => [UriConstraints::CONSTRAINT_PATH_PREFIX => 'prefix'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => true, 'expectedUri' => 'http://some-domain.tld/prefix'],
+            ['constraints' => [UriConstraints::CONSTRAINT_PATH_PREFIX => 'prefix', UriConstraints::CONSTRAINT_PATH => '/some/path'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => '/prefixsome/path'],
+            ['constraints' => [UriConstraints::CONSTRAINT_PATH_PREFIX => 'prefix/', UriConstraints::CONSTRAINT_PATH => '/some/path'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => '/prefix/some/path'],
+            ['constraints' => [UriConstraints::CONSTRAINT_PATH_PREFIX => 'prefix', UriConstraints::CONSTRAINT_PATH => '/some/path'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => true, 'expectedUri' => 'http://some-domain.tld/prefixsome/path'],
+            ['constraints' => [UriConstraints::CONSTRAINT_PATH_PREFIX => 'prefix/', UriConstraints::CONSTRAINT_PATH => '/some/path'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => true, 'expectedUri' => 'http://some-domain.tld/prefix/some/path'],
 
             ['constraints' => [UriConstraints::CONSTRAINT_PATH_SUFFIX => 'suffix'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => '/suffix'],
             ['constraints' => [UriConstraints::CONSTRAINT_PATH_SUFFIX => 'suffix'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => true, 'expectedUri' => 'http://some-domain.tld/suffix'],

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/UriConstraintsTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/UriConstraintsTest.php
@@ -80,7 +80,7 @@ class UriConstraintsTest extends UnitTestCase
             ['constraints' => [UriConstraints::CONSTRAINT_PATH_PREFIX => '/prefix', UriConstraints::CONSTRAINT_PATH => '/some/path'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => '/prefix/some/path'],
             ['constraints' => [UriConstraints::CONSTRAINT_PATH_PREFIX => '/prefix', UriConstraints::CONSTRAINT_PATH => '/some/path'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => true, 'expectedUri' => 'http://some-domain.tld/prefix/some/path'],
 
-            ['constraints' => [UriConstraints::CONSTRAINT_PATH_SUFFIX => 'suffix'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => 'suffix'],
+            ['constraints' => [UriConstraints::CONSTRAINT_PATH_SUFFIX => 'suffix'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => '/suffix'],
             ['constraints' => [UriConstraints::CONSTRAINT_PATH_SUFFIX => 'suffix'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => true, 'expectedUri' => 'http://some-domain.tld/suffix'],
             ['constraints' => [UriConstraints::CONSTRAINT_PATH_SUFFIX => 'suffix', UriConstraints::CONSTRAINT_PATH => '/some/path'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => '/some/pathsuffix'],
             ['constraints' => [UriConstraints::CONSTRAINT_PATH_SUFFIX => 'suffix', UriConstraints::CONSTRAINT_PATH => '/some/path'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => true, 'expectedUri' => 'http://some-domain.tld/some/pathsuffix'],

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/RouterTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/RouterTest.php
@@ -207,7 +207,7 @@ class RouterTest extends UnitTestCase
         $router->_set('routes', $mockRoutes);
 
         $resolvedUri = $router->resolve(new ResolveContext($this->mockBaseUri, $routeValues, false));
-        self::assertSame('route2', $resolvedUri->getPath());
+        self::assertSame('/route2', $resolvedUri->getPath());
     }
 
     /**
@@ -288,7 +288,7 @@ class RouterTest extends UnitTestCase
         $router->_set('routerCachingService', $mockRouterCachingService);
 
         $router->expects(self::never())->method('createRoutesFromConfiguration');
-        self::assertSame('cached/path', (string)$router->resolve($resolveContext));
+        self::assertSame('/cached/path', (string)$router->resolve($resolveContext));
     }
 
     /**
@@ -314,7 +314,7 @@ class RouterTest extends UnitTestCase
         $router->_set('routes', [$mockRoute1, $mockRoute2]);
 
         $this->mockRouterCachingService->expects(self::once())->method('storeResolvedUriConstraints')->with($resolveContext, $mockResolvedUriConstraints);
-        self::assertSame('resolved/path', (string)$router->resolve($resolveContext));
+        self::assertSame('/resolved/path', (string)$router->resolve($resolveContext));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/UriBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/UriBuilderTest.php
@@ -782,7 +782,7 @@ class UriBuilderTest extends UnitTestCase
     {
         $this->mockHttpRequest->expects(self::atLeastOnce())->method('getServerParams')->willReturn(['SCRIPT_NAME' => '/document-root/index.php']);
         $this->mockRouter->expects(self::once())->method('resolve')->willReturnCallback(function (ResolveContext $resolveContext) {
-            self::assertSame('/document-root/', $resolveContext->getUriPathPrefix());
+            self::assertSame('document-root/', $resolveContext->getUriPathPrefix());
             return $this->getMockBuilder(UriInterface::class)->getMock();
         });
 
@@ -800,7 +800,7 @@ class UriBuilderTest extends UnitTestCase
         $this->inject($this->uriBuilder, 'environment', $mockEnvironment);
 
         $this->mockRouter->expects(self::once())->method('resolve')->willReturnCallback(function (ResolveContext $resolveContext) {
-            self::assertSame('/index.php/', $resolveContext->getUriPathPrefix());
+            self::assertSame('index.php/', $resolveContext->getUriPathPrefix());
             return $this->getMockBuilder(UriInterface::class)->getMock();
         });
 


### PR DESCRIPTION
## Problem Description

(this is hard to explain, checked into this with @bwaidelich).

In case all of the following conditions are met::

1) RoutePartHandler with custom hostname
   - you have a custom RoutePartHandler, which...
   - returns a `ResolveResult`, which ...
   - switches to a different hostname (using `->withHost(...)`
2) and you create a link through through this route,

then: the URL contains two slashes after the hostname (i.e. `http://my-host//test`).

## Steps to Reproduce

(see test case)

## Root Cause Analysis

### Preamble

With Flow 6.0, a very subtle change to the URL handling happened:

- For Flow < 6.0, we had our own Uri implementation, where the withPath() method looked like this: https://github.com/neos/flow-development-collection/blob/5.3/Neos.Flow/Classes/Http/Uri.php#L577-L600.
- For Flow = 6.0, we switched to `GuzzleHttp\Psr7\Uri`, whose method looks like: https://github.com/guzzle/psr7/blob/1.x/src/Uri.php#L487
- pay special attention to the `validateState()` method, which contains this block:
   https://github.com/guzzle/psr7/blob/2595b33c1c924889b474d324f3d719fa40b6954e/src/Uri.php#L750-L757

```php
if ($this->getAuthority() === '') {
...
} elseif (isset($this->path[0]) && $this->path[0] !== '/') {
            @trigger_error(
                'The path of a URI with an authority must start with a slash "/" or be empty. Automagically fixing the URI ' .
                'by adding a leading slash to the path is deprecated since version 1.4 and will throw an exception instead.',
                E_USER_DEPRECATED
            );
            $this->path = '/'. $this->path;
            //throw new \InvalidArgumentException('The path of a URI with an authority must start with a slash "/" or be empty');
        }
```

**This means Guzzle normalizes all URL parts to start with leading slashes, but only if we have an authority set (i.e. a host).**

### Usage in Flow

In Flow, we had the following logic:

- UriBuilder::build() contains a call to RequestInformationHelper::getScriptRequestPath(), which always generates a path starting with a "/". Thus, `$uriPathPrefix` there contains **at least** a `/`.
- **Additional Gimmick**: In the constructor of `ResolveContext`, some logic has been added with #1215 ( + #1185 ), which lead to the situation that **even if $uriPathPrefix would be empty and $forceAbsoluteUri would be `true`, *the `$uriPathPrefix` would still be set to `/`***
- This is then used in `Router::resolve()`, where the path prefix (`/`) from the afoementioned ResolveContext is applied to the `$uriConstraints`.
- Now, in `UriConstraints::applyTo()`, the following block is executed:

```php
        if (isset($this->constraints[self::CONSTRAINT_PATH]) && $this->constraints[self::CONSTRAINT_PATH] !== $templateUri->getPath()) {
            $uri = $uri->withPath($this->constraints[self::CONSTRAINT_PATH]);
        }
        if (isset($this->constraints[self::CONSTRAINT_PATH_PREFIX])) {
            $uri = $uri->withPath($this->constraints[self::CONSTRAINT_PATH_PREFIX] . $uri->getPath());
        }
```

In the first `if`-block, the URI path is set. Normally, this is a *non-absolute path*, but **guzzle normalizes this to be an absolute path** (see the section above).

Then comes the second `if`-block, where a `/` is prepended to the absolute path, leading to the `//` situation.

**NOTE: This error can only be triggered when the RoutePartHandler returns a *different* host than the original one; as otherwise, the auto-prefixing is not done in Guzzle.**.

## How to fix this

- We simply trim the `$uriPathPrefix` to not start with `/` in the UriBuilder.
- Additionally, we add safeguards in `ResolveContext` so that the $uriPathPrefix is never starting with a `/`.
- Additionally, we add safeguards in `UriConstraints` so that the `withPathPrefix` is never generating a prefix starting with a `/`.

Finally, we do a **cleanup**; moving code related to base-URLs-with-paths around a bit (see #1215 + #1185 ); so that this is actually done in the `UriConstraints::applyTo` method.

### Affected Versions

Flow 6.0.0

Resolves: #1803

<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->


**What I did**

**How I did it**

**How to verify it**

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
