### PR TITLE
BUGFIX: Register ObjectManager::shutdown() before ConfigurationManage…

### DIFF
--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -104,8 +104,9 @@ class Package extends BasePackage
             $dispatcher->connect(Monitor\FileMonitor::class, 'filesHaveChanged', Cache\CacheManager::class, 'flushSystemCachesByChangedFiles');
         }
 
-        $dispatcher->connect(Core\Bootstrap::class, 'bootstrapShuttingDown', Configuration\ConfigurationManager::class, 'shutdown');
+        // The ObjectManager has to be shutdown before the ConfigurationManager, see https://github.com/neos/flow-development-collection/issues/2183
         $dispatcher->connect(Core\Bootstrap::class, 'bootstrapShuttingDown', ObjectManagement\ObjectManagerInterface::class, 'shutdown');
+        $dispatcher->connect(Core\Bootstrap::class, 'bootstrapShuttingDown', Configuration\ConfigurationManager::class, 'shutdown');
 
         $dispatcher->connect(Core\Bootstrap::class, 'bootstrapShuttingDown', Reflection\ReflectionService::class, 'saveToCache');
 

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ObjectManagerTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ObjectManagerTest.php
@@ -11,6 +11,10 @@ namespace Neos\Flow\Tests\Functional\ObjectManagement;
  * source code.
  */
 
+use Neos\Flow\Configuration\ConfigurationManager;
+use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Flow\SignalSlot\Dispatcher;
 use Neos\Flow\Tests\FunctionalTestCase;
 
 /**
@@ -67,6 +71,35 @@ class ObjectManagerTest extends FunctionalTestCase
         \Neos\Flow\Core\Bootstrap::$staticObjectManager->shutdown();
 
         $this->assertTrue($entity->isDestructed());
+    }
+
+    /**
+     * ObjectManager has to be shutdown before the ConfigurationManager
+     * @see https://github.com/neos/flow-development-collection/issues/2183
+     * @test
+     */
+    public function objectManagerShutdownSlotIsRegisteredBeforeConfigurationManager()
+    {
+        $dispatcher = $this->objectManager->get(Dispatcher::class);
+        $slots = $dispatcher->getSlots(Bootstrap::class, 'bootstrapShuttingDown');
+
+        $slotClassNames = array_column($slots, 'class');
+        $relevantSlots = array_filter($slotClassNames, function (string $className) {
+            return in_array(
+                $className,
+                [
+                    ObjectManagerInterface::class,
+                    ConfigurationManager::class
+                ],
+                true
+            );
+        });
+
+        $first = reset($relevantSlots);
+        $last = end($relevantSlots);
+
+        self::assertSame(ObjectManagerInterface::class, $first);
+        self::assertSame(ConfigurationManager::class, $last);
     }
 
     /**


### PR DESCRIPTION
The `ObjectManager::shutdown()` method will trigger the `shutdownObject()` lifecycle method of
all registered objects. If the `ConfigurationManager` is shutdown beforehand, the configuration
may be in an uninitialized state.

This change swaps the order in which `ConfigurationManager::shutdown()` and `…::shutdown()`
are registered in the Flow's `Package.php` to make sure that the `ConfigurationManager` is still
initialized while the `ObjectManager` is being shut down.

Resolves: #2183 
