### PR TITLE
FEATURE: Run garbage collection of configured caches

### DIFF
--- a/Neos.Flow/Classes/Command/CacheCommandController.php
+++ b/Neos.Flow/Classes/Command/CacheCommandController.php
@@ -431,21 +431,23 @@ class CacheCommandController extends CommandController
      * @return void
      * @throws NoSuchCacheException
      */
-    public function garbageCollectionCommand(string $cacheIdentifier = null) {
+    public function collectGarbageCommand(string $cacheIdentifier = null): void
+    {
         if ($cacheIdentifier !== null) {
             $cache = $this->cacheManager->getCache($cacheIdentifier);
             $cache->collectGarbage();
 
-            $this->outputLine('Garbage Collection for cache "%s" completed', [$cacheIdentifier]);
+            $this->outputLine('<success>Garbage Collection for cache "%s" completed</success>', [$cacheIdentifier]);
         } else {
             $cacheConfigurations = $this->cacheManager->getCacheConfigurations();
             unset($cacheConfigurations['Default']);
             ksort($cacheConfigurations);
 
             foreach ($cacheConfigurations as $identifier => $configuration) {
+                $this->outputLine('Garbage Collection for cache "%s"', [$identifier]);
                 $cache = $this->cacheManager->getCache($identifier);
                 $cache->collectGarbage();
-                $this->outputLine('Garbage Collection for cache "%s" completed', [$identifier]);
+                $this->outputLine('<success>Completed</success>', [$identifier]);
             }
         }
 

--- a/Neos.Flow/Classes/Command/CacheCommandController.php
+++ b/Neos.Flow/Classes/Command/CacheCommandController.php
@@ -450,7 +450,6 @@ class CacheCommandController extends CommandController
                 $this->outputLine('<success>Completed</success>', [$identifier]);
             }
         }
-
     }
 
     /**

--- a/Neos.Flow/Classes/Command/CacheCommandController.php
+++ b/Neos.Flow/Classes/Command/CacheCommandController.php
@@ -427,7 +427,7 @@ class CacheCommandController extends CommandController
      * can differ and might not remove any data, depending on possibilities of
      * the backend.
      *
-     * @param bool $quiet If set, this command only outputs errors & warnings
+     * @param string $cacheIdentifier If set, this command only applies to the given cache
      * @return void
      * @throws NoSuchCacheException
      */

--- a/Neos.Flow/Classes/Command/CacheCommandController.php
+++ b/Neos.Flow/Classes/Command/CacheCommandController.php
@@ -419,6 +419,40 @@ class CacheCommandController extends CommandController
     }
 
     /**
+     * Cache Garbage Collection
+     *
+     * Runs the Garbage Collection (collectGarbage) method on all registered caches.
+     *
+     * Though the method is defined in the BackendInterface, the implementation
+     * can differ and might not remove any data, depending on possibilities of
+     * the backend.
+     *
+     * @param bool $quiet If set, this command only outputs errors & warnings
+     * @return void
+     * @throws NoSuchCacheException
+     */
+    public function garbageCollectionCommand(string $cacheIdentifier = null) {
+        if ($cacheIdentifier !== null) {
+            $cache = $this->cacheManager->getCache($cacheIdentifier);
+            $cache->collectGarbage();
+
+            $this->outputLine('Garbage Collection for cache "%s" completed', [$cacheIdentifier]);
+        } else {
+            $cacheConfigurations = $this->cacheManager->getCacheConfigurations();
+            $defaultConfiguration = $cacheConfigurations['Default'];
+            unset($cacheConfigurations['Default']);
+            ksort($cacheConfigurations);
+
+            foreach ($cacheConfigurations as $identifier => $configuration) {
+                $cache = $this->cacheManager->getCache($identifier);
+                $cache->collectGarbage();
+                $this->outputLine('Garbage Collection for cache "%s" completed', [$identifier]);
+            }
+        }
+
+    }
+
+    /**
      * Call system function
      *
      * @Flow\Internal

--- a/Neos.Flow/Classes/Command/CacheCommandController.php
+++ b/Neos.Flow/Classes/Command/CacheCommandController.php
@@ -447,7 +447,7 @@ class CacheCommandController extends CommandController
                 $this->outputLine('Garbage Collection for cache "%s"', [$identifier]);
                 $cache = $this->cacheManager->getCache($identifier);
                 $cache->collectGarbage();
-                $this->outputLine('<success>Completed</success>', [$identifier]);
+                $this->outputLine('<success>Completed</success>');
             }
         }
     }

--- a/Neos.Flow/Classes/Command/CacheCommandController.php
+++ b/Neos.Flow/Classes/Command/CacheCommandController.php
@@ -439,7 +439,6 @@ class CacheCommandController extends CommandController
             $this->outputLine('Garbage Collection for cache "%s" completed', [$cacheIdentifier]);
         } else {
             $cacheConfigurations = $this->cacheManager->getCacheConfigurations();
-            $defaultConfiguration = $cacheConfigurations['Default'];
             unset($cacheConfigurations['Default']);
             ksort($cacheConfigurations);
 


### PR DESCRIPTION
In order to run garbage collection the following command
has been introduced

`./flow cache:collectgarbage`

which will iterator over all configured caches and
run the corresponding `collectGarbage` method.

You can also run garbage collection on a single cache
by definined the cache identifier

`./flow cache:collectgarbage --cache-identifier Flow_Monitor`

Resolves #863