### PR TITLE
BUGFIX: Parse single-line docblock comments correctly

### DIFF
--- a/Neos.Flow/Classes/Reflection/DocCommentParser.php
+++ b/Neos.Flow/Classes/Reflection/DocCommentParser.php
@@ -47,10 +47,7 @@ class DocCommentParser
 
         $lines = explode(chr(10), $docComment);
         foreach ($lines as $line) {
-            $line = trim($line);
-            if ($line === '*/') {
-                break;
-            }
+            $line = trim(str_replace('*/', '', $line));
             if ($line !== '' && strpos($line, '* @') !== false) {
                 $this->parseTag(substr($line, strpos($line, '@')));
             } elseif (count($this->tags) === 0) {

--- a/Neos.Flow/Classes/Reflection/DocCommentParser.php
+++ b/Neos.Flow/Classes/Reflection/DocCommentParser.php
@@ -47,7 +47,7 @@ class DocCommentParser
 
         $lines = explode(chr(10), $docComment);
         foreach ($lines as $line) {
-            $line = trim(str_replace('*/', '', $line));
+            $line = trim(preg_replace('/\*\/$/', '', $line));
             if ($line !== '' && strpos($line, '* @') !== false) {
                 $this->parseTag(substr($line, strpos($line, '@')));
             } elseif (count($this->tags) === 0) {

--- a/Neos.Flow/Tests/Unit/Reflection/DocCommentParserTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/DocCommentParserTest.php
@@ -38,4 +38,24 @@ class DocCommentParserTest extends UnitTestCase
         $parser->parseDocComment('/**' . chr(10) . ' * @var $foo integer' . chr(13) . chr(10) . ' * @var $bar string' . chr(10) . ' */');
         $this->assertEquals(['$foo integer', '$bar string'], $parser->getTagValues('var'));
     }
+
+    /**
+     * @test
+     */
+    public function singleLineTagIsParsedCorrectly()
+    {
+        $parser = new DocCommentParser();
+        $parser->parseDocComment('/** @return Foo[] */');
+        $this->assertEquals([ 'Foo[]' ], $parser->getTagValues('return'));
+    }
+    /**
+     * @test
+     */
+    public function singleLineDescriptionIsParsedCorrectly()
+    {
+        $parser = new DocCommentParser();
+        $parser->parseDocComment('/** Description goes here */');
+
+        $this->assertEquals('Description goes here', $parser->getDescription());
+    }
 }


### PR DESCRIPTION
Fixes #1900

<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->


**What I did**
Single line docblocks would break AOP compilation because the end-comment string `*/` would be interpreted as part of the comment.

**How I did it**
The end-comment string `*/` is now removed from all lines before parsing them. This means that the previous check for the end of the comment `if ($line === '*/`)` no longer works but as far as I could determine this explicit check is not actually needed.

**How to verify it**
There are tests

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
