### PR TITLE
Added all new types introduced since PHP7.1 to not being qualified

### DIFF
--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1381,7 +1381,7 @@ class ReflectionService
         }
 
         $returnType = $method->getDeclaredReturnType();
-        if ($returnType !== null && !in_array($returnType, ['self', 'null', 'callable', 'void']) && !TypeHandling::isSimpleType($returnType)) {
+        if ($returnType !== null && !in_array($returnType, ['self', 'null', 'callable', 'void', 'iterable', 'object', 'mixed']) && !TypeHandling::isSimpleType($returnType)) {
             $returnType = '\\' . $returnType;
         }
         if ($method->isDeclaredReturnTypeNullable()) {


### PR DESCRIPTION
Since PHP 7.1 iterable, object and mixed are new allowed PHP types, which are not allowed to be "qualified".

But having a method returning one of those (and having a corresponding type-hint) did lead to a proxy method, annotated with \type, which will lead to a PHP Fatal error: Type declaration 'type' must be unqualified in ...

This resolves #2498

List of types taken from here:
https://www.php.net/manual/de/language.types.declarations.php

(and yes, this commit includes one type, which is part of PHP8.0 which is not (yet?) supported by Flow 6.3, but I guess it will not harm anyone and definitely makes live easier in upwards versions.