### PR TITLE
FEATURE: Resolve authentication token by simple name

### DIFF
--- a/Neos.Flow/Classes/Security/Authentication/AuthenticationTokenResolver.php
+++ b/Neos.Flow/Classes/Security/Authentication/AuthenticationTokenResolver.php
@@ -1,0 +1,61 @@
+<?php
+namespace Neos\Flow\Security\Authentication;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Flow\Security\Exception\NoAuthenticationTokenFoundException;
+
+/**
+ * The authentication token resolver. It resolves the class name of a authentication token based on names.
+ *
+ * @Flow\Scope("singleton")
+ */
+class AuthenticationTokenResolver
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    protected $objectManager;
+
+    /**
+     * Constructor.
+     *
+     * @param ObjectManagerInterface $objectManager The object manager
+     */
+    public function __construct(ObjectManagerInterface $objectManager)
+    {
+        $this->objectManager = $objectManager;
+    }
+
+    /**
+     * Resolves the class name of an authentication token. If a valid provider class name is given, it is just returned.
+     *
+     * @param string $tokenName The (short) name of the token
+     * @return string The object name of the authentication token
+     * @throws NoAuthenticationTokenFoundException
+     */
+    public function resolveTokenClass($providerName)
+    {
+        $className = $this->objectManager->getClassNameByObjectName($providerName);
+        if ($className !== false) {
+            return $className;
+        }
+
+        $className = $this->objectManager->getClassNameByObjectName('Neos\Flow\Security\Authentication\Token\\' . $providerName);
+        if ($className !== false) {
+            return $className;
+        }
+
+        throw new NoAuthenticationTokenFoundException('An authentication provider with the name "' . $providerName . '" could not be resolved.', 1217154134);
+    }
+}

--- a/Neos.Flow/Classes/Security/Authentication/TokenAndProviderFactory.php
+++ b/Neos.Flow/Classes/Security/Authentication/TokenAndProviderFactory.php
@@ -49,6 +49,11 @@ class TokenAndProviderFactory implements TokenAndProviderFactoryInterface
     protected $providerResolver;
 
     /**
+     * @var AuthenticationTokenResolver
+     */
+    protected $tokenResolver;
+
+    /**
      * @var RequestPatternResolver
      */
     protected $requestPatternResolver;
@@ -56,11 +61,13 @@ class TokenAndProviderFactory implements TokenAndProviderFactoryInterface
     /**
      * @param AuthenticationProviderResolver $providerResolver The provider resolver
      * @param RequestPatternResolver $requestPatternResolver The request pattern resolver
+     * @param AuthenticationTokenResolver $tokenResolver The token resolver
      */
