### PR TITLE
FEATURE: Add StaticResource EEL Helper

### DIFF
--- a/Neos.Flow/Classes/ResourceManagement/EelHelper/StaticResourceHelper.php
+++ b/Neos.Flow/Classes/ResourceManagement/EelHelper/StaticResourceHelper.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\ResourceManagement\EelHelper;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Eel\ProtectedContextAwareInterface;
+use Neos\Flow\ResourceManagement\ResourceManager;
+use Neos\Flow\I18n\Service as I18nService;
+
+class StaticResourceHelper implements ProtectedContextAwareInterface
+{
+    /**
+     * @Flow\Inject
+     * @var ResourceManager
+     */
+    protected $resourceManager;
+
+    /**
+     * @Flow\Inject
+     * @var I18nService
+     */
+    protected $i18nService;
+
+    /**
+     * Get the public uri of a package resource
+     *
+     * @param string $packageKey
+     * @param string $pathAndFilename
+     * @param bool $localize
+     * @return string
+     */
+    public function uri(string $packageKey, string $pathAndFilename, bool $localize = false): string
+    {
+        $resourcePath = sprintf('resource://%s/%s', $packageKey, $pathAndFilename);
+        if ($localize === true) {
+            $resourcePath = $this->i18nService->getLocalizedFilename($resourcePath);
+        }
+        return $this->resourceManager->getPublicPackageResourceUriByPath($resourcePath);
+    }
+
+    /**
+     * Get the content of a package resource
+     *
+     * @param string $packageKey
+     * @param string $pathAndFilename
+     * @param bool $localize
+     * @return string
+     */
+    public function content(string $packageKey, string $pathAndFilename, bool $localize = false): string
+    {
+        $resourcePath = sprintf('resource://%s/%s', $packageKey, $pathAndFilename);
+        if ($localize === true) {
+            $resourcePath = $this->i18nService->getLocalizedFilename($resourcePath);
+        }
+        $content = file_get_contents($resourcePath);
+        return $content ?: '';
+    }
+
+    /**
+     * @param string $methodName
+     * @return bool
+     */
+    public function allowsCallOfMethod($methodName)
+    {
+        return true;
+    }
+}

--- a/Neos.Flow/Classes/ResourceManagement/EelHelper/StaticResourceHelper.php
+++ b/Neos.Flow/Classes/ResourceManagement/EelHelper/StaticResourceHelper.php
@@ -35,9 +35,9 @@ class StaticResourceHelper implements ProtectedContextAwareInterface
     /**
      * Get the public uri of a package resource
      *
-     * @param string $packageKey
-     * @param string $pathAndFilename
-     * @param bool $localize
+     * @param string $packageKey Package key where the resource is from.
+     * @param string $pathAndFilename The path and filename of the resource. Has to start with "Public/..." as private resources do not have a uri.
+     * @param bool $localize If enabled localizing of the resource is attempted by adding locales from the current locale-chain between filename and extension.
      * @return string
      */
     public function uri(string $packageKey, string $pathAndFilename, bool $localize = false): string
@@ -49,9 +49,9 @@ class StaticResourceHelper implements ProtectedContextAwareInterface
     /**
      * Get the content of a package resource
      *
-     * @param string $packageKey
-     * @param string $pathAndFilename
-     * @param bool $localize
+     * @param string $packageKey Package key where the resource is from.
+     * @param string $pathAndFilename The path and filename of the resource. Starting with "Public/..." or "Private/..."
+     * @param bool $localize If enabled localizing of the resource is attempted by adding locales from the current locale-chain between filename and extension.
      * @return string
      */
     public function content(string $packageKey, string $pathAndFilename, bool $localize = false): string
@@ -82,7 +82,7 @@ class StaticResourceHelper implements ProtectedContextAwareInterface
      * @param string $methodName
      * @return bool
      */
-    public function allowsCallOfMethod($methodName)
+    public function allowsCallOfMethod($methodName): bool
     {
         return true;
     }

--- a/Neos.Flow/Classes/ResourceManagement/EelHelper/StaticResourceHelper.php
+++ b/Neos.Flow/Classes/ResourceManagement/EelHelper/StaticResourceHelper.php
@@ -44,7 +44,8 @@ class StaticResourceHelper implements ProtectedContextAwareInterface
     {
         $resourcePath = sprintf('resource://%s/%s', $packageKey, $pathAndFilename);
         if ($localize === true) {
-            $resourcePath = $this->i18nService->getLocalizedFilename($resourcePath);
+            $localizedResourcePathData = $this->i18nService->getLocalizedFilename($resourcePath);
+            $resourcePath = $localizedResourcePathData[0] ?? $resourcePath;
         }
         return $this->resourceManager->getPublicPackageResourceUriByPath($resourcePath);
     }
