### PR TITLE
TASK: Make JsonView datetime format configurable

### DIFF
--- a/Neos.Flow/Classes/Mvc/View/JsonView.php
+++ b/Neos.Flow/Classes/Mvc/View/JsonView.php
@@ -29,7 +29,8 @@ class JsonView extends AbstractView
      * @var array
      */
     protected $supportedOptions = [
-        'jsonEncodingOptions' => [0, 'Bitmask of supported Encoding options. See http://php.net/manual/en/json.constants.php', 'integer']
+        'jsonEncodingOptions' => [0, 'Bitmask of supported Encoding options. See https://php.net/manual/en/json.constants.php', 'integer'],
+        'datetimeFormat' => [\DateTime::ISO8601, 'The datetime format to use for all DateTime objects. See https://www.php.net/manual/en/class.datetime.php#datetime.synopsis', 'string']
     ];
 
     /**
@@ -273,7 +274,7 @@ class JsonView extends AbstractView
     protected function transformObject($object, array $configuration)
     {
         if ($object instanceof \DateTimeInterface) {
-            return $object->format(\DateTime::ISO8601);
+            return $object->format($this->getOption('datetimeFormat'));
         } else {
             $propertyNames = ObjectAccess::getGettablePropertyNames($object);
 

--- a/Neos.Flow/Tests/Unit/Mvc/View/JsonViewTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/View/JsonViewTest.php
@@ -152,7 +152,7 @@ class JsonViewTest extends UnitTestCase
      */
     public function testTransformValue($object, $configuration, $expected, $description)
     {
-        $jsonView = $this->getAccessibleMock(Mvc\View\JsonView::class, ['dummy'], [], '', false);
+        $jsonView = $this->getAccessibleMock(Mvc\View\JsonView::class, ['dummy'], [], '');
 
         $actual = $jsonView->_call('transformValue', $object, $configuration);
 

--- a/Neos.Flow/Tests/Unit/Mvc/View/JsonViewTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/View/JsonViewTest.php
@@ -481,7 +481,7 @@ class JsonViewTest extends UnitTestCase
         $this->view->assign('array', $array);
         $this->view->setVariablesToRender(['array']);
 
-        $expectedResult = json_encode(['foo' => '2021-05-02 13:00:00 UTC']);
+        $expectedResult = json_encode(['foo' => '2021-05-02 13:00:00 GMT+00:00']);
 
         $actualResult = $this->view->render();
         $this->assertEquals($expectedResult, $actualResult);

--- a/Neos.Flow/Tests/Unit/Mvc/View/JsonViewTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/View/JsonViewTest.php
@@ -481,7 +481,7 @@ class JsonViewTest extends UnitTestCase
         $this->view->assign('array', $array);
         $this->view->setVariablesToRender(['array']);
 
-        $expectedResult = json_encode(['foo' => '2021-05-02 13:00:00 GMT+00:00']);
+        $expectedResult = json_encode(['foo' => '2021-05-02 13:00:00 GMT+0000']);
 
         $actualResult = $this->view->render();
         $this->assertEquals($expectedResult, $actualResult);

--- a/Neos.Flow/Tests/Unit/Mvc/View/JsonViewTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/View/JsonViewTest.php
@@ -475,7 +475,7 @@ class JsonViewTest extends UnitTestCase
      */
     public function viewObeysDateTimeFormatOption()
     {
-        $array = ['foo' => new DateTime('2021-05-02T13:00:00+0000')];
+        $array = ['foo' => new \DateTime('2021-05-02T13:00:00+0000')];
 
         $this->view->setOption('datetimeFormat', 'Y-m-d H:i:s T');
         $this->view->assign('array', $array);

--- a/Neos.Flow/Tests/Unit/Mvc/View/JsonViewTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/View/JsonViewTest.php
@@ -469,4 +469,21 @@ class JsonViewTest extends UnitTestCase
         $unexpectedResult = json_encode($array);
         $this->assertNotEquals($unexpectedResult, $actualResult);
     }
+
+    /**
+     * @test
+     */
+    public function viewObeysDateTimeFormatOption()
+    {
+        $array = ['foo' => new DateTime('2021-05-02T13:00:00+0000')];
+
+        $this->view->setOption('datetimeFormat', 'Y-m-d H:i:s T');
+        $this->view->assign('array', $array);
+        $this->view->setVariablesToRender(['array']);
+
+        $expectedResult = json_encode(['foo' => '2021-05-02 13:00:00 UTC']);
+
+        $actualResult = $this->view->render();
+        $this->assertEquals($expectedResult, $actualResult);
+    }
 }


### PR DESCRIPTION
This allows to override the badly chosen default format of DateTimeInterface::ISO8601 which is not really compatible to ISO8601 in the JsonView options `datetimeFormat` - see https://www.php.net/manual/en/class.datetimeinterface.php#datetime.constants.iso8601