### PR TITLE
FEATURE: Configure Routes from annotation

### DIFF
--- a/Neos.Flow/Classes/Annotations/Route.php
+++ b/Neos.Flow/Classes/Annotations/Route.php
@@ -20,11 +20,18 @@ namespace Neos\Flow\Annotations;
 final class Route
 {
     /**
+     * Name
+     *
+     * @var string|null
+     */
+    public $name;
+
+    /**
      * HTTP Methods
      *
-     * @var array
+     * @var array|null
      */
-    public $httpMethods = [];
+    public $httpMethods;
 
     /**
      * URI Pattern
@@ -36,6 +43,22 @@ final class Route
     public $uriPattern;
 
     /**
+     * Format
+     *
+     * Example: html
+     *
+     * @var string|null
+     */
+    public $format;
+
+    /**
+     * Append Exceeding Arguments
+     *
+     * @var bool|null
+     */
+    public $appendExceedingArguments;
+
+    /**
      * @param array $values
      */
     public function __construct(array $values)
@@ -45,6 +68,9 @@ final class Route
         }
 
         $this->uriPattern = $values['uriPattern'];
-        $this->httpMethods = $values['httpMethods'] ?? [];
+        $this->name = $values['name'] ?? null;
+        $this->httpMethods = $values['httpMethods'] ?? null;
+        $this->format = $values['format'] ?? null;
+        $this->appendExceedingArguments = $values['appendExceedingArguments'] ?? null;
     }
 }

--- a/Neos.Flow/Classes/Annotations/Route.php
+++ b/Neos.Flow/Classes/Annotations/Route.php
@@ -34,7 +34,7 @@ final class Route
     public $httpMethods = ['GET'];
 
     /**
-	 * URI Pattern. (Can be given as anonymous argument.)
+     * URI Pattern. (Can be given as anonymous argument.)
      *
      * Example: 'path/to/action/{actionArgument}'
      *
@@ -71,13 +71,13 @@ final class Route
         $this->name = $values['name'] ?? null;
 
         if (isset($values['httpMethods'])) {
-			$this->httpMethods = $values['httpMethods'];
-		}
+            $this->httpMethods = $values['httpMethods'];
+        }
         if (isset($values['format'])) {
-			$this->format = $values['format'];
-		}
+            $this->format = $values['format'];
+        }
         if (isset($values['appendExceedingArguments'])) {
-			$this->appendExceedingArguments = $values['appendExceedingArguments'];
-		}
+            $this->appendExceedingArguments = $values['appendExceedingArguments'];
+        }
     }
 }

--- a/Neos.Flow/Classes/Annotations/Route.php
+++ b/Neos.Flow/Classes/Annotations/Route.php
@@ -27,16 +27,16 @@ final class Route
     public $name;
 
     /**
-     * HTTP Methods
+     * HTTP Methods. Default to GET
      *
-     * @var array|null
+     * @var array
      */
-    public $httpMethods;
+    public $httpMethods = ['GET'];
 
     /**
-     * URI Pattern
+	 * URI Pattern. (Can be given as anonymous argument.)
      *
-     * Example: GRANT
+     * Example: 'path/to/action/{actionArgument}'
      *
      * @var string
      */
@@ -49,28 +49,35 @@ final class Route
      *
      * @var string|null
      */
-    public $format;
+    public $format = 'html';
 
     /**
      * Append Exceeding Arguments
      *
-     * @var bool|null
+     * @var bool
      */
-    public $appendExceedingArguments;
+    public $appendExceedingArguments = false;
 
     /**
      * @param array $values
      */
     public function __construct(array $values)
     {
-        if (!isset($values['uriPattern'])) {
+        if (!isset($values['value']) && !isset($values['uriPattern'])) {
             throw new \InvalidArgumentException('uriPattern is not provided.', 1615113040);
         }
 
-        $this->uriPattern = $values['uriPattern'];
+        $this->uriPattern = $values['uriPattern'] ?? $values['value'];
         $this->name = $values['name'] ?? null;
-        $this->httpMethods = $values['httpMethods'] ?? null;
-        $this->format = $values['format'] ?? null;
-        $this->appendExceedingArguments = $values['appendExceedingArguments'] ?? null;
+
+        if (isset($values['httpMethods'])) {
+			$this->httpMethods = $values['httpMethods'];
+		}
+        if (isset($values['format'])) {
+			$this->format = $values['format'];
+		}
+        if (isset($values['appendExceedingArguments'])) {
+			$this->appendExceedingArguments = $values['appendExceedingArguments'];
+		}
     }
 }

