### PR TITLE
!!! BUGFIX: Remove unused MD5 in ResourceMetaDataInterface

### DIFF
--- a/Neos.Flow/Classes/ResourceManagement/PersistentResource.php
+++ b/Neos.Flow/Classes/ResourceManagement/PersistentResource.php
@@ -316,30 +316,6 @@ class PersistentResource implements ResourceMetaDataInterface, CacheAwareInterfa
     }
 
     /**
-     * Returns the MD5 hash of the content of this resource
-     *
-     * @return string The MD5 hash
-     * @api
-     */
-    public function getMd5()
-    {
-        return $this->md5;
-    }
-
-    /**
-     * Sets the MD5 hash of the content of this resource
-     *
-     * @param string $md5 The MD5 hash
-     * @return void
-     * @api
-     */
-    public function setMd5($md5)
-    {
-        $this->throwExceptionIfProtected();
-        $this->md5 = $md5;
-    }
-
-    /**
      * Returns the path to a local file representing this resource for use with read-only file operations such as reading or copying.
      *
      * Note that you must not store or publish file paths returned from this method as they will change with every request.

--- a/Neos.Flow/Classes/ResourceManagement/PersistentResource.php
+++ b/Neos.Flow/Classes/ResourceManagement/PersistentResource.php
@@ -78,14 +78,6 @@ class PersistentResource implements ResourceMetaDataInterface, CacheAwareInterfa
     protected $sha1;
 
     /**
-     * MD5 hash identifying the content attached to this resource
-     *
-     * @var string
-     * @ORM\Column(length=32)
-     */
-    protected $md5;
-
-    /**
      * As soon as the PersistentResource has been published, modifying this object is not allowed
      *
      * @Flow\Transient

--- a/Neos.Flow/Classes/ResourceManagement/ResourceMetaDataInterface.php
+++ b/Neos.Flow/Classes/ResourceManagement/ResourceMetaDataInterface.php
@@ -81,19 +81,4 @@ interface ResourceMetaDataInterface
      * @return void
      */
     public function setSha1($sha1);
-
-    /**
-     * Returns the md5 hash of the content of this storage object
-     *
-     * @return string The md5 hash
-     */
-    public function getMd5();
-
-    /**
-     * Sets the md5 hash of the content of this storage object
-     *
-     * @param string $md5 The md5 hash
-     * @return void
-     */
-    public function setMd5($md5);
 }

--- a/Neos.Flow/Classes/ResourceManagement/Storage/FileSystemStorage.php
+++ b/Neos.Flow/Classes/ResourceManagement/Storage/FileSystemStorage.php
@@ -156,7 +156,6 @@ class FileSystemStorage implements StorageInterface
             $object = new StorageObject();
             $object->setFilename($resource->getFilename());
             $object->setSha1($resource->getSha1());
