### PR TITLE
BUGFIX: Correct default log file size

### DIFF
--- a/Neos.Flow/Configuration/Settings.Log.yaml
+++ b/Neos.Flow/Configuration/Settings.Log.yaml
@@ -44,7 +44,7 @@ Neos:
           logFileURL: '%FLOW_PATH_DATA%Logs/I18n.log'
           createParentDirectories: true
           severityThreshold: '%LOG_INFO%'
-          maximumLogFileSize: 1048576
+          maximumLogFileSize: 10485760
           logFilesToKeep: 1
 
       throwables:


### PR DESCRIPTION
Updating https://github.com/neos/flow-development-collection/pull/1998 to correct version.