### PR TITLE
BUGFIX: Don't convert route options to strings when merging subroutes

### DIFF
--- a/Neos.Flow/Classes/Configuration/RouteConfigurationProcessor.php
+++ b/Neos.Flow/Classes/Configuration/RouteConfigurationProcessor.php
@@ -212,7 +212,7 @@ class RouteConfigurationProcessor
      *
      * @param string|array $value
      * @param array $variables
-     * @return string
+     * @return mixed
      */
     protected function replacePlaceholders($value, array $variables)
     {

--- a/Neos.Flow/Classes/Configuration/RouteConfigurationProcessor.php
+++ b/Neos.Flow/Classes/Configuration/RouteConfigurationProcessor.php
@@ -217,7 +217,7 @@ class RouteConfigurationProcessor
     protected function replacePlaceholders($value, array $variables)
     {
         if (is_array($value)) {
-            foreach($value as $arrayKey => $arrayValue) {
+            foreach ($value as $arrayKey => $arrayValue) {
                 $value[$arrayKey] = $this->replacePlaceholders($arrayValue, $variables);
             }
         } elseif (is_string($value)) {

--- a/Neos.Flow/Classes/Configuration/RouteConfigurationProcessor.php
+++ b/Neos.Flow/Classes/Configuration/RouteConfigurationProcessor.php
@@ -193,16 +193,10 @@ class RouteConfigurationProcessor
                     $mergedSubRouteConfiguration['uriPattern'] = rtrim($this->replacePlaceholders($routeConfiguration['uriPattern'], [$subRouteKey => '']), '/');
                 }
                 if (isset($mergedSubRouteConfiguration['defaults'])) {
-                    foreach ($mergedSubRouteConfiguration['defaults'] as $key => $defaultValue) {
-                        $mergedSubRouteConfiguration['defaults'][$key] = $this->replacePlaceholders($defaultValue, $variables);
-                    }
+                    $mergedSubRouteConfiguration['defaults'] = $this->replacePlaceholders($mergedSubRouteConfiguration['defaults'], $variables);
                 }
                 if (isset($mergedSubRouteConfiguration['routeParts'])) {
-                    foreach ($mergedSubRouteConfiguration['routeParts'] as $routePartKey => $routePartValue) {
-                        foreach ($mergedSubRouteConfiguration['routeParts'][$routePartKey]['options'] ?? [] as $optionKey => $optionValue) {
-                            $mergedSubRouteConfiguration['routeParts'][$routePartKey]['options'][$optionKey] = $this->replacePlaceholders($optionValue, $variables);
-                        }
-                    }
+                    $mergedSubRouteConfiguration['routeParts'] = $this->replacePlaceholders($mergedSubRouteConfiguration['routeParts'], $variables);
                 }
                 $mergedSubRouteConfiguration = Arrays::arrayMergeRecursiveOverrule($routeConfiguration, $mergedSubRouteConfiguration);
                 unset($mergedSubRouteConfiguration['subRoutes']);
@@ -216,16 +210,21 @@ class RouteConfigurationProcessor
     /**
      * Replaces placeholders in the format <variableName> with the corresponding variable of the specified $variables collection.
      *
-     * @param string $string
+     * @param string|array $value
      * @param array $variables
      * @return string
      */
-    protected function replacePlaceholders($string, array $variables)
+    protected function replacePlaceholders($value, array $variables)
     {
-        foreach ($variables as $variableName => $variableValue) {
-            $string = str_replace('<' . $variableName . '>', $variableValue, $string);
+        if (is_array($value)) {
+            foreach($value as $arrayKey => $arrayValue) {
+                $value[$arrayKey] = $this->replacePlaceholders($arrayValue, $variables);
+            }
+        } elseif (is_string($value)) {
+            foreach ($variables as $variableName => $variableValue) {
+                $value = str_replace('<' . $variableName . '>', $variableValue, $value);
+            }
         }
-
-        return $string;
+        return $value;
     }
 }

--- a/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -1441,7 +1441,58 @@ EOD;
         $routeConfigurationProcessor = $this->getAccessibleMock(RouteConfigurationProcessor::class, ['dummy'], [], '', false);
         $actualResult = $routeConfigurationProcessor->_call('buildSubrouteConfigurations', $routesConfiguration, $subRoutesConfiguration, 'WelcomeSubroutes', $subRouteOptions);
 
-        self::assertEquals($expectedResult, $actualResult);
+        self::assertSame($expectedResult, $actualResult);
+    }
+
+    /**
+     * @test
+     */
+    public function buildSubrouteConfigurationsWontReplaceNonStringValues()
+    {
+        $routesConfiguration = [
+            [
+                'name' => 'Root',
+                'uriPattern' => '<Subroutes>',
+            ]
+        ];
+        $subRouteOptions = [
+            'package' => 'Subroutes',
+            'variables' => [
+                'suffix' => '.html',
+            ]
+        ];
+        $subRoutesConfiguration = [
+            [
+                'name' => 'SubRoute',
+                'uriPattern' => '{foo}<suffix>',
+                'routeParts' => [
+                    'foo' => [
+                        'handler' => 'Some\RoutePart\Handler',
+                        'options' => [
+                            'someOption' => true
+                        ],
+                    ],
+                ],
+            ]
+        ];
+        $expectedResult = [
+            [
+                'name' => 'Root :: SubRoute',
+                'uriPattern' => '{foo}.html',
+                'routeParts' => [
+                    'foo' => [
+                        'handler' => 'Some\RoutePart\Handler',
+                        'options' => [
+                            'someOption' => true
+                        ],
+                    ],
+                ],
+            ]
+        ];
+        $routeConfigurationProcessor = $this->getAccessibleMock(RouteConfigurationProcessor::class, ['dummy'], [], '', false);
+        $actualResult = $routeConfigurationProcessor->_call('buildSubrouteConfigurations', $routesConfiguration, $subRoutesConfiguration, 'Subroutes', $subRouteOptions);
+
+        self::assertSame($expectedResult, $actualResult);
     }
 
     /**


### PR DESCRIPTION
Adjusts the `RouteConfigurationProcessor` so that it doesn't implicitly
convert route configuration options to strings when merging routes.

Background:

This fixes a regression introduced with #2145 that lead to the Neos
route

```yaml
-
  name: 'Homepage'
  uriPattern: '{node}'
  routeParts:
    'node':
      options:
        onlyMatchSiteNodes: true
```

to be converted such that the `onlyMatchSiteNodes` option was casted
to a string of `"1"` leading to the homepage route resolving all node links.

Resolves: #2142