### PR TITLE
TASK: Avoid opening database connection if nothing to persist

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/PersistenceManager.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/PersistenceManager.php
@@ -14,6 +14,7 @@ namespace Neos\Flow\Persistence\Doctrine;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Tools\SchemaTool;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Log\ThrowableStorageInterface;
@@ -65,6 +66,12 @@ class PersistenceManager extends AbstractPersistenceManager
     protected $reflectionService;
 
     /**
+     * A runtime flag to pass the argument of the persistAll() call to the onFlush() event listener
+     * @var boolean
+     */
+    protected $onlyAllowedObjects;
+
+    /**
      * Injects the (system) logger based on PSR-3.
      *
      * @param LoggerInterface $logger
@@ -86,23 +93,43 @@ class PersistenceManager extends AbstractPersistenceManager
      */
     public function persistAll($onlyAllowedObjects = false)
     {
-        if ($onlyAllowedObjects) {
-            $unitOfWork = $this->entityManager->getUnitOfWork();
-            /** @var \Doctrine\ORM\UnitOfWork $unitOfWork */
-            $unitOfWork->computeChangeSets();
+        if (!$this->entityManager->isOpen()) {
+            $this->logger->error('persistAll() skipped flushing data, the Doctrine EntityManager is closed. Check the logs for error message.', LogEnvironment::fromMethodName(__METHOD__));
+            return;
+        }
+
+        $this->onlyAllowedObjects = $onlyAllowedObjects;
+        $this->entityManager->flush();
+        $this->onlyAllowedObjects = false;
+        $this->emitAllObjectsPersisted();
+    }
+
+    /**
+     * Doctrine onFlush listener that checks for only allowed objects and reconnects
+     * if the database connection was closed.
+     *
+     * @param OnFlushEventArgs $args
+     * @throws PersistenceException
+     */
+    public function onFlush(OnFlushEventArgs $args) {
+        $unitOfWork = $args->getEntityManager()->getUnitOfWork();
+        if ($unitOfWork->getScheduledEntityInsertions() === []
+            && $unitOfWork->getScheduledEntityUpdates() === []
+            && $unitOfWork->getScheduledEntityDeletions() === []
+            && $unitOfWork->getScheduledCollectionDeletions() === []
+            && $unitOfWork->getScheduledCollectionUpdates() === []
+        ) {
+            return;
+        }
+
+        if ($this->onlyAllowedObjects) {
             $objectsToBePersisted = $unitOfWork->getScheduledEntityUpdates() + $unitOfWork->getScheduledEntityDeletions() + $unitOfWork->getScheduledEntityInsertions();
             foreach ($objectsToBePersisted as $object) {
                 $this->throwExceptionIfObjectIsNotAllowed($object);
             }
         }
 
-        if (!$this->entityManager->isOpen()) {
-            $this->logger->error('persistAll() skipped flushing data, the Doctrine EntityManager is closed. Check the logs for error message.', LogEnvironment::fromMethodName(__METHOD__));
-            return;
-        }
-
-        /** @var Connection $connection */
-        $connection = $this->entityManager->getConnection();
+        $connection = $args->getEntityManager()->getConnection();
         try {
             if ($connection->ping() === false) {
                 $this->logger->info('Reconnecting the Doctrine EntityManager to the persistence backend.', LogEnvironment::fromMethodName(__METHOD__));
@@ -113,9 +140,6 @@ class PersistenceManager extends AbstractPersistenceManager
             $message = $this->throwableStorage->logThrowable($exception);
             $this->logger->error($message, LogEnvironment::fromMethodName(__METHOD__));
         }
-
-        $this->entityManager->flush();
-        $this->emitAllObjectsPersisted();
     }
 
     /**

--- a/Neos.Flow/Configuration/Settings.Persistence.yaml
+++ b/Neos.Flow/Configuration/Settings.Persistence.yaml
@@ -39,7 +39,7 @@ Neos:
         eventSubscribers: []
         eventListeners:
           'Neos\Flow\Persistence\Doctrine\PersistenceManager':
-            events: ['onFLush']
+            events: ['onFlush']
             listener: 'Neos\Flow\Persistence\Doctrine\PersistenceManager'
           'Neos\Flow\Persistence\Doctrine\ObjectValidationAndDeDuplicationListener':
             events: ['onFlush']

--- a/Neos.Flow/Configuration/Settings.Persistence.yaml
+++ b/Neos.Flow/Configuration/Settings.Persistence.yaml
@@ -38,6 +38,9 @@ Neos:
         # See Flow manual, chapter "Persistence" for further information on how to subscribe to Doctrine events.
         eventSubscribers: []
         eventListeners:
+          'Neos\Flow\Persistence\Doctrine\PersistenceManager':
+            events: ['onFLush']
+            listener: 'Neos\Flow\Persistence\Doctrine\PersistenceManager'
           'Neos\Flow\Persistence\Doctrine\ObjectValidationAndDeDuplicationListener':
             events: ['onFlush']
             listener: 'Neos\Flow\Persistence\Doctrine\ObjectValidationAndDeDuplicationListener'

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/PersistenceManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/PersistenceManagerTest.php
@@ -14,6 +14,7 @@ namespace Neos\Flow\Tests\Unit\Persistence\Doctrine;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\UnitOfWork;
 use Neos\Flow\Log\ThrowableStorageInterface;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
@@ -61,6 +62,9 @@ class PersistenceManagerTest extends UnitTestCase
 
         $this->mockEntityManager = $this->getMockBuilder(\Doctrine\ORM\EntityManager::class)->disableOriginalConstructor()->getMock();
         $this->mockEntityManager->expects($this->any())->method('isOpen')->willReturn(true);
+        $this->mockEntityManager->method('flush')->willReturnCallback(function() {
+            $this->persistenceManager->onFlush(new OnFlushEventArgs($this->mockEntityManager));
+        });
         $this->inject($this->persistenceManager, 'entityManager', $this->mockEntityManager);
 
         $this->mockUnitOfWork = $this->getMockBuilder(\Doctrine\ORM\UnitOfWork::class)->disableOriginalConstructor()->getMock();
@@ -106,8 +110,6 @@ class PersistenceManagerTest extends UnitTestCase
         $this->mockUnitOfWork->expects($this->any())->method('getScheduledEntityUpdates')->willReturn($scheduledEntityUpdates);
         $this->mockUnitOfWork->expects($this->any())->method('getScheduledEntityDeletions')->willReturn($scheduledEntityDeletes);
         $this->mockUnitOfWork->expects($this->any())->method('getScheduledEntityInsertions')->willReturn($scheduledEntityInsertions);
-
-        $this->mockEntityManager->expects($this->never())->method('flush');
 
         $this->persistenceManager->persistAll(true);
     }
@@ -161,7 +163,6 @@ class PersistenceManagerTest extends UnitTestCase
     public function persistAllReconnectsConnectionWhenConnectionLost()
     {
         $this->mockPing->willReturn(false);
-        $this->mockEntityManager->expects($this->exactly(1))->method('flush')->willReturn(null);
 
         $this->mockConnection->expects($this->at(0))->method('close');
         $this->mockConnection->expects($this->at(1))->method('connect');
@@ -175,7 +176,7 @@ class PersistenceManagerTest extends UnitTestCase
      */
     public function persistAllThrowsOriginalExceptionWhenEntityManagerGotClosed()
     {
-        $this->mockEntityManager->expects($this->exactly(1))->method('flush')->willThrowException(new \Doctrine\DBAL\DBALException('Dummy error that closed the entity manager'));
+        $this->mockEntityManager->method('flush')->willThrowException(new \Doctrine\DBAL\DBALException('Dummy error that closed the entity manager'));
 
         $this->mockConnection->expects($this->never())->method('close');
         $this->mockConnection->expects($this->never())->method('connect');


### PR DESCRIPTION
Also, this avoids calling calculateChangeset() twice for requests that only want allowed objects to be persisted.

Resolves #1893