### PR TITLE
BUGFIX: Fix output of request and response in throwable storage

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -26,8 +26,6 @@ use Neos\Flow\Core\ProxyClassLoader;
 use Neos\Flow\Error\Debugger;
 use Neos\Flow\Error\ErrorHandler;
 use Neos\Flow\Error\ProductionExceptionHandler;
-use Neos\Flow\Http\Helper\RequestInformationHelper;
-use Neos\Flow\Http\HttpRequestHandlerInterface;
 use Neos\Flow\Log\PsrLoggerFactoryInterface;
 use Neos\Flow\Log\ThrowableStorage\FileStorage;
 use Neos\Flow\Log\ThrowableStorageInterface;
@@ -263,36 +261,7 @@ class Scripts
         }
 
         /** @var ThrowableStorageInterface $throwableStorage */
-        $throwableStorage = $storageClassName::createWithOptions($storageOptions);
-
-        $throwableStorage->setBacktraceRenderer(function ($backtrace) {
-            return Debugger::getBacktraceCode($backtrace, false, true);
-        });
-
-        $throwableStorage->setRequestInformationRenderer(function () {
-            $output = '';
-            if (!(Bootstrap::$staticObjectManager instanceof ObjectManagerInterface)) {
-                return $output;
-            }
-
-            $bootstrap = Bootstrap::$staticObjectManager->get(Bootstrap::class);
-            /* @var Bootstrap $bootstrap */
-            $requestHandler = $bootstrap->getActiveRequestHandler();
-            if (!$requestHandler instanceof HttpRequestHandlerInterface) {
-                return $output;
-            }
-
-            $request = $requestHandler->getHttpRequest();
-            $response = $requestHandler->getHttpResponse();
-            // TODO: Sensible error output
-            $output .= PHP_EOL . 'HTTP REQUEST:' . PHP_EOL . ($request ? '[request was empty]' : RequestInformationHelper::renderRequestHeaders($request)) . PHP_EOL;
-            $output .= PHP_EOL . 'HTTP RESPONSE:' . PHP_EOL . ($response ? '[response was empty]' : $response->getStatusCode()) . PHP_EOL;
-            $output .= PHP_EOL . 'PHP PROCESS:' . PHP_EOL . 'Inode: ' . getmyinode() . PHP_EOL . 'PID: ' . getmypid() . PHP_EOL . 'UID: ' . getmyuid() . PHP_EOL . 'GID: ' . getmygid() . PHP_EOL . 'User: ' . get_current_user() . PHP_EOL;
-
-            return $output;
-        });
-
-        return $throwableStorage;
+        return $storageClassName::createWithOptions($storageOptions);
     }
 
     /**

--- a/Neos.Flow/Classes/Log/ThrowableStorage/FileStorage.php
+++ b/Neos.Flow/Classes/Log/ThrowableStorage/FileStorage.php
@@ -10,6 +10,8 @@ use Neos\Flow\Log\PlainTextFormatter;
 use Neos\Flow\Log\ThrowableStorageInterface;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Utility\Files;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Stores detailed information about throwables into files.
@@ -56,7 +58,7 @@ class FileStorage implements ThrowableStorageInterface
     {
         $this->storagePath = $storagePath;
 
-        $this->requestInformationRenderer = function () {
+        $this->requestInformationRenderer = static function () {
             $output = '';
             if (!(Bootstrap::$staticObjectManager instanceof ObjectManagerInterface)) {
                 return $output;
@@ -69,17 +71,17 @@ class FileStorage implements ThrowableStorageInterface
                 return $output;
             }
 
-            $request = $requestHandler->getHttpRequest();
-            $response = $requestHandler->getHttpResponse();
+            $request = $requestHandler->getComponentContext()->getHttpRequest();
+            $response = $requestHandler->getComponentContext()->getHttpResponse();
             // TODO: Sensible error output
-            $output .= PHP_EOL . 'HTTP REQUEST:' . PHP_EOL . ($request == '' ? '[request was empty]' : RequestInformationHelper::renderRequestHeaders($request)) . PHP_EOL;
-            $output .= PHP_EOL . 'HTTP RESPONSE:' . PHP_EOL . ($response == '' ? '[response was empty]' : $response->getStatusCode()) . PHP_EOL;
+            $output .= PHP_EOL . 'HTTP REQUEST:' . PHP_EOL . ($request instanceof RequestInterface ? RequestInformationHelper::renderRequestHeaders($request) : '[request was empty]') . PHP_EOL;
+            $output .= PHP_EOL . 'HTTP RESPONSE:' . PHP_EOL . ($response instanceof ResponseInterface ? $response->getStatusCode() : '[response was empty]') . PHP_EOL;
             $output .= PHP_EOL . 'PHP PROCESS:' . PHP_EOL . 'Inode: ' . getmyinode() . PHP_EOL . 'PID: ' . getmypid() . PHP_EOL . 'UID: ' . getmyuid() . PHP_EOL . 'GID: ' . getmygid() . PHP_EOL . 'User: ' . get_current_user() . PHP_EOL;
 
             return $output;
         };
 
-        $this->backtraceRenderer = function ($backtrace) {
+        $this->backtraceRenderer = static function ($backtrace) {
             return Debugger::getBacktraceCode($backtrace, false, true);
         };
     }


### PR DESCRIPTION
Fixed the checking for valid request and response objects.
Remove superflous configuration of throwablestorage in `Scripts::initializeExceptionStorage`