### PR TITLE
BUGFIX: Prevent wrong code replacements in migration

### DIFF
--- a/Neos.Flow/Migrations/Code/Version20201109224100.php
+++ b/Neos.Flow/Migrations/Code/Version20201109224100.php
@@ -33,7 +33,7 @@ class Version20201109224100 extends AbstractMigration
     public function up()
     {
         $this->searchAndReplace('Doctrine\DBAL\Migrations\AbstractMigration', 'Doctrine\Migrations\AbstractMigration', ['php']);
-        $this->searchAndReplaceRegex('/public function getDescription\(\)(\s*\{)?$/m', 'public function getDescription(): string $1', ['php']);
+        $this->searchAndReplaceRegex('/(Neos\\\Flow\\\Persistence\\\Doctrine\\\Migrations.+)public function getDescription\(\)(\s*\{)?$/sm', '$1public function getDescription(): string $2', ['php']);
         $this->searchAndReplaceRegex('/public function (up|down|preUp|postUp|preDown|postDown)\(Schema \$schema\)(\s*\{)?$/m', 'public function $1(Schema \$schema): void $2', ['php']);
     }
 }

--- a/Neos.Flow/Migrations/Code/Version20201109224100.php
+++ b/Neos.Flow/Migrations/Code/Version20201109224100.php
@@ -33,7 +33,7 @@ class Version20201109224100 extends AbstractMigration
     public function up()
     {
         $this->searchAndReplace('Doctrine\DBAL\Migrations\AbstractMigration', 'Doctrine\Migrations\AbstractMigration', ['php']);
-        $this->searchAndReplaceRegex('/(Neos\\\Flow\\\Persistence\\\Doctrine\\\Migrations.+)public function getDescription\(\)(\s*\{)?$/sm', '$1public function getDescription(): string $2', ['php']);
+        $this->searchAndReplaceRegex('/(namespace Neos\\\Flow\\\Persistence\\\Doctrine\\\Migrations.+)public function getDescription\(\)(\s*\{)?$/sm', '$1public function getDescription(): string $2', ['php']);
         $this->searchAndReplaceRegex('/public function (up|down|preUp|postUp|preDown|postDown)\(Schema \$schema\)(\s*\{)?$/m', 'public function $1(Schema \$schema): void $2', ['php']);
     }
 }


### PR DESCRIPTION
**What I did**
I added the Flow migration namespace to the regex in code migration Version20201109224100. This prevents getDescription methods that are not part of a doctrine migration class to be changed (see #2363).

**How I did it**
I added the namespace to the regex (which makes the regex a bit ugly). I am not sure if it was perhaps better to collect all relevant files (e.g. based on directory structure) instead and apply all searchAndReplace operations only to those files.

**How to verify it**
Create a regular class and a doctrine migration and add a getDescription method without return type signature to both classes. When you execute the code migration, only the method signature of the doctrine migration class should be changed.