### PR TITLE
BUGFIX: Correctly reflect type of aliased classes in method typehints

### DIFF
--- a/Neos.Flow/Classes/Reflection/ParameterReflection.php
+++ b/Neos.Flow/Classes/Reflection/ParameterReflection.php
@@ -56,13 +56,10 @@ class ParameterReflection extends \ReflectionParameter
      */
     public function getBuiltinType()
     {
-        if (!is_callable([$this, 'getType'])) {
-            return null;
-        }
         $type = $this->getType();
         if ($type === null || !$type->isBuiltin()) {
             return null;
         }
-        return (string)$type;
+        return $type instanceof \ReflectionNamedType ? $type->getName() : (string)$type;
     }
 }

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1766,11 +1766,11 @@ class ReflectionService
                 'position' => $parameterData[self::DATA_PARAMETER_POSITION],
                 'optional' => isset($parameterData[self::DATA_PARAMETER_OPTIONAL]),
                 'type' => $parameterData[self::DATA_PARAMETER_TYPE],
-                'class' => isset($parameterData[self::DATA_PARAMETER_CLASS]) ? $parameterData[self::DATA_PARAMETER_CLASS] : null,
+                'class' => $parameterData[self::DATA_PARAMETER_CLASS] ?? null,
                 'array' => isset($parameterData[self::DATA_PARAMETER_ARRAY]),
                 'byReference' => isset($parameterData[self::DATA_PARAMETER_BY_REFERENCE]),
                 'allowsNull' => isset($parameterData[self::DATA_PARAMETER_ALLOWS_NULL]),
-                'defaultValue' => isset($parameterData[self::DATA_PARAMETER_DEFAULT_VALUE]) ? $parameterData[self::DATA_PARAMETER_DEFAULT_VALUE] : null,
+                'defaultValue' => $parameterData[self::DATA_PARAMETER_DEFAULT_VALUE] ?? null,
                 'scalarDeclaration' => isset($parameterData[self::DATA_PARAMETER_SCALAR_DECLARATION])
             ];
         }
@@ -1785,7 +1785,7 @@ class ReflectionService
      * @param MethodReflection $method The parameter's method
      * @return array Parameter information array
      */
-    protected function convertParameterReflectionToArray(ParameterReflection $parameter, MethodReflection $method = null)
+    protected function convertParameterReflectionToArray(ParameterReflection $parameter, MethodReflection $method)
     {
         $parameterInformation = [
             self::DATA_PARAMETER_POSITION => $parameter->getPosition()
@@ -1803,32 +1803,34 @@ class ReflectionService
             $parameterInformation[self::DATA_PARAMETER_ALLOWS_NULL] = true;
         }
 
-        $parameterClass = $parameter->getClass();
-        if ($parameterClass !== null) {
-            $parameterInformation[self::DATA_PARAMETER_CLASS] = $parameterClass->getName();
-        }
-        if ($parameter->isOptional() && $parameter->isDefaultValueAvailable()) {
-            $parameterInformation[self::DATA_PARAMETER_DEFAULT_VALUE] = $parameter->getDefaultValue();
-        }
-        if ($method !== null) {
+        $parameterType = null;
+        if ($parameter->getType() !== null) {
+            $parameterType = $parameter->getType() instanceof \ReflectionNamedType ? $parameter->getType()->getName() : (string)$parameter->getType();
+        } else {
             $paramAnnotations = $method->isTaggedWith('param') ? $method->getTagValues('param') : [];
             if (isset($paramAnnotations[$parameter->getPosition()])) {
                 $explodedParameters = explode(' ', $paramAnnotations[$parameter->getPosition()]);
                 if (count($explodedParameters) >= 2) {
                     $parameterType = $this->expandType($method->getDeclaringClass(), $explodedParameters[0]);
-                    $parameterInformation[self::DATA_PARAMETER_TYPE] = $this->cleanClassName($parameterType);
-                }
-            }
-            if (!$parameter->isArray()) {
-                $builtinType = $parameter->getBuiltinType();
-                if ($builtinType !== null) {
-                    $parameterInformation[self::DATA_PARAMETER_TYPE] = $builtinType;
-                    $parameterInformation[self::DATA_PARAMETER_SCALAR_DECLARATION] = true;
                 }
             }
         }
-        if (!isset($parameterInformation[self::DATA_PARAMETER_TYPE]) && $parameterClass !== null) {
-            $parameterInformation[self::DATA_PARAMETER_TYPE] = $this->cleanClassName($parameterClass->getName());
+        if ($parameter->getClass() !== null) {
+            // We use parameter type here to make class_alias usage work and return the hinted class name instead of the alias
+            $parameterInformation[self::DATA_PARAMETER_CLASS] = $parameterType;
+        }
+        if ($parameter->isOptional() && $parameter->isDefaultValueAvailable()) {
+            $parameterInformation[self::DATA_PARAMETER_DEFAULT_VALUE] = $parameter->getDefaultValue();
+        }
+        if (!$parameter->isArray()) {
+            $builtinType = $parameter->getBuiltinType();
+            if ($builtinType !== null) {
+                $parameterInformation[self::DATA_PARAMETER_TYPE] = $builtinType;
+                $parameterInformation[self::DATA_PARAMETER_SCALAR_DECLARATION] = true;
+            }
+        }
+        if (!isset($parameterInformation[self::DATA_PARAMETER_TYPE]) && $parameterType !== null) {
+            $parameterInformation[self::DATA_PARAMETER_TYPE] = $this->cleanClassName($parameterType);
         } elseif (!isset($parameterInformation[self::DATA_PARAMETER_TYPE])) {
             $parameterInformation[self::DATA_PARAMETER_TYPE] = $parameter->isArray() ? 'array' : 'mixed';
         }

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -177,7 +177,7 @@ class ReflectionService
     /**
      * @var array
      */
-    protected $settings;
+    protected $settings = [];
 
     /**
      * Array of annotation classnames and the names of classes which are annotated with them
@@ -1406,7 +1406,7 @@ class ReflectionService
         $paramAnnotations = $method->isTaggedWith('param') ? $method->getTagValues('param') : [];
 
         $this->classReflectionData[$className][self::DATA_CLASS_METHODS][$methodName][self::DATA_METHOD_PARAMETERS][$parameter->getName()] = $this->convertParameterReflectionToArray($parameter, $method);
-        if ($this->settings['logIncorrectDocCommentHints'] !== true) {
+        if (!isset($this->settings['logIncorrectDocCommentHints']) || $this->settings['logIncorrectDocCommentHints'] !== true) {
             return;
         }
 

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1806,14 +1806,6 @@ class ReflectionService
         $parameterType = null;
         if ($parameter->getType() !== null) {
             $parameterType = $parameter->getType() instanceof \ReflectionNamedType ? $parameter->getType()->getName() : (string)$parameter->getType();
-        } else {
-            $paramAnnotations = $method->isTaggedWith('param') ? $method->getTagValues('param') : [];
-            if (isset($paramAnnotations[$parameter->getPosition()])) {
-                $explodedParameters = explode(' ', $paramAnnotations[$parameter->getPosition()]);
-                if (count($explodedParameters) >= 2) {
-                    $parameterType = $this->expandType($method->getDeclaringClass(), $explodedParameters[0]);
-                }
-            }
         }
         if ($parameter->getClass() !== null) {
             // We use parameter type here to make class_alias usage work and return the hinted class name instead of the alias
@@ -1821,6 +1813,13 @@ class ReflectionService
         }
         if ($parameter->isOptional() && $parameter->isDefaultValueAvailable()) {
             $parameterInformation[self::DATA_PARAMETER_DEFAULT_VALUE] = $parameter->getDefaultValue();
+        }
+        $paramAnnotations = $method->isTaggedWith('param') ? $method->getTagValues('param') : [];
+        if (isset($paramAnnotations[$parameter->getPosition()])) {
+            $explodedParameters = explode(' ', $paramAnnotations[$parameter->getPosition()]);
+            if (count($explodedParameters) >= 2) {
+                $parameterType = $this->expandType($method->getDeclaringClass(), $explodedParameters[0]);
+            }
         }
         if (!$parameter->isArray()) {
             $builtinType = $parameter->getBuiltinType();

--- a/Neos.Flow/Tests/Unit/Reflection/Fixture/AliasedClass.php
+++ b/Neos.Flow/Tests/Unit/Reflection/Fixture/AliasedClass.php
@@ -1,0 +1,17 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Reflection\Fixture;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Aliased class for the Reflection tests
+ */
+class_alias(ClassWithAlias::class, AliasedClass::class);

--- a/Neos.Flow/Tests/Unit/Reflection/Fixture/ClassWithAlias.php
+++ b/Neos.Flow/Tests/Unit/Reflection/Fixture/ClassWithAlias.php
@@ -1,0 +1,19 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Reflection\Fixture;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Dummy class for the Reflection tests, which will get an alias through class_alias
+ */
+class ClassWithAlias
+{
+}

--- a/Neos.Flow/Tests/Unit/Reflection/Fixture/ClassWithAliasDependency.php
+++ b/Neos.Flow/Tests/Unit/Reflection/Fixture/ClassWithAliasDependency.php
@@ -1,0 +1,20 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Reflection\Fixture;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Dummy class for the Reflection tests, with a method that has a dependency on an aliased class
+ */
+class ClassWithAliasDependency
+{
+    public function injectDependency(AliasedClass $class) {}
+}

--- a/Neos.Flow/Tests/Unit/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/ReflectionServiceTest.php
@@ -36,8 +36,10 @@ class ReflectionServiceTest extends UnitTestCase
         $this->reflectionService = $this->getAccessibleMock(ReflectionService::class, null);
 
         $this->mockAnnotationReader = $this->getMockBuilder('Doctrine\Common\Annotations\Reader')->disableOriginalConstructor()->getMock();
-        $this->mockAnnotationReader->expects($this->any())->method('getClassAnnotations')->will($this->returnValue([]));
+        $this->mockAnnotationReader->method('getClassAnnotations')->willReturn([]);
+        $this->mockAnnotationReader->method('getMethodAnnotations')->willReturn([]);
         $this->inject($this->reflectionService, 'annotationReader', $this->mockAnnotationReader);
+        $this->reflectionService->_set('initialized', true);
     }
 
     /**
@@ -65,6 +67,16 @@ class ReflectionServiceTest extends UnitTestCase
     public function reflectClassThrowsExceptionForClassesWithNoMatchingFilename()
     {
         $this->reflectionService->_call('reflectClass', Fixture\ClassWithDifferentNameDifferent::class);
+    }
+
+    /**
+     * @test
+     */
+    public function getMethodParametersReturnsCorrectTypeForAliasedClass()
+    {
+        $this->reflectionService->_call('reflectClass', Fixture\ClassWithAliasDependency::class);
+        $parameters = $this->reflectionService->getMethodParameters(Fixture\ClassWithAliasDependency::class, 'injectDependency');
+        $this->assertEquals(Fixture\AliasedClass::class, array_pop($parameters)['class']);
     }
 
     /**


### PR DESCRIPTION
The namespace change introduced with doctrine/persistence 1.3.x makes use of `class_alias` to create a b/c layer over the old class names (see https://github.com/greg0ire/type_deprecation_experiment). However, this broke for a couple of our depending packages that still used the old `Doctrine\Common\Persistence\ObjectMananger` class as a method typehint.
The reason is, that PHP Reflection returns different values for aliased method parameter types when using `ReflectionParameter::getClass()->getName()` vs. `ReflectionParameter::getType()->getName()`.
The former returns the name of the actual class, instead of the alias, while the latter returns the actual name that was used in the typehint, regardless if it is an alias only.

In turn, this led our dependency injection to try to inject classes that it was not aware of and led to issues like https://github.com/yeebase/Yeebase.TwoFactorAuthentication/issues/3 or https://github.com/neos/Neos.EventSourcing/issues/249
It was not an issue for injections that were not typehinted via PHP, e.g. `@Flow\Inject` instead of setter/constructor injection.

This change fixes that retrospectively, by always reflecting the actual class name that is specified in the typehint and hence allowing usage of `class_alias`.

Thanks a lot @alcaeus for helping me figure this out!