### PR TITLE
BUGFIX: Allow URI-building from CLI context

### DIFF
--- a/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
+++ b/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
@@ -361,7 +361,7 @@ class UriBuilder
         $uriPathPrefix = RequestInformationHelper::getScriptRequestPath($httpRequest) . $uriPathPrefix;
         $uriPathPrefix = ltrim($uriPathPrefix, '/');
 
-        $resolveContext = new ResolveContext($this->baseUriProvider->getConfiguredBaseUriOrFallbackToCurrentRequest(), $arguments, $this->createAbsoluteUri, $uriPathPrefix);
+        $resolveContext = new ResolveContext($this->baseUriProvider->getConfiguredBaseUriOrFallbackToCurrentRequest($httpRequest), $arguments, $this->createAbsoluteUri, $uriPathPrefix);
         $resolvedUri = $this->router->resolve($resolveContext);
         if ($this->section !== '') {
             $resolvedUri = $resolvedUri->withFragment($this->section);

--- a/Neos.Flow/Tests/Unit/Http/BaseUriProviderTest.php
+++ b/Neos.Flow/Tests/Unit/Http/BaseUriProviderTest.php
@@ -1,0 +1,102 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Http;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use GuzzleHttp\Psr7\Uri;
+use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\Core\RequestHandlerInterface;
+use Neos\Flow\Http\BaseUriProvider;
+use Neos\Flow\Http\Component\ComponentContext;
+use Neos\Flow\Http\Exception as HttpException;
+use Neos\Flow\Http\HttpRequestHandlerInterface;
+use Neos\Flow\Tests\UnitTestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Test case for the BaseUriProvider class
+ */
+class BaseUriProviderTest extends UnitTestCase
+{
+    /**
+     * @var BaseUriProvider
+     */
+    private $baseUriProvider;
+
+    protected function setUp(): void
+    {
+        $this->baseUriProvider = new BaseUriProvider();
+    }
+
+    /**
+     * @test
+     */
+    public function getConfiguredBaseUriOrFallbackToCurrentRequestReturnsConfiguredBaseUriByDefault(): void
+    {
+        $configuredBaseUri = 'http://some-base.uri/';
+        $this->inject($this->baseUriProvider, 'configuredBaseUri', $configuredBaseUri);
+
+        self::assertSame($configuredBaseUri, (string)$this->baseUriProvider->getConfiguredBaseUriOrFallbackToCurrentRequest());
+    }
+
+    /**
+     * @test
+     */
+    public function getConfiguredBaseUriOrFallbackToCurrentRequestReturnsBaseUriOfCurrentlyActiveRequestIfNoBaseUriIsConfigured(): void
+    {
+        $mockBootstrap = $this->getMockBuilder(Bootstrap::class)->disableOriginalConstructor()->getMock();
+        $mockHttpRequestHandler = $this->getMockBuilder(HttpRequestHandlerInterface::class)->getMock();
+        $mockComponentContext = $this->getMockBuilder(ComponentContext::class)->disableOriginalConstructor()->getMock();
+        $mockServerRequest = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
+        $uri = new Uri('http://uri-from-current-request/some/path');
+        $mockServerRequest->method('getUri')->willReturn($uri);
+        $mockComponentContext->method('getHttpRequest')->willReturn($mockServerRequest);
+        $mockHttpRequestHandler->method('getComponentContext')->willReturn($mockComponentContext);
+        $mockBootstrap->method('getActiveRequestHandler')->willReturn($mockHttpRequestHandler);
+
+        $this->inject($this->baseUriProvider, 'bootstrap', $mockBootstrap);
+
+        self::assertSame('http://uri-from-current-request/', (string)$this->baseUriProvider->getConfiguredBaseUriOrFallbackToCurrentRequest());
+    }
+
+    /**
+     * @test
+     */
+    public function getConfiguredBaseUriOrFallbackToCurrentRequestReturnsBaseUriFromFallbackRequestIfNoBaseUriIsConfiguredAndCurrentHttpRequestCantBeDetermined(): void
+    {
+        $mockBootstrap = $this->getMockBuilder(Bootstrap::class)->disableOriginalConstructor()->getMock();
+        $mockNonHttpRequestHandler = $this->getMockBuilder(RequestHandlerInterface::class)->getMock();
+        $mockBootstrap->method('getActiveRequestHandler')->willReturn($mockNonHttpRequestHandler);
+
+        $this->inject($this->baseUriProvider, 'bootstrap', $mockBootstrap);
+
+        $mockFallbackRequest = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
+        $uri = new Uri('https://uri-from-fallback-request/some/path');
+        $mockFallbackRequest->method('getUri')->willReturn($uri);
+
+        self::assertSame('https://uri-from-fallback-request/', (string)$this->baseUriProvider->getConfiguredBaseUriOrFallbackToCurrentRequest($mockFallbackRequest));
+    }
+
+    /**
+     * @test
+     */
+    public function getConfiguredBaseUriOrFallbackToCurrentRequestThrowsExceptionIfNoBaseUriIsConfiguredAndCurrentHttpRequestCantBeDeterminedAndNoFallbackRequestIsSpecified(): void
+    {
+        $mockBootstrap = $this->getMockBuilder(Bootstrap::class)->disableOriginalConstructor()->getMock();
+        $mockNonHttpRequestHandler = $this->getMockBuilder(RequestHandlerInterface::class)->getMock();
+        $mockBootstrap->method('getActiveRequestHandler')->willReturn($mockNonHttpRequestHandler);
+
+        $this->inject($this->baseUriProvider, 'bootstrap', $mockBootstrap);
+
+        $this->expectException(HttpException::class);
+        $this->baseUriProvider->getConfiguredBaseUriOrFallbackToCurrentRequest();
+    }
+}


### PR DESCRIPTION
This adds a parameter `$fallbackRequest` to `BaseUriProvider::getConfiguredBaseUriOrFallbackToCurrentRequest()`
that allows it to work in contextx where the active HTTP request
can't get hold of (i.g. in CLI mode).

This also adjusts `UriBuilder::build()` to make use of that new parameter
such that the following code works again from CLI:

```php
$httpRequest = ServerRequest::fromGlobals();
$actionRequest = ActionRequest::fromHttpRequest($httpRequest);
$uriBuilder = new UriBuilder();
$uriBuilder->setRequest($actionRequest);
$uriBuilder->uriFor(...);
```

Previously this would throw an HTTP exception
```
No base URI could be provided. This probably means a call was made outside of an HTTP
request and a base URI was neither configured nor set during runtime.
```
when executed in CLI context.

Fixes: #2084