### PR TITLE
 BUGFIX: Set session cookie after flash message storage

### DIFF
--- a/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
+++ b/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
@@ -20,10 +20,12 @@ use Neos\Flow\Http\Component\ComponentChain;
 use Neos\Flow\Http\Component\ComponentContext;
 use Neos\Flow\Http;
 use Neos\Flow\Mvc\Dispatcher;
+use Neos\Flow\Mvc\FlashMessage\FlashMessageService;
 use Neos\Flow\Mvc\Routing\RouterInterface;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Session\SessionInterface;
+use Neos\Flow\Session\SessionManager;
 use Neos\Flow\Tests\FunctionalTestRequestHandler;
 use Neos\Flow\Validation\ValidatorResolver;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -124,10 +126,13 @@ class InternalRequestEngine implements RequestEngineInterface
         } catch (\Throwable $throwable) {
             $componentContext->replaceHttpResponse($this->prepareErrorResponse($throwable, $componentContext->getHttpResponse()));
         }
-        $session = $this->bootstrap->getObjectManager()->get(SessionInterface::class);
+        $session = $objectManager->get(SessionInterface::class);
         if ($session->isStarted()) {
             $session->close();
         }
+        // FIXME: ObjectManager should forget all instances created during the request
+        $objectManager->forgetInstance(SessionManager::class);
+        $objectManager->forgetInstance(FlashMessageService::class);
         $this->persistenceManager->clearState();
         return $componentContext->getHttpResponse();
     }

--- a/Neos.Flow/Configuration/Settings.Http.yaml
+++ b/Neos.Flow/Configuration/Settings.Http.yaml
@@ -68,7 +68,7 @@ Neos:
               position: 'start'
               component: 'Neos\Flow\Session\Http\SessionResponseComponent'
             'flashMessages':
-              position: 'after setSessionCookie'
+              position: 'before setSessionCookie'
               component: 'Neos\Flow\Mvc\FlashMessage\FlashMessageComponent'
             'poweredByHeader':
               component: 'Neos\Flow\Http\Component\PoweredByComponent'

--- a/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
@@ -16,9 +16,6 @@ use Neos\Flow\Http\ContentStream;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Http\Cookie;
 use Neos\Flow\Mvc\Controller\MvcPropertyMappingConfigurationService;
-use Neos\Flow\Mvc\FlashMessage\FlashMessageService;
-use Neos\Flow\Mvc\FlashMessage\FlashMessageStorageInterface;
-use Neos\Flow\Session\SessionManager;
 use Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\StandardController;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures\TestEntity;
 use Neos\Flow\Tests\FunctionalTestCase;
@@ -542,7 +539,9 @@ class ActionControllerTest extends FunctionalTestCase
         $request = $this->serverRequestFactory->createServerRequest('GET', new Uri('http://localhost/test/mvc/actioncontrollertest/redirectWithFlashMessage'));
         $response = $this->browser->sendRequest($request);
 
-        $sessionCookies = array_map(static function ($cookie) { return Cookie::createFromRawSetCookieHeader($cookie); }, $response->getHeader('Set-Cookie'));
+        $sessionCookies = array_map(static function ($cookie) {
+            return Cookie::createFromRawSetCookieHeader($cookie);
+        }, $response->getHeader('Set-Cookie'));
         self::assertNotEmpty($sessionCookies);
 
         $redirect = $response->getHeaderLine('Location');

--- a/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
@@ -14,7 +14,12 @@ namespace Neos\Flow\Tests\Functional\Mvc;
 use GuzzleHttp\Psr7\ServerRequest;
 use Neos\Flow\Http\ContentStream;
 use GuzzleHttp\Psr7\Uri;
+use Neos\Flow\Http\Cookie;
 use Neos\Flow\Mvc\Controller\MvcPropertyMappingConfigurationService;
