### PR TITLE
TASK: Add migration for ComponentContext deprecation

### DIFF
--- a/Neos.Flow/Migrations/Code/Version20201207104500.php
+++ b/Neos.Flow/Migrations/Code/Version20201207104500.php
@@ -22,23 +22,18 @@ namespace Neos\Flow\Core\Migrations;
  */
 class Version20201207104500 extends AbstractMigration
 {
-    /**
-     * @return string
-     */
-    public function getIdentifier()
+
+    public function getIdentifier(): string
     {
         return 'Neos.Flow-20201207104500';
     }
 
-    /**
-     * @return void
-     */
-    public function up()
+    public function up(): void
     {
         $this->searchAndReplace('use Neos\Flow\Http\Component\SetHeaderComponent;', '', ['php']);
-        $this->searchAndReplaceRegex('/->setComponentParameter\(\\?(:?[A-Za-z]\\)*SetHeaderComponent::class, (.*)\);/', '->setHttpHeader($1);', ['php']);
+        $this->searchAndReplaceRegex('/->setComponentParameter\((\\\\Neos\\\\Flow\\\\Http\\\\Component\\\\)?SetHeaderComponent::class, /', '->setHttpHeader(', ['php']);
         $this->searchAndReplace('use Neos\Flow\Http\Component\ReplaceHttpResponseComponent;', '', ['php']);
-        $this->searchAndReplaceRegex('/->setComponentParameter\(\\?(:?[A-Za-z]\\)*ReplaceHttpResponseComponent::class, \\?(:?[A-Za-z]\\)*ReplaceHttpResponseComponent::PARAMETER_RESPONSE, (.*)\);/', '->replaceHttpResponse($1);', ['php']);
+        $this->searchAndReplaceRegex('/->setComponentParameter\((\\\\Neos\\\\Flow\\\\Http\\\\Component\\\\)?ReplaceHttpResponseComponent::class, /', '->replaceHttpResponse(', ['php']);
         $this->searchAndReplace('->getComponentContext()->getHttpRequest()', '->getHttpRequest()', ['php']);
         $this->searchAndReplace('->getComponentContext()->replaceHttpRequest(', '->setHttpRequest(', ['php']);
     }

--- a/Neos.Flow/Migrations/Code/Version20201207104500.php
+++ b/Neos.Flow/Migrations/Code/Version20201207104500.php
@@ -33,7 +33,7 @@ class Version20201207104500 extends AbstractMigration
         $this->searchAndReplace('use Neos\Flow\Http\Component\SetHeaderComponent;', '', ['php']);
         $this->searchAndReplaceRegex('/->setComponentParameter\((\\\\Neos\\\\Flow\\\\Http\\\\Component\\\\)?SetHeaderComponent::class, /',\s*'->setHttpHeader(', ['php']);
         $this->searchAndReplace('use Neos\Flow\Http\Component\ReplaceHttpResponseComponent;', '', ['php']);
-        $this->searchAndReplaceRegex('/->setComponentParameter\((\\\\Neos\\\\Flow\\\\Http\\\\Component\\\\)?ReplaceHttpResponseComponent::class, /', '->replaceHttpResponse(', ['php']);
+        $this->searchAndReplaceRegex('/->setComponentParameter\((\\\\Neos\\\\Flow\\\\Http\\\\Component\\\\)?ReplaceHttpResponseComponent::class,\s*/', '->replaceHttpResponse(', ['php']);
         $this->searchAndReplace('->getComponentContext()->getHttpRequest()', '->getHttpRequest()', ['php']);
         $this->searchAndReplace('->getComponentContext()->replaceHttpRequest(', '->setHttpRequest(', ['php']);
     }

--- a/Neos.Flow/Migrations/Code/Version20201207104500.php
+++ b/Neos.Flow/Migrations/Code/Version20201207104500.php
@@ -1,0 +1,45 @@
+<?php
+namespace Neos\Flow\Core\Migrations;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Adjust code to deprecation of ComponentContext/ComponentParameters
+ *
+ * - remove "use Neos\Flow\Http\Component\SetHeaderComponent;" and "use Neos\Flow\Http\Component\ReplaceHttpResponseComponent;"
+ * - use "->setHttpHeader('Foo', 'bar')" instead of "->setComponentParameter(SetHeaderComponent::class, 'Foo', 'bar')"
+ * - use "->replaceHttpResponse($response)" instead of "->setComponentParameter(ReplaceHttpResponseComponent::class, ReplaceHttpResponseComponent::PARAMETER_RESPONSE, $response)"
+ * - use "->getHttpRequest()" instead of "->getComponentContext()->getHttpRequest()"
+ * - use "->setHttpRequest(...)" instead of "->getComponentContext()->replaceHttpRequest(...)"
+ */
+class Version20201207104500 extends AbstractMigration
+{
+    /**
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return 'Neos.Flow-20201207104500';
+    }
+
+    /**
+     * @return void
+     */
+    public function up()
+    {
+        $this->searchAndReplace('use Neos\Flow\Http\Component\SetHeaderComponent;', '', ['php']);
+        $this->searchAndReplaceRegex('/->setComponentParameter\(\\?(:?[A-Za-z]\\)*SetHeaderComponent::class, (.*)\);/', '->setHttpHeader($1);', ['php']);
+        $this->searchAndReplace('use Neos\Flow\Http\Component\ReplaceHttpResponseComponent;', '', ['php']);
+        $this->searchAndReplaceRegex('/->setComponentParameter\(\\?(:?[A-Za-z]\\)*ReplaceHttpResponseComponent::class, \\?(:?[A-Za-z]\\)*ReplaceHttpResponseComponent::PARAMETER_RESPONSE, (.*)\);/', '->replaceHttpResponse($1);', ['php']);
+        $this->searchAndReplace('->getComponentContext()->getHttpRequest()', '->getHttpRequest()', ['php']);
+        $this->searchAndReplace('->getComponentContext()->replaceHttpRequest(', '->setHttpRequest(', ['php']);
+    }
+}

--- a/Neos.Flow/Migrations/Code/Version20201207104500.php
+++ b/Neos.Flow/Migrations/Code/Version20201207104500.php
@@ -31,7 +31,7 @@ class Version20201207104500 extends AbstractMigration
     public function up(): void
     {
         $this->searchAndReplace('use Neos\Flow\Http\Component\SetHeaderComponent;', '', ['php']);
-        $this->searchAndReplaceRegex('/->setComponentParameter\((\\\\Neos\\\\Flow\\\\Http\\\\Component\\\\)?SetHeaderComponent::class, /', '->setHttpHeader(', ['php']);
+        $this->searchAndReplaceRegex('/->setComponentParameter\((\\\\Neos\\\\Flow\\\\Http\\\\Component\\\\)?SetHeaderComponent::class, /',\s*'->setHttpHeader(', ['php']);
         $this->searchAndReplace('use Neos\Flow\Http\Component\ReplaceHttpResponseComponent;', '', ['php']);
         $this->searchAndReplaceRegex('/->setComponentParameter\((\\\\Neos\\\\Flow\\\\Http\\\\Component\\\\)?ReplaceHttpResponseComponent::class, /', '->replaceHttpResponse(', ['php']);
         $this->searchAndReplace('->getComponentContext()->getHttpRequest()', '->getHttpRequest()', ['php']);


### PR DESCRIPTION
This adds some basic code migrations for the move away from HTTP Components.

Related: #2019, #2258