### PR TITLE
FEATURE: Improved Routing CLI commands

### DIFF
--- a/Neos.Flow/Classes/Command/RoutingCommandController.php
+++ b/Neos.Flow/Classes/Command/RoutingCommandController.php
@@ -18,14 +18,18 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
 use Neos\Flow\Cli\Exception\StopCommandException;
 use Neos\Flow\Configuration\ConfigurationManager;
+use Neos\Flow\Http\Helper\RequestInformationHelper;
 use Neos\Flow\Mvc\Exception\InvalidRoutePartValueException;
 use Neos\Flow\Mvc\Routing\Dto\ResolveContext;
 use Neos\Flow\Mvc\Routing\Dto\RouteContext;
 use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
+use Neos\Flow\Mvc\Routing\Dto\RouteTags;
+use Neos\Flow\Mvc\Routing\Dto\UriConstraints;
 use Neos\Flow\Mvc\Routing\Route;
 use Neos\Flow\Mvc\Routing\Router;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Http\Factories\ServerRequestFactory;
+use Neos\Utility\Arrays;
 
 /**
  * Command controller for tasks related to routing
@@ -67,12 +71,21 @@ class RoutingCommandController extends CommandController
      */
     public function listCommand(): void
     {
-        $this->outputLine('Currently registered routes:');
+        $this->outputLine('<b>Currently registered routes:</b>');
+        $rows = [];
         /** @var Route $route */
         foreach ($this->router->getRoutes() as $index => $route) {
-            $uriPattern = $route->getUriPattern();
-            $this->outputLine(str_pad(($index + 1) . '. ' . $uriPattern, 80) . $route->getName());
+            $routeNumber = $index + 1;
+            $rows[] = [
+                '#' => $routeNumber,
+                'uriPattern' => $route->getUriPattern(),
+                'httpMethods' => $route->hasHttpMethodConstraints() ? implode(', ', $route->getHttpMethods()) : '<i>any</i>',
+                'name' => $route->getName(),
+            ];
         }
+        $this->output->outputTable($rows, ['#', 'Uri Pattern', 'HTTP Method(s)', 'Name']);
+        $this->outputLine();
+        $this->outputLine('Run <i>./flow routing:show <index></i> to show details for a route');
     }
 
     /**
@@ -82,24 +95,30 @@ class RoutingCommandController extends CommandController
      *
      * @param integer $index The index of the route as given by routing:list
      * @return void
+     * @throws StopCommandException
      */
     public function showCommand(int $index): void
     {
+        /** @var Route[] $routes */
         $routes = $this->router->getRoutes();
-        if (isset($routes[$index - 1])) {
-            /** @var Route $route */
-            $route = $routes[$index - 1];
+        if (!isset($routes[$index - 1])) {
+            $this->outputLine('<error>Route %d was not found!</error>', [$index]);
+            $this->outputLine('Run <i>./flow routing:list</i> to show all registered routes');
+            $this->quit(1);
+            return;
+        }
+        $route = $routes[$index - 1];
 
-            $this->outputLine('<b>Information for route ' . $index . ':</b>');
-            $this->outputLine('  Name: ' . $route->getName());
-            $this->outputLine('  Pattern: ' . $route->getUriPattern());
-            $this->outputLine('  Defaults: ');
-            foreach ($route->getDefaults() as $defaultKey => $defaultValue) {
-                $this->outputLine('    - ' . $defaultKey . ' => ' . $defaultValue);
-            }
-            $this->outputLine('  Append: ' . ($route->getAppendExceedingArguments() ? 'true' : 'false'));
-        } else {
-            $this->outputLine('Route ' . $index . ' was not found!');
+        $this->outputLine('<b>Information for route #' . $index . ':</b>');
+        $this->outputLine();
+        $this->outputLine('<b>Name:</b> %s', [$route->getName()]);
+        $this->outputLine('<b>URI Pattern:</b> %s', [$route->getUriPattern() === '' ? '<i>(empty)</i>' : $route->getUriPattern()]);
+        $this->outputLine('<b>HTTP method(s):</b> %s', [$route->hasHttpMethodConstraints() ? implode(', ', $route->getHttpMethods()) : '<i>any</i>']);
+        $this->outputLine('<b>Defaults:</b>');
+        $this->outputArray($route->getDefaults(), 2);
+        if ($route->getAppendExceedingArguments()) {
+            $this->outputLine();
+            $this->outputLine('  Exceeding arguments will be appended as query string');
         }
     }
 
@@ -116,61 +135,103 @@ class RoutingCommandController extends CommandController
      * @param string $action Action name, default is 'index'
      * @param string $format Requested Format name default is 'html'
      * @return void
+     * @throws StopCommandException | InvalidRoutePartValueException
+     * @deprecated @see resolveCommand()
+     * @internal
      */
     public function getPathCommand(string $package, string $controller = 'Standard', string $action = 'index', string $format = 'html'): void
     {
         $packageParts = explode('\\', $package, 2);
         $package = $packageParts[0];
-        $subpackage = isset($packageParts[1]) ? $packageParts[1] : null;
+        $subpackage = $packageParts[1] ?? null;
 
+        $this->resolveCommand($package, $controller, $action, $format, $subpackage, null);
+    }
+
+    /**
+     * Build an URI for the given parameters
+     *
+     * This command takes package, controller and action and displays the
+     * resolved URI and which route matched (if any):
+     *
+     * ./flow routing:resolve Some.Package --controller SomeController --additional-arguments="{\"some-argument\": \"some-value\"}"
+     *
+     * @param string $package Package key (according to "@package" route value)
+     * @param string|null $controller Controller name (according to "@controller" route value), default is 'Standard'
+     * @param string|null $action Action name (according to "@action" route value), default is 'index'
+     * @param string|null $format Requested Format name (according to "@format" route value), default is 'html'
+     * @param string|null $subpackage SubPackage name (according to "@subpackage" route value)
+     * @param string|null $additionalArguments Additional route values as JSON string. Make sure to specify this option as described in the description in order to prevent parsing issues
+     * @param string|null $parameters Route parameters as JSON string. Make sure to specify this option as described in the description in order to prevent parsing issues
+     * @param string|null $baseUri Base URI of the simulated request, default ist 'http://localhost'
+     * @param bool|null $forceAbsoluteUri Whether or not to force the creation of an absolute URI
+     * @return void
+     * @throws StopCommandException | InvalidRoutePartValueException
+     */
+    public function resolveCommand(string $package, string $controller = null, string $action = null, string $format = null, string $subpackage = null, string $additionalArguments = null, string $parameters = null, string $baseUri = null, bool $forceAbsoluteUri = null): void {
         $routeValues = [
             '@package' => $package,
-            '@subpackage' => $subpackage,
-            '@controller' => $controller,
-            '@action' => $action,
-            '@format' => $format
+            '@controller' => $controller ?? 'Standard',
+            '@action' => $action ?? 'index',
+            '@format' => $format ?? 'html'
         ];
+        if ($subpackage !== null) {
+            $routeValues['@subpackage'] = $subpackage;
+        }
+        $additionalArgumentsValue = $this->parseJsonToArray($additionalArguments);
+        if ($additionalArgumentsValue !== []) {
+            $routeValues = Arrays::arrayMergeRecursiveOverrule($routeValues, $additionalArgumentsValue);
+        }
+        $routeParameters = $this->createRouteParametersFromJson($parameters);
+        $resolveContext = new ResolveContext(new Uri($baseUri ?? 'http://localhost'), $routeValues, $forceAbsoluteUri ?? false, '', $routeParameters);
 
         $this->outputLine('<b>Resolving:</b>');
-        $this->outputLine('  Package: ' . $routeValues['@package']);
-        $this->outputLine('  Subpackage: ' . $routeValues['@subpackage']);
-        $this->outputLine('  Controller: ' . $routeValues['@controller']);
-        $this->outputLine('  Action: ' . $routeValues['@action']);
-        $this->outputLine('  Format: ' . $routeValues['@format']);
+        $this->outputLine('  <b>Values:</b>');
+        $this->outputArray($resolveContext->getRouteValues(), 4);
+        $this->outputLine('  <b>Base URI:</b> %s', [$resolveContext->getBaseUri()]);
+        $this->outputLine('  <b>Force absolute URI:</b> %s', [$resolveContext->isForceAbsoluteUri() ? 'yes' : 'no']);
+        if (!$resolveContext->getParameters()->isEmpty()) {
+            $this->outputLine('  <b>Parameters:</b>');
+            $this->outputArray($resolveContext->getParameters()->toArray(), 4);
+        }
+        $this->outputLine();
+        $this->output('  <b>=> Controller:</b> ');
+        $this->outputControllerObjectName($package, $subpackage, $controller);
+        $this->outputLine();
 
-        $baseUri = new Uri('http://localhost');
-        $resolveContext = new ResolveContext($baseUri, $routeValues, false, '', RouteParameters::createEmpty());
-
-        $controllerObjectName = null;
-        /** @var $route Route */
-        foreach ($this->router->getRoutes() as $route) {
-            try {
-                $resolves = $route->resolves($resolveContext);
-                $controllerObjectName = $this->getControllerObjectName($package, $subpackage, $controller);
-            } catch (InvalidRoutePartValueException $exception) {
-                $resolves = false;
-            }
-
-            if ($resolves === true) {
-                $this->outputLine('<b>Route:</b>');
-                $this->outputLine('  Name: ' . $route->getName());
-                $this->outputLine('  Pattern: ' . $route->getUriPattern());
-
-                $this->outputLine('<b>Generated URI:</b>');
-                $resolvedUri = $route->getResolvedUriConstraints() !== null ? $route->getResolvedUriConstraints()->applyTo(new Uri(''), false) : '-';
-                $this->outputLine('  ' . $resolvedUri);
-
-                if ($controllerObjectName !== null) {
-                    $this->outputLine('<b>Controller:</b>');
-                    $this->outputLine('  ' . $controllerObjectName);
-                } else {
-                    $this->outputLine('<b>Controller Error:</b>');
-                    $this->outputLine('  !!! Controller Object was not found !!!');
-                }
-                return;
+        /** @var Route|null $resolvedRoute */
+        $resolvedRoute = null;
+        $resolvedRouteNumber = 0;
+        foreach ($this->router->getRoutes() as $index => $route) {
+            /** @var Route $route */
+            if ($route->resolves($resolveContext) === true) {
+                $resolvedRoute = $route;
+                $resolvedRouteNumber = $index + 1;
+                break;
             }
         }
-        $this->outputLine('<b>No Matching Controller found</b>');
+
+        if ($resolvedRoute === null) {
+            $this->outputLine('<error>No route could resolve these values...</error>');
+            $this->quit(1);
+            return;
+        }
+
+        /** @var UriConstraints $uriConstraints */
+        $uriConstraints = $resolvedRoute->getResolvedUriConstraints();
+        $resolvedUri = $uriConstraints->applyTo($resolveContext->getBaseUri(), $resolveContext->isForceAbsoluteUri());
+
+        $this->outputLine('<b><success>Route resolved!</success></b>');
+        $this->outputLine('<b>Name:</b> %s', [$resolvedRoute->getName()]);
+        $this->outputLine('<b>Pattern:</b> %s', [$resolvedRoute->getUriPattern() === '' ? '<i>(empty)</i>' : $resolvedRoute->getUriPattern()]);
+
+        $this->outputLine();
+        $this->outputLine('<b>Resolved URI:</b> <success>%s</success>', [$resolvedUri]);
+        $this->outputLine();
+
+        $this->outputRouteTags($resolvedRoute->getResolvedTags());
+
+        $this->outputLine('Run <i>./flow routing:show %d</i> to show details about this route', [$resolvedRouteNumber]);
     }
 
     /**
@@ -181,66 +242,194 @@ class RoutingCommandController extends CommandController
      *
      * @param string $path The route path to resolve
      * @param string $method The request method (GET, POST, PUT, DELETE, ...) to simulate
-     * @return void
-     * @throws InvalidRoutePartValueException
-     * @throws StopCommandException
+     * @throws InvalidRoutePartValueException | StopCommandException
+     * @deprecated @see matchCommand()
+     * @internal
      */
     public function routePathCommand(string $path, string $method = 'GET'): void
     {
-        $httpRequest = $this->serverRequestFactory->createServerRequest($method, (new Uri('http://localhost/'))->withPath($path));
-        $routeContext = new RouteContext($httpRequest, RouteParameters::createEmpty());
-
-        /** @var Route $route */
-        foreach ($this->router->getRoutes() as $route) {
-            if ($route->matches($routeContext) === true) {
-                $routeValues = $route->getMatchResults();
-
-                $this->outputLine('<b>Path:</b>');
-                $this->outputLine('  ' . $path);
-
-                $this->outputLine('<b>Route:</b>');
-                $this->outputLine('  Name: ' . $route->getName());
-                $this->outputLine('  Pattern: ' . $route->getUriPattern());
-
-                $this->outputLine('<b>Result:</b>');
-                $this->outputLine('  Package: ' . ($routeValues['@package'] ?? '-'));
-                $this->outputLine('  Subpackage: ' . ($routeValues['@subpackage'] ?? '-'));
-                $this->outputLine('  Controller: ' . ($routeValues['@controller'] ?? '-'));
-                $this->outputLine('  Action: ' . ($routeValues['@action'] ?? '-'));
-                $this->outputLine('  Format: ' . ($routeValues['@format'] ?? '-'));
-
-                $controllerObjectName = $this->getControllerObjectName($routeValues['@package'] ?? '', $routeValues['@subpackage'] ?? '', $routeValues['@controller'] ?? '');
-                if ($controllerObjectName === null) {
-                    $this->outputLine('<b>Controller Error:</b>');
-                    $this->outputLine('  !!! No Controller Object found !!!');
-                    $this->quit(1);
-                }
-                $this->outputLine('<b>Controller:</b>');
-                $this->outputLine('  ' . $controllerObjectName);
-                $this->quit(0);
-            }
-        }
-        $this->outputLine('No matching Route was found');
-        $this->quit(1);
+        $this->matchCommand('/' . ltrim($path, '/'), $method, null);
     }
 
     /**
-     * Returns the object name of the controller defined by the package, subpackage key and
-     * controller name or NULL if the controller does not exist
+     * Match the given URI to a corresponding route
      *
-     * @param string $packageKey the package key of the controller
-     * @param string|null $subPackageKey the subpackage key of the controller
-     * @param string $controllerName the controller name excluding the "Controller" suffix
-     * @return string|null The controller's Object Name or NULL if the controller does not exist
+     * This command takes an incoming URI and displays the
+     * matched Route and the mapped routing values (if any):
+     *
+     * ./flow routing:match "/de" --parameters="{\"requestUriHost\": \"localhost\"}"
+     *
+     * @param string $uri The incoming route, absolute or relative
+     * @param string|null $method The HTTP method to simulate (default is 'GET')
+     * @param string|null $parameters Route parameters as JSON string. Make sure to specify this option as described in the description in order to prevent parsing issues
+     * @throws InvalidRoutePartValueException | StopCommandException
      */
-    protected function getControllerObjectName(string $packageKey, ?string $subPackageKey, string $controllerName): ?string
+    public function matchCommand(string $uri, string $method = null, string $parameters = null): void
     {
-        $possibleObjectName = '@package\@subpackage\Controller\@controllerController';
-        $possibleObjectName = str_replace('@package', str_replace('.', '\\', $packageKey), $possibleObjectName);
-        $possibleObjectName = str_replace('@subpackage', $subPackageKey, $possibleObjectName);
-        $possibleObjectName = str_replace('@controller', $controllerName, $possibleObjectName);
-        $possibleObjectName = str_replace('\\\\', '\\', $possibleObjectName);
+        $method = $method ?? 'GET';
+        $requestUri = new Uri($uri);
+        if (isset($requestUri->getPath()[0]) && $requestUri->getPath()[0] !== '/') {
+            $this->outputLine('<error>The URI "%s" is not valid. The path has to start with a "/"</error>', [$requestUri]);
+            $this->quit(1);
+            return;
+        }
+        $httpRequest = $this->serverRequestFactory->createServerRequest($method, $requestUri);
+        $routeParameters = $this->createRouteParametersFromJson($parameters);
+        $routeContext = new RouteContext($httpRequest, $routeParameters);
 
-        return $this->objectManager->getCaseSensitiveObjectName($possibleObjectName);
+        $this->outputLine('<b>Matching:</b>');
+        $this->outputLine('  <b>URI:</b> %s', [$httpRequest->getUri()]);
+        $this->outputLine('  <b>Path:</b> %s', [RequestInformationHelper::getRelativeRequestPath($httpRequest)]);
+        $this->outputLine('  <b>HTTP Method:</b> %s', [$method]);
+        if (!$routeContext->getParameters()->isEmpty()) {
+            $this->outputLine('  <b>Parameters:</b>');
+            $this->outputArray($routeContext->getParameters()->toArray(), 4);
+        }
+        $this->outputLine();
+
+        /** @var Route|null $matchedRoute */
+        $matchedRoute = null;
+        $matchedRouteNumber = 0;
+        foreach ($this->router->getRoutes() as $index => $route) {
+            /** @var Route $route */
+            if ($route->matches($routeContext) === true) {
+                $matchedRoute = $route;
+                $matchedRouteNumber = $index + 1;
+                break;
+            }
+        }
+
+        if ($matchedRoute === null) {
+            $this->outputLine('<error>No route could match %s request to URL <i>%s</i>...</error>', [$method, $requestUri]);
+            $this->quit(1);
+            return;
+        }
+
+        $this->outputLine('<b><success>Route matched!</success></b>');
+        $this->outputLine('<b>Name:</b> %s', [$matchedRoute->getName()]);
+        $this->outputLine('<b>Pattern:</b> %s', [$matchedRoute->getUriPattern() === '' ? '<i>(empty)</i>' : $matchedRoute->getUriPattern()]);
+
+        $this->outputLine();
+        $this->outputLine('<b>Results:</b>');
+        $matchResults = $matchedRoute->getMatchResults();
+        $this->outputArray($matchResults, 2);
+
+        $this->outputLine();
+        $this->output('<b>Matched Controller:</b> ');
+        $this->outputControllerObjectName($matchResults['@package'] ?? '', $matchResults['@subpackage'] ?? null, $matchResults['@controller'] ?? null);
+        $this->outputLine();
+
+        $this->outputRouteTags($matchedRoute->getMatchedTags());
+
+        $this->outputLine('Run <i>./flow routing:show %d</i> to show details about this route', [$matchedRouteNumber]);
+    }
+
+    /**
+     * @param string|null $json
+     * @return RouteParameters
+     * @throws StopCommandException
+     */
+    private function createRouteParametersFromJson(?string $json): RouteParameters
+    {
+        $routeParameters = RouteParameters::createEmpty();
+        if ($json === null) {
+            return $routeParameters;
+        }
+        foreach ($this->parseJsonToArray($json) as $parameterName => $parameterValue) {
+            try {
+                $routeParameters = $routeParameters->withParameter($parameterName, $parameterValue);
+            } catch (\InvalidArgumentException $exception) {
+                $this->outputLine('<error>Failed to create Route Parameters from the given JSON string "%s": %s</error>', [$json, $exception->getMessage()]);
+                $this->quit(1);
+            }
+        }
+        return $routeParameters;
+    }
+
+    /**
+     * Parses the given JSON string as array
+     *
+     * @param string|null $json
+     * @return array
+     * @throws StopCommandException
+     */
+    private function parseJsonToArray(?string $json): array
+    {
+        if ($json === null) {
+            return [];
+        }
+        try {
+            $parsedValue = \json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            $this->outputLine('<error>Failed to parse <i>%s</i> as JSON: %s</error>', [$json, $e->getMessage()]);
+            $this->quit(1);
+            return [];
+        }
+        if (!is_array($parsedValue)) {
+            $this->outputLine('<error>Failed to parse <i>%s</i> to an array, please a provide valid JSON object that can be represented as PHP array</error>', [$json]);
+            $this->quit(1);
+            return [];
+        }
+        return $parsedValue;
+    }
+
+    /**
+     * Outputs a (potentially multi-dimensional) array to the console
+     *
+     * @param array $array
+     * @param int $indention
+     */
+    private function outputArray(array $array, int $indention): void
+    {
+        foreach ($array as $key => $value) {
+            $this->output('%s%s:', [str_pad(' ', $indention), $key]);
+            if (is_array($value)) {
+                $this->outputLine();
+                $this->outputArray($value, $indention + 2);
+                return;
+            }
+            if (is_object($value)) {
+                $this->outputLine(' object (%s)', [get_class($value)]);
+            }
+            $this->outputLine(' %s', [$value]);
+        }
+    }
+
+    /**
+     * Outputs the controller object name that corresponds to the given package, subpackage and controller to the console
+     *
+     * If the corresponding class is not known to the ObjectManager, an error message is added
+     *
+     * @param string $package
+     * @param string|null $subpackage
+     * @param string|null $controller
+     */
+    private function outputControllerObjectName(string $package, ?string $subpackage, ?string $controller): void
+    {
+        $possibleControllerObjectName = str_replace(['@package', '@subpackage', '@controller', '\\\\'], [str_replace('.', '\\', $package), $subpackage, $controller, '\\'], '@package\@subpackage\Controller\@controllerController');
+        $controllerObjectName = $this->objectManager->getCaseSensitiveObjectName($possibleControllerObjectName);
+        if ($controllerObjectName === null) {
+            $this->outputLine('<error>%s</error> (no corresponding class exists)', [$possibleControllerObjectName]);
+        } else {
+            $this->outputLine('<success>%s</success>', [$controllerObjectName]);
+        }
+    }
+
+
+    /**
+     * Outputs route tags to the console, if there are any
+     *
+     * @param RouteTags|null $routeTags
+     */
+    private function outputRouteTags(?RouteTags $routeTags): void
+    {
+        if ($routeTags === null) {
+            return;
+        }
+        if ($routeTags->getTags() !== []) {
+            $this->outputLine('<b>Tags:</b>');
+            $this->outputArray($routeTags->getTags(), 2);
+        }
+        $this->outputLine();
     }
 }

--- a/Neos.Flow/Classes/Command/RoutingCommandController.php
+++ b/Neos.Flow/Classes/Command/RoutingCommandController.php
@@ -359,10 +359,9 @@ class RoutingCommandController extends CommandController
         if ($json === null) {
             return [];
         }
-        try {
-            $parsedValue = \json_decode($json, true, 512, JSON_THROW_ON_ERROR);
-        } catch (\JsonException $e) {
-            $this->outputLine('<error>Failed to parse <i>%s</i> as JSON: %s</error>', [$json, $e->getMessage()]);
+        $parsedValue = \json_decode($json, true);
+        if ($parsedValue === null && \json_last_error() !== JSON_ERROR_NONE) {
+            $this->outputLine('<error>Failed to parse <i>%s</i> as JSON: %s</error>', [$json, \json_last_error_msg()]);
             $this->quit(1);
             return [];
         }

--- a/Neos.Flow/Classes/Command/RoutingCommandController.php
+++ b/Neos.Flow/Classes/Command/RoutingCommandController.php
@@ -203,6 +203,7 @@ class RoutingCommandController extends CommandController
         /** @var Route|null $resolvedRoute */
         $resolvedRoute = null;
         $resolvedRouteNumber = 0;
+        /** @var int $index */
         foreach ($this->router->getRoutes() as $index => $route) {
             /** @var Route $route */
             if ($route->resolves($resolveContext) === true) {
@@ -291,6 +292,7 @@ class RoutingCommandController extends CommandController
         /** @var Route|null $matchedRoute */
         $matchedRoute = null;
         $matchedRouteNumber = 0;
+        /** @var int $index */
         foreach ($this->router->getRoutes() as $index => $route) {
             /** @var Route $route */
             if ($route->matches($routeContext) === true) {

--- a/Neos.Flow/Classes/Command/RoutingCommandController.php
+++ b/Neos.Flow/Classes/Command/RoutingCommandController.php
@@ -168,7 +168,8 @@ class RoutingCommandController extends CommandController
      * @return void
      * @throws StopCommandException | InvalidRoutePartValueException
      */
-    public function resolveCommand(string $package, string $controller = null, string $action = null, string $format = null, string $subpackage = null, string $additionalArguments = null, string $parameters = null, string $baseUri = null, bool $forceAbsoluteUri = null): void {
+    public function resolveCommand(string $package, string $controller = null, string $action = null, string $format = null, string $subpackage = null, string $additionalArguments = null, string $parameters = null, string $baseUri = null, bool $forceAbsoluteUri = null): void
+    {
         $routeValues = [
             '@package' => $package,
             '@controller' => $controller ?? 'Standard',


### PR DESCRIPTION
Overhauled `./flow routing:*` commands with a better UX and
some new features:

* The output of the `routing:show` and `routing:list` commands
  has been cleaned up and information like supported HTTP methods
  were added
* The `routing:getPath` command was deprecated in favor of a new
  `routing:resolve` command that now supports all of the latest
  routing features and has a more informative output
* The `routing:routePath` command was deprecated in favor of a new
  `routing:match` command accordingly.

Related: #1126