### PR TITLE
Remove JSON_PRETTY_PRINT

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/DataTypes/JsonArrayType.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/DataTypes/JsonArrayType.php
@@ -131,7 +131,7 @@ class JsonArrayType extends DoctrineJsonArrayType
         $this->initializeDependencies();
         $this->encodeObjectReferences($array);
 
-        return json_encode($array, JSON_PRETTY_PRINT | JSON_FORCE_OBJECT | JSON_UNESCAPED_UNICODE);
+        return json_encode($array, JSON_FORCE_OBJECT | JSON_UNESCAPED_UNICODE);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/DataTypes/JsonArrayTypeTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/DataTypes/JsonArrayTypeTest.php
@@ -54,6 +54,6 @@ class JsonArrayTypeTest extends UnitTestCase
     public function passSimpleArrayAndConvertToJson()
     {
         $json = $this->jsonArrayTypeMock->convertToDatabaseValue(['simplestring',1,['nestedArray']], $this->abstractPlatformMock);
-        self::assertEquals("{\n    \"0\": \"simplestring\",\n    \"1\": 1,\n    \"2\": {\n        \"0\": \"nestedArray\"\n    }\n}", $json);
+        self::assertEquals('{"0":"simplestring","1":1,"2":{"0":"nestedArray"}}', $json);
     }
 }


### PR DESCRIPTION
This removes saving JSON with pretty print in our Doctrine `JsonArrayType`,
saving the extra bytes.