### PR TITLE
BUGFIX: Persist doctrine entities unknown to the reflection service

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/ObjectValidationAndDeDuplicationListener.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/ObjectValidationAndDeDuplicationListener.php
@@ -92,7 +92,8 @@ class ObjectValidationAndDeDuplicationListener
         $knownValueObjects = [];
         foreach ($entityInsertions as $entity) {
             $className = TypeHandling::getTypeForValue($entity);
-            if ($this->reflectionService->getClassSchema($className)->getModelType() === ClassSchema::MODELTYPE_VALUEOBJECT) {
+            $classSchema = $this->reflectionService->getClassSchema($className);
+            if ($classSchema !== null && $classSchema->getModelType() === ClassSchema::MODELTYPE_VALUEOBJECT) {
                 $identifier = $this->persistenceManager->getIdentifierByObject($entity);
 
                 if (isset($knownValueObjects[$className][$identifier]) || $unitOfWork->getEntityPersister($className)->exists($entity)) {


### PR DESCRIPTION
This fix is needed since commit 2f860a586753551b64785c91a87798ad124bb171 of version 5.3.13

Doctrine entities from third party packages that are not included by the Flow setting Neos.Flow.object.includeClasses are not known to the reflection service anymore when running in Production context. This resulted in an exception when calling the deduplicateValueObjectInsertions() function when having such entities scheuduled for insertion. The added not null check fixes this exception but also skips the duplication validation for those entities.

The related reflection and caching issue which brought up this problem is addressed in https://github.com/neos/flow-development-collection/issues/1950
