### PR TITLE
FEATURE: CLI parse array type controller arguments

### DIFF
--- a/Neos.Flow/Classes/Cli/RequestBuilder.php
+++ b/Neos.Flow/Classes/Cli/RequestBuilder.php
@@ -216,8 +216,7 @@ class RequestBuilder
                     $argumentValue = $this->getValueOfCurrentCommandLineOption($rawArgument, $rawCommandLineArguments, $optionalArguments[$argumentName]['type']);
                     if ($optionalArguments[$argumentName]['type'] == 'array') {
                         $commandLineArguments[$optionalArguments[$argumentName]['parameterName']][] = $argumentValue;
-                    }
-                    else {
+                    } else {
                         $commandLineArguments[$optionalArguments[$argumentName]['parameterName']] = $argumentValue;
                     }
                 } elseif (isset($requiredArguments[$argumentName])) {
@@ -228,8 +227,7 @@ class RequestBuilder
                     $argumentValue = $this->getValueOfCurrentCommandLineOption($rawArgument, $rawCommandLineArguments, $requiredArguments[$argumentName]['type']);
                     if ($requiredArguments[$argumentName]['type'] == 'array') {
                         $commandLineArguments[$requiredArguments[$argumentName]['parameterName']][] = $argumentValue;
-                    }
-                    else {
+                    } else {
                         $commandLineArguments[$requiredArguments[$argumentName]['parameterName']] = $argumentValue;
                         unset($requiredArguments[$argumentName]);
                     }

--- a/Neos.Flow/Classes/Cli/RequestBuilder.php
+++ b/Neos.Flow/Classes/Cli/RequestBuilder.php
@@ -214,15 +214,25 @@ class RequestBuilder
 
                 if (isset($optionalArguments[$argumentName])) {
                     $argumentValue = $this->getValueOfCurrentCommandLineOption($rawArgument, $rawCommandLineArguments, $optionalArguments[$argumentName]['type']);
-                    $commandLineArguments[$optionalArguments[$argumentName]['parameterName']] = $argumentValue;
+                    if ($optionalArguments[$argumentName]['type'] == 'array') {
+                        $commandLineArguments[$optionalArguments[$argumentName]['parameterName']][] = $argumentValue;
+                    }
+                    else {
+                        $commandLineArguments[$optionalArguments[$argumentName]['parameterName']] = $argumentValue;
+                    }
                 } elseif (isset($requiredArguments[$argumentName])) {
                     if ($decidedToUseUnnamedArguments) {
                         throw new InvalidArgumentMixingException(sprintf('Unexpected named argument "%s". If you use unnamed arguments, all required arguments must be passed without a name.', $argumentName), 1309971821);
                     }
                     $decidedToUseNamedArguments = true;
                     $argumentValue = $this->getValueOfCurrentCommandLineOption($rawArgument, $rawCommandLineArguments, $requiredArguments[$argumentName]['type']);
-                    $commandLineArguments[$requiredArguments[$argumentName]['parameterName']] = $argumentValue;
-                    unset($requiredArguments[$argumentName]);
+                    if ($requiredArguments[$argumentName]['type'] == 'array') {
+                        $commandLineArguments[$requiredArguments[$argumentName]['parameterName']][] = $argumentValue;
+                    }
+                    else {
+                        $commandLineArguments[$requiredArguments[$argumentName]['parameterName']] = $argumentValue;
+                        unset($requiredArguments[$argumentName]);
+                    }
                 }
             } else {
                 if (count($requiredArguments) > 0) {

--- a/Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php
@@ -441,4 +441,22 @@ class RequestBuilderTest extends UnitTestCase
         $request = $this->requestBuilder->build('acme.test:default:list firstArgumentValue ' . $quotedArgument);
         self::assertEquals($expectedArguments, $request->getArguments());
     }
+
+    /**
+     * @test
+     */
+    public function arrayArgumentIsParsedCorrectly(){
+        $methodParameters = [
+            'a1' => ['optional' => false, 'type' => 'array'],
+            'a2' => ['optional' => true, 'type' => 'array'],
+        ];
+        $this->mockCommandManager->expects(self::once())->method('getCommandMethodParameters')->with('Acme\Test\Command\DefaultCommandController', 'listCommand')->will(self::returnValue($methodParameters));
+
+        $expectedArguments = [
+            'a1' => ['1', 'x'], 'a2' => ['y', 'z']
+        ];
+
+        $request = $this->requestBuilder->build('acme.test:default:list --a1 1 --a2 y --a1 x --a2 z');
+        self::assertEquals($expectedArguments, $request->getArguments());
+    }
 }

--- a/Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php
@@ -445,7 +445,8 @@ class RequestBuilderTest extends UnitTestCase
     /**
      * @test
      */
-    public function arrayArgumentIsParsedCorrectly(){
+    public function arrayArgumentIsParsedCorrectly()
+    {
         $methodParameters = [
             'a1' => ['optional' => false, 'type' => 'array'],
             'a2' => ['optional' => true, 'type' => 'array'],


### PR DESCRIPTION
**What I did**

With this PR, a CLI command can make use of array's as an argument type.

If an argument is given multiple times and the type is an array, the argument values are pushed at the end of the array.

As an example, this can be handy, if you need to process multiple language dimensions, nodes or urls, like
```
./flow my.pckg:index --dimension en --dimension de
```

Maybe this can also be considered for the 7.2 release?

**How I did it**

The CLI `RequestBuilder` now distinguishes between array and non-array arguments. If an argument is of type `array` the argumentValue is appended to the array.

**How to verify it**

Create a command controller command with an array signature like
```
public function indexCommand(array $dimension){
```
and then use the argument `--dimension` multiple times.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
