### PR TITLE
FEATURE: Allow split sources for all configurations

### DIFF
--- a/Neos.Flow/Classes/Configuration/ConfigurationManager.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationManager.php
@@ -117,10 +117,10 @@ class ConfigurationManager
      * @var array
      */
     protected $configurationTypes = [
-        self::CONFIGURATION_TYPE_CACHES => ['processingType' => self::CONFIGURATION_PROCESSING_TYPE_DEFAULT, 'allowSplitSource' => false],
-        self::CONFIGURATION_TYPE_OBJECTS => ['processingType' => self::CONFIGURATION_PROCESSING_TYPE_OBJECTS, 'allowSplitSource' => false],
-        self::CONFIGURATION_TYPE_ROUTES => ['processingType' => self::CONFIGURATION_PROCESSING_TYPE_ROUTES, 'allowSplitSource' => false],
-        self::CONFIGURATION_TYPE_POLICY => ['processingType' => self::CONFIGURATION_PROCESSING_TYPE_POLICY, 'allowSplitSource' => false],
+        self::CONFIGURATION_TYPE_CACHES => ['processingType' => self::CONFIGURATION_PROCESSING_TYPE_DEFAULT, 'allowSplitSource' => true],
+        self::CONFIGURATION_TYPE_OBJECTS => ['processingType' => self::CONFIGURATION_PROCESSING_TYPE_OBJECTS, 'allowSplitSource' => true],
+        self::CONFIGURATION_TYPE_ROUTES => ['processingType' => self::CONFIGURATION_PROCESSING_TYPE_ROUTES, 'allowSplitSource' => true],
+        self::CONFIGURATION_TYPE_POLICY => ['processingType' => self::CONFIGURATION_PROCESSING_TYPE_POLICY, 'allowSplitSource' => true],
         self::CONFIGURATION_TYPE_SETTINGS => ['processingType' => self::CONFIGURATION_PROCESSING_TYPE_SETTINGS, 'allowSplitSource' => true]
     ];
 
@@ -282,7 +282,7 @@ class ConfigurationManager
      * @throws \InvalidArgumentException on invalid configuration processing type
      * @return void
      */
-    public function registerConfigurationType(string $configurationType, string $configurationProcessingType = self::CONFIGURATION_PROCESSING_TYPE_DEFAULT, bool $allowSplitSource = false)
+    public function registerConfigurationType(string $configurationType, string $configurationProcessingType = self::CONFIGURATION_PROCESSING_TYPE_DEFAULT, bool $allowSplitSource = true)
     {
         $configurationProcessingTypes = [
             self::CONFIGURATION_PROCESSING_TYPE_DEFAULT,

--- a/Neos.Flow/Classes/Configuration/ConfigurationManager.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationManager.php
@@ -119,7 +119,7 @@ class ConfigurationManager
     protected $configurationTypes = [
         self::CONFIGURATION_TYPE_CACHES => ['processingType' => self::CONFIGURATION_PROCESSING_TYPE_DEFAULT, 'allowSplitSource' => true],
         self::CONFIGURATION_TYPE_OBJECTS => ['processingType' => self::CONFIGURATION_PROCESSING_TYPE_OBJECTS, 'allowSplitSource' => true],
-        self::CONFIGURATION_TYPE_ROUTES => ['processingType' => self::CONFIGURATION_PROCESSING_TYPE_ROUTES, 'allowSplitSource' => true],
+        self::CONFIGURATION_TYPE_ROUTES => ['processingType' => self::CONFIGURATION_PROCESSING_TYPE_ROUTES, 'allowSplitSource' => false],
         self::CONFIGURATION_TYPE_POLICY => ['processingType' => self::CONFIGURATION_PROCESSING_TYPE_POLICY, 'allowSplitSource' => true],
         self::CONFIGURATION_TYPE_SETTINGS => ['processingType' => self::CONFIGURATION_PROCESSING_TYPE_SETTINGS, 'allowSplitSource' => true]
     ];

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Configuration.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Configuration.rst
@@ -65,11 +65,11 @@ defined in their own dedicated file:
 ``Objects.yaml``
   Contains object configuration, i.e. options which configure objects and the
   combination of those on a lower level. See the :ref:`ch-object-management` chapter for more
-  information.
+  information. Objects have `Split configuration sources`_ enabled.
 
 ``Policy.yaml``
   Contains the configuration of the security policies of the system. See the :ref:`ch-security`
-  chapter for details.
+  chapter for details. Policy has `Split configuration sources`_ enabled.
 
 ``PackageStates.php``
   Contains a list of packages and their current state, for  example if they are active
@@ -81,6 +81,7 @@ defined in their own dedicated file:
   configuration file are registered in an early stage of the boot process and profit
   from mechanisms such as automatic flushing by the File Monitor. See the chapter about
   the :ref:`ch-caching` for details.
+  Caches have `Split configuration sources`_ enabled.
 
 ``Views.yaml``
   Contains configurations for Views, for example the lookup paths for templates.
@@ -104,7 +105,7 @@ which come with the Flow distribution for getting more examples.
 .. code-block:: yaml
 
     #                                                                        #
-    # Settings Configuration for the Neos.Viewhelpertest Package            #
+    # Settings Configuration for the Neos.Viewhelpertest Package             #
     #                                                                        #
 
     Neos:
@@ -229,8 +230,8 @@ configuration of type ``Models`` is requested:
         Models.Quux.yaml
 
 .. note::
-    Split configuration is only supported for the ``CONFIGURATION_PROCESSING_TYPE_DEFAULT`` and
-    ``CONFIGURATION_PROCESSING_TYPE_SETTINGS`` processing types.
+    Split configuration is supported for all except ``CONFIGURATION_PROCESSING_TYPE_ROUTES`` processing types.
+    This is because Routing uses a custom include semantic that shares the naming convention with split sources.
 
 Accessing Settings
 ==================


### PR DESCRIPTION
This change sets `$allowSplitSource` to `true` for all configuration types.

In addition it changes the default value for that flag to true in the method
`registerConfigurationType()`.

Resolves #603 