### PR TITLE
!!! BUGFIX: Make FluidAdaptor compatible with TYPO3Fluid 2.5.11+ and 2.6.10+

### DIFF
--- a/Neos.FluidAdaptor/Classes/Core/Parser/SyntaxTree/ResourceUriNode.php
+++ b/Neos.FluidAdaptor/Classes/Core/Parser/SyntaxTree/ResourceUriNode.php
@@ -49,8 +49,6 @@ class ResourceUriNode extends ViewHelperNode
         $this->uninitializedViewHelper = $this->viewHelperResolver->createViewHelperInstanceFromClassName($this->viewHelperClassName);
         $this->uninitializedViewHelper->setViewHelperNode($this);
         $this->argumentDefinitions = $this->viewHelperResolver->getArgumentDefinitionsForViewHelper($this->uninitializedViewHelper);
-        $this->rewriteBooleanNodesInArgumentsObjectTree($this->argumentDefinitions, $this->arguments);
-        $this->validateArguments($this->argumentDefinitions, $this->arguments);
     }
 
     /**

--- a/Neos.FluidAdaptor/Classes/Core/Parser/SyntaxTree/ResourceUriNode.php
+++ b/Neos.FluidAdaptor/Classes/Core/Parser/SyntaxTree/ResourceUriNode.php
@@ -49,6 +49,8 @@ class ResourceUriNode extends ViewHelperNode
         $this->uninitializedViewHelper = $this->viewHelperResolver->createViewHelperInstanceFromClassName($this->viewHelperClassName);
         $this->uninitializedViewHelper->setViewHelperNode($this);
         $this->argumentDefinitions = $this->viewHelperResolver->getArgumentDefinitionsForViewHelper($this->uninitializedViewHelper);
+        $this->rewriteBooleanNodesInArgumentsObjectTree($this->argumentDefinitions, $this->arguments);
+        $this->validateArguments($this->argumentDefinitions, $this->arguments);
     }
 
     /**

--- a/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractViewHelper.php
@@ -148,6 +148,52 @@ abstract class AbstractViewHelper extends FluidAbstractViewHelper
     }
 
     /**
+     * Register a new argument. Call this method from your ViewHelper subclass
+     * inside the initializeArguments() method.
+     *
+     * @param string $name Name of the argument
+     * @param string $type Type of the argument
+     * @param string $description Description of the argument
+     * @param boolean $required If true, argument is required. Defaults to false.
+     * @param mixed $defaultValue Default value of argument
+     * @param boolean|null $escape Can be toggled to TRUE to force escaping of variables and inline syntax passed as argument value.
+     * @return FluidAbstractViewHelper $this, to allow chaining.
+     * @throws Exception
+     * @api
+     */
+    protected function registerArgument($name, $type, $description, $required = false, $defaultValue = null, $escape = null)
+    {
+        if (array_key_exists($name, $this->argumentDefinitions)) {
+            throw new Exception('Argument "' . $name . '" has already been defined, thus it should not be defined again.', 1253036401);
+        }
+        return parent::registerArgument($name, $type, $description, $required, $defaultValue, $escape);
+    }
+
+    /**
+     * Overrides a registered argument. Call this method from your ViewHelper subclass
+     * inside the initializeArguments() method if you want to override a previously registered argument.
+     *
+     * @see registerArgument()
+     *
+     * @param string $name Name of the argument
+     * @param string $type Type of the argument
+     * @param string $description Description of the argument
+     * @param boolean $required If true, argument is required. Defaults to false.
+     * @param mixed $defaultValue Default value of argument
+     * @param boolean|null $escape Can be toggled to TRUE to force escaping of variables and inline syntax passed as argument value.
+     * @return FluidAbstractViewHelper $this, to allow chaining.
+     * @throws Exception
+     * @api
+     */
+    protected function overrideArgument($name, $type, $description, $required = false, $defaultValue = null, $escape = null)
+    {
+        if (!array_key_exists($name, $this->argumentDefinitions)) {
+            throw new Exception('Argument "' . $name . '" has not been defined, thus it can\'t be overridden.', 1279212461);
+        }
+        return parent::overrideArgument($name, $type, $description, $required, $defaultValue, $escape);
+    }
+
+    /**
      * Registers render method arguments
      *
      * @return void

--- a/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractViewHelper.php
@@ -156,16 +156,17 @@ abstract class AbstractViewHelper extends FluidAbstractViewHelper
      * @param string $description Description of the argument
      * @param boolean $required If true, argument is required. Defaults to false.
      * @param mixed $defaultValue Default value of argument
+     * @param boolean|null $escape Can be toggled to TRUE to force escaping of variables and inline syntax passed as argument value.
      * @return FluidAbstractViewHelper $this, to allow chaining.
      * @throws Exception
      * @api
      */
-    protected function registerArgument($name, $type, $description, $required = false, $defaultValue = null)
+    protected function registerArgument($name, $type, $description, $required = false, $defaultValue = null, $escape = null)
     {
         if (array_key_exists($name, $this->argumentDefinitions)) {
             throw new Exception('Argument "' . $name . '" has already been defined, thus it should not be defined again.', 1253036401);
         }
-        return parent::registerArgument($name, $type, $description, $required, $defaultValue);
+        return parent::registerArgument($name, $type, $description, $required, $defaultValue, $escape);
     }
 
     /**
@@ -179,16 +180,17 @@ abstract class AbstractViewHelper extends FluidAbstractViewHelper
      * @param string $description Description of the argument
      * @param boolean $required If true, argument is required. Defaults to false.
      * @param mixed $defaultValue Default value of argument
+     * @param boolean|null $escape Can be toggled to TRUE to force escaping of variables and inline syntax passed as argument value.
      * @return FluidAbstractViewHelper $this, to allow chaining.
      * @throws Exception
      * @api
      */
