### PR TITLE
BUGFIX: Authentication tests don't depend on test running within a second

### DIFF
--- a/Neos.Flow/Tests/Functional/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
+++ b/Neos.Flow/Tests/Functional/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
@@ -72,7 +72,7 @@ class PersistedUsernamePasswordProviderTest extends FunctionalTestCase
         $this->assertTrue($this->authenticationToken->isAuthenticated());
 
         $account = $this->accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName('username', 'myTestProvider');
-        $this->assertEquals((new \DateTime())->format(\DateTime::W3C), $account->getLastSuccessfulAuthenticationDate()->format(\DateTime::W3C));
+        $this->assertNotNull($account->getLastSuccessfulAuthenticationDate());
         $this->assertEquals(0, $account->getFailedAuthenticationCount());
     }
 
@@ -120,7 +120,7 @@ class PersistedUsernamePasswordProviderTest extends FunctionalTestCase
         $this->persistedUsernamePasswordProvider->authenticate($this->authenticationToken);
 
         $account = $this->accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName('username', 'myTestProvider');
-        $this->assertEquals((new \DateTime())->format(\DateTime::W3C), $account->getLastSuccessfulAuthenticationDate()->format(\DateTime::W3C));
+        $this->assertNotNull($account->getLastSuccessfulAuthenticationDate());
         $this->assertEquals(0, $account->getFailedAuthenticationCount());
     }
 }


### PR DESCRIPTION
This prevents the tests from failing occasionally because the test starts directly before the current second switches.