### PR TITLE
TASK: Tweak polyfill replacements

### DIFF
--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -54,12 +54,8 @@
     },
     "replace": {
         "typo3/flow": "self.version",
-        "symfony/polyfill-php54": "*",
-        "symfony/polyfill-php55": "*",
-        "symfony/polyfill-php56": "*",
         "symfony/polyfill-php70": "*",
         "symfony/polyfill-php71": "*",
-        "symfony/polyfill-php72": "*",
         "symfony/polyfill-mbstring": "*"
     },
     "suggest": {

--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -55,8 +55,7 @@
     "replace": {
         "typo3/flow": "self.version",
         "symfony/polyfill-php70": "*",
-        "symfony/polyfill-php71": "*",
-        "symfony/polyfill-mbstring": "*"
+        "symfony/polyfill-php71": "*"
     },
     "suggest": {
         "ext-curl": "To use the \\Neos\\Flow\\Http\\Client\\CurlEngine",

--- a/Neos.Utility.Unicode/composer.json
+++ b/Neos.Utility.Unicode/composer.json
@@ -15,6 +15,9 @@
     "mikey179/vfsstream": "^1.6.1",
     "phpunit/phpunit": "~7.1"
   },
+  "replace": {
+    "symfony/polyfill-mbstring": "*"
+  },
   "autoload": {
     "psr-4": {
       "Neos\\Utility\\Unicode\\": "Classes"

--- a/composer.json
+++ b/composer.json
@@ -33,12 +33,8 @@
     "replace": {
         "typo3/eel": "self.version",
         "typo3/flow": "self.version",
-        "symfony/polyfill-php54": "*",
-        "symfony/polyfill-php55": "*",
-        "symfony/polyfill-php56": "*",
         "symfony/polyfill-php70": "*",
         "symfony/polyfill-php71": "*",
-        "symfony/polyfill-php72": "*",
         "symfony/polyfill-mbstring": "*",
         "typo3/kickstart": "self.version",
         "neos/cache": "self.version",


### PR DESCRIPTION
The replacements added according to the symfony/polyfill README (and
tweaked recently to actually appear in the split manifest) lead to an
installation issue (composer/composer#9834)

Thus this removes the PHP 5 polyfills (those not being replaced should
not be an issue) to fix that. Also, since we require PHP 7.1, the 7.2
polyfill must not be replaced.