### PR TITLE
BUGFIX: Skip private methods in SessionObjectMethodsPointcutFilter

### DIFF
--- a/Neos.Flow/Classes/Session/Aspect/SessionObjectMethodsPointcutFilter.php
+++ b/Neos.Flow/Classes/Session/Aspect/SessionObjectMethodsPointcutFilter.php
@@ -16,6 +16,7 @@ use Neos\Flow\Aop\Pointcut\PointcutFilterInterface;
 use Neos\Flow\ObjectManagement\CompileTimeObjectManager;
 use Neos\Flow\ObjectManagement\Configuration\Configuration as ObjectConfiguration;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Reflection\ClassReflection;
 
 /**
  * Pointcut filter matching proxyable methods in objects of scope session
@@ -63,6 +64,11 @@ class SessionObjectMethodsPointcutFilter implements PointcutFilterInterface
         }
 
         if (preg_match('/^(?:__wakeup|__construct|__destruct|__sleep|__serialize|__unserialize|__clone|shutdownObject|initializeObject|inject.*)$/', $methodName) !== 0) {
+            return false;
+        }
+
+        $classReflection = new ClassReflection($className);
+        if ($classReflection->hasMethod($methodName) && $classReflection->getMethod($methodName)->isPrivate()) {
             return false;
         }
 

--- a/Neos.Flow/Classes/Session/Aspect/SessionObjectMethodsPointcutFilter.php
+++ b/Neos.Flow/Classes/Session/Aspect/SessionObjectMethodsPointcutFilter.php
@@ -62,7 +62,7 @@ class SessionObjectMethodsPointcutFilter implements PointcutFilterInterface
             return false;
         }
 
-        if (preg_match('/^__wakeup|__construct|__destruct|__sleep|__serialize|__unserialize|__clone|shutdownObject|initializeObject|inject.*$/', $methodName) !== 0) {
+        if (preg_match('/^(?:__wakeup|__construct|__destruct|__sleep|__serialize|__unserialize|__clone|shutdownObject|initializeObject|inject.*)$/', $methodName) !== 0) {
             return false;
         }
 


### PR DESCRIPTION
The matches() method did not skip private methods, so Flow tried to build interceptors for them. That breaks as of the bugfix in https://github.com/neos/flow-development-collection/pull/2131, leading to https://github.com/neos/flow-development-collection/issues/2190

Additionally a potential bug in the regular expression used to skip certain methods is fixed. Without the grouping the first alternative was anchored to the start, the last to the end, but others could be anywhere in the string.