### PR TITLE
BUGFIX: Don't overwrite previous Set-Cookie headers in the session component

### DIFF
--- a/Neos.Flow/Classes/Session/Http/SessionResponseComponent.php
+++ b/Neos.Flow/Classes/Session/Http/SessionResponseComponent.php
@@ -38,7 +38,7 @@ class SessionResponseComponent implements ComponentInterface
             return;
         }
 
-        $response = $response->withHeader('Set-Cookie', (string)$currentSession->getSessionCookie());
+        $response = $response->withAddedHeader('Set-Cookie', (string)$currentSession->getSessionCookie());
         $componentContext->replaceHttpResponse($response);
     }
 }


### PR DESCRIPTION
This would e.g. overwrite cookies set with the FlashMessage CookieStorage.

Related to #1807

Replacement for #1808 targeted onto 5.1