### PR TITLE
!!! BUGFIX: Do not create 412 Status 'Precondition Failed' in standard compliance helper

### DIFF
--- a/Neos.Flow/Classes/Http/Helper/ResponseInformationHelper.php
+++ b/Neos.Flow/Classes/Http/Helper/ResponseInformationHelper.php
@@ -157,15 +157,6 @@ abstract class ResponseInformationHelper
             if ($lastModifiedDate <= $ifModifiedSinceDate) {
                 $response = $response->withStatus(304);
             }
-        } elseif ($request->hasHeader('If-Unmodified-Since') && $response->hasHeader('Last-Modified')
-            && (($statusCode >= 200 && $statusCode <= 299) || $statusCode === 412)) {
-            $unmodifiedSince = $request->getHeader('If-Unmodified-Since')[0];
-            $unmodifiedSinceDate = \DateTime::createFromFormat(DATE_RFC2822, $unmodifiedSince);
-            $lastModified = $response->getHeader('Last-Modified')[0];
-            $lastModifiedDate = \DateTime::createFromFormat(DATE_RFC2822, $lastModified);
-            if ($lastModifiedDate > $unmodifiedSinceDate) {
-                $response = $response->withStatus(412);
-            }
         }
 
         if (in_array($response->getStatusCode(), [100, 101, 204, 304])) {


### PR DESCRIPTION
As defined in RFC 7232 section 4.2 the http status 412 indicates that a precondition for a request failed
and that the requested operation could not be executed which only makes sense for non safe requests.

The bug in here is that this is checked after the fact so Flow would still perform the operation but the standard compliance component would add a precondition failed header and thus not prevent the in flight collision but make the problem harder to understand.

This change removes the code for the 412 status from the standard compliance helper. If any application would want to use the status it should evaluate the precondition headers and throw an exception with 412 status if needed.

Fixes: #2062