### PR TITLE
BUGFIX: reflectionService if more than one implementation class is available

### DIFF
--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -19,7 +19,6 @@ use Neos\Cache\Frontend\FrontendInterface;
 use Neos\Cache\Frontend\StringFrontend;
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Core\ApplicationContext;
-use Neos\Flow\ObjectManagement\Proxy\ProxyInterface;
 use Neos\Flow\Package;
 use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Persistence\RepositoryInterface;

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -435,14 +435,14 @@ class ReflectionService
         if (count($classNamesFound) === 1) {
             return $classNamesFound[0];
         }
-        if (count($classNamesFound) !== 2 || !isset($this->classReflectionData[ProxyInterface::class][self::DATA_INTERFACE_IMPLEMENTATIONS])) {
+        if (count($classNamesFound) !== 2 || !isset($this->classReflectionData[$interfaceName][self::DATA_INTERFACE_IMPLEMENTATIONS])) {
             return false;
         }
 
-        if (isset($this->classReflectionData[ProxyInterface::class][self::DATA_INTERFACE_IMPLEMENTATIONS][$classNamesFound[0]])) {
+        if (isset($this->classReflectionData[$interfaceName][self::DATA_INTERFACE_IMPLEMENTATIONS][$classNamesFound[0]])) {
             return $classNamesFound[0];
         }
-        if (isset($this->classReflectionData[ProxyInterface::class][self::DATA_INTERFACE_IMPLEMENTATIONS][$classNamesFound[1]])) {
+        if (isset($this->classReflectionData[$interfaceName][self::DATA_INTERFACE_IMPLEMENTATIONS][$classNamesFound[1]])) {
             return $classNamesFound[1];
         }
 


### PR DESCRIPTION
To be honest, I don't know exactly what I did, but it seems reasonable, when I look at the code, and (more important) it fixed my issue I had in NEOS:
Besides the Neos-Backend-Users I derived a custom Frontend-User-Class by extending Neos/Neos/../User, therefore my class is also implementing the Neos\ContentRepository\Domain\Model\UserInterface, but then the ReflectionService failed to fetch the correct implementation class when I tried to log into the backend. (Error "Class '' does not exist") because there was no value in $this->classReflectionData[ProxyInterface::class][self::DATA_INTERFACE_IMPLEMENTATIONS]
