### PR TITLE
TASK: Throw exception if HTTP chain is configured

### DIFF
--- a/Neos.Flow/Classes/Http/RequestHandler.php
+++ b/Neos.Flow/Classes/Http/RequestHandler.php
@@ -198,7 +198,6 @@ class RequestHandler implements HttpRequestHandlerInterface
             throw new FlowException('The settings still contain configuration for the no longer supported HTTP component chain.' . chr(10) .
                 'The component chain has been replaced in favor of PSR-15 middlewares with Flow version 7.0, please make sure to migrate any components accordingly.' . chr(10) .
                 'To see which components are still configured, run ./flow configuration:show --path Neos.Flow.http.chain', 1606912674);
-
         }
     }
 }


### PR DESCRIPTION
Adjusts the default HTTP `RequestHandler` so that it throws
an exception if the (no longer supported) `Neos.Flow.http.chain`
is configured:

    Exception #1606912674 in line 104 of Packages/Framework/Neos.Flow/Classes/Http/RequestHandler.php:
    The settings still contain configuration for the no longer supported HTTP component chain.
    The component chain has been replaced in favor of PSR-15 middlewares with Flow version 7.0,
    please make sure to migrate any components accordingly.
    To see which components are still configured, run ./flow configuration:show --path Neos.Flow.http.chain

This will hopefully prevent some subtle bugs due to some components
that no longer work as expected.

Related: #2258