### PR TITLE
FEATURE: Support PHP8 attributes

### DIFF
--- a/Neos.Flow/Classes/Annotations/After.php
+++ b/Neos.Flow/Classes/Annotations/After.php
@@ -11,30 +11,28 @@ namespace Neos\Flow\Annotations;
  * source code.
  */
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Declares a method as an after advice to be triggered after any
  * pointcut matching the given expression.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 final class After
 {
     /**
      * The pointcut expression. (Can be given as anonymous argument.)
      * @var string
+     * @Required
      */
     public $pointcutExpression;
 
-    /**
-     * @param array $values
-     * @throws \InvalidArgumentException
-     */
-    public function __construct(array $values)
+    public function __construct(string $pointcutExpression)
     {
-        if (!isset($values['value']) && !isset($values['pointcutExpression'])) {
-            throw new \InvalidArgumentException('An After annotation must specify a pointcut expression.', 1318456620);
-        }
-        $this->pointcutExpression = isset($values['pointcutExpression']) ? $values['pointcutExpression'] : $values['value'];
+        $this->pointcutExpression = $pointcutExpression;
     }
 }

--- a/Neos.Flow/Classes/Annotations/AfterReturning.php
+++ b/Neos.Flow/Classes/Annotations/AfterReturning.php
@@ -11,30 +11,28 @@ namespace Neos\Flow\Annotations;
  * source code.
  */
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Declares a method as an after returning advice to be triggered
  * after any pointcut matching the given expression returns.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 final class AfterReturning
 {
     /**
      * The pointcut expression. (Can be given as anonymous argument.)
      * @var string
+     * @Required
      */
     public $pointcutExpression;
 
-    /**
-     * @param array $values
-     * @throws \InvalidArgumentException
-     */
-    public function __construct(array $values)
+    public function __construct(string $pointcutExpression)
     {
-        if (!isset($values['value']) && !isset($values['pointcutExpression'])) {
-            throw new \InvalidArgumentException('An AfterReturning annotation must specify a pointcut expression.', 1318456618);
-        }
-        $this->pointcutExpression = isset($values['pointcutExpression']) ? $values['pointcutExpression'] : $values['value'];
+        $this->pointcutExpression = $pointcutExpression;
     }
 }

--- a/Neos.Flow/Classes/Annotations/AfterThrowing.php
+++ b/Neos.Flow/Classes/Annotations/AfterThrowing.php
@@ -11,30 +11,28 @@ namespace Neos\Flow\Annotations;
  * source code.
  */
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Declares a method as an after throwing advice to be triggered
  * after any pointcut matching the given expression throws an exception.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 final class AfterThrowing
 {
     /**
      * The pointcut expression. (Can be given as anonymous argument.)
      * @var string
+     * @Required
      */
     public $pointcutExpression;
 
-    /**
-     * @param array $values
-     * @throws \InvalidArgumentException
-     */
-    public function __construct(array $values)
+    public function __construct(string $pointcutExpression)
     {
-        if (!isset($values['value']) && !isset($values['pointcutExpression'])) {
-            throw new \InvalidArgumentException('An AfterThrowing annotation must specify a pointcut expression.', 1318456616);
-        }
-        $this->pointcutExpression = isset($values['pointcutExpression']) ? $values['pointcutExpression'] : $values['value'];
+        $this->pointcutExpression = $pointcutExpression;
     }
 }

--- a/Neos.Flow/Classes/Annotations/Around.php
+++ b/Neos.Flow/Classes/Annotations/Around.php
@@ -11,30 +11,28 @@ namespace Neos\Flow\Annotations;
  * source code.
  */
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Declares a method as an around advice to be triggered around any
  * pointcut matching the given expression.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 final class Around
 {
     /**
      * The pointcut expression. (Can be given as anonymous argument.)
      * @var string
+     * @Required
      */
     public $pointcutExpression;
 
-    /**
-     * @param array $values
-     * @throws \InvalidArgumentException
-     */
-    public function __construct(array $values)
+    public function __construct(string $pointcutExpression)
     {
-        if (!isset($values['value']) && !isset($values['pointcutExpression'])) {
-            throw new \InvalidArgumentException('An Around annotation must specify a pointcut expression.', 1318456614);
-        }
-        $this->pointcutExpression = isset($values['pointcutExpression']) ? $values['pointcutExpression'] : $values['value'];
+        $this->pointcutExpression = $pointcutExpression;
     }
 }

--- a/Neos.Flow/Classes/Annotations/Aspect.php
+++ b/Neos.Flow/Classes/Annotations/Aspect.php
@@ -20,6 +20,7 @@ namespace Neos\Flow\Annotations;
  * @Annotation
  * @Target("CLASS")
  */
+#[\Attribute(\Attribute::TARGET_CLASS)]
 final class Aspect
 {
 }

--- a/Neos.Flow/Classes/Annotations/Autowiring.php
+++ b/Neos.Flow/Classes/Annotations/Autowiring.php
@@ -11,13 +11,17 @@ namespace Neos\Flow\Annotations;
  * source code.
  */
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Used to disable autowiring for Dependency Injection on the
  * whole class or on the annotated property only.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"METHOD", "CLASS"})
  */
+#[\Attribute(\Attribute::TARGET_METHOD|\Attribute::TARGET_CLASS)]
 final class Autowiring
 {
     /**
@@ -26,15 +30,8 @@ final class Autowiring
      */
     public $enabled = true;
 
-    /**
-     * @param array $values
-     */
-    public function __construct(array $values)
+    public function __construct(bool $enabled = true)
     {
-        if (isset($values['enabled'])) {
-            $this->enabled = (boolean)$values['enabled'];
-        } elseif (isset($values['value'])) {
-            $this->enabled = (boolean)$values['value'];
-        }
+        $this->enabled = $enabled;
     }
 }

