### PR TITLE
FEATURE: Allow StringLengthValidator to ignore HTML tags

### DIFF
--- a/Neos.Flow/Classes/Validation/Validator/StringLengthValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/StringLengthValidator.php
@@ -26,7 +26,8 @@ class StringLengthValidator extends AbstractValidator
      */
     protected $supportedOptions = [
         'minimum' => [0, 'Minimum length for a valid string', 'integer'],
-        'maximum' => [PHP_INT_MAX, 'Maximum length for a valid string', 'integer']
+        'maximum' => [PHP_INT_MAX, 'Maximum length for a valid string', 'integer'],
+        'ignoreHtml' => [false, 'If true, HTML tags will be stripped before counting the characters', 'boolean'],
     ];
 
     /**
@@ -56,6 +57,9 @@ class StringLengthValidator extends AbstractValidator
             return;
         }
 
+        if (isset($this->options['ignoreHtml']) && $this->options['ignoreHtml'] === true) {
+            $value = strip_tags($value);
+        }
         $stringLength = Unicode\Functions::strlen($value);
         $isValid = true;
         if ($stringLength < $this->options['minimum']) {

--- a/Neos.Flow/Tests/Unit/Validation/Validator/StringLengthValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/StringLengthValidatorTest.php
@@ -206,4 +206,22 @@ class StringLengthValidatorTest extends AbstractValidatorTestcase
         $this->validatorOptions(['maximum' => 8]);
         self::assertFalse($this->validator->validate('überlang')->hasErrors());
     }
+
+    /**
+     * @test
+     */
+    public function validateCountsHtmlTagsByDefault()
+    {
+        $this->validatorOptions(['maximum' => 14]);
+        $this->assertTrue($this->validator->validate('Some <b>bold</b> text')->hasErrors());
+    }
+
+    /**
+     * @test
+     */
+    public function validateStripsHtmlTagsIfIgnoreHtmlOptionIsSet()
+    {
+        $this->validatorOptions(['maximum' => 14, 'ignoreHtml' => true]);
+        $this->assertFalse($this->validator->validate('Some <b>bold</b> text')->hasErrors());
+    }
 }


### PR DESCRIPTION
Adds an option `ignoreHtml` to the `StringLengthValidator`

Usage:

    $validator = new StringLengthValidator(['maximum' => 14, 'ignoreHtml' => true]);
    $validator->validate('Some <b>bold</b> text')->hasErrors(); // false

Resolves: neos/neos-ui#2579