### PR TITLE
FEATURE: Array Debugger tolerates iterables

### DIFF
--- a/Neos.Flow/Classes/Error/Debugger.php
+++ b/Neos.Flow/Classes/Error/Debugger.php
@@ -140,7 +140,7 @@ class Debugger
             }
         } elseif (is_numeric($variable)) {
             $dump = sprintf('%s %s', gettype($variable), self::ansiEscapeWrap($variable, '35', $ansiColors));
-        } elseif (is_array($variable)) {
+        } elseif (is_iterable($variable)) {
             $dump = self::renderArrayDump($variable, $level + 1, $plaintext, $ansiColors);
         } elseif (is_object($variable)) {
             $dump = self::renderObjectDump($variable, $level + 1, true, $plaintext, $ansiColors);
@@ -158,13 +158,13 @@ class Debugger
     /**
      * Renders a dump of the given array
      *
-     * @param array $array
+     * @param iterable $array
      * @param integer $level
      * @param boolean $plaintext
      * @param boolean $ansiColors
      * @return string
      */
-    protected static function renderArrayDump(array $array, int $level, bool $plaintext = false, bool $ansiColors = false): string
+    protected static function renderArrayDump(iterable $array, int $level, bool $plaintext = false, bool $ansiColors = false): string
     {
         if (is_array($array)) {
             $dump = 'array' . (count($array) ? '(' . count($array) . ')' : '(empty)');
@@ -197,9 +197,8 @@ class Debugger
         $scope = '';
         $additionalAttributes = '';
 
-        if ($object instanceof \Doctrine\Common\Collections\Collection || $object instanceof \ArrayObject) {
-            // The doctrine Debug utility usually returns a \stdClass object that we need to cast to array.
-            return self::renderArrayDump((array)\Doctrine\Common\Util\Debug::export($object, 3), $level, $plaintext, $ansiColors);
+        if (is_iterable($object)) {
+            return self::renderArrayDump($object, $level, $plaintext, $ansiColors);
         }
 
         // Objects returned from Doctrine's Debug::export function are stdClass with special properties:


### PR DESCRIPTION
This change lets the debug-array-renderer use the pseudo type iterable (Array or Traversable) instead of array. That way all foreachachble objects are rendered as an array. 

This replaces the previous exceptions for ArrayObjects and DoctrineCollections and will also enable to properly debug other Traversable objects aswell.
