### PR TITLE
BUGFIX: Return correct type for EEL trunc math helper

### DIFF
--- a/Neos.Eel/Classes/Helper/MathHelper.php
+++ b/Neos.Eel/Classes/Helper/MathHelper.php
@@ -492,9 +492,9 @@ class MathHelper implements ProtectedContextAwareInterface
         $sign = $this->sign($x);
         switch ($sign) {
             case -1:
-                return ceil($x);
+                return (int)ceil($x);
             case 1:
-                return floor($x);
+                return (int)floor($x);
             default:
                 return $sign;
         }


### PR DESCRIPTION
The internally used `ceil` and `floor` methods of the `trunc` helper return a float which doesn’t
match the signature anymore and leads to unexpected comparison issues when using this helper in Fusion.

**What I did**

Cast the return values to int.

**How I did it**

See above

**How to verify it**

Call `trunc` with a positive int as parameter and check the type of the returned value. Instead of an int you would get a float.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
