### PR TITLE
BUGFIX: Allow objects to be serialized twice without loosing their relations to persisted properties

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
@@ -228,6 +228,7 @@ class ProxyClassBuilder
                 $propertyVarTags[$propertyName] = isset($varTagValues[0]) ? $varTagValues[0] : null;
             }
             $code = "        \$this->Flow_Object_PropertiesToSerialize = array();
+        unset(\$this->Flow_Persistence_RelatedEntities);
 
         \$transientProperties = " . var_export($transientProperties, true) . ";
         \$propertyVarTags = " . var_export($propertyVarTags, true) . ";

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/ObjectHoldingAnEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/ObjectHoldingAnEntity.php
@@ -1,0 +1,12 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
+
+use Neos\Flow\Tests\Functional\Persistence\Fixtures\TestEntity;
+
+class ObjectHoldingAnEntity
+{
+    /**
+     * @var TestEntity
+     */
+    public $testEntity;
+}

--- a/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
@@ -182,6 +182,26 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function objectsWithPersistedEntitiesCanBeSerializedMultipleTimes()
+    {
+        $persistedEntity = new Fixtures\TestEntity();
+        $persistedEntity->setName('Flow');
+        $this->testEntityRepository->add($persistedEntity);
+        $this->persistenceManager->persistAll();
+
+        $objectHoldingTheEntity = new Fixtures\ObjectHoldingAnEntity();
+        $objectHoldingTheEntity->testEntity = $persistedEntity;
+
+        for ($i = 0; $i < 2; $i++) {
+            $serializedData = serialize($objectHoldingTheEntity);
+            $unserializedObjectHoldingTheEntity = unserialize($serializedData);
+            $this->assertInstanceOf(Fixtures\TestEntity::class, $unserializedObjectHoldingTheEntity->testEntity);
+        }
+    }
+
+    /**
+     * @test
+     */
     public function newEntitiesWhichAreNotAddedToARepositoryYetAreAlreadyKnownToGetObjectByIdentifier()
     {
         $expectedEntity = new Fixtures\TestEntity();


### PR DESCRIPTION
This should solve the issue described in #2009 
