### PR TITLE
!!!TASK: Rename 'uploadExtensionBlacklist' setting to 'extensionsBlockedFromUpload'

### DIFF
--- a/Neos.Flow/Classes/ResourceManagement/ResourceManager.php
+++ b/Neos.Flow/Classes/ResourceManagement/ResourceManager.php
@@ -625,7 +625,7 @@ class ResourceManager
             throw new Exception('The given upload file "' . strip_tags($pathInfo['basename']) . '" was not uploaded through PHP. As it could pose a security risk it cannot be imported.', 1422461503);
         }
 
-        if (isset($pathInfo['extension']) && array_key_exists(strtolower($pathInfo['extension']), $this->settings['uploadExtensionsExcluded']) && $this->settings['uploadExtensionsExcluded'][strtolower($pathInfo['extension'])] === true) {
+        if (isset($pathInfo['extension']) && array_key_exists(strtolower($pathInfo['extension']), $this->settings['extensionsBlockedFromUpload']) && $this->settings['extensionsBlockedFromUpload'][strtolower($pathInfo['extension'])] === true) {
             throw new Exception('The extension of the given upload file "' . strip_tags($pathInfo['basename']) . '" is excluded. As it could pose a security risk it cannot be imported.', 1447148472);
         }
 

--- a/Neos.Flow/Classes/ResourceManagement/ResourceManager.php
+++ b/Neos.Flow/Classes/ResourceManagement/ResourceManager.php
@@ -625,7 +625,7 @@ class ResourceManager
             throw new Exception('The given upload file "' . strip_tags($pathInfo['basename']) . '" was not uploaded through PHP. As it could pose a security risk it cannot be imported.', 1422461503);
         }
 
-        if (isset($pathInfo['extension']) && array_key_exists(strtolower($pathInfo['extension']), $this->settings['uploadExtensionBlacklist']) && $this->settings['uploadExtensionBlacklist'][strtolower($pathInfo['extension'])] === true) {
+        if (isset($pathInfo['extension']) && array_key_exists(strtolower($pathInfo['extension']), $this->settings['uploadExtensionsExcluded']) && $this->settings['uploadExtensionsExcluded'][strtolower($pathInfo['extension'])] === true) {
             throw new Exception('The extension of the given upload file "' . strip_tags($pathInfo['basename']) . '" is blacklisted. As it could pose a security risk it cannot be imported.', 1447148472);
         }
 

--- a/Neos.Flow/Configuration/Settings.Resource.yaml
+++ b/Neos.Flow/Configuration/Settings.Resource.yaml
@@ -7,7 +7,7 @@ Neos:
     resource:
       # A list of filename extensions that must not be uploaded through the resource
       # management.
-      uploadExtensionBlacklist: &uploadExtensionBlacklist
+      uploadExtensionsExcluded: &uploadExtensionsExcluded
         'aspx': true
         'cgi': true
         'php3': true
@@ -62,7 +62,7 @@ Neos:
           targetOptions:
             path: '%FLOW_PATH_WEB%_Resources/Static/Packages/'
             baseUri: '_Resources/Static/Packages/'
-            extensionBlacklist: *uploadExtensionBlacklist
+            excludedExtensions: *uploadExtensionsExcluded
 
             # If the symlinks should be relative instead of absolute
             #relativeSymlinks: false
@@ -73,7 +73,7 @@ Neos:
           targetOptions:
             path: '%FLOW_PATH_WEB%_Resources/Persistent/'
             baseUri: '_Resources/Persistent/'
-            extensionBlacklist: *uploadExtensionBlacklist
+            excludedExtensions: *uploadExtensionsExcluded
 
             # If the generated URI path segment containing the sha1 should be divided into multiple segments (recommended if you expect many resources):
             subdivideHashPathSegment: true

--- a/Neos.Flow/Configuration/Settings.Resource.yaml
+++ b/Neos.Flow/Configuration/Settings.Resource.yaml
@@ -7,7 +7,7 @@ Neos:
     resource:
       # A list of filename extensions that must not be uploaded through the resource
       # management.
-      uploadExtensionsExcluded: &uploadExtensionsExcluded
+      extensionsBlockedFromUpload: &extensionsBlockedFromUpload
         'aspx': true
         'cgi': true
         'php3': true
@@ -62,7 +62,7 @@ Neos:
           targetOptions:
             path: '%FLOW_PATH_WEB%_Resources/Static/Packages/'
             baseUri: '_Resources/Static/Packages/'
-            excludedExtensions: *uploadExtensionsExcluded
+            excludedExtensions: *extensionsBlockedFromUpload
 
             # If the symlinks should be relative instead of absolute
             #relativeSymlinks: false
@@ -73,7 +73,7 @@ Neos:
           targetOptions:
             path: '%FLOW_PATH_WEB%_Resources/Persistent/'
             baseUri: '_Resources/Persistent/'
-            excludedExtensions: *uploadExtensionsExcluded
+            excludedExtensions: *extensionsBlockedFromUpload
 
             # If the generated URI path segment containing the sha1 should be divided into multiple segments (recommended if you expect many resources):
             subdivideHashPathSegment: true

--- a/Neos.Flow/Migrations/Code/Version20200813181400.php
+++ b/Neos.Flow/Migrations/Code/Version20200813181400.php
@@ -1,0 +1,35 @@
+<?php
+namespace Neos\Flow\Core\Migrations;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Configuration\ConfigurationManager;
+use Neos\Flow\Log\PsrLoggerFactory;
+
+/**
+ * Adjust "Settings.yaml" to new naming of settings (see https://github.com/neos/flow-development-collection/pull/2051)
+ */
+class Version20200813181400 extends AbstractMigration
+{
+
+    public function getIdentifier()
+    {
+        return 'Neos.Flow-20200813181400';
+    }
+
+    /**
+     * @return void
+     */
+    public function up()
+    {
+        $this->moveSettingsPaths('Neos.Flow.resource.uploadExtensionBlacklist','Neos.Flow.resource.extensionsBlockedFromUpload');
+    }
+}

--- a/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.resource.schema.yaml
+++ b/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.resource.schema.yaml
@@ -1,7 +1,7 @@
 type: dictionary
 additionalProperties: false
 properties:
-  'uploadExtensionBlacklist':
+  'uploadExtensionsExcluded':
     type: dictionary
     additionalProperties:
       type: boolean

--- a/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.resource.schema.yaml
+++ b/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.resource.schema.yaml
@@ -1,7 +1,7 @@
 type: dictionary
 additionalProperties: false
 properties:
-  'uploadExtensionsExcluded':
+  'extensionsBlockedFromUpload':
     type: dictionary
     additionalProperties:
       type: boolean


### PR DESCRIPTION
As part of our move to getting rid of bad wording in our code base, this changes the setting `Neos.Flow.resource.uploadExtensionsBlacklist` to the much more descriptive `Neos.Flow.resource.extensionsBlockedFromUpload`.

This is breaking as it changes the path to a setting, but is covered by a code migration.

Related to #2024