### PR TITLE
FEATURE: Introduce connection factory

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/ConnectionFactory.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/ConnectionFactory.php
@@ -20,7 +20,7 @@ use Doctrine\ORM\EntityManagerInterface;
  *
  * @Flow\Scope("singleton")
  */
-class ConnectionFactory
+final class ConnectionFactory
 {
     /**
      * @Flow\Inject

--- a/Neos.Flow/Classes/Persistence/Doctrine/ConnectionFactory.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/ConnectionFactory.php
@@ -1,0 +1,44 @@
+<?php
+namespace Neos\Flow\Persistence\Doctrine;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Connection factory for Doctrine connection class
+ *
+ * @Flow\Scope("singleton")
+ */
+class ConnectionFactory
+{
+    /**
+     * @Flow\Inject
+     * @var EntityManagerInterface
+     */
+    protected $entityManager;
+
+    /**
+     * Factory method which creates an Connection from
+     * the injected EntityManager.
+     *
+     * This ensure, that configured database and similar settings
+     * from Neos.Flow.persistence.doctrine is registered as expected
+     *
+     * @return Connection
+     */
+    public function create(): Connection
+    {
+        return $this->entityManager->getConnection();
+    }
+}

--- a/Neos.Flow/Configuration/Objects.yaml
+++ b/Neos.Flow/Configuration/Objects.yaml
@@ -367,6 +367,10 @@ Doctrine\ORM\EntityManagerInterface:
   scope: singleton
   factoryObjectName: Neos\Flow\Persistence\Doctrine\EntityManagerFactory
 
+Doctrine\DBAL\Connection:
+  scope: singleton
+  factoryObjectName: Neos\Flow\Persistence\Doctrine\ConnectionFactory
+
 Neos\Flow\Persistence\PersistenceManagerInterface:
   className: Neos\Flow\Persistence\Doctrine\PersistenceManager
 


### PR DESCRIPTION
Questions:
 - [x] Should it be registred in Objects.yaml that it is used when injection the Connection directly?
 -  ~Should it have a options argument, so you can override configuration?~ (nope - see comment below)
 - [x] When using `singleton` in Objects.yaml can a custom factory override it (write tests and create test package) (@sorenmalling) (https://github.com/neos/flow-development-collection/pull/2169#discussion_r503796927) (find result in https://github.com/neos/flow-development-collection/pull/2169#issuecomment-708324572)


Resolves: #2170