### PR TITLE
BUGFIX: Inject Dispatcher lazily

### DIFF
--- a/Neos.Flow/Classes/Mvc/DispatchComponent.php
+++ b/Neos.Flow/Classes/Mvc/DispatchComponent.php
@@ -21,7 +21,7 @@ use Neos\Flow\Http\Component\ComponentInterface;
 class DispatchComponent implements ComponentInterface
 {
     /**
-     * @Flow\Inject(lazy=false)
+     * @Flow\Inject
      * @var Dispatcher
      */
     protected $dispatcher;


### PR DESCRIPTION
This might seem like a micro optimisation but in fact we create the whole HTTP chain (components) before starting to run the chain, so if something cancels the chain the components after it would still be build. The components itself are a minor problem but I will provide a change for master to lazily create those as well, but the dependency chain of the dispatcher is so big that this change can actually make a difference when combined with something like the FullPageCache package.
