### PR TITLE
BUGFIX: Allow non-standard status codes in redirects

### DIFF
--- a/Neos.Flow/Classes/Mvc/ActionResponse.php
+++ b/Neos.Flow/Classes/Mvc/ActionResponse.php
@@ -213,12 +213,12 @@ final class ActionResponse
             $actionResponse->setContentType($this->contentType);
         }
 
-        if ($this->statusCode !== null) {
-            $actionResponse->setStatusCode($this->statusCode);
-        }
-
         if ($this->redirectUri !== null) {
             $actionResponse->setRedirectUri($this->redirectUri);
+        }
+
+        if ($this->statusCode !== null) {
+            $actionResponse->setStatusCode($this->statusCode);
         }
 
         foreach ($this->componentParameters as $componentClass => $parameters) {

--- a/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
@@ -560,4 +560,15 @@ class ActionControllerTest extends FunctionalTestCase
         $expected = json_encode(['Redirect FlashMessage']);
         self::assertSame($expected, $redirectResponse->getBody()->getContents());
     }
+
+    /**
+     * @test
+     */
+    public function nonstandardStatusCodeIsReturnedWithRedirect()
+    {
+        $this->browser->setFollowRedirects(false);
+        $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertesta/redirect');
+        self::assertSame(302, $response->getStatusCode());
+        self::assertSame('http://some.uri', $response->getHeaderLine('Location'));
+    }
 }

--- a/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/ActionControllerTestAController.php
+++ b/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/ActionControllerTestAController.php
@@ -99,4 +99,12 @@ class ActionControllerTestAController extends ActionController
     public function b()
     {
     }
+
+    /**
+     * @return void
+     */
+    public function redirectAction()
+    {
+        $this->redirectToUri('http://some.uri', 0, 302);
+    }
 }


### PR DESCRIPTION
Redirecting from controllers using redirectToUri allows the developer to
set the status code to be used. However the actual status code returned
to the client was always 303.

Changing the order so that statusCode is being handled after redirectUri fixes the issue.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
