### PR TITLE
BUGFIX: Add the FlashMessageComponent to http chain

### DIFF
--- a/Neos.Flow/Configuration/Settings.Http.yaml
+++ b/Neos.Flow/Configuration/Settings.Http.yaml
@@ -67,6 +67,9 @@ Neos:
             'setSessionCookie':
               position: 'start'
               component: 'Neos\Flow\Session\Http\SessionResponseComponent'
+            'flashMessages':
+              position: 'after setSessionCookie'
+              component: 'Neos\Flow\Mvc\FlashMessage\FlashMessageComponent'
             'poweredByHeader':
               component: 'Neos\Flow\Http\Component\PoweredByComponent'
             'standardsCompliance':

--- a/Neos.Flow/Configuration/Settings.Mvc.yaml
+++ b/Neos.Flow/Configuration/Settings.Mvc.yaml
@@ -27,7 +27,7 @@ Neos:
         containers:
           'default':
             position: 'end'
-            storage: 'Neos\Flow\Mvc\FlashMessage\Storage\FlashMessageCookieStorage'
+            storage: 'Neos\Flow\Mvc\FlashMessage\Storage\FlashMessageSessionStorage'
 
           # Custom FlashMessage containers can be added here:
           # Example:


### PR DESCRIPTION
This unfortunately got lost when rebasing the feature and was unnoticed till now.

Needs to be 'after setSessionCookie' because that component always overrides the 'Set-Cookie' header right now (see #1810). Apparently, flash message `CookieStorage` doesn't play well with this, hence we also need to change the default storage to `SessionStorage` at least until that is resolved.

Resolves #1807