### PR TITLE
BUGFIX: Deprecate unused MD5 in ResourceMetaDataInterface

### DIFF
--- a/Neos.Flow/Classes/ResourceManagement/PersistentResource.php
+++ b/Neos.Flow/Classes/ResourceManagement/PersistentResource.php
@@ -319,7 +319,7 @@ class PersistentResource implements ResourceMetaDataInterface, CacheAwareInterfa
      * Returns the MD5 hash of the content of this resource
      *
      * @return string The MD5 hash
-     * @api
+     * @deprecated since 6.3 – use getSha1() instead or md5(stream_get_contents($resource->getStream())) if you need an MD5 hash
      */
     public function getMd5()
     {
@@ -331,7 +331,7 @@ class PersistentResource implements ResourceMetaDataInterface, CacheAwareInterfa
      *
      * @param string $md5 The MD5 hash
      * @return void
-     * @api
+     * @deprecated since 6.3, @see getMd5()
      */
     public function setMd5($md5)
     {

--- a/Neos.Flow/Classes/ResourceManagement/PersistentResource.php
+++ b/Neos.Flow/Classes/ResourceManagement/PersistentResource.php
@@ -319,7 +319,7 @@ class PersistentResource implements ResourceMetaDataInterface, CacheAwareInterfa
      * Returns the MD5 hash of the content of this resource
      *
      * @return string The MD5 hash
-     * @deprecated since 6.3 – use getSha1() instead or md5(stream_get_contents($resource->getStream())) if you need an MD5 hash
+     * @deprecated since 6.3, will be removed with 7.0 – use getSha1() instead or md5(stream_get_contents($resource->getStream())) if you need an MD5 hash
      */
     public function getMd5()
     {
@@ -331,7 +331,7 @@ class PersistentResource implements ResourceMetaDataInterface, CacheAwareInterfa
      *
      * @param string $md5 The MD5 hash
      * @return void
-     * @deprecated since 6.3, @see getMd5()
+     * @deprecated since 6.3, will be removed with 7.0 – @see getMd5()
      */
     public function setMd5($md5)
     {

--- a/Neos.Flow/Classes/ResourceManagement/ResourceMetaDataInterface.php
+++ b/Neos.Flow/Classes/ResourceManagement/ResourceMetaDataInterface.php
@@ -86,6 +86,7 @@ interface ResourceMetaDataInterface
      * Returns the md5 hash of the content of this storage object
      *
      * @return string The md5 hash
+     * @deprecated since 6.3, will be removed with 7.0 – use getSha1() instead or md5(stream_get_contents($resource->getStream())) if you need an MD5 hash
      */
     public function getMd5();
 
@@ -94,6 +95,7 @@ interface ResourceMetaDataInterface
      *
      * @param string $md5 The md5 hash
      * @return void
+     * @deprecated since 6.3, will be removed with 7.0 – @see getMd5()
      */
     public function setMd5($md5);
 }

--- a/Neos.Flow/Classes/ResourceManagement/Storage/StorageObject.php
+++ b/Neos.Flow/Classes/ResourceManagement/Storage/StorageObject.php
@@ -187,6 +187,7 @@ class StorageObject implements ResourceMetaDataInterface
      * Returns the md5 hash of the content of this storage object
      *
      * @return string The MD5 hash
+     * @deprecated since 6.3, will be removed with 7.0 – use getSha1() instead or md5(stream_get_contents($resource->getStream())) if you need an MD5 hash
      */
     public function getMd5()
     {
@@ -198,6 +199,7 @@ class StorageObject implements ResourceMetaDataInterface
      *
      * @param string $md5 The MD5 hash
      * @return void
+     * @deprecated since 6.3, will be removed with 7.0 – @see getMd5()
      */
     public function setMd5($md5)
     {


### PR DESCRIPTION
Marks `ResourceMetaDataInterface::getMd5()` and `ResourceMetaDataInterface::setMd5()` deprecated.

This affects the implementing classes `PersistentResource` and `StorageObject`.

Related: #2112
Related: #2113