### PR TITLE
FEATURE: Add optional nonblocking locking

### DIFF
--- a/Neos.Utility.Lock/Classes/FlockLockStrategy.php
+++ b/Neos.Utility.Lock/Classes/FlockLockStrategy.php
@@ -138,7 +138,7 @@ class FlockLockStrategy implements LockStrategyInterface
     protected function applyFlock(bool $exclusiveLock, bool $nonblocking)
     {
         $lockOption = $exclusiveLock === true ? LOCK_EX : LOCK_SH;
-        if ($nonblocking){
+        if ($nonblocking) {
             $lockOption |= LOCK_NB;
         }
 

--- a/Neos.Utility.Lock/Classes/FlockLockStrategy.php
+++ b/Neos.Utility.Lock/Classes/FlockLockStrategy.php
@@ -138,7 +138,7 @@ class FlockLockStrategy implements LockStrategyInterface
     protected function applyFlock(bool $exclusiveLock, bool $nonblocking)
     {
         $lockOption = $exclusiveLock === true ? LOCK_EX : LOCK_SH;
-        if($nonblocking){
+        if ($nonblocking){
             $lockOption |= LOCK_NB;
         }
 

--- a/Neos.Utility.Lock/Classes/Lock.php
+++ b/Neos.Utility.Lock/Classes/Lock.php
@@ -45,15 +45,16 @@ class Lock
 
     /**
      * @param string $subject
-     * @param boolean $exclusiveLock TRUE to, acquire an exclusive (write) lock, FALSE for a shared (read) lock. An exclusive lock ist the default.
+     * @param boolean $exclusiveLock true to, acquire an exclusive (write) lock, false for a shared (read) lock. An exclusive lock ist the default.
+     * @param boolean $nonblocking true to, acquire the lock in nonblocking mode, false for a blocking lock. A blocking lock is the default.
      */
-    public function __construct(string $subject, bool $exclusiveLock = true)
+    public function __construct(string $subject, bool $exclusiveLock = true, bool $nonblocking = false)
     {
         if (self::$lockManager === null) {
             return;
         }
         $this->lockStrategy = self::$lockManager->getLockStrategyInstance();
-        $this->lockStrategy->acquire($subject, $exclusiveLock);
+        $this->lockStrategy->acquire($subject, $exclusiveLock, $nonblocking);
     }
 
     /**
@@ -78,7 +79,7 @@ class Lock
 
     /**
      * Releases the lock
-     * @return boolean TRUE on success, FALSE otherwise
+     * @return boolean true on success, false otherwise
      */
     public function release(): bool
     {

--- a/Neos.Utility.Lock/Classes/LockStrategyInterface.php
+++ b/Neos.Utility.Lock/Classes/LockStrategyInterface.php
@@ -20,13 +20,14 @@ interface LockStrategyInterface
 {
     /**
      * @param string $subject
-     * @param boolean $exclusiveLock TRUE to, acquire an exclusive (write) lock, FALSE for a shared (read) lock.
+     * @param boolean $exclusiveLock true to, acquire an exclusive (write) lock, false for a shared (read) lock.
+     * @param boolean $nonblocking true to, acquire the lock in nonblocking mode, false for a blocking lock lock.
      * @return void
      */
-    public function acquire($subject, $exclusiveLock);
+    public function acquire(string $subject, bool $exclusiveLock, bool $nonblocking = false);
 
     /**
-     * @return boolean TRUE on success, FALSE otherwise
+     * @return boolean true on success, false otherwise
      */
-    public function release();
+    public function release(): bool;
 }


### PR DESCRIPTION
I added an optional parameter for nonblocking locks. If the lock could not be acquired, the method `applyFlock` throws an Exception.

Before this non blocking feature, it was not possible, that `applyFlock` throws an Exception, since flock always blocked and thus always returned true after successfully acquiring the lock. So this is kind of a bug in the expected interface of the implementation.