### PR TITLE
FEATURE: Accept \Traversable as a collection type in validation

### DIFF
--- a/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
+++ b/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
@@ -34,7 +34,7 @@ abstract class TypeHandling
     /**
      * @var array
      */
-    protected static $collectionTypes = ['array', \ArrayObject::class, \SplObjectStorage::class, Collection::class, \IteratorAggregate::class];
+    protected static $collectionTypes = ['array', \ArrayObject::class, \SplObjectStorage::class, Collection::class, \Traversable::class];
 
     /**
      * Returns an array with type information, including element type for

--- a/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
+++ b/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
@@ -34,7 +34,7 @@ abstract class TypeHandling
     /**
      * @var array
      */
-    protected static $collectionTypes = ['array', \ArrayObject::class, \SplObjectStorage::class, Collection::class, \Traversable::class];
+    protected static $collectionTypes = ['array', \Traversable::class];
 
     /**
      * Returns an array with type information, including element type for

--- a/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
+++ b/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
@@ -34,7 +34,7 @@ abstract class TypeHandling
     /**
      * @var array
      */
-    protected static $collectionTypes = ['array', \ArrayObject::class, \SplObjectStorage::class, Collection::class];
+    protected static $collectionTypes = ['array', \ArrayObject::class, \SplObjectStorage::class, Collection::class, \IteratorAggregate::class];
 
     /**
      * Returns an array with type information, including element type for

--- a/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
@@ -203,7 +203,8 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
             ['SplObjectStorage', true],
             ['Doctrine\Common\Collections\Collection', true],
             ['Doctrine\Common\Collections\ArrayCollection', true],
-            ['IteratorAggregate', true]
+            ['IteratorAggregate', true],
+            ['Iterator', true]
         ];
     }
 

--- a/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
@@ -203,7 +203,7 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
             ['SplObjectStorage', true],
             ['Doctrine\Common\Collections\Collection', true],
             ['Doctrine\Common\Collections\ArrayCollection', true],
-            ['\IteratorAggregate', true]
+            ['IteratorAggregate', true]
         ];
     }
 

--- a/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
@@ -202,7 +202,8 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
             ['ArrayObject', true],
             ['SplObjectStorage', true],
             ['Doctrine\Common\Collections\Collection', true],
-            ['Doctrine\Common\Collections\ArrayCollection', true]
+            ['Doctrine\Common\Collections\ArrayCollection', true],
+            ['\IteratorAggregate', true]
         ];
     }
 


### PR DESCRIPTION
This adds \Traversable to the array of valid collectionTypes in the TypeHandling class.

Fixes: #2201 
