### PR TITLE
BUGFIX: Avoid exception in findIdentifiersByTag()

### DIFF
--- a/Neos.Cache/Classes/Backend/FileBackend.php
+++ b/Neos.Cache/Classes/Backend/FileBackend.php
@@ -250,11 +250,9 @@ class FileBackend extends SimpleFileBackend implements PhpCapableBackendInterfac
             if ($expiryTime !== 0 && $expiryTime < $now) {
                 continue;
             }
-           $extractedTags = substr($metaData, 0, -self::EXPIRYTIME_LENGTH);
-           if ($extractedTags === false) {
-               continue;
-           }
-            if (!in_array($searchedTag, explode(' ', $extractedTags))) {
+
+            $extractedTags = substr($metaData, 0, -self::EXPIRYTIME_LENGTH);
+            if ($extractedTags === false || !in_array($searchedTag, explode(' ', $extractedTags))) {
                 continue;
             }
 

--- a/Neos.Cache/Classes/Backend/FileBackend.php
+++ b/Neos.Cache/Classes/Backend/FileBackend.php
@@ -246,6 +246,9 @@ class FileBackend extends SimpleFileBackend implements PhpCapableBackendInterfac
             $fileSize = filesize($cacheEntryPathAndFilename);
             $index = (integer)$this->readCacheFile($cacheEntryPathAndFilename, $fileSize - self::DATASIZE_DIGITS, self::DATASIZE_DIGITS);
             $metaData = $this->readCacheFile($cacheEntryPathAndFilename, $index, $fileSize - $index - self::DATASIZE_DIGITS);
+            if ($metaData === false) {
+                continue;
+            }
             $expiryTime = (integer)substr($metaData, -self::EXPIRYTIME_LENGTH, self::EXPIRYTIME_LENGTH);
             if ($expiryTime !== 0 && $expiryTime < $now) {
                 continue;

--- a/Neos.Cache/Classes/Backend/FileBackend.php
+++ b/Neos.Cache/Classes/Backend/FileBackend.php
@@ -250,7 +250,7 @@ class FileBackend extends SimpleFileBackend implements PhpCapableBackendInterfac
             if ($expiryTime !== 0 && $expiryTime < $now) {
                 continue;
             }
-            if (!in_array($searchedTag, explode(' ', substr($metaData, 0, -self::EXPIRYTIME_LENGTH)))) {
+            if (!in_array($searchedTag, explode(' ', (string)substr($metaData, 0, -self::EXPIRYTIME_LENGTH)))) {
                 continue;
             }
 

--- a/Neos.Cache/Classes/Backend/FileBackend.php
+++ b/Neos.Cache/Classes/Backend/FileBackend.php
@@ -250,7 +250,11 @@ class FileBackend extends SimpleFileBackend implements PhpCapableBackendInterfac
             if ($expiryTime !== 0 && $expiryTime < $now) {
                 continue;
             }
-            if (!in_array($searchedTag, explode(' ', (string)substr($metaData, 0, -self::EXPIRYTIME_LENGTH)))) {
+           $extractedTags = substr($metaData, 0, -self::EXPIRYTIME_LENGTH);
+           if ($extractedTags === false) {
+               continue;
+           }
+            if (!in_array($searchedTag, explode(' ', $extractedTags))) {
                 continue;
             }
 


### PR DESCRIPTION
When `substr($metaData, 0, -self::EXPIRYTIME_LENGTH)`on
`$metadata` in the cache `FileBackend.findIdentifiersByTag()`
method fails, `false` is passed to `explode()` causing:

`Exception in line 253 of /…/FileBackend.php: explode() expects
parameter 2 to be string, boolean given`

This fixes that by casting the result to a string.
