### PR TITLE
TASK: Adjust docblock to hint at variadic arguments

### DIFF
--- a/Neos.Flow/Classes/Persistence/QueryInterface.php
+++ b/Neos.Flow/Classes/Persistence/QueryInterface.php
@@ -223,7 +223,7 @@ interface QueryInterface
      * takes one or more constraints and concatenates them with a boolean AND.
      * It also accepts a single array of constraints to be concatenated.
      *
-     * @param mixed $constraint1 The first of multiple constraints or an array of constraints.
+     * @param mixed ...$constraint1 The first of multiple constraints or an array of constraints.
      * @return object
      * @api
      */
@@ -234,7 +234,7 @@ interface QueryInterface
      * takes one or more constraints and concatenates them with a boolean OR.
      * It also accepts a single array of constraints to be concatenated.
      *
-     * @param mixed $constraint1 The first of multiple constraints or an array of constraints.
+     * @param mixed ...$constraint1 The first of multiple constraints or an array of constraints.
      * @return object
      * @api
      */


### PR DESCRIPTION
This helps psalm (and IDEs) understand the method takes multiple arguments and not just one.