### PR TITLE
TASK: Disallow installing guzzlehttp/psr7 2.0

### DIFF
--- a/Neos.Http.Factories/composer.json
+++ b/Neos.Http.Factories/composer.json
@@ -9,7 +9,7 @@
     "require": {
         "php": "^7.1",
         "psr/http-factory": "^1.0",
-        "guzzlehttp/psr7": "^1.4, !=1.8.0 || ~2.0"
+        "guzzlehttp/psr7": "^1.4, !=1.8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "neos/composer-plugin": "^2.0",
         "composer/composer": "^1.9 || ^2.0",
         "typo3fluid/fluid": "~2.5.11 || ^2.6.10",
-        "guzzlehttp/psr7": "^1.4, !=1.8.0 || ~2.0",
+        "guzzlehttp/psr7": "^1.4, !=1.8.0",
         "ext-mbstring": "*"
     },
     "replace": {


### PR DESCRIPTION
It is incompatible with versions < 1.7 due to the replaced `stream_for` method. The ~2.0 dependency was added before the actual 2.0 release and this breaking change was added later, making it incompatible. If 2.0+ is needed, you need to upgrade to Flow 7.1