### PR TITLE
BUGFIX: Check existence and disable new rendering limitations

### DIFF
--- a/Neos.Flow/Classes/Cli/ConsoleOutput.php
+++ b/Neos.Flow/Classes/Cli/ConsoleOutput.php
@@ -389,6 +389,12 @@ class ConsoleOutput
     {
         if ($this->progressBar === null) {
             $this->progressBar = new ProgressBar($this->output);
+            if (is_callable([$this->progressBar, 'minSecondsBetweenRedraws'])) {
+                $this->progressBar->minSecondsBetweenRedraws(0);
+            }
+            if (is_callable([$this->progressBar, 'maxSecondsBetweenRedraws'])) {
+                $this->progressBar->maxSecondsBetweenRedraws(0);
+            }
         }
         return $this->progressBar;
     }


### PR DESCRIPTION
The symfony/console package got new limitations for rendering
the progress bar in quick succession with minor version 4.4.

We need to disable these limitations by default for now as they
break our own tests.

We should think about following the defaults in the future and
adjust our tests accordingly.
