### PR TITLE
BUGFIX: Correctly recognize NULL method arguments in JoinPoint

### DIFF
--- a/Neos.Flow/Classes/Aop/JoinPoint.php
+++ b/Neos.Flow/Classes/Aop/JoinPoint.php
@@ -172,7 +172,7 @@ class JoinPoint implements JoinPointInterface
      */
     public function isMethodArgument($argumentName): bool
     {
-        return isset($this->methodArguments[$argumentName]);
+        return array_key_exists($argumentName, $this->methodArguments);
     }
 
     /**


### PR DESCRIPTION
Fixes #970