### PR TITLE
BUGFIX: Fix setting sub-package key in ActionRequest

### DIFF
--- a/Neos.Flow/Classes/Mvc/ActionRequest.php
+++ b/Neos.Flow/Classes/Mvc/ActionRequest.php
@@ -403,7 +403,7 @@ class ActionRequest implements RequestInterface
      */
     public function setControllerSubpackageKey(?string $subpackageKey): void
     {
-        $this->controllerSubpackageKey = $subpackageKey ?? null;
+        $this->controllerSubpackageKey = (empty($subpackageKey) ? null : $subpackageKey);
     }
 
     /**

--- a/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
@@ -256,7 +256,7 @@ abstract class AbstractController implements ControllerInterface
      * @see forward()
      * @api
      */
-    protected function redirect($actionName, $controllerName = null, $packageKey = null, array $arguments = null, $delay = 0, $statusCode = 303, $format = null)
+    protected function redirect($actionName, $controllerName = null, $packageKey = null, array $arguments = [], $delay = 0, $statusCode = 303, $format = null)
     {
         if ($packageKey !== null && strpos($packageKey, '\\') !== false) {
             list($packageKey, $subpackageKey) = explode('\\', $packageKey, 2);

--- a/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
+++ b/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
@@ -286,7 +286,7 @@ class UriBuilder
      * @see build()
      * @throws Exception\MissingActionNameException if $actionName parameter is empty
      */
-    public function uriFor(string $actionName, array $controllerArguments = [], string $controllerName = null, string $packageKey = null, string $subPackageKey = null)
+    public function uriFor(?string $actionName, array $controllerArguments = [], ?string $controllerName = null, ?string $packageKey = null, ?string $subPackageKey = null)
     {
         if (empty($actionName)) {
             throw new Exception\MissingActionNameException('The URI Builder could not build a URI linking to an action controller because no action name was specified. Please check the stack trace to see which code or template was requesting the link and check the arguments passed to the URI Builder.', 1354629891);

--- a/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
+++ b/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
@@ -285,8 +285,9 @@ class UriBuilder
      * @api
      * @see build()
      * @throws Exception\MissingActionNameException if $actionName parameter is empty
+     * @throws \Neos\Flow\Http\Exception
      */
-    public function uriFor(?string $actionName, array $controllerArguments = [], ?string $controllerName = null, ?string $packageKey = null, ?string $subPackageKey = null)
+    public function uriFor(string $actionName, array $controllerArguments = [], string $controllerName = null, string $packageKey = null, string $subPackageKey = null)
     {
         if (empty($actionName)) {
             throw new Exception\MissingActionNameException('The URI Builder could not build a URI linking to an action controller because no action name was specified. Please check the stack trace to see which code or template was requesting the link and check the arguments passed to the URI Builder.', 1354629891);

--- a/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
+++ b/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
@@ -291,6 +291,9 @@ class UriBuilder
         if (empty($actionName)) {
             throw new Exception\MissingActionNameException('The URI Builder could not build a URI linking to an action controller because no action name was specified. Please check the stack trace to see which code or template was requesting the link and check the arguments passed to the URI Builder.', 1354629891);
         }
+        if (empty($controllerName)) {
+            $controllerName = $this->request->getControllerName();
+        }
         if (empty($packageKey) && empty($subPackageKey)) {
             $subPackageKey = $this->request->getControllerSubpackageKey();
         }
@@ -299,7 +302,7 @@ class UriBuilder
         }
 
         $controllerArguments['@action'] = strtolower($actionName);
-        $controllerArguments['@controller'] = strtolower(empty($controllerName) ? $this->request->getControllerName() : $controllerName);
+        $controllerArguments['@controller'] = strtolower($controllerName);
         $controllerArguments['@package'] = strtolower($packageKey);
         if ($subPackageKey !== null) {
             $controllerArguments['@subpackage'] = strtolower($subPackageKey);

--- a/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
+++ b/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
@@ -286,28 +286,25 @@ class UriBuilder
      * @see build()
      * @throws Exception\MissingActionNameException if $actionName parameter is empty
      */
-    public function uriFor($actionName, $controllerArguments = [], $controllerName = null, $packageKey = null, $subPackageKey = null)
+    public function uriFor(string $actionName, array $controllerArguments = [], string $controllerName = null, string $packageKey = null, string $subPackageKey = null)
     {
-        if ($actionName === null || $actionName === '') {
+        if (empty($actionName)) {
             throw new Exception\MissingActionNameException('The URI Builder could not build a URI linking to an action controller because no action name was specified. Please check the stack trace to see which code or template was requesting the link and check the arguments passed to the URI Builder.', 1354629891);
         }
-        $controllerArguments['@action'] = strtolower($actionName);
-        if ($controllerName !== null) {
-            $controllerArguments['@controller'] = strtolower($controllerName);
-        } else {
-            $controllerArguments['@controller'] = strtolower($this->request->getControllerName());
-        }
-        if ($packageKey === null && $subPackageKey === null) {
+        if (empty($packageKey) && empty($subPackageKey)) {
             $subPackageKey = $this->request->getControllerSubpackageKey();
         }
-        if ($packageKey === null) {
+        if (empty($packageKey)) {
             $packageKey = $this->request->getControllerPackageKey();
         }
+
+        $controllerArguments['@action'] = strtolower($actionName);
+        $controllerArguments['@controller'] = strtolower(empty($controllerName) ? $this->request->getControllerName() : $controllerName);
         $controllerArguments['@package'] = strtolower($packageKey);
         if ($subPackageKey !== null) {
             $controllerArguments['@subpackage'] = strtolower($subPackageKey);
         }
-        if ($this->format !== null && $this->format !== '') {
+        if (!empty($this->format)) {
             $controllerArguments['@format'] = $this->format;
         }
 

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/UriBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/UriBuilderTest.php
@@ -149,7 +149,7 @@ class UriBuilderTest extends UnitTestCase
     public function uriForThrowsExceptionIfActionNameIsNotSpecified()
     {
         $this->expectException(Mvc\Routing\Exception\MissingActionNameException::class);
-        $this->uriBuilder->uriFor(null, [], 'SomeController', 'SomePackage');
+        $this->uriBuilder->uriFor('', [], 'SomeController', 'SomePackage');
     }
 
     /**
@@ -221,7 +221,7 @@ class UriBuilderTest extends UnitTestCase
 
         $expectedArguments = ['@action' => 'show', '@controller' => 'somecontroller', '@package' => 'somepackage', '@subpackage' => ''];
 
-        $this->uriBuilder->uriFor('show', null, 'SomeController', 'SomePackage', '');
+        $this->uriBuilder->uriFor('show', [], 'SomeController', 'SomePackage', '');
         self::assertEquals($expectedArguments, $this->uriBuilder->getLastArguments());
     }
 


### PR DESCRIPTION
The ActionRequest needs to set the sub-package key to null when an
empty string is input. This used to be the case earlier and the
handling is effectively just reverted to that behaviour by this.

Fixes #1819