### PR TITLE
FEATURE:  I18n.translate() now accept $source to contain dots instead of only a path to the translation file

### DIFF
--- a/Neos.Flow/Classes/I18n/EelHelper/TranslationHelper.php
+++ b/Neos.Flow/Classes/I18n/EelHelper/TranslationHelper.php
@@ -112,7 +112,7 @@ class TranslationHelper implements ProtectedContextAwareInterface
         $translationParameterToken
             ->value($originalLabel)
             ->arguments($arguments)
-            ->source($source)
+            ->source(str_replace('.', '/', $source))
             ->package($package)
             ->quantity($quantity);
 


### PR DESCRIPTION
**What I did**
`translateByExplicitlyPassedOrderedArguments()` and `I18n.translate()` now accept `$source` argument to contain dots instead of only a path to the translation file.

When we use translations we use for example the shorthand
```php
{I18n.translate('Muensmedia.DistributionPackage:NodeTypes.Content.Todo.Container:ui.label')}
```
when we want to pass arguments we had to use
```php
${I18n.translate('progress', null, {solved: this.checkedElementsCount, total: this.checkboxCount}, 'NodeTypes/Content/Todo/Container', 'Muensmedia.DistributionPackage')}
```
As you can see, you have to pass the **path** to the translation file instead of the well known dot-notation.

This commit enables you to use also the well known dot-notation for the source argument:
```php
${I18n.translate('progress', null, {solved: this.checkedElementsCount, total: this.checkboxCount}, 'NodeTypes.Content.Todo.Container', 'Muensmedia.DistributionPackage')}
```

**How I did it**
In the method `translateByShortHandString()` we already replace dots with slashes, so I just copied this behavior to the method `translateByExplicitlyPassedOrderedArguments()`
https://github.com/neos/flow-development-collection/blob/5b7b57523ab1a3b05105227e0a5266ece2777038/Neos.Flow/Classes/I18n/EelHelper/TranslationHelper.php#L140

**How to verify it**

**Checklist**

- [X] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [X] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
