### PR TITLE
BUGFIX: Make sure to use only a consistent DatesReaderCache

### DIFF
--- a/Neos.Flow/Classes/I18n/Cldr/Reader/DatesReader.php
+++ b/Neos.Flow/Classes/I18n/Cldr/Reader/DatesReader.php
@@ -261,8 +261,9 @@ class DatesReader
         self::validateFormatType($formatType);
         self::validateFormatLength($formatLength);
 
-        if (isset($this->parsedFormatsIndices[(string)$locale][$formatType][$formatLength])) {
-            return $this->parsedFormats[$this->parsedFormatsIndices[(string)$locale][$formatType][$formatLength]];
+        $parsedFormatIndex = $this->parsedFormatsIndices[(string)$locale][$formatType][$formatLength] ?? '';
+        if (isset($this->parsedFormats[$parsedFormatIndex])) {
+            return $this->parsedFormats[$parsedFormatIndex];
         }
 
         $model = $this->cldrRepository->getModelForLocale($locale);


### PR DESCRIPTION
It might happen that there is a discrepancy between parsedFormatsIndices and parsedFormats cache. We need to make sure we are accessing the consistent information instead of relying that both are there, to avoid a PHP exception.

Resolves #564 

The problem described in #564 is not easy to reproduce, as it only happens "once in a while" in production. See issue comments for further information.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
