### PR TITLE
BUGFIX: Correct printed path for created doctrine migrations

### DIFF
--- a/Neos.Flow/Classes/Command/DoctrineCommandController.php
+++ b/Neos.Flow/Classes/Command/DoctrineCommandController.php
@@ -496,7 +496,7 @@ class DoctrineCommandController extends CommandController
             if ($selectedPackage !== $choices[0]) {
                 /** @var Package $selectedPackage */
                 $selectedPackage = $packages[$selectedPackage];
-                $targetPathAndFilename = Files::concatenatePaths([$selectedPackage->getPackagePath(), 'Migrations', $this->doctrineService->getDatabasePlatformName(), basename($migrationClassPathAndFilename)]);
+                $targetPathAndFilename = Files::concatenatePaths(['Packages', $selectedPackage->getPackagePath(), 'Migrations', $this->doctrineService->getDatabasePlatformName(), basename($migrationClassPathAndFilename)]);
                 Files::createDirectoryRecursively(dirname($targetPathAndFilename));
                 rename($migrationClassPathAndFilename, $targetPathAndFilename);
                 $this->outputLine('The migration was moved to: <comment>%s</comment>', [substr($targetPathAndFilename, strlen(FLOW_PATH_PACKAGES))]);

--- a/Neos.Flow/Classes/Command/DoctrineCommandController.php
+++ b/Neos.Flow/Classes/Command/DoctrineCommandController.php
@@ -496,10 +496,10 @@ class DoctrineCommandController extends CommandController
             if ($selectedPackage !== $choices[0]) {
                 /** @var Package $selectedPackage */
                 $selectedPackage = $packages[$selectedPackage];
-                $targetPathAndFilename = Files::concatenatePaths(['Packages', $selectedPackage->getPackagePath(), 'Migrations', $this->doctrineService->getDatabasePlatformName(), basename($migrationClassPathAndFilename)]);
+                $targetPathAndFilename = Files::concatenatePaths([$selectedPackage->getPackagePath(), 'Migrations', $this->doctrineService->getDatabasePlatformName(), basename($migrationClassPathAndFilename)]);
                 Files::createDirectoryRecursively(dirname($targetPathAndFilename));
                 rename($migrationClassPathAndFilename, $targetPathAndFilename);
-                $this->outputLine('The migration was moved to: <comment>%s</comment>', [substr($targetPathAndFilename, strlen(FLOW_PATH_PACKAGES))]);
+                $this->outputLine('The migration was moved to: <comment>%s</comment>', [substr($targetPathAndFilename, strlen(FLOW_PATH_ROOT))]);
                 $this->outputLine();
                 $this->outputLine('Next Steps:');
             } else {


### PR DESCRIPTION
Tweaks the output of the `doctrine:migrationgenerate` command so that it renders the path of the new migration relative to the root directory.

Before:

    The migration was moved to: Application/<Package.Key>/Migrations/<DB-Type>/Version<Version>.php

Now:

    The migration was moved to: Packages/Application/<Package.Key>/Migrations/<DB-Type>/Version<Version>.php

Fixes #2296 