### PR TITLE
TASK: Use yield instead of AppendIterator in getObjects

### DIFF
--- a/Neos.Flow/Classes/ResourceManagement/Collection.php
+++ b/Neos.Flow/Classes/ResourceManagement/Collection.php
@@ -157,22 +157,15 @@ class Collection implements CollectionInterface
      */
     public function getObjects(callable $callback = null)
     {
-        $objects = [];
         if ($this->storage instanceof PackageStorage && $this->pathPatterns !== []) {
-            $objects = new \AppendIterator();
             foreach ($this->pathPatterns as $pathPattern) {
-                $objects->append($this->storage->getObjectsByPathPattern($pathPattern, $callback));
+                foreach ($this->storage->getObjectsByPathPattern($pathPattern, $callback) as $storageObject) {
+                    yield $storageObject;
+                }
             }
         } else {
-            $objects = $this->storage->getObjectsByCollection($this, $callback);
+            return $this->storage->getObjectsByCollection($this, $callback);
         }
-
-        // TODO: Implement filter manipulation here:
-        // foreach ($objects as $object) {
-        // 	$object->setStream(function() { return fopen('/tmp/test.txt', 'rb');});
-        // }
-
-        return $objects;
     }
 
     /**


### PR DESCRIPTION
The method docblock stated that it returns a `Generator`, while in reality for a `PackageStorage` with patterns, it would fall back to an `AppendIterator`.
This change instead makes use of `yield` to return the `StorageObjects` in a memory-efficient manner.