### PR TITLE
BUGFIX: Avoid trying to autowire constructor arguments for factory created objects

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
@@ -377,6 +377,9 @@ class ConfigurationBuilder
                 continue;
             }
 
+            if ($objectConfiguration->isCreatedByFactory()) {
+                continue;
+            }
 
             $className = $objectConfiguration->getClassName();
             if (!$this->reflectionService->hasMethod($className, '__construct')) {

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationBuilderTest.php
@@ -16,6 +16,7 @@ use Neos\Flow\ObjectManagement\Configuration\Configuration;
 use Neos\Flow\ObjectManagement\Configuration\ConfigurationArgument;
 use Neos\Flow\ObjectManagement\Configuration\ConfigurationBuilder;
 use Neos\Flow\ObjectManagement\Configuration\ConfigurationProperty;
+use Neos\Flow\ObjectManagement\Exception\UnresolvedDependenciesException;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\Annotations as Flow;
@@ -204,5 +205,46 @@ class ConfigurationBuilderTest extends UnitTestCase
 
         $expectedConfigurationArgument = new ConfigurationArgument(1, 'Neos.Foo.Bar', ConfigurationArgument::ARGUMENT_TYPES_SETTING);
         $this->assertEquals($expectedConfigurationArgument, $builtObjectConfiguration->getArguments()[1]);
+    }
+
+    /**
+     * @test
+     */
+    public function objectsCreatedByFactoryShouldNotFailOnMissingConstructorArguments()
+    {
+        $configurationArray = [
+            'scope' => 'singleton',
+            'factoryObjectName' => 'TestFactory',
+        ];
+
+        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy']);
+        $dummyObjectConfiguration = [$configurationBuilder->_call('parseConfigurationArray', __CLASS__, $configurationArray)];
+
+        $reflectionServiceMock = $this->createMock(ReflectionService::class);
+
+        $reflectionServiceMock
+            ->method('hasMethod')
+            ->with(__CLASS__, '__construct')
+            ->will($this->returnValue(true));
+
+        $reflectionServiceMock
+            ->method('getMethodParameters')
+            ->with(__CLASS__, '__construct')
+            ->will($this->returnValue([
+                'testArray' => [
+                    'position' => 0,
+                    'optional' => false,
+                    'class' => null,
+                    'allowsNull' => false
+                ]
+            ]));
+
+        $configurationBuilder->injectReflectionService($reflectionServiceMock);
+        try {
+            $configurationBuilder->_callRef('autowireArguments', $dummyObjectConfiguration);
+        } catch (UnresolvedDependenciesException $e) {
+            self::fail('Factory created objects should not throw UnresolvedDependenciesException by autowiring constructor arguments');
+        }
+        self::assertEquals([], $dummyObjectConfiguration[0]->getArguments());
     }
 }


### PR DESCRIPTION
This bug was uncovered with the previous fix to not map arguments to the object when a factory is configured (see #1967).
That way (singleton) objects which expected a (non-optional/nullable) constructor argument that could not be autowired (e.g. because it was a scalar) would lead to the exception "Could not autowire required constructor argument ... for singleton class ...".
This change fixes that, by completely skipping autowiring for objects configured with a factory. The factory has full responsibility to create and wire the constructor arguments correctly.
