### PR TITLE
BUGFIX: Allow Doctrine object manager to appear as different class names

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
@@ -186,7 +186,7 @@ class ObjectManager implements ObjectManagerInterface
     public function get($objectName)
     {
         // XXX: This is a b/c fix for the deprecation of doctrine ObjectManager. Remove this with Flow 6.0
-        if ($objectName === \Doctrine\Common\Persistence\ObjectManager::class) {
+        if ($objectName === \Doctrine\Common\Persistence\ObjectManager::class || $objectName === \Doctrine\Persistence\ObjectManager::class) {
             $objectName = \Doctrine\ORM\EntityManagerInterface::class;
         }
 


### PR DESCRIPTION
The Doctrine object manager used to be Doctrine\Common but got moved
to Doctrine\Persistence. Both are intrefaces.

Doctrine provides a compatibility layer implemented as class_alias().

There are situations where legacy code calls for Doctrine\Common, the
PHP feature of class_alias mapps to Doctrine\Persistence and Flow does
not know about it.