### PR TITLE
FEATURE: Optional argument to kickstart package with custom package directory

### DIFF
--- a/Neos.Flow/Classes/Composer/ComposerUtility.php
+++ b/Neos.Flow/Classes/Composer/ComposerUtility.php
@@ -22,6 +22,8 @@ use Neos\Utility\Files;
  */
 class ComposerUtility
 {
+    public const FLOW_PACKAGE_TYPE_PREFIXES = ['typo3-flow-', 'neos-'];
+
     /**
      * Runtime cache for composer.json data
      *
@@ -116,7 +118,7 @@ class ComposerUtility
      */
     public static function isFlowPackageType(string $packageType): bool
     {
-        foreach (['typo3-flow-', 'neos-'] as $allowedPackageTypePrefix) {
+        foreach (self::FLOW_PACKAGE_TYPE_PREFIXES as $allowedPackageTypePrefix) {
             if (strpos($packageType, $allowedPackageTypePrefix) === 0) {
                 return true;
             }

--- a/Neos.Kickstarter/Classes/Command/KickstartCommandController.php
+++ b/Neos.Kickstarter/Classes/Command/KickstartCommandController.php
@@ -18,6 +18,7 @@ use Neos\Utility\Arrays;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
 use Neos\Kickstarter\Utility\Validation;
+use Neos\Utility\Files;
 
 /**
  * Command controller for the Kickstart generator
@@ -47,10 +48,11 @@ class KickstartCommandController extends CommandController
      *
      * @param string $packageKey The package key, for example "MyCompany.MyPackageName"
      * @param string $packageType Optional package type, e.g. "neos-plugin"
+     * @param string $packageDirectory Optional package directory
      * @return string
      * @see neos.flow:package:create
      */
-    public function packageCommand($packageKey, $packageType = PackageInterface::DEFAULT_COMPOSER_TYPE)
+    public function packageCommand($packageKey, $packageType = PackageInterface::DEFAULT_COMPOSER_TYPE, string $packageDirectory = null)
     {
         $this->validatePackageKey($packageKey);
 
@@ -64,7 +66,16 @@ class KickstartCommandController extends CommandController
             $this->quit(1);
         }
 
-        $this->packageManager->createPackage($packageKey, ['type' => $packageType]);
+        $packagesPath = null;
+        if ($packageDirectory !== null) {
+            $packagesPath = Files::concatenatePaths([
+                FLOW_PATH_ROOT,
+                $packageDirectory,
+                $this->packageManager->getPackagesPathByType($packageType, false),
+            ]);
+        }
+
+        $this->packageManager->createPackage($packageKey, ['type' => $packageType], $packagesPath);
         $this->actionControllerCommand($packageKey, 'Standard');
         $this->documentationCommand($packageKey);
     }


### PR DESCRIPTION
I added a new optional argument to specify a custom package directory to the kickstart:package command.

Usage:

`./flow kickstart:package Acme.Demo --package-directory=Plugins`

The command will create the new package in the specified directory and also create a symbolic link within the default package directory, e.g. `Packages`.

Belongs to https://github.com/neos/flow-development-collection/issues/1680