### PR TITLE
!!! BUGFIX: Define default SAMESITE attribute to LAX

### DIFF
--- a/Neos.Flow/Classes/Http/Cookie.php
+++ b/Neos.Flow/Classes/Http/Cookie.php
@@ -143,7 +143,7 @@ class Cookie
             throw new \InvalidArgumentException('The parameter "path" passed to the Cookie constructor must be a valid path as per RFC 6265, Section 4.1.1.', 1345123078);
         }
 
-        $sameSite = $sameSite === null ? self::SAMESITE_LAX : $sameSite;
+        $sameSite = $sameSite ?? self::SAMESITE_LAX;
         if (!\in_array($sameSite, [self::SAMESITE_LAX, self::SAMESITE_STRICT, self::SAMESITE_NONE], true)) {
             throw new \InvalidArgumentException('The parameter "sameSite" passed to the Cookie constructor must be a valid samesite value. Possible values are "none", "strict" and "lax"', 1584955500);
         }

--- a/Neos.Flow/Classes/Http/Cookie.php
+++ b/Neos.Flow/Classes/Http/Cookie.php
@@ -143,7 +143,6 @@ class Cookie
             throw new \InvalidArgumentException('The parameter "path" passed to the Cookie constructor must be a valid path as per RFC 6265, Section 4.1.1.', 1345123078);
         }
 
-        $sameSite = $sameSite === null ? self::SAMESITE_LAX : $sameSite;
         if (!\in_array($sameSite, [self::SAMESITE_LAX, self::SAMESITE_STRICT, self::SAMESITE_NONE], true)) {
             throw new \InvalidArgumentException('The parameter "sameSite" passed to the Cookie constructor must be a valid samesite value. Possible values are "none", "strict" and "lax"', 1606595726);
         }

--- a/Neos.Flow/Classes/Http/Cookie.php
+++ b/Neos.Flow/Classes/Http/Cookie.php
@@ -122,7 +122,7 @@ class Cookie
      * @api
      * @throws \InvalidArgumentException
      */
-    public function __construct($name, $value = null, $expires = 0, $maximumAge = null, $domain = null, $path = '/', $secure = false, $httpOnly = true, $sameSite = 'lax')
+    public function __construct($name, $value = null, $expires = 0, $maximumAge = null, $domain = null, $path = '/', $secure = false, $httpOnly = true, $sameSite = null)
     {
         if (preg_match(self::PATTERN_TOKEN, $name) !== 1) {
             throw new \InvalidArgumentException('The parameter "name" passed to the Cookie constructor must be a valid token as per RFC 2616, Section 2.2.', 1345101977);
@@ -143,8 +143,9 @@ class Cookie
             throw new \InvalidArgumentException('The parameter "path" passed to the Cookie constructor must be a valid path as per RFC 6265, Section 4.1.1.', 1345123078);
         }
 
+        $sameSite = $sameSite === null ? self::SAMESITE_LAX : $sameSite;
         if (!\in_array($sameSite, [self::SAMESITE_LAX, self::SAMESITE_STRICT, self::SAMESITE_NONE], true)) {
-            throw new \InvalidArgumentException('The parameter "sameSite" passed to the Cookie constructor must be a valid samesite value. Possible values are "none", "strict" and "lax"', 1606595726);
+            throw new \InvalidArgumentException('The parameter "sameSite" passed to the Cookie constructor must be a valid samesite value. Possible values are "none", "strict" and "lax"', 1584955500);
         }
 
         $this->name = $name;

--- a/Neos.Flow/Classes/Http/Cookie.php
+++ b/Neos.Flow/Classes/Http/Cookie.php
@@ -122,7 +122,7 @@ class Cookie
      * @api
      * @throws \InvalidArgumentException
      */
-    public function __construct($name, $value = null, $expires = 0, $maximumAge = null, $domain = null, $path = '/', $secure = false, $httpOnly = true, $sameSite = null)
+    public function __construct($name, $value = null, $expires = 0, $maximumAge = null, $domain = null, $path = '/', $secure = false, $httpOnly = true, $sameSite = 'lax')
     {
         if (preg_match(self::PATTERN_TOKEN, $name) !== 1) {
             throw new \InvalidArgumentException('The parameter "name" passed to the Cookie constructor must be a valid token as per RFC 2616, Section 2.2.', 1345101977);
@@ -142,8 +142,10 @@ class Cookie
         if ($path !== null && preg_match(self::PATTERN_PATH, $path) !== 1) {
             throw new \InvalidArgumentException('The parameter "path" passed to the Cookie constructor must be a valid path as per RFC 6265, Section 4.1.1.', 1345123078);
         }
-        if (!\in_array($sameSite, [self::SAMESITE_LAX, self::SAMESITE_STRICT, self::SAMESITE_NONE, null], true)) {
-            throw new \InvalidArgumentException('The parameter "sameSite" passed to the Cookie constructor must be a valid samesite value. Possible values are "none", "strict", "lax" and null', 1584955500);
+
+        $sameSite = is_null($sameSite) ? self::SAMESITE_LAX : $sameSite;
+        if (!\in_array($sameSite, [self::SAMESITE_LAX, self::SAMESITE_STRICT, self::SAMESITE_NONE], true)) {
+            throw new \InvalidArgumentException('The parameter "sameSite" passed to the Cookie constructor must be a valid samesite value. Possible values are "none", "strict" and "lax"', 1606595726);
         }
 
         $this->name = $name;
@@ -154,7 +156,7 @@ class Cookie
         $this->path = $path;
         $this->secure = ($secure == true) || $sameSite === self::SAMESITE_NONE;
         $this->httpOnly = ($httpOnly == true);
-        $this->sameSite = is_null($sameSite) ? self::SAMESITE_LAX : $sameSite;
+        $this->sameSite = $sameSite;
     }
 
     /**
@@ -191,7 +193,7 @@ class Cookie
         $pathAttribute = null;
         $secureAttribute = false;
         $httpOnlyAttribute = true;
-        $sameSite = null;
+        $sameSite = self::SAMESITE_LAX;
 
         if ($unparsedAttributes !== '') {
             foreach (explode(';', $unparsedAttributes) as $cookieAttributeValueString) {

--- a/Neos.Flow/Classes/Http/Cookie.php
+++ b/Neos.Flow/Classes/Http/Cookie.php
@@ -143,7 +143,7 @@ class Cookie
             throw new \InvalidArgumentException('The parameter "path" passed to the Cookie constructor must be a valid path as per RFC 6265, Section 4.1.1.', 1345123078);
         }
 
-        $sameSite = is_null($sameSite) ? self::SAMESITE_LAX : $sameSite;
+        $sameSite = $sameSite === null ? self::SAMESITE_LAX : $sameSite;
         if (!\in_array($sameSite, [self::SAMESITE_LAX, self::SAMESITE_STRICT, self::SAMESITE_NONE], true)) {
             throw new \InvalidArgumentException('The parameter "sameSite" passed to the Cookie constructor must be a valid samesite value. Possible values are "none", "strict" and "lax"', 1606595726);
         }

--- a/Neos.Flow/Classes/Http/Cookie.php
+++ b/Neos.Flow/Classes/Http/Cookie.php
@@ -154,7 +154,7 @@ class Cookie
         $this->path = $path;
         $this->secure = ($secure == true) || $sameSite === self::SAMESITE_NONE;
         $this->httpOnly = ($httpOnly == true);
-        $this->sameSite = $sameSite;
+        $this->sameSite = is_null($sameSite) ? self::SAMESITE_LAX : $sameSite;
     }
 
     /**

--- a/Neos.Flow/Configuration/Settings.Session.yaml
+++ b/Neos.Flow/Configuration/Settings.Session.yaml
@@ -56,5 +56,5 @@ Neos:
         domain: NULL
 
         # The cookie samesite.
-        # possible values: 'none', 'strict', 'lax' and null
-        samesite: NULL
+        # possible values: 'none', 'strict' and 'lax'
+        samesite: 'lax'

--- a/Neos.Flow/Tests/Unit/Http/CookieTest.php
+++ b/Neos.Flow/Tests/Unit/Http/CookieTest.php
@@ -258,15 +258,6 @@ class CookieTest extends UnitTestCase
     /**
      * @test
      */
-    public function SameSiteReturnsNull()
-    {
-        $cookie = new Cookie('foo', 'bar');
-        $this->assertNull($cookie->getSameSite());
-    }
-
-    /**
-     * @test
-     */
     public function SameSiteReturnsNone()
     {
         $cookie = new Cookie('foo', 'bar', 0, null, 'neos.io', '/', true, false, Cookie::SAMESITE_NONE);
@@ -335,25 +326,25 @@ class CookieTest extends UnitTestCase
         $expiredCookie->expire();
 
         return [
-            [new Cookie('foo', 'bar'), 'foo=bar; Path=/; HttpOnly'],
-            [new Cookie('MyFoo25', 'bar'), 'MyFoo25=bar; Path=/; HttpOnly'],
-            [new Cookie('MyFoo25', true), 'MyFoo25=1; Path=/; HttpOnly'],
-            [new Cookie('MyFoo25', false), 'MyFoo25=0; Path=/; HttpOnly'],
-            [new Cookie('foo', 'bar', 0), 'foo=bar; Path=/; HttpOnly'],
-            [new Cookie('MyFoo25'), 'MyFoo25=; Path=/; HttpOnly'],
-            [new Cookie('foo', 'It\'s raining cats and dogs.'), 'foo=It%27s+raining+cats+and+dogs.; Path=/; HttpOnly'],
-            [new Cookie('foo', 'Some characters, like "double quotes" must be escaped.'), 'foo=Some+characters%2C+like+%22double+quotes%22+must+be+escaped.; Path=/; HttpOnly'],
-            [new Cookie('foo', 'bar', 1345108546), 'foo=bar; Expires=Thu, 16-Aug-2012 09:15:46 GMT; Path=/; HttpOnly'],
-            [new Cookie('foo', 'bar', \DateTime::createFromFormat('U', 1345108546)), 'foo=bar; Expires=Thu, 16-Aug-2012 09:15:46 GMT; Path=/; HttpOnly'],
-            [new Cookie('foo', 'bar', 0, null, 'flow.neos.io'), 'foo=bar; Domain=flow.neos.io; Path=/; HttpOnly'],
-            [new Cookie('foo', 'bar', 0, null, 'flow.neos.io', '/about'), 'foo=bar; Domain=flow.neos.io; Path=/about; HttpOnly'],
-            [new Cookie('foo', 'bar', 0, null, 'neos.io', '/', true), 'foo=bar; Domain=neos.io; Path=/; Secure; HttpOnly'],
-            [new Cookie('foo', 'bar', 0, null, 'neos.io', '/', true, false), 'foo=bar; Domain=neos.io; Path=/; Secure'],
+            [new Cookie('foo', 'bar'), 'foo=bar; Path=/; HttpOnly; SameSite=lax'],
+            [new Cookie('MyFoo25', 'bar'), 'MyFoo25=bar; Path=/; HttpOnly; SameSite=lax'],
+            [new Cookie('MyFoo25', true), 'MyFoo25=1; Path=/; HttpOnly; SameSite=lax'],
+            [new Cookie('MyFoo25', false), 'MyFoo25=0; Path=/; HttpOnly; SameSite=lax'],
+            [new Cookie('foo', 'bar', 0), 'foo=bar; Path=/; HttpOnly; SameSite=lax'],
+            [new Cookie('MyFoo25'), 'MyFoo25=; Path=/; HttpOnly; SameSite=lax'],
+            [new Cookie('foo', 'It\'s raining cats and dogs.'), 'foo=It%27s+raining+cats+and+dogs.; Path=/; HttpOnly; SameSite=lax'],
+            [new Cookie('foo', 'Some characters, like "double quotes" must be escaped.'), 'foo=Some+characters%2C+like+%22double+quotes%22+must+be+escaped.; Path=/; HttpOnly; SameSite=lax'],
+            [new Cookie('foo', 'bar', 1345108546), 'foo=bar; Expires=Thu, 16-Aug-2012 09:15:46 GMT; Path=/; HttpOnly; SameSite=lax'],
+            [new Cookie('foo', 'bar', \DateTime::createFromFormat('U', 1345108546)), 'foo=bar; Expires=Thu, 16-Aug-2012 09:15:46 GMT; Path=/; HttpOnly; SameSite=lax'],
+            [new Cookie('foo', 'bar', 0, null, 'flow.neos.io'), 'foo=bar; Domain=flow.neos.io; Path=/; HttpOnly; SameSite=lax'],
+            [new Cookie('foo', 'bar', 0, null, 'flow.neos.io', '/about'), 'foo=bar; Domain=flow.neos.io; Path=/about; HttpOnly; SameSite=lax'],
+            [new Cookie('foo', 'bar', 0, null, 'neos.io', '/', true), 'foo=bar; Domain=neos.io; Path=/; Secure; HttpOnly; SameSite=lax'],
+            [new Cookie('foo', 'bar', 0, null, 'neos.io', '/', true, false), 'foo=bar; Domain=neos.io; Path=/; Secure; SameSite=lax'],
             [new Cookie('foo', 'bar', 0, null, 'neos.io', '/', true, true, Cookie::SAMESITE_NONE), 'foo=bar; Domain=neos.io; Path=/; Secure; HttpOnly; SameSite=none'],
             [new Cookie('foo', 'bar', 0, null, 'neos.io', '/', true, true, Cookie::SAMESITE_STRICT), 'foo=bar; Domain=neos.io; Path=/; Secure; HttpOnly; SameSite=strict'],
             [new Cookie('foo', 'bar', 0, null, 'neos.io', '/', true, true, Cookie::SAMESITE_LAX), 'foo=bar; Domain=neos.io; Path=/; Secure; HttpOnly; SameSite=lax'],
-            [new Cookie('foo', 'bar', 0, 3600), 'foo=bar; Max-Age=3600; Path=/; HttpOnly'],
-            [$expiredCookie, 'foo=bar; Expires=Thu, 27-May-1976 12:00:00 GMT; Path=/; HttpOnly']
+            [new Cookie('foo', 'bar', 0, 3600), 'foo=bar; Max-Age=3600; Path=/; HttpOnly; SameSite=lax'],
+            [$expiredCookie, 'foo=bar; Expires=Thu, 27-May-1976 12:00:00 GMT; Path=/; HttpOnly; SameSite=lax']
         ];
     }
 
@@ -496,7 +487,7 @@ class CookieTest extends UnitTestCase
     public function createCookieFromRawIgnoresSameSiteAttributeIfValueIsEmpty()
     {
         $cookie = Cookie::createFromRawSetCookieHeader('ckName=someValue; SameSite=; more=nothing');
-        $this->assertNull($cookie->getSameSite());
+        $this->assertSame(Cookie::SAMESITE_LAX, $cookie->getSameSite());
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Http/CookieTest.php
+++ b/Neos.Flow/Tests/Unit/Http/CookieTest.php
@@ -296,7 +296,7 @@ class CookieTest extends UnitTestCase
      */
     public function SameSiteThrowsExceptionForInvalidValues()
     {
-        $this->expectExceptionCode(1584955500);
+        $this->expectExceptionCode(1606595726);
         new Cookie('foo', 'bar', 0, null, 'neos.io', '/', false, false, 'foo');
     }
 

--- a/Neos.Flow/Tests/Unit/Http/CookieTest.php
+++ b/Neos.Flow/Tests/Unit/Http/CookieTest.php
@@ -296,7 +296,7 @@ class CookieTest extends UnitTestCase
      */
     public function SameSiteThrowsExceptionForInvalidValues()
     {
-        $this->expectExceptionCode(1606595726);
+        $this->expectExceptionCode(1584955500);
         new Cookie('foo', 'bar', 0, null, 'neos.io', '/', false, false, 'foo');
     }
 

--- a/Neos.Flow/Tests/Unit/Http/Middleware/SessionMiddlewareTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Middleware/SessionMiddlewareTest.php
@@ -54,7 +54,7 @@ class SessionMiddlewareTest extends UnitTestCase
         'secure' => false,
         'httponly' => true,
         'domain' => null,
-        'samesite' => null,
+        'samesite' => Cookie::SAMESITE_LAX,
     ];
 
     public function setUp(): void

--- a/Neos.Flow/Tests/Unit/Http/Middleware/SessionMiddlewareTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Middleware/SessionMiddlewareTest.php
@@ -141,12 +141,12 @@ class SessionMiddlewareTest extends UnitTestCase
     public function sessionCookieSettingsProvider(): array
     {
         return [
-            ['sessionCookieSettings' => [], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Path=/; HttpOnly'],
-            ['sessionCookieSettings' => ['lifetime' => 123], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Max-Age=123; Path=/; HttpOnly'],
-            ['sessionCookieSettings' => ['path' => '/some/path'], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Path=/some/path; HttpOnly'],
-            ['sessionCookieSettings' => ['secure' => true], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Path=/; Secure; HttpOnly'],
-            ['sessionCookieSettings' => ['httponly' => false], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Path=/'],
-            ['sessionCookieSettings' => ['domain' => 'neos.io'], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Domain=neos.io; Path=/; HttpOnly'],
+            ['sessionCookieSettings' => [], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Path=/; HttpOnly; SameSite=lax'],
+            ['sessionCookieSettings' => ['lifetime' => 123], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Max-Age=123; Path=/; HttpOnly; SameSite=lax'],
+            ['sessionCookieSettings' => ['path' => '/some/path'], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Path=/some/path; HttpOnly; SameSite=lax'],
+            ['sessionCookieSettings' => ['secure' => true], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Path=/; Secure; HttpOnly; SameSite=lax'],
+            ['sessionCookieSettings' => ['httponly' => false], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Path=/; SameSite=lax'],
+            ['sessionCookieSettings' => ['domain' => 'neos.io'], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Domain=neos.io; Path=/; HttpOnly; SameSite=lax'],
             ['sessionCookieSettings' => ['samesite' => 'none'], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Path=/; Secure; HttpOnly; SameSite=none'],
             ['sessionCookieSettings' => ['samesite' => 'strict'], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Path=/; HttpOnly; SameSite=strict'],
             ['sessionCookieSettings' => ['samesite' => 'lax'], 'expectedNewCookieValue' => 'session_cookie_name=session-id; Path=/; HttpOnly; SameSite=lax'],

--- a/Neos.Flow/Tests/Unit/Session/SessionTest.php
+++ b/Neos.Flow/Tests/Unit/Session/SessionTest.php
@@ -28,6 +28,7 @@ use Neos\Flow\Session\Exception\SessionNotStartedException;
 use Neos\Flow\Session\Session;
 use Neos\Flow\Session\SessionManager;
 use Neos\Cache\Frontend\VariableFrontend;
+use Neos\Flow\Http\Cookie;
 use Neos\Flow\Security\Authentication\Token\UsernamePassword;
 use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\Account;
@@ -83,7 +84,7 @@ class SessionTest extends UnitTestCase
                 'secure' => false,
                 'httponly' => true,
                 'domain' => null,
-                'samesite' => null
+                'samesite' => Cookie::SAMESITE_LAX
             ]
         ]
     ];


### PR DESCRIPTION
The neos-ui complaining with warning in the modern browsers because our session cookie has no defined same site attribute and so the browser expect to have a same site with the lax value or none but with the secure attribute.

As the browsers use LAX as default we now also define that.
For mor information read https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite

Resolves: #2031

![Screenshot 2020-11-24 at 10 31 02](https://user-images.githubusercontent.com/1014126/100076002-fbaaee00-2e40-11eb-9feb-40cc23cf7219.png)



**What I did**
Define `SameSite=Lax` when no sameSite is defined.

**How to verify it**
Just load the neos backend and check the dev console for warning. There should be no warning regarding session cookies.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
