### PR TITLE
BUGFIX: Don't access static properties in annotation classes

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
@@ -286,10 +286,10 @@ return ' . var_export($this->storedProxyClasses, true) . ';';
     {
         $annotationAsString = '@\\' . get_class($annotation);
 
-        $optionNames = get_object_vars($annotation);
+        $optionDefaults = get_class_vars(get_class($annotation));
+        $optionValues = get_object_vars($annotation);
         $optionsAsStrings = [];
-        foreach ($optionNames as $optionName => $optionDefault) {
-            $optionValue = $annotation->$optionName;
+        foreach ($optionValues as $optionName => $optionValue) {
             $optionValueAsString = '';
             if (is_object($optionValue)) {
                 $optionValueAsString = self::renderAnnotation($optionValue);
@@ -307,7 +307,7 @@ return ' . var_export($this->storedProxyClasses, true) . ';';
                     $optionsAsStrings[] = $optionValueAsString;
                     break;
                 default:
-                    if ($optionValue === $optionDefault) {
+                    if ($optionValue === $optionDefaults[$optionName]) {
                         break;
                     }
                     $optionsAsStrings[] = $optionName . '=' . $optionValueAsString;

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
@@ -286,7 +286,7 @@ return ' . var_export($this->storedProxyClasses, true) . ';';
     {
         $annotationAsString = '@\\' . get_class($annotation);
 
-        $optionNames = get_class_vars(get_class($annotation));
+        $optionNames = get_object_vars($annotation);
         $optionsAsStrings = [];
         foreach ($optionNames as $optionName => $optionDefault) {
             $optionValue = $annotation->$optionName;


### PR DESCRIPTION
`get_class_vars()` will also return static properties. Hence we also try to access static properties for rendering the annotation and access them non-statically. This will lead to errors.

See https://github.com/zircote/swagger-php/issues/359#issuecomment-303058035 / https://github.com/zircote/swagger-php/issues/359#issuecomment-303227013

This solves that by using `get_object_vars()`, which will only return non-static properties with their current values.