### PR TITLE
FEATURE: Configurable PersistedUsernamePasswordProvider lookup name

### DIFF
--- a/Neos.Flow/Classes/Security/Authentication/Provider/PersistedUsernamePasswordProvider.php
+++ b/Neos.Flow/Classes/Security/Authentication/Provider/PersistedUsernamePasswordProvider.php
@@ -91,7 +91,7 @@ class PersistedUsernamePasswordProvider extends AbstractProvider
             return;
         }
 
-        $providerName = $this->options['lookupName'] ?? $this->name;
+        $providerName = $this->options['lookupProviderName'] ?? $this->name;
         $this->securityContext->withoutAuthorizationChecks(function () use ($username, &$account, $providerName) {
             $account = $this->accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName($username, $providerName);
         });

--- a/Neos.Flow/Classes/Security/Authentication/Provider/PersistedUsernamePasswordProvider.php
+++ b/Neos.Flow/Classes/Security/Authentication/Provider/PersistedUsernamePasswordProvider.php
@@ -91,8 +91,9 @@ class PersistedUsernamePasswordProvider extends AbstractProvider
             return;
         }
 
-        $this->securityContext->withoutAuthorizationChecks(function () use ($username, &$account) {
-            $account = $this->accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName($username, $this->name);
+        $providerName = $this->options['lookupName'] ?? $this->name;
+        $this->securityContext->withoutAuthorizationChecks(function () use ($username, &$account, $providerName) {
+            $account = $this->accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName($username, $providerName);
         });
 
         $authenticationToken->setAuthenticationStatus(TokenInterface::WRONG_CREDENTIALS);

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Security.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Security.rst
@@ -527,6 +527,44 @@ providers as you like, but keep in mind that the order matters.
   description to know if a specific provider needs more options to be configured and
   which.
 
+Parallel authentication for the same account
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Accounts are bound to an authentication provider and by default the ``PersistedUsernamePasswordProvider`` will only
+lookup accounts that belong to the provider (i.e. with an ``authenticationProviderName`` that is equal to the configured
+provider name, ``SomeAuthenticationProvider`` in this example.
+That lookup name can be changed via the ``lookupProviderName`` option that allows the provider to lookup accounts for
+a different configuration. This can be useful in order to re-use the same provider & accounts for multiple authentication
+types, for example classic form-based and HTTP basic auth:
+
+.. code-block:: yaml
+
+  Neos:
+    Flow:
+      security:
+        authentication:
+          providers:
+            'Acme.SomePackage:Default':
+              requestPatterns:
+                # ...
+              provider: PersistedUsernamePasswordProvider
+              token: UsernamePassword
+              entryPoint: WebRedirect
+              entryPointOptions:
+                routeValues:
+                  '@package': Acme.SomePackage
+                  '@controller': Authentication
+                  '@action': login
+
+            'Acme.SomePackage:Default.HttpBasic':
+              requestPatterns:
+                # ...
+              provider: PersistedUsernamePasswordProvider
+              providerOptions:
+                lookupProviderName: 'Acme.SomePackage:Default'
+              token: UsernamePasswordHttpBasic
+              entryPoint: HttpBasic
+
 Multi-factor authentication strategy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
@@ -107,7 +107,7 @@ class PersistedUsernamePasswordProviderTest extends UnitTestCase
     /**
      * @test
      */
-    public function authenticatingAnUsernamePasswordTokenRespectsTheConfiguredLookupName()
+    public function authenticatingAnUsernamePasswordTokenRespectsTheConfiguredLookupProviderName()
     {
         $this->mockHashService->expects(self::once())->method('validatePassword')->with('password', '8bf0abbb93000e2e47f0e0a80721e834,80f117a78cff75f3f73793fd02aa9086')->will(self::returnValue(true));
 
@@ -120,7 +120,7 @@ class PersistedUsernamePasswordProviderTest extends UnitTestCase
 
         $this->mockToken->expects(self::once())->method('setAccount')->with($this->mockAccount);
 
-        $persistedUsernamePasswordProvider = PersistedUsernamePasswordProvider::create('providerName', ['lookupName' => 'customLookupName']);
+        $persistedUsernamePasswordProvider = PersistedUsernamePasswordProvider::create('providerName', ['lookupProviderName' => 'customLookupName']);
         $this->inject($persistedUsernamePasswordProvider, 'hashService', $this->mockHashService);
         $this->inject($persistedUsernamePasswordProvider, 'accountRepository', $this->mockAccountRepository);
         $this->inject($persistedUsernamePasswordProvider, 'persistenceManager', $this->mockPersistenceManager);

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
@@ -107,7 +107,7 @@ class PersistedUsernamePasswordProviderTest extends UnitTestCase
     /**
      * @test
      */
-    public function authenticatingAnUsernamePasswordTokenRespectsTheConfiguredLookupProviderName()
+    public function authenticatingAndUsernamePasswordTokenRespectsTheConfiguredLookupProviderName()
     {
         $this->mockHashService->expects(self::once())->method('validatePassword')->with('password', '8bf0abbb93000e2e47f0e0a80721e834,80f117a78cff75f3f73793fd02aa9086')->will(self::returnValue(true));
 

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Tests\Unit\Security\Authentication\Provider;
 
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Security;
+use Neos\Flow\Security\Authentication\Provider\PersistedUsernamePasswordProvider;
 use Neos\Flow\Tests\UnitTestCase;
 
 /**
@@ -101,6 +102,31 @@ class PersistedUsernamePasswordProviderTest extends UnitTestCase
 
         $this->persistedUsernamePasswordProvider->authenticate($this->mockToken);
         self::assertSame(\Neos\Flow\Security\Authentication\TokenInterface::AUTHENTICATION_SUCCESSFUL, $lastAuthenticationStatus);
+    }
+
+    /**
+     * @test
+     */
+    public function authenticatingAnUsernamePasswordTokenRespectsTheConfiguredLookupName()
+    {
+        $this->mockHashService->expects(self::once())->method('validatePassword')->with('password', '8bf0abbb93000e2e47f0e0a80721e834,80f117a78cff75f3f73793fd02aa9086')->will(self::returnValue(true));
+
+        $this->mockAccount->expects(self::once())->method('getCredentialsSource')->will(self::returnValue('8bf0abbb93000e2e47f0e0a80721e834,80f117a78cff75f3f73793fd02aa9086'));
+
+        $this->mockAccountRepository->expects(self::once())->method('findActiveByAccountIdentifierAndAuthenticationProviderName')->with('admin', 'customLookupName')->will(self::returnValue($this->mockAccount));
+
+        $this->mockToken->expects(self::atLeastOnce())->method('getUsername')->will(self::returnValue('admin'));
+        $this->mockToken->expects(self::atLeastOnce())->method('getPassword')->will(self::returnValue('password'));
+
+        $this->mockToken->expects(self::once())->method('setAccount')->with($this->mockAccount);
+
+        $persistedUsernamePasswordProvider = PersistedUsernamePasswordProvider::create('providerName', ['lookupName' => 'customLookupName']);
+        $this->inject($persistedUsernamePasswordProvider, 'hashService', $this->mockHashService);
+        $this->inject($persistedUsernamePasswordProvider, 'accountRepository', $this->mockAccountRepository);
+        $this->inject($persistedUsernamePasswordProvider, 'persistenceManager', $this->mockPersistenceManager);
+        $this->inject($persistedUsernamePasswordProvider, 'securityContext', $this->mockSecurityContext);
+
+        $persistedUsernamePasswordProvider->authenticate($this->mockToken);
     }
 
     /**


### PR DESCRIPTION
Adds an option `lookupProviderName` to the `PersistedUsernamePasswordProvider` that allows the provider to be reused for multiple authentication types.

Example:

```yaml
Neos:
  Flow:
    security:
      authentication:
        providers:
          'Acme.SomePackage:Default':
            provider: PersistedUsernamePasswordProvider
            token: UsernamePassword
          'Acme.SomePackage:Default.HttpBasic':
            provider: PersistedUsernamePasswordProvider
            providerOptions:
              lookupProviderName: 'Acme.SomePackage:Default'
            token: UsernamePasswordHttpBasic
            entryPoint: HttpBasic
```

Resolves: #1996 