### PR TITLE
BUGFIX: Correctly handle missing configuration with identity creation

### DIFF
--- a/Neos.Flow/Classes/ResourceManagement/ResourceTypeConverter.php
+++ b/Neos.Flow/Classes/ResourceManagement/ResourceTypeConverter.php
@@ -237,7 +237,7 @@ class ResourceTypeConverter extends AbstractTypeConverter
                 return $resource;
             }
 
-            if ($configuration->getConfigurationValue(ResourceTypeConverter::class, self::CONFIGURATION_IDENTITY_CREATION_ALLOWED) !== true) {
+            if ($configuration === null || $configuration->getConfigurationValue(ResourceTypeConverter::class, self::CONFIGURATION_IDENTITY_CREATION_ALLOWED) !== true) {
                 throw new InvalidPropertyMappingConfigurationException('Creation of resource objects with identity not allowed. To enable this, you need to set the PropertyMappingConfiguration Value "CONFIGURATION_IDENTITY_CREATION_ALLOWED" to true');
             }
         }


### PR DESCRIPTION
The code did not handle a missing `$configuration` when converting an hash and data array containing an identifier.

See https://github.com/neos/flow-development-collection/pull/1931/files#r503144893