### PR TITLE
BUGFIX: Avoid passing signal information depending on other signals to same slot

### DIFF
--- a/Neos.Flow/Classes/SignalSlot/Dispatcher.php
+++ b/Neos.Flow/Classes/SignalSlot/Dispatcher.php
@@ -149,6 +149,7 @@ class Dispatcher
         }
 
         foreach ($this->slots[$signalClassName][$signalName] as $slotInformation) {
+            $finalSlotArguments = $signalArguments;
             if (isset($slotInformation['object'])) {
                 $object = $slotInformation['object'];
             } elseif (strpos($slotInformation['method'], '::') === 0) {
@@ -176,13 +177,13 @@ class Dispatcher
             }
 
             if ($slotInformation['useSignalInformationObject'] === true) {
-                call_user_func([$object, $slotInformation['method']], new SignalInformation($signalClassName, $signalName, $signalArguments));
+                call_user_func([$object, $slotInformation['method']], new SignalInformation($signalClassName, $signalName, $finalSignalArguments));
             } else {
                 if ($slotInformation['passSignalInformation'] === true) {
-                    $signalArguments[] = $signalClassName . '::' . $signalName;
+                    $finalSignalArguments[] = $signalClassName . '::' . $signalName;
                 }
                 // Need to use call_user_func_array here, because $object may be the class name when the slot is a static method
-                call_user_func_array([$object, $slotInformation['method']], $signalArguments);
+                call_user_func_array([$object, $slotInformation['method']], $finalSignalArguments);
             }
         }
     }

--- a/Neos.Flow/Classes/SignalSlot/Dispatcher.php
+++ b/Neos.Flow/Classes/SignalSlot/Dispatcher.php
@@ -149,7 +149,7 @@ class Dispatcher
         }
 
         foreach ($this->slots[$signalClassName][$signalName] as $slotInformation) {
-            $finalSlotArguments = $signalArguments;
+            $finalSignalArguments = $signalArguments;
             if (isset($slotInformation['object'])) {
                 $object = $slotInformation['object'];
             } elseif (strpos($slotInformation['method'], '::') === 0) {


### PR DESCRIPTION
This fixes a regression introduced with #2216

Fixes neos/content-repository-search#42