### PR TITLE
BUGFIX: WithAddedHeader does not overwrite existing header

### DIFF
--- a/Neos.Flow/Classes/Http/AbstractMessage.php
+++ b/Neos.Flow/Classes/Http/AbstractMessage.php
@@ -434,7 +434,7 @@ abstract class AbstractMessage implements MessageInterface
     public function withAddedHeader($name, $value)
     {
         $newMessage = clone $this;
-        $newMessage->setHeader($name, $value);
+        $newMessage->setHeader($name, $value, false);
 
         return $newMessage;
     }

--- a/Neos.Flow/Tests/Unit/Http/AbstractMessageTest.php
+++ b/Neos.Flow/Tests/Unit/Http/AbstractMessageTest.php
@@ -64,6 +64,20 @@ class AbstractMessageTest extends UnitTestCase
     /**
      * @test
      */
+    public function withAddedHeaderActuallyAddsHeader()
+    {
+        $message = $this->getAbstractMessageMock();
+        $message = $message
+            ->withAddedHeader('MyHeader', 'MyValue')
+            ->withAddedHeader('MyHeader', 'OtherValue');
+
+        $expectedHeaders = ['MyHeader' => ['MyValue', 'OtherValue']];
+        $this->assertEquals($expectedHeaders, $message->getHeaders()->getAll());
+    }
+
+    /**
+     * @test
+     */
     public function getHeaderReturnsAStringOrAnArray()
     {
         $message = $this->getAbstractMessageMock();


### PR DESCRIPTION
Previously the PSR-7 forward compatibility method `withAddedHeader()` would overwrite existing headers and was hence the same as `withHeader()`. This change fixes that by correctly setting the `$overwrite` argument in the delegate method.

See https://github.com/neos/flow-development-collection/pull/2361#discussion_r588867079