### PR TITLE
Added currently failing test case to UriConstraintsTest applyToTests …

### DIFF
--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/UriConstraintsTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/UriConstraintsTest.php
@@ -86,6 +86,7 @@ class UriConstraintsTest extends UnitTestCase
             ['constraints' => [UriConstraints::CONSTRAINT_PATH_SUFFIX => 'suffix'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => true, 'expectedUri' => 'http://some-domain.tld/suffix'],
             ['constraints' => [UriConstraints::CONSTRAINT_PATH_SUFFIX => 'suffix', UriConstraints::CONSTRAINT_PATH => '/some/path'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => '/some/pathsuffix'],
             ['constraints' => [UriConstraints::CONSTRAINT_PATH_SUFFIX => 'suffix', UriConstraints::CONSTRAINT_PATH => '/some/path'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => true, 'expectedUri' => 'http://some-domain.tld/some/pathsuffix'],
+            ['constraints' => [UriConstraints::CONSTRAINT_PATH_SUFFIX => 'suffix', UriConstraints::CONSTRAINT_PATH_PREFIX => '/prefix/', UriConstraints::CONSTRAINT_PATH => '/some/path', UriConstraints::CONSTRAINT_HOST => 'localhost'], 'templateUri' => 'http://localhost/prefix/', 'forceAbsoluteUri' => false, 'expectedUri' => '/prefix/somepathsuffix'],
         ];
     }
 


### PR DESCRIPTION
…to reproduce #2312

**What I did**
Added a test case to reproduce #2312
The testcase is reproducing what the Router passes to applyTo on my configuration.
Configuration is:
- Windows 10
- PHP 7.4.10
- IIS with Virtual Directory (in this case /prefix) pointing to Web directory of flow
