### PR TITLE
TASK: Move DoctrineMigrations folder to Temporary Data folder

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/Service.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Service.php
@@ -217,7 +217,7 @@ class Service
      */
     protected function getDependencyFactory(): DependencyFactory
     {
-        $migrationsPath = Files::concatenatePaths([FLOW_PATH_DATA, 'Temporary', 'DoctrineMigrations']);
+        $migrationsPath = Files::concatenatePaths([FLOW_PATH_TEMPORARY, 'DoctrineMigrations']);
         if (!is_dir($migrationsPath)) {
             Files::createDirectoryRecursively($migrationsPath);
         }

--- a/Neos.Flow/Classes/Persistence/Doctrine/Service.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Service.php
@@ -217,7 +217,7 @@ class Service
      */
     protected function getDependencyFactory(): DependencyFactory
     {
-        $migrationsPath = Files::concatenatePaths([FLOW_PATH_DATA, 'DoctrineMigrations']);
+        $migrationsPath = Files::concatenatePaths([FLOW_PATH_DATA, 'Temporary', 'DoctrineMigrations']);
         if (!is_dir($migrationsPath)) {
             Files::createDirectoryRecursively($migrationsPath);
         }


### PR DESCRIPTION
Move DoctrineMigrations folder to the Temporary folder. See related ticket #2425 for explanation on the topic

Resolves: #2425 