### PR TITLE
BUGFIX: Ignore ProxyClass in code coverage of phpunit

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php
@@ -257,6 +257,7 @@ class ProxyClass
             $classDocumentation .= ' * ' . Compiler::renderAnnotation($annotation) . "\n";
         }
 
+        $classDocumentation .= " * @codeCoverageIgnore\n";
         $classDocumentation .= " */\n";
         return $classDocumentation;
     }


### PR DESCRIPTION
Add the @codeCoverageIgnore annotation to proxy class to ignore it in the coverage report.

- [ x ] Code follows the PSR-2 coding style
- [ x ] Tests have been created, run and adjusted as needed
- [ x ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
