### PR TITLE
BUGFIX: Browser arguments are the request parsed body

### DIFF
--- a/Neos.Flow/Classes/Http/Client/Browser.php
+++ b/Neos.Flow/Classes/Http/Client/Browser.php
@@ -160,7 +160,7 @@ class Browser
         }
 
         if (!empty($arguments)) {
-            $request = $request->withQueryParams($arguments);
+            $request = $request->withParsedBody($arguments);
         }
         if (!empty($files)) {
             $files = UploadedFilesHelper::upcastUploadedFiles($files, $arguments);

--- a/Neos.Flow/Tests/Functional/Http/Client/BrowserTest.php
+++ b/Neos.Flow/Tests/Functional/Http/Client/BrowserTest.php
@@ -40,6 +40,26 @@ class BrowserTest extends FunctionalTestCase
                 '@format' => 'html'
             ]
         );
+        $this->registerRoute(
+            'Functional Test - Http::Client::BrowserTest',
+            'test/http/request(/{@action})',
+            [
+                '@package' => 'Neos.Flow',
+                '@subpackage' => 'Tests\Functional\Http\Fixtures',
+                '@controller' => 'Request',
+                '@action' => 'index',
+                '@format' => 'html'
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function argumentsAreSentAsRequestBodyEvenInGetRequest()
+    {
+        $response = $this->browser->request('http://localhost/test/http/request/body', 'GET', ['foo' => 'bar']);
+        self::assertEquals(json_encode(['foo' => 'bar']), $response->getBody()->getContents());
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/Http/Fixtures/Controller/RequestController.php
+++ b/Neos.Flow/Tests/Functional/Http/Fixtures/Controller/RequestController.php
@@ -1,0 +1,25 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Http\Fixtures\Controller;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Mvc\Controller\ActionController;
+
+class RequestController extends ActionController
+{
+    /**
+     * @return string
+     */
+    public function bodyAction()
+    {
+        return json_encode($this->request->getHttpRequest()->getParsedBody());
+    }
+}


### PR DESCRIPTION
Since 6.0 the Browser `$arguments` were accidentially moved to the request query parameters, while they should reflect the post body arguments.

The docblock even states that:
`@param array $arguments Arguments to send in the request body`

Note that this slightly changes behaviour if you adapted your usage of Browser since 6.0. If you want to send query parameters, you should instead provide an `Uri` instance with the parameters, as was already the case prior to 6.0.