### PR TITLE
TASK: Use count instead of find in repository deleting resource

### DIFF
--- a/Neos.Flow/Classes/ResourceManagement/ResourceManager.php
+++ b/Neos.Flow/Classes/ResourceManagement/ResourceManager.php
@@ -327,9 +327,9 @@ class ResourceManager
 
         $collectionName = $resource->getCollectionName();
 
-        $result = $this->resourceRepository->findBySha1AndCollectionName($resource->getSha1(), $collectionName);
-        if (count($result) > 1) {
-            $this->logger->debug(sprintf('Not removing storage data of resource %s (%s) because it is still in use by %s other PersistentResource object(s).', $resource->getFilename(), $resource->getSha1(), count($result) - 1));
+        $result = $this->resourceRepository->countBySha1AndCollectionName($resource->getSha1(), $collectionName);
+        if ($result > 1) {
+            $this->logger->debug(sprintf('Not removing storage data of resource %s (%s) because it is still in use by %s other PersistentResource object(s).', $resource->getFilename(), $resource->getSha1(), $result - 1));
         } else {
             if (!isset($this->collections[$collectionName])) {
                 $this->logger->warning(sprintf('Could not remove storage data of resource %s (%s) because it refers to the unknown collection "%s".', $resource->getFilename(), $resource->getSha1(), $collectionName), LogEnvironment::fromMethodName(__METHOD__));

--- a/Neos.Flow/Classes/ResourceManagement/ResourceRepository.php
+++ b/Neos.Flow/Classes/ResourceManagement/ResourceRepository.php
@@ -263,7 +263,7 @@ class ResourceRepository extends Repository
      *
      * @return int
      */
-    public function countBySha1AndCollectionName($sha1Hash, $collectionName)
+    public function countBySha1AndCollectionName(string $sha1Hash, string $collectionName): int
     {
         $query = $this->createQuery();
         $query->matching(

--- a/Neos.Flow/Classes/ResourceManagement/ResourceRepository.php
+++ b/Neos.Flow/Classes/ResourceManagement/ResourceRepository.php
@@ -256,6 +256,33 @@ class ResourceRepository extends Repository
     }
 
     /**
+     * Counts all resources with the same SHA1 hash and collection
+     *
+     * @param string $sha1Hash
+     * @param string $collectionName
+     *
+     * @return int
+     */
+    public function countBySha1AndCollectionName($sha1Hash, $collectionName)
+    {
+        $query = $this->createQuery();
+        $query->matching(
+            $query->logicalAnd(
+                $query->equals('sha1', $sha1Hash),
+                $query->equals('collectionName', $collectionName)
+            )
+        );
+        $noOfResources = $query->count();
+        foreach ($this->addedResources as $importedResource) {
+            if ($importedResource->getSha1() === $sha1Hash && $importedResource->getCollectionName() === $collectionName) {
+                $noOfResources++;
+            }
+        }
+
+        return $noOfResources;
+    }
+
+    /**
      * Find one resource by SHA1
      *
      * @param string $sha1Hash


### PR DESCRIPTION
This introduces a new function in the resourceRepository that allows to count the number of times a file is referenced in a PersistentResource. This function is used in deleteResource of the ResourceManager to improve speed when a file is used in a lot of Persistent Resources.
Same change as with #2229 but should now be merged into Flow 5.3.

Fixes #2228