### PR TITLE
TASK: Add test that covers signal arguments by reference passing

### DIFF
--- a/Neos.Flow/Tests/Functional/SignalSlot/Fixtures/SubClass.php
+++ b/Neos.Flow/Tests/Functional/SignalSlot/Fixtures/SubClass.php
@@ -22,12 +22,20 @@ class SubClass extends AbstractClass
 {
     public $slotWasCalled = false;
 
+    public $referencedArray = [];
+
     /**
      * @return void
      */
     public function triggerSomethingSignalFromSubClass()
     {
         $this->emitSomething();
+    }
+
+    public function triggerSignalWithByReferenceArgument()
+    {
+        $this->referencedArray = [];
+        $this->emitSignalWithReferenceArgument($this->referencedArray);
     }
 
     /**
@@ -38,11 +46,20 @@ class SubClass extends AbstractClass
     {
     }
 
+    public function emitSignalWithReferenceArgument(array &$array): void
+    {
+    }
+
     /**
      * @return void
      */
     public function somethingSlot()
     {
         $this->slotWasCalled = true;
+    }
+
+    public function referencedArraySlot(array &$array): void
+    {
+        $array['foo'] = 'bar';
     }
 }

--- a/Neos.Flow/Tests/Functional/SignalSlot/Fixtures/SubClass.php
+++ b/Neos.Flow/Tests/Functional/SignalSlot/Fixtures/SubClass.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Tests\Functional\SignalSlot\Fixtures;
 
 use Doctrine\ORM\Mapping as ORM;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\SignalSlot\SignalInformation;
 
 /**
  * A concrete class for testing signals in abstract classes
@@ -46,6 +47,9 @@ class SubClass extends AbstractClass
     {
     }
 
+    /**
+     * @Flow\Signal
+     */
     public function emitSignalWithReferenceArgument(array &$array): void
     {
     }
@@ -61,5 +65,10 @@ class SubClass extends AbstractClass
     public function referencedArraySlot(array &$array): void
     {
         $array['foo'] = 'bar';
+    }
+
+    public function referencedArraySlotWithSignalInformation(SignalInformation $si): void
+    {
+        $si->getSignalArguments()['array']['foo'] = 'bar';
     }
 }

--- a/Neos.Flow/Tests/Functional/SignalSlot/SignalSlotTest.php
+++ b/Neos.Flow/Tests/Functional/SignalSlot/SignalSlotTest.php
@@ -37,4 +37,19 @@ class SignalSlotTest extends FunctionalTestCase
         $subClass->triggerSomethingSignalFromAbstractClass();
         self::assertTrue($subClass->slotWasCalled, 'from abstract class');
     }
+
+    /**
+     * @test
+     */
+    public function slotsReceiveArgumentsAsReference()
+    {
+        $subClass = new Fixtures\SubClass();
+
+        $dispatcher = $this->objectManager->get(Dispatcher::class);
+        $dispatcher->connect(Fixtures\SubClass::class, 'signalWithReferenceArgument', $subClass, 'referencedArraySlot');
+
+        $subClass->triggerSignalWithByReferenceArgument();
+        self::assertArrayHasKey('foo', $subClass->referencedArray);
+        self::assertEquals('bar', $subClass->referencedArray['foo']);
+    }
 }

--- a/Neos.Flow/Tests/Functional/SignalSlot/SignalSlotTest.php
+++ b/Neos.Flow/Tests/Functional/SignalSlot/SignalSlotTest.php
@@ -52,4 +52,19 @@ class SignalSlotTest extends FunctionalTestCase
         self::assertArrayHasKey('foo', $subClass->referencedArray);
         self::assertEquals('bar', $subClass->referencedArray['foo']);
     }
+
+    /**
+     * @test
+     */
+    public function slotsReceiveArgumentsAsReferenceInSignalInformation()
+    {
+        $subClass = new Fixtures\SubClass();
+
+        $dispatcher = $this->objectManager->get(Dispatcher::class);
+        $dispatcher->wire(Fixtures\SubClass::class, 'signalWithReferenceArgument', $subClass, 'referencedArraySlotWithSignalInformation');
+
+        $subClass->triggerSignalWithByReferenceArgument();
+        self::assertArrayHasKey('foo', $subClass->referencedArray);
+        self::assertEquals('bar', $subClass->referencedArray['foo']);
+    }
 }

--- a/Neos.Flow/Tests/Unit/SignalSlot/DispatcherTest.php
+++ b/Neos.Flow/Tests/Unit/SignalSlot/DispatcherTest.php
@@ -306,6 +306,48 @@ class DispatcherTest extends UnitTestCase
     /**
      * @test
      */
+    public function dispatchPassesSignalArgumentsAsReferenceInSignalInformation(): void
+    {
+        $mockSlot = function (SignalInformation $s) {
+            $s->getSignalArguments()[0]['foo'] = 'bar';
+        };
+
+        $mockObjectManager = $this->createMock(ObjectManagerInterface::class);
+
+        $dispatcher = new Dispatcher();
+        $dispatcher->wire('SignalClassName', 'methodName', $mockSlot);
+        $dispatcher->injectObjectManager($mockObjectManager);
+
+        $referencedArray = [];
+        $passedArguments = [&$referencedArray];
+        $dispatcher->dispatch('SignalClassName', 'methodName', $passedArguments);
+        self::assertEquals('bar', $referencedArray['foo']);
+    }
+
+    /**
+     * @test
+     */
+    public function dispatchPassesSignalArgumentsAsReference(): void
+    {
+        $mockSlot = function (array &$array) {
+            $array['foo'] = 'bar';
+        };
+
+        $mockObjectManager = $this->createMock(ObjectManagerInterface::class);
+
+        $dispatcher = new Dispatcher();
+        $dispatcher->connect('SignalClassName', 'methodName', $mockSlot);
+        $dispatcher->injectObjectManager($mockObjectManager);
+
+        $referencedArray = [];
+        $passedArguments = [&$referencedArray];
+        $dispatcher->dispatch('SignalClassName', 'methodName', $passedArguments);
+        self::assertEquals('bar', $referencedArray['foo']);
+    }
+
+    /**
+     * @test
+     */
     public function dispatchPassesSignalInformationObjectIfWireWasUsed(): void
     {
         $receivedArguments = [];


### PR DESCRIPTION
These tests verify that our current signal/slot dispatching works with byReference arguments.

Related to #2412