### PR TITLE
BUGFIX: Change empty check on target collection to `valid()` in resource:copy

### DIFF
--- a/Neos.Flow/Classes/Command/ResourceCommandController.php
+++ b/Neos.Flow/Classes/Command/ResourceCommandController.php
@@ -161,7 +161,7 @@ class ResourceCommandController extends CommandController
             $this->quit(1);
         }
 
-        if (!empty($targetCollection->getObjects())) {
+        if (!$targetCollection->getObjects()) {
             $this->outputLine('The target collection "%s" is not empty.', [$targetCollectionName]);
             $this->quit(1);
         }

--- a/Neos.Flow/Classes/Command/ResourceCommandController.php
+++ b/Neos.Flow/Classes/Command/ResourceCommandController.php
@@ -161,7 +161,7 @@ class ResourceCommandController extends CommandController
             $this->quit(1);
         }
 
-        if (!$targetCollection->getObjects()) {
+        if ($targetCollection->getObjects()->valid()) {
             $this->outputLine('The target collection "%s" is not empty.', [$targetCollectionName]);
             $this->quit(1);
         }


### PR DESCRIPTION
`$targetCollection->getObjects()` method returns a generator, which will always return `false` in an `empty()` check.
This makes it impossible to use `resource:copy` as this always fails with a `The target collection "tmpNewCollection" is not empty.` error.

The problem is mentioned here: https://github.com/neos/flow-development-collection/issues/2510

**What I did**
Change `!empty()` against a `->valid()` check

**How to verify it**
Use `resource:copy` to copy assets to an empty Storage.

**Checklist**
- [x] Code follows the PSR-2 coding style
- ~~[ ] Tests have been created, run and adjusted as needed~~ (not needed)
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)

This replaced PR https://github.com/neos/flow-development-collection/pull/2512