### PR TITLE
BUGFIX: Outdated class name in @covers annotation

### DIFF
--- a/Neos.Flow/Tests/Unit/I18n/LocaleTypeConverterTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/LocaleTypeConverterTest.php
@@ -19,7 +19,7 @@ use Neos\Flow\Tests\UnitTestCase;
 /**
  * Testcase for the Locale type converter
  *
- * @covers \TYPO3\Flow\I18n\LocaleTypeConverter<extended>
+ * @covers \Neos\Flow\I18n\LocaleTypeConverter<extended>
  */
 class LocaleTypeConverterTest extends UnitTestCase
 {


### PR DESCRIPTION
This fixes running tests with code coverage.
