### PR TITLE
BUGFIX: Uploaded file upcasting with multiple files

### DIFF
--- a/Neos.Flow/Classes/Http/Helper/UploadedFilesHelper.php
+++ b/Neos.Flow/Classes/Http/Helper/UploadedFilesHelper.php
@@ -31,19 +31,20 @@ abstract class UploadedFilesHelper
         $upcastedUploads = [];
 
         foreach ($uploadedFiles as $key => $value) {
-            $currentPath[] = $key;
             if ($value instanceof UploadedFileInterface) {
-                $originallySubmittedResourcePath = array_merge($currentPath, ['originallySubmittedResource']);
-                $collectionNamePath = array_merge($currentPath, ['__collectionName']);
+                $originallySubmittedResourcePath = array_merge($currentPath, [$key, 'originallySubmittedResource']);
+                $collectionNamePath = array_merge($currentPath, [$key, '__collectionName']);
                 $upcastedUploads[$key] = self::upcastUploadedFile(
                     $value,
                     Arrays::getValueByPath($arguments, $originallySubmittedResourcePath),
                     Arrays::getValueByPath($arguments, $collectionNamePath)
                 );
-            }
-
-            if (is_array($value)) {
-                $upcastedUploads[$key] = self::upcastUploadedFiles($value, $arguments, $currentPath);
+            } elseif (is_array($value)) {
+                $upcastedUploads[$key] = self::upcastUploadedFiles(
+                    $value,
+                    $arguments,
+                    array_merge($currentPath, [$key])
+                );
             }
         }
 


### PR DESCRIPTION
When uploading multiple files (i.e. in an array), the existing files (persisted resource) would be dropped.

By modifying the `$currentPath` value, Flow built a wrong path:
The first file would be fine - f.e. path "files.0", but the second one will fail due to the path being "files.0.1" instead of "files.1".

fixes #1857 