-            $object->setMd5($resource->getMd5());
             $object->setFileSize($resource->getFileSize());
             $object->setStream(function () use ($resource) {
                 return $this->getStreamByResource($resource);

--- a/Neos.Flow/Classes/ResourceManagement/Storage/PackageStorage.php
+++ b/Neos.Flow/Classes/ResourceManagement/Storage/PackageStorage.php
@@ -106,7 +106,6 @@ class PackageStorage extends FileSystemStorage
         $object = new StorageObject();
         $object->setFilename($pathInfo['basename']);
         $object->setSha1(sha1_file($resourcePathAndFilename));
-        $object->setMd5(md5_file($resourcePathAndFilename));
         $object->setFileSize(filesize($resourcePathAndFilename));
         if (isset($pathInfo['dirname'])) {
             $object->setRelativePublicationPath($this->prepareRelativePublicationPath($pathInfo['dirname'], $resourcePackage->getPackageKey(), $resourcePackage->getResourcesPath()));

--- a/Neos.Flow/Classes/ResourceManagement/Storage/StorageObject.php
+++ b/Neos.Flow/Classes/ResourceManagement/Storage/StorageObject.php
@@ -62,13 +62,6 @@ class StorageObject implements ResourceMetaDataInterface
     protected $sha1;
 
     /**
-     * MD5 hash identifying this object's data
-     *
-     * @var string
-     */
-    protected $md5;
-
-    /**
      * A stream (or, before it is used the first time, a Closure which returns a stream) which can deliver the data of this Object
      *
      * @var \Closure|resource

--- a/Neos.Flow/Classes/ResourceManagement/Storage/StorageObject.php
+++ b/Neos.Flow/Classes/ResourceManagement/Storage/StorageObject.php
@@ -184,27 +184,6 @@ class StorageObject implements ResourceMetaDataInterface
     }
 
     /**
-     * Returns the md5 hash of the content of this storage object
-     *
-     * @return string The MD5 hash
-     */
-    public function getMd5()
-    {
-        return $this->md5;
-    }
-
-    /**
-     * Sets the md5 hash of the content of this storage object
-     *
-     * @param string $md5 The MD5 hash
-     * @return void
-     */
-    public function setMd5($md5)
-    {
-        $this->md5 = $md5;
-    }
-
-    /**
      * Sets the data stream which can deliver the content of this storage object
      *
      * Instead of providing a stream (PHP resource), you can also pass a Closure which returns a stream when it is

--- a/Neos.Flow/Classes/ResourceManagement/Storage/WritableFileSystemStorage.php
+++ b/Neos.Flow/Classes/ResourceManagement/Storage/WritableFileSystemStorage.php
@@ -142,7 +142,6 @@ class WritableFileSystemStorage extends FileSystemStorage implements WritableSto
         $resource->setFileSize(filesize($targetPathAndFilename));
         $resource->setCollectionName($collectionName);
         $resource->setSha1($sha1Hash);
-        $resource->setMd5(md5_file($targetPathAndFilename));
 
         return $resource;
     }

--- a/Neos.Flow/Migrations/Mysql/Version20200908155620.php
+++ b/Neos.Flow/Migrations/Mysql/Version20200908155620.php
@@ -1,0 +1,75 @@
+<?php
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Flow\ResourceManagement\PersistentResource;
+use Neos\Flow\ResourceManagement\ResourceRepository;
+
+class Version20200908155620 extends AbstractMigration
+{
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return 'Drop "md5" column of the "resource" table';
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+
+        $this->addSql('ALTER TABLE neos_flow_resourcemanagement_persistentresource DROP md5');
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on "mysql".');
+
+        $this->addSql('ALTER TABLE neos_flow_resourcemanagement_persistentresource ADD md5 VARCHAR(32) NOT NULL');
+    }
+
+    /**
+     * Add md5 content hash for resources.
+     *
+     * @param Schema $schema
+     * @return void
+     */
+    public function postDown(Schema $schema)
+    {
+        $resourceRepository = Bootstrap::$staticObjectManager->get(ResourceRepository::class);
+        $persistenceManager = Bootstrap::$staticObjectManager->get(PersistenceManagerInterface::class);
+        $filename = FLOW_PATH_DATA . 'tmp_md5_migration';
+
+        $iterator = $resourceRepository->findAllIterator();
+        foreach ($resourceRepository->iterate($iterator) as $resource) {
+            /* @var PersistentResource $resource */
+            $stream = $resource->getStream();
+            if (is_resource($stream)) {
+                $file = fopen($filename, 'w');
+                stream_copy_to_stream($resource->getStream(), $file);
+                fclose($file);
+
+                $this->connection->executeUpdate(
+                    'UPDATE neos_flow_resourcemanagement_persistentresource SET md5 = ? WHERE persistence_object_identifier = ?',
+                    [md5_file($filename), $persistenceManager->getIdentifierByObject($resource)]
+                );
+
+                unlink($filename);
+            }
+        }
+    }
+}

--- a/Neos.Flow/Migrations/Postgresql/Version20200908155621.php
+++ b/Neos.Flow/Migrations/Postgresql/Version20200908155621.php
@@ -1,0 +1,75 @@
+<?php
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Flow\ResourceManagement\PersistentResource;
+use Neos\Flow\ResourceManagement\ResourceRepository;
+
+class Version20200908155621 extends AbstractMigration
+{
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return 'Drop "md5" column of the "resource" table';
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on "postgresql".');
+
+        $this->addSql('ALTER TABLE neos_flow_resourcemanagement_persistentresource DROP md5');
+    }
+
+    /**
+     * @param Schema $schema
+     * @return void
+     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'postgresql', 'Migration can only be executed safely on "postgresql".');
+
+        $this->addSql('ALTER TABLE neos_flow_resourcemanagement_persistentresource ADD md5 VARCHAR(32) NOT NULL');
+    }
+
+    /**
+     * Add md5 content hash for resources.
+     *
+     * @param Schema $schema
+     * @return void
+     */
+    public function postDown(Schema $schema)
+    {
+        $resourceRepository = Bootstrap::$staticObjectManager->get(ResourceRepository::class);
+        $persistenceManager = Bootstrap::$staticObjectManager->get(PersistenceManagerInterface::class);
+        $filename = FLOW_PATH_DATA . 'tmp_md5_migration';
+
+        $iterator = $resourceRepository->findAllIterator();
+        foreach ($resourceRepository->iterate($iterator) as $resource) {
+            /* @var PersistentResource $resource */
+            $stream = $resource->getStream();
+            if (is_resource($stream)) {
+                $file = fopen($filename, 'w');
+                stream_copy_to_stream($resource->getStream(), $file);
+                fclose($file);
+
+                $this->connection->executeUpdate(
+                    'UPDATE neos_flow_resourcemanagement_persistentresource SET md5 = ? WHERE persistence_object_identifier = ?',
+                    [md5_file($filename), $persistenceManager->getIdentifierByObject($resource)]
+                );
+
+                unlink($filename);
+            }
+        }
+    }
+}

--- a/Neos.Flow/Migrations/Postgresql/Version20200908155621.php
+++ b/Neos.Flow/Migrations/Postgresql/Version20200908155621.php
@@ -1,8 +1,8 @@
 <?php
 namespace Neos\Flow\Persistence\Doctrine\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\ResourceManagement\PersistentResource;
@@ -52,24 +52,18 @@ class Version20200908155621 extends AbstractMigration
     {
         $resourceRepository = Bootstrap::$staticObjectManager->get(ResourceRepository::class);
         $persistenceManager = Bootstrap::$staticObjectManager->get(PersistenceManagerInterface::class);
-        $filename = FLOW_PATH_DATA . 'tmp_md5_migration';
 
         $iterator = $resourceRepository->findAllIterator();
         foreach ($resourceRepository->iterate($iterator) as $resource) {
             /* @var PersistentResource $resource */
-            $stream = $resource->getStream();
-            if (is_resource($stream)) {
-                $file = fopen($filename, 'w');
-                stream_copy_to_stream($resource->getStream(), $file);
-                fclose($file);
-
-                $this->connection->executeUpdate(
-                    'UPDATE neos_flow_resourcemanagement_persistentresource SET md5 = ? WHERE persistence_object_identifier = ?',
-                    [md5_file($filename), $persistenceManager->getIdentifierByObject($resource)]
-                );
-
-                unlink($filename);
+            if (!is_resource($resource->getStream())) {
+                continue;
             }
+
+            $this->connection->executeUpdate(
+                'UPDATE neos_flow_resourcemanagement_persistentresource SET md5 = ? WHERE persistence_object_identifier = ?',
+                [md5(stream_get_contents($resource->getStream())), $persistenceManager->getIdentifierByObject($resource)]
+            );
         }
     }
 }


### PR DESCRIPTION
Removes the `md5` property from persistent resources that is obsolete since
we introduced a `sha1` field.

Note:

This change is marked breaking because it removes the two API methods
`PersistentResource::getMd5()` and `PersistentResource::setMd5()`.
In practice this should never be an issue really.

Instead of `PersistentResource::getMd5()` one could use `PersistentResource::getSha1()`
in order to retrieve a unique hash for a file.
In case a MD5 hash is required, the following one can do `md5(stream_get_contents($resource->getStream()))`

Fixes: #2112