### PR TITLE
!!! BUGFIX: Prevent collection setters from overwriting collections

### DIFF
--- a/Neos.Flow/Classes/Property/TypeConverter/PersistentObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/PersistentObjectConverter.php
@@ -222,8 +222,8 @@ class PersistentObjectConverter extends ObjectConverter
                 );
                 throw new InvalidTargetException($exceptionMessage, 1297935345);
             }
-            if ($isCollectionType && $originalValue !== ObjectAccess::getProperty($object, $propertyName)) {
-                throw new TypeConverterException(sprintf('You overwrote the collection property "%s" of type "%s". This will lead to data loss. Read more about it and how to prevent this here: ', $propertyName, $targetType), 1602324196);
+            if ($isCollectionType && $originalValue !== ObjectAccess::getProperty($object, $propertyName, true)) {
+                throw new TypeConverterException(sprintf('You overwrote the collection property "%s" of type "%s". This will lead to data loss. Read more about it and how to prevent this here: ADDLINKHERE', $propertyName, $targetType), 1602324196);
             }
         }
 

--- a/Neos.Flow/Classes/Property/TypeConverter/PersistentObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/PersistentObjectConverter.php
@@ -208,9 +208,8 @@ class PersistentObjectConverter extends ObjectConverter
             }
             $propertyType = TypeHandling::getTypeForValue($propertyValue);
             $isCollectionType = TypeHandling::isCollectionType($propertyType);
-            //$isAggregateRelation = TODO: Check if element type is aggregate root
             if ($isCollectionType) {
-                $originalValue = ObjectAccess::getProperty($object, $propertyName);
+                $originalValue = ObjectAccess::getProperty($object, $propertyName, true);
             }
             $result = ObjectAccess::setProperty($object, $propertyName, $propertyValue);
             if ($result === false) {

--- a/Neos.Flow/Classes/Property/TypeConverter/PersistentObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/PersistentObjectConverter.php
@@ -19,6 +19,7 @@ use Neos\Flow\Property\Exception\InvalidPropertyMappingConfigurationException;
 use Neos\Flow\Property\Exception\InvalidSourceException;
 use Neos\Flow\Property\Exception\InvalidTargetException;
 use Neos\Flow\Property\Exception\TargetNotFoundException;
+use Neos\Flow\Property\Exception\TypeConverterException;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
 use Neos\Flow\Property\TypeConverter\Error\TargetNotFoundError;
 use Neos\Utility\ObjectAccess;
@@ -205,6 +206,12 @@ class PersistentObjectConverter extends ObjectConverter
                     throw new InvalidTargetException($exceptionMessage, 1421498771);
                 }
             }
+            $propertyType = TypeHandling::getTypeForValue($propertyValue);
+            $isCollectionType = TypeHandling::isCollectionType($propertyType);
+            //$isAggregateRelation = TODO: Check if element type is aggregate root
+            if ($isCollectionType) {
+                $originalValue = ObjectAccess::getProperty($object, $propertyName);
+            }
             $result = ObjectAccess::setProperty($object, $propertyName, $propertyValue);
             if ($result === false) {
                 $exceptionMessage = sprintf(
@@ -214,6 +221,9 @@ class PersistentObjectConverter extends ObjectConverter
                     $targetType
                 );
                 throw new InvalidTargetException($exceptionMessage, 1297935345);
+            }
+            if ($isCollectionType && $originalValue !== ObjectAccess::getProperty($object, $propertyName)) {
+                throw new TypeConverterException(sprintf('You overwrote the collection property "%s" of type "%s". This will lead to data loss. Read more about it and how to prevent this here: ', $propertyName, $targetType), 1602324196);
             }
         }
 

--- a/Neos.Flow/Classes/Property/TypeConverter/PersistentObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/PersistentObjectConverter.php
@@ -222,7 +222,7 @@ class PersistentObjectConverter extends ObjectConverter
                 throw new InvalidTargetException($exceptionMessage, 1297935345);
             }
             if ($isCollectionType && $originalValue !== ObjectAccess::getProperty($object, $propertyName, true)) {
-                throw new TypeConverterException(sprintf('You overwrote the collection property "%s" of type "%s". This will lead to data loss. Read more about it and how to prevent this here: ADDLINKHERE', $propertyName, $targetType), 1602324196);
+                throw new TypeConverterException(sprintf('You overwrote the collection property "%s" of type "%s". This will lead to data loss. Read more about it and how to prevent this here: https://www.neos.io/go/flow-7-0-release-notes.html', $propertyName, $targetType), 1602324196);
             }
         }
 


### PR DESCRIPTION
Overwriting a collection will lead to all related entities being deleted as of Doctrine ORM 2.6+, if the relation has orphanRemoval, as do all *ToMany relations to non-aggregate roots in Flow.

This is marked breaking, because if you have setters for collections in your domain models that simply replace the collection property, this will now throw an exception (to avoid leading to possible data loss).
You should replace your collection setters with code like this:

```php
/**
 * @ORM\OneToMany(mappedBy="parent")
 * @var Collection<MyEntity>
 */
protected $myCollection;

public function __constructor()
{
    $this->myCollection = new ArrayCollection();
}

public function setMyCollection(Collection $newCollection)
{
    foreach ($this->myCollection as $child) {
        if (!$newCollection->contains($child)) {
            $this->myCollection->removeElement($child);
        }
    }
    foreach ($newCollection as $child) {
        if (!$this->myCollection->contains($child)) {
            $this->myCollection->add($child);
        }
    }
}
```

i.e. only initialize the collection in your constructor and never replace it in a method, only add/removeElement to it.

Related to #2159