### PR TITLE
BUGFIX: AjaxWidgetsMiddleware initializes SecurityContext

### DIFF
--- a/Neos.FluidAdaptor/Classes/Core/Widget/AjaxWidgetMiddleware.php
+++ b/Neos.FluidAdaptor/Classes/Core/Widget/AjaxWidgetMiddleware.php
@@ -79,6 +79,7 @@ class AjaxWidgetMiddleware implements MiddlewareInterface
 
         $actionRequest = $this->actionRequestFactory->createActionRequest($httpRequest, ['__widgetContext' => $widgetContext]);
         $actionRequest->setControllerObjectName($widgetContext->getControllerObjectName());
+        $this->securityContext->setRequest($actionRequest);
 
         $actionResponse = new ActionResponse();
 

--- a/Neos.FluidAdaptor/Configuration/Settings.yaml
+++ b/Neos.FluidAdaptor/Configuration/Settings.yaml
@@ -3,7 +3,7 @@ Neos:
     http:
       middlewares:
         'ajaxWidget':
-          position: 'after securityEntryPoint'
+          position: 'before routing'
           middleware: 'Neos\FluidAdaptor\Core\Widget\AjaxWidgetMiddleware'
     mvc:
       view:

--- a/Neos.FluidAdaptor/Configuration/Settings.yaml
+++ b/Neos.FluidAdaptor/Configuration/Settings.yaml
@@ -3,7 +3,7 @@ Neos:
     http:
       middlewares:
         'ajaxWidget':
-          position: 'before routing'
+          position: 'after securityEntryPoint'
           middleware: 'Neos\FluidAdaptor\Core\Widget\AjaxWidgetMiddleware'
     mvc:
       view:


### PR DESCRIPTION
Otherwise, the security context is not initialized and security would not work but throw an exception (e.g. Neos.Setup)