### PR TITLE
FEATURE: Improve 304 response handling

### DIFF
--- a/Neos.Flow/Classes/Http/Helper/ResponseInformationHelper.php
+++ b/Neos.Flow/Classes/Http/Helper/ResponseInformationHelper.php
@@ -151,7 +151,7 @@ abstract class ResponseInformationHelper
     {
         $statusCode = $response->getStatusCode();
         if ($request->hasHeader('If-None-Match') && in_array($request->getMethod(), ['HEAD', 'GET'])
-            && $response->hasHeader('ETag') && $statusCode === 200 ) {
+            && $response->hasHeader('ETag') && $statusCode === 200) {
             $ifNoneMatchHeaders = $request->getHeader('If-None-Match');
             $eTagHeader = $response->getHeader('ETag')[0];
             foreach ($ifNoneMatchHeaders as $ifNoneMatchHeader) {
@@ -160,7 +160,8 @@ abstract class ResponseInformationHelper
                     break;
                 }
             }
-        } else if ($request->hasHeader('If-Modified-Since') && $response->hasHeader('Last-Modified') && $statusCode === 200) {
+        } elseif ($request->hasHeader('If-Modified-Since') && in_array($request->getMethod(), ['HEAD', 'GET'])
+            && $response->hasHeader('Last-Modified') && $statusCode === 200) {
             $ifModifiedSince = $request->getHeader('If-Modified-Since')[0];
             $ifModifiedSinceDate = \DateTime::createFromFormat(DATE_RFC2822, $ifModifiedSince);
             $lastModified = $response->getHeader('Last-Modified')[0];

--- a/Neos.Flow/Tests/Unit/Http/Helper/ResponseInformationHelperTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Helper/ResponseInformationHelperTest.php
@@ -90,7 +90,10 @@ class ResponseInformationHelperTest extends UnitTestCase
             // when etag matches a 304 result is creatd
             ['GET', ['If-None-Match' => '"12345"'], 200, ['ETag' => '"12345"'], 304],
             ['HEAD', ['If-None-Match' => '"12345"'], 200, ['ETag' => '"12345"'], 304],
-            // etags comparison ignodes weakness indicator
+            // multiple if-none-match headers
+            ['HEAD', ['If-None-Match' => ['"abcd"', '"12345"', '"5678"']], 200, ['ETag' => '"12345"'], 304],
+            ['HEAD', ['If-None-Match' => ['"abcd"', '"56789"', '"defg"']], 200, ['ETag' => '"12345"'], 200],
+            // etags comparison ignores weakness indicator
             ['GET', ['If-None-Match' => 'W/"12345"'], 200, ['ETag' => '"12345"'], 304],
             ['GET', ['If-None-Match' => '"12345"'], 200, ['ETag' => 'W/"12345"'], 304],
             ['GET', ['If-None-Match' => 'W/"12345"'], 200, ['ETag' => 'W/"12345"'], 304],

--- a/Neos.Flow/Tests/Unit/Http/Helper/ResponseInformationHelperTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Helper/ResponseInformationHelperTest.php
@@ -28,4 +28,60 @@ class ResponseInformationHelperTest extends UnitTestCase
 
         self::assertEquals('5', $contentLengthHeaderValues);
     }
+
+    /**
+     * @test
+     */
+    public function makeStandardCompliantEnsuresEmptyBodyForHeadRequests()
+    {
+        $request = ServerRequest::fromGlobals()->withMethod('HEAD');
+        $response = new Response(200, ['X-FOO' => 'bar', 'Content-Length' => 5], '12345');
+        $compliantResponse = ResponseInformationHelper::makeStandardsCompliant($response, $request);
+        self::assertEmpty((string)$compliantResponse->getBody());
+        self::assertSame($response->getHeaders(), $compliantResponse->getHeaders());
+    }
+
+    /**
+     * @test
+     */
+    public function makeStandardCompliantEnsuresEmptyBodyOn304Responses()
+    {
+        $request = ServerRequest::fromGlobals();
+        $response = new Response(304, [], '12345');
+        $compliantResponse = ResponseInformationHelper::makeStandardsCompliant($response, $request);
+        self::assertFalse($compliantResponse->hasHeader('Content-Length'));
+        self::assertEmpty((string)$compliantResponse->getBody());
+    }
+
+    public function makeStandardCompliantRemovesNotAllowedHeadersFrom304ResponseDataProvider()
+    {
+        return [
+            ['Cache-Control' , 'max-age=60' , true],
+            ['Content-Location', '/example', true],
+            ['Date', 'Wed, 21 Oct 2015 07:28:00 GMT', true],
+            ['ETag', '"33a64df551425fcc55e4d42a148795d9f25f89d4"', true],
+            ['Expires', 'Wed, 21 Oct 2015 07:28:00 GMT', true],
+            ['Vary', 'Accept-Encoding,Cookie', true],
+            ['Content-Length', 5, false],
+            ['X-Foo', 'bar', false]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider makeStandardCompliantRemovesNotAllowedHeadersFrom304ResponseDataProvider
+     */
+    public function makeStandardCompliantRemovesNotAllowedHeadersFrom304Response($headerName, $headerValue, $keepHeader)
+    {
+        $request = ServerRequest::fromGlobals();
+        $response = new Response(304);
+        $response = $response->withHeader($headerName, $headerValue);
+        $compliantResponse = ResponseInformationHelper::makeStandardsCompliant($response, $request);
+        if ($keepHeader) {
+            self::assertTrue($compliantResponse->hasHeader($headerName));
+            self::assertSame($response->getHeader($headerName), $compliantResponse->getHeader($headerName));
+        } else {
+            self::assertFalse($compliantResponse->hasHeader('Content-Length'));
+        }
+    }
 }

--- a/Neos.Flow/Tests/Unit/Http/Helper/ResponseInformationHelperTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Helper/ResponseInformationHelperTest.php
@@ -135,39 +135,6 @@ class ResponseInformationHelperTest extends UnitTestCase
         $request = ServerRequest::fromGlobals();
         $response = new Response(304, [], '12345');
         $compliantResponse = ResponseInformationHelper::makeStandardsCompliant($response, $request);
-        self::assertFalse($compliantResponse->hasHeader('Content-Length'));
         self::assertEmpty((string)$compliantResponse->getBody());
-    }
-
-    public function makeStandardCompliantRemovesNotAllowedHeadersFrom304ResponseDataProvider()
-    {
-        return [
-            ['Cache-Control' , 'max-age=60' , true],
-            ['Content-Location', '/example', true],
-            ['Date', 'Wed, 21 Oct 2015 07:28:00 GMT', true],
-            ['ETag', '"33a64df551425fcc55e4d42a148795d9f25f89d4"', true],
-            ['Expires', 'Wed, 21 Oct 2015 07:28:00 GMT', true],
-            ['Vary', 'Accept-Encoding,Cookie', true],
-            ['Content-Length', 5, false],
-            ['X-Foo', 'bar', false]
-        ];
-    }
-
-    /**
-     * @test
-     * @dataProvider makeStandardCompliantRemovesNotAllowedHeadersFrom304ResponseDataProvider
-     */
-    public function makeStandardCompliantRemovesNotAllowedHeadersFrom304Response($headerName, $headerValue, $keepHeader)
-    {
-        $request = ServerRequest::fromGlobals();
-        $response = new Response(304);
-        $response = $response->withHeader($headerName, $headerValue);
-        $compliantResponse = ResponseInformationHelper::makeStandardsCompliant($response, $request);
-        if ($keepHeader) {
-            self::assertTrue($compliantResponse->hasHeader($headerName));
-            self::assertSame($response->getHeader($headerName), $compliantResponse->getHeader($headerName));
-        } else {
-            self::assertFalse($compliantResponse->hasHeader('Content-Length'));
-        }
     }
 }


### PR DESCRIPTION
For responses that match the following conditions an 304 status is returned:
- The request method is GET or HEAD.
- The response status is 200 status.
- The response has has ETag header that matches one of the If-None-Match headers of the request.

!!! The generation of the Etag header is not part of this change and is the job of the application.

Other changes: 
- 304 responses now have an empty body
- Only GET and HEAD Requests will receive 304 status based on ETag and Last-Modified headers

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
