### PR TITLE
BUGFIX: Correct indention for throwables config

### DIFF
--- a/Neos.Flow/Configuration/Settings.Log.yaml
+++ b/Neos.Flow/Configuration/Settings.Log.yaml
@@ -52,8 +52,8 @@ Neos:
                 maximumLogFileSize: 10485760
                 logFilesToKeep: 1
 
-          throwables:
-            storageClass: Neos\Flow\Log\ThrowableStorage\FileStorage
-            optionsByImplementation:
-              'Neos\Flow\Log\ThrowableStorage\FileStorage':
-                storagePath: '%FLOW_PATH_DATA%Logs/Exceptions'
+      throwables:
+        storageClass: Neos\Flow\Log\ThrowableStorage\FileStorage
+        optionsByImplementation:
+          'Neos\Flow\Log\ThrowableStorage\FileStorage':
+            storagePath: '%FLOW_PATH_DATA%Logs/Exceptions'


### PR DESCRIPTION
The configuration of the throwable exceptions should not be part of the `psr3` level. And the default config did not work since 6.0. The method `initializeExceptionStorage` still expects the configuration to be at the path `Neos.Flow.log.throwables`.

Fixes: #2082