### PR TITLE
BUGFIX: Fix default order of middleware components

### DIFF
--- a/Neos.Flow/Configuration/Settings.Http.yaml
+++ b/Neos.Flow/Configuration/Settings.Http.yaml
@@ -31,10 +31,10 @@ Neos:
           position: 'start 100'
           middleware: 'Neos\Flow\Http\Middleware\StandardsComplianceMiddleware'
         'trustedProxies':
-          position: 'start'
+          position: 'start 50'
           middleware: 'Neos\Flow\Http\Middleware\TrustedProxiesMiddleware'
         'session':
-          position: 'start'
+          position: 'start 10'
           middleware: 'Neos\Flow\Http\Middleware\SessionMiddleware'
 
         # The execution order of the following middleware components is deliberately not specified.

--- a/Neos.Flow/Configuration/Settings.Http.yaml
+++ b/Neos.Flow/Configuration/Settings.Http.yaml
@@ -26,32 +26,34 @@ Neos:
 
       # Defines the PSR-15 middlewares that a request goes through in a flow
       middlewares:
+        # The following middleware components are executed first since they influence the incoming request or outgoing response
+        'standardsCompliance':
+          position: 'start 100'
+          middleware: 'Neos\Flow\Http\Middleware\StandardsComplianceMiddleware'
         'trustedProxies':
           position: 'start'
           middleware: 'Neos\Flow\Http\Middleware\TrustedProxiesMiddleware'
+        'session':
+          position: 'start'
+          middleware: 'Neos\Flow\Http\Middleware\SessionMiddleware'
+
+        # The execution order of the following middleware components is deliberately not specified.
+        # To run a middleware before or after an existing one, you can use "position: before <name>" or "position: after <name>"
         'routing':
-          # needs to be "after trustedProxies" because AjaxWidget comes "before routing" but still needs to be after trustedProxies
-          position: 'after trustedProxies'
           middleware: 'Neos\Flow\Mvc\Routing\RoutingMiddleware'
-        'standardsCompliance':
-          position: 'after trustedProxies'
-          middleware: 'Neos\Flow\Http\Middleware\StandardsComplianceMiddleware'
         'poweredByHeader':
           middleware: 'Neos\Flow\Http\Middleware\PoweredByMiddleware'
-        'session':
-          position: '10'
-          middleware: 'Neos\Flow\Http\Middleware\SessionMiddleware'
         'flashMessages':
-          position: 'after session'
           middleware: 'Neos\Flow\Mvc\FlashMessage\FlashMessageMiddleware'
         'parseBody':
-          position: 'before dispatch'
           middleware: 'Neos\Flow\Http\Middleware\RequestBodyParsingMiddleware'
         'securityEntryPoint':
-          position: 'before dispatch'
           middleware: 'Neos\Flow\Http\Middleware\SecurityEntryPointMiddleware'
+
+        # The dispatch middleware component is usually executed at the end of the chain since it creates the Response instance
+        # that is then passed back through the chain
         'dispatch':
-          position: 'end'
+          position: 'end 100'
           middleware: 'Neos\Flow\Mvc\DispatchMiddleware'
 
       trustedProxies:


### PR DESCRIPTION
Adjusts the order of the Middleware components so that
the `SessionMiddleware` is executed before the `RoutingMiddleware`.

Otherwise session based authentication won't work until the
routing middleware was executed.

This also removes most of the explicit `position` configurations
in order to avoid too much interdependency.

If a 3rd party middleware needs to be executed before/after another
one, it can still use `position: before/after <name>`  of course.
Depending on the order of _multiple_ other components is considered
bad practice. But if that's really required one could still add a
`position` setting to the existing middleware configuration.

Related: #2019