--- a/Neos.Flow/Classes/Annotations/Before.php
+++ b/Neos.Flow/Classes/Annotations/Before.php
@@ -11,30 +11,28 @@ namespace Neos\Flow\Annotations;
  * source code.
  */
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Declares a method as an before advice to be triggered before any
  * pointcut matching the given expression.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 final class Before
 {
     /**
      * The pointcut expression. (Can be given as anonymous argument.)
      * @var string
+     * @Required
      */
     public $pointcutExpression;
 
-    /**
-     * @param array $values
-     * @throws \InvalidArgumentException
-     */
-    public function __construct(array $values)
+    public function __construct(string $pointcutExpression)
     {
-        if (!isset($values['value']) && !isset($values['pointcutExpression'])) {
-            throw new \InvalidArgumentException('A Before annotation must specify a pointcut expression.', 1318456622);
-        }
-        $this->pointcutExpression = isset($values['pointcutExpression']) ? $values['pointcutExpression'] : $values['value'];
+        $this->pointcutExpression = $pointcutExpression;
     }
 }

--- a/Neos.Flow/Classes/Annotations/CompileStatic.php
+++ b/Neos.Flow/Classes/Annotations/CompileStatic.php
@@ -17,6 +17,7 @@ use Doctrine\Common\Annotations\Annotation as DoctrineAnnotation;
  * @Annotation
  * @DoctrineAnnotation\Target({"METHOD"})
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 final class CompileStatic
 {
 }

--- a/Neos.Flow/Classes/Annotations/Entity.php
+++ b/Neos.Flow/Classes/Annotations/Entity.php
@@ -28,7 +28,7 @@ final class Entity
 {
     /**
      * Name of the repository class to use for managing the entity.
-     * @var string
+     * @var string|null
      */
     public $repositoryClass;
 

--- a/Neos.Flow/Classes/Annotations/Entity.php
+++ b/Neos.Flow/Classes/Annotations/Entity.php
@@ -11,6 +11,8 @@ namespace Neos\Flow\Annotations;
  * source code.
  */
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Marks an object as an entity.
  *
@@ -18,8 +20,10 @@ namespace Neos\Flow\Annotations;
  * with that.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("CLASS")
  */
+#[\Attribute(\Attribute::TARGET_CLASS)]
 final class Entity
 {
     /**
@@ -33,4 +37,10 @@ final class Entity
      * @var boolean
      */
     public $readOnly = false;
+
+    public function __construct(?string $repositoryClass = null, bool $readOnly = false)
+    {
+        $this->repositoryClass = $repositoryClass;
+        $this->readOnly = $readOnly;
+    }
 }

--- a/Neos.Flow/Classes/Annotations/FlushesCaches.php
+++ b/Neos.Flow/Classes/Annotations/FlushesCaches.php
@@ -19,6 +19,7 @@ namespace Neos\Flow\Annotations;
  * @Annotation
  * @Target("METHOD")
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 final class FlushesCaches
 {
 }

--- a/Neos.Flow/Classes/Annotations/Identity.php
+++ b/Neos.Flow/Classes/Annotations/Identity.php
@@ -23,6 +23,7 @@ namespace Neos\Flow\Annotations;
  * @Annotation
  * @Target("PROPERTY")
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class Identity
 {
 }

--- a/Neos.Flow/Classes/Annotations/IgnoreValidation.php
+++ b/Neos.Flow/Classes/Annotations/IgnoreValidation.php
@@ -11,6 +11,8 @@ namespace Neos\Flow\Annotations;
  * source code.
  */
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Used to ignore validation on a specific method argument or class property.
  *
@@ -18,8 +20,10 @@ namespace Neos\Flow\Annotations;
  * processing, the "evaluate" option can be set to true (while still ignoring any validation error).
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"METHOD", "PROPERTY"})
  */
+#[\Attribute(\Attribute::TARGET_METHOD|\Attribute::TARGET_PROPERTY|\Attribute::IS_REPEATABLE)]
 final class IgnoreValidation
 {
     /**
@@ -34,18 +38,9 @@ final class IgnoreValidation
      */
     public $evaluate = false;
 
-    /**
-     * @param array $values
-     * @throws \InvalidArgumentException
-     */
-    public function __construct(array $values)
+    public function __construct(string $argumentName, bool $evaluate = false)
     {
-        if (isset($values['value']) || isset($values['argumentName'])) {
-            $this->argumentName = ltrim(isset($values['argumentName']) ? $values['argumentName'] : $values['value'], '$');
-        }
-
-        if (isset($values['evaluate'])) {
-            $this->evaluate = (boolean)$values['evaluate'];
-        }
+        $this->argumentName = ltrim($argumentName, '$');
+        $this->evaluate = $evaluate;
     }
 }

--- a/Neos.Flow/Classes/Annotations/Inject.php
+++ b/Neos.Flow/Classes/Annotations/Inject.php
@@ -11,6 +11,8 @@ namespace Neos\Flow\Annotations;
  * source code.
  */
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Used to enable property injection.
  *
