### PR TITLE
TASK: Make ActionResponse::getContentType non-nullable

### DIFF
--- a/Neos.Flow/Classes/Mvc/ActionResponse.php
+++ b/Neos.Flow/Classes/Mvc/ActionResponse.php
@@ -247,9 +247,9 @@ final class ActionResponse
     /**
      * @return string
      */
-    public function getContentType(): ?string
+    public function getContentType(): string
     {
-        return $this->contentType;
+        return $this->contentType ?? '';
     }
 
     /**


### PR DESCRIPTION
This removes the nullability of the `getContentType()` getter on the `ActionResponse`, which was only added to technically fit the possibility that the value is `null` without thinking about the API.
A content type of empty string is already enough to denote a "not set/unspecified" case and an additional `null` only makes the API more complex than needed.
This change is not technically breaking, even though it changes a return type, since the new return type is more strict. It could be breaking if you check for a `null` return value only without handling an empty string case. You should use the `hasContentType()` method before calling the getter.

Follow-up to #2458 which is a follow-up to #2180 