### PR TITLE
BUGFIX: Finalize introduction of role and privilege metadata

### DIFF
--- a/Neos.Flow/Classes/Command/SecurityCommandController.php
+++ b/Neos.Flow/Classes/Command/SecurityCommandController.php
@@ -359,7 +359,7 @@ class SecurityCommandController extends CommandController
     public function listRolesCommand(bool $includeAbstract = false): void
     {
         $roles = $this->policyService->getRoles($includeAbstract);
-        $this->output->outputTable(array_map(static function(Role $role) {
+        $this->output->outputTable(array_map(static function (Role $role) {
             $id = $role->getIdentifier();
             if ($role->isAbstract()) {
                 $id .= ' (*)';

--- a/Neos.Flow/Classes/Command/SecurityCommandController.php
+++ b/Neos.Flow/Classes/Command/SecurityCommandController.php
@@ -15,10 +15,12 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cache\CacheManager;
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Cli\CommandController;
+use Neos\Flow\Configuration\Exception\InvalidConfigurationTypeException;
 use Neos\Flow\Mvc\Controller\AbstractController;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Security\Cryptography\RsaWalletServicePhp;
+use Neos\Flow\Security\Exception as SecurityException;
 use Neos\Flow\Security\Exception\NoSuchRoleException;
 use Neos\Flow\Security\Policy\PolicyService;
 use Neos\Flow\Security\Authorization\Privilege\Method\MethodPrivilegeInterface;
@@ -345,6 +347,79 @@ class SecurityCommandController extends CommandController
                 $this->outputLine('  ' . $methodName);
             }
             $this->outputLine();
+        }
+    }
+
+    /**
+     * List all configured roles
+     *
+     * @param bool $includeAbstract Set this flag to include abstract roles
+     * @throws InvalidConfigurationTypeException | SecurityException
+     */
+    public function listRolesCommand(bool $includeAbstract = false): void
+    {
+        $roles = $this->policyService->getRoles($includeAbstract);
+        $this->output->outputTable(array_map(static function(Role $role) {
+            $id = $role->getIdentifier();
+            if ($role->isAbstract()) {
+                $id .= ' (*)';
+            }
+            return [$id, $role->getLabel()];
+        }, $roles), ['Id', 'Label']);
+        if ($includeAbstract) {
+            $this->outputLine(' (*) = abstract role');
+        }
+        $this->outputLine();
+        $this->outputLine('Run <i>./flow security:describeRole <id></i> to show details for a role');
+    }
+
+    /**
+     * Show details of a specified role
+     *
+     * @param string $role identifier of the role to describe (for example "Neos.Flow:Everybody")
+     * @throws InvalidConfigurationTypeException | SecurityException
+     */
+    public function describeRoleCommand(string $role): void
+    {
+        $roleInstance = $this->policyService->getRole($role);
+        $this->outputLine('Details of the <b>%s</b> role:', [$roleInstance->getIdentifier()]);
+        $this->outputLine();
+        if ($roleInstance->isAbstract()) {
+            $this->outputLine('<b>Note:</b> This is an <i>abstract</i> role so it\'t can\'t be assigned to accounts directly');
+            $this->outputLine();
+        }
+        $this->outputLine('<b>Name:</b> %s', [$roleInstance->getName()]);
+        $this->outputLine('<b>Package:</b> %s', [$roleInstance->getPackageKey()]);
+        if ($roleInstance->getLabel() !== $roleInstance->getName()) {
+            $this->outputLine('<b>Label:</b> %s', [$roleInstance->getLabel()]);
+        }
+        if (!empty($roleInstance->getDescription())) {
+            $this->outputLine('<b>Description:</b>');
+            $this->outputFormatted($roleInstance->getDescription(), [], 1);
+        }
+        $this->outputLine();
+        $this->outputLine('<b>Parent role(s):</b>');
+        $parentRoles = $roleInstance->getAllParentRoles();
+        if ($parentRoles === []) {
+            $this->outputLine('-');
+        } else {
+            foreach ($parentRoles as $parentRole) {
+                $this->outputLine(' * %s', [$parentRole->getIdentifier()]);
+            }
+        }
+        $privileges = $roleInstance->getPrivileges();
+        $this->outputLine();
+        $this->outputLine('<b>Privileges:</b>');
+        if ($privileges === []) {
+            $this->outputLine('-');
+        } else {
+            foreach ($privileges as $privilege) {
+                $target = $privilege->getPrivilegeTarget();
+                $this->outputLine(' * %s: <i>%s</i>', [$privilege->getPrivilegeTargetIdentifier(), strtoupper($privilege->getPermission())]);
+                if ($target->getLabel() !== $privilege->getPrivilegeTargetIdentifier()) {
+                    $this->outputFormatted($target->getLabel(), [], 5);
+                }
+            }
         }
     }
 }

--- a/Neos.Flow/Classes/Security/Policy/PolicyService.php
+++ b/Neos.Flow/Classes/Security/Policy/PolicyService.php
@@ -107,7 +107,7 @@ class PolicyService
         $privilegeTargetsForEverybody = $this->privilegeTargets;
 
         $this->roles = [];
-        $everybodyRole = new Role('Neos.Flow:Everybody');
+        $everybodyRole = new Role('Neos.Flow:Everybody', [], (string)($this->policyConfiguration['roles']['Neos.Flow:Everybody']['label'] ?? ''), (string)($this->policyConfiguration['roles']['Neos.Flow:Everybody']['description'] ?? ''));
         $everybodyRole->setAbstract(true);
         if (isset($this->policyConfiguration['roles'])) {
             foreach ($this->policyConfiguration['roles'] as $roleIdentifier => $roleConfiguration) {

--- a/Neos.Flow/Configuration/Policy.yaml
+++ b/Neos.Flow/Configuration/Policy.yaml
@@ -9,11 +9,17 @@
 roles:
   'Neos.Flow:Everybody':
     abstract: true
+    label: 'Magic "everybody" role'
+    description: 'This magic role is always active, even if no account is authenticated'
 
   'Neos.Flow:Anonymous':
     abstract: true
+    label: 'Magic "anonymous" role'
+    description: 'This magic role is active if no account is authenticated'
 
   'Neos.Flow:AuthenticatedUser':
     abstract: true
+    label: 'Magic "authenticated user" role'
+    description: 'This magic role is active if an account is authenticated'
 
 privilegeTargets: []

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Security.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Security.rst
@@ -959,8 +959,8 @@ All policy definitions are configured in the ``Policy.yaml`` files.
 *Privilege Targets*
 
 In general a Privilege Target is the definition pointing to something you want to protect.
-It consists of a **Privilege Type**, a **unique name** and a **matcher expression** defining which
-things should be protected by this target.
+It consists of a **Privilege Type**, a **unique name**, an optional human readable **label** and a **matcher expression**
+defining which things should be protected by this target.
 
 The privilege type defines the nature of the element to protect. This could be the execution of a certain action in your
 system, the retrieval of objects from the database, or any other kind of action you want to supervise in your
@@ -977,6 +977,7 @@ methods.
     'Neos\Flow\Security\Authorization\Privilege\Method\MethodPrivilege':
 
       'Acme.MyPackage:RestrictedController.customerAction':
+        label: 'Optional label to describe this privilege target'
         matcher: 'method(Acme\MyPackage\Controller\RestrictedController->customerAction())'
 
       'Acme.MyPackage:RestrictedController.adminAction':
@@ -985,7 +986,10 @@ methods.
       'Acme.MyPackage:editOwnPost':
         matcher: 'method(Acme\MyPackage\Controller\PostController->editAction(post.owner == current.userService.currentUser))'
 
+.. note:
 
+  The label will be rendered by the ``./flow security:describeRole <role>`` CLI command for a corresponding role and it
+  can be used to render a more human readable description in UIs (such as the user management module in the Neos backend)
 
 Privilege targets are defined in the ``Policy.yaml`` file of your package and are grouped by their respective types,
 which are define by the fully qualified classname of the privilege type to be used (e.g.
@@ -1026,6 +1030,8 @@ privileges to them.
 
   roles:
     'Acme.MyPackage:Administrator':
+      label: 'Optional label for this role'
+      description: 'Optional description of this role'
       privileges: []
 
     'Acme.MyPackage:Customer':
@@ -1044,6 +1050,11 @@ configure yourself. This role will also be present, if no account is authenticat
 
 Likewise, the magic role ``Neos.Flow:Anonymous`` is added to the security context if no user
 is authenticated and ``Neos.Flow:AuthenticatedUser`` if there is an authenticated user.
+
+.. note:
+
+  The label and description will be rendered by the ``./flow security:describeRole <role>`` CLI command for a corresponding role
+  and it can be used to render more human readable descriptions in UIs (such as the user management module in the Neos backend)
 
 *Defining Privileges and Permissions*
 

--- a/Neos.Flow/Resources/Private/Schema/Policy.schema.yaml
+++ b/Neos.Flow/Resources/Private/Schema/Policy.schema.yaml
@@ -10,6 +10,7 @@ properties:
         type: dictionary
         additionalProperties: false
         properties:
+          'label': {type: string}
           'matcher':
             type: string
             required: true
@@ -29,6 +30,8 @@ properties:
       additionalProperties: false
       properties:
         'abstract': {type: boolean}
+        'label': {type: string}
+        'description': {type: string}
         'parentRoles':
           type: array
           items: {type: string}


### PR DESCRIPTION
This builds upon the work started with #2166 and

* Fixes the Policy schema
* Adds label & description to the "magic" base roles
* Adds CLI commands in order to make use of the metadata
  within Flow

Usage:

    ./flow security:listRoles --include-abstract
    ./flow security:describeRole Neos.Flow:Everybody

Related: #2162