### PR TITLE
Allow psalm checks to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
 jobs:
   allow_failures:
     - php: nightly
+    - env: STATIC_ANALYSIS=true
   fast_finish: true
   exclude:
     # this excludes jobs with "no env" by using the single DUMMY defined above


### PR DESCRIPTION
Adjusts the Travis CI configuration allowing static analysis (psalm) to fail
since they are very fragile at the moment.