### PR TITLE
BUGFIX: Allow passing syslog() priorities constants to Logger.log()

### DIFF
--- a/Neos.Flow.Log/Classes/Psr/Logger.php
+++ b/Neos.Flow.Log/Classes/Psr/Logger.php
@@ -66,13 +66,15 @@ class Logger implements LoggerInterface
      */
     public function log($level, $message, array $context = [])
     {
-        $backendLogLevel = self::LOGLEVEL_MAPPING[$level];
+        if (is_string($level) === true) {
+            $level = self::LOGLEVEL_MAPPING[$level];
+        }
 
         list($packageKey, $className, $methodName) = $this->extractLegacyDataFromContext($context);
         $additionalData = $this->removeLegacyDataFromContext($context);
 
         foreach ($this->backends as $backend) {
-            $backend->append($message, $backendLogLevel, $additionalData, $packageKey, $className, $methodName);
+            $backend->append($message, $level, $additionalData, $packageKey, $className, $methodName);
         }
     }
 


### PR DESCRIPTION
<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->


**What I did**

`Logger.log()` should accept [syslog() priority constants](https://www.php.net/manual/en/function.syslog.php) (e.g. `LOG_INFO`) instead of strings (e.g. `'info'`) for the `$level` function parameter.

**How to verify it**

```php
$logger->log('Hello, world.', LOG_INFO);
$logger->log('Hello, world.', 'info');
```

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html) => Flow 4.x does not use PSR-style loggers and is therefore not affected.