### PR TITLE
TASK: Constrain doctrine/orm to < 2.9 due to currently breaking

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "psr/http-server-middleware": "^1.0",
         "psr/http-server-handler": "^1.0",
         "ramsey/uuid": "^3.0 || ^4.0",
-        "doctrine/orm": "^2.6",
+        "doctrine/orm": "^2.6, <2.9",
         "doctrine/migrations": "^1.8",
         "doctrine/dbal": "^2.9",
         "doctrine/common": "^2.4",


### PR DESCRIPTION
See https://github.com/doctrine/orm/pull/8266#issuecomment-850421549