### PR TITLE
BUGFIX: Reduce maximum line length to 80 chars

### DIFF
--- a/Neos.Flow/Scripts/migrate.php
+++ b/Neos.Flow/Scripts/migrate.php
@@ -26,7 +26,7 @@ define('FLOW_PATH_ROOT', str_replace('//', '/', str_replace('\\', '/', (realpath
 define('FLOW_PATH_WEB', FLOW_PATH_ROOT . 'Web/');
 define('FLOW_PATH_CONFIGURATION', FLOW_PATH_ROOT . 'Configuration/');
 define('FLOW_PATH_DATA', FLOW_PATH_ROOT . 'Data/');
-define('MAXIMUM_LINE_LENGTH', 84);
+define('MAXIMUM_LINE_LENGTH', 80);
 define('STYLE_DEFAULT', 0);
 define('STYLE_ERROR', 31);
 define('STYLE_WARNING', 33);


### PR DESCRIPTION
This reduces the maximum line length of output to 80 chars when running core migrations.

See https://stackoverflow.com/questions/4651012/why-is-the-default-terminal-width-80-characters for more information
