### PR TITLE
TASK: Allow installing Doctrine 2.9

### DIFF
--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -36,7 +36,7 @@
 
         "ramsey/uuid": "^3.0 || ^4.0",
 
-        "doctrine/orm": "^2.7",
+        "doctrine/orm": "^2.7, <2.9 || ^2.9.3",
         "doctrine/migrations": "^3.0",
         "doctrine/dbal": "^2.12",
         "doctrine/common": "^2.13.1 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "psr/http-server-middleware": "^1.0",
         "psr/http-server-handler": "^1.0",
         "ramsey/uuid": "^3.0 || ^4.0",
-        "doctrine/orm": "^2.7, <2.9",
+        "doctrine/orm": "^2.7, <2.9 || ^2.9.3",
         "doctrine/migrations": "^3.0",
         "doctrine/dbal": "^2.12",
         "doctrine/common": "^2.13.1 || ^3.0",


### PR DESCRIPTION
As of doctrine/orm 2.9.3 it is again compatible with Flow (see #2495), so we can allow installing it (again).