### PR TITLE
TASK: Run post-update scripts only once 

### DIFF
--- a/Neos.Flow/Classes/Composer/InstallerScripts.php
+++ b/Neos.Flow/Classes/Composer/InstallerScripts.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Composer;
 
 /*
@@ -40,8 +42,11 @@ class InstallerScripts
      *
      * @param Event $event
      * @return void
+     * @throws Exception\InvalidConfigurationException
+     * @throws \Neos\Flow\Package\Exception
+     * @throws \Neos\Utility\Exception\FilesException
      */
-    public static function postUpdateAndInstall(Event $event)
+    public static function postUpdateAndInstall(Event $event): void
     {
 
         if (self::$postUpdateAndInstallAlreadyRun) {
@@ -81,9 +86,11 @@ class InstallerScripts
      *
      * @param PackageEvent $event
      * @return void
+     * @throws Exception\InvalidConfigurationException
      * @throws Exception\UnexpectedOperationException
+     * @throws \Neos\Utility\Exception\FilesException
      */
-    public static function postPackageUpdateAndInstall(PackageEvent $event)
+    public static function postPackageUpdateAndInstall(PackageEvent $event): void
     {
         if (self::$postPackageUpdateAndInstallAlreadyRun) {
             return;
@@ -119,8 +126,9 @@ class InstallerScripts
      *
      * @param string $installerResourcesDirectory Path to the installer directory that contains the Distribution/Essentials and/or Distribution/Defaults directories.
      * @return void
+     * @throws \Neos\Utility\Exception\FilesException
      */
-    protected static function copyDistributionFiles(string $installerResourcesDirectory)
+    protected static function copyDistributionFiles(string $installerResourcesDirectory): void
     {
         $essentialsPath = $installerResourcesDirectory . 'Distribution/Essentials';
         if (is_dir($essentialsPath)) {
@@ -140,7 +148,7 @@ class InstallerScripts
      * @return void
      * @throws Exception\InvalidConfigurationException
      */
-    protected static function runPackageScripts(string $staticMethodReference)
+    protected static function runPackageScripts(string $staticMethodReference): void
     {
         $className = substr($staticMethodReference, 0, strpos($staticMethodReference, '::'));
         $methodName = substr($staticMethodReference, strpos($staticMethodReference, '::') + 2);

--- a/Neos.Flow/Classes/Composer/InstallerScripts.php
+++ b/Neos.Flow/Classes/Composer/InstallerScripts.php
@@ -48,7 +48,6 @@ class InstallerScripts
      */
     public static function postUpdateAndInstall(Event $event): void
     {
-
         if (self::$postUpdateAndInstallAlreadyRun) {
             return;
         }


### PR DESCRIPTION
Previously the scripts were run for every package at the end of the install process.
The scripts only need to be run once.