### PR TITLE
TASK: Improve exception when a class can not be loaded during AOP building

### DIFF
--- a/Neos.Flow/Classes/Aop/AspectContainer.php
+++ b/Neos.Flow/Classes/Aop/AspectContainer.php
@@ -84,9 +84,6 @@ class AspectContainer
      */
     public function __construct(string $className)
     {
-        if (!class_exists($className)) {
-            throw new InvalidTargetClassException(sprintf('The class "%s" is not loadable for AOP proxy building. This is most likely an inconsistency with the caches. Try running `./flow flow:cache:flush` and if that does not help, check the class exists and is correctly namespaced.', $className), 1607422151);
-        }
         $this->className = $className;
     }
 

--- a/Neos.Flow/Classes/Aop/AspectContainer.php
+++ b/Neos.Flow/Classes/Aop/AspectContainer.php
@@ -84,6 +84,9 @@ class AspectContainer
      */
     public function __construct(string $className)
     {
+        if (!class_exists($className)) {
+            throw new InvalidTargetClassException(sprintf('The class "%s" is not loadable for AOP proxy building. This is most likely an inconsistency with the caches. Try running `./flow flow:cache:flush` and if that does not help, check the class exists and is correctly namespaced.', $className), 1607422151);
+        }
         $this->className = $className;
     }
 

--- a/Neos.Flow/Classes/Aop/Builder/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/Aop/Builder/ProxyClassBuilder.php
@@ -15,6 +15,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Aop\AdvicesTrait;
 use Neos\Flow\Aop\AspectContainer;
 use Neos\Flow\Aop\PropertyIntroduction;
+use Neos\Flow\Aop\Exception\InvalidTargetClassException;
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Log\Utility\LogEnvironment;
 use Neos\Flow\ObjectManagement\CompileTimeObjectManager;
@@ -315,6 +316,9 @@ class ProxyClassBuilder
     {
         $aspectContainer = new AspectContainer($aspectClassName);
         $methodNames = get_class_methods($aspectClassName);
+        if ($methodNames === null) {
+            throw new InvalidTargetClassException(sprintf('The class "%s" is not loadable for AOP proxy building. This is most likely an inconsistency with the caches. Try running `./flow flow:cache:flush` and if that does not help, check the class exists and is correctly namespaced.', $aspectClassName), 1607422151);
+        }
 
         foreach ($methodNames as $methodName) {
             foreach ($this->reflectionService->getMethodAnnotations($aspectClassName, $methodName) as $annotation) {


### PR DESCRIPTION
This will now throw an exception that suggests to flush caches or check the existence and namespacing of the aspect class.

Until now such a case would lead to an unhelpful exception of:
```
Warning: Invalid argument supplied for foreach() in /…/Packages/Framework/Neos.Flow/Classes/Aop/Builder/ProxyClassBuilder.php line 319
```
because the following `get_class_methods()` call would return `null` which is not checked for.