### PR TITLE
BUGFIX: Check if PdoBackend cache tables exist in setup

### DIFF
--- a/Neos.Cache/Classes/Backend/PdoBackend.php
+++ b/Neos.Cache/Classes/Backend/PdoBackend.php
@@ -569,6 +569,10 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
             $result->addNotice(new Notice('SQLite database tables are created automatically and don\'t need to be set up'));
             return $result;
         }
+        if ($this->tableExists($this->cacheTableName) && $this->tableExists($this->tagsTableName)) {
+            $result->addNotice(new Notice('The database tables already exist and don\'t need to be set up'));
+            return $result;
+        }
         $result->addNotice(new Notice('Creating database tables "%s" & "%s"...', null, [$this->cacheTableName, $this->tagsTableName]));
         try {
             $this->createCacheTables();


### PR DESCRIPTION
Running the setup for a PdoBackend multiple times should
not lead to an error, similar to other Backends.

Resolves: #2039

**What I did**
Allow PdoBackend::setup() to be called multiple times.

**How I did it**
Check if cache tables exist in PdoBackend::setup() before creating them.

**How to verify it**
See #2039