### PR TITLE
BUGFIX: Ensure ActionReponse properties end up in any HttpResponse

### DIFF
--- a/Neos.Flow/Classes/Mvc/ActionResponse.php
+++ b/Neos.Flow/Classes/Mvc/ActionResponse.php
@@ -38,9 +38,12 @@ final class ActionResponse
     /**
      * The HTTP status code
      *
-     * @var integer
+     * Note the getter has a default value,
+     * but internally this can be null to signify a status code was never set explicitly.
+     *
+     * @var integer|null
      */
-    protected $statusCode = 200;
+    protected $statusCode;
 
     /**
      * @var string
@@ -185,7 +188,7 @@ final class ActionResponse
      */
     public function getStatusCode(): int
     {
-        return $this->statusCode;
+        return $this->statusCode ?? 200;
     }
 
     /**
@@ -205,6 +208,7 @@ final class ActionResponse
         if ($this->hasContent()) {
             $actionResponse->setContent($this->content);
         }
+
         if ($this->contentType !== null) {
             $actionResponse->setContentType($this->contentType);
         }
@@ -236,8 +240,9 @@ final class ActionResponse
     public function mergeIntoComponentContext(ComponentContext $componentContext): ComponentContext
     {
         $httpResponse = $componentContext->getHttpResponse();
-        $httpResponse = $httpResponse
-            ->withStatus($this->statusCode);
+        if ($this->statusCode !== null) {
+            $httpResponse = $httpResponse->withStatus($this->statusCode);
+        }
 
         if ($this->hasContent()) {
             $httpResponse = $httpResponse->withBody($this->content);
@@ -280,9 +285,8 @@ final class ActionResponse
      */
     public function applyToHttpResponse(ResponseInterface $httpResponse): ResponseInterface
     {
-        if ($this->statusCode !== 200) {
-            $httpResponse = $httpResponse
-                ->withStatus($this->statusCode);
+        if ($this->statusCode !== null) {
+            $httpResponse = $httpResponse->withStatus($this->statusCode);
         }
 
         if ($this->hasContent()) {

--- a/Neos.Flow/Classes/Mvc/ActionResponse.php
+++ b/Neos.Flow/Classes/Mvc/ActionResponse.php
@@ -289,7 +289,7 @@ final class ActionResponse
             $httpResponse = $httpResponse->withBody($this->content);
         }
 
-        if ($this->contentType) {
+        if ($this->contentType !== null) {
             $httpResponse = $httpResponse->withHeader('Content-Type', $this->contentType);
         }
 

--- a/Neos.Flow/Classes/Mvc/ActionResponse.php
+++ b/Neos.Flow/Classes/Mvc/ActionResponse.php
@@ -293,7 +293,7 @@ final class ActionResponse
             $httpResponse = $httpResponse->withHeader('Content-Type', $this->contentType);
         }
 
-        if ($this->redirectUri) {
+        if ($this->redirectUri !== null) {
             $httpResponse = $httpResponse->withHeader('Location', (string)$this->redirectUri);
         }
 

--- a/Neos.Flow/Classes/Mvc/Controller/ActionController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ActionController.php
@@ -767,7 +767,8 @@ class ActionController extends AbstractController
         }
 
         if ($result instanceof ResponseInterface) {
-            $this->response->setComponentParameter(ReplaceHttpResponseComponent::class, ReplaceHttpResponseComponent::PARAMETER_RESPONSE, $result);
+            $finalResponse = $this->response->applyToHttpResponse($result);
+            $this->response->setComponentParameter(ReplaceHttpResponseComponent::class, ReplaceHttpResponseComponent::PARAMETER_RESPONSE, $finalResponse);
         }
 
         if (is_object($result) && is_callable([$result, '__toString'])) {


### PR DESCRIPTION
To fix a bug in Neos this ensures that the ActionReponse properties
are applied to a HTTP response rendered
by a View (a new feature in 6.0).

Technically this should not be necessary as any HTTP response rendered
by a View should be understood as being "complete", sadly that is not
always the case with plugins and widgets so we need to take this detour
for now to apply the properties. In the future this should happen in
the respective Views directly and no longer be the responsiblity of
the MVC or HTTP layer.
