### PR TITLE
BUGFIX: Check for valid session identifier before accessing the cache

### DIFF
--- a/Neos.Flow/Classes/Session/Session.php
+++ b/Neos.Flow/Classes/Session/Session.php
@@ -340,6 +340,7 @@ class Session implements CookieEnabledInterface
         }
         $sessionIdentifier = $this->sessionCookie->getValue();
         if ($this->metaDataCache->isValidEntryIdentifier($sessionIdentifier) === false) {
+            $this->logger->warning('SESSION IDENTIFIER INVALID: ' . $sessionIdentifier, LogEnvironment::fromMethodName(__METHOD__));
             return false;
         }
         $sessionMetaData = $this->metaDataCache->get($sessionIdentifier);

--- a/Neos.Flow/Classes/Session/Session.php
+++ b/Neos.Flow/Classes/Session/Session.php
@@ -338,7 +338,11 @@ class Session implements CookieEnabledInterface
         if ($this->sessionCookie === null || $this->started === true) {
             return false;
         }
-        $sessionMetaData = $this->metaDataCache->get($this->sessionCookie->getValue());
+        $sessionIdentifier = $this->sessionCookie->getValue();
+        if ($this->metaDataCache->isValidEntryIdentifier($sessionIdentifier) === false) {
+            return false;
+        }
+        $sessionMetaData = $this->metaDataCache->get($sessionIdentifier);
         if ($sessionMetaData === false) {
             return false;
         }


### PR DESCRIPTION
Currently it is possible to change the cookie value of `Neos_Flow_Session` (`TYPO3_Flow_Session`) to an invalid cache identifier. This leads to an `InvalidArgumentException` and an error code 500. 
This pull requests checks the validity of the session identifier before attempting to access the `metaDataCache`.

Retargeted follow-up to #1132
Thanks @Torsten85 and sorry for being late with accepting this