### PR TITLE
TASK: Set dependency on neos/fluid-adaptor in neos/kickstarter

### DIFF
--- a/Neos.Kickstarter/composer.json
+++ b/Neos.Kickstarter/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "neos/flow": "~7.0.0",
-        "neos/fluid-adaptor": "*",
+        "neos/fluid-adaptor": "~7.0.0",
         "neos/utility-arrays": "*"
     },
     "autoload": {


### PR DESCRIPTION
This should have been done automagically, see https://github.com/neos/flow-development-distribution/pull/56