### PR TITLE
BUGFIX: Trim enclosing double quotes from session cookie

### DIFF
--- a/Neos.Flow/Classes/Session/Http/SessionRequestComponent.php
+++ b/Neos.Flow/Classes/Session/Http/SessionRequestComponent.php
@@ -74,7 +74,8 @@ class SessionRequestComponent implements ComponentInterface
     {
         return new Cookie(
             $name,
-            $value,
+            // @see https://github.com/neos/flow-development-collection/issues/2133
+            trim(urldecode($value), '"'),
             0,
             $this->sessionSettings['cookie']['lifetime'],
             $this->sessionSettings['cookie']['domain'],

--- a/Neos.Flow/Tests/Unit/Http/Component/SessionRequestComponentTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Component/SessionRequestComponentTest.php
@@ -1,0 +1,210 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Http\Component;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Http\Component\ComponentContext;
+use Neos\Flow\Http\Cookie;
+use Neos\Flow\Session\Http\SessionRequestComponent;
+use Neos\Flow\Session\SessionInterface;
+use Neos\Flow\Session\SessionManager;
+use Neos\Flow\Tests\UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Test case for the SessionRequestComponent
+ */
+class SessionRequestComponentTest extends UnitTestCase
+{
+
+    /**
+     * @var SessionRequestComponent
+     */
+    private $sessionRequestComponent;
+
+    /**
+     * @var SessionManager|MockObject
+     */
+    private $mockSessionManager;
+
+    /**
+     * @var ServerRequestInterface|MockObject
+     */
+    private $mockHttpRequest;
+
+    /**
+     * @var ComponentContext|MockObject
+     */
+    private $mockComponentContext;
+
+    /**
+     * @var array
+     */
+    private $defaultSessionCookieSettings = [
+        'lifetime' => 0,
+        'path' => '/',
+        'secure' => false,
+        'httponly' => true,
+        'domain' => null,
+        'samesite' => null,
+    ];
+
+    public function setUp(): void
+    {
+        $this->sessionRequestComponent = new SessionRequestComponent();
+
+        $this->mockSessionManager = $this->getMockBuilder(SessionManager::class)->disableOriginalConstructor()->getMock();
+        $this->mockSessionManager->method('getCurrentSession')->willReturn($this->getMockBuilder(SessionInterface::class)->getMock());
+        $this->inject($this->sessionRequestComponent, 'sessionManager', $this->mockSessionManager);
+
+        $this->mockHttpRequest = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
+
+        $this->mockComponentContext = $this->getMockBuilder(ComponentContext::class)->disableOriginalConstructor()->getMock();
+        $this->mockComponentContext->method('getHttpRequest')->willReturn($this->mockHttpRequest);
+
+
+        $this->inject($this->sessionRequestComponent, 'sessionSettings', [
+            'name' => 'session_cookie_name',
+            'cookie' => $this->defaultSessionCookieSettings,
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function handleCreatesSessionIfNoCookiesAreSet(): void {
+        $this->mockHttpRequest->method('getCookieParams')->willReturn([]);
+
+        $this->mockSessionManager->expects($this->once())->method('createCurrentSessionFromCookie')->willReturnCallback(static function (Cookie $cookie) {
+            self::assertSame('session_cookie_name', $cookie->getName());
+        });
+
+        $this->sessionRequestComponent->handle($this->mockComponentContext);
+    }
+
+    /**
+     * @test
+     */
+    public function handleCreatesSessionIfNoSessionCookieIsSet(): void {
+        $this->mockHttpRequest->method('getCookieParams')->willReturn([
+            'some_cookie' => 'some_value',
+            'some_other_cookie' => 'some other value',
+        ]);
+
+        $this->mockSessionManager->expects($this->once())->method('createCurrentSessionFromCookie')->willReturnCallback(static function (Cookie $cookie) {
+            self::assertSame('session_cookie_name', $cookie->getName());
+        });
+
+        $this->sessionRequestComponent->handle($this->mockComponentContext);
+    }
+
+    /**
+     * @test
+     */
+    public function handleCreatesSessionIfSessionCookieIsNull(): void {
+        $this->mockHttpRequest->method('getCookieParams')->willReturn([
+            'session_cookie_name' => null,
+        ]);
+
+        $this->mockSessionManager->expects($this->once())->method('createCurrentSessionFromCookie')->willReturnCallback(static function (Cookie $cookie) {
+            self::assertSame('session_cookie_name', $cookie->getName());
+        });
+
+        $this->sessionRequestComponent->handle($this->mockComponentContext);
+    }
+
+    /**
+     * @test
+     */
+    public function handleInitializesSessionFromSessionCookieIfItExists(): void {
+        $this->mockHttpRequest->method('getCookieParams')->willReturn([
+            'session_cookie_name' => 'some_value',
+        ]);
+
+        $this->mockSessionManager->expects($this->once())->method('initializeCurrentSessionFromCookie')->willReturnCallback(static function (Cookie $cookie) {
+            self::assertSame('session_cookie_name', $cookie->getName());
+        });
+
+        $this->sessionRequestComponent->handle($this->mockComponentContext);
+    }
+
+    public function sessionCookieSettingsProvider(): array
+    {
+        return [
+            ['sessionCookieSettings' => [], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Path=/; HttpOnly'],
+            ['sessionCookieSettings' => ['lifetime' => 123], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Max-Age=123; Path=/; HttpOnly'],
+            ['sessionCookieSettings' => ['path' => '/some/path'], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Path=/some/path; HttpOnly'],
+            ['sessionCookieSettings' => ['secure' => true], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Path=/; Secure; HttpOnly'],
+            ['sessionCookieSettings' => ['httponly' => false], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Path=/'],
+            ['sessionCookieSettings' => ['domain' => 'neos.io'], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Domain=neos.io; Path=/; HttpOnly'],
+            ['sessionCookieSettings' => ['samesite' => 'none'], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Path=/; Secure; HttpOnly; SameSite=none'],
+            ['sessionCookieSettings' => ['samesite' => 'strict'], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Path=/; HttpOnly; SameSite=strict'],
+            ['sessionCookieSettings' => ['samesite' => 'lax'], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Path=/; HttpOnly; SameSite=lax'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider sessionCookieSettingsProvider
+     */
+    public function newSessionCookiesTakeSessionCookieSettingsIntoAccount(array $sessionCookieSettings, string $expectedCookie): void {
+        $this->mockHttpRequest->method('getCookieParams')->willReturn(['session_cookie_name' => 'session-id']);
+
+        $this->inject($this->sessionRequestComponent, 'sessionSettings', [
+            'name' => 'session_cookie_name',
+            'cookie' => array_merge($this->defaultSessionCookieSettings, $sessionCookieSettings),
+        ]);
+
+        $this->mockSessionManager->expects($this->once())->method('initializeCurrentSessionFromCookie')->willReturnCallback(static function (Cookie $cookie) use ($expectedCookie) {
+            self::assertSame($expectedCookie, (string)$cookie);
+        });
+
+        $this->sessionRequestComponent->handle($this->mockComponentContext);
+    }
+
+    public function cookieValueDataProvider(): array
+    {
+        return [
+            ['sessionCookieValue' => 123, 'expectedNewCookieValue' => '123'],
+            ['sessionCookieValue' => '', 'expectedNewCookieValue' => ''],
+            ['sessionCookieValue' => 'some String', 'expectedNewCookieValue' => 'some String'],
+            ['sessionCookieValue' => '"leading quote', 'expectedNewCookieValue' => 'leading quote'],
+            ['sessionCookieValue' => 'trailing quote"', 'expectedNewCookieValue' => 'trailing quote'],
+            ['sessionCookieValue' => '"quotes"', 'expectedNewCookieValue' => 'quotes'],
+            ['sessionCookieValue' => '""double quotes"', 'expectedNewCookieValue' => 'double quotes'],
+            ['sessionCookieValue' => '%22encoded quotes%22', 'expectedNewCookieValue' => 'encoded quotes'],
+
+            // Note: The following test cases merely document the status quo.
+            // The cookie values are valid according to https://tools.ietf.org/html/rfc6265#section-4.1.1 but we might want to tweak the behavior in the future
+            ['sessionCookieValue' => '   whitespace   ', 'expectedNewCookieValue' => '   whitespace   '],
+            ['sessionCookieValue' => "\t" . 'tabs' . "\t", 'expectedNewCookieValue' => '	tabs	'],
+            ['sessionCookieValue' => 'semicolon;', 'expectedNewCookieValue' => 'semicolon;'],
+            ['sessionCookieValue' => '%C3%BCrl%20encoded', 'expectedNewCookieValue' => 'ürl encoded'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider cookieValueDataProvider
+     */
+    public function valueFromSessionCookieIsCleanedBeforeANewCookieIsCreated($sessionCookieValue, $expectedNewCookieValue): void {
+        $this->mockHttpRequest->method('getCookieParams')->willReturn([
+            'session_cookie_name' => $sessionCookieValue,
+        ]);
+
+        $this->mockSessionManager->expects($this->once())->method('initializeCurrentSessionFromCookie')->willReturnCallback(static function (Cookie $cookie) use ($expectedNewCookieValue) {
+            self::assertSame($expectedNewCookieValue, $cookie->getValue());
+        });
+
+        $this->sessionRequestComponent->handle($this->mockComponentContext);
+    }
+}

--- a/Neos.Flow/Tests/Unit/Http/Component/SessionRequestComponentTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Component/SessionRequestComponentTest.php
@@ -81,7 +81,8 @@ class SessionRequestComponentTest extends UnitTestCase
     /**
      * @test
      */
-    public function handleCreatesSessionIfNoCookiesAreSet(): void {
+    public function handleCreatesSessionIfNoCookiesAreSet(): void
+    {
         $this->mockHttpRequest->method('getCookieParams')->willReturn([]);
 
         $this->mockSessionManager->expects($this->once())->method('createCurrentSessionFromCookie')->willReturnCallback(static function (Cookie $cookie) {
@@ -94,7 +95,8 @@ class SessionRequestComponentTest extends UnitTestCase
     /**
      * @test
      */
-    public function handleCreatesSessionIfNoSessionCookieIsSet(): void {
+    public function handleCreatesSessionIfNoSessionCookieIsSet(): void
+    {
         $this->mockHttpRequest->method('getCookieParams')->willReturn([
             'some_cookie' => 'some_value',
             'some_other_cookie' => 'some other value',
@@ -110,7 +112,8 @@ class SessionRequestComponentTest extends UnitTestCase
     /**
      * @test
      */
-    public function handleCreatesSessionIfSessionCookieIsNull(): void {
+    public function handleCreatesSessionIfSessionCookieIsNull(): void
+    {
         $this->mockHttpRequest->method('getCookieParams')->willReturn([
             'session_cookie_name' => null,
         ]);
@@ -125,7 +128,8 @@ class SessionRequestComponentTest extends UnitTestCase
     /**
      * @test
      */
-    public function handleInitializesSessionFromSessionCookieIfItExists(): void {
+    public function handleInitializesSessionFromSessionCookieIfItExists(): void
+    {
         $this->mockHttpRequest->method('getCookieParams')->willReturn([
             'session_cookie_name' => 'some_value',
         ]);
@@ -156,7 +160,8 @@ class SessionRequestComponentTest extends UnitTestCase
      * @test
      * @dataProvider sessionCookieSettingsProvider
      */
-    public function newSessionCookiesTakeSessionCookieSettingsIntoAccount(array $sessionCookieSettings, string $expectedCookie): void {
+    public function newSessionCookiesTakeSessionCookieSettingsIntoAccount(array $sessionCookieSettings, string $expectedCookie): void
+    {
         $this->mockHttpRequest->method('getCookieParams')->willReturn(['session_cookie_name' => 'session-id']);
 
         $this->inject($this->sessionRequestComponent, 'sessionSettings', [
@@ -196,7 +201,8 @@ class SessionRequestComponentTest extends UnitTestCase
      * @test
      * @dataProvider cookieValueDataProvider
      */
-    public function valueFromSessionCookieIsCleanedBeforeANewCookieIsCreated($sessionCookieValue, $expectedNewCookieValue): void {
+    public function valueFromSessionCookieIsCleanedBeforeANewCookieIsCreated($sessionCookieValue, $expectedNewCookieValue): void
+    {
         $this->mockHttpRequest->method('getCookieParams')->willReturn([
             'session_cookie_name' => $sessionCookieValue,
         ]);


### PR DESCRIPTION
According to RFC 6265 https://tools.ietf.org/html/rfc6265#section-4.1.1 a cookie
value may be enclosed in double quotes.
This change takes this into account by removing the first and last double quote of a
value (enclosing double quotes) when starting/resuming a session.

Fixes: #2133