### PR TITLE
TASK: Correctly extract target branch for pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Set Flow target branch name
-        run: echo "FLOW_TARGET_VERSION=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+        run: echo "FLOW_TARGET_VERSION=${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
         working-directory: .
 
       - name: Checkout


### PR DESCRIPTION
For PRs the `GITHUB_REF` points to `refs/pull/$PRNUMBER/merge`, which does not contain the base branch at all.