### PR TITLE
FEATURE: Emit a signal when view is resolved

### DIFF
--- a/Neos.Flow/Classes/Mvc/Controller/ActionController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ActionController.php
@@ -593,8 +593,20 @@ class ActionController extends AbstractController
         $viewOptions = isset($viewsConfiguration['options']) ? $viewsConfiguration['options'] : [];
         $view = $viewObjectName::createWithOptions($viewOptions);
 
+        $this->emitViewResolved($view);
+
         return $view;
     }
+
+    /**
+     * Emit that the view is resolved. The passed ViewInterface reference,
+     * gives the possibility to add variables to the view,
+     * before passing it on to further rendering
+     *
+     * @param ViewInterface $view
+     * @Flow\Signal
+     */
+    protected function emitViewResolved(ViewInterface $view) {}
 
     /**
      * Determines the fully qualified view object name.

--- a/Neos.Flow/Classes/Mvc/Controller/ActionController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ActionController.php
@@ -606,7 +606,8 @@ class ActionController extends AbstractController
      * @param ViewInterface $view
      * @Flow\Signal
      */
-    protected function emitViewResolved(ViewInterface $view) {}
+    protected function emitViewResolved(ViewInterface $view) {
+    }
 
     /**
      * Determines the fully qualified view object name.

--- a/Neos.Flow/Classes/Mvc/Controller/ActionController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ActionController.php
@@ -606,7 +606,8 @@ class ActionController extends AbstractController
      * @param ViewInterface $view
      * @Flow\Signal
      */
-    protected function emitViewResolved(ViewInterface $view) {
+    protected function emitViewResolved(ViewInterface $view)
+    {
     }
 
     /**

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Templating.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Templating.rst
@@ -393,6 +393,51 @@ You can pass arbitrary objects to the view, using ``$this->view->assign($identif
 from within the controller. See the above paragraphs about Object Accessors for details
 how to use the passed data.
 
+Passing data to the view from outside a controller
+--------------------------------------------------
+
+You can also pass data to the view from outside a controller. This can be useful for
+general data, that you want to be available without having to assign it in each action.
+
+Once the view is resolved inside the ``ActionController``, the signal ``viewResolved``
+is being emitted and you can add data.
+
+This is possible with the Signal/Slot dispatcher from your ``Package.php`` file::
+
+    <?php
+    namespace Vendor\Namespace;
+
+    use Neos\Flow\Core\Bootstrap;
+    use Neos\Flow\Mvc\Controller\ActionController;
+    use Neos\Flow\Mvc\View\ViewInterface;
+    use Neos\Flow\Package\Package as BasePackage;
+
+
+    /**
+     * The Flow Package
+     */
+    class Package extends BasePackage
+    {
+
+        /**
+         * Invokes custom PHP code directly after the package manager has been initialized.
+         *
+         * @param Bootstrap $bootstrap The current bootstrap
+         * @return void
+         */
+        public function boot(Bootstrap $bootstrap)
+        {
+
+            $dispatcher = $bootstrap->getSignalSlotDispatcher();
+
+            $dispatcher->connect(ActionController::class, 'viewResolved', function (ViewInterface $view) {
+                $view->assign('settingPassedFromSignal', 'sun is shining');
+            });
+
+        }
+    }
+
+
 Layouts
 =======
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Templating.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Templating.rst
@@ -430,7 +430,7 @@ This is possible with the Signal/Slot dispatcher from your ``Package.php`` file:
 
             $dispatcher = $bootstrap->getSignalSlotDispatcher();
 
-            $dispatcher->connect(ActionController::class, 'viewResolved', function (ViewInterface $view) {
+            $dispatcher->connect(ActionController::class, 'viewResolved', static function (ViewInterface $view) {
                 $view->assign('settingPassedFromSignal', 'sun is shining');
             });
 


### PR DESCRIPTION
In order for a package to interact with the rendering views available variables
a signal is being emitted upon resolving of the view.

The variables will be available in the view in the MVC context only

Resolves #1902

**What I did**

I added a Signal/Slot once the view has been resolved

**How to verify it**

Test functionality with the following package

https://github.com/sorenmalling/SorenMalling.EmitViewResolved