### PR TITLE
TASK: Remove PHP 7.2 from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ branches:
 # on PHP nightly builds. See this for more information:
 # https://docs.travis-ci.com/user/build-matrix/#rows-that-are-allowed-to-fail
 php:
-  - 7.2
   - 7.3
   - 7.4
   - nightly
@@ -26,16 +25,8 @@ jobs:
     # this excludes jobs with "no env" by using the single DUMMY defined above
     - env: DUMMY=true
   include:
-    - php: 7.2
+    - php: 7.3
       env: STATIC_ANALYSIS=true
-    - php: 7.2
-      env: DB=mysql
-      addons:
-        mariadb: '10.2'
-    - php: 7.2
-      env: DB=mysql BEHAT=true
-      addons:
-        mariadb: '10.2'
     - php: 7.3
       env: DB=mysql
       addons:


### PR DESCRIPTION
This removes the PHP 7.2. builds from travis and raises the PHP version for static analysis to PHP 7.3