### PR TITLE
!!!FEATURE: Allow unidirectional OneToMany relations

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -684,6 +684,11 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
                             $inverseJoinColumn['unique'] = true;
                         }
                     }
+                    foreach ($joinTable['joinColumns'] as &$joinColumn) {
+                        if (!isset($joinColumn['onDelete'])) {
+                            $joinColumn['onDelete'] = 'cascade';
+                        }
+                    }
 
                     $mapping['joinTable'] = $joinTable;
                     $metadata->mapManyToMany($mapping);

--- a/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -683,6 +683,9 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
                         if (!isset($inverseJoinColumn['unique'])) {
                             $inverseJoinColumn['unique'] = true;
                         }
+                        if (!isset($inverseJoinColumn['onDelete'])) {
+                            $inverseJoinColumn['onDelete'] = 'cascade';
+                        }
                     }
                     foreach ($joinTable['joinColumns'] as &$joinColumn) {
                         if (!isset($joinColumn['onDelete'])) {

--- a/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -1149,7 +1149,8 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
             $this->reflectionService->getClassNamesByAnnotation(ORM\MappedSuperclass::class),
             $this->reflectionService->getClassNamesByAnnotation(ORM\Embeddable::class)
         );
-        $this->classNames = array_filter($this->classNames,
+        $this->classNames = array_filter(
+            $this->classNames,
             function ($className) {
                 return !interface_exists($className, false)
                         && strpos($className, Compiler::ORIGINAL_CLASSNAME_SUFFIX) === false;

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
@@ -400,6 +400,8 @@ with their name, scope and meaning:
 | ``OneToOne``     |          | ``targetEntity`` parameter can be omitted, it is taken   |
 |                  |          | from the ``@var`` annotation.                            |
 |                  |          |                                                          |
+|                  |          | See below for unidirectional ``OneToMany`` relations!    |
+|                  |          |                                                          |
 |                  |          | The ``cascade`` attribute is set to cascade all          |
 |                  |          | operations on associations within aggregate boundaries.  |
 |                  |          | In that case orphanRemoval is turned on as well.         |
@@ -419,6 +421,35 @@ with their name, scope and meaning:
 
 Doctrine supports many more annotations, for a full reference please consult the Doctrine
 2 ORM documentation.
+
+On unidirectional ``OneToMany`` relations
+-----------------------------------------
+
+Inside a single aggregate `OneToMany` relations are normally best modeled unidirectionally.
+Bidirectional relations always are harder to manage correctly and can easily lead to
+unintentional traversal of entity hierarchies with all the drawbacks.
+
+Since Doctrines `OneToMany` annotation is always bidrectional and also dictates the owning
+side of the relation (at the unexpected side from a modeling PoV), it is not straightforward
+to model this correctly.
+
+In Flow specifically, we try to follow DDD best practices in modelling and this means, that
+the aggregate root is the entry point and the entity that is sent to a repository to persist
+it and all its sub-entities. This can not be achieved with the standard doctrine `OneToMany`
+annotation when the one side is supposed to be closer to the root.
+
+So Flow allows the you to annotate such a relation simply as:
+
+
+.. code-block:: php
+
+  /**
+   * @ORM\OneToMany
+   * @var Collection<Comment>
+   */
+
+This is done by remapping `OneToMany` annotations without a `mappedBy` as `ManyToMany` with
+an unique constraint.
 
 On Value Object handling with Doctrine
 --------------------------------------

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Post.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Post.php
@@ -11,6 +11,8 @@ namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
  * source code.
  */
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures;
@@ -52,7 +54,13 @@ class Post
     protected $comment;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection<Fixtures\Post>
+     * @var Collection<Fixtures\Tag>
+     * @ORM\OneToMany
+     */
+    protected $tags;
+
+    /**
+     * @var Collection<Fixtures\Post>
      * @ORM\ManyToMany
      * @ORM\JoinTable(inverseJoinColumns={@ORM\JoinColumn(name="related_post_id")})
      */
@@ -63,6 +71,12 @@ class Post
      * @ORM\ManyToOne
      */
     protected $author;
+
+    public function __construct()
+    {
+        $this->tags = new ArrayCollection();
+        $this->related = new ArrayCollection();
+    }
 
     /**
      * @return string
@@ -113,6 +127,30 @@ class Post
     public function getComment()
     {
         return $this->comment;
+    }
+
+    /**
+     * @param Tag $tag
+     */
+    public function addTag(Tag $tag)
+    {
+        $this->tags->add($tag);
+    }
+
+    /**
+     * @param Tag $tag
+     */
+    public function removeTag(Tag $tag)
+    {
+        $this->tags->removeElement($tag);
+    }
+
+    /**
+     * @return Collection
+     */
+    public function getTags()
+    {
+        return $this->tags;
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Tag.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Tag.php
@@ -1,0 +1,41 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * A sample entity for tests
+ *
+ * @Flow\Entity
+ */
+class Tag
+{
+    /**
+     * @var string
+     */
+    protected $name = '';
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1683,11 +1683,12 @@
     </MoreSpecificReturnType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php">
-    <ArgumentTypeCoercion occurrences="8">
+    <ArgumentTypeCoercion occurrences="9">
       <code>$metadata</code>
       <code>$metadata</code>
       <code>$metadata</code>
       <code>$metadata</code>
+      <code>$joinTableAnnotation</code>
       <code>$joinTableAnnotation</code>
       <code>$columnAnnotation</code>
       <code>$joinColumnAnnotation</code>
@@ -1769,9 +1770,6 @@
       <code>$pdoException-&gt;getCode()</code>
       <code>$pdoException-&gt;getCode()</code>
     </InvalidScalarArgument>
-    <NullArgument occurrences="1">
-      <code>null</code>
-    </NullArgument>
     <PropertyTypeCoercion occurrences="1">
       <code>$entityManager</code>
     </PropertyTypeCoercion>
@@ -2884,9 +2882,6 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Utility/Algorithms.php">
-    <InvalidCast occurrences="1">
-      <code>Uuid::uuid4()</code>
-    </InvalidCast>
     <UndefinedConstant occurrences="1">
       <code>UUID_TYPE_RANDOM</code>
     </UndefinedConstant>


### PR DESCRIPTION
Inside a single aggregate `OneToMany` relations are normally best modelled unidirectionally. Bidirectional relations always are harder to manage correctly and can easily lead to unintentional traversal of entity hierarchies with all the drawbacks.
Since Doctrines `OneToMany` annotation is always bidrectional and also dictates the owning side of the relation (at the unexpected side from a modelling PoV), it is not straightforward to modell this correctly.

In Flow specifically, we try to follow DDD best practices in modelling and this means, that the aggregate root is the entry point and the entity that is sent to a repository to persist it and all its subentities. This can not be achieved with the standard doctrine `OneToMany` annotation when the one side is supposed to be closer to the root.

This change allows the user to annotate such a relation simply as:
```php
    /**
     * @ORM\OneToMany
     * @var Collection<Comment>
     */
```

This is done by remapping `OneToMany` annotations without a `mappedBy` as `ManyToMany` with a unique constraint.

Resolves #2054 #1395