@@ -61,7 +62,8 @@ class StaticResourceHelper implements ProtectedContextAwareInterface
     {
         $resourcePath = sprintf('resource://%s/%s', $packageKey, $pathAndFilename);
         if ($localize === true) {
-            $resourcePath = $this->i18nService->getLocalizedFilename($resourcePath);
+            $localizedResourcePathData = $this->i18nService->getLocalizedFilename($resourcePath);
+            $resourcePath = $localizedResourcePathData[0] ?? $resourcePath;
         }
         $content = file_get_contents($resourcePath);
         return $content ?: '';

--- a/Neos.Flow/Classes/ResourceManagement/EelHelper/StaticResourceHelper.php
+++ b/Neos.Flow/Classes/ResourceManagement/EelHelper/StaticResourceHelper.php
@@ -42,11 +42,7 @@ class StaticResourceHelper implements ProtectedContextAwareInterface
      */
     public function uri(string $packageKey, string $pathAndFilename, bool $localize = false): string
     {
-        $resourcePath = $this->getResourcePath($packageKey, $pathAndFilename);
-        if ($localize === true) {
-            $localizedResourcePathData = $this->i18nService->getLocalizedFilename($resourcePath);
-            $resourcePath = $localizedResourcePathData[0] ?? $resourcePath;
-        }
+        $resourcePath = $this->getLocalizedResourcePath($packageKey, $pathAndFilename, $localize);
         return $this->resourceManager->getPublicPackageResourceUriByPath($resourcePath);
     }
 
@@ -60,25 +56,26 @@ class StaticResourceHelper implements ProtectedContextAwareInterface
      */
     public function content(string $packageKey, string $pathAndFilename, bool $localize = false): string
     {
-        $resourcePath = $this->getResourcePath($packageKey, $pathAndFilename);
+        $resourcePath = $this->getLocalizedResourcePath($packageKey, $pathAndFilename, $localize);
+        return file_get_contents($resourcePath) ?: '';
+    }
+
+    /**
+     * Get a resource://.. url for the given arguments and apply localization if needed
+     *
+     * @param string $packageKey
+     * @param string $pathAndFilename
+     * @param bool $localize
+     * @return string
+     */
+    protected function getLocalizedResourcePath(string $packageKey, string $pathAndFilename, bool $localize = false): string
+    {
+        $resourcePath = sprintf('resource://%s/%s', $packageKey, $pathAndFilename);
         if ($localize === true) {
             $localizedResourcePathData = $this->i18nService->getLocalizedFilename($resourcePath);
             $resourcePath = $localizedResourcePathData[0] ?? $resourcePath;
         }
-        $content = file_get_contents($resourcePath);
-        return $content ?: '';
-    }
-
-    /**
-     * Get a resource://.. url for the given arguments
-     *
-     * @param string $packageKey
-     * @param string $pathAndFilename
-     * @return string
-     */
-    protected function getResourcePath(string $packageKey, string $pathAndFilename): string
-    {
-        return sprintf('resource://%s/%s', $packageKey, $pathAndFilename);
+        return $resourcePath;
     }
 
     /**

--- a/Neos.Flow/Classes/ResourceManagement/EelHelper/StaticResourceHelper.php
+++ b/Neos.Flow/Classes/ResourceManagement/EelHelper/StaticResourceHelper.php
@@ -42,7 +42,7 @@ class StaticResourceHelper implements ProtectedContextAwareInterface
      */
     public function uri(string $packageKey, string $pathAndFilename, bool $localize = false): string
     {
-        $resourcePath = sprintf('resource://%s/%s', $packageKey, $pathAndFilename);
+        $resourcePath = $this->getResourcePath($packageKey, $pathAndFilename);
         if ($localize === true) {
             $localizedResourcePathData = $this->i18nService->getLocalizedFilename($resourcePath);
             $resourcePath = $localizedResourcePathData[0] ?? $resourcePath;
@@ -60,13 +60,25 @@ class StaticResourceHelper implements ProtectedContextAwareInterface
      */
     public function content(string $packageKey, string $pathAndFilename, bool $localize = false): string
     {
-        $resourcePath = sprintf('resource://%s/%s', $packageKey, $pathAndFilename);
+        $resourcePath = $this->getResourcePath($packageKey, $pathAndFilename);
         if ($localize === true) {
             $localizedResourcePathData = $this->i18nService->getLocalizedFilename($resourcePath);
             $resourcePath = $localizedResourcePathData[0] ?? $resourcePath;
         }
         $content = file_get_contents($resourcePath);
         return $content ?: '';
+    }
+
+    /**
+     * Get a resource://.. url for the given arguments
+     *
+     * @param string $packageKey
+     * @param string $pathAndFilename
+     * @return string
+     */
+    protected function getResourcePath(string $packageKey, string $pathAndFilename): string
+    {
+        return sprintf('resource://%s/%s', $packageKey, $pathAndFilename);
     }
 
     /**


### PR DESCRIPTION
Add a helper to read the uri and content of static (package) resources as this
previously often tedious. The primary usecase is creating resource urls in afx.

StaticResource.uri (packageKey, pathAndFilename, localize)
- (string) packageKey
- (string) pathAndFilename
- (boolean, optional) localize = false

StaticResource.content (packageKey, pathAndFilename, localize)
- (string) packageKey
- (string) pathAndFilename
- (boolean, optional) localize = false

example use in afx:
```
  <!-- create static resource uri -->
  <link rel="stylesheet" href={StaticResource.uri('Neos.Demo', 'Public/Styles/Main.css')} media="all" />

  <!-- get static resource content -->
  <style>{StaticResource.content('Neos.Demo', 'Public/Styles/Main.css')}</style>
```
Resolves: #2175