### PR TITLE
TASK: Remove version number from ext-json dependency

### DIFF
--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -10,7 +10,7 @@
 
         "ext-zlib": "*",
         "ext-SPL": "*",
-        "ext-json": "^1.2",
+        "ext-json": "*",
         "ext-reflection": "*",
         "ext-xml": "*",
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "psr/log": "^1.0",
         "ext-zlib": "*",
         "ext-SPL": "*",
-        "ext-json": "^1.2",
+        "ext-json": "*",
         "ext-reflection": "*",
         "ext-xml": "*",
         "psr/http-message": "^1.0",


### PR DESCRIPTION
This has been at ^1.2 for ages, basically since Flow exists. Now, that
version is really, really old (from 2006) and the package has long been
moved from PECL into the PHP source (see https://pecl.php.net/package/json)

With PHP 7.4.0RC6 (at least), the version reported for ext-json is the
same as the PHP version, this blocks installation via composer.

Those two facts seems to warrant a simple * for that extension dependency,
like for the other PHP extensions we depend on.
