### PR TITLE
TASK: Remove fusion dependencies

### DIFF
--- a/Neos.Kickstarter/composer.json
+++ b/Neos.Kickstarter/composer.json
@@ -7,8 +7,6 @@
         "php": "^7.3 || ^8.0",
         "neos/flow": "~7.1.0",
         "neos/fluid-adaptor": "~7.1.0",
-        "neos/fusion-afx": "*",
-        "neos/fusion-form": "*",
         "neos/utility-arrays": "*"
     },
     "autoload": {


### PR DESCRIPTION
Only the created package has a dependency on Fusion, iff it uses generated Fusion templates

This needs to be followed up with a change that will add those dependencies to the created packages composer manifest via some way.