### PR TITLE
BUGFIX: Allow for multiple authentication header

### DIFF
--- a/Neos.Flow/Classes/Security/Authentication/Token/BearerToken.php
+++ b/Neos.Flow/Classes/Security/Authentication/Token/BearerToken.php
@@ -50,14 +50,14 @@ class BearerToken extends AbstractToken implements SessionlessTokenInterface
             return;
         }
 
-        $authorizationHeader = $httpRequest->getHeader('Authorization')[0];
+        $this->setAuthenticationStatus(TokenInterface::NO_CREDENTIALS_GIVEN);
 
-        if (substr($authorizationHeader, 0, 7) !== 'Bearer ') {
-            $this->setAuthenticationStatus(TokenInterface::NO_CREDENTIALS_GIVEN);
-            throw new AuthenticationRequiredException('Could not extract access token from Authorization header: "Bearer" keyword is missing', 1616222749);
+        foreach ($httpRequest->getHeader('Authorization') as $authorizationHeader) {
+            if (strpos($authorizationHeader, 'Bearer ') === 0) {
+                $this->credentials['bearer'] = substr($authorizationHeader, strlen('Bearer '));
+                return;
+            }
         }
-
-        $this->credentials['bearer'] = substr($authorizationHeader, strlen('Bearer '));
     }
 
     /**

--- a/Neos.Flow/Classes/Security/Authentication/Token/BearerToken.php
+++ b/Neos.Flow/Classes/Security/Authentication/Token/BearerToken.php
@@ -55,6 +55,7 @@ class BearerToken extends AbstractToken implements SessionlessTokenInterface
         foreach ($httpRequest->getHeader('Authorization') as $authorizationHeader) {
             if (strpos($authorizationHeader, 'Bearer ') === 0) {
                 $this->credentials['bearer'] = substr($authorizationHeader, strlen('Bearer '));
+                $this->setAuthenticationStatus(TokenInterface::AUTHENTICATION_NEEDED);
                 return;
             }
         }


### PR DESCRIPTION
This allows to use the BearerToken in combination with other
authentication header bases authentications like UsernamePasswordHttpBasic

closes #2490
