### PR TITLE
FEATURE: Allow configuring static factory methods in Objects.yaml

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/CompileTimeObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/CompileTimeObjectManager.php
@@ -308,6 +308,7 @@ class CompileTimeObjectManager extends ObjectManager
     protected function buildObjectsArray()
     {
         $objects = [];
+        /* @var $objectConfiguration Configuration */
         foreach ($this->objectConfigurations as $objectConfiguration) {
             $objectName = $objectConfiguration->getObjectName();
             $objects[$objectName] = [
@@ -318,7 +319,7 @@ class CompileTimeObjectManager extends ObjectManager
             if ($objectConfiguration->getClassName() !== $objectName) {
                 $objects[$objectName]['c'] = $objectConfiguration->getClassName();
             }
-            if ($objectConfiguration->getFactoryObjectName() !== '') {
+            if ($objectConfiguration->isCreatedByFactory()) {
                 $objects[$objectName]['f'] = [
                     $objectConfiguration->getFactoryObjectName(),
                     $objectConfiguration->getFactoryMethodName()

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/Configuration.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/Configuration.php
@@ -192,6 +192,8 @@ class Configuration
     {
         $this->factoryObjectName = $objectName;
         if ($this->factoryMethodName === '') {
+            // Needed for b/c because all configured factory objects should default to 'create' method, but not having
+            // a factory object should not lead to a global static 'create' factory method
             $this->factoryMethodName = 'create';
         }
     }

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/Configuration.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/Configuration.php
@@ -53,10 +53,10 @@ class Configuration
     protected $factoryObjectName = '';
 
     /**
-     * Name of the factory method. Only used if $factoryObjectName is set.
+     * Name of the factory method.
      * @var string
      */
-    protected $factoryMethodName = 'create';
+    protected $factoryMethodName = '';
 
     /**
      * @var string
@@ -191,6 +191,9 @@ class Configuration
     public function setFactoryObjectName($objectName)
     {
         $this->factoryObjectName = $objectName;
+        if ($this->factoryMethodName === '') {
+            $this->factoryMethodName = 'create';
+        }
     }
 
     /**

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/Configuration.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/Configuration.php
@@ -229,13 +229,13 @@ class Configuration
     }
 
     /**
-     * Returns true if factoryObjectName and factoryMethodName are defined.
+     * Returns true if factoryObjectName or factoryMethodName are defined.
      *
      * @return boolean
      */
     public function isCreatedByFactory()
     {
-        return ($this->factoryObjectName !== '' && $this->factoryMethodName !== '');
+        return ($this->factoryObjectName !== '' || $this->factoryMethodName !== '');
     }
 
     /**

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
@@ -128,7 +128,7 @@ class ConfigurationBuilder
                     throw new InvalidObjectConfigurationException('Tried to set a differing class name for class "' . $objectName . '" in the object configuration of package "' . $packageKey . '". Setting "className" is only allowed for interfaces, please check your Objects.yaml."', 1295954589);
                 }
 
-                if (empty($newObjectConfiguration->getClassName()) && empty($newObjectConfiguration->getFactoryObjectName())) {
+                if (empty($newObjectConfiguration->getClassName()) && !$newObjectConfiguration->isCreatedByFactory()) {
                     $count = count($this->reflectionService->getAllImplementationClassNamesForInterface($objectName));
                     $hint = ($count ? 'It seems like there is no class which implements that interface, maybe the object configuration is obsolete?' : sprintf('There are %s classes implementing that interface, therefore you must specify a specific class in your object configuration.', $count));
                     throw new InvalidObjectConfigurationException('The object configuration for "' . $objectName . '" in the object configuration of package "' . $packageKey . '" lacks a "className" entry. ' . $hint, 1422566751);
@@ -305,7 +305,7 @@ class ConfigurationBuilder
                 $objectName = $objectNameOrConfiguration['name'];
                 unset($objectNameOrConfiguration['name']);
             } else {
-                if (isset($objectNameOrConfiguration['factoryObjectName'])) {
+                if (isset($objectNameOrConfiguration['factoryObjectName']) || isset($objectNameOrConfiguration['factoryMethodName'])) {
                     $objectName = null;
                 } else {
                     $annotations = $this->reflectionService->getPropertyTagValues($parentObjectConfiguration->getClassName(), $propertyName, 'var');
@@ -339,10 +339,10 @@ class ConfigurationBuilder
                 $objectName = $objectNameOrConfiguration['name'];
                 unset($objectNameOrConfiguration['name']);
             } else {
-                if (isset($objectNameOrConfiguration['factoryObjectName'])) {
+                if (isset($objectNameOrConfiguration['factoryObjectName']) || isset($objectNameOrConfiguration['factoryMethodName'])) {
                     $objectName = null;
                 } else {
-                    throw new InvalidObjectConfigurationException('Object configuration for argument "' . $argumentName . '" contains neither object name nor factory object name in ' . $configurationSourceHint, 1417431742);
+                    throw new InvalidObjectConfigurationException('Object configuration for argument "' . $argumentName . '" contains neither object name nor factory object or method name in ' . $configurationSourceHint, 1417431742);
                 }
             }
             $objectConfiguration = $this->parseConfigurationArray($objectName, $objectNameOrConfiguration, $configurationSourceHint . ', argument "' . $argumentName . '"');

--- a/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
@@ -663,7 +663,7 @@ class ProxyClassBuilder
     protected function buildCustomFactoryCall($customFactoryObjectName, $customFactoryMethodName, array $arguments)
     {
         $parametersCode = $this->buildMethodParametersCode($arguments);
-        return '\Neos\Flow\Core\Bootstrap::$staticObjectManager->get(\'' . $customFactoryObjectName . '\')->' . $customFactoryMethodName . '(' . $parametersCode . ')';
+        return ($customFactoryObjectName ? '\Neos\Flow\Core\Bootstrap::$staticObjectManager->get(\'' . $customFactoryObjectName . '\')->' : '') . $customFactoryMethodName . '(' . $parametersCode . ')';
     }
 
     /**

--- a/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
@@ -21,7 +21,6 @@ use Neos\Flow\Core\ApplicationContext;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\DependencyInjection\DependencyProxy;
 use Neos\Flow\Security\Context;
-use Neos\Utility\ObjectAccess;
 
 /**
  * Object Manager

--- a/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
@@ -495,7 +495,6 @@ class ObjectManager implements ObjectManagerInterface
      */
     protected function buildObjectByFactory($objectName)
     {
-        $configurationManager = $this->get(ConfigurationManager::class);
         $factory = $this->objects[$objectName]['f'][0] ? $this->get($this->objects[$objectName]['f'][0]) : null;
         $factoryMethodName = $this->objects[$objectName]['f'][1];
 
@@ -503,7 +502,7 @@ class ObjectManager implements ObjectManagerInterface
         foreach ($this->objects[$objectName]['fa'] as $index => $argumentInformation) {
             switch ($argumentInformation['t']) {
                 case ObjectConfigurationArgument::ARGUMENT_TYPES_SETTING:
-                    $factoryMethodArguments[$index] = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, $argumentInformation['v']);
+                    $factoryMethodArguments[$index] = $this->get(ConfigurationManager::class)->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, $argumentInformation['v']);
                 break;
                 case ObjectConfigurationArgument::ARGUMENT_TYPES_STRAIGHTVALUE:
                     $factoryMethodArguments[$index] = $argumentInformation['v'];

--- a/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
@@ -497,7 +497,7 @@ class ObjectManager implements ObjectManagerInterface
     protected function buildObjectByFactory($objectName)
     {
         $configurationManager = $this->get(ConfigurationManager::class);
-        $factory = $this->get($this->objects[$objectName]['f'][0]);
+        $factory = $this->objects[$objectName]['f'][0] ? $this->get($this->objects[$objectName]['f'][0]) : null;
         $factoryMethodName = $this->objects[$objectName]['f'][1];
 
         $factoryMethodArguments = [];
@@ -515,11 +515,11 @@ class ObjectManager implements ObjectManagerInterface
             }
         }
 
-        if (count($factoryMethodArguments) === 0) {
-            return $factory->$factoryMethodName();
+        if ($factory !== null) {
+            return $factory->$factoryMethodName(...$factoryMethodArguments);
         }
 
-        return call_user_func_array([$factory, $factoryMethodName], $factoryMethodArguments);
+        return $factoryMethodName(...$factoryMethodArguments);
     }
 
     /**
@@ -538,7 +538,7 @@ class ObjectManager implements ObjectManagerInterface
         }
 
         try {
-            $object = ObjectAccess::instantiateClass($className, $arguments);
+            $object = new $className(...$arguments);
             unset($this->classesBeingInstantiated[$className]);
             return $object;
         } catch (\Exception $exception) {

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ObjectManagement.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ObjectManagement.rst
@@ -1233,6 +1233,19 @@ passed through to the custom factory method:
 	    1:
 	      value: 'systemLogger'
 
+*Example: YAML configuration for a static custom factory method*
+
+.. code-block:: yaml
+
+	Acme\Foo\Object:
+	  scope: prototype
+	  factoryMethodName: Acme\Foo\ObjectFactory::fromValue
+	  arguments:
+	    1:
+	      settings: 'Acme.Foo.Object.ConfigurableValue'
+
+Note that if you only specify the `factoryMethodName`, it needs to be the fully qualified name.
+
 *Example: PHP code using the custom factory* ::
 
 	$myCache = $objectManager->get(\Neos\Flow\Log\PsrSystemLoggerInterface::class);

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationTest.php
@@ -130,6 +130,7 @@ class ConfigurationTest extends UnitTestCase
      */
     public function theDefaultFactoryMethodNameIsCreate()
     {
+        $this->objectConfiguration->setFactoryObjectName(__CLASS__);
         self::assertSame('create', $this->objectConfiguration->getFactoryMethodName());
     }
 }

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Fixture/StaticFactory.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Fixture/StaticFactory.php
@@ -1,0 +1,30 @@
+<?php
+namespace Neos\Flow\Tests\Unit\ObjectManagement\Fixture;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Fixture class for unit tests mainly of the object manager
+ *
+ */
+class StaticFactory
+{
+    /**
+     * @param string $property
+     * @return BasicClass
+     */
+    public static function create(string $property): BasicClass
+    {
+        $instance = new BasicClass();
+        $instance->setSomeProperty($property);
+        return $instance;
+    }
+}

--- a/Neos.Flow/Tests/Unit/ObjectManagement/ObjectManagerTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/ObjectManagerTest.php
@@ -13,6 +13,8 @@ namespace Neos\Flow\Tests\Unit\ObjectManagement;
 
 require_once(__DIR__ . '/Fixture/BasicClass.php');
 
+use Neos\Flow\Core\ApplicationContext;
+use Neos\Flow\ObjectManagement\Configuration\ConfigurationArgument;
 use Neos\Flow\ObjectManagement\ObjectManager;
 use Neos\Flow\Tests\Unit\ObjectManagement\Fixture\BasicClass;
 use Neos\Flow\Tests\UnitTestCase;
@@ -68,5 +70,29 @@ class ObjectManagerTest extends UnitTestCase
         } else {
             self::assertSame($object1, $object2);
         }
+    }
+
+    /**
+     * @test
+     */
+    public function staticFactoryGeneratedPrototypeObject()
+    {
+        $objects = [
+            BasicClass::class => [
+                'f' => ['', 'Neos\Flow\Tests\Unit\ObjectManagement\Fixture\StaticFactory::create'],
+                'fa' => [
+                    ['t' => ConfigurationArgument::ARGUMENT_TYPES_STRAIGHTVALUE, 'v' => 'Foo']
+                ],
+                's' => ObjectConfiguration::SCOPE_PROTOTYPE
+            ]
+        ];
+
+        $context = $this->getMockBuilder(ApplicationContext::class)->disableOriginalConstructor()->getMock();
+        $objectManager = new ObjectManager($context);
+        $objectManager->setObjects($objects);
+
+        $instance = $objectManager->get(BasicClass::class);
+        self::assertInstanceOf(BasicClass::class, $instance);
+        self::assertSame($instance->getSomeProperty(), 'Foo');
     }
 }

--- a/Neos.Utility.ObjectHandling/Classes/ObjectAccess.php
+++ b/Neos.Utility.ObjectHandling/Classes/ObjectAccess.php
@@ -435,13 +435,45 @@ abstract class ObjectAccess
      * Instantiates the class named `$className` using the `$arguments` as constructor
      * arguments (in array order).
      *
+     * For less than 7 arguments `new` is used, for more a `ReflectionClass` is created
+     * and `newInstanceArgs` is used.
+     *
+     * Note: this should be used sparingly, just calling `new` yourself or using Dependency
+     * Injection are most probably better alternatives.
+     *
      * @param string $className
      * @param array $arguments
      * @return object
-     * @deprecated directly use "new $className(...$arguments)" instead
      */
     public static function instantiateClass($className, $arguments)
     {
-        return new $className(...$arguments);
+        switch (count($arguments)) {
+            case 0:
+                $object = new $className();
+            break;
+            case 1:
+                $object = new $className($arguments[0]);
+            break;
+            case 2:
+                $object = new $className($arguments[0], $arguments[1]);
+            break;
+            case 3:
+                $object = new $className($arguments[0], $arguments[1], $arguments[2]);
+            break;
+            case 4:
+                $object = new $className($arguments[0], $arguments[1], $arguments[2], $arguments[3]);
+            break;
+            case 5:
+                $object = new $className($arguments[0], $arguments[1], $arguments[2], $arguments[3], $arguments[4]);
+            break;
+            case 6:
+                $object = new $className($arguments[0], $arguments[1], $arguments[2], $arguments[3], $arguments[4], $arguments[5]);
+            break;
+            default:
+                $class = new \ReflectionClass($className);
+                $object = $class->newInstanceArgs($arguments);
+        }
+
+        return $object;
     }
 }

--- a/Neos.Utility.ObjectHandling/Classes/ObjectAccess.php
+++ b/Neos.Utility.ObjectHandling/Classes/ObjectAccess.php
@@ -435,45 +435,13 @@ abstract class ObjectAccess
      * Instantiates the class named `$className` using the `$arguments` as constructor
      * arguments (in array order).
      *
-     * For less than 7 arguments `new` is used, for more a `ReflectionClass` is created
-     * and `newInstanceArgs` is used.
-     *
-     * Note: this should be used sparingly, just calling `new` yourself or using Dependency
-     * Injection are most probably better alternatives.
-     *
      * @param string $className
      * @param array $arguments
      * @return object
+     * @deprecated directly use "new $className(...$arguments)" instead
      */
     public static function instantiateClass($className, $arguments)
     {
-        switch (count($arguments)) {
-            case 0:
-                $object = new $className();
-            break;
-            case 1:
-                $object = new $className($arguments[0]);
-            break;
-            case 2:
-                $object = new $className($arguments[0], $arguments[1]);
-            break;
-            case 3:
-                $object = new $className($arguments[0], $arguments[1], $arguments[2]);
-            break;
-            case 4:
-                $object = new $className($arguments[0], $arguments[1], $arguments[2], $arguments[3]);
-            break;
-            case 5:
-                $object = new $className($arguments[0], $arguments[1], $arguments[2], $arguments[3], $arguments[4]);
-            break;
-            case 6:
-                $object = new $className($arguments[0], $arguments[1], $arguments[2], $arguments[3], $arguments[4], $arguments[5]);
-            break;
-            default:
-                $class = new \ReflectionClass($className);
-                $object = $class->newInstanceArgs($arguments);
-        }
-
-        return $object;
+        return new $className(...$arguments);
     }
 }


### PR DESCRIPTION
This change allows to configure static factory methods in `Objects.yaml` by only specifying a `factoryMethodName` and leaving out `factoryObjectName`.

Example:
```
Acme\My\Class:
  factoryMethodName: Acme\My\Class::fromStatic
  arguments:
    1:
      setting: Acme.My.Class.ConfigurableValue
```

Before this would have required to create a non-static factory method inside a dedicated factory class (to avoid cyclic instanciation).