### PR TITLE
BUGFIX: Objects configured with factory don't receive factory arguments

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/CompileTimeObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/CompileTimeObjectManager.php
@@ -325,7 +325,7 @@ class CompileTimeObjectManager extends ObjectManager
                 ];
 
                 $objects[$objectName]['fa'] = [];
-                $factoryMethodArguments = $objectConfiguration->getArguments();
+                $factoryMethodArguments = $objectConfiguration->getFactoryArguments();
                 if (count($factoryMethodArguments) > 0) {
                     foreach ($factoryMethodArguments as $index => $argument) {
                         $objects[$objectName]['fa'][$index] = [

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/Configuration.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/Configuration.php
@@ -59,6 +59,12 @@ class Configuration
     protected $factoryMethodName = 'create';
 
     /**
+     * Arguments of the factory method
+     * @var array
+     */
+    protected $factoryArguments = [];
+
+    /**
      * @var string
      */
     protected $scope = self::SCOPE_PROTOTYPE;
@@ -380,7 +386,7 @@ class Configuration
             $this->arguments = [];
         } else {
             foreach ($arguments as $argument) {
-                if ($argument !== null && $argument instanceof ConfigurationArgument) {
+                if ($argument instanceof ConfigurationArgument) {
                     $this->setArgument($argument);
                 } else {
                     throw new InvalidConfigurationException(sprintf('Only ConfigurationArgument instances are allowed, "%s" given', is_object($argument) ? get_class($argument) : gettype($argument)), 1449217803);
@@ -416,7 +422,39 @@ class Configuration
         $argumentsCount = $lastArgument->getIndex();
         $sortedArguments = [];
         for ($index = 1; $index <= $argumentsCount; $index++) {
-            $sortedArguments[$index] = isset($this->arguments[$index]) ? $this->arguments[$index] : null;
+            $sortedArguments[$index] = $this->arguments[$index] ?? null;
+        }
+        return $sortedArguments;
+    }
+
+    /**
+     * Setter function for a single factory method argument
+     *
+     * @param ConfigurationArgument $argument The argument
+     * @return void
+     */
+    public function setFactoryArgument(ConfigurationArgument $argument)
+    {
+        $this->factoryArguments[$argument->getIndex()] = $argument;
+    }
+
+    /**
+     * Returns a sorted array of factory method arguments indexed by position (starting with "1")
+     *
+     * @return array<ConfigurationArgument> A sorted array of ConfigurationArgument objects with the argument position as index
+     */
+    public function getFactoryArguments()
+    {
+        if (count($this->factoryArguments) < 1) {
+            return [];
+        }
+
+        asort($this->factoryArguments);
+        $lastArgument = end($this->factoryArguments);
+        $argumentsCount = $lastArgument->getIndex();
+        $sortedArguments = [];
+        for ($index = 1; $index <= $argumentsCount; $index++) {
+            $sortedArguments[$index] = $this->factoryArguments[$index] ?? null;
         }
         return $sortedArguments;
     }

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
@@ -225,7 +225,11 @@ class ConfigurationBuilder
                             } else {
                                 throw new InvalidObjectConfigurationException('Invalid configuration syntax. Expecting "value", "object" or "setting" as value for argument "' . $argumentName . '", instead found "' . (is_array($argumentValue) ? implode(', ', array_keys($argumentValue)) : $argumentValue) . '" (source: ' . $objectConfiguration->getConfigurationSourceHint() . ')', 1230563250);
                             }
-                            $objectConfiguration->setArgument($argument);
+                            if (isset($rawConfigurationOptions['factoryObjectName'])) {
+                                $objectConfiguration->setFactoryArgument($argument);
+                            } else {
+                                $objectConfiguration->setArgument($argument);
+                            }
                         }
                     }
                 break;

--- a/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
@@ -278,7 +278,7 @@ class ProxyClassBuilder
                             $argumentValueObjectName = $argumentValue->getObjectName();
                             $argumentValueClassName = $argumentValue->getClassName();
                             if ($argumentValueClassName === null) {
-                                $preparedArgument = $this->buildCustomFactoryCall($argumentValue->getFactoryObjectName(), $argumentValue->getFactoryMethodName(), $argumentValue->getArguments());
+                                $preparedArgument = $this->buildCustomFactoryCall($argumentValue->getFactoryObjectName(), $argumentValue->getFactoryMethodName(), $argumentValue->getFactoryArguments());
                                 $assignments[$argumentPosition] = $assignmentPrologue . $preparedArgument;
                             } else {
                                 if ($this->objectConfigurations[$argumentValueObjectName]->getScope() === Configuration::SCOPE_PROTOTYPE) {
@@ -408,7 +408,7 @@ class ProxyClassBuilder
         $propertyObjectName = $propertyConfiguration->getObjectName();
         $propertyClassName = $propertyConfiguration->getClassName();
         if ($propertyClassName === null) {
-            $preparedSetterArgument = $this->buildCustomFactoryCall($propertyConfiguration->getFactoryObjectName(), $propertyConfiguration->getFactoryMethodName(), $propertyConfiguration->getArguments());
+            $preparedSetterArgument = $this->buildCustomFactoryCall($propertyConfiguration->getFactoryObjectName(), $propertyConfiguration->getFactoryMethodName(), $propertyConfiguration->getFactoryArguments());
         } else {
             if (!is_string($propertyClassName) || !isset($this->objectConfigurations[$propertyClassName])) {
                 $configurationSource = $objectConfiguration->getConfigurationSourceHint();


### PR DESCRIPTION
Until now a class configured to be constructed by a factory with arguments would end up giving those arguments to both the factory and the class constructor. This can lead to errors when the class constructor expects different arguments.
This change fixes that by separating the arguments for the factory from the class constructor arguments. The `arguments` setting in `Objects.yaml` will refer to the factory method arguments when `factoryObjectName` is given, otherwise to the class constructor arguments.

Fixes #1933