### PR TITLE
BUGFIX: Set Flow_Security_Cryptography_HashService defaultLifetime explicitly

### DIFF
--- a/Neos.Flow/Configuration/Caches.yaml
+++ b/Neos.Flow/Configuration/Caches.yaml
@@ -119,6 +119,8 @@ Flow_Security_Cryptography_HashService:
   frontend: Neos\Cache\Frontend\StringFrontend
   backend: Neos\Cache\Backend\SimpleFileBackend
   persistent: true
+  backendOptions:
+    defaultLifetime: 0
 
 
 # Flow_Session_*


### PR DESCRIPTION
Otherwise changing the default configs defaultLifetime will also make this cache be emptied unexpectedly and unnecessarily.