### PR TITLE
BUGFIX: retrieve package by case insensitive packageKey

### DIFF
--- a/Neos.Flow/Classes/Package/PackageManager.php
+++ b/Neos.Flow/Classes/Package/PackageManager.php
@@ -751,7 +751,8 @@ class PackageManager implements PackageManagerInterface
             $packageConfiguration = $this->preparePackageStateConfiguration($packageKey, $packagePath, $composerManifest, $state);
             if (isset($newPackageStatesConfiguration['packages'][$composerManifest['name']])) {
                 throw new PackageException(
-                    sprintf('The package with the name "%s" was found more than once, please make sure it exists only once. Paths "%s" and "%s".',
+                    sprintf(
+                        'The package with the name "%s" was found more than once, please make sure it exists only once. Paths "%s" and "%s".',
                         $composerManifest['name'],
                         $packageConfiguration['packagePath'],
                         $newPackageStatesConfiguration['packages'][$composerManifest['name']]['packagePath']),

--- a/Neos.Flow/Classes/Package/PackageManager.php
+++ b/Neos.Flow/Classes/Package/PackageManager.php
@@ -194,7 +194,7 @@ class PackageManager implements PackageManagerInterface
             throw new Exception\UnknownPackageException('Package "' . $packageKey . '" is not available. Please check if the package exists and that the package key is correct (package keys are case sensitive).', 1166546734);
         }
 
-        return $this->packages[$packageKey];
+        return $this->packages[$this->getCaseSensitivePackageKey($packageKey)];
     }
 
     /**

--- a/Neos.Flow/Classes/Package/PackageManager.php
+++ b/Neos.Flow/Classes/Package/PackageManager.php
@@ -755,7 +755,8 @@ class PackageManager implements PackageManagerInterface
                         'The package with the name "%s" was found more than once, please make sure it exists only once. Paths "%s" and "%s".',
                         $composerManifest['name'],
                         $packageConfiguration['packagePath'],
-                        $newPackageStatesConfiguration['packages'][$composerManifest['name']]['packagePath']),
+                        $newPackageStatesConfiguration['packages'][$composerManifest['name']]['packagePath']
+                    ),
                     1493030262
                 );
             }


### PR DESCRIPTION
**What I did**

The `PackageManager::getPackage($packageKey)` method should throw an exception or return the found package. There is a case, such that `getPackage` returns `null`. In recent php versions, this causes a php error because the return value of the api `public function getPackage($packageKey): PackageInterface` is not met:

```
Exception in line 514 of /var/www/Data/Temporary/Development/Cache/Code/Flow_Object_Classes/Neos_Flow_ResourceManagement_Streams_ResourceStreamWrapper.php: Return value of Neos\Flow\Package\PackageManager::getPackage() must implement interface Neos\Flow\Package\PackageInterface, null returned - See also: 202106101712258f223a.txt
```

In older flow versions (4.0 and up), this might also be a problem, because the method actually can return null instead of throwing an exception.

**Problem analysis**

The problem occures, because the check, if an exception should be thrown by `isPackageAvailable()`, ignores the case during the check, whereas the actual return statement `return $this->packages[$packageKey];` needs the correct case.

**How I did it**

I'm using `$this->getCaseSensitivePackageKey($packageKey)` to retrieve the key in the correct case, such that `$this->packages` returns the correct package.

**How to verify it**

A call like `$packageManager->getPackage('Neos.some.package.with.wrong.case')` should throw a php error in recent versions.

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