@@ -18,8 +20,10 @@ namespace Neos\Flow\Annotations;
  * to inject a value as specified by the var annotation.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("PROPERTY")
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class Inject
 {
     /**
@@ -42,13 +46,9 @@ final class Inject
     /**
      * @param array $values
      */
-    public function __construct(array $values)
+    public function __construct(?string $name = null, bool $lazy = true)
     {
-        if (isset($values['lazy'])) {
-            $this->lazy = (boolean)$values['lazy'];
-        }
-        if (isset($values['name'])) {
-            $this->name = $values['name'];
-        }
+        $this->lazy = $lazy;
+        $this->name = $name;
     }
 }

--- a/Neos.Flow/Classes/Annotations/Inject.php
+++ b/Neos.Flow/Classes/Annotations/Inject.php
@@ -39,7 +39,7 @@ final class Inject
      * This is useful if the object name does not match the class name of the object to be injected:
      * (at)Inject(name="Some.Package:Some.Virtual.Object")
      *
-     * @var string
+     * @var string|null
      */
     public $name;
 

--- a/Neos.Flow/Classes/Annotations/InjectConfiguration.php
+++ b/Neos.Flow/Classes/Annotations/InjectConfiguration.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\Annotations;
  */
 
 use Neos\Flow\Configuration\ConfigurationManager;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * Used to enable property injection for configuration including settings.
@@ -20,8 +21,10 @@ use Neos\Flow\Configuration\ConfigurationManager;
  * to inject the configured configuration.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("PROPERTY")
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class InjectConfiguration
 {
     /**
@@ -55,19 +58,12 @@ final class InjectConfiguration
      */
     public $type = ConfigurationManager::CONFIGURATION_TYPE_SETTINGS;
 
-    /**
-     * @param array $values
-     */
-    public function __construct(array $values)
+    public function __construct(?string $path = null, ?string $package = null, ?string $type = null)
     {
-        if (isset($values['value']) || isset($values['path'])) {
-            $this->path = isset($values['path']) ? (string)$values['path'] : (string)$values['value'];
-        }
-        if (isset($values['package'])) {
-            $this->package = (string)$values['package'];
-        }
-        if (isset($values['type'])) {
-            $this->type = (string)$values['type'];
+        $this->path = $path;
+        $this->package = $package;
+        if ($type !== null) {
+            $this->type = $type;
         }
     }
 }

--- a/Neos.Flow/Classes/Annotations/InjectConfiguration.php
+++ b/Neos.Flow/Classes/Annotations/InjectConfiguration.php
@@ -35,7 +35,7 @@ final class InjectConfiguration
      *
      * Example: session.name
      *
-     * @var string
+     * @var string|null
      */
     public $path;
 
@@ -47,7 +47,7 @@ final class InjectConfiguration
      *
      * Example: Neos.Flow
      *
-     * @var string
+     * @var string|null
      */
     public $package;
 

--- a/Neos.Flow/Classes/Annotations/Internal.php
+++ b/Neos.Flow/Classes/Annotations/Internal.php
@@ -20,6 +20,7 @@ namespace Neos\Flow\Annotations;
  * @Annotation
  * @Target("METHOD")
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 final class Internal
 {
 }

--- a/Neos.Flow/Classes/Annotations/Introduce.php
+++ b/Neos.Flow/Classes/Annotations/Introduce.php
@@ -11,18 +11,23 @@ namespace Neos\Flow\Annotations;
  * source code.
  */
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Introduces the given interface or property into any target class matching
  * the given pointcut expression.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"CLASS", "PROPERTY"})
  */
+#[\Attribute(\Attribute::TARGET_CLASS|\Attribute::TARGET_PROPERTY|\Attribute::IS_REPEATABLE)]
 final class Introduce
 {
     /**
      * The pointcut expression. (Can be given as anonymous argument.)
      * @var string
+     * @Required
      */
     public $pointcutExpression;
 
@@ -39,22 +44,10 @@ final class Introduce
      */
     public $traitName;
 
-    /**
-     * @param array $values
-     * @throws \InvalidArgumentException
-     */
-    public function __construct(array $values)
+    public function __construct(string $pointcutExpression, ?string $interfaceName = null, ?string $traitName = null)
     {
-        if (!isset($values['value']) && !isset($values['pointcutExpression'])) {
-            throw new \InvalidArgumentException('An Introduce annotation must specify a pointcut expression.', 1318456624);
-        }
-        $this->pointcutExpression = isset($values['pointcutExpression']) ? $values['pointcutExpression'] : $values['value'];
-
-        if (isset($values['interfaceName'])) {
-            $this->interfaceName = $values['interfaceName'];
-        }
-        if (isset($values['traitName'])) {
-            $this->traitName = $values['traitName'];
-        }
+        $this->pointcutExpression = $pointcutExpression;
+        $this->interfaceName = $interfaceName;
+        $this->traitName = $traitName;
     }
 }

--- a/Neos.Flow/Classes/Annotations/Introduce.php
+++ b/Neos.Flow/Classes/Annotations/Introduce.php
@@ -33,14 +33,14 @@ final class Introduce
 
     /**
      * The interface name to introduce.
-     * @var string
+     * @var string|null
      */
     public $interfaceName;
 
     /**
      * The trait name to introduce
      *
-     * @var string
+     * @var string|null
      */
     public $traitName;
 

--- a/Neos.Flow/Classes/Annotations/Lazy.php
+++ b/Neos.Flow/Classes/Annotations/Lazy.php
@@ -20,6 +20,7 @@ namespace Neos\Flow\Annotations;
  * @Annotation
  * @Target({"CLASS", "PROPERTY"})
  */
