### PR TITLE
BUGFIX: Reduce the migration message to one line

### DIFF
--- a/Neos.Flow/Migrations/Code/Version20201205172733.php
+++ b/Neos.Flow/Migrations/Code/Version20201205172733.php
@@ -14,8 +14,7 @@ namespace Neos\Flow\Core\Migrations;
 use Neos\Utility\Files;
 
 /**
- * This migration does not actually change any code. It just displays a warning if a PHP file still refers
- * to the no longer existing ComponentInterface
+ * This migration does not actually change any code. It just displays a warning if a PHP file still refers to the no longer existing ComponentInterface
  */
 class Version20201205172733 extends AbstractMigration
 {


### PR DESCRIPTION
Currently only the first part of the line is displayed

![image](https://user-images.githubusercontent.com/642226/102323341-a5812480-3f80-11eb-8582-bc9cee431d2a.png)
