### PR TITLE
BUGFIX: ActionResponse contains negotiated media type as content-type

### DIFF
--- a/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
@@ -113,6 +113,7 @@ abstract class AbstractController implements ControllerInterface
         if ($mediaType === null) {
             $this->throwStatus(406);
         }
+        $this->response->setContentType($mediaType);
         if ($request->getFormat() === '') {
             $this->request->setFormat(MediaTypes::getFilenameExtensionFromMediaType($mediaType));
         }

--- a/Neos.Flow/Tests/Functional/Mvc/AbstractControllerTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/AbstractControllerTest.php
@@ -75,4 +75,13 @@ class AbstractControllerTest extends FunctionalTestCase
         $response = $this->browser->request('http://localhost/test/mvc/abstractcontrollertesta/forward?actionName=fourth&passSomeObjectArguments=1&arguments[nonObject1]=First&arguments[nonObject2]=42');
         self::assertEquals('fourthAction-First-42-Neos\Error\Messages\Message', $response->getBody()->getContents());
     }
+
+    /**
+     * @test
+     */
+    public function responseContainsNegotiatedContentType()
+    {
+        $response = $this->browser->request('http://localhost/test/mvc/abstractcontrollertesta/second');
+        self::assertEquals('text/plain', $response->getHeaderLine('Content-Type'));
+    }
 }

--- a/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/AbstractControllerTestAController.php
+++ b/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/AbstractControllerTestAController.php
@@ -24,6 +24,8 @@ use Neos\Error\Messages\Message;
  */
 class AbstractControllerTestAController extends ActionController
 {
+    protected $supportedMediaTypes = ['text/plain'];
+
     /**
      * An action which forwards using the given parameters
      *
@@ -37,7 +39,6 @@ class AbstractControllerTestAController extends ActionController
     public function forwardAction($actionName, $controllerName = null, $packageKey = null, array $arguments = [], $passSomeObjectArguments = false)
     {
         if ($passSomeObjectArguments) {
-            $arguments['__object1'] = new Message('Some test message', 12345);
             $arguments['__object1'] = new Message('Some test message', 67890);
         }
         $this->forward($actionName, $controllerName, $packageKey, $arguments);


### PR DESCRIPTION
This sets the negotiated media type from the Controller in the `ActionResponse`.