### PR TITLE
BUGFIX: Always run composer from Flow root path

### DIFF
--- a/Neos.Flow/Classes/Package/PackageManager.php
+++ b/Neos.Flow/Classes/Package/PackageManager.php
@@ -20,6 +20,8 @@ use Neos\Flow\SignalSlot\Dispatcher;
 use Neos\Utility\Files;
 use Neos\Utility\OpcodeCacheHelper;
 use Neos\Flow\Package\Exception as PackageException;
+use Composer\Console\Application as ComposerApplication;
+use Symfony\Component\Console\Input\ArrayInput;
 
 /**
  * The default Flow Package Manager
@@ -383,7 +385,19 @@ class PackageManager implements PackageManagerInterface
         $manifest = ComposerUtility::writeComposerManifest($packagePath, $packageKey, $manifest);
 
         if ($runComposerRequireForTheCreatedPackage) {
-            exec('composer require ' . $manifest['name'] . ' @dev');
+            $composerRequireArguments = new ArrayInput([
+                'command' => 'require',
+                'packages' => [$manifest['name'] . ' @dev'],
+                '--working-dir' => FLOW_PATH_ROOT
+            ]);
+
+            $composerApplication = new ComposerApplication();
+            $composerApplication->setAutoExit(false);
+            $composerErrorCode = $composerApplication->run($composerRequireArguments);
+
+            if ($composerErrorCode !== 0) {
+                throw new Exception("The installation was not successful. Composer returned the error code: $composerErrorCode", 1572187932);
+            }
         }
 
         $refreshedPackageStatesConfiguration = $this->rescanPackages();

--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -44,7 +44,9 @@
         "symfony/console": "~4.1.1",
 
         "neos/composer-plugin": "^2.0.0",
-        "neos/utility-pdo": "~5.2.0"
+        "neos/utility-pdo": "~5.2.0",
+
+        "composer/composer": "^1.9"
     },
     "replace": {
         "typo3/flow": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "symfony/dom-crawler": "~4.1.5",
         "symfony/console": "~4.1.1",
         "neos/composer-plugin": "^2.0.0",
+        "composer/composer": "^1.9",
         "typo3fluid/fluid": "~2.5.3",
         "ext-mbstring": "*"
     },
@@ -111,7 +112,6 @@
     "require-dev": {
         "mikey179/vfsstream": "~1.6",
         "phpunit/phpunit": "~7.1",
-        "neos/flow": "*",
         "doctrine/orm": "~2.6.0",
         "doctrine/common": ">=2.4,<2.8-dev"
     },


### PR DESCRIPTION
This bugfix ensures, that the `composer require` command always gets executed in the Flow root path (by calling composer require with the --working-direcory flag set to `FLOW_PATH_ROOT `.)

It also introduces the `composer/composer` package to the codebase to replace the `exec` command.

Fixes #1832
Fixes #1778
