### PR TITLE
BUGFIX: Allow numeric arrays in request body

### DIFF
--- a/Neos.Flow/Classes/Mvc/DispatchComponent.php
+++ b/Neos.Flow/Classes/Mvc/DispatchComponent.php
@@ -99,7 +99,9 @@ class DispatchComponent implements ComponentInterface
 
         $parsedBody = $this->parseRequestBody($httpRequest);
         if ($parsedBody !== []) {
-            $arguments = Arrays::arrayMergeRecursiveOverrule($arguments, $parsedBody);
+            if (Arrays::array_all(array_keys($parsedBody), 'is_string')) {
+                $arguments = Arrays::arrayMergeRecursiveOverrule($arguments, $parsedBody);
+            }
             $httpRequest = $httpRequest->withParsedBody($parsedBody);
         }
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ModelViewController.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ModelViewController.rst
@@ -311,6 +311,14 @@ later sources replace earlier ones
 * body (typically from POST or PUT requests)
 * file uploads (derived from $_FILES)
 
+.. note::
+
+  If you submit a request body that will be parsed into a PHP array, e.g. a JSON
+  array or object, and it contains numeric keys, Flow will not automatically map
+  this into controller arguments, as numbers are no valid PHP variable names.
+  You can access the full request body then via `$this->request->getHttpRequest()->getParsedBody()`
+  inside your controller.
+
 Internal Arguments
 ~~~~~~~~~~~~~~~~~~
 

--- a/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
@@ -126,6 +126,21 @@ class ActionControllerTest extends FunctionalTestCase
     }
 
     /**
+     * @test
+     */
+    public function arrayRequestBodyIsNotMappedByDefault()
+    {
+        $body = json_encode(['foo']);
+        $request = Request::create(new Uri('http://localhost/test/mvc/actioncontrollertesta/postArrayBody?getArgument=getValue'), 'POST');
+        $request->setContent($body);
+        $request->setHeader('Content-Type', 'application/json');
+        $request->setHeader('Content-Length', count_chars($body));
+
+        $response = $this->browser->sendRequest($request);
+        $this->assertEquals('postArrayBodyAction-getValue-'.$body, $response->getContent());
+    }
+
+    /**
      * RFC 2616 / 10.4.5 (404 Not Found)
      *
      * @test

--- a/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/ActionControllerTestAController.php
+++ b/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/ActionControllerTestAController.php
@@ -76,6 +76,15 @@ class ActionControllerTestAController extends ActionController
     }
 
     /**
+     * @param string $getArgument
+     * @return string
+     */
+    public function postArrayBodyAction($getArgument)
+    {
+        return 'postArrayBodyAction-' . $getArgument . '-' . json_encode($this->request->getHttpRequest()->getParsedBody());
+    }
+
+    /**
      * @Flow\Validate("brokenArgument1", type="StringLength", options={"maximum": 3})
      * @Flow\Validate("brokenArgument2", type="StringLength", options={"minimum": 100})
      * @Flow\IgnoreValidation("brokenArgument1")

--- a/Neos.Utility.Arrays/Classes/Arrays.php
+++ b/Neos.Utility.Arrays/Classes/Arrays.php
@@ -184,11 +184,11 @@ abstract class Arrays
     }
 
     /**
-     * Iterate the array and check if any of the array values hold the predicate.
+     * Iterate the array and check if any of the array values pass the predicate.
      *
      * @param array $array
-     * @param callable $predicate callable( mixed $value )
-     * @return bool True if any of the array values hold the predicate, false if none do
+     * @param callable $predicate callable( mixed $value ): bool
+     * @return bool True if any of the array values pass the predicate, false if none do
      */
     public static function array_any(array $array, callable $predicate)
     {
@@ -201,11 +201,11 @@ abstract class Arrays
     }
 
     /**
-     * Iterate the array and check if all of the array values hold the predicate.
+     * Iterate the array and check if all of the array values pass the predicate.
      *
      * @param array $array
-     * @param callable $predicate callable( mixed $value )
-     * @return bool True if all of the array values hold the predicate, false if any don't
+     * @param callable $predicate callable( mixed $value ): bool
+     * @return bool True if all of the array values pass the predicate, false if any don't
      */
     public static function array_all(array $array, callable $predicate)
     {

--- a/Neos.Utility.Arrays/Classes/Arrays.php
+++ b/Neos.Utility.Arrays/Classes/Arrays.php
@@ -184,6 +184,40 @@ abstract class Arrays
     }
 
     /**
+     * Iterate the array and check if any of the array values hold the predicate.
+     *
+     * @param array $array
+     * @param callable $predicate callable( mixed $value )
+     * @return bool True if any of the array values hold the predicate, false if none do
+     */
+    public static function array_any(array $array, callable $predicate)
+    {
+        foreach ($array as $key => $value) {
+            if ($predicate($value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Iterate the array and check if all of the array values hold the predicate.
+     *
+     * @param array $array
+     * @param callable $predicate callable( mixed $value )
+     * @return bool True if all of the array values hold the predicate, false if any don't
+     */
+    public static function array_all(array $array, callable $predicate)
+    {
+        foreach ($array as $value) {
+            if (!$predicate($value)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * Returns the value of a nested array by following the specifed path.
      *
      * @param array &$array The array to traverse as a reference


### PR DESCRIPTION
When sending e.g. a JSON request with an array as body (`["foo","bar"]`), Flow would throw an exception because it could not map the numeric keys to valid argument names.

This change fixes that by just not merging those bodies into the controller arguments. If you want to access such a request body, you can now use `$this->request->getHttpRequest()->getParsedBody()` from inside your controller.
Associative arrays with valid string keys will still be automatically mapped.

Related to https://github.com/neos/flow-development-collection/pull/1606, which states that mapping an array is possible.