### PR TITLE
BUGFIX: Prevent connection error when calling getIterator for PdoBackend

### DIFF
--- a/Neos.Cache/Classes/Backend/PdoBackend.php
+++ b/Neos.Cache/Classes/Backend/PdoBackend.php
@@ -518,6 +518,12 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
      */
     public function rewind()
     {
+        try {
+            $this->connect();
+        } catch (Exception $e) {
+            return;
+        }
+
         if ($this->cacheEntriesIterator !== null) {
             $this->cacheEntriesIterator->rewind();
             return;


### PR DESCRIPTION
**What I did**

Call `connect` in `rewind` method to make sure that a connection exists.