### PR TITLE
BUGFIX: FileSystemStorage::getObjects correctly returns a generator of StorageObject

### DIFF
--- a/Neos.Flow/Classes/ResourceManagement/Storage/FileSystemStorage.php
+++ b/Neos.Flow/Classes/ResourceManagement/Storage/FileSystemStorage.php
@@ -167,6 +167,10 @@ class FileSystemStorage implements StorageInterface
             }
             $iteration++;
         }
+        if ($iteration === 0) {
+            // required because if the collection is empty, this should still return an empty generator
+            yield from [];
+        }
     }
 
     /**

--- a/Neos.Flow/Classes/ResourceManagement/Storage/FileSystemStorage.php
+++ b/Neos.Flow/Classes/ResourceManagement/Storage/FileSystemStorage.php
@@ -131,12 +131,12 @@ class FileSystemStorage implements StorageInterface
      * Retrieve all Objects stored in this storage.
      *
      * @param callable $callback Function called after each iteration
-     * @return \Generator<Object>
+     * @return \Generator<StorageObject>
      */
     public function getObjects(callable $callback = null)
     {
         foreach ($this->resourceManager->getCollectionsByStorage($this) as $collection) {
-            yield $this->getObjectsByCollection($collection, $callback);
+            yield from $this->getObjectsByCollection($collection, $callback);
         }
     }
 
@@ -145,7 +145,7 @@ class FileSystemStorage implements StorageInterface
      *
      * @param callable $callback Function called after each iteration
      * @param CollectionInterface $collection
-     * @return \Generator<Object>
+     * @return \Generator<StorageObject>
      */
     public function getObjectsByCollection(CollectionInterface $collection, callable $callback = null)
     {


### PR DESCRIPTION
Somehow this went unnoticed and the `getObjects()` method returned a generator generator. Also the element type docblock was wrong.