### PR TITLE
TASK: Fix link target of CGL on one page PDF

### DIFF
--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartV/CodingGuideLines/PHP.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartV/CodingGuideLines/PHP.rst
@@ -25,7 +25,7 @@ CGL on One Page
 .. figure:: Images/Flow_Coding_Guidelines_on_one_page.png
     :alt: The Coding Guidelines on One Page
     :class: screenshot-detail
-    :target: ../../../_downloads/Flow_Coding_Guidelines_on_one_page.pdf
+    :target: Pdf/Flow_Coding_Guidelines_on_one_page.pdf
 
     The Coding Guidelines on One Page
 


### PR DESCRIPTION
Clicking the preview image on https://flowframework.readthedocs.io/en/stable/TheDefinitiveGuide/PartV/CodingGuideLines/PHP.html#cgl-on-one-page leads to a 404 currently