### PR TITLE
TASK: Exclude breaking 1.8.0 guzzle/psr7 version

### DIFF
--- a/Neos.Http.Factories/composer.json
+++ b/Neos.Http.Factories/composer.json
@@ -9,7 +9,7 @@
     "require": {
         "php": "^7.1",
         "psr/http-factory": "^1.0",
-        "guzzlehttp/psr7": "^1.4"
+        "guzzlehttp/psr7": "^1.4, !=1.8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "neos/composer-plugin": "^2.0",
         "composer/composer": "^1.9 || ^2.0",
         "typo3fluid/fluid": "~2.5.11 || ^2.6.10",
-        "guzzlehttp/psr7": "^1.4",
+        "guzzlehttp/psr7": "^1.4, !=1.8.0",
         "ext-mbstring": "*"
     },
     "replace": {


### PR DESCRIPTION
This is a workaround for https://github.com/guzzle/psr7/pull/401 - 🤞 it will be fixed with 1.8.1