### PR TITLE
TASK: Fix documentation for firewall option "rejectAll"

### DIFF
--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Security.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Security.rst
@@ -1633,7 +1633,7 @@ security interceptors.
 
 .. note::
 
-  You might have noticed the ``rejectAll`` option. If this is set to ``yes``,
+  You might have noticed the ``rejectAll`` option. If this is set to ``true``,
   only request which are explicitly allowed by a request filter will be able
   to pass the firewall.
 


### PR DESCRIPTION
The ``rejectAll`` option needs to be set as boolean. 
See:  https://github.com/neos/flow-development-collection/blob/6.3/Neos.Flow/Classes/Security/Authorization/FilterFirewall.php#L53