### PR TITLE
BUGFIX: Make php binary setting check use realpath

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -855,7 +855,7 @@ class Scripts
             return;
         }
 
-        if (strcmp(PHP_BINARY, $configuredPhpBinaryPathAndFilename) !== 0) {
+        if (strcasecmp(PHP_BINARY, $configuredPhpBinaryPathAndFilename) !== 0) {
             throw new FlowException(sprintf('You are running the Flow CLI with a PHP binary different from the one Flow is configured to use internally. ' .
                 'Flow has been run with "%s", while the PHP version Flow is configured to use for subrequests is "%s". Make sure to configure Flow to ' .
                 'use the same PHP binary by setting the "Neos.Flow.core.phpBinaryPathAndFilename" configuration option to "%s". Flush the ' .

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -841,7 +841,7 @@ class Scripts
         }
 
         // Try to resolve which binary file PHP is pointing to
-        exec($phpBinaryPathAndFilename . ' -r "echo PHP_BINARY;"', $output, $result);
+        exec($phpBinaryPathAndFilename . ' -r "echo realpath(PHP_BINARY);"', $output, $result);
         if ($result === 0 && sizeof($output) === 1) {
             // Resolve any wrapper
             $configuredPhpBinaryPathAndFilename = $output[0];
@@ -855,12 +855,13 @@ class Scripts
             return;
         }
 
-        if (strcasecmp(PHP_BINARY, $configuredPhpBinaryPathAndFilename) !== 0) {
+        $realPhpBinary = realpath(PHP_BINARY);
+        if (strcmp($realPhpBinary, $configuredPhpBinaryPathAndFilename) !== 0) {
             throw new FlowException(sprintf('You are running the Flow CLI with a PHP binary different from the one Flow is configured to use internally. ' .
                 'Flow has been run with "%s", while the PHP version Flow is configured to use for subrequests is "%s". Make sure to configure Flow to ' .
                 'use the same PHP binary by setting the "Neos.Flow.core.phpBinaryPathAndFilename" configuration option to "%s". Flush the ' .
                 'caches by removing the folder Data/Temporary before running ./flow again.',
-                PHP_BINARY, $configuredPhpBinaryPathAndFilename, PHP_BINARY), 1536303119);
+                $realPhpBinary, $configuredPhpBinaryPathAndFilename, $realPhpBinary), 1536303119);
         }
     }
 


### PR DESCRIPTION
The check if the current executing php binary path as set in `PHP_BINARY` matches the given setting in `phpBinaryPathAndFilename` was case-sensitive. This check is only done when the setting is specified and should guarantee that the path specified refers to the same binary as the one executing the current script. On Windows, the filesystem is case-insensitive by default though (Windows 10 has options to make it case-sensitive) and the chance that someone accidentially gets the casing of the path wrong on windows is (arguably) much more likely than someone having different versions of php installed on a case-sensitive filesystem in pathes `/foo/PHP/php` and `/foo/php/php` respectively.
~Even if that would be the case, if the two versions do not match the check at `ensureWebSubrequestsUseCurrentlyRunningPhpVersion` would still throw an error with an even more specific message.~

So this will prevent irritating errors on Windows in the form of 
![image](https://user-images.githubusercontent.com/4259532/85157246-83217f00-b25b-11ea-8ebb-abc95b30e09a.png)