### PR TITLE
TASK: Update documentation to remove deprecated Doctrine connection

### DIFF
--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
@@ -1166,6 +1166,9 @@ that connection wrapper by setting the following options in your packages ``Sett
                user: 'user'             # adjust to your database user
                password: 'pass'         # adjust to your database password
 
+.. note::
+	In doctrine/dbal versions lower then 2.11 the wrapper class was named `MasterSlaveConnection`, so you need to adjust to that if you are such a version.
+
 With this setup, Doctrine will use one of the replica connections picked once per request randomly
 for all queries until the first writing query (e.g. insert or update) is executed. From that point
 on the primary server will be used solely. This is to solve the problems of replication lag and

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
@@ -1138,12 +1138,12 @@ Doctrine tries to keep existing data as far as possible, avoiding lossy actions.
 	``flow:doctrine:migrationversion --version all --add`` to avoid migration
 	errors later.
 
-Doctrine Connection Wrappers - Master/Slave Connections
+Doctrine Connection Wrappers - Primary/Replica Connections
 -------------------------------------------------------
 
 Doctrine 2 allows to create Connection wrapper classes, that change the way Doctrine connects
-to your database. A common use case is a master/slave replication setup, with one master server
-and several slaves that share the load for all reading queries.
+to your database. A common use case is a primary/replica setup, with one primary server
+and several read replicas that share the load for all reading queries.
 Doctrine already provides a wrapper for such a connection and you can configure Flow to use
 that connection wrapper by setting the following options in your packages ``Settings.yaml``:
 
@@ -1153,28 +1153,28 @@ that connection wrapper by setting the following options in your packages ``Sett
      Flow:
        persistence:
          backendOptions:
-           wrapperClass: 'Doctrine\DBAL\Connections\MasterSlaveConnection'
-           master:
+           wrapperClass: 'Doctrine\DBAL\Connections\PrimaryReadReplicaConnection'
+           primary:
              host: '127.0.0.1'      # adjust to your master database host
              dbname: 'master'       # adjust to your database name
              user: 'user'           # adjust to your database user
              password: 'pass'       # adjust to your database password
-           slaves:
-             slave1:
+           replicas:
+             replica1:
                host: '127.0.0.1'        # adjust to your slave database host
-               dbname: 'slave1'         # adjust to your database name
+               dbname: 'replica1'       # adjust to your database name
                user: 'user'             # adjust to your database user
                password: 'pass'         # adjust to your database password
 
-With this setup, Doctrine will use one of the slave connections picked once per request randomly
+With this setup, Doctrine will use one of the replica connections picked once per request randomly
 for all queries until the first writing query (e.g. insert or update) is executed. From that point
-on the master server will be used solely. This is to solve the problems of replication lag and
+on the primary server will be used solely. This is to solve the problems of replication lag and
 possibly inconsistent query results.
 
 .. tip::
 
-	You can also setup the master database as a slave, if you want to also use it for load-balancing
-	reading queries. However, this might lead to higher load on the master database and should be
+	You can also setup the primary database as a replica, if you want to also use it for load-balancing
+	reading queries. However, this might lead to higher load on the primary database and should be
 	well observed.
 
 Known issues


### PR DESCRIPTION
Since doctrine/dbal 2.11 PrimaryReadReplicaConnection should be used.
This change updates the documentation to reflect this change.
See https://github.com/doctrine/dbal/issues/4052 for details.