### PR TITLE
!!! FEATURE: Enable URL Rewriting by default

### DIFF
--- a/Neos.Flow/Classes/Utility/Environment.php
+++ b/Neos.Flow/Classes/Utility/Environment.php
@@ -109,7 +109,7 @@ class Environment
      */
     public function isRewriteEnabled(): bool
     {
-        return (bool)Bootstrap::getEnvironmentConfigurationSetting('FLOW_REWRITEURLS');
+        return (string)Bootstrap::getEnvironmentConfigurationSetting('FLOW_REWRITEURLS') !== '0';
     }
 
     /**

--- a/Neos.Flow/Resources/Private/Installer/Distribution/Defaults/Web/.htaccess
+++ b/Neos.Flow/Resources/Private/Installer/Distribution/Defaults/Web/.htaccess
@@ -17,8 +17,8 @@
 	# Enable URL rewriting
 	RewriteEngine On
 
-	# Set flag so we know URL rewriting is available
-	SetEnv FLOW_REWRITEURLS 1
+	# Set flag to "0" to disable URL rewriting
+	# SetEnv FLOW_REWRITEURLS 0
 
 	# You will have to change the path in the following option if you
 	# experience problems while your installation is located in a subdirectory

--- a/Neos.Flow/Scripts/PhpDevelopmentServerRouter.php
+++ b/Neos.Flow/Scripts/PhpDevelopmentServerRouter.php
@@ -28,9 +28,6 @@ if (DIRECTORY_SEPARATOR !== '/' && trim(getenv('FLOW_ROOTPATH'), '"\' ') === '')
 $_SERVER['SCRIPT_FILENAME'] = $_SERVER['FLOW_ROOTPATH'] . 'Web/index.php';
 $_SERVER['SCRIPT_NAME'] = '/index.php';
 
-// we want to have nice URLs
-putenv('FLOW_REWRITEURLS=1');
-
 $context = \Neos\Flow\Core\Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT') ?: 'Development';
 $bootstrap = new \Neos\Flow\Core\Bootstrap($context);
 $bootstrap->run();

--- a/Neos.Flow/Tests/FunctionalTestCase.php
+++ b/Neos.Flow/Tests/FunctionalTestCase.php
@@ -378,10 +378,8 @@ abstract class FunctionalTestCase extends \Neos\Flow\Tests\BaseTestCase
         $_FILES = [];
         $_SERVER = [
             'REDIRECT_FLOW_CONTEXT' => 'Development',
-            'REDIRECT_FLOW_REWRITEURLS' => '1',
             'REDIRECT_STATUS' => '200',
             'FLOW_CONTEXT' => 'Testing',
-            'FLOW_REWRITEURLS' => '1',
             'HTTP_HOST' => 'localhost',
             'HTTP_USER_AGENT' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.52.7 (KHTML, like Gecko) Version/5.1.2 Safari/534.52.7',
             'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',


### PR DESCRIPTION
This flips the default behavior for the `FLOW_REWRITEURLS` environment
variable: If it is _not_ specified (or contains a value other than `0`)
URL rewriting will be enabled.

Previously URL rewriting was enabled with a corresponding `SetEnv` configuration
for Apache.
For other servers and CLI a corresponding configuration (or a
`putenv('FLOW_REWRITEURLS=1')` call at runtime) was required in order to
activate URL rewriting.

This could be a breaking change in case you relied on the previous behavior.
For example: Using the `UriBuilder` in CLI previously created URLs in the format `/index.php/some/path`. Now it will lead to `/some/path` by default.
To re-establish the former behavior, the `FLOW_REWRITEURLS` can be set to 0 explicitly, for example via `putenv('FLOW_REWRITEURLS=1');`.