### PR TITLE
BUGFIX: Take into account that a cookie value may be enclosed in double quotes

### DIFF
--- a/Neos.Flow/Classes/Http/Cookie.php
+++ b/Neos.Flow/Classes/Http/Cookie.php
@@ -122,7 +122,7 @@ class Cookie
         }
 
         $this->name = $name;
-        $this->value = $value;
+        $this->value = $value === null ? null : preg_replace('/^"(.*)"$/', '$1', $value);
         $this->expiresTimestamp = $expires;
         $this->maximumAge = $maximumAge;
         $this->domain = $domain;


### PR DESCRIPTION
According to RFC 6265 https://tools.ietf.org/html/rfc6265#section-4.1.1 a cookie value may be enclosed in double quotes.
This change takes this into account by removing the first and last double quote of a value (enclosing double quotes).

Fixes: #2133

**What I did**
Take into account that according to https://tools.ietf.org/html/rfc6265#section-4.1.1 Cookie values may be enclosed in double quotes.

**How I did it**
Stripping enclosing double quotes from the Cookie value.

**How to verify it**
Creating a cookie and adding quotes around it in the dev tools of your browser.
Before the change this leads to an exception, after the change it works as expected.
As an alternative you can use an Android phone that behaves like this but we don't have one in our office.