### PR TITLE
BUGFIX: Do not renew session id for sessionless tokens being authenti…

### DIFF
--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -18,6 +18,8 @@ use Neos\Flow\Package\PackageManager;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Flow\ResourceManagement\ResourceRepository;
 use Neos\Flow\Security\Authentication\AuthenticationProviderManager;
+use Neos\Flow\Security\Authentication\Token\SessionlessTokenInterface;
+use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\Context;
 
 /**
@@ -109,9 +111,9 @@ class Package extends BasePackage
 
         $dispatcher->connect(Command\CoreCommandController::class, 'finishedCompilationRun', Security\Authorization\Privilege\Method\MethodPrivilegePointcutFilter::class, 'savePolicyCache');
 
-        $dispatcher->connect(Security\Authentication\AuthenticationProviderManager::class, 'authenticatedToken', function () use ($bootstrap) {
+        $dispatcher->connect(Security\Authentication\AuthenticationProviderManager::class, 'authenticatedToken', function (TokenInterface $token) use ($bootstrap) {
             $session = $bootstrap->getObjectManager()->get(Session\SessionInterface::class);
-            if ($session->isStarted()) {
+            if ($session->isStarted() && !$token instanceof SessionlessTokenInterface) {
                 $session->renewId();
             }
         });


### PR DESCRIPTION
After the refactoring of #1407 not all tokens are stored in the SecurityContext, but in the Session. But only those, which do not implement SessionlessTokenInterface (which had been stored in the session before, if a session had been started).
As the tokens are not longer persisted, the provider has no chance, but to authenticate the token with every request (which sounds fine and expectable for me).
But if a session is started, the authentication of a session less token leads to renewal of the session id. Now in every request - which leads to rough times for concurrent requests.

This change makes sure session ids only get renewed, if the token was not sessionless.