### PR TITLE
BUGFIX: Make sure to use only a consistent NumbersReaderCache

### DIFF
--- a/Neos.Flow/Classes/I18n/Cldr/Reader/NumbersReader.php
+++ b/Neos.Flow/Classes/I18n/Cldr/Reader/NumbersReader.php
@@ -223,8 +223,9 @@ class NumbersReader
         self::validateFormatType($formatType);
         self::validateFormatLength($formatLength);
 
-        if (isset($this->parsedFormatsIndices[(string)$locale][$formatType][$formatLength])) {
-            return $this->parsedFormats[$this->parsedFormatsIndices[(string)$locale][$formatType][$formatLength]];
+        $parsedFormatIndex = $this->parsedFormatsIndices[(string)$locale][$formatType][$formatLength] ?? '';
+        if (isset($this->parsedFormats[$parsedFormatIndex])) {
+            return $this->parsedFormats[$parsedFormatIndex];
         }
 
         if ($formatLength === self::FORMAT_LENGTH_DEFAULT) {


### PR DESCRIPTION
It might happen that there is a discrepancy between parsedFormatsIndices and parsedFormats cache. We need to make sure we are accessing the consistent information instead of relying that both are there, to avoid a PHP exception.

Same fix was already applied to DatesReader, see https://github.com/neos/flow-development-collection/pull/1899.

Resolves #564

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