+#[\Attribute(\Attribute::TARGET_CLASS|\Attribute::TARGET_PROPERTY)]
 final class Lazy
 {
 }

--- a/Neos.Flow/Classes/Annotations/MapRequestBody.php
+++ b/Neos.Flow/Classes/Annotations/MapRequestBody.php
@@ -11,6 +11,8 @@ namespace Neos\Flow\Annotations;
  * source code.
  */
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Used to map the request body to a single action argument.
  *
@@ -18,24 +20,21 @@ namespace Neos\Flow\Annotations;
  * map the full body into a single argument without wrapping the request body.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"METHOD"})
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 final class MapRequestBody
 {
     /**
      * Name of the argument to map the request body into. (Can be given as anonymous argument.)
      * @var string
+     * @Required
      */
     public $argumentName;
 
-    /**
-     * @param array $values
-     * @throws \InvalidArgumentException
-     */
-    public function __construct(array $values)
+    public function __construct(string $argumentName)
     {
-        if (isset($values['value']) || isset($values['argumentName'])) {
-            $this->argumentName = ltrim($values['argumentName'] ?? $values['value'], '$');
-        }
+        $this->argumentName = ltrim($argumentName, '$');
     }
 }

--- a/Neos.Flow/Classes/Annotations/Pointcut.php
+++ b/Neos.Flow/Classes/Annotations/Pointcut.php
@@ -11,30 +11,28 @@ namespace Neos\Flow\Annotations;
  * source code.
  */
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Declares a named pointcut. The annotated method does not become an advice
  * but can be used as a named pointcut instead of the given expression.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 final class Pointcut
 {
     /**
      * The pointcut expression. (Can be given as anonymous argument.)
      * @var string
+     * @Required
      */
     public $expression;
 
-    /**
-     * @param array $values
-     * @throws \InvalidArgumentException
-     */
-    public function __construct(array $values)
+    public function __construct(string $expression)
     {
-        if (!isset($values['value']) && !isset($values['expression'])) {
-            throw new \InvalidArgumentException('A Pointcut annotation must specify a pointcut expression.', 1318456604);
-        }
-        $this->expression = isset($values['expression']) ? $values['expression'] : $values['value'];
+        $this->expression = $expression;
     }
 }

--- a/Neos.Flow/Classes/Annotations/Proxy.php
+++ b/Neos.Flow/Classes/Annotations/Proxy.php
@@ -11,6 +11,8 @@ namespace Neos\Flow\Annotations;
  * source code.
  */
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Used to disable proxy building for an object.
  *
@@ -18,8 +20,10 @@ namespace Neos\Flow\Annotations;
  * on the object.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("CLASS")
  */
+#[\Attribute(\Attribute::TARGET_CLASS)]
 final class Proxy
 {
     /**
@@ -28,15 +32,8 @@ final class Proxy
      */
     public $enabled = true;
 
-    /**
-     * @param array $values
-     */
-    public function __construct(array $values)
+    public function __construct(bool $enabled = true)
     {
-        if (isset($values['enabled'])) {
-            $this->enabled = (boolean)$values['enabled'];
-        } elseif (isset($values['value'])) {
-            $this->enabled = (boolean)$values['value'];
-        }
+        $this->enabled = $enabled;
     }
 }

--- a/Neos.Flow/Classes/Annotations/Scope.php
+++ b/Neos.Flow/Classes/Annotations/Scope.php
@@ -11,12 +11,16 @@ namespace Neos\Flow\Annotations;
  * source code.
  */
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Used to set the scope of an object.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("CLASS")
  */
+#[\Attribute(\Attribute::TARGET_CLASS)]
 final class Scope
 {
     /**
@@ -25,13 +29,10 @@ final class Scope
      */
     public $value = 'prototype';
 
-    /**
-     * @param array $values
-     */
-    public function __construct(array $values)
+    public function __construct(?string $value = null)
     {
-        if (isset($values['value'])) {
-            $this->value = $values['value'];
+        if ($value !== null) {
+            $this->value = $value;
         }
     }
 }

--- a/Neos.Flow/Classes/Annotations/Session.php
+++ b/Neos.Flow/Classes/Annotations/Session.php
@@ -11,13 +11,17 @@ namespace Neos\Flow\Annotations;
  * source code.
  */
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Used to control the behavior of session handling when the annotated
  * method is called.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("METHOD")
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 final class Session
 {
     /**
@@ -25,4 +29,9 @@ final class Session
      * @var boolean
      */
     public $autoStart = false;
+
+    public function __construct(bool $autoStart = false)
+    {
+        $this->autoStart = $autoStart;
+    }
 }

--- a/Neos.Flow/Classes/Annotations/Signal.php
+++ b/Neos.Flow/Classes/Annotations/Signal.php
@@ -21,6 +21,7 @@ namespace Neos\Flow\Annotations;
  * @Annotation
  * @Target("METHOD")
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 final class Signal
 {
 }

--- a/Neos.Flow/Classes/Annotations/SkipCsrfProtection.php
+++ b/Neos.Flow/Classes/Annotations/SkipCsrfProtection.php
@@ -22,6 +22,7 @@ namespace Neos\Flow\Annotations;
  * @Annotation
  * @Target("METHOD")
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 final class SkipCsrfProtection
 {
 }

--- a/Neos.Flow/Classes/Annotations/Transient.php
+++ b/Neos.Flow/Classes/Annotations/Transient.php
@@ -21,6 +21,7 @@ namespace Neos\Flow\Annotations;
  * @Annotation
  * @Target("PROPERTY")
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class Transient
 {
 }

--- a/Neos.Flow/Classes/Annotations/Validate.php
+++ b/Neos.Flow/Classes/Annotations/Validate.php
@@ -25,7 +25,7 @@ final class Validate
 {
     /**
      * The validator type, either a FQCN or a Flow validator class name.
-     * @var string
+     * @var string|null
      */
     public $type;
 

--- a/Neos.Flow/Classes/Annotations/Validate.php
+++ b/Neos.Flow/Classes/Annotations/Validate.php
@@ -11,12 +11,16 @@ namespace Neos\Flow\Annotations;
  * source code.
  */
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Controls how a property or method argument will be validated by Flow.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"METHOD", "PROPERTY"})
  */
