### PR TITLE
BUGFIX: Use lazy EntityManager injection to prevent recursive instanciation

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/PersistenceManager.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/PersistenceManager.php
@@ -23,6 +23,7 @@ use Neos\Flow\Persistence\AbstractPersistenceManager;
 use Neos\Flow\Persistence\Exception\KnownObjectException;
 use Neos\Flow\Persistence\Exception as PersistenceException;
 use Neos\Flow\Persistence\Exception\UnknownObjectException;
+use Neos\Flow\ObjectManagement\DependencyInjection\DependencyProxy;
 use Neos\Utility\ObjectAccess;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Validation\ValidatorResolver;
@@ -48,7 +49,7 @@ class PersistenceManager extends AbstractPersistenceManager
     protected $throwableStorage;
 
     /**
-     * @Flow\Inject(lazy=false)
+     * @Flow\Inject
      * @var EntityManagerInterface
      */
     protected $entityManager;
@@ -313,6 +314,9 @@ class PersistenceManager extends AbstractPersistenceManager
         // "driver" is used only for Doctrine, thus we (mis-)use it here
         // additionally, when no path is set, skip this step, assuming no DB is needed
         if ($this->settings['backendOptions']['driver'] !== null && $this->settings['backendOptions']['path'] !== null) {
+            if ($this->entityManager instanceof DependencyProxy) {
+                $this->entityManager->_activateDependency();
+            }
             $schemaTool = new SchemaTool($this->entityManager);
             if ($this->settings['backendOptions']['driver'] === 'pdo_sqlite') {
                 $schemaTool->createSchema($this->entityManager->getMetadataFactory()->getAllMetadata());


### PR DESCRIPTION
With the changes in #2423 the PersistenceManager was registered as a Doctrine EventListener.
Hence, when building the EntityManager, the PersistenceManager got instanciated with a completely new non-lazy EntityManager. This caused errors when trying to persist entities, as they were not known to that instance of the EntityManager.
This change makes the EntityManager instanciation lazy again and handles the type mismatch of the lazy DependencyProxy in the SchemaTool.

This is an alternative fix to #2448