### PR TITLE
FEATURE: Cli ProgressBar is public accessible

### DIFF
--- a/Neos.Flow/Classes/Cli/ConsoleOutput.php
+++ b/Neos.Flow/Classes/Cli/ConsoleOutput.php
@@ -389,7 +389,7 @@ class ConsoleOutput
      *
      * @return ProgressBar
      */
-    protected function getProgressBar(): ProgressBar
+    public function getProgressBar(): ProgressBar
     {
         if ($this->progressBar === null) {
             $this->progressBar = new ProgressBar($this->output);


### PR DESCRIPTION
**What I did**

The access modifier for `getProgressBar()` in `ConsoleOutput.php` is now public.

I'm using reflection to access the progressbar in a project to use symfonie's time estimation for a long running command. I think there shouldn't be much harm in just making `getProgressBar()` public.

Maybe this could go into the 7.1 release?

[Symfony Progressbar Docs](https://symfony.com/doc/current/components/console/helpers/progressbar.html)

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
