### PR TITLE
BUGFIX: `Array.filter` fails with empty callback

### DIFF
--- a/Neos.Eel/Classes/Helper/ArrayHelper.php
+++ b/Neos.Eel/Classes/Helper/ArrayHelper.php
@@ -445,7 +445,11 @@ class ArrayHelper implements ProtectedContextAwareInterface
      */
     public function filter(array $array, callable $callback = null): array
     {
-        return array_filter($array, $callback, ARRAY_FILTER_USE_BOTH);
+        if (is_null($callback)) {
+            return array_filter($array);
+        } else {
+            return array_filter($array, $callback, ARRAY_FILTER_USE_BOTH);
+        }
     }
 
     /**

--- a/Neos.Eel/Tests/Unit/Helper/ArrayHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/ArrayHelperTest.php
@@ -617,6 +617,15 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
                     2 => 'c',
                 ],
             ],
+            'test with empty filter function' => [
+                [1,null,2,null,3],
+                null,
+                [
+                    0 => 1,
+                    2 => 2,
+                    4 => 3,
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
According to the documentation and method signature the callback argument in the Array.filter Eel method is optional.

Also the underlying php function array_filter supports beeing called without a callback. In which case it filters empty values which is really handy in places. However due to the passed flag ARRAY_FILTER_USE_BOTH this leads to an error.

The code adjusts the call to array_filter to only pass callback and ARRAY_FILTER_USE_BOTH if the filter is not null and adds a testcase for an empty filter.

Resolves: #2401 2401