### PR TITLE
BUGFIX: Allow numeric array body in request

### DIFF
--- a/Neos.Flow/Classes/Mvc/ActionRequest.php
+++ b/Neos.Flow/Classes/Mvc/ActionRequest.php
@@ -470,7 +470,7 @@ class ActionRequest implements RequestInterface
     public function setArgument($argumentName, $value)
     {
         $argumentName = (string)$argumentName;
-        if (empty($argumentName)) {
+        if ($argumentName === '') {
             throw new Exception\InvalidArgumentNameException('Invalid argument name (must be a non-empty string).', 1210858767);
         }
 

--- a/Neos.Flow/Classes/Mvc/DispatchComponent.php
+++ b/Neos.Flow/Classes/Mvc/DispatchComponent.php
@@ -98,7 +98,9 @@ class DispatchComponent implements ComponentInterface
         $arguments = $httpRequest->getArguments();
 
         $parsedBody = $this->parseRequestBody($httpRequest);
-        $httpRequest = $httpRequest->withParsedBody($parsedBody);
+        if ($parsedBody !== null) {
+            $httpRequest = $httpRequest->withParsedBody($parsedBody);
+        }
         if (is_array($parsedBody) && $parsedBody !== []) {
             $arguments = Arrays::arrayMergeRecursiveOverrule($arguments, $parsedBody);
         }

--- a/Neos.Flow/Classes/Mvc/DispatchComponent.php
+++ b/Neos.Flow/Classes/Mvc/DispatchComponent.php
@@ -98,11 +98,10 @@ class DispatchComponent implements ComponentInterface
         $arguments = $httpRequest->getArguments();
 
         $parsedBody = $this->parseRequestBody($httpRequest);
-        if ($parsedBody !== []) {
+        $httpRequest = $httpRequest->withParsedBody($parsedBody);
+        if (is_array($parsedBody) && $parsedBody !== []) {
             $arguments = Arrays::arrayMergeRecursiveOverrule($arguments, $parsedBody);
-            $httpRequest = $httpRequest->withParsedBody($parsedBody);
         }
-
 
         $routingMatchResults = $componentContext->getParameter(Routing\RoutingComponent::class, 'matchResults');
         if ($routingMatchResults !== null) {
@@ -125,19 +124,20 @@ class DispatchComponent implements ComponentInterface
      * Parses the request body according to the media type.
      *
      * @param HttpRequest $httpRequest
-     * @return array
+     * @return null|array|string|integer
      */
     protected function parseRequestBody(HttpRequest $httpRequest)
     {
         $requestBody = $httpRequest->getContent();
         if ($requestBody === null || $requestBody === '') {
-            return [];
+            return $requestBody;
         }
 
         $mediaTypeConverter = $this->objectManager->get(MediaTypeConverterInterface::class);
         $propertyMappingConfiguration = new PropertyMappingConfiguration();
         $propertyMappingConfiguration->setTypeConverter($mediaTypeConverter);
         $propertyMappingConfiguration->setTypeConverterOption(MediaTypeConverterInterface::class, MediaTypeConverterInterface::CONFIGURATION_MEDIA_TYPE, $httpRequest->getHeader('Content-Type'));
+        // FIXME: The MediaTypeConverter returns an empty array for "error cases", which might be unintended
         $arguments = $this->propertyMapper->convert($requestBody, 'array', $propertyMappingConfiguration);
 
         return $arguments;

--- a/Neos.Flow/Classes/Property/TypeConverter/MediaTypeConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/MediaTypeConverter.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Property\TypeConverter;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+use Neos\Flow\Validation\Error;
 use Neos\Utility\Arrays;
 use Neos\Utility\MediaTypes;
 
@@ -50,7 +51,7 @@ class MediaTypeConverter extends AbstractTypeConverter implements MediaTypeConve
      * @param string $targetType must be "array"
      * @param array $convertedChildProperties
      * @param PropertyMappingConfigurationInterface $configuration
-     * @return array
+     * @return array|string|integer Note that this TypeConverter may return a non-array in case of JSON media type, even though he declares to only convert to array
      * @api
      */
     public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
@@ -71,7 +72,7 @@ class MediaTypeConverter extends AbstractTypeConverter implements MediaTypeConve
      *
      * @param string $requestBody the raw request body
      * @param string $mediaType the configured media type (for example "application/json")
-     * @return array
+     * @return array|string|integer
      * @api
      */
     protected function convertMediaType($requestBody, $mediaType)


### PR DESCRIPTION
When sending e.g. a JSON request with an array as body (["foo","bar"]), Flow would throw an exception "Invalid argument name (must be a non-empty string)." when visiting the array key "0" due to the `empty()` check.
This change fixes that by backporting a fix that is already in place in Flow 6.0+ which only checks for empty string.

Such an array can not be mapped to a controller argument, but you can still technically access the argument from the controller via `$this->arguments->getArgument("0")` or the whole body via
`$this->request->getHttpRequest()->getParsedBody()`.

Replaces #1913