### PR TITLE
TASK: Allow finer control of accepted read and write latency of FileBackends

### DIFF
--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
@@ -355,20 +355,28 @@ Options
 
 :title:`Simple file cache backend options`
 
-+-----------------+----------------------------------------+-----------+--------+---------+
-| Option          | Description                            | Mandatory | Type   | Default |
-+=================+========================================+===========+========+=========+
-| cacheDirectory  | Full path leading to a custom cache    | No        | string |         |
-|                 | directory.                             |           |        |         |
-|                 |                                        |           |        |         |
-|                 | :title:`Example:`                      |           |        |         |
-|                 |                                        |           |        |         |
-|                 | * /tmp/my-cache-directory/             |           |        |         |
-+-----------------+----------------------------------------+-----------+--------+---------+
-| defaultLifeTime | Cache entry lifetime is **not          | No        |        |         |
-|                 | supported** in this backend. Entries   |           |        |         |
-|                 | never expire!                          |           |        |         |
-+-----------------+----------------------------------------+-----------+--------+---------+
++-------------------------------------+----------------------------------------+-----------+--------+---------+
+| Option                              | Description                            | Mandatory | Type   | Default |
++=====================================+========================================+===========+========+=========+
+| cacheDirectory                      | Full path leading to a custom cache    | No        | string |         |
+|                                     | directory.                             |           |        |         |
+|                                     |                                        |           |        |         |
+|                                     | :title:`Example:`                      |           |        |         |
+|                                     |                                        |           |        |         |
+|                                     | * /tmp/my-cache-directory/             |           |        |         |
++-------------------------------------+----------------------------------------+-----------+--------+---------+
+| defaultLifeTime                     | Cache entry lifetime is **not          | No        |        |         |
+|                                     | supported** in this backend. Entries   |           |        |         |
+|                                     | never expire!                          |           |        |         |
++-------------------------------------+----------------------------------------+-----------+--------+---------+
+| maxAcceptedReadLatencyMicroSeconds  | Maximal allowed microseconds to spend  | No        | int    | 10000   |
+|                                     | waiting for acquiring a shared lock    |           |        |         |
+|                                     | for reading a cache entry              |           |        |         |
++-------------------------------------+----------------------------------------+-----------+--------+---------+
+| maxAcceptedWriteLatencyMicroSeconds | Maximal allowed microseconds to spend  | No        | int    | 10000   |
+|                                     | waiting for acquiring an exclusive     |           |        |         |
+|                                     | lock for writing a cache entry         |           |        |         |
++-------------------------------------+----------------------------------------+-----------+--------+---------+
 
 Neos\\Cache\\Backend\\FileBackend
 ---------------------------------
@@ -406,16 +414,24 @@ Options
 
 :title:`File cache backend options`
 
-+----------------+----------------------------------------+-----------+--------+---------+
-| Option         | Description                            | Mandatory | Type   | Default |
-+================+========================================+===========+========+=========+
-| cacheDirectory | Full path leading to a custom cache    | No        | string |         |
-|                | directory.                             |           |        |         |
-|                |                                        |           |        |         |
-|                | :title:`Example:`                      |           |        |         |
-|                |                                        |           |        |         |
-|                | * /tmp/my-cache-directory/             |           |        |         |
-+----------------+----------------------------------------+-----------+--------+---------+
++-------------------------------------+----------------------------------------+-----------+--------+---------+
+| Option                              | Description                            | Mandatory | Type   | Default |
++=====================================+========================================+===========+========+=========+
+| cacheDirectory                      | Full path leading to a custom cache    | No        | string |         |
+|                                     | directory.                             |           |        |         |
+|                                     |                                        |           |        |         |
+|                                     | :title:`Example:`                      |           |        |         |
+|                                     |                                        |           |        |         |
+|                                     | * /tmp/my-cache-directory/             |           |        |         |
++-------------------------------------+----------------------------------------+-----------+--------+---------+
+| maxAcceptedReadLatencyMicroSeconds  | Maximal allowed microseconds to spend  | No        | int    | 10000   |
+|                                     | waiting for acquiring a shared lock    |           |        |         |
+|                                     | for reading a cache entry              |           |        |         |
++-------------------------------------+----------------------------------------+-----------+--------+---------+
+| maxAcceptedWriteLatencyMicroSeconds | Maximal allowed microseconds to spend  | No        | int    | 10000   |
+|                                     | waiting for acquiring an exclusive     |           |        |         |
+|                                     | lock for writing a cache entry         |           |        |         |
++-------------------------------------+----------------------------------------+-----------+--------+---------+
 
 Neos\\Cache\\Backend\\PdoBackend
 --------------------------------


### PR DESCRIPTION
This change raises the default maximal wait time for FileBackend operations to 10 ms, while not affecting the performance on filesystems, which are able to react in the previous latency window.

Additionally it minimizes the random factor of waiting, but maintains the randomized acquiring strategy to let eventual races settle, by repeating the randomized wait time until a fixed amount of time has passed.

The amount of time passing is configurable for read and write latency.