-    public function __construct(AuthenticationProviderResolver $providerResolver, RequestPatternResolver $requestPatternResolver)
+    public function __construct(AuthenticationProviderResolver $providerResolver, RequestPatternResolver $requestPatternResolver, AuthenticationTokenResolver $tokenResolver)
     {
         $this->providerResolver = $providerResolver;
         $this->requestPatternResolver = $requestPatternResolver;
+        $this->tokenResolver = $tokenResolver;
     }
 
     /**
@@ -152,8 +159,12 @@ class TokenAndProviderFactory implements TokenAndProviderFactoryInterface
             /** @var $tokenInstance TokenInterface */
             $tokenInstance = null;
             foreach ($providerInstance->getTokenClassNames() as $tokenClassName) {
-                if (isset($providerConfiguration['token']) && $providerConfiguration['token'] !== $tokenClassName) {
-                    continue;
+                if (isset($providerConfiguration['token'])) {
+                    $tokenObjectName = $this->tokenResolver->resolveTokenClass((string)$providerConfiguration['token']);
+
+                    if ($tokenObjectName !== $tokenClassName) {
+                        continue;
+                    }
                 }
 
                 $tokenInstance = new $tokenClassName();

--- a/Neos.Flow/Classes/Security/Exception/NoAuthenticationTokenFoundException.php
+++ b/Neos.Flow/Classes/Security/Exception/NoAuthenticationTokenFoundException.php
@@ -1,0 +1,21 @@
+<?php
+namespace Neos\Flow\Security\Exception;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A "NoAuthenticationTokenFound" Exception
+ *
+ * @api
+ */
+class NoAuthenticationTokenFoundException extends \Neos\Flow\Security\Exception
+{
+}

--- a/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationTokenResolverTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationTokenResolverTest.php
@@ -1,0 +1,77 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Security\Authentication;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\ObjectManagement\ObjectManager;
+use Neos\Flow\Security\Authentication\AuthenticationTokenResolver;
+use Neos\Flow\Security\Exception\NoAuthenticationTokenFoundException;
+use Neos\Flow\Tests\UnitTestCase;
+
+/**
+ * Testcase for the security token resolver
+ */
+class AuthenticationTokenResolverTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function resolveTokenObjectNameThrowsAnExceptionIfNoProviderIsAvailable()
+    {
+        $this->expectException(NoAuthenticationTokenFoundException::class);
+        $mockObjectManager = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->getMock();
+        $mockObjectManager->expects(self::any())->method('getClassNameByObjectName')->will(self::returnValue(false));
+
+        $providerResolver = new AuthenticationTokenResolver($mockObjectManager);
+
+        $providerResolver->resolveTokenClass('notExistingClass');
+    }
+
+    /**
+     * @test
+     */
+    public function resolveTokenReturnsTheCorrectTokenForAShortName()
+    {
+        $longClassNameForTest = 'Neos\Flow\Security\Authentication\Token\ValidShortName';
+
+        $getCaseSensitiveObjectNameCallback = function () use ($longClassNameForTest) {
+            $args = func_get_args();
+
+            if ($args[0] === $longClassNameForTest) {
+                return $longClassNameForTest;
+            }
+
+            return false;
+        };
+
+        $mockObjectManager = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->getMock();
+        $mockObjectManager->expects(self::any())->method('getClassNameByObjectName')->will(self::returnCallBack($getCaseSensitiveObjectNameCallback));
+
+        $providerResolver = new AuthenticationTokenResolver($mockObjectManager);
+        $providerClass = $providerResolver->resolveTokenClass('ValidShortName');
+
+        self::assertEquals($longClassNameForTest, $providerClass, 'The wrong classname has been resolved');
+    }
+
+    /**
+     * @test
+     */
+    public function resolveTokenReturnsTheCorrectTokenForACompleteClassName()
+    {
+        $mockObjectManager = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->getMock();
+        $mockObjectManager->expects(self::any())->method('getClassNameByObjectName')->with('existingTokenClass')->will(self::returnValue('existingTokenClass'));
+
+        $providerResolver = new AuthenticationTokenResolver($mockObjectManager);
+        $providerClass = $providerResolver->resolveTokenClass('existingTokenClass');
+
+        self::assertEquals('existingTokenClass', $providerClass, 'The wrong classname has been resolved');
+    }
+}

--- a/Neos.Flow/Tests/Unit/Security/Authentication/TokenAndProviderFactoryTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/TokenAndProviderFactoryTest.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\Tests\Unit\Security\Authentication;
  */
 
 use Neos\Flow\Security\Authentication\AuthenticationProviderResolver;
+use Neos\Flow\Security\Authentication\AuthenticationTokenResolver;
 use Neos\Flow\Security\Authentication\TokenAndProviderFactory;
 use Neos\Flow\Security\Exception\InvalidAuthenticationProviderException;
 use Neos\Flow\Security\RequestPatternResolver;
@@ -29,8 +30,9 @@ class TokenAndProviderFactoryTest extends UnitTestCase
     {
         $mockProviderResolver = $this->getMockBuilder(AuthenticationProviderResolver::class)->disableOriginalConstructor()->getMock();
         $mockRequestPatternResolver = $this->getMockBuilder(RequestPatternResolver::class)->disableOriginalConstructor()->getMock();
+        $mockTokenResolver = $this->getMockBuilder(AuthenticationTokenResolver::class)->disableOriginalConstructor()->getMock();
 
-        $tokenAndProviderFactory = new TokenAndProviderFactory($mockProviderResolver, $mockRequestPatternResolver);
+        $tokenAndProviderFactory = new TokenAndProviderFactory($mockProviderResolver, $mockRequestPatternResolver, $mockTokenResolver);
 
         self::assertEquals([], $tokenAndProviderFactory->getProviders(), 'The array of providers should be empty.');
         self::assertEquals([], $tokenAndProviderFactory->getTokens(), 'The array of tokens should be empty.');
@@ -50,8 +52,9 @@ class TokenAndProviderFactoryTest extends UnitTestCase
 
         $mockProviderResolver = $this->getMockBuilder(AuthenticationProviderResolver::class)->disableOriginalConstructor()->getMock();
         $mockRequestPatternResolver = $this->getMockBuilder(RequestPatternResolver::class)->disableOriginalConstructor()->getMock();
+        $mockTokenResolver = $this->getMockBuilder(AuthenticationTokenResolver::class)->disableOriginalConstructor()->getMock();
 
-        $tokenAndProviderFactory = new TokenAndProviderFactory($mockProviderResolver, $mockRequestPatternResolver);
+        $tokenAndProviderFactory = new TokenAndProviderFactory($mockProviderResolver, $mockRequestPatternResolver, $mockTokenResolver);
         $tokenAndProviderFactory->injectSettings(['security' => ['authentication' => ['providers' => $providerConfiguration]]]);
 
         $tokenAndProviderFactory->getProviders();


### PR DESCRIPTION
The documentation has long been showing that you can define
a security token by it's simple name, if in the Neos.Flow
package.

This has not been really true, since there was no resolving
from the simple string, similar to how providers has been
resolved.

This change brings the same resolving functionality as the
provider

Resolves #947

**How I did it**

Added a new Resolver class, with exact same functionality as the AuthenticationProviderResolver class

**How to verify it**

Use the documentation example of a token and provider example

https://flowframework.readthedocs.io/en/6.0/TheDefinitiveGuide/PartIII/Security.html#reuse-of-tokens-and-providers