### PR TITLE
BUGFIX: Ensure cache backends are prepared before usage

### DIFF
--- a/Neos.Cache/Classes/Backend/TaggableMultiBackend.php
+++ b/Neos.Cache/Classes/Backend/TaggableMultiBackend.php
@@ -54,6 +54,7 @@ class TaggableMultiBackend extends MultiBackend implements TaggableBackendInterf
      */
     public function flushByTag(string $tag): int
     {
+        $this->prepareBackends();
         $count = 0;
         foreach ($this->backends as $backend) {
             try {
@@ -72,6 +73,7 @@ class TaggableMultiBackend extends MultiBackend implements TaggableBackendInterf
      */
     public function findIdentifiersByTag(string $tag): array
     {
+        $this->prepareBackends();
         $identifiers = [];
         foreach ($this->backends as $backend) {
             try {


### PR DESCRIPTION
If the flushByTag or findIdentifiersByTag methods of the TaggableMultiBackend are used before backend initialization by other methods, the backends have to be prepared. Otherwise, `$this->backends` is an empty array and no cache entries are flushed.

**What I did**
I added the `$this->prepareBackends()` calls in the two methods.

**How to verify it**
- Configure the TaggableMultiBackend for the Neos_Fusion_Content cache
- Change a node property in the Neos backend
- Reload the page

Before this change, the change of the node property was saved to the db, but the cache was not flushed. Thus, the incorrect property value was shown in the Neos backend after a page reload.