### PR TITLE
TASK: Fix unit tests

### DIFF
--- a/Neos.Flow/Tests/Unit/Http/Helper/RequestInformationHelperTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Helper/RequestInformationHelperTest.php
@@ -20,7 +20,7 @@ class RequestInformationHelperTest extends UnitTestCase
             ->withAddedHeader('Authorization', 'Bearer SomeToken');
 
         $renderedHeaders = RequestInformationHelper::renderRequestHeaders($request);
-        self::assertStringContainsString('SomePassword', $renderedHeaders);
-        self::assertStringContainsString('SomeToken', $renderedHeaders);
+        self::assertStringNotContainsString('SomePassword', $renderedHeaders);
+        self::assertStringNotContainsString('SomeToken', $renderedHeaders);
     }
 }


### PR DESCRIPTION
Fixes the `RequestInformationHelperTest` that fails since 441b61b4b5b7a9b9340f77ea992c323a40d2f13c