### PR TITLE
BUGFIX: Correctly extract port from memcached servers setting

### DIFF
--- a/Neos.Cache/Classes/Backend/MemcachedBackend.php
+++ b/Neos.Cache/Classes/Backend/MemcachedBackend.php
@@ -119,10 +119,10 @@ class MemcachedBackend extends IndependentAbstractBackend implements TaggableBac
             if (strpos($server, 'tcp://') === 0) {
                 $port = $defaultPort;
                 $server = substr($server, 6);
+            }
 
-                if (strpos($server, ':') !== false) {
-                    list($host, $port) = explode(':', $server, 2);
-                }
+            if (strpos($server, ':') !== false) {
+                [$host, $port] = explode(':', $server, 2);
             }
 
             $this->memcache->addServer($host, $port);

--- a/Neos.Cache/Classes/Backend/MemcachedBackend.php
+++ b/Neos.Cache/Classes/Backend/MemcachedBackend.php
@@ -91,6 +91,9 @@ class MemcachedBackend extends IndependentAbstractBackend implements TaggableBac
             throw new Exception('The PHP extension "memcache" or "memcached" must be installed and loaded in order to use the Memcache backend.', 1213987706);
         }
         parent::__construct($environmentConfiguration, $options);
+        if (!count($this->servers)) {
+            throw new Exception('No servers were given to Memcache', 1213115903);
+        }
     }
 
     /**

--- a/Neos.Cache/Classes/Backend/MemcachedBackend.php
+++ b/Neos.Cache/Classes/Backend/MemcachedBackend.php
@@ -122,7 +122,8 @@ class MemcachedBackend extends IndependentAbstractBackend implements TaggableBac
             }
 
             if (strpos($server, ':') !== false) {
-                [$host, $port] = explode(':', $server, 2);
+                [$host, $portValue] = explode(':', $server, 2);
+                $port = (int)$portValue;
             }
 
             $this->memcache->addServer($host, $port);


### PR DESCRIPTION
This fixes the extraction of the port from the `servers` option(s) if they are not bound to the `tcp://` protocol and checks for missing `servers` option in constructor.