### PR TITLE
BUGFIX: Make InstallerScripts compatible to composer version 2.0+

### DIFF
--- a/Neos.Flow/Classes/Composer/InstallerScripts.php
+++ b/Neos.Flow/Classes/Composer/InstallerScripts.php
@@ -68,7 +68,7 @@ class InstallerScripts
         if (!$operation instanceof InstallOperation && !$operation instanceof UpdateOperation) {
             throw new Exception\UnexpectedOperationException('Handling of operation with type "' . $operation->getJobType() . '" not supported', 1348750840);
         }
-        $package = ($operation->getJobType() === 'install') ? $operation->getPackage() : $operation->getTargetPackage();
+        $package = ($operation instanceof InstallOperation) ? $operation->getPackage() : $operation->getTargetPackage();
         $packageExtraConfig = $package->getExtra();
         $installPath = $event->getComposer()->getInstallationManager()->getInstallPath($package);
 
@@ -80,7 +80,7 @@ class InstallerScripts
             $evaluatedInstallerResources = true;
         }
 
-        if ($operation->getJobType() === 'install') {
+        if ($operation instanceof InstallOperation) {
             if (isset($packageExtraConfig['typo3/flow']['post-install'])) {
                 self::runPackageScripts($packageExtraConfig['typo3/flow']['post-install']);
             }
@@ -89,7 +89,7 @@ class InstallerScripts
             }
         }
 
-        if ($operation->getJobType() === 'update') {
+        if ($operation instanceof UpdateOperation) {
             if (isset($packageExtraConfig['typo3/flow']['post-update'])) {
                 self::runPackageScripts($packageExtraConfig['typo3/flow']['post-update']);
             }


### PR DESCRIPTION
Instead of querying the removed method ::getJobType we now check the class of the job instance like we do in the first lines of the method.

Cherry-picked from: f10e2570b04ad03efe27b1e2821e8d66f40cab3b

Fixes: #2187