### PR TITLE
BUGFIX: Flush classSchemataRuntimeCache before saving production data

### DIFF
--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -2151,6 +2151,7 @@ class ReflectionService
     protected function saveProductionData()
     {
         $this->reflectionDataRuntimeCache->flush();
+        $this->classSchemataRuntimeCache->flush();
 
         $classNames = [];
         foreach ($this->classReflectionData as $className => $reflectionData) {


### PR DESCRIPTION
Currently the method `saveProductionData()` from the `ReflectionService`
writes to both caches `reflectionDataRuntimeCache` and
`classSchemataRuntimeCache` but flushes only the former first.

Additionally the `hasFrozenCacheInProduction()` method only checks
the first cache.

This allows a race condition where the `classSchemataRuntimeCache` is
built and frozen but `reflectionDataRuntimeCache` isn't.

This change ensures the `classSchemataRuntimeCache` is also flushed.

Error message:

```
Exception #1323344192 in line 68 of /var/www/Packages/Libraries/neos/cache/Classes/Frontend/VariableFrontend.php: Cannot add or modify cache entry because the backend of cache "Flow_Reflection_RuntimeClassSchemata" is frozen.
```
