### PR TITLE
FEATURE: Introduce ability to add Fluid namespaces via configuration

### DIFF
--- a/Neos.FluidAdaptor/Classes/Core/ViewHelper/ViewHelperResolver.php
+++ b/Neos.FluidAdaptor/Classes/Core/ViewHelper/ViewHelperResolver.php
@@ -54,6 +54,12 @@ class ViewHelperResolver extends \TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperRes
     protected $namespaces = [];
 
     /**
+     * @Flow\InjectConfiguration(path="defaultNamespaces")
+     * @var array
+     */
+    protected $defaultNamespacesFromConfiguration;
+
+    /**
      * ViewHelperResolver constructor.
      */
     public function __construct()
@@ -77,6 +83,10 @@ class ViewHelperResolver extends \TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperRes
                 $viewHelperNamespace .= 'ViewHelpers';
                 $this->addNamespace(strtolower($package->getPackageKey()), $viewHelperNamespace);
             }
+        }
+
+        foreach ($this->defaultNamespacesFromConfiguration as $identifier => $namespace) {
+            $this->addNamespace($identifier, $namespace);
         }
     }
 

--- a/Neos.FluidAdaptor/Classes/Core/ViewHelper/ViewHelperResolver.php
+++ b/Neos.FluidAdaptor/Classes/Core/ViewHelper/ViewHelperResolver.php
@@ -59,14 +59,6 @@ class ViewHelperResolver extends \TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperRes
      */
     protected $namespacesFromConfiguration;
 
-    /**
-     * ViewHelperResolver constructor.
-     */
-    public function __construct()
-    {
-        $this->setNamespaces($this->getDefaultNamespaces());
-    }
-
     public function initializeObject($reason)
     {
         if ($reason === ObjectManagerInterface::INITIALIZATIONCAUSE_RECREATED) {
@@ -88,19 +80,6 @@ class ViewHelperResolver extends \TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperRes
         foreach ($this->namespacesFromConfiguration as $identifier => $namespace) {
             $this->addNamespace($identifier, $namespace);
         }
-    }
-
-    /**
-     *
-     */
-    public function getDefaultNamespaces()
-    {
-        return [
-            'f' => [
-                'TYPO3Fluid\\Fluid\\ViewHelpers',
-                'Neos\\FluidAdaptor\\ViewHelpers'
-            ]
-        ];
     }
 
     /**

--- a/Neos.FluidAdaptor/Classes/Core/ViewHelper/ViewHelperResolver.php
+++ b/Neos.FluidAdaptor/Classes/Core/ViewHelper/ViewHelperResolver.php
@@ -54,10 +54,10 @@ class ViewHelperResolver extends \TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperRes
     protected $namespaces = [];
 
     /**
-     * @Flow\InjectConfiguration(path="defaultNamespaces")
+     * @Flow\InjectConfiguration(path="namespaces")
      * @var array
      */
-    protected $defaultNamespacesFromConfiguration;
+    protected $namespacesFromConfiguration;
 
     /**
      * ViewHelperResolver constructor.
@@ -85,7 +85,7 @@ class ViewHelperResolver extends \TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperRes
             }
         }
 
-        foreach ($this->defaultNamespacesFromConfiguration as $identifier => $namespace) {
+        foreach ($this->namespacesFromConfiguration as $identifier => $namespace) {
             $this->addNamespace($identifier, $namespace);
         }
     }

--- a/Neos.FluidAdaptor/Configuration/Settings.yaml
+++ b/Neos.FluidAdaptor/Configuration/Settings.yaml
@@ -57,8 +57,8 @@ Neos:
             namespaces:
               f: 'Neos\FluidAdaptor\ViewHelpers'
 
-  # # Example default namespaces
-  # FluidAdaptor:
-  #   namespaces:
-  #     p: 'Company\Package\ViewHelpers'
-  #     d: 'Acme\Demo\ViewHelpers'
+  FluidAdaptor:
+    namespaces:
+      f:
+        - 'TYPO3Fluid\Fluid\ViewHelpers'
+        - 'Neos\FluidAdaptor\ViewHelpers'

--- a/Neos.FluidAdaptor/Configuration/Settings.yaml
+++ b/Neos.FluidAdaptor/Configuration/Settings.yaml
@@ -56,3 +56,9 @@ Neos:
           options:
             namespaces:
               f: 'Neos\FluidAdaptor\ViewHelpers'
+
+  # # Example default namespaces
+  # FluidAdaptor:
+  #   defaultNamespaces:
+  #     p: 'Company\Package\ViewHelpers
+  #     d: 'Acme\Demo\ViewHelpers'

--- a/Neos.FluidAdaptor/Configuration/Settings.yaml
+++ b/Neos.FluidAdaptor/Configuration/Settings.yaml
@@ -59,6 +59,6 @@ Neos:
 
   # # Example default namespaces
   # FluidAdaptor:
-  #   defaultNamespaces:
-  #     p: 'Company\Package\ViewHelpers
+  #   namespaces:
+  #     p: 'Company\Package\ViewHelpers'
   #     d: 'Acme\Demo\ViewHelpers'


### PR DESCRIPTION
**What I did**
Added the ability to add Fluid namespaces via configuration.

**How I did it**
By adding a new configuration option:
```
Neos:
    FluidAdaptor: 
      defaultNamespaces
```
This configuration is used, to add namespaces inside the ViewHelperResolver.

**How to verify it**
Add a default namespace in Settings.yaml and try to use its view helpers in any template, without including the namespace there.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)

Resolves: #2375 