### PR TITLE
TASK: Add release notes for 6.0

### DIFF
--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartV/ReleaseNotes/600.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartV/ReleaseNotes/600.rst
@@ -1,0 +1,102 @@
+========
+Flow 6.0
+========
+
+This major release of Flow brings a few bigger features and a lot of
+modernisation of the existing code base.
+
+====================
+Upgrade Instructions
+====================
+
+This section contains instructions for upgrading your Flow 5.3
+based applications to Flow 6.0.
+
+* We now require PHP 7.2.x or higher
+* If you are using a MySQL based database you must use at least 
+  MySQL 5.7.7 or MariaDB 10.2.2
+
+In general just make sure to run the following commands::
+
+ ./flow flow:cache:flush --force
+ ./flow flow:core:migrate
+ ./flow database:setcharset
+ ./flow doctrine:migrate
+ ./flow resource:publish
+
+If you are upgrading from a lower version than 5.3, be sure to read the
+upgrade instructions from the previous Release Notes first.
+
+Upgrading your Packages
+-----------------------
+
+Upgrading existing code
+^^^^^^^^^^^^^^^^^^^^^^^
+
+There have been major API changes in Flow 6.0 which require your code to be adjusted. As with earlier changes to Flow
+that required code changes on the user side we provide a code migration tool.
+
+Given you have a Flow system with your (outdated) package in place you should run the following before attempting to fix
+anything by hand::
+
+ ./flow core:migrate --package-key Acme.Demo
+
+The package key is optional, if left out it will work on all packages it finds (except for library packages and packages
+prefixed with "Neos.*") - for the first run you might want to limit things a little to keep the overview,
+though.
+
+Make sure to run::
+
+ ./flow help core:migrate
+
+to see all the other helpful options this command provides.
+
+Also make sure to read the changes below.
+
+Inside core:migrate
+"""""""""""""""""""
+
+The tool roughly works like this:
+
+* Collect all code migrations from packages
+
+* Collect all files from all packages (except *Framework* and
+  *Libraries*) or the package given with ``--package-key``
+* For each migration and package
+
+  * Check for clean git working copy (otherwise skip it)
+  * Check if migration is needed (looks for Migration footers in commit
+    messages)
+  * Apply migration and commit the changes
+
+Afterwards you probably get a list of warnings and notes from the
+migrations, check those to see if anything needs to be done manually.
+
+Check the created commits and feel free to amend as needed, should
+things be missing or wrong. The only thing you must keep in place from
+the generated commits is the migration data in ``composer.json``. It is
+used to detect if a migration has been applied already, so if you drop
+it, things might get out of hands in the future.
+
+================
+What has changed
+================
+
+Flow 6.0 comes with some breaking changes and removes several deprecated
+functionalities, be sure to read the following changes and adjust
+your code respectively. For a full list of changes please refer
+to the changelog.
+
+In general type hints were added to a lot of Flow core methods,
+if you get type errors check how you use those methods and report
+a bug in case the type hint seems wrong or the call happens in the
+core and seems unrelated to your code.
+
+Also the YAML parser component we use is stricter now, so any
+parsing errors you get are actually broken YAML that was just ignored
+beforehand with unclear outcome.
+
+Additionally render method arguments in ViewHelpers are deprecated and should be
+replaced with `registerArgument` calls as was done with all integrated VieHelpers for this release.
+
+<!-- INSERT FEATURE CHANGELOG HERE -->


### PR DESCRIPTION
This is an (mostly empty) stub for the till now missing 6.0 release notes

TODO: Update with most important changes - see https://github.com/neos/flow-development-collection/blob/6.0/Neos.Flow/Documentation/TheDefinitiveGuide/PartV/ChangeLogs/600.rst
and https://www.neos.io/blog/neos-5-0-and-flow-6-0-released.html