### PR TITLE
TASK: Disable old class loader in testing context by default

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -894,6 +894,6 @@ class Scripts
      */
     protected static function useClassLoader(Bootstrap $bootstrap)
     {
-        return (!FLOW_ONLY_COMPOSER_LOADER || $bootstrap->getContext()->isTesting());
+        return (defined('FLOW_ONLY_COMPOSER_LOADER') && FLOW_ONLY_COMPOSER_LOADER === false);
     }
 }

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -894,6 +894,6 @@ class Scripts
      */
     protected static function useClassLoader(Bootstrap $bootstrap)
     {
-        return (defined('FLOW_ONLY_COMPOSER_LOADER') && FLOW_ONLY_COMPOSER_LOADER === false);
+        return !FLOW_ONLY_COMPOSER_LOADER;
     }
 }


### PR DESCRIPTION
This makes our own tests only use the old class loader if the `FLOW_ONLY_COMPOSER_LOADER` env var is set to `false`.

Related to #2417