### PR TITLE
BUGFIX: Support nested fluid variables by using the original fluid method

### DIFF
--- a/Neos.FluidAdaptor/Classes/Core/ViewHelper/TemplateVariableContainer.php
+++ b/Neos.FluidAdaptor/Classes/Core/ViewHelper/TemplateVariableContainer.php
@@ -49,6 +49,23 @@ class TemplateVariableContainer extends StandardVariableProvider implements Vari
     }
 
     /**
+     * @param string $propertyPath
+     * @return string
+     */
+    protected function resolveSubVariableReferences($propertyPath)
+    {
+        if (strpos($propertyPath, '{') !== false) {
+            // NOTE: This is an inclusion of https://github.com/TYPO3/Fluid/pull/472 to allow multiple nested variables
+            preg_match_all('/(\{.*?\})/', $propertyPath, $matches);
+            foreach ($matches[1] as $match) {
+                $subPropertyPath = substr($match, 1, -1);
+                $propertyPath = str_replace($match, $this->getByPath($subPropertyPath), $propertyPath);
+            }
+        }
+        return $propertyPath;
+    }
+
+    /**
      * @param mixed $subject
      * @param string $propertyName
      * @return NULL|string

--- a/Neos.FluidAdaptor/Tests/Functional/View/StandaloneViewTest.php
+++ b/Neos.FluidAdaptor/Tests/Functional/View/StandaloneViewTest.php
@@ -181,6 +181,22 @@ class StandaloneViewTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function variablesCanBeNested()
+    {
+        $standaloneView = new StandaloneView(null, $this->standaloneViewNonce);
+        $standaloneView->assign('type', 'thing');
+        $standaloneView->assign('flavor', 'yellow');
+        $standaloneView->assign('config', ['thing' => ['value' => ['yellow' => 'Okayish']]]);
+        $standaloneView->setTemplateSource('{config.{type}.value.{flavor}}');
+
+        $expected = 'Okayish';
+        $actual = $standaloneView->render();
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
     public function partialWithDefaultLocationIsUsedIfNoPartialPathIsSetExplicitly()
     {
         $httpRequest = Request::create(new Uri('http://localhost'));


### PR DESCRIPTION
With this patch it's possible to use the fluid variable nesting feature as well as a specific accessor per element on the path.

**How to use it**

Create a fluid template with nested variables that access an array value:
```html
{config.{type}.value.{flavor}}
```
Assign an array and the two keys:
```php
$this->view->assign('type', 'thing');
$this->view->assign('flavor', 'yellow');
$this->view->assign('config', ['thing' => ['value' => ['yellow' => 'Okayish']]]);
```
