### PR TITLE
BUGFIX: Flow CacheAdapter extends doctrine CacheAdapter

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/CacheAdapter.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/CacheAdapter.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Persistence\Doctrine;
  * source code.
  */
 
-use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\CacheProvider;
 use Neos\Flow\Annotations as Flow;
 use Neos\Cache\Frontend\FrontendInterface;
 use Neos\Flow\Security\Context;
@@ -19,7 +19,7 @@ use Neos\Flow\Security\Context;
 /**
  * Cache adapter to use Flow caches as Doctrine cache
  */
-class CacheAdapter implements Cache
+class CacheAdapter extends CacheProvider
 {
     /**
      * @var FrontendInterface


### PR DESCRIPTION
This fixes the exception for the change in doctrine/persistence 2.2, that was an intentional documented bc-break for moving towards PSR-6 

See https://github.com/doctrine/persistence/pull/144/files#diff-9a566def484817e003ce815d52fae09a8c2b459c443fe015047ae043e170ef1a

Resolves #2479
Related to https://github.com/doctrine/persistence/issues/179