### PR TITLE
TASK: Fix "Required parameter follows optional parameter" deprecation in PHP8

### DIFF
--- a/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -71,7 +71,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
      * @return boolean
      * @api
      */
-    protected static function evaluateCondition($arguments = null, RenderingContextInterface $renderingContext)
+    protected static function evaluateCondition($arguments, RenderingContextInterface $renderingContext)
     {
         return (boolean)$arguments['condition'];
     }

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Security/IfAccessViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Security/IfAccessViewHelper.php
@@ -95,7 +95,7 @@ class IfAccessViewHelper extends AbstractConditionViewHelper
      * @param RenderingContextInterface $renderingContext
      * @return boolean
      */
-    protected static function evaluateCondition($arguments = null, RenderingContextInterface $renderingContext)
+    protected static function evaluateCondition($arguments, RenderingContextInterface $renderingContext)
     {
         $objectManager = $renderingContext->getObjectManager();
         /** @var Context $securityContext */

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Security/IfAuthenticatedViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Security/IfAuthenticatedViewHelper.php
@@ -69,7 +69,7 @@ class IfAuthenticatedViewHelper extends AbstractConditionViewHelper
      * @param RenderingContextInterface $renderingContext
      * @return bool
      */
-    protected static function evaluateCondition($arguments = null, RenderingContextInterface $renderingContext)
+    protected static function evaluateCondition($arguments, RenderingContextInterface $renderingContext)
     {
         $objectManager = $renderingContext->getObjectManager();
         /** @var Context $securityContext */

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Security/IfHasRoleViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Security/IfHasRoleViewHelper.php
@@ -107,7 +107,7 @@ class IfHasRoleViewHelper extends AbstractConditionViewHelper
      * @param RenderingContextInterface $renderingContext
      * @return boolean
      */
-    protected static function evaluateCondition($arguments = null, RenderingContextInterface $renderingContext)
+    protected static function evaluateCondition($arguments, RenderingContextInterface $renderingContext)
     {
         $objectManager = $renderingContext->getObjectManager();
         /** @var PolicyService $policyService */

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Validation/IfHasErrorsViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Validation/IfHasErrorsViewHelper.php
@@ -76,7 +76,7 @@ class IfHasErrorsViewHelper extends AbstractConditionViewHelper
      * @param FlowAwareRenderingContextInterface|RenderingContextInterface $renderingContext
      * @return boolean
      */
-    protected static function evaluateCondition($arguments = null, RenderingContextInterface $renderingContext)
+    protected static function evaluateCondition($arguments, RenderingContextInterface $renderingContext)
     {
         /** @var ActionRequest $request */
         /** @var FlowAwareRenderingContextInterface $renderingContext */


### PR DESCRIPTION
The method signature change is not breaking and prevents a deprecation warning when running on PHP 8. The `null` default was never used, because the method is never called without arguments anyway.

Resolves #2435