### PR TITLE
TASK: Rename Doctrine\Common\Persistence -> Doctrine\Persistence

### DIFF
--- a/Neos.Flow/Classes/Command/DoctrineCommandController.php
+++ b/Neos.Flow/Classes/Command/DoctrineCommandController.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Command;
  * source code.
  */
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Util\Debug;
 use Doctrine\DBAL\Migrations\MigrationException;
 use Neos\Flow\Annotations as Flow;

--- a/Neos.Flow/Classes/Persistence/Doctrine/Mapping/ClassMetadata.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Mapping/ClassMetadata.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Persistence\Doctrine\Mapping;
  * source code.
  */
 
-use Doctrine\Common\Persistence\Mapping\ReflectionService as DoctrineReflectionService;
+use Doctrine\Persistence\Mapping\ReflectionService as DoctrineReflectionService;
 use Neos\Flow\Reflection\ClassReflection;
 
 /**

--- a/Neos.Flow/Classes/Persistence/Doctrine/Repository.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Repository.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Persistence\Doctrine;
  * source code.
  */
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Internal\Hydration\IterableResult;

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/ConjunctionGenerator.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/ConjunctionGenerator.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Security\Authorization\Privilege\Entity\Doctrine;
  * source code.
  */
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Filter\SQLFilter as DoctrineSqlFilter;
 use Neos\Flow\Annotations as Flow;
 

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/DisjunctionGenerator.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/DisjunctionGenerator.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Security\Authorization\Privilege\Entity\Doctrine;
  * source code.
  */
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Filter\SQLFilter as DoctrineSqlFilter;
 use Neos\Flow\Annotations as Flow;
 

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/EntityPrivilege.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/EntityPrivilege.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Security\Authorization\Privilege\Entity\Doctrine;
  * source code.
  */
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Neos\Eel\Context as EelContext;

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/FalseConditionGenerator.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/FalseConditionGenerator.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Security\Authorization\Privilege\Entity\Doctrine;
  * source code.
  */
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Filter\SQLFilter as DoctrineSqlFilter;
 use Neos\Flow\Annotations as Flow;
 

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/NotExpressionGenerator.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/NotExpressionGenerator.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Security\Authorization\Privilege\Entity\Doctrine;
  * source code.
  */
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Filter\SQLFilter as DoctrineSqlFilter;
 use Neos\Flow\Annotations as Flow;
 

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/PropertyConditionGenerator.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/PropertyConditionGenerator.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Security\Authorization\Privilege\Entity\Doctrine;
  * source code.
  */
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\Query\Filter\SQLFilter as DoctrineSqlFilter;

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/SqlGeneratorInterface.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/SqlGeneratorInterface.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Security\Authorization\Privilege\Entity\Doctrine;
  * source code.
  */
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Filter\SQLFilter as DoctrineSqlFilter;
 use Neos\Flow\Annotations as Flow;
 

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/TrueConditionGenerator.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/TrueConditionGenerator.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Security\Authorization\Privilege\Entity\Doctrine;
  * source code.
  */
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Filter\SQLFilter as DoctrineSqlFilter;
 use Neos\Flow\Annotations as Flow;
 

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/EntityPrivilegeInterface.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/EntityPrivilegeInterface.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Security\Authorization\Privilege\Entity;
  * source code.
  */
 
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\ClassMetadata;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Security\Authorization\Privilege\PrivilegeInterface;
 

--- a/Neos.Flow/Tests/Unit/Reflection/Fixture/Model/EntityWithDoctrineProxy.php
+++ b/Neos.Flow/Tests/Unit/Reflection/Fixture/Model/EntityWithDoctrineProxy.php
@@ -11,21 +11,21 @@ class EntityWithDoctrineProxy extends Entity implements \Doctrine\ORM\Proxy\Prox
      *      three parameters, being respectively the proxy object to be initialized, the method that triggered the
      *      initialization process and an array of ordered parameters that were passed to that method.
      *
-     * @see \Doctrine\Common\Persistence\Proxy::__setInitializer
+     * @see \Doctrine\Persistence\Proxy::__setInitializer
      */
     public $__initializer__;
 
     /**
      * @var \Closure the callback responsible of loading properties that need to be copied in the cloned object
      *
-     * @see \Doctrine\Common\Persistence\Proxy::__setCloner
+     * @see \Doctrine\Persistence\Proxy::__setCloner
      */
     public $__cloner__;
 
     /**
      * @var boolean flag indicating if this object was already initialized
      *
-     * @see \Doctrine\Common\Persistence\Proxy::__isInitialized
+     * @see \Doctrine\Persistence\Proxy::__isInitialized
      */
     public $__isInitialized__ = false;
 
@@ -33,7 +33,7 @@ class EntityWithDoctrineProxy extends Entity implements \Doctrine\ORM\Proxy\Prox
      * @var array properties to be lazy loaded, with keys being the property
      *            names and values being their default values
      *
-     * @see \Doctrine\Common\Persistence\Proxy::__getLazyProperties
+     * @see \Doctrine\Persistence\Proxy::__getLazyProperties
      */
     public static $lazyPropertiesDefaults = [];
 

--- a/Neos.Utility.ObjectHandling/Tests/Unit/Fixture/Model/EntityWithDoctrineProxy.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/Fixture/Model/EntityWithDoctrineProxy.php
@@ -23,21 +23,21 @@ class EntityWithDoctrineProxy extends Entity implements Proxy
      *      three parameters, being respectively the proxy object to be initialized, the method that triggered the
      *      initialization process and an array of ordered parameters that were passed to that method.
      *
-     * @see \Doctrine\Common\Persistence\Proxy::__setInitializer
+     * @see \Doctrine\Persistence\Proxy::__setInitializer
      */
     public $__initializer__;
 
     /**
      * @var \Closure the callback responsible of loading properties that need to be copied in the cloned object
      *
-     * @see \Doctrine\Common\Persistence\Proxy::__setCloner
+     * @see \Doctrine\Persistence\Proxy::__setCloner
      */
     public $__cloner__;
 
     /**
      * @var boolean flag indicating if this object was already initialized
      *
-     * @see \Doctrine\Common\Persistence\Proxy::__isInitialized
+     * @see \Doctrine\Persistence\Proxy::__isInitialized
      */
     public $__isInitialized__ = false;
 
@@ -45,7 +45,7 @@ class EntityWithDoctrineProxy extends Entity implements Proxy
      * @var array properties to be lazy loaded, with keys being the property
      *            names and values being their default values
      *
-     * @see \Doctrine\Common\Persistence\Proxy::__getLazyProperties
+     * @see \Doctrine\Persistence\Proxy::__getLazyProperties
      */
     public static $lazyPropertiesDefaults = [];
 


### PR DESCRIPTION
This fixes psalm errors due to the namespace renaming of various doctrine classes in doctrine/orm 2.7.3 release. The old class name was an alias since 2.7, so this should not break anything. 🤞