### PR TITLE
TASK: Remove typo3 namespace replacements

### DIFF
--- a/Neos.Eel/composer.json
+++ b/Neos.Eel/composer.json
@@ -20,9 +20,6 @@
             "Neos\\Eel\\Tests\\": "Classes"
         }
     },
-    "replace": {
-        "typo3/eel": "self.version"
-    },
     "extra": {
         "neos": {
             "package-key": "Neos.Eel"

--- a/Neos.Flow/Classes/Composer/InstallerScripts.php
+++ b/Neos.Flow/Classes/Composer/InstallerScripts.php
@@ -75,35 +75,22 @@ class InstallerScripts
         $packageExtraConfig = $package->getExtra();
         $installPath = $event->getComposer()->getInstallationManager()->getInstallPath($package);
 
-        $evaluatedInstallerResources = false;
         if (isset($packageExtraConfig['neos']['installer-resource-folders'])) {
             foreach ($packageExtraConfig['neos']['installer-resource-folders'] as $installerResourceDirectory) {
                 static::copyDistributionFiles($installPath . $installerResourceDirectory);
             }
-            $evaluatedInstallerResources = true;
         }
 
         if ($operation->getJobType() === 'install') {
-            if (isset($packageExtraConfig['typo3/flow']['post-install'])) {
-                self::runPackageScripts($packageExtraConfig['typo3/flow']['post-install']);
-            }
             if (isset($packageExtraConfig['neos/flow']['post-install'])) {
                 self::runPackageScripts($packageExtraConfig['neos/flow']['post-install']);
             }
         }
 
         if ($operation->getJobType() === 'update') {
-            if (isset($packageExtraConfig['typo3/flow']['post-update'])) {
-                self::runPackageScripts($packageExtraConfig['typo3/flow']['post-update']);
-            }
             if (isset($packageExtraConfig['neos/flow']['post-update'])) {
                 self::runPackageScripts($packageExtraConfig['neos/flow']['post-update']);
             }
-        }
-
-        // TODO: Deprecated from Flow 3.1 remove three versions after.
-        if (!$evaluatedInstallerResources && isset($packageExtraConfig['typo3/flow']['manage-resources']) && $packageExtraConfig['typo3/flow']['manage-resources'] === true) {
-            static::copyDistributionFiles($installPath . 'Resources/Private/Installer/');
         }
     }
 

--- a/Neos.Flow/Tests/FunctionalTestCase.php
+++ b/Neos.Flow/Tests/FunctionalTestCase.php
@@ -193,7 +193,7 @@ abstract class FunctionalTestCase extends \Neos\Flow\Tests\BaseTestCase
             $this->testingProvider = $this->objectManager->get(\Neos\Flow\Security\Authentication\Provider\TestingProvider::class);
             $this->testingProvider->setName('TestingProvider');
 
-            $this->registerRoute('functionaltestroute', 'typo3/flow/test', [
+            $this->registerRoute('functionaltestroute', 'neos/flow/test', [
                 '@package' => 'Neos.Flow',
                 '@subpackage' => 'Tests\Functional\Mvc\Fixtures',
                 '@controller' => 'Standard',
@@ -432,7 +432,7 @@ abstract class FunctionalTestCase extends \Neos\Flow\Tests\BaseTestCase
         $responseFactory = new ResponseFactory();
 
         $requestHandler = self::$bootstrap->getActiveRequestHandler();
-        $request = $serverRequestFactory->createServerRequest('GET', 'http://localhost/typo3/flow/test');
+        $request = $serverRequestFactory->createServerRequest('GET', 'http://localhost/neos/flow/test');
         $componentContext = new ComponentContext($request, $responseFactory->createResponse());
         $requestHandler->setComponentContext($componentContext);
     }

--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -54,9 +54,6 @@
     "require-dev": {
         "vimeo/psalm": "~3.10.0"
     },
-    "replace": {
-        "typo3/flow": "self.version"
-    },
     "suggest": {
         "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",
         "doctrine/data-fixtures": "To manage and execute the loading of data fixtures for the Doctrine ORM or ODM",

--- a/Neos.Kickstarter/composer.json
+++ b/Neos.Kickstarter/composer.json
@@ -19,9 +19,6 @@
             "Neos\\Kickstarter\\Tests\\": "Tests"
         }
     },
-    "replace": {
-        "typo3/kickstart": "self.version"
-    },
     "extra": {
         "neos": {
             "package-key": "Neos.Kickstarter"

--- a/Neos.Utility.Schema/Readme.rst
+++ b/Neos.Utility.Schema/Readme.rst
@@ -19,4 +19,4 @@ Dependencies
 ------------
 
 Uses the Flow Error objects to return structured validation results therefore depends on
-typo3/flow for now.
+neos/flow for now.

--- a/composer.json
+++ b/composer.json
@@ -35,9 +35,6 @@
         "ext-mbstring": "*"
     },
     "replace": {
-        "typo3/eel": "self.version",
-        "typo3/flow": "self.version",
-        "typo3/kickstart": "self.version",
         "neos/cache": "self.version",
         "neos/eel": "self.version",
         "neos/error-messages": "self.version",


### PR DESCRIPTION
There never was and never will be a typo3/flow version of 6.3+