### PR TITLE
BUGFIX: EntityPrivilege fails on empty IN condition

### DIFF
--- a/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/PropertyConditionGenerator.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/PropertyConditionGenerator.php
@@ -482,7 +482,7 @@ class PropertyConditionGenerator implements SqlGeneratorInterface
                     }
                 }
                 $parameter = implode(',', $parameters);
-            } elseif ($this->getRawParameterValue($operandDefinition) !== null) {
+            } elseif ($this->getRawParameterValue($operandDefinition) !== null && $this->getRawParameterValue($operandDefinition) !== []) {
                 $parameter = $sqlFilter->getParameter($operandDefinition);
             }
         } catch (\InvalidArgumentException $exception) {

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/PropertyConditionGenerator.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/PropertyConditionGenerator.php
@@ -482,7 +482,7 @@ class PropertyConditionGenerator implements SqlGeneratorInterface
                     }
                 }
                 $parameter = implode(',', $parameters);
-            } elseif ($this->getRawParameterValue($operandDefinition) !== null && $this->getRawParameterValue($operandDefinition) !== []) {
+            } elseif (!($this->getRawParameterValue($operandDefinition) === null || ($this->operator === 'in' && $this->getRawParameterValue($operandDefinition) === []))) {
                 $parameter = $sqlFilter->getParameter($operandDefinition);
             }
         } catch (\InvalidArgumentException $exception) {


### PR DESCRIPTION
**What I did**
Fixed the behavior of the `\Neos\Flow\Security\Authorization\Privilege\Entity\Doctrine\EntityPrivilege` if you execute an `in` operation on an empty array.

**How to verify it**
```yaml
matcher: 'isType("Neos\Neos\Domain\Model\Site") && !property("nodeName").in("context.userInformationContext.siteNodeNames")'
```

If `getSiteNodeNames()` evaluates to `[]` which is possible and valid, the PropertyGenerator tries to to `getParameter()` on this value which can only be applied to scalar values.

This is caused by only checking on an exact `null`, but an empty array should also be ignored.

Rebased follow-up to #1681