### PR TITLE
FEATURE: Add meta data to roles and privilegeTargets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ before_install:
   - git clone https://github.com/neos/flow-development-distribution.git -b ${NEOS_TARGET_VERSION}
   - cd flow-development-distribution
 install:
-  - composer self-update -q
+  - composer self-update --1 -q
   - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi;
   - composer update --no-progress --no-interaction
   - php Build/BuildEssentials/TravisCi/ComposerManifestUpdater.php .

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/AbstractPrivilege.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/AbstractPrivilege.php
@@ -190,7 +190,7 @@ abstract class AbstractPrivilege implements PrivilegeInterface
      *
      * @return string
      */
-    public function getParsedMatcher()
+    public function getParsedMatcher(): string
     {
         $parsedMatcher = $this->matcher;
         // TODO: handle parameters that are not strings

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/PrivilegeTarget.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/PrivilegeTarget.php
@@ -48,14 +48,21 @@ class PrivilegeTarget
     protected $objectManager;
 
     /**
+     * @var string
+     */
+    protected $label;
+
+    /**
      * @param string $identifier
      * @param string $privilegeClassName
      * @param string $matcher
      * @param Parameter\PrivilegeParameterDefinition[] $parameterDefinitions
+     * @param string $label
      */
-    public function __construct(string $identifier, string $privilegeClassName, string $matcher, array $parameterDefinitions = [])
+    public function __construct(string $identifier, string $privilegeClassName, string $matcher, array $parameterDefinitions = [], string $label = '')
     {
         $this->identifier = $identifier;
+        $this->label = empty($label) ? $identifier : $label;
         $this->privilegeClassName = $privilegeClassName;
         $this->matcher = $matcher;
         $this->parameterDefinitions = $parameterDefinitions;
@@ -71,7 +78,6 @@ class PrivilegeTarget
     {
         $this->objectManager = $objectManager;
     }
-
 
     /**
      * @return string
@@ -134,6 +140,14 @@ class PrivilegeTarget
         $privilege->injectObjectManager($this->objectManager);
 
         return $privilege;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLabel(): string
+    {
+        return $this->label;
     }
 
     /**

--- a/Neos.Flow/Classes/Security/Policy/PolicyService.php
+++ b/Neos.Flow/Classes/Security/Policy/PolicyService.php
@@ -114,12 +114,8 @@ class PolicyService
                 if ($roleIdentifier === 'Neos.Flow:Everybody') {
                     $role = $everybodyRole;
                 } else {
-                    $role = new Role($roleIdentifier);
+                    $role = new Role($roleIdentifier, [], (string)($roleConfiguration['label'] ?? ''), (string)($roleConfiguration['description'] ?? ''));
                     $role->setAbstract((bool)($roleConfiguration['abstract'] ?? false));
-                    if (isset($roleConfiguration['label'])) {
-                        $role->setLabel((string)$roleConfiguration['label']);
-                    }
-                    $role->setDescription((string)($roleConfiguration['description'] ?? ''));
                 }
 
                 if (isset($roleConfiguration['privileges'])) {

--- a/Neos.Flow/Classes/Security/Policy/PolicyService.php
+++ b/Neos.Flow/Classes/Security/Policy/PolicyService.php
@@ -115,9 +115,11 @@ class PolicyService
                     $role = $everybodyRole;
                 } else {
                     $role = new Role($roleIdentifier);
-                    if (isset($roleConfiguration['abstract'])) {
-                        $role->setAbstract((boolean)$roleConfiguration['abstract']);
+                    $role->setAbstract((bool)($roleConfiguration['abstract'] ?? false));
+                    if (isset($roleConfiguration['label'])) {
+                        $role->setLabel((string)$roleConfiguration['label']);
                     }
+                    $role->setDescription((string)($roleConfiguration['description'] ?? ''));
                 }
 
                 if (isset($roleConfiguration['privileges'])) {
@@ -183,6 +185,7 @@ class PolicyService
         if (!isset($this->policyConfiguration['privilegeTargets'])) {
             return;
         }
+
         foreach ($this->policyConfiguration['privilegeTargets'] as $privilegeClassName => $privilegeTargetsConfiguration) {
             foreach ($privilegeTargetsConfiguration as $privilegeTargetIdentifier => $privilegeTargetConfiguration) {
                 if (!isset($privilegeTargetConfiguration['matcher'])) {
@@ -199,7 +202,9 @@ class PolicyService
                     }
                     $parameterDefinitions[$parameterName] = new PrivilegeParameterDefinition($parameterName, $privilegeTargetConfiguration['parameters'][$parameterName]['className']);
                 }
-                $privilegeTarget = new PrivilegeTarget($privilegeTargetIdentifier, $privilegeClassName, $privilegeTargetConfiguration['matcher'], $parameterDefinitions);
+
+                $label = $privilegeTargetConfiguration['label'] ?? $privilegeTargetIdentifier;
+                $privilegeTarget = new PrivilegeTarget($privilegeTargetIdentifier, $privilegeClassName, $privilegeTargetConfiguration['matcher'], $parameterDefinitions, $label);
                 $privilegeTarget->injectObjectManager($this->objectManager);
                 $this->privilegeTargets[$privilegeTargetIdentifier] = $privilegeTarget;
             }
@@ -234,7 +239,7 @@ class PolicyService
         if ($this->hasRole($roleIdentifier)) {
             return $this->roles[$roleIdentifier];
         }
-        throw new NoSuchRoleException(sprintf('Role with rolIdentifier %s has not been found', $roleIdentifier), 1602423622);
+        throw new NoSuchRoleException(sprintf('Role with roleIdentifier %s has not been found', $roleIdentifier), 1602423622);
     }
 
     /**

--- a/Neos.Flow/Classes/Security/Policy/Role.php
+++ b/Neos.Flow/Classes/Security/Policy/Role.php
@@ -79,9 +79,10 @@ class Role
     /**
      * @param string $identifier The fully qualified identifier of this role (Vendor.Package:Role)
      * @param Role[] $parentRoles
-     * @throws \InvalidArgumentException
+     * @param string $label A label for this role
+     * @param string $description A description on this role
      */
-    public function __construct(string $identifier, array $parentRoles = [])
+    public function __construct(string $identifier, array $parentRoles = [], string $label = '', string $description = '')
     {
         if (preg_match(self::ROLE_IDENTIFIER_PATTERN, $identifier, $matches) !== 1) {
             throw new \InvalidArgumentException('The role identifier must follow the pattern "Vendor.Package:RoleName", but "' . $identifier . '" was given. Please check the code or policy configuration creating or defining this role.', 1365446549);
@@ -89,7 +90,8 @@ class Role
         $this->identifier = $identifier;
         $this->packageKey = $matches[1];
         $this->name = $matches[2];
-        $this->label = $matches[2];
+        $this->label = $label ?: $matches[2];
+        $this->description = $description;
         $this->parentRoles = $parentRoles;
     }
 
@@ -291,26 +293,10 @@ class Role
     }
 
     /**
-     * @param string $label
-     */
-    public function setLabel(string $label): void
-    {
-        $this->label = $label;
-    }
-
-    /**
      * @return string
      */
     public function getDescription(): string
     {
         return $this->description;
-    }
-
-    /**
-     * @param string $description
-     */
-    public function setDescription(string $description): void
-    {
-        $this->description = $description;
     }
 }

--- a/Neos.Flow/Classes/Security/Policy/Role.php
+++ b/Neos.Flow/Classes/Security/Policy/Role.php
@@ -47,9 +47,23 @@ class Role
     /**
      * Whether or not the role is "abstract", meaning it can't be assigned to accounts directly but only serves as a "template role" for other roles to inherit from
      *
-     * @var boolean
+     * @var bool
      */
     protected $abstract = false;
+
+    /**
+     * A human readable label for this role
+     *
+     * @var string
+     */
+    protected $label;
+
+    /**
+     * A description for this role
+     *
+     * @var string
+     */
+    protected $description;
 
     /**
      * @Flow\Transient
@@ -75,6 +89,7 @@ class Role
         $this->identifier = $identifier;
         $this->packageKey = $matches[1];
         $this->name = $matches[2];
+        $this->label = $matches[2];
         $this->parentRoles = $parentRoles;
     }
 
@@ -265,5 +280,37 @@ class Role
     public function __toString()
     {
         return $this->identifier;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    /**
+     * @param string $label
+     */
+    public function setLabel(string $label): void
+    {
+        $this->label = $label;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param string $description
+     */
+    public function setDescription(string $description): void
+    {
+        $this->description = $description;
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/Policy/RoleTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Policy/RoleTest.php
@@ -24,25 +24,37 @@ class RoleTest extends UnitTestCase
      *
      * @return array
      */
-    public function roleIdentifiersAndPackageKeysAndNames()
+    public function roleIdentifiersAndPackageKeysAndNames(): array
     {
         return [
-            ['Neos.Flow:Everybody', 'Everybody', 'Neos.Flow'],
-            ['Acme.Demo:Test', 'Test', 'Acme.Demo'],
-            ['Acme.Demo.Sub:Test', 'Test', 'Acme.Demo.Sub']
+            ['Neos.Flow:Everybody', 'Everybody', 'Neos.Flow', 'A role for everybody', 'The role is automatically assigned to every session'],
+            ['Acme.Demo:Test', 'Test', 'Acme.Demo', 'just a label', ''],
+            ['Acme.Demo.Sub:Test', 'Test', 'Acme.Demo.Sub', '', 'A descriptive description']
         ];
     }
 
     /**
      * @dataProvider roleIdentifiersAndPackageKeysAndNames
      * @test
+     * @param string $roleIdentifier
+     * @param string $name
+     * @param string $packageKey
+     * @param string $label
+     * @param string $description
      */
-    public function setNameAndPackageKeyWorks($roleIdentifier, $name, $packageKey)
+    public function setNameTolePropertiesWork(string $roleIdentifier, string $name, string $packageKey, string $label, string $description): void
     {
-        $role = new Role($roleIdentifier);
+        $role = new Role($roleIdentifier, [], $label, $description);
 
         self::assertEquals($name, $role->getName());
         self::assertEquals($packageKey, $role->getPackageKey());
+        self::assertEquals($description, $role->getDescription());
+
+        if ($label === '') {
+            self::assertEquals($role->getName(), $role->getLabel());
+        } else {
+            self::assertEquals($label, $role->getLabel());
+        }
     }
 
     /**


### PR DESCRIPTION
This adds the optional configuration values label and description
to role definitions and label to privilege targets. The meta data can
be used to document roles and privilegeTarget and to guide
administrators to assign the correct roles to users.

Example:

```
  'Neos.Neos:UserManager':
    label: Neos User Manager
    description: A user with this role is able to create, edit and delete users which has the same or a subset of his own roles.
    privileges:
    ...
```

Resolves: #2162