-    protected function overrideArgument($name, $type, $description, $required = false, $defaultValue = null)
+    protected function overrideArgument($name, $type, $description, $required = false, $defaultValue = null, $escape = null)
     {
         if (!array_key_exists($name, $this->argumentDefinitions)) {
             throw new Exception('Argument "' . $name . '" has not been defined, thus it can\'t be overridden.', 1279212461);
         }
-        return parent::overrideArgument($name, $type, $description, $required, $defaultValue);
+        return parent::overrideArgument($name, $type, $description, $required, $defaultValue, $escape);
     }
 
     /**

--- a/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractViewHelper.php
@@ -148,52 +148,6 @@ abstract class AbstractViewHelper extends FluidAbstractViewHelper
     }
 
     /**
-     * Register a new argument. Call this method from your ViewHelper subclass
-     * inside the initializeArguments() method.
-     *
-     * @param string $name Name of the argument
-     * @param string $type Type of the argument
-     * @param string $description Description of the argument
-     * @param boolean $required If true, argument is required. Defaults to false.
-     * @param mixed $defaultValue Default value of argument
-     * @param boolean|null $escape Can be toggled to TRUE to force escaping of variables and inline syntax passed as argument value.
-     * @return FluidAbstractViewHelper $this, to allow chaining.
-     * @throws Exception
-     * @api
-     */
-    protected function registerArgument($name, $type, $description, $required = false, $defaultValue = null, $escape = null)
-    {
-        if (array_key_exists($name, $this->argumentDefinitions)) {
-            throw new Exception('Argument "' . $name . '" has already been defined, thus it should not be defined again.', 1253036401);
-        }
-        return parent::registerArgument($name, $type, $description, $required, $defaultValue, $escape);
-    }
-
-    /**
-     * Overrides a registered argument. Call this method from your ViewHelper subclass
-     * inside the initializeArguments() method if you want to override a previously registered argument.
-     *
-     * @see registerArgument()
-     *
-     * @param string $name Name of the argument
-     * @param string $type Type of the argument
-     * @param string $description Description of the argument
-     * @param boolean $required If true, argument is required. Defaults to false.
-     * @param mixed $defaultValue Default value of argument
-     * @param boolean|null $escape Can be toggled to TRUE to force escaping of variables and inline syntax passed as argument value.
-     * @return FluidAbstractViewHelper $this, to allow chaining.
-     * @throws Exception
-     * @api
-     */
-    protected function overrideArgument($name, $type, $description, $required = false, $defaultValue = null, $escape = null)
-    {
-        if (!array_key_exists($name, $this->argumentDefinitions)) {
-            throw new Exception('Argument "' . $name . '" has not been defined, thus it can\'t be overridden.', 1279212461);
-        }
-        return parent::overrideArgument($name, $type, $description, $required, $defaultValue, $escape);
-    }
-
-    /**
      * Registers render method arguments
      *
      * @return void

--- a/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -103,7 +103,7 @@ class AbstractViewHelperTest extends \Neos\Flow\Tests\UnitTestCase
 
     /**
      * @test
-     * @expectedException \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
+     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function registeringTheSameArgumentNameAgainThrowsException()
     {
@@ -143,7 +143,7 @@ class AbstractViewHelperTest extends \Neos\Flow\Tests\UnitTestCase
 
     /**
      * @test
-     * @expectedException \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
+     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception
      */
     public function overrideArgumentThrowsExceptionWhenTryingToOverwriteAnNonexistingArgument()
     {

--- a/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -103,7 +103,7 @@ class AbstractViewHelperTest extends \Neos\Flow\Tests\UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     * @expectedException \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
      */
     public function registeringTheSameArgumentNameAgainThrowsException()
     {
@@ -143,7 +143,7 @@ class AbstractViewHelperTest extends \Neos\Flow\Tests\UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\FluidAdaptor\Core\ViewHelper\Exception
+     * @expectedException \TYPO3Fluid\Fluid\Core\ViewHelper\Exception
      */
     public function overrideArgumentThrowsExceptionWhenTryingToOverwriteAnNonexistingArgument()
     {

--- a/Neos.FluidAdaptor/composer.json
+++ b/Neos.FluidAdaptor/composer.json
@@ -8,7 +8,7 @@
 		"neos/cache": "*",
 		"neos/utility-files": "*",
 		"neos/utility-objecthandling": "*",
-		"typo3fluid/fluid": "^2.5",
+		"typo3fluid/fluid": "~2.5.11 || ^2.6.10",
 		"psr/log": "^1.0"
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/console": "^4.2",
         "neos/composer-plugin": "^2.0",
         "composer/composer": "^1.9",
-        "typo3fluid/fluid": "^2.5",
+        "typo3fluid/fluid": "~2.5.11 || 2.6.10",
         "ext-mbstring": "*"
     },
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/console": "^4.2",
         "neos/composer-plugin": "^2.0",
         "composer/composer": "^1.9",
-        "typo3fluid/fluid": "~2.5.11 || 2.6.10",
+        "typo3fluid/fluid": "~2.5.11 || ^2.6.10",
         "ext-mbstring": "*"
     },
     "replace": {


### PR DESCRIPTION
This is breaking in case you created your own ViewHelper that overrides the `registerArgument()` or `overrideArgument()` method. In that case you need to add a new boolean optional argument `$escape = null` and forward that to the parent method.

This is a backport of #2257
Fixes #2260 