### PR TITLE
BUGFIX: Fix arguments to redis::watch() command

### DIFF
--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -153,7 +153,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
 
         do {
             // Watch the given keys for changes so if the TTL is changed during the transaction it can be retried
-            $this->redis->watch($keysToWatch);
+            $this->redis->watch(...$keysToWatch);
 
             foreach ($redisTags as $i => $tag) {
                 $expire = $this->calculateRemainingLifetimeForKey($tag['key'], $lifetime);

--- a/Neos.Cache/Tests/Unit/Backend/RedisBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/RedisBackendTest.php
@@ -245,11 +245,9 @@ class RedisBackendTest extends BaseTestCase
         $this->redis->expects($this->once())
             ->method('watch')
             ->with(
-                [
-                    'Foo_Cache:tag:baz',
-                    'Foo_Cache:tags:foo',
-                    'Foo_Cache:entry:foo'
-                ]
+                'Foo_Cache:tag:baz',
+                'Foo_Cache:tags:foo',
+                'Foo_Cache:entry:foo'
             );
 
         $this->backend->set('foo', 'bar', ['baz']);


### PR DESCRIPTION
According to https://github.com/phpredis/phpredis#example-114 `watch()` takes a list of keys as array, but in https://github.com/phpredis/phpredis/blob/develop/redis.c#L1360 / https://github.com/phpredis/phpredis/blob/develop/redis_commands.c#L3391 the arguments are passed like for e.g. sdiff, which takes a variable amount of string keys.

Related to #2052 