### PR TITLE
TASK: Some psalm corrections

### DIFF
--- a/Neos.Flow/Classes/Mvc/Routing/IdentityRoutePart.php
+++ b/Neos.Flow/Classes/Mvc/Routing/IdentityRoutePart.php
@@ -56,6 +56,7 @@ class IdentityRoutePart extends DynamicRoutePart
      * The object type (class name) of the entity this route part belongs to
      *
      * @var string
+     * @psalm-var class-string
      */
     protected $objectType;
 
@@ -68,6 +69,7 @@ class IdentityRoutePart extends DynamicRoutePart
 
     /**
      * @param string $objectType
+     * @psalm-param class-string $objectType
      * @return void
      */
     public function setObjectType($objectType)
@@ -77,6 +79,7 @@ class IdentityRoutePart extends DynamicRoutePart
 
     /**
      * @return string
+     * @psalm-return class-string
      */
     public function getObjectType()
     {

--- a/Neos.Flow/Classes/Mvc/Routing/ObjectPathMapping.php
+++ b/Neos.Flow/Classes/Mvc/Routing/ObjectPathMapping.php
@@ -31,6 +31,7 @@ class ObjectPathMapping
      * Class name of the object this mapping belongs to
      *
      * @var string
+     * @psalm-var class-string
      * @ORM\Id
      * @Flow\Validate(type="NotEmpty")
      */
@@ -111,6 +112,7 @@ class ObjectPathMapping
 
     /**
      * @param string $objectType
+     * @psalm-param class-string $objectType
      */
     public function setObjectType($objectType)
     {
@@ -119,6 +121,7 @@ class ObjectPathMapping
 
     /**
      * @return string
+     * @psalm-return class-string
      */
     public function getObjectType()
     {

--- a/Neos.Flow/Classes/Persistence/Doctrine/PersistenceManager.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/PersistenceManager.php
@@ -184,6 +184,7 @@ class PersistenceManager extends AbstractPersistenceManager
      *
      * @param mixed $identifier
      * @param string|null $objectType
+     * @psalm-param class-string|null $objectType
      * @param boolean $useLazyLoading Set to true if you want to use lazy loading for this object
      * @return object The object for the identifier if it is known, or NULL
      * @throws \RuntimeException

--- a/Neos.Flow/Classes/Persistence/Doctrine/Repository.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Repository.php
@@ -49,6 +49,7 @@ abstract class Repository extends EntityRepository implements RepositoryInterfac
      * Warning: if you think you want to set this,
      * look at RepositoryInterface::ENTITY_CLASSNAME first!
      *
+     * @psalm-var class-string
      * @var string
      */
     protected $objectType;
@@ -68,10 +69,12 @@ abstract class Repository extends EntityRepository implements RepositoryInterfac
     {
         if ($classMetadata === null) {
             if (defined('static::ENTITY_CLASSNAME') === false) {
-                $this->objectType = preg_replace(['/\\\Repository\\\/', '/Repository$/'], ['\\Model\\', ''], get_class($this));
+                $objectType = preg_replace(['/\\\Repository\\\/', '/Repository$/'], ['\\Model\\', ''], get_class($this));
             } else {
-                $this->objectType = static::ENTITY_CLASSNAME;
+                $objectType = static::ENTITY_CLASSNAME;
             }
+            assert(class_exists($objectType));
+            $this->objectType = $objectType;
             $classMetadata = $entityManager->getClassMetadata($this->objectType);
         }
         parent::__construct($entityManager, $classMetadata);

--- a/Neos.Flow/Classes/Persistence/Doctrine/Repository.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Repository.php
@@ -68,12 +68,12 @@ abstract class Repository extends EntityRepository implements RepositoryInterfac
     public function __construct(EntityManagerInterface $entityManager, ClassMetadata $classMetadata = null)
     {
         if ($classMetadata === null) {
+            /** @psalm-var class-string $objectType */
             if (defined('static::ENTITY_CLASSNAME') === false) {
                 $objectType = preg_replace(['/\\\Repository\\\/', '/Repository$/'], ['\\Model\\', ''], get_class($this));
             } else {
                 $objectType = static::ENTITY_CLASSNAME;
             }
-            assert(class_exists($objectType));
             $this->objectType = $objectType;
             $classMetadata = $entityManager->getClassMetadata($this->objectType);
         }

--- a/Neos.Flow/Classes/Persistence/PersistenceManagerInterface.php
+++ b/Neos.Flow/Classes/Persistence/PersistenceManagerInterface.php
@@ -95,6 +95,7 @@ interface PersistenceManagerInterface
      *
      * @param mixed $identifier
      * @param string|null $objectType
+     * @psalm-param class-string|null $objectType
      * @param boolean $useLazyLoading Set to true if you want to use lazy loading for this object
      * @return object The object for the identifier if it is known, or NULL
      * @api

--- a/Neos.Flow/Classes/Persistence/Repository.php
+++ b/Neos.Flow/Classes/Persistence/Repository.php
@@ -32,6 +32,7 @@ abstract class Repository implements RepositoryInterface
      * look at RepositoryInterface::ENTITY_CLASSNAME first!
      *
      * @var string
+     * @psalm-var class-string
      */
     protected $entityClassName;
 
@@ -46,10 +47,12 @@ abstract class Repository implements RepositoryInterface
     public function __construct()
     {
         if (defined('static::ENTITY_CLASSNAME') === false) {
-            $this->entityClassName = preg_replace(['/\\\Repository\\\/', '/Repository$/'], ['\\Model\\', ''], get_class($this));
+            $entityClassName = preg_replace(['/\\\Repository\\\/', '/Repository$/'], ['\\Model\\', ''], get_class($this));
         } else {
-            $this->entityClassName = static::ENTITY_CLASSNAME;
+            $entityClassName = static::ENTITY_CLASSNAME;
         }
+        assert(class_exists($entityClassName));
+        $this->entityClassName = $entityClassName;
     }
 
     /**
@@ -59,6 +62,7 @@ abstract class Repository implements RepositoryInterface
      * by the repository.
      *
      * @return string
+     * @psalm-return class-string
      * @api
      */
     public function getEntityClassName(): string

--- a/Neos.Flow/Classes/Persistence/Repository.php
+++ b/Neos.Flow/Classes/Persistence/Repository.php
@@ -46,12 +46,12 @@ abstract class Repository implements RepositoryInterface
      */
     public function __construct()
     {
+        /** @psalm-var class-string $entityClassName */
         if (defined('static::ENTITY_CLASSNAME') === false) {
             $entityClassName = preg_replace(['/\\\Repository\\\/', '/Repository$/'], ['\\Model\\', ''], get_class($this));
         } else {
             $entityClassName = static::ENTITY_CLASSNAME;
         }
-        assert(class_exists($entityClassName));
         $this->entityClassName = $entityClassName;
     }
 

--- a/Neos.Flow/Classes/Property/TypeConverter/PersistentObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/PersistentObjectConverter.php
@@ -162,6 +162,7 @@ class PersistentObjectConverter extends ObjectConverter
      */
     public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
     {
+        assert(class_exists($targetType));
         if (is_array($source)) {
             if ($this->reflectionService->isClassAnnotatedWith($targetType, ValueObject::class)) {
                 if (isset($source['__identity']) && (count($source) > 1)) {
@@ -225,6 +226,7 @@ class PersistentObjectConverter extends ObjectConverter
      *
      * @param array $source
      * @param string $targetType
+     * @psalm-param class-string $targetType
      * @param array $convertedChildProperties
      * @param PropertyMappingConfigurationInterface $configuration
      * @return object|TargetNotFoundError
@@ -281,6 +283,7 @@ class PersistentObjectConverter extends ObjectConverter
      *
      * @param mixed $identity
      * @param string $targetType
+     * @psalm-param class-string $targetType
      * @return object
      * @throws TargetNotFoundException
      * @throws InvalidSourceException

--- a/Neos.Flow/Classes/Property/TypeConverter/PersistentObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/PersistentObjectConverter.php
@@ -162,7 +162,7 @@ class PersistentObjectConverter extends ObjectConverter
      */
     public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
     {
-        assert(class_exists($targetType));
+        /** @psalm-var class-string $targetType */
         if (is_array($source)) {
             if ($this->reflectionService->isClassAnnotatedWith($targetType, ValueObject::class)) {
                 if (isset($source['__identity']) && (count($source) > 1)) {

--- a/Neos.Flow/Classes/Reflection/ClassReflection.php
+++ b/Neos.Flow/Classes/Reflection/ClassReflection.php
@@ -110,7 +110,7 @@ class ClassReflection extends \ReflectionClass
      * that a ClassReflection object is returned instead of the
      * orginal ReflectionClass instance.
      *
-     * @return ClassReflection|bool Reflection of the parent class - if any
+     * @return ClassReflection|false Reflection of the parent class - if any
      */
     public function getParentClass()
     {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -979,10 +979,9 @@
     <PossiblyNullArgument occurrences="1">
       <code>$pathAttribute</code>
     </PossiblyNullArgument>
-    <PossiblyNullPropertyAssignmentValue occurrences="3">
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
       <code>$domain</code>
       <code>$maximumAge</code>
-      <code>$sameSite</code>
     </PossiblyNullPropertyAssignmentValue>
     <UnsafeInstantiation occurrences="1"/>
   </file>
@@ -2025,12 +2024,6 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Reflection/ClassReflection.php">
-    <FalsableReturnStatement occurrences="1">
-      <code>($parentClass === false) ? false : new ClassReflection($parentClass-&gt;getName())</code>
-    </FalsableReturnStatement>
-    <InvalidFalsableReturnType occurrences="1">
-      <code>ClassReflection</code>
-    </InvalidFalsableReturnType>
     <InvalidNullableReturnType occurrences="1">
       <code>MethodReflection</code>
     </InvalidNullableReturnType>
@@ -2055,6 +2048,11 @@
     <PossiblyFalseArgument occurrences="1">
       <code>strpos($line, '@')</code>
     </PossiblyFalseArgument>
+  </file>
+  <file src="Packages/Framework/Neos.Flow/Classes/Reflection/Exception/ClassLoadingForReflectionFailedException.php">
+    <UndefinedClass occurrences="1">
+      <code>\Neos\Flow\Http\Component\ComponentInterface</code>
+    </UndefinedClass>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Reflection/MethodReflection.php">
     <InvalidNullableReturnType occurrences="1">
@@ -2274,12 +2272,6 @@
       <code>$source</code>
     </UndefinedInterfaceMethod>
   </file>
-  <file src="Packages/Framework/Neos.Flow/Classes/ResourceManagement/Storage/FileSystemStorage.php">
-    <LessSpecificImplementedReturnType occurrences="2">
-      <code>\Generator&lt;Object&gt;</code>
-      <code>\Generator&lt;Object&gt;</code>
-    </LessSpecificImplementedReturnType>
-  </file>
   <file src="Packages/Framework/Neos.Flow/Classes/ResourceManagement/Storage/PackageStorage.php">
     <PossiblyInvalidArrayOffset occurrences="1">
       <code>$pathInfo['basename']</code>
@@ -2433,26 +2425,6 @@
       <code>$account</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-  </file>
-  <file src="Packages/Framework/Neos.Flow/Classes/Security/Authentication/Token/PasswordToken.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
-      <code>void</code>
-    </ImplementedReturnTypeMismatch>
-  </file>
-  <file src="Packages/Framework/Neos.Flow/Classes/Security/Authentication/Token/TestingToken.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
-      <code>void</code>
-    </ImplementedReturnTypeMismatch>
-  </file>
-  <file src="Packages/Framework/Neos.Flow/Classes/Security/Authentication/Token/UsernamePassword.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
-      <code>void</code>
-    </ImplementedReturnTypeMismatch>
-  </file>
-  <file src="Packages/Framework/Neos.Flow/Classes/Security/Authentication/Token/UsernamePasswordHttpBasic.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
-      <code>void</code>
-    </ImplementedReturnTypeMismatch>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Security/Authentication/TokenAndProviderFactory.php">
     <ArgumentTypeCoercion occurrences="1">


### PR DESCRIPTION
This makes use of psalm specific docblock attributes for class-string types.
That tells Psalm to make sure that the value is always given a ::class constant

https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#class-string