### PR TITLE
BUGFIX: Add missing imports for removed SetHeaderComponent and ReplaceHttpResponseComponent

### DIFF
--- a/Neos.Flow/Classes/Mvc/ActionResponse.php
+++ b/Neos.Flow/Classes/Mvc/ActionResponse.php
@@ -9,6 +9,8 @@ use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 use GuzzleHttp\Psr7\Stream;
 use GuzzleHttp\Psr7\Response;
+use Neos\Flow\Http\Component\SetHeaderComponent;
+use Neos\Flow\Http\Component\ReplaceHttpResponseComponent;
 
 /**
  * The minimal MVC response object.


### PR DESCRIPTION
This fixes the missing namespace imports for correct `SetHeaderComponent` and `ReplaceHttpResponseComponent` b/c class names.