### PR TITLE
BUGFIX: Fix error handling for importing resources

### DIFF
--- a/Neos.Flow/Classes/ResourceManagement/Storage/WritableFileSystemStorage.php
+++ b/Neos.Flow/Classes/ResourceManagement/Storage/WritableFileSystemStorage.php
@@ -63,9 +63,7 @@ class WritableFileSystemStorage extends FileSystemStorage implements WritableSto
                 throw new StorageException(sprintf('Could import the content stream to temporary file "%s".', $temporaryTargetPathAndFilename), 1380880079);
             }
         } else {
-            try {
-                copy($source, $temporaryTargetPathAndFilename);
-            } catch (\Exception $exception) {
+            if (copy($source, $temporaryTargetPathAndFilename) === false) {
                 throw new StorageException(sprintf('Could not copy the file from "%s" to temporary file "%s".', $source, $temporaryTargetPathAndFilename), 1375198876);
             }
         }


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->

While working with `ResourceManager` I noticed that importing non-existent resources would fail later in the process than expected: They would only fail when trying to copy the temporary file to it's persistent location instead of failing when fetching the original file.

**What I did**
This PR fixes the incorrect error handling of fetching files when importing resources.

**How I did it**
The code assumed that `copy` would throw an exception if it failed - however, it returns `false` in that case.

**How to verify it**
Try to import a non-existent resource (e.g. http://example.com/this-file-does-not-exist). It should now correctly throw the `Could not copy the file from "..." to temporary file "..."` exception  from `WritableFileSystemStorage::importResource` instead of the much later `The temporary file of the file import could not be moved to the final target "..."` from `WritableFileSystemStorage::moveTemporaryFileToFinalDestination`

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
