### PR TITLE
!!! TASK: Remove custom FluidAdaptor Exceptions on invalid ArgumentDefinition

### DIFF
--- a/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractViewHelper.php
@@ -79,56 +79,6 @@ abstract class AbstractViewHelper extends FluidAbstractViewHelper
     }
 
     /**
-     * Register a new argument. Call this method from your ViewHelper subclass
-     * inside the initializeArguments() method.
-     *
-     * This exists only to throw our own exception!
-     *
-     * @param string $name Name of the argument
-     * @param string $type Type of the argument
-     * @param string $description Description of the argument
-     * @param boolean $required If true, argument is required. Defaults to false.
-     * @param mixed $defaultValue Default value of argument
-     * @param boolean|null $escape Can be toggled to TRUE to force escaping of variables and inline syntax passed as argument value.
-     * @return FluidAbstractViewHelper $this, to allow chaining.
-     * @throws Exception
-     * @api
-     */
-    protected function registerArgument($name, $type, $description, $required = false, $defaultValue = null, $escape = null)
-    {
-        if (array_key_exists($name, $this->argumentDefinitions)) {
-            throw new Exception('Argument "' . $name . '" has already been defined, thus it should not be defined again.', 1253036401);
-        }
-        return parent::registerArgument($name, $type, $description, $required, $defaultValue, $escape);
-    }
-
-    /**
-     * Overrides a registered argument. Call this method from your ViewHelper subclass
-     * inside the initializeArguments() method if you want to override a previously registered argument.
-     *
-     * This exists only to throw our own exception!
-     *
-     * @see registerArgument()
-     *
-     * @param string $name Name of the argument
-     * @param string $type Type of the argument
-     * @param string $description Description of the argument
-     * @param boolean $required If true, argument is required. Defaults to false.
-     * @param mixed $defaultValue Default value of argument
-     * @param boolean|null $escape Can be toggled to TRUE to force escaping of variables and inline syntax passed as argument value.
-     * @return FluidAbstractViewHelper $this, to allow chaining.
-     * @throws Exception
-     * @api
-     */
-    protected function overrideArgument($name, $type, $description, $required = false, $defaultValue = null, $escape = null)
-    {
-        if (!array_key_exists($name, $this->argumentDefinitions)) {
-            throw new Exception('Argument "' . $name . '" has not been defined, thus it can\'t be overridden.', 1279212461);
-        }
-        return parent::overrideArgument($name, $type, $description, $required, $defaultValue, $escape);
-    }
-
-    /**
      * @return boolean
      */
     public function isEscapingInterceptorEnabled(): bool

--- a/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -12,7 +12,6 @@ namespace Neos\FluidAdaptor\Tests\Unit\Core\ViewHelper;
  */
 
 use Neos\Flow\Mvc\Controller\ControllerContext;
-use Neos\FluidAdaptor\Core\ViewHelper\Exception;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Tests\UnitTestCase;
@@ -21,6 +20,7 @@ use Neos\FluidAdaptor\Core\ViewHelper\TemplateVariableContainer;
 use Neos\FluidAdaptor\View\TemplateView;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
 use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
 
 require_once(__DIR__ . '/../Fixtures/TestViewHelper.php');
 require_once(__DIR__ . '/../Fixtures/TestViewHelper2.php');


### PR DESCRIPTION
This removes the `Neos\FluidAdaptor\Core\Exception`s when the ArgumentDefinition is invalid in favor of the native TYPO3 Fluid exceptions. With this we remove the boilerplate we have to keep in sync with upstream.

See https://github.com/TYPO3/Fluid/issues/529 and https://github.com/neos/flow-development-collection/pull/2257#issuecomment-728825319