### PR TITLE
BUGFIX: Set-Cookie headers mustn't be imploded

### DIFF
--- a/Neos.Flow/Classes/Http/Helper/ResponseInformationHelper.php
+++ b/Neos.Flow/Classes/Http/Helper/ResponseInformationHelper.php
@@ -121,7 +121,13 @@ abstract class ResponseInformationHelper
 
         $preparedHeaders[] = $statusHeader;
         foreach ($response->getHeaders() as $name => $values) {
-            $preparedHeaders[] = $name . ': ' . implode(', ', $values);
+            if (strtolower($name) === 'set-cookie') {
+                foreach ($values as $value) {
+                    $preparedHeaders[] = $name . ': ' . $value;
+                }
+            } else {
+                $preparedHeaders[] = $name . ': ' . implode(', ', $values);
+            }
         }
 
         return $preparedHeaders;

--- a/Neos.Flow/Classes/Http/RequestHandler.php
+++ b/Neos.Flow/Classes/Http/RequestHandler.php
@@ -167,7 +167,7 @@ class RequestHandler implements HttpRequestHandlerInterface
         $response = $this->componentContext->getHttpResponse();
         ob_implicit_flush(1);
         foreach (ResponseInformationHelper::prepareHeaders($response) as $prepareHeader) {
-            header($prepareHeader);
+            header($prepareHeader, false);
         }
         // Flush and stop all output buffers before sending the whole body in one go, as output buffering has no use any more
         // and just makes sending large files impossible without running out of memory


### PR DESCRIPTION
PSR-7 `getHeaderLine()` defaults to concatenating header values with a comma. This doesn't work for the `Set-Cookie` header, so it must be treated uniquely.

Now having multiple headers of the same name, `header()` must be used without replacement of duplicate headers (which is default).

See:
https://www.php-fig.org/psr/psr-7/#headers-with-multiple-values
https://tools.ietf.org/html/rfc7230#section-3.2.2
https://github.com/guzzle/psr7/issues/298

/cc @kitsunet @albe 