### PR TITLE
TASK: Fix return type annotation for TokenInterface::updateCredentials()

### DIFF
--- a/Neos.Flow/Classes/Security/Authentication/TokenInterface.php
+++ b/Neos.Flow/Classes/Security/Authentication/TokenInterface.php
@@ -123,7 +123,7 @@ interface TokenInterface
      * Note: You should not persist the credentials!
      *
      * @param ActionRequest $actionRequest The current request instance
-     * @return boolean true if this token needs to be (re-)authenticated
+     * @return void
      */
     public function updateCredentials(ActionRequest $actionRequest);
 


### PR DESCRIPTION
The result of this call is not used (see https://github.com/neos/flow-development-collection/blob/af7b3374688878b822528b4a761741f1102de1cf/Neos.Flow/Classes/Security/Context.php#L787)
