### PR TITLE
TASK: Replace symfony polyfills due to min PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,13 @@
         "neos/utility-opcodecache": "self.version",
         "neos/utility-pdo": "self.version",
         "neos/utility-schema": "self.version",
-        "neos/utility-unicode": "self.version"
+        "neos/utility-unicode": "self.version",
+        "symfony/polyfill-php54": "*",
+        "symfony/polyfill-php55": "*",
+        "symfony/polyfill-php56": "*",
+        "symfony/polyfill-php70": "*",
+        "symfony/polyfill-php71": "*",
+        "symfony/polyfill-mbstring": "*"
     },
     "suggest": {
         "ext-memcache": "If you have a memcache server and want to use it for caching.",


### PR DESCRIPTION
See https://github.com/symfony/polyfill#design

This prevents installing the symfony polyfills for php <= 7.1 and mbstring, since those are requirements of this Flow version.