### PR TITLE
BUGFIX: Keep authorization checks disabled if an exception is swallowed

### DIFF
--- a/Neos.Flow/Classes/Security/Context.php
+++ b/Neos.Flow/Classes/Security/Context.php
@@ -217,12 +217,8 @@ class Context
         try {
             /** @noinspection PhpUndefinedMethodInspection */
             $callback->__invoke();
-        } catch (\Exception $exception) {
-            $this->authorizationChecksDisabled = false;
-            throw $exception;
-        }
-        if ($authorizationChecksAreAlreadyDisabled === false) {
-            $this->authorizationChecksDisabled = false;
+        } finally {
+            $this->authorizationChecksDisabled = $authorizationChecksAreAlreadyDisabled;
         }
     }
 

--- a/Neos.Flow/Tests/Unit/Security/ContextTest.php
+++ b/Neos.Flow/Tests/Unit/Security/ContextTest.php
@@ -1090,6 +1090,49 @@ class ContextTest extends UnitTestCase
     /**
      * @test
      */
+    public function withoutAuthorizationChecksKeepsAuthorizationCheckCorrectlyWhenCalledNestedAndExceptionFromInnerClosureIsCaught()
+    {
+        /** @var Context $securityContext */
+        $securityContext = $this->getAccessibleMock(Context::class, ['initialize']);
+        $self = $this;
+        $securityContext->withoutAuthorizationChecks(function () use ($securityContext, $self) {
+            try {
+                $securityContext->withoutAuthorizationChecks(function () use ($securityContext, $self) {
+                    $self->assertTrue($securityContext->areAuthorizationChecksDisabled());
+                    throw new \Exception('Some exception');
+                });
+            } catch (\Exception $exception) {
+            }
+            $self->assertTrue($securityContext->areAuthorizationChecksDisabled());
+        });
+        self::assertFalse($securityContext->areAuthorizationChecksDisabled());
+    }
+
+    /**
+     * @test
+     */
+    public function withoutAuthorizationChecksKeepsAuthorizationCheckCorrectlyWhenCalledNestedAndExceptionFromOuterClosureIsCaught()
+    {
+        /** @var Context $securityContext */
+        $securityContext = $this->getAccessibleMock(Context::class, ['initialize']);
+        $self = $this;
+        $securityContext->withoutAuthorizationChecks(function () use ($securityContext, $self) {
+            try {
+                $securityContext->withoutAuthorizationChecks(function () use ($securityContext, $self) {
+                    $self->assertTrue($securityContext->areAuthorizationChecksDisabled());
+                });
+
+                throw new \Exception('Some exception');
+            } catch (\Exception $exception) {
+            }
+            $self->assertTrue($securityContext->areAuthorizationChecksDisabled());
+        });
+        self::assertFalse($securityContext->areAuthorizationChecksDisabled());
+    }
+
+    /**
+     * @test
+     */
     public function getContextHashReturnsStaticStringIfAuthorizationChecksAreDisabled()
     {
         $self = $this;


### PR DESCRIPTION
When code is wrapped in a `Security\Context::withoutAuthorizationChecks()` call
and exceptions are caught, authorization checks are no longer disabled in the outer
closure leading to exceptions like
```
The security Context cannot be initialized yet
```

This change fixes this by resetting the `authorizationChecksDisabled` to the
previous value in a `finally` block.

Fixes: #2521