### PR TITLE
BUGFIX: Fix creation of translations with targetLanguageKeys defined

### DIFF
--- a/Neos.Kickstarter/Classes/Service/GeneratorService.php
+++ b/Neos.Kickstarter/Classes/Service/GeneratorService.php
@@ -411,7 +411,7 @@ class GeneratorService
             $parsedXliffArray = $xliffParser->getParsedData($sourceLanguageFile);
             foreach ($targetLanguageKeys as $targetLanguageKey) {
                 $contextVariables['targetLanguageKey'] = $targetLanguageKey;
-                $contextVariables['translationUnits'] = $parsedXliffArray['translationUnits'];
+                $contextVariables['translationUnits'] = $parsedXliffArray[0]['translationUnits'];
 
                 $templatePathAndFilename = 'resource://Neos.Kickstarter/Private/Generator/Translations/TargetLanguageTemplate.xlf.tmpl';
                 $fileContent = $this->renderTemplate($templatePathAndFilename, $contextVariables);


### PR DESCRIPTION
**What I did**

Previously, when trying to create translation files with targetLanguageKeys defined (`flow kickstart:translation --target-language-keys="de"` for example), an error was thrown. 
The error said, that translationUnits is not defined in Neos\Kickstarter\Service\GeneratorService. This is, because Neos\Flow\I18n\Xliff\V12\XliffParser::getParsedData will return an array (for each <file>-Entry in the Xliff-File, typically only one entry). So we need to use the first item of that data to get the translationUnits from it. 

**How I did it**

I only made a little change and added `[0]` to `$parsedXliffArray` in `Neos\Kickstarter\Service\GeneratorService::generateTranslation()`.

**How to verify it**

1. Try to kickstart a translation with `--target-language-keys` defined. An error will be thrown.
2. Change `$parsedXliffArray['translationUnits']` to `$parsedXliffArray[0]['translationUnits']` in the foreach loop of `Neos\Kickstarter\Service\GeneratorService::generateTranslation()`.
3. Retry to kickstart the translations.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
  - Lowest maintained branch is 4.3, so the PR is created against that version.