+use Neos\Flow\Mvc\FlashMessage\FlashMessageService;
+use Neos\Flow\Mvc\FlashMessage\FlashMessageStorageInterface;
+use Neos\Flow\Session\SessionManager;
+use Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\StandardController;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures\TestEntity;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Psr\Http\Message\ServerRequestFactoryInterface;
@@ -37,6 +42,14 @@ class ActionControllerTest extends FunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->registerRoute('test', 'test/mvc/actioncontrollertest(/{@action})', [
+            '@package' => 'Neos.Flow',
+            '@subpackage' => 'Tests\Functional\Mvc\Fixtures',
+            '@controller' => 'Standard',
+            '@action' => 'index',
+            '@format' =>'html'
+        ]);
 
         $this->registerRoute('testa', 'test/mvc/actioncontrollertesta(/{@action})', [
             '@package' => 'Neos.Flow',
@@ -519,5 +532,33 @@ class ActionControllerTest extends FunctionalTestCase
 
         $response = $this->browser->sendRequest($request);
         self::assertSame('Entity "Foo" updated', $response->getBody()->getContents());
+    }
+
+    /**
+     * @test
+     */
+    public function flashMessagesGetRenderedAfterRedirect()
+    {
+        $request = $this->serverRequestFactory->createServerRequest('GET', new Uri('http://localhost/test/mvc/actioncontrollertest/redirectWithFlashMessage'));
+        $response = $this->browser->sendRequest($request);
+
+        $sessionCookies = array_map(static function ($cookie) { return Cookie::createFromRawSetCookieHeader($cookie); }, $response->getHeader('Set-Cookie'));
+        self::assertNotEmpty($sessionCookies);
+
+        $redirect = $response->getHeaderLine('Location');
+        self::assertNotEmpty($redirect);
+
+        $this->objectManager->forgetInstance(StandardController::class);
+
+        $cookies = array_reduce($sessionCookies, static function ($out, $cookie) {
+            $out[$cookie->getName()] = $cookie->getValue();
+            return $out;
+        }, []);
+        $redirectRequest = $this->serverRequestFactory->createServerRequest('GET', new Uri($redirect))
+            ->withCookieParams($cookies);
+        $redirectResponse = $this->browser->sendRequest($redirectRequest);
+
+        $expected = json_encode(['Redirect FlashMessage']);
+        self::assertSame($expected, $redirectResponse->getBody()->getContents());
     }
 }

--- a/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/StandardController.php
+++ b/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/StandardController.php
@@ -36,7 +36,9 @@ class StandardController extends ActionController
     public function targetAction()
     {
         $flashMessages = $this->controllerContext->getFlashMessageContainer()->getMessagesAndFlush();
-        return json_encode(array_map(static function (Message $message) { return $message->getMessage(); }, $flashMessages));
+        return json_encode(array_map(static function (Message $message) {
+            return $message->getMessage();
+        }, $flashMessages));
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/StandardController.php
+++ b/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/StandardController.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ActionController;
+use Neos\Error\Messages\Message;
 
 /**
  * A controller fixture
@@ -27,5 +28,23 @@ class StandardController extends ActionController
     public function indexAction()
     {
         return 'index action';
+    }
+
+    /**
+     * @return string
+     */
+    public function targetAction()
+    {
+        $flashMessages = $this->controllerContext->getFlashMessageContainer()->getMessagesAndFlush();
+        return json_encode(array_map(static function (Message $message) { return $message->getMessage(); }, $flashMessages));
+    }
+
+    /**
+     * @return string
+     */
+    public function redirectWithFlashMessageAction()
+    {
+        $this->addFlashMessage('Redirect FlashMessage');
+        $this->redirect('target');
     }
 }


### PR DESCRIPTION
The FlashMessages component by default uses the SessionStorage, which depends on sending the session cookie through the SessionResponse component. However, the FlashMessages component was configured to be run **after** the session component. That way, unless a session was (still) open, the `Set-Cookie` was not sent and hence the flash message got lost.
This was primarily visible after logging out and redirecting the user with a flash message.

Thanks @astehlik for finding the root cause!

Resolves #1807 