### PR TITLE
TASK: Support header title for table output in console

### DIFF
--- a/Neos.Flow/Classes/Cli/ConsoleOutput.php
+++ b/Neos.Flow/Classes/Cli/ConsoleOutput.php
@@ -138,12 +138,16 @@ class ConsoleOutput
      *
      * @param array $rows
      * @param array $headers
+     * @param string $headerTitle
      */
-    public function outputTable(array $rows, array $headers = null): void
+    public function outputTable(array $rows, array $headers = null, string $headerTitle = null): void
     {
         $table = $this->getTable();
         if ($headers !== null) {
             $table->setHeaders($headers);
+        }
+        if ($headerTitle !== null) {
+            $table->setHeaderTitle($headerTitle);
         }
         $table->setRows($rows);
         $table->render();


### PR DESCRIPTION
The [Symfony Console Table components](https://symfony.com/doc/current/components/console/helpers/table.html) supports settings a header title for a table.

So should we :-)