### PR TITLE
Catch any exception on setting doctrine cache and return according bo…

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/CacheAdapter.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/CacheAdapter.php
@@ -84,7 +84,12 @@ class CacheAdapter implements Cache
      */
     public function save($id, $data, $lifeTime = 0)
     {
-        $this->cache->set($this->convertCacheIdentifier($id), $data, [], $lifeTime);
+        try {
+            $this->cache->set($this->convertCacheIdentifier($id), $data, [], $lifeTime);
+            return true;
+        } catch (\Exception $exception) {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
Follow up to https://github.com/neos/flow-development-collection/pull/2480/#issuecomment-844185326 when the issue was found to live inside our CacheAdapter and missing return value