### PR TITLE
TASK: Add integration build on a neos distribution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,17 @@ jobs:
         composer-arguments: [''] # to run --ignore-platform-reqs in experimental builds
         static-analysis: ['no']
         experimental: [false]
+        integration: [false] # to install in a full neos-distribution and check things still work
         include:
           - php-versions: '7.3'
             static-analysis: 'psalm'
             experimental: false
+            dependencies: 'highest'
+
+          - php-version: '7.3'
+            static-analysis: 'no'
+            experimental: false
+            integration: true
             dependencies: 'highest'
 
           # Experimental build for PHP 8
@@ -102,7 +109,7 @@ jobs:
       - name: Checkout development distribution
         uses: actions/checkout@v2
         with:
-          repository: neos/flow-development-distribution
+          repository: ${{ matrix.integration == true && 'neos/neos-development-distribution' || 'neos/flow-development-distribution' }}
           ref: ${{ env.FLOW_TARGET_VERSION }}
           path: ${{ env.FLOW_DIST_FOLDER }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip travis]')"
-    name: "PHP ${{ matrix.php-versions }} Test ${{ matrix.static-analysis != 'no' && matrix.static-analysis || '' }} (deps: ${{ matrix.dependencies }})"
+    name: "PHP ${{ matrix.php-versions }} Test ${{ matrix.static-analysis != 'no' && matrix.static-analysis || '' }} ${{ matrix.integration && 'integration' || '' }} (deps: ${{ matrix.dependencies }})"
 
     continue-on-error: ${{ matrix.experimental }}
 
@@ -28,7 +28,7 @@ jobs:
             experimental: false
             dependencies: 'highest'
 
-          - php-version: '7.3'
+          - php-versions: '7.3'
             static-analysis: 'no'
             experimental: false
             integration: true


### PR DESCRIPTION
Adds an additional build matrix entry that will try to run tests within a neos-development-distribution to make sure things still work.

Follow-up to #2200 