### PR TITLE
FEATURE: Consider route variables in handler options

### DIFF
--- a/Neos.Flow/Classes/Configuration/RouteConfigurationProcessor.php
+++ b/Neos.Flow/Classes/Configuration/RouteConfigurationProcessor.php
@@ -197,10 +197,11 @@ class RouteConfigurationProcessor
                         $mergedSubRouteConfiguration['defaults'][$key] = $this->replacePlaceholders($defaultValue, $variables);
                     }
                 }
-                foreach ($mergedSubRouteConfiguration['routeParts'] ?? [] as $routePartKey => $routePartValue) {
-                    $mergedSubRouteConfiguration['routeParts'][$routePartKey] = $this->replacePlaceholders($routePartValue, $variables);
-                    foreach ($mergedSubRouteConfiguration['routeParts'][$routePartKey]['options'] ?? [] as $optionKey => $optionValue) {
-                        $mergedSubRouteConfiguration['routeParts'][$routePartKey]['options'][$optionKey] = $this->replacePlaceholders($optionValue, $variables);
+                if (isset($mergedSubRouteConfiguration['routeParts'])) {
+                    foreach ($mergedSubRouteConfiguration['routeParts'] as $routePartKey => $routePartValue) {
+                        foreach ($mergedSubRouteConfiguration['routeParts'][$routePartKey]['options'] ?? [] as $optionKey => $optionValue) {
+                            $mergedSubRouteConfiguration['routeParts'][$routePartKey]['options'][$optionKey] = $this->replacePlaceholders($optionValue, $variables);
+                        }
                     }
                 }
                 $mergedSubRouteConfiguration = Arrays::arrayMergeRecursiveOverrule($routeConfiguration, $mergedSubRouteConfiguration);

--- a/Neos.Flow/Classes/Configuration/RouteConfigurationProcessor.php
+++ b/Neos.Flow/Classes/Configuration/RouteConfigurationProcessor.php
@@ -176,12 +176,12 @@ class RouteConfigurationProcessor
      */
     protected function buildSubRouteConfigurations(array $routesConfiguration, array $subRoutesConfiguration, $subRouteKey, array $subRouteOptions)
     {
-        $variables = isset($subRouteOptions['variables']) ? $subRouteOptions['variables'] : [];
+        $variables = $subRouteOptions['variables'] ?? [];
         $mergedSubRoutesConfigurations = [];
         foreach ($subRoutesConfiguration as $subRouteConfiguration) {
             foreach ($routesConfiguration as $routeConfiguration) {
                 $mergedSubRouteConfiguration = $subRouteConfiguration;
-                $mergedSubRouteConfiguration['name'] = sprintf('%s :: %s', isset($routeConfiguration['name']) ? $routeConfiguration['name'] : 'Unnamed Route', isset($subRouteConfiguration['name']) ? $subRouteConfiguration['name'] : 'Unnamed Subroute');
+                $mergedSubRouteConfiguration['name'] = sprintf('%s :: %s', $routeConfiguration['name'] ?? 'Unnamed Route', $subRouteConfiguration['name'] ?? 'Unnamed Subroute');
                 $mergedSubRouteConfiguration['name'] = $this->replacePlaceholders($mergedSubRouteConfiguration['name'], $variables);
                 if (!isset($mergedSubRouteConfiguration['uriPattern'])) {
                     throw new Exception\ParseErrorException('No uriPattern defined in route configuration "' . $mergedSubRouteConfiguration['name'] . '".', 1274197615);
@@ -195,6 +195,12 @@ class RouteConfigurationProcessor
                 if (isset($mergedSubRouteConfiguration['defaults'])) {
                     foreach ($mergedSubRouteConfiguration['defaults'] as $key => $defaultValue) {
                         $mergedSubRouteConfiguration['defaults'][$key] = $this->replacePlaceholders($defaultValue, $variables);
+                    }
+                }
+                foreach ($mergedSubRouteConfiguration['routeParts'] ?? [] as $routePartKey => $routePartValue) {
+                    $mergedSubRouteConfiguration['routeParts'][$routePartKey] = $this->replacePlaceholders($routePartValue, $variables);
+                    foreach ($mergedSubRouteConfiguration['routeParts'][$routePartKey]['options'] ?? [] as $optionKey => $optionValue) {
+                        $mergedSubRouteConfiguration['routeParts'][$routePartKey]['options'][$optionKey] = $this->replacePlaceholders($optionValue, $variables);
                     }
                 }
                 $mergedSubRouteConfiguration = Arrays::arrayMergeRecursiveOverrule($routeConfiguration, $mergedSubRouteConfiguration);

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Routing.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Routing.rst
@@ -543,8 +543,8 @@ This will load the SubRoutes from a file ``Routes.Foo.yaml`` in the ``My.Demo`` 
 With that feature you can include multiple Routes with your package (for example providing different URI styles).
 Furthermore you can nest routes in order to minimize duplication in your configuration. You nest SubRoutes by including
 different SubRoutes from within a SubRoute, using the same syntax as before.
-Additionally you can specify a set of ``variables`` that will be replaced in ``name``, ``uriPattern`` and ``defaults``
-of merged routes:
+Additionally you can specify a set of ``variables`` that will be replaced in ``name``, ``uriPattern``, ``defaults`` and
+``handler options`` of merged routes:
 
 Imagine the following setup:
 

--- a/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -1367,20 +1367,28 @@ EOD;
         $subRouteOptions = [
             'package' => 'Welcome',
             'variables' => [
-                'someVariable' => 'someValue'
+                'someVariable' => 'someValue',
+                'someOtherVariable' => 'someOtherValue'
             ]
         ];
         $subRoutesConfiguration = [
             [
                 'name' => 'Standard Route',
-                'uriPattern' => 'foo',
+                'uriPattern' => '{foo}',
                 'defaults' => [
                     '@package' => 'OverriddenPackage',
                     '@controller' => 'Standard',
                     '@action' => '<someVariable>'
-                ]
-            ],
-            [
+                ],
+                'routeParts' => [
+                    'foo' => [
+                        'handler' => 'Some\RoutePart\Handler',
+                        'options' => [
+                            'someOption' => '<someOtherVariable>'
+                        ],
+                    ],
+                ],
+            ], [
                 'name' => 'Fallback',
                 'uriPattern' => '',
                 'defaults' => [
@@ -1390,7 +1398,7 @@ EOD;
                       '@package' => '',
                       '@subpackage' => '',
                       '@controller' => '',
-                      '@action' => 'index',
+                      '@action' => '<someOtherVariable>',
                       'currentPage' => '1'
                     ]
                 ],
@@ -1399,14 +1407,21 @@ EOD;
         $expectedResult = [
             [
                 'name' => 'Welcome :: Standard Route',
-                'uriPattern' => 'welcome/foo',
+                'uriPattern' => 'welcome/{foo}',
                 'defaults' => [
                     '@package' => 'OverriddenPackage',
                     '@controller' => 'Standard',
                     '@action' => 'someValue'
                 ],
-            ],
-            [
+                'routeParts' => [
+                    'foo' => [
+                        'handler' => 'Some\RoutePart\Handler',
+                        'options' => [
+                            'someOption' => 'someOtherValue'
+                        ],
+                    ],
+                ],
+            ], [
                 'name' => 'Welcome :: Fallback',
                 'uriPattern' => 'welcome',
                 'defaults' => [
@@ -1417,7 +1432,7 @@ EOD;
                         '@package' => '',
                         '@subpackage' => '',
                         '@controller' => '',
-                        '@action' => 'index',
+                        '@action' => 'someOtherValue',
                         'currentPage' => '1'
                     ]
                 ],


### PR DESCRIPTION
Allows variables to be used in route part handler options like:

```yaml
-
  name: 'Some route'
  uriPattern: 'some/{part}'
  defaults:
    # ...
  routeParts:
    'part':
      handler:   'Some\RoutePart\Handler'
      options:
        someOption: '<someVariable>'
```

Related: https://github.com/neos/neos-development-collection/issues/3020
Resolves: #2142