### PR TITLE
BUGFIX: Resolve SqlLogger when it is a dependency proxy

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/Logging/SqlLogger.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Logging/SqlLogger.php
@@ -37,7 +37,7 @@ class SqlLogger implements \Doctrine\DBAL\Logging\SQLLogger
      */
     public function startQuery($sql, array $params = null, array $types = null)
     {
-        if ($this->logger instanceof DependendcyProxy) {
+        if ($this->logger instanceof DependencyProxy) {
             $this->logger->_activateDependency();
         }
         // this is a safeguard for when no logger might be available...

--- a/Neos.Flow/Classes/Persistence/Doctrine/Logging/SqlLogger.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Logging/SqlLogger.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Persistence\Doctrine\Logging;
  * source code.
  */
 
+use Neos\Flow\ObjectManagement\DependencyInjection\DependencyProxy;
 use Neos\Flow\Log\Utility\LogEnvironment;
 use Psr\Log\LoggerInterface;
 
@@ -36,6 +37,9 @@ class SqlLogger implements \Doctrine\DBAL\Logging\SQLLogger
      */
     public function startQuery($sql, array $params = null, array $types = null)
     {
+        if ($this->logger instanceof DependendcyProxy) {
+            $this->logger->_activateDependency();
+        }
         // this is a safeguard for when no logger might be available...
         if ($this->logger instanceof LoggerInterface) {
             $this->logger->debug($sql, array_merge(LogEnvironment::fromMethodName(__METHOD__), ['params' => $params, 'types' => $types]));


### PR DESCRIPTION
The SqlLogger did not log anything since Flow 6.0 due to a instanceof check, when it was a dependency proxy. This change resolves the dependency.

Resolves #1854