--- a/Neos.Flow/Classes/Annotations/Route.php
+++ b/Neos.Flow/Classes/Annotations/Route.php
@@ -1,0 +1,50 @@
+<?php
+namespace Neos\Flow\Annotations;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Used to configure Routes from a method
+ *
+ * @Annotation
+ * @Target("METHOD")
+ */
+final class Route
+{
+    /**
+     * HTTP Methods
+     *
+     * @var array
+     */
+    public $httpMethods = [];
+
+    /**
+     * URI Pattern
+     *
+     * Example: GRANT
+     *
+     * @var string
+     */
+    public $uriPattern;
+
+    /**
+     * @param array $values
+     */
+    public function __construct(array $values)
+    {
+        if (!isset($values['uriPattern'])) {
+            throw new \InvalidArgumentException('uriPattern is not provided.', 1615113040);
+        }
+
+        $this->uriPattern = $values['uriPattern'];
+        $this->httpMethods = $values['httpMethods'] ?? [];
+    }
+}

--- a/Neos.Flow/Classes/Mvc/Routing/Exception/InvalidAnnotatedMethodException.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Exception/InvalidAnnotatedMethodException.php
@@ -1,0 +1,20 @@
+<?php
+namespace Neos\Flow\Mvc\Routing\Exception;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Invalid Annotated Method Exception.
+ *
+ */
+class InvalidAnnotatedMethodException extends \Neos\Flow\Mvc\Exception
+{
+}

--- a/Neos.Flow/Classes/Mvc/Routing/Router.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Router.php
@@ -297,7 +297,7 @@ class Router implements RouterInterface
     public function configureRouteAnnotatedMethods(array &$routerConfiguration): void
     {
         $annotatedRoutes = static::resolveRouteAnnotatedMethods($this->objectManager);
-        $routerConfiguration = array_merge($routerConfiguration, array_values($annotatedRoutes));
+        $routerConfiguration = array_merge(array_values($annotatedRoutes), $routerConfiguration);
     }
 
 

--- a/Neos.Flow/Classes/Mvc/Routing/Router.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Router.php
@@ -390,7 +390,7 @@ class Router implements RouterInterface
     protected function initializeRoutesConfiguration()
     {
         if ($this->routesConfiguration === null) {
-            $routesConfiguration = $this->configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_ROUTES);
+            $routesConfiguration = $this->configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_ROUTES) ?? [];
             $this->emitConfigurationLoaded($routesConfiguration);
             $this->routesConfiguration = $routesConfiguration;
         }

--- a/Neos.Flow/Classes/Mvc/Routing/Router.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Router.php
@@ -292,7 +292,7 @@ class Router implements RouterInterface
      * @param ObjectManagerInterface $objectManager
      * @Flow\CompileStatic
      * @return array
