### PR TITLE
BUGFIX: Adapt virtual objects change to factory arguments bugfix

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
@@ -170,7 +170,7 @@ class ConfigurationBuilder
 
         $this->autowireArguments($objectConfigurations);
         $this->autowireProperties($objectConfigurations);
-        $this->wireFactoryyArguments($objectConfigurations);
+        $this->wireFactoryArguments($objectConfigurations);
 
         return $objectConfigurations;
     }

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
@@ -170,7 +170,7 @@ class ConfigurationBuilder
 
         $this->autowireArguments($objectConfigurations);
         $this->autowireProperties($objectConfigurations);
-        $this->wireObjectArguments($objectConfigurations);
+        $this->wireFactoryyArguments($objectConfigurations);
 
         return $objectConfigurations;
     }
@@ -376,7 +376,7 @@ class ConfigurationBuilder
     }
 
     /**
-     * Creates a "virtual object configuration" for object arguments, turning:
+     * Creates a "virtual object configuration" for factory arguments, turning:
      *
      * 'Some\Class\Name':
      *   factoryObjectName: 'Some\Factory\Class'
@@ -400,12 +400,12 @@ class ConfigurationBuilder
      * @param array &$objectConfigurations
      * @return void
      */
-    protected function wireObjectArguments(array &$objectConfigurations)
+    protected function wireFactoryArguments(array &$objectConfigurations)
     {
         /** @var Configuration $objectConfiguration */
         foreach ($objectConfigurations as $objectConfiguration) {
             /** @var ConfigurationArgument $argument */
-            foreach ($objectConfiguration->getArguments() as $index => $argument) {
+            foreach ($objectConfiguration->getFactoryArguments() as $index => $argument) {
                 if ($argument === null || $argument->getType() !== ConfigurationArgument::ARGUMENT_TYPES_OBJECT) {
                     continue;
                 }


### PR DESCRIPTION
The original code only attempted to fix newly introduced factory arguments, but since #1967 those factory arguments are separated from object arguments. Hence this "fix" didn't work any more.