### PR TITLE
TASK: Trigger GitHub rebase action only on /rebase

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,9 +1,0 @@
-workflow "Automatic Rebase" {
-  on = "issue_comment"
-  resolves = "Rebase"
-}
-
-action "Rebase" {
-  uses = "docker://cirrusactions/rebase:latest"
-  secrets = ["GITHUB_TOKEN"]
-}

--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -1,0 +1,12 @@
+on: issue_comment
+name: Automatic Rebase
+jobs:
+  rebase:
+    name: Rebase
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Rebase
+      uses: docker://cirrusactions/rebase:latest
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -1,12 +1,24 @@
-on: issue_comment
+on:
+  issue_comment:
+    types: [created]
 name: Automatic Rebase
 jobs:
   rebase:
     name: Rebase
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Rebase
-      uses: docker://cirrusactions/rebase:latest
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+      - name: Automatic Rebase
+        uses: cirrus-actions/rebase@1.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # https://github.community/t5/GitHub-Actions/Workflow-is-failing-if-no-job-can-be-ran-due-to-condition/m-p/38186#M3250
+  always_job:
+    name: Always run job
+    runs-on: ubuntu-latest
+    steps:
+      - name: Always run
+        run: echo "This job is used to prevent the workflow to fail when all other jobs are skipped."


### PR DESCRIPTION
Idea is that a `/rebase` comment rebases the current PR on top of the destination branch, so that we are sure that latest state is included. Current implementation tries the rebase on every comment (see results in https://github.com/neos/flow-development-collection/actions).

In 6.1/6.2 the action was already converted to "v2" style (see https://github.com/neos/flow-development-collection/pull/1765).

So in 5.3 first cherry-picked the conversion from 
After that changed the workflow definition so it looks exactly like the documented:
https://github.com/cirrus-actions/rebase