### PR TITLE
TASK: Don't install latest psalm in travis runs every time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,6 @@ install:
   - composer update --no-progress --no-interaction
   - php Build/BuildEssentials/TravisCi/ComposerManifestUpdater.php .
   - composer update --no-progress --no-interaction
-  - if [ "$STATIC_ANALYSIS" = "true" ]; then composer require --dev vimeo/psalm; fi
 before_script:
   - echo 'date.timezone = "Africa/Tunis"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - echo 'opcache.fast_shutdown = 0' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -49,6 +49,9 @@
 
         "composer/composer": "^1.9"
     },
+    "require-dev": {
+        "vimeo/psalm": "~3.10.0"
+    },
     "replace": {
         "typo3/flow": "self.version"
     },

--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,7 @@
     "require-dev": {
         "mikey179/vfsstream": "~1.6",
         "phpunit/phpunit": "~8.1",
-        "vimeo/psalm": "^3.4",
+        "vimeo/psalm": "~3.10.0",
         "doctrine/orm": "^2.6",
         "doctrine/common": "^2.4"
     },


### PR DESCRIPTION
This should make the psalm runs more consistent by pinning the psalm version to a minor. If we want to update to a newer version to cover new checks, we now need to manually update the dependency version and fix new errors by changing our codebase or the psalm-baseline.