### PR TITLE
BUGFIX: Remove fragment/query in setBaseUri()

### DIFF
--- a/Neos.Flow/Classes/Http/Request.php
+++ b/Neos.Flow/Classes/Http/Request.php
@@ -289,7 +289,7 @@ class Request extends BaseRequest implements ServerRequestInterface
             $baseUri = new Uri($baseUri);
         }
 
-        $this->attributes[self::ATTRIBUTE_BASE_URI] = $baseUri;
+        $this->attributes[self::ATTRIBUTE_BASE_URI] = $baseUri->withQuery('')->withFragment('');
     }
 
     /**


### PR DESCRIPTION
When `setBaseUri()` is used with an URI that has query parameters
or a fragment, this leads to broken link generation. Usually a non-issue,
since `detectBaseUri()` is used most often, and that removes those
already.
