### PR TITLE
TASK: Print a helpful message, if autoload.php can not be found in CLI

### DIFF
--- a/Neos.Flow/Scripts/flow.php
+++ b/Neos.Flow/Scripts/flow.php
@@ -39,7 +39,18 @@ if (isset($argv[1]) && ($argv[1] === 'neos.flow:core:setfilepermissions' || $arg
     array_shift($argv);
     require(__DIR__ . '/migrate.php');
 } else {
-    $composerAutoloader = require(__DIR__ . '/../../../Libraries/autoload.php');
+    $autoloadFilePath = __DIR__ . '/../../../Libraries/autoload.php';
+    if (file_exists($autoloadFilePath)) {
+        $composerAutoloader = require($autoloadFilePath);
+    } else {
+        echo("Composers 'autoload.php' file was not found. The file is expected to be located in the path:" . PHP_EOL . PHP_EOL);
+        echo(sprintf("%s", $autoloadFilePath) . PHP_EOL . PHP_EOL);
+        echo("This could be due to a missing 'config' => 'vendor-dir' section of your root 'composer.json' file.". PHP_EOL . PHP_EOL);
+        echo("The section key and value should look like the following" . PHP_EOL);
+        echo("\"vendor-dir\": \"Packages/Libraries\"" . PHP_EOL);
+        echo("Update your 'composer.json' file and run the 'composer update' command." . PHP_EOL);
+        exit(1);
+    }
 
     if (DIRECTORY_SEPARATOR !== '/' && trim(getenv('FLOW_ROOTPATH'), '"\' ') === '') {
         $absoluteRootpath = dirname(realpath(__DIR__ . '/../../../'));

--- a/Neos.Flow/Scripts/flow.php
+++ b/Neos.Flow/Scripts/flow.php
@@ -39,17 +39,17 @@ if (isset($argv[1]) && ($argv[1] === 'neos.flow:core:setfilepermissions' || $arg
     array_shift($argv);
     require(__DIR__ . '/migrate.php');
 } else {
-    $composerAutoloader = dirname(__DIR__, 3) . '/Libraries/autoload.php';
-    if (!file_exists($composerAutoloader)) {
+    $autoloaderPath = dirname(__DIR__, 3) . '/Libraries/autoload.php';
+    if (!file_exists($autoloaderPath)) {
         echo 'Composers "autoload.php" file was not found. The file is expected to be located in the path:' . PHP_EOL . PHP_EOL;
-        echo $composerAutoloader . PHP_EOL . PHP_EOL;
+        echo $autoloaderPath . PHP_EOL . PHP_EOL;
         echo 'This could be due to a missing "config" => "vendor-dir" section of your root "composer.json" file.' . PHP_EOL . PHP_EOL;
         echo 'The section key and value should look like the following:' . PHP_EOL;
         echo '"vendor-dir": "Packages/Libraries"' . PHP_EOL;
         echo 'Update your "composer.json" file accordingly and run the "composer update" command.' . PHP_EOL;
         exit(1);
     }
-    require($composerAutoloader);
+    $composerAutoloader = require($autoloaderPath);
 
     if (DIRECTORY_SEPARATOR !== '/' && trim(getenv('FLOW_ROOTPATH'), '"\' ') === '') {
         $absoluteRootpath = dirname(realpath(__DIR__ . '/../../../'));

--- a/Neos.Flow/Scripts/flow.php
+++ b/Neos.Flow/Scripts/flow.php
@@ -40,9 +40,7 @@ if (isset($argv[1]) && ($argv[1] === 'neos.flow:core:setfilepermissions' || $arg
     require(__DIR__ . '/migrate.php');
 } else {
     $autoloadFilePath = __DIR__ . '/../../../Libraries/autoload.php';
-    if (file_exists($autoloadFilePath)) {
-        $composerAutoloader = require($autoloadFilePath);
-    } else {
+    if (!file_exists($autoloadFilePath)) {
         echo("Composers 'autoload.php' file was not found. The file is expected to be located in the path:" . PHP_EOL . PHP_EOL);
         echo(sprintf("%s", $autoloadFilePath) . PHP_EOL . PHP_EOL);
         echo("This could be due to a missing 'config' => 'vendor-dir' section of your root 'composer.json' file.". PHP_EOL . PHP_EOL);
@@ -51,6 +49,8 @@ if (isset($argv[1]) && ($argv[1] === 'neos.flow:core:setfilepermissions' || $arg
         echo("Update your 'composer.json' file and run the 'composer update' command." . PHP_EOL);
         exit(1);
     }
+
+    $composerAutoloader = require($autoloadFilePath);
 
     if (DIRECTORY_SEPARATOR !== '/' && trim(getenv('FLOW_ROOTPATH'), '"\' ') === '') {
         $absoluteRootpath = dirname(realpath(__DIR__ . '/../../../'));

--- a/Neos.Flow/Scripts/flow.php
+++ b/Neos.Flow/Scripts/flow.php
@@ -39,10 +39,10 @@ if (isset($argv[1]) && ($argv[1] === 'neos.flow:core:setfilepermissions' || $arg
     array_shift($argv);
     require(__DIR__ . '/migrate.php');
 } else {
-    $autoloadFilePath = dirname(__DIR__, 3) . '/Libraries/autoload.php';
-    if (!file_exists($autoloadFilePath)) {
+    $composerAutoloader = dirname(__DIR__, 3) . '/Libraries/autoload.php';
+    if (!file_exists($composerAutoloader)) {
         echo 'Composers "autoload.php" file was not found. The file is expected to be located in the path:' . PHP_EOL . PHP_EOL;
-        echo $autoloadFilePath . PHP_EOL . PHP_EOL;
+        echo $composerAutoloader . PHP_EOL . PHP_EOL;
         echo 'This could be due to a missing "config" => "vendor-dir" section of your root "composer.json" file.' . PHP_EOL . PHP_EOL;
         echo 'The section key and value should look like the following:' . PHP_EOL;
         echo '"vendor-dir": "Packages/Libraries"' . PHP_EOL;

--- a/Neos.Flow/Scripts/flow.php
+++ b/Neos.Flow/Scripts/flow.php
@@ -49,6 +49,7 @@ if (isset($argv[1]) && ($argv[1] === 'neos.flow:core:setfilepermissions' || $arg
         echo 'Update your "composer.json" file accordingly and run the "composer update" command.' . PHP_EOL;
         exit(1);
     }
+    require($composerAutoloader);
 
     if (DIRECTORY_SEPARATOR !== '/' && trim(getenv('FLOW_ROOTPATH'), '"\' ') === '') {
         $absoluteRootpath = dirname(realpath(__DIR__ . '/../../../'));

--- a/Neos.Flow/Scripts/flow.php
+++ b/Neos.Flow/Scripts/flow.php
@@ -39,18 +39,16 @@ if (isset($argv[1]) && ($argv[1] === 'neos.flow:core:setfilepermissions' || $arg
     array_shift($argv);
     require(__DIR__ . '/migrate.php');
 } else {
-    $autoloadFilePath = __DIR__ . '/../../../Libraries/autoload.php';
+    $autoloadFilePath = dirname(__DIR__, 3) . '/Libraries/autoload.php';
     if (!file_exists($autoloadFilePath)) {
-        echo("Composers 'autoload.php' file was not found. The file is expected to be located in the path:" . PHP_EOL . PHP_EOL);
-        echo(sprintf("%s", $autoloadFilePath) . PHP_EOL . PHP_EOL);
-        echo("This could be due to a missing 'config' => 'vendor-dir' section of your root 'composer.json' file.". PHP_EOL . PHP_EOL);
-        echo("The section key and value should look like the following" . PHP_EOL);
-        echo("\"vendor-dir\": \"Packages/Libraries\"" . PHP_EOL);
-        echo("Update your 'composer.json' file and run the 'composer update' command." . PHP_EOL);
+        echo 'Composers "autoload.php" file was not found. The file is expected to be located in the path:' . PHP_EOL . PHP_EOL;
+        echo $autoloadFilePath . PHP_EOL . PHP_EOL;
+        echo 'This could be due to a missing "config" => "vendor-dir" section of your root "composer.json" file.' . PHP_EOL . PHP_EOL;
+        echo 'The section key and value should look like the following:' . PHP_EOL;
+        echo '"vendor-dir": "Packages/Libraries"' . PHP_EOL;
+        echo 'Update your "composer.json" file accordingly and run the "composer update" command.' . PHP_EOL;
         exit(1);
     }
-
-    $composerAutoloader = require($autoloadFilePath);
 
     if (DIRECTORY_SEPARATOR !== '/' && trim(getenv('FLOW_ROOTPATH'), '"\' ') === '') {
         $absoluteRootpath = dirname(realpath(__DIR__ . '/../../../'));


### PR DESCRIPTION
This adds a helpful message to the CLI output like this, if the Composer autoload file is mssing:

```
> ./flow
Composers autoload.php file was not found. The file is expected to be located in the path:

/Users/soren/Projects/flow-development-distribution/Packages/Framework/Neos.Flow/Scripts/../../../Libraries/autoload.php

This could be due to a missing 'config' => 'vendor-dir' section of your root 'composer.json' file.

The section key and value should look like the following
"vendor-dir": "Packages/Libraries"
Update your 'composer.json' file and run the 'composer update' command.
```

Resolves #2282 