+#[\Attribute(\Attribute::TARGET_METHOD|\Attribute::TARGET_PROPERTY|\Attribute::IS_REPEATABLE)]
 final class Validate
 {
     /**
@@ -43,27 +47,18 @@ final class Validate
      */
     public $validationGroups = ['Default'];
 
-    /**
-     * @param array $values
-     * @throws \InvalidArgumentException
-     */
-    public function __construct(array $values)
+    public function __construct(?string $argumentName = null, string $type = null, ?array $validationGroups = null, array $options = [])
     {
-        if (!isset($values['type'])) {
-            throw new \InvalidArgumentException('Validate annotations must be given a validator type.', 1318494791);
-        }
-        $this->type = $values['type'];
+        $this->type = $type;
 
-        if (isset($values['options']) && is_array($values['options'])) {
-            $this->options = $values['options'];
-        }
+        $this->options = $options;
 
-        if (isset($values['value']) || isset($values['argumentName'])) {
-            $this->argumentName = ltrim(isset($values['argumentName']) ? $values['argumentName'] : $values['value'], '$');
+        if ($argumentName !== null) {
+            $this->argumentName = ltrim($argumentName, '$');
         }
 
-        if (isset($values['validationGroups']) && is_array($values['validationGroups'])) {
-            $this->validationGroups = $values['validationGroups'];
+        if ($validationGroups !== null) {
+            $this->validationGroups = $validationGroups;
         }
     }
 }

--- a/Neos.Flow/Classes/Annotations/Validate.php
+++ b/Neos.Flow/Classes/Annotations/Validate.php
@@ -47,7 +47,7 @@ final class Validate
      */
     public $validationGroups = ['Default'];
 
-    public function __construct(?string $argumentName = null, string $type = null, ?array $validationGroups = null, array $options = [])
+    public function __construct(?string $argumentName = null, string $type = null, array $options = [], ?array $validationGroups = null)
     {
         $this->type = $type;
 

--- a/Neos.Flow/Classes/Annotations/ValidationGroups.php
+++ b/Neos.Flow/Classes/Annotations/ValidationGroups.php
@@ -12,11 +12,14 @@ namespace Neos\Flow\Annotations;
  */
 
 use Doctrine\Common\Annotations\Annotation as DoctrineAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * @Annotation
+ * @NamedArgumentConstructor
  * @DoctrineAnnotation\Target({"METHOD"})
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 final class ValidationGroups
 {
     /**
@@ -25,15 +28,8 @@ final class ValidationGroups
      */
     public $validationGroups = ['Default', 'Controller'];
 
-    /**
-     * @param array $values
-     */
-    public function __construct(array $values)
+    public function __construct(array $validationGroups)
     {
-        if (isset($values['validationGroups']) && is_array($values['validationGroups'])) {
-            $this->validationGroups = $values['validationGroups'];
-        } elseif (isset($values['value']) && is_array($values['value'])) {
-            $this->validationGroups = $values['value'];
-        }
+        $this->validationGroups = $validationGroups;
     }
 }

--- a/Neos.Flow/Classes/Annotations/ValueObject.php
+++ b/Neos.Flow/Classes/Annotations/ValueObject.php
@@ -11,6 +11,8 @@ namespace Neos\Flow\Annotations;
  * source code.
  */
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Marks the annotate class as a value object.
  *
@@ -20,8 +22,10 @@ namespace Neos\Flow\Annotations;
  * of the value object.
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target("CLASS")
  */
+#[\Attribute(\Attribute::TARGET_CLASS)]
 final class ValueObject
 {
     /**
@@ -29,4 +33,9 @@ final class ValueObject
      * @var boolean
      */
     public $embedded = true;
+
+    public function __construct(bool $embedded = true)
+    {
+        $this->embedded = $embedded;
+    }
 }

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
@@ -286,6 +286,29 @@ return ' . var_export($this->storedProxyClasses, true) . ';';
 
 
     /**
+     * Render the source (string) form of a PHP Attribute.
+     * @param \ReflectionAttribute $attribute
+     * @return string
+     */
+    public static function renderAttribute($attribute): string
+    {
+        $attributeAsString = '\\' . $attribute->getName();
+        if (count($attribute->getArguments()) > 0) {
+            $argumentsAsString = [];
+            foreach ($attribute->getArguments() as $argumentName => $argumentValue) {
+                $renderedArgumentValue = var_export($argumentValue, true);
+                if (is_numeric($argumentName)) {
+                    $argumentsAsString[] = $renderedArgumentValue;
+                } else {
+                    $argumentsAsString[] = "$argumentName: $renderedArgumentValue";
+                }
+            }
+            $attributeAsString .= '(' . implode(', ', $argumentsAsString) . ')';
+        }
+        return "#[$attributeAsString]";
+    }
+
+    /**
      * Render the source (string) form of an Annotation instance.
      *
      * @param \Doctrine\Common\Annotations\Annotation $annotation

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php
@@ -162,6 +162,7 @@ class ProxyClass
      */
     public function addProperty($name, $initialValueCode, $visibility = 'private', $docComment = '')
     {
+        // TODO: Add support for PHP attributes?
         $this->properties[$name] = [
             'initialValueCode' => $initialValueCode,
             'visibility' => $visibility,
@@ -259,6 +260,12 @@ class ProxyClass
 
         $classDocumentation .= " * @codeCoverageIgnore\n";
         $classDocumentation .= " */\n";
+        if (PHP_MAJOR_VERSION >= 8) {
+            foreach ($classReflection->getAttributes() as $attribute) {
+                $classDocumentation .= Compiler::renderAttribute($attribute) . "\n";
+            }
+        }
+
         return $classDocumentation;
     }
 

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethod.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethod.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\ObjectManagement\Proxy;
  */
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Reflection\MethodReflection;
 use Neos\Flow\Reflection\ReflectionService;
 
 /**
@@ -238,9 +239,17 @@ class ProxyMethod
             foreach ($methodAnnotations as $annotation) {
                 $methodDocumentation .= '     * ' . Compiler::renderAnnotation($annotation) . "\n";
             }
-        }
+            $methodDocumentation .= "     */\n";
 
-        $methodDocumentation .= "     */\n";
+            if (PHP_MAJOR_VERSION >= 8) {
+                $method = new MethodReflection($className, $methodName);
+                foreach ($method->getAttributes() as $attribute) {
+                    $methodDocumentation .= '    ' . Compiler::renderAttribute($attribute) . "\n";
+                }
+            }
+        } else {
+            $methodDocumentation .= "     */\n";
+        }
         return $methodDocumentation;
     }
 

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1251,6 +1251,13 @@ class ReflectionService
             $this->annotatedClasses[$annotationClassName][$className] = true;
             $this->classReflectionData[$className][self::DATA_CLASS_ANNOTATIONS][] = $annotation;
         }
+        if (PHP_MAJOR_VERSION >= 8) {
+            foreach ($class->getAttributes() as $attribute) {
+                $annotationClassName = $attribute->getName();
+                $this->annotatedClasses[$annotationClassName][$className] = true;
+                $this->classReflectionData[$className][self::DATA_CLASS_ANNOTATIONS][] = $attribute->newInstance();
+            }
+        }
 
         /** @var $property PropertyReflection */
         foreach ($class->getProperties() as $property) {
@@ -1291,6 +1298,11 @@ class ReflectionService
 
         foreach ($this->annotationReader->getPropertyAnnotations($property, $propertyName) as $annotation) {
             $this->classReflectionData[$className][self::DATA_CLASS_PROPERTIES][$propertyName][self::DATA_PROPERTY_ANNOTATIONS][get_class($annotation)][] = $annotation;
+        }
+        if (PHP_MAJOR_VERSION >= 8) {
+            foreach ($property->getAttributes() as $attribute) {
+                $this->classReflectionData[$className][self::DATA_CLASS_PROPERTIES][$propertyName][self::DATA_PROPERTY_ANNOTATIONS][$attribute->getName()][] = $attribute->newInstance();
+            }
         }
 
         return $visibility;
@@ -1378,6 +1390,15 @@ class ReflectionService
                 $this->classesByMethodAnnotations[$annotationClassName][$className] = [];
             }
             $this->classesByMethodAnnotations[$annotationClassName][$className][] = $methodName;
+        }
+        if (PHP_MAJOR_VERSION >= 8) {
+            foreach ($method->getAttributes() as $attribute) {
+                $annotationClassName = $attribute->getName();
+                if (!isset($this->classesByMethodAnnotations[$annotationClassName][$className])) {
+                    $this->classesByMethodAnnotations[$annotationClassName][$className] = [];
+                }
+                $this->classesByMethodAnnotations[$annotationClassName][$className][] = $methodName;
+            }
         }
 
         $returnType = $method->getDeclaredReturnType();

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassWithPhpAttributes.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassWithPhpAttributes.php
@@ -1,0 +1,24 @@
+<?php
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A class with PHP 8 attributes
+ * @Flow\Scope("prototype")
+ */
+#[SampleAttribute(ClassWithPhpAttributes::class, options: ['baz', 'quux'])]
+#[SampleAttribute(ClassWithPhpAttributes::class, ['foo' => 'bar'])]
+class ClassWithPhpAttributes
+{
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/SampleAttribute.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/SampleAttribute.php
@@ -1,0 +1,16 @@
+<?php
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class SampleAttribute
+{
+    public string $class;
+    public array $options;
+    public string $argWithDefault;
+    public function __construct(string $class, array $options = [], string $argWithDefault = 'default')
+    {
+        $this->class = $class;
+        $this->options = $options;
+        $this->argWithDefault = $argWithDefault;
+    }
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/SampleAttribute.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/SampleAttribute.php
@@ -4,9 +4,9 @@ namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class SampleAttribute
 {
-    public string $class;
-    public array $options;
-    public string $argWithDefault;
+    public $class;
+    public $options;
+    public $argWithDefault;
     public function __construct(string $class, array $options = [], string $argWithDefault = 'default')
     {
         $this->class = $class;

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
@@ -129,4 +129,19 @@ class ProxyCompilerTest extends FunctionalTestCase
         $reflectionClass = new ClassReflection(Fixtures\FinalClassWithDependencies::class);
         self::assertTrue($reflectionClass->isFinal());
     }
+
+    /**
+     * @test
+     */
+    public function attributesArePreserved()
+    {
+        if (PHP_MAJOR_VERSION < 8) {
+            $this->markTestSkipped('Only for PHP 8 with Attributes');
+        }
+        $reflectionClass = new ClassReflection(Fixtures\ClassWithPhpAttributes::class);
+        $attributes = $reflectionClass->getAttributes();
+        self::assertCount(2, $attributes);
+        self::assertEquals(Fixtures\SampleAttribute::class, $attributes[0]->getName());
+        self::assertEquals(Fixtures\ClassWithPhpAttributes::class, $attributes[0]->getArguments()[0]);
+    }
 }

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/CompilerTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/CompilerTest.php
@@ -45,11 +45,11 @@ class CompilerTest extends UnitTestCase
         $sessionWithAutoStart->autoStart = true;
         return [
             [
-                new Signal([]),
+                new Signal(),
                 '@\Neos\Flow\Annotations\Signal'
             ],
             [
-                new Scope(['value' => 'singleton']),
+                new Scope('singleton'),
                 '@\Neos\Flow\Annotations\Scope("singleton")'
             ],
             [
@@ -69,27 +69,27 @@ class CompilerTest extends UnitTestCase
                 '@\Neos\Flow\Annotations\Session'
             ],
             [
-                new Validate(['value' => 'foo1', 'type' => 'bar1']),
+                new Validate('foo1', 'bar1'),
                 '@\Neos\Flow\Annotations\Validate(type="bar1", argumentName="foo1")'
             ],
             [
-                new Validate(['type' => 'bar1', 'options' => ['minimum' => 2]]),
+                new Validate(null, 'bar1', ['minimum' => 2]),
                 '@\Neos\Flow\Annotations\Validate(type="bar1", options={ "minimum"=2 })'
             ],
             [
-                new Validate(['type' => 'bar1', 'options' => ['foo' => ['bar' => 'baz']]]),
+                new Validate(null, 'bar1', ['foo' => ['bar' => 'baz']]),
                 '@\Neos\Flow\Annotations\Validate(type="bar1", options={ "foo"={ "bar"="baz" } })'
             ],
             [
-                new Validate(['type' => 'bar1', 'options' => ['foo' => 'hubbabubba', 'bar' => true]]),
+                new Validate(null, 'bar1', ['foo' => 'hubbabubba', 'bar' => true]),
                 '@\Neos\Flow\Annotations\Validate(type="bar1", options={ "foo"="hubbabubba", "bar"=true })'
             ],
             [
-                new Validate(['type' => 'bar1', 'options' => [new Inject([])]]),
+                new Validate(null, 'bar1', [new Inject()]),
                 '@\Neos\Flow\Annotations\Validate(type="bar1", options={ @\Neos\Flow\Annotations\Inject })'
             ],
             [
-                new Validate(['type' => 'bar1', 'options' => [new Validate(['type' => 'bar1', 'options' => ['foo' => 'hubbabubba']])]]),
+                new Validate(null, 'bar1', [new Validate(null, 'bar1', ['foo' => 'hubbabubba'])]),
                 '@\Neos\Flow\Annotations\Validate(type="bar1", options={ @\Neos\Flow\Annotations\Validate(type="bar1", options={ "foo"="hubbabubba" }) })'
             ],
         ];

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyMethodTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyMethodTest.php
@@ -27,10 +27,10 @@ class ProxyMethodTest extends \Neos\Flow\Tests\UnitTestCase
 
         $mockReflectionService = $this->getMockBuilder(ReflectionService::class)->disableOriginalConstructor()->getMock();
         $mockReflectionService->expects(self::any())->method('hasMethod')->will(self::returnValue(true));
-        $mockReflectionService->expects(self::any())->method('getMethodTagsValues')->with('My\Class\Name', 'myMethod')->will(self::returnValue([
+        $mockReflectionService->expects(self::any())->method('getMethodTagsValues')->with('My\ClassName', 'myMethod')->will(self::returnValue([
             'param' => ['string $name']
         ]));
-        $mockReflectionService->expects(self::any())->method('getMethodAnnotations')->with('My\Class\Name', 'myMethod')->will(self::returnValue([
+        $mockReflectionService->expects(self::any())->method('getMethodAnnotations')->with('My\ClassName', 'myMethod')->will(self::returnValue([
             $validateFoo1,
             $validateFoo2,
             new Flow\SkipCsrfProtection([])
@@ -38,7 +38,8 @@ class ProxyMethodTest extends \Neos\Flow\Tests\UnitTestCase
 
         $mockProxyMethod = $this->getAccessibleMock(ProxyMethod::class, ['dummy'], [], '', false);
         $mockProxyMethod->injectReflectionService($mockReflectionService);
-        $methodDocumentation = $mockProxyMethod->_call('buildMethodDocumentation', 'My\Class\Name', 'myMethod');
+        eval('namespace My; class ClassName { public function myMethod() {} }');
+        $methodDocumentation = $mockProxyMethod->_call('buildMethodDocumentation', 'My\ClassName', 'myMethod');
 
         $expected =
             '    /**' . chr(10) .

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyMethodTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyMethodTest.php
@@ -22,8 +22,8 @@ class ProxyMethodTest extends \Neos\Flow\Tests\UnitTestCase
      */
     public function buildMethodDocumentationAddsAllExpectedAnnotations()
     {
-        $validateFoo1 = new Flow\Validate(['value' => 'foo1', 'type' => 'bar1']);
-        $validateFoo2 = new Flow\Validate(['value' => 'foo2', 'type' => 'bar2']);
+        $validateFoo1 = new Flow\Validate('foo1', 'bar1');
+        $validateFoo2 = new Flow\Validate('foo2', 'bar2');
 
         $mockReflectionService = $this->getMockBuilder(ReflectionService::class)->disableOriginalConstructor()->getMock();
         $mockReflectionService->expects(self::any())->method('hasMethod')->will(self::returnValue(true));

--- a/Neos.Flow/Tests/Unit/Validation/ValidatorResolverTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/ValidatorResolverTest.php
@@ -276,19 +276,19 @@ class ValidatorResolverTest extends UnitTestCase
 
         ];
         $validateAnnotations = [
-            new Annotations\Validate([
-                'type' => 'Foo',
-                'options' => ['bar' => 'baz'],
-                'argumentName' => '$arg1'
-            ]),
-            new Annotations\Validate([
-                'type' => 'Bar',
-                'argumentName' => '$arg1'
-            ]),
-            new Annotations\Validate([
-                'type' => 'TYPO3\TestPackage\Quux',
-                'argumentName' => '$arg2'
-            ]),
+            new Annotations\Validate(
+                '$arg1',
+                'Foo',
+                ['bar' => 'baz']
+            ),
+            new Annotations\Validate(
+                '$arg1',
+                'Bar'
+            ),
+            new Annotations\Validate(
+                '$arg2',
+                'Neos\TestPackage\Quux'
+            ),
         ];
 
         $mockReflectionService = $this->getMockBuilder(ReflectionService::class)->disableOriginalConstructor()->getMock();
@@ -315,7 +315,7 @@ class ValidatorResolverTest extends UnitTestCase
             ['array'],
             ['Foo', ['bar' => 'baz']],
             ['Bar'],
-            ['TYPO3\TestPackage\Quux']
+            ['Neos\TestPackage\Quux']
         )
         ->willReturnOnConsecutiveCalls(
             $conjunction1,
@@ -324,7 +324,7 @@ class ValidatorResolverTest extends UnitTestCase
             $mockArrayValidator,
             $mockFooValidator,
             $mockBarValidator,
-            $mockQuuxValidator,
+            $mockQuuxValidator
         );
 
         $validatorResolver->_set('reflectionService', $mockReflectionService);
@@ -375,10 +375,10 @@ class ValidatorResolverTest extends UnitTestCase
             ]
         ];
         $validateAnnotations = [
-            new Annotations\Validate([
-                'type' => 'Neos\TestPackage\Quux',
-                'argumentName' => '$arg2'
-            ]),
+            new Annotations\Validate(
+                '$arg2',
+                'Neos\TestPackage\Quux'
+            ),
         ];
 
         $mockReflectionService = $this->getMockBuilder(ReflectionService::class)->disableOriginalConstructor()->getMock();
@@ -584,21 +584,25 @@ class ValidatorResolverTest extends UnitTestCase
         ];
         $validateAnnotations = [
             'foo' => [
-                new Annotations\Validate([
-                    'type' => 'Foo',
-                    'options' => ['bar' => 'baz'],
-                ]),
-                new Annotations\Validate([
-                    'type' => 'Bar',
-                ]),
-                new Annotations\Validate([
-                    'type' => 'Baz',
-                ]),
+                new Annotations\Validate(
+                    null,
+                    'Foo',
+                    ['bar' => 'baz']
+                ),
+                new Annotations\Validate(
+                    null,
+                    'Bar'
+                ),
+                new Annotations\Validate(
+                    null,
+                    'Baz'
+                ),
             ],
             'bar' => [
-                new Annotations\Validate([
-                    'type' => 'Neos\TestPackage\Quux',
-                ]),
+                new Annotations\Validate(
+                    null,
+                    'Neos\TestPackage\Quux'
+                ),
             ],
         ];
 
@@ -621,11 +625,11 @@ class ValidatorResolverTest extends UnitTestCase
             ->withConsecutive(
                 [get_class($mockObject), 'foo', Annotations\Validate::class],
                 [get_class($mockObject), 'bar', Annotations\Validate::class],
-                [get_class($mockObject), 'baz', Annotations\Validate::class],
+                [get_class($mockObject), 'baz', Annotations\Validate::class]
             )->willReturnOnConsecutiveCalls(
                 $validateAnnotations['foo'],
                 $validateAnnotations['bar'],
-                [],
+                []
             );
         $mockObjectManager = $this->createMock(ObjectManagerInterface::class);
         $mockObjectManager->method('get')->with(ReflectionService::class)->willReturn($mockReflectionService);


### PR DESCRIPTION
This allows to use all existing Annotations as PHP8 Attributes and makes the ReflectionService pick up attributes like annotations.
Hence all `is*AnnotatedWith()` and `*Annotation()` methods will return attribute classes as if they were annotations.

```
#[Flow\Scope("singleton")]
class MyClass {

    /**
     * @var LoggerInterface
     */
    #[Flow\Inject]
    protected $logger;
```

Note though, that this means a class that has both annotation and the equal attribute will behave as if all annotations were duplicated.

Also, in case you manually instanciated an Annotation class, you need to adjust to the changed constructor, which no longer takes a named array, but the list of actual properties.
In most cases instead of `new Flow\Inject($args)` you can probably do `new Flow\Inject(...$args)` with PHP8 and named parameters.

For Doctrine Annotations - see https://github.com/doctrine/orm/pull/8266 which will be available with 2.9