### PR TITLE
BUGFIX: Null coalesce content type in ActionResponse getter

### DIFF
--- a/Neos.Flow/Classes/Mvc/ActionResponse.php
+++ b/Neos.Flow/Classes/Mvc/ActionResponse.php
@@ -196,7 +196,7 @@ final class ActionResponse
      */
     public function getContentType(): string
     {
-        return $this->contentType;
+        return $this->contentType ?? '';
     }
 
     /**


### PR DESCRIPTION
The current PHP typehint of `: string` will cause this method to throw an error when `setContentType()` was not called before with a valid string. In Flow 7 we lifted the typehint to `?string`, but IMO that does only complicate the API unnecessarily, because `''` is not a valid content type any way and hence indistinguishable from "did not set content type" for any useful means and purposes.
Hence I suggest using null coalescing instead (and changing the 7+ typehint back to `string`, though that would be breaking).

See also discussion in https://github.com/neos/flow-development-collection/pull/2180#discussion_r550197400