### PR TITLE
BUGFIX: Ensure memcache value is a string before searching for chunk

### DIFF
--- a/Neos.Cache/Classes/Backend/MemcachedBackend.php
+++ b/Neos.Cache/Classes/Backend/MemcachedBackend.php
@@ -260,7 +260,7 @@ class MemcachedBackend extends IndependentAbstractBackend implements TaggableBac
     public function get(string $entryIdentifier)
     {
         $value = $this->memcache->get($this->identifierPrefix . $entryIdentifier);
-        if (substr($value, 0, 13) === 'Flow*chunked:') {
+        if ($value !== false && substr($value, 0, 13) === 'Flow*chunked:') {
             list(, $chunkCount) = explode(':', $value);
             $value = '';
             for ($chunkNumber = 1; $chunkNumber < $chunkCount; $chunkNumber++) {


### PR DESCRIPTION
`Memcache->get()` can return `false` if the key is not set, 
so the type must be checked before checking if the value was chunked.

**How to verify it**

Configure some caches to use Memcached as backend.
Flush the cache.
Go to the Neos login page: an exception is shown.

Apply the fix.
Flush the cache.
Go to the Neos login page: the login form is displayed.

Fixes: #2194 
