### PR TITLE
BUGFIX: Allow Views to replace the response in AjaxWidgetContext

### DIFF
--- a/Neos.FluidAdaptor/Classes/Core/Widget/AjaxWidgetComponent.php
+++ b/Neos.FluidAdaptor/Classes/Core/Widget/AjaxWidgetComponent.php
@@ -16,12 +16,14 @@ use Neos\Flow\Http\Component\ComponentChain;
 use Neos\Flow\Http\Component\ComponentInterface;
 use Neos\Flow\Http\Component\Exception as ComponentException;
 use Neos\Flow\Http\Component\ComponentContext;
+use Neos\Flow\Http\Component\ReplaceHttpResponseComponent;
 use Neos\Flow\Mvc\ActionRequestFactory;
 use Neos\Flow\Mvc\ActionResponse;
 use Neos\Flow\Mvc\Dispatcher;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Security\Cryptography\HashService;
 use Neos\Utility\Arrays;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
@@ -89,6 +91,14 @@ class AjaxWidgetComponent implements ComponentInterface
 
         // stop processing the current component chain
         $componentContext->setParameter(ComponentChain::class, 'cancel', true);
+
+        // replace response, if the dispatched request returns a PSR-7 response
+        $possibleResponse = $componentContext->getParameter(ReplaceHttpResponseComponent::class, ReplaceHttpResponseComponent::PARAMETER_RESPONSE);
+        if (!$possibleResponse instanceof ResponseInterface) {
+            return;
+        }
+
+        $componentContext->replaceHttpResponse($possibleResponse);
     }
 
     /**

--- a/Neos.FluidAdaptor/Resources/Private/Templates/Tests/Functional/Core/Fixtures/ViewHelpers/SomeAjax/Index.html
+++ b/Neos.FluidAdaptor/Resources/Private/Templates/Tests/Functional/Core/Fixtures/ViewHelpers/SomeAjax/Index.html
@@ -1,2 +1,3 @@
 SomeAjaxController::indexAction()
 {f:widget.uri(action: 'ajax', ajax: true, arguments: {option1: 'xyz'}) -> f:format.raw()}
+{f:widget.uri(action: 'ajaxWithCustomView', ajax: true, arguments: {option1: 'xyz'}) -> f:format.raw()}

--- a/Neos.FluidAdaptor/Tests/Functional/Core/Fixtures/ViewHelpers/Controller/SomeAjaxController.php
+++ b/Neos.FluidAdaptor/Tests/Functional/Core/Fixtures/ViewHelpers/Controller/SomeAjaxController.php
@@ -12,12 +12,17 @@ namespace Neos\FluidAdaptor\Tests\Functional\Core\Fixtures\ViewHelpers\Controlle
  */
 
 use Neos\FluidAdaptor\Core\Widget\AbstractWidgetController;
+use Neos\FluidAdaptor\Tests\Functional\Core\Fixtures\ViewHelpers\Controller\View\CustomView;
 
 /**
  * Controller of the test AJAX widget
  */
 class SomeAjaxController extends AbstractWidgetController
 {
+    protected $viewFormatToObjectNameMap = [
+        'custom' => CustomView::class
+    ];
+
     /**
      * The default action which is invoked when the widget is rendered as part of a
      * Fluid template.
@@ -41,5 +46,9 @@ class SomeAjaxController extends AbstractWidgetController
         $options = (isset($this->widgetConfiguration['option1']) ? '"' . $this->widgetConfiguration['option1'] . '"' : '""') . ', ';
         $options .= (isset($this->widgetConfiguration['option2']) ? '"' . $this->widgetConfiguration['option2'] . '"' : '""') . '';
         return sprintf('SomeAjaxController::ajaxAction(%s)', $options);
+    }
+
+    public function ajaxWithCustomViewAction()
+    {
     }
 }

--- a/Neos.FluidAdaptor/Tests/Functional/Core/Fixtures/ViewHelpers/Controller/View/CustomView.php
+++ b/Neos.FluidAdaptor/Tests/Functional/Core/Fixtures/ViewHelpers/Controller/View/CustomView.php
@@ -1,0 +1,23 @@
+<?php
+namespace Neos\FluidAdaptor\Tests\Functional\Core\Fixtures\ViewHelpers\Controller\View;
+
+/*
+ * This file is part of the Neos.FluidAdaptor package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use GuzzleHttp\Psr7\Response;
+use Neos\Flow\Mvc\View\AbstractView;
+
+class CustomView extends AbstractView
+{
+    public function render()
+    {
+        return new Response(418, ['X-Flow-Special-Header' => 'YEAH!'], 'Hello World!');
+    }
+}

--- a/Neos.FluidAdaptor/Tests/Functional/Core/WidgetTest.php
+++ b/Neos.FluidAdaptor/Tests/Functional/Core/WidgetTest.php
@@ -183,4 +183,17 @@ class WidgetTest extends FunctionalTestCase
         self::assertSame(500, $response->getStatusCode());
         self::assertSame('1380284579', $response->getHeaderLine('X-Flow-ExceptionCode'));
     }
+
+    /**
+     * @test
+     */
+    public function aCustomViewResponseIsRespectedInAjaxContext(): void
+    {
+        $response = $this->browser->request('http://localhost/test/widget/ajaxtest');
+        [,, $ajaxWidgetUri] = explode(chr(10), $response->getBody()->getContents());
+
+        $response = $this->browser->request('http://localhost/' . $ajaxWidgetUri . '&@format=custom');
+        self::assertSame(418, $response->getStatusCode());
+        self::assertSame('Hello World!', $response->getBody()->getContents());
+    }
 }


### PR DESCRIPTION
If a WidgetController has a view returning a PSR-7 response, it
was not replaced in Ajax context. Now the behavior of the
ReplaceComponent is merged into the AjaxWidgetComponent, so the
expected ActionController behavior can be guaranteed

Solves: #2027 
