### PR TITLE
TASK: Use argument unpacking instead of call_user_func_array

### DIFF
--- a/Neos.Eel/Classes/Helper/ArrayHelper.php
+++ b/Neos.Eel/Classes/Helper/ArrayHelper.php
@@ -43,7 +43,7 @@ class ArrayHelper implements ProtectedContextAwareInterface
                 $argument = [$argument];
             }
         }
-        return call_user_func_array('array_merge', $arguments);
+        return array_merge(...$arguments);
     }
 
     /**

--- a/Neos.Eel/Classes/Helper/MathHelper.php
+++ b/Neos.Eel/Classes/Helper/MathHelper.php
@@ -332,10 +332,9 @@ class MathHelper implements ProtectedContextAwareInterface
     {
         $arguments = func_get_args();
         if ($arguments !== []) {
-            return call_user_func_array('max', func_get_args());
-        } else {
-            return -INF;
+            return max(...$arguments);
         }
+        return -INF;
     }
 
     /**
@@ -347,10 +346,9 @@ class MathHelper implements ProtectedContextAwareInterface
     {
         $arguments = func_get_args();
         if ($arguments !== []) {
-            return call_user_func_array('min', func_get_args());
-        } else {
-            return INF;
+            return min(...$arguments);
         }
+        return INF;
     }
 
     /**

--- a/Neos.Eel/Tests/Unit/Helper/ArrayHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/ArrayHelperTest.php
@@ -43,7 +43,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
     public function concatWorks($arguments, $expected)
     {
         $helper = new ArrayHelper();
-        $result = call_user_func_array([$helper, 'concat'], $arguments);
+        $result = $helper->concat(...$arguments);
         $this->assertEquals($expected, $result);
     }
 
@@ -470,7 +470,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
     public function rangeWorks($arguments, $expected)
     {
         $helper = new ArrayHelper();
-        $result = call_user_func_array([$helper, 'range'], $arguments);
+        $result = $helper->range(...$arguments);
         $this->assertEquals($expected, $result);
     }
 
@@ -500,7 +500,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
     public function setWorks($arguments, $expected)
     {
         $helper = new ArrayHelper();
-        $result = call_user_func_array([$helper, 'set'], $arguments);
+        $result = $helper->set(...$arguments);
         $this->assertEquals($expected, $result);
     }
 

--- a/Neos.Eel/Tests/Unit/Helper/JsonHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/JsonHelperTest.php
@@ -78,7 +78,7 @@ class JsonHelperTest extends \Neos\Flow\Tests\UnitTestCase
     public function parseWorks($arguments, $expected)
     {
         $helper = new JsonHelper();
-        $result = call_user_func_array([$helper, 'parse'], $arguments);
+        $result = $helper->parse(...$arguments);
         $this->assertEquals($expected, $result);
     }
 }

--- a/Neos.Flow/Classes/Aop/AdvicesTrait.php
+++ b/Neos.Flow/Classes/Aop/AdvicesTrait.php
@@ -54,7 +54,7 @@ trait AdvicesTrait
         }
         $methodName = $joinPoint->getMethodName();
         if (isset($this->Flow_Aop_Proxy_methodIsInAdviceMode[$methodName])) {
-            return call_user_func_array(['self', $joinPoint->getMethodName()], $joinPoint->getMethodArguments());
+            return self::$methodName(...$joinPoint->getMethodArguments());
         }
     }
 }

--- a/Neos.Flow/Classes/Aop/AdvicesTrait.php
+++ b/Neos.Flow/Classes/Aop/AdvicesTrait.php
@@ -52,7 +52,8 @@ trait AdvicesTrait
         if (__CLASS__ !== $joinPoint->getClassName()) {
             return parent::Flow_Aop_Proxy_invokeJoinPoint($joinPoint);
         }
-        if (isset($this->Flow_Aop_Proxy_methodIsInAdviceMode[$joinPoint->getMethodName()])) {
+        $methodName = $joinPoint->getMethodName();
+        if (isset($this->Flow_Aop_Proxy_methodIsInAdviceMode[$methodName])) {
             return call_user_func_array(['self', $joinPoint->getMethodName()], $joinPoint->getMethodArguments());
         }
     }

--- a/Neos.Flow/Classes/Aop/AdvicesTrait.php
+++ b/Neos.Flow/Classes/Aop/AdvicesTrait.php
@@ -54,7 +54,8 @@ trait AdvicesTrait
         }
         $methodName = $joinPoint->getMethodName();
         if (isset($this->Flow_Aop_Proxy_methodIsInAdviceMode[$methodName])) {
-            return self::$methodName(...$joinPoint->getMethodArguments());
+            $arguments = array_values($joinPoint->getMethodArguments());
+            return self::$methodName(...$arguments);
         }
     }
 }

--- a/Neos.Flow/Classes/Cli/CommandController.php
+++ b/Neos.Flow/Classes/Cli/CommandController.php
@@ -261,9 +261,9 @@ class CommandController implements ControllerInterface
             $this->outputLine('<b>Warning:</b> This command is <b>DEPRECATED</b>%s%s', [$suggestedCommandMessage, PHP_EOL]);
         }
 
-        $commandResult = call_user_func_array([$this, $this->commandMethodName], $preparedArguments);
+        $commandResult = $this->{$this->commandMethodName}(...$preparedArguments);
 
-        if (is_string($commandResult) && strlen($commandResult) > 0) {
+        if (is_string($commandResult) && $commandResult !== '') {
             $this->response->appendContent($commandResult);
         } elseif (is_object($commandResult) && method_exists($commandResult, '__toString')) {
             $this->response->appendContent((string)$commandResult);

--- a/Neos.Flow/Classes/Mvc/Controller/ActionController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ActionController.php
@@ -462,7 +462,7 @@ class ActionController extends AbstractController
         $validationResult = $this->arguments->getValidationResults();
 
         if (!$validationResult->hasErrors()) {
-            $actionResult = call_user_func_array([$this, $this->actionMethodName], $preparedArguments);
+            $actionResult = $this->{$this->actionMethodName}(...$preparedArguments);
         } else {
             $actionIgnoredArguments = static::getActionIgnoredValidationArguments($this->objectManager);
             if (isset($actionIgnoredArguments[$this->actionMethodName])) {
@@ -487,9 +487,9 @@ class ActionController extends AbstractController
             }
 
             if ($shouldCallActionMethod) {
-                $actionResult = call_user_func_array([$this, $this->actionMethodName], $preparedArguments);
+                $actionResult = $this->{$this->actionMethodName}(...$preparedArguments);
             } else {
-                $actionResult = call_user_func([$this, $this->errorMethodName]);
+                $actionResult = $this->{$this->errorMethodName}();
             }
         }
 

--- a/Neos.Flow/Classes/ObjectManagement/DependencyInjection/DependencyProxy.php
+++ b/Neos.Flow/Classes/ObjectManagement/DependencyInjection/DependencyProxy.php
@@ -96,6 +96,6 @@ class DependencyProxy
      */
     public function __call($methodName, array $arguments)
     {
-        return call_user_func_array([$this->_activateDependency(), $methodName], $arguments);
+        return $this->_activateDependency()->$methodName(...$arguments);
     }
 }

--- a/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
@@ -521,11 +521,7 @@ class ObjectManager implements ObjectManagerInterface
             }
         }
 
-        if (count($factoryMethodArguments) === 0) {
-            return $factory->$factoryMethodName();
-        } else {
-            return call_user_func_array([$factory, $factoryMethodName], $factoryMethodArguments);
-        }
+        return $factory->$factoryMethodName(...$factoryMethodArguments);
     }
 
     /**
@@ -544,7 +540,7 @@ class ObjectManager implements ObjectManagerInterface
         }
 
         try {
-            $object = ObjectAccess::instantiateClass($className, $arguments);
+            $object = new $className(...$arguments);
             unset($this->classesBeingInstantiated[$className]);
             return $object;
         } catch (\Exception $exception) {

--- a/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
@@ -19,7 +19,6 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\DependencyInjection\DependencyProxy;
 use Neos\Flow\Security\Context;
 use Neos\Utility\Arrays;
-use Neos\Utility\ObjectAccess;
 
 /**
  * Object Manager

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyConstructor.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyConstructor.php
@@ -73,7 +73,7 @@ class ProxyConstructor extends ProxyMethod
             return '';
         }
         if (count($this->reflectionService->getMethodParameters($this->fullOriginalClassName, $this->methodName)) > 0) {
-            return "        call_user_func_array('parent::" . $methodName . "', \$arguments);\n";
+            return "        parent::" . $methodName . "(...\$arguments);\n";
         } else {
             return "        parent::" . $methodName . "();\n";
         }

--- a/Neos.Flow/Classes/Persistence/Doctrine/Query.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Query.php
@@ -423,7 +423,7 @@ class Query implements QueryInterface
         } else {
             $constraints = func_get_args();
         }
-        return call_user_func_array([$this->queryBuilder->expr(), 'andX'], $constraints);
+        return $this->queryBuilder->expr()->andX(...$constraints);
     }
 
     /**
@@ -442,7 +442,7 @@ class Query implements QueryInterface
         } else {
             $constraints = func_get_args();
         }
-        return call_user_func_array([$this->queryBuilder->expr(), 'orX'], $constraints);
+        return $this->queryBuilder->expr()->orX(...$constraints);
     }
 
     /**

--- a/Neos.Flow/Classes/Session/Aspect/LazyLoadingAspect.php
+++ b/Neos.Flow/Classes/Session/Aspect/LazyLoadingAspect.php
@@ -118,7 +118,7 @@ class LazyLoadingAspect
         if ($this->sessionOriginalInstances[$objectName] === $proxy) {
             return $joinPoint->getAdviceChain()->proceed($joinPoint);
         } else {
-            return call_user_func_array([$this->sessionOriginalInstances[$objectName], $methodName], $joinPoint->getMethodArguments());
+            return $this->sessionOriginalInstances[$objectName]->$methodName(...$joinPoint->getMethodArguments());
         }
     }
 }

--- a/Neos.Flow/Classes/Session/Aspect/LazyLoadingAspect.php
+++ b/Neos.Flow/Classes/Session/Aspect/LazyLoadingAspect.php
@@ -118,7 +118,8 @@ class LazyLoadingAspect
         if ($this->sessionOriginalInstances[$objectName] === $proxy) {
             return $joinPoint->getAdviceChain()->proceed($joinPoint);
         } else {
-            return $this->sessionOriginalInstances[$objectName]->$methodName(...$joinPoint->getMethodArguments());
+            $arguments = array_values($joinPoint->getMethodArguments());
+            return $this->sessionOriginalInstances[$objectName]->$methodName(...$arguments);
         }
     }
 }

--- a/Neos.Flow/Classes/SignalSlot/Dispatcher.php
+++ b/Neos.Flow/Classes/SignalSlot/Dispatcher.php
@@ -133,11 +133,11 @@ class Dispatcher
             if ($slotInformation['passSignalInformation'] === true) {
                 $finalSignalArguments[] = $signalClassName . '::' . $signalName;
             }
-            $methodName = $slotInformation['method'];
-            if (!method_exists($object, $methodName)) {
-                throw new Exception\InvalidSlotException('The slot method ' . get_class($object) . '->' . $methodName . '() does not exist.', 1245673368);
+            if (!method_exists($object, $slotInformation['method'])) {
+                throw new Exception\InvalidSlotException('The slot method ' . get_class($object) . '->' . $slotInformation['method'] . '() does not exist.', 1245673368);
             }
-            $object->$methodName(...$finalSignalArguments);
+            // Need to use call_user_func_array here, because $object may be the class name when the slot is a static method
+            call_user_func_array([$object, $slotInformation['method']], $finalSignalArguments);
         }
     }
 

--- a/Neos.Flow/Classes/SignalSlot/Dispatcher.php
+++ b/Neos.Flow/Classes/SignalSlot/Dispatcher.php
@@ -133,10 +133,11 @@ class Dispatcher
             if ($slotInformation['passSignalInformation'] === true) {
                 $finalSignalArguments[] = $signalClassName . '::' . $signalName;
             }
-            if (!method_exists($object, $slotInformation['method'])) {
-                throw new Exception\InvalidSlotException('The slot method ' . get_class($object) . '->' . $slotInformation['method'] . '() does not exist.', 1245673368);
+            $methodName = $slotInformation['method'];
+            if (!method_exists($object, $methodName)) {
+                throw new Exception\InvalidSlotException('The slot method ' . get_class($object) . '->' . $methodName . '() does not exist.', 1245673368);
             }
-            call_user_func_array([$object, $slotInformation['method']], $finalSignalArguments);
+            $object->$methodName(...$finalSignalArguments);
         }
     }
 

--- a/Neos.Flow/Tests/Behavior/Features/Bootstrap/SecurityOperationsTrait.php
+++ b/Neos.Flow/Tests/Behavior/Features/Bootstrap/SecurityOperationsTrait.php
@@ -178,7 +178,7 @@ trait SecurityOperationsTrait
             $instance = $this->objectManager->get($className);
 
             try {
-                $result = call_user_func_array([$instance, $methodName], Arrays::trimExplode(',', $arguments));
+                $result = $instance->$methodName(...Arrays::trimExplode(',', $arguments));
                 if ($not === 'not') {
                     Assert::fail('Method should not be callable');
                 }

--- a/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractViewHelper.php
@@ -114,7 +114,7 @@ abstract class AbstractViewHelper extends FluidAbstractViewHelper
         $renderMethodParameters = [];
         foreach ($this->argumentDefinitions as $argumentName => $argumentDefinition) {
             if ($argumentDefinition instanceof ArgumentDefinition && $argumentDefinition->isMethodParameter()) {
-                $renderMethodParameters[$argumentName] = $this->arguments[$argumentName];
+                $renderMethodParameters[] = $this->arguments[$argumentName];
             }
         }
 

--- a/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractViewHelper.php
@@ -119,7 +119,7 @@ abstract class AbstractViewHelper extends FluidAbstractViewHelper
         }
 
         try {
-            return call_user_func_array([$this, 'render'], $renderMethodParameters);
+            return $this->render(...$renderMethodParameters);
         } catch (Exception $exception) {
             if (!$this->objectManager->getContext()->isProduction()) {
                 throw $exception;

--- a/Neos.Utility.ObjectHandling/Classes/ObjectAccess.php
+++ b/Neos.Utility.ObjectHandling/Classes/ObjectAccess.php
@@ -435,45 +435,13 @@ abstract class ObjectAccess
      * Instantiates the class named `$className` using the `$arguments` as constructor
      * arguments (in array order).
      *
-     * For less than 7 arguments `new` is used, for more a `ReflectionClass` is created
-     * and `newInstanceArgs` is used.
-     *
-     * Note: this should be used sparingly, just calling `new` yourself or using Dependency
-     * Injection are most probably better alternatives.
-     *
      * @param string $className
      * @param array $arguments
      * @return object
+     * @deprecated directly use "new $className(...$arguments)" instead
      */
     public static function instantiateClass($className, $arguments)
     {
-        switch (count($arguments)) {
-            case 0:
-                $object = new $className();
-            break;
-            case 1:
-                $object = new $className($arguments[0]);
-            break;
-            case 2:
-                $object = new $className($arguments[0], $arguments[1]);
-            break;
-            case 3:
-                $object = new $className($arguments[0], $arguments[1], $arguments[2]);
-            break;
-            case 4:
-                $object = new $className($arguments[0], $arguments[1], $arguments[2], $arguments[3]);
-            break;
-            case 5:
-                $object = new $className($arguments[0], $arguments[1], $arguments[2], $arguments[3], $arguments[4]);
-            break;
-            case 6:
-                $object = new $className($arguments[0], $arguments[1], $arguments[2], $arguments[3], $arguments[4], $arguments[5]);
-            break;
-            default:
-                $class = new \ReflectionClass($className);
-                $object = $class->newInstanceArgs($arguments);
-        }
-
-        return $object;
+        return new $className(...$arguments);
     }
 }


### PR DESCRIPTION
This is supported since PHP 5.6 and is actually faster than call_user_func_array at least since PHP 7.
Just be sure to not use it in places where the method is static or a Closure.
This also deprecates `ObjectAccess::instantiateClass()` (retrospectively). It will be removed with Flow 7.