### PR TITLE
TASK: Add a primary key to "tags" table for MySQL/MariaDB

### DIFF
--- a/Neos.Cache/Resources/Private/mysql.DDL.sql
+++ b/Neos.Cache/Resources/Private/mysql.DDL.sql
@@ -8,7 +8,7 @@ CREATE TABLE "cache" (
   "lifetime" INTEGER UNSIGNED DEFAULT '0' NOT NULL,
   "content" MEDIUMTEXT,
   PRIMARY KEY ("identifier", "cache", "context")
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE "tags" (
   "pk" INT NOT NULL AUTO_INCREMENT,
@@ -17,7 +17,7 @@ CREATE TABLE "tags" (
   "context" VARCHAR(150) NOT NULL,
   "tag" VARCHAR(250) NOT NULL,
   PRIMARY KEY ("pk")
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 CREATE INDEX "identifier" ON tags ("identifier", "cache", "context");
 CREATE INDEX "tag" ON "tags" ("tag");
 

--- a/Neos.Cache/Resources/Private/mysql.DDL.sql
+++ b/Neos.Cache/Resources/Private/mysql.DDL.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+CREATE TABLE "cache" (
+  "identifier" VARCHAR(250) NOT NULL,
+  "cache" VARCHAR(250) NOT NULL,
+  "context" VARCHAR(150) NOT NULL,
+  "created" INTEGER UNSIGNED NOT NULL,
+  "lifetime" INTEGER UNSIGNED DEFAULT '0' NOT NULL,
+  "content" MEDIUMTEXT,
+  PRIMARY KEY ("identifier", "cache", "context")
+);
+
+CREATE TABLE "tags" (
+  "pk" INT NOT NULL AUTO_INCREMENT,
+  "identifier" VARCHAR(250) NOT NULL,
+  "cache" VARCHAR(250) NOT NULL,
+  "context" VARCHAR(150) NOT NULL,
+  "tag" VARCHAR(250) NOT NULL,
+  PRIMARY KEY ("pk")
+);
+CREATE INDEX "identifier" ON tags ("identifier", "cache", "context");
+CREATE INDEX "tag" ON "tags" ("tag");
+
+COMMIT;

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
@@ -426,22 +426,12 @@ to clean up hard disk space or memory.
 
 .. note::
 
-  There is currently very little production experience with this  backend, especially
-  not with a capable database like Oracle. We appreciate any feedback for real life use
-  cases of this cache.
+  The definition for the cache tables can be found in the directory
+  ``Neos.Cache/Resources/Private/``.
 
-.. note::
-
-  When *not using SQLite*, you have to create the needed caching tables manually.
-  The table definition (as used automatically for SQLite) can be found in the
-  file ``Neos.Flow/Resources/Private/Cache/SQL/DDL.sql``. It works unchanged for
-  MySQL, for other RDBMS you might need to adjust the DDL manually.
-
-.. note::
-
-  When *not using SQLite* the maximum length of each cache entry is restricted.
-  The default in ``Neos.Flow/Resources/Private/Cache/SQL/DDL.sql``
-  is ``MEDIUMTEXT`` (16mb on MySQL), which should be sufficient in most cases.
+  The maximum size of each cache entry is limited to what a ``MEDIUMTEXT`` type
+  can hold. When using MySQL/MariaDB that is 16MiB, other databases may have
+  a different limit.
 
 .. warning::
 
@@ -457,24 +447,21 @@ Options
 
 :title:`Pdo cache backend options`
 
-+----------------+----------------------------------------+-----------+--------+---------+
-| Option         | Description                            | Mandatory | Type   | Default |
-+================+========================================+===========+========+=========+
-| dataSourceName | Data source name for connecting to the | Yes       | string |         |
-|                | database.                              |           |        |         |
-|                |                                        |           |        |         |
-|                | :title:`Examples:`                     |           |        |         |
-|                |                                        |           |        |         |
-|                | * mysql:host=localhost;dbname=test     |           |        |         |
-|                | * sqlite:/path/to/sqlite.db            |           |        |         |
-|                | * sqlite::memory:                      |           |        |         |
-+----------------+----------------------------------------+-----------+--------+---------+
-| username       | Username to use for the database       | No        |        |         |
-|                | connection                             |           |        |         |
-+----------------+----------------------------------------+-----------+--------+---------+
-| password       | Password to use for the database       | No        |        |         |
-|                | connection                             |           |        |         |
-+----------------+----------------------------------------+-----------+--------+---------+
++----------------+----------------------------------------------------+-----------+--------+---------+
+| Option         | Description                                        | Mandatory | Type   | Default |
++================+====================================================+===========+========+=========+
+| dataSourceName | Data source name for connecting to the database.   | Yes       | string |         |
+|                |                                                    |           |        |         |
+|                | :title:`Examples:`                                 |           |        |         |
+|                |                                                    |           |        |         |
+|                | * mysql:host=localhost;dbname=test;charset=utf8mb4 |           |        |         |
+|                | * sqlite:/path/to/sqlite.db                        |           |        |         |
+|                | * sqlite::memory:                                  |           |        |         |
++----------------+----------------------------------------------------+-----------+--------+---------+
+| username       | Username to use for the database connection        | No        |        |         |
++----------------+----------------------------------------------------+-----------+--------+---------+
+| password       | Password to use for the database connection.       | No        |        |         |
++----------------+----------------------------------------------------+-----------+--------+---------+
 
 Neos\\Cache\\Backend\\RedisBackend
 ----------------------------------


### PR DESCRIPTION
Note: No migrations exist for the PDO cache backend!

To make sure the cache and tags tables are up-to-date, you need to
remove them manually and the run the cache:setup CLI command to have
them recreated with the most recent definition.

Unless you have persistent caches, that should be no problem, but
give that a thought first.

The reasoning behind this change is explained in the documentation
of MySQL and MariaDB.

For MySQL https://dev.mysql.com/doc/refman/8.0/en/innodb-index-types.html
explains:

> If the table has no PRIMARY KEY or suitable UNIQUE index, InnoDB
> internally generates a hidden clustered index named GEN_CLUST_INDEX
> on a synthetic column containing row ID values. The rows are ordered
> by the ID that InnoDB assigns to the rows in such a table. The row
> ID is a 6-byte field that increases monotonically as new rows are
> inserted. Thus, the rows ordered by the row ID are physically in
> insertion order.

For MariaDB it is very similar:

> In XtraDB/InnoDB tables, all indexes contain the primary key as a
> suffix. Thus, when using this storage engine, keeping the primary
> key as small as possible is particularly important. If a primary
> key does not exist and there are no UNIQUE indexes, InnoDB creates
> a 6-bytes clustered index which is invisible to the user.

(see https://mariadb.com/kb/en/library/getting-started-with-indexes/)

The bottom line is, InnoDB actually needs a PK and creates a "hidden"
one, if needed. So it takes the guesswork out of the table setup, to
actually define one.

Even more details can be found online in this article and it's links:
https://federico-razzoli.com/why-mysql-tables-need-a-primary-key