-	 * @throws InvalidAnnotatedMethodException if a none-Action method is annotated
+     * @throws InvalidAnnotatedMethodException if a none-Action method is annotated
      */
     protected static function resolveRouteAnnotatedMethods(ObjectManagerInterface $objectManager): array
     {
@@ -320,13 +320,14 @@ class Router implements RouterInterface
                 $subject = substr($controllerObjectName, strlen($controllerPackageKey) + 1);
                 preg_match(
                     '/
-			^(
-				Controller
-			|
-				(?P<subpackageKey>.+)\\\\Controller
-			)
-			\\\\(?P<controllerName>[a-z\\\\]+)Controller
-			$/ix',
+                        ^(
+                            Controller
+                        |
+                            (?P<subpackageKey>.+)\\\\Controller
+                        )
+                        \\\\(?P<controllerName>[a-z\\\\]+)Controller
+                        $
+                    /ix',
                     $subject,
                     $matches
                 );
@@ -337,19 +338,19 @@ class Router implements RouterInterface
                 $annotation = $reflectionService->getMethodAnnotation($controllerClassName, $methodName, Flow\Route::class);
 
                 $defaults = [
-                	'@package' => $controllerPackageKey,
-					'@subpackage' => $controllerSubpackageKey,
-					'@controller' => $controllerName,
-					'@action' => substr($methodName, 0, -6),
-					'@format' => $annotation->format
-				];
+                    '@package' => $controllerPackageKey,
+                    '@subpackage' => $controllerSubpackageKey,
+                    '@controller' => $controllerName,
+                    '@action' => substr($methodName, 0, -6),
+                    '@format' => $annotation->format
+                ];
 
                 $routeConfiguration = [
                     'name' => $annotation->name ?? sprintf('Annotated Route (%s->%s)', $controllerClassName, $methodName),
                     'uriPattern' => $annotation->uriPattern,
                     'defaults' => $defaults,
-					'httpMethods' => $annotation->httpMethods,
-					'appendExceedingArguments' => $annotation->appendExceedingArguments
+                    'httpMethods' => $annotation->httpMethods,
+                    'appendExceedingArguments' => $annotation->appendExceedingArguments
                 ];
                 $annotatedRoutes[] = $routeConfiguration;
             }
@@ -365,9 +366,9 @@ class Router implements RouterInterface
     protected function initializeRoutesConfiguration()
     {
         if ($this->routesConfiguration === null) {
-			$annotatedRoutes = $this->initializeAnnotatedRoutes();
+            $annotatedRoutes = $this->initializeAnnotatedRoutes();
             $configuredRoutes = $this->configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_ROUTES);
-			$this->routesConfiguration = array_merge(array_values($annotatedRoutes), $configuredRoutes);
+            $this->routesConfiguration = array_merge(array_values($annotatedRoutes), $configuredRoutes);
         }
     }
 }

--- a/Neos.Flow/Classes/Mvc/Routing/Router.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Router.php
@@ -394,6 +394,5 @@ class Router implements RouterInterface
             $this->emitConfigurationLoaded($routesConfiguration);
             $this->routesConfiguration = $routesConfiguration;
         }
-
     }
 }

--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -13,6 +13,7 @@ namespace Neos\Flow;
 
 use Neos\Flow\Core\Booting\Step;
 use Neos\Flow\Http\Helper\SecurityHelper;
+use Neos\Flow\Mvc\Routing\Router;
 use Neos\Flow\ObjectManagement\CompileTimeObjectManager;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\Flow\Package\PackageManager;
@@ -127,6 +128,7 @@ class Package extends BasePackage
 
         $dispatcher->connect(Tests\FunctionalTestCase::class, 'functionalTestTearDown', Mvc\Routing\RouterCachingService::class, 'flushCaches');
 
+        $dispatcher->connect(Router::class, 'configurationLoaded', Router::class, 'configureRouteAnnotatedMethods');
         $dispatcher->connect(Configuration\ConfigurationManager::class, 'configurationManagerReady', function (Configuration\ConfigurationManager $configurationManager) {
             $configurationManager->registerConfigurationType('Views', Configuration\ConfigurationManager::CONFIGURATION_PROCESSING_TYPE_APPEND);
         });

--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -13,7 +13,6 @@ namespace Neos\Flow;
 
 use Neos\Flow\Core\Booting\Step;
 use Neos\Flow\Http\Helper\SecurityHelper;
-use Neos\Flow\Mvc\Routing\Router;
 use Neos\Flow\ObjectManagement\CompileTimeObjectManager;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\Flow\Package\PackageManager;

--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -128,7 +128,6 @@ class Package extends BasePackage
 
         $dispatcher->connect(Tests\FunctionalTestCase::class, 'functionalTestTearDown', Mvc\Routing\RouterCachingService::class, 'flushCaches');
 
-        $dispatcher->connect(Router::class, 'configurationLoaded', Router::class, 'configureRouteAnnotatedMethods');
         $dispatcher->connect(Configuration\ConfigurationManager::class, 'configurationManagerReady', function (Configuration\ConfigurationManager $configurationManager) {
             $configurationManager->registerConfigurationType('Views', Configuration\ConfigurationManager::CONFIGURATION_PROCESSING_TYPE_APPEND);
         });

--- a/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/RouteAnnotatedController.php
+++ b/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/RouteAnnotatedController.php
@@ -30,13 +30,13 @@ class RouteAnnotatedController extends ActionController
         return 'Hello';
     }
 
-	/**
-	 * @Flow\Route("hello/{name}")
-	 * @param string $name
-	 * @return string
-	 */
-	public function annotatedUriWithArgumentAction(string $name)
-	{
-		return 'Hello ' . $name;
-	}
+    /**
+     * @Flow\Route("hello/{name}")
+     * @param string $name
+     * @return string
+     */
+    public function annotatedUriWithArgumentAction(string $name)
+    {
+        return 'Hello ' . $name;
+    }
 }

--- a/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/RouteAnnotatedController.php
+++ b/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/RouteAnnotatedController.php
@@ -1,0 +1,32 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\Controller\ActionController;
+
+/**
+ * A route annotated controller fixture
+ *
+ * @Flow\Scope("singleton")
+ */
+class RouteAnnotatedController extends ActionController
+{
+    /**
+     * @Flow\Route(uriPattern="annotated/uri/pattern")
+     * @return string
+     */
+    public function annotatedWithUriPatternAction()
+    {
+        return 'Hello';
+    }
+}

--- a/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/RouteAnnotatedController.php
+++ b/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/RouteAnnotatedController.php
@@ -22,11 +22,21 @@ use Neos\Flow\Mvc\Controller\ActionController;
 class RouteAnnotatedController extends ActionController
 {
     /**
-     * @Flow\Route(uriPattern="annotated/uri/pattern")
+     * @Flow\Route("annotated/uri/pattern")
      * @return string
      */
     public function annotatedWithUriPatternAction()
     {
         return 'Hello';
     }
+
+	/**
+	 * @Flow\Route("hello/{name}")
+	 * @param string $name
+	 * @return string
+	 */
+	public function annotatedUriWithArgumentAction(string $name)
+	{
+		return 'Hello ' . $name;
+	}
 }

--- a/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
@@ -415,4 +415,22 @@ class RoutingTest extends FunctionalTestCase
         // reset router configuration for following tests
         $this->router->setRoutesConfiguration(null);
     }
+
+    /**
+     * @test
+     */
+    public function resolveUriPatternFromRouteAnnotation()
+    {
+        $routeValues = [
+            '@package' => 'Neos.Flow',
+            '@subpackage' => 'Tests\Functional\Http\Fixtures',
+            '@controller' => 'RouteAnnotated',
+            '@action' => 'annotatedWithUriPattern',
+            '@format' => 'html'
+        ];
+        $baseUri = new Uri('http://localhost');
+        $actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, false, 'index.php/', RouteParameters::createEmpty()));
+
+        self::assertSame('/index.php/annotated/uri/pattern', (string)$actualResult);
+    }
 }

--- a/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
@@ -433,4 +433,24 @@ class RoutingTest extends FunctionalTestCase
 
         self::assertSame('/index.php/annotated/uri/pattern', (string)$actualResult);
     }
+
+
+	/**
+	 * @test
+	 */
+	public function resolveUriPatternFromRouteAnnotationWithArgument()
+	{
+		$routeValues = [
+			'@package' => 'Neos.Flow',
+			'@subpackage' => 'Tests\Functional\Http\Fixtures',
+			'@controller' => 'RouteAnnotated',
+			'@action' => 'annotatedUriWithArgument',
+			'@format' => 'html',
+			'name' => 'soren'
+		];
+		$baseUri = new Uri('http://localhost');
+		$actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, false, 'index.php/', RouteParameters::createEmpty()));
+
+		self::assertSame('/index.php/hello/soren', (string)$actualResult);
+	}
 }

--- a/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
@@ -435,22 +435,22 @@ class RoutingTest extends FunctionalTestCase
     }
 
 
-	/**
-	 * @test
-	 */
-	public function resolveUriPatternFromRouteAnnotationWithArgument()
-	{
-		$routeValues = [
-			'@package' => 'Neos.Flow',
-			'@subpackage' => 'Tests\Functional\Http\Fixtures',
-			'@controller' => 'RouteAnnotated',
-			'@action' => 'annotatedUriWithArgument',
-			'@format' => 'html',
-			'name' => 'soren'
-		];
-		$baseUri = new Uri('http://localhost');
-		$actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, false, 'index.php/', RouteParameters::createEmpty()));
+    /**
+     * @test
+     */
+    public function resolveUriPatternFromRouteAnnotationWithArgument()
+    {
+        $routeValues = [
+            '@package' => 'Neos.Flow',
+            '@subpackage' => 'Tests\Functional\Http\Fixtures',
+            '@controller' => 'RouteAnnotated',
+            '@action' => 'annotatedUriWithArgument',
+            '@format' => 'html',
+            'name' => 'soren'
+        ];
+        $baseUri = new Uri('http://localhost');
+        $actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, false, 'index.php/', RouteParameters::createEmpty()));
 
-		self::assertSame('/index.php/hello/soren', (string)$actualResult);
-	}
+        self::assertSame('/index.php/hello/soren', (string)$actualResult);
+    }
 }

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/RouterTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/RouterTest.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Tests\Unit\Mvc\Routing;
 
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Configuration\ConfigurationManager;
+use Neos\Flow\Mvc\Controller\AbstractController;
 use Neos\Flow\Mvc\Exception\InvalidRouteSetupException;
 use Neos\Flow\Mvc\Exception\NoMatchingRouteException;
 use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
@@ -23,6 +24,9 @@ use Neos\Flow\Mvc\Routing\Route;
 use Neos\Flow\Mvc\Routing\Router;
 use Neos\Flow\Mvc\Routing\RouterCachingService;
 use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\ObjectManagement\ObjectManager;
+use Neos\Flow\Reflection\ReflectionService;
+use Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\RouteAnnotatedController;
 use Neos\Flow\Tests\UnitTestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
@@ -405,6 +409,13 @@ class RouterTest extends UnitTestCase
     {
         /** @var Router|\PHPUnit\Framework\MockObject\MockObject $router */
         $router = $this->getAccessibleMock(Router::class, ['dummy']);
+        $mockReflectionService = $this->getMockBuilder(ReflectionService::class)->disableOriginalConstructor()->getMock();
+        $mockReflectionService->expects(self::once())->method('getAllSubClassNamesForClass')->with(AbstractController::class)->willReturn([RouteAnnotatedController::class]);
+
+        $mockObjectManager = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->getMock();
+        $mockObjectManager->expects(self::once())->method('get')->with(ReflectionService::class)->willReturn($mockReflectionService);
+
+        $this->inject($router, 'objectManager', $mockObjectManager);
         $this->inject($router, 'routerCachingService', $this->mockRouterCachingService);
         $this->inject($router, 'logger', $this->mockSystemLogger);
 


### PR DESCRIPTION
WIP and not working (will throw a exception in runtime build)

 * Add a signal to the `initializeRoutesConfiguration` method of the router
 * Introduces a resolve method to get controller class and action name
 * Adds it to the routerConfigruation values from the Routes.yaml file available
 * Passes it through the loop of `createRoutesFromConfiguration` to go through checks and validation with the other registered routes


## Question and tasks

- [x] Should the objectManager be injected into the router for the single purpose of using in the compileStatic method introduced?
- [x] Split a controllerClass and action name into the values needed for building configuration (@{package|subpackage|controller|action}) - what method can do that?
- [x] Write tests
- [ ] Update docs

Related #2059 