### PR TITLE
BUGFIX: fix resource publishing

### DIFF
--- a/Neos.Flow/Classes/ResourceManagement/Collection.php
+++ b/Neos.Flow/Classes/ResourceManagement/Collection.php
@@ -164,8 +164,11 @@ class Collection implements CollectionInterface
                 }
             }
         } else {
-            return $this->storage->getObjectsByCollection($this, $callback);
+            yield from $this->storage->getObjectsByCollection($this, $callback);
         }
+
+        // NOTE: NEVER mix "return" and "yield" in the same function; this
+        // leads to totally unpredictable effects.
     }
 
     /**


### PR DESCRIPTION
This fixes a regression introduced in #1842:

In this change, a "yield" and a "return" call were introduced in the
same method; so that the early return was not properly executed
because PHP somehow thought this is a fully-suspendable function,
although only one part of the "if"-statement was suspendable.

Related: #1842