### PR TITLE
TASK: Raise minimal guzzlehttp/psr7 to 1.7

### DIFF
--- a/Neos.Http.Factories/composer.json
+++ b/Neos.Http.Factories/composer.json
@@ -9,7 +9,7 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "psr/http-factory": "^1.0",
-        "guzzlehttp/psr7": "^1.4.1, !=1.8.0"
+        "guzzlehttp/psr7": "^1.7, !=1.8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "composer/composer": "^1.9 || ^2.0",
         "egulias/email-validator": "^2.1 || ^3.0",
         "typo3fluid/fluid": "~2.5.11 || ^2.6.10",
-        "guzzlehttp/psr7": "^1.4.1, !=1.8.0",
+        "guzzlehttp/psr7": "^1.7, !=1.8.0",
         "ext-mbstring": "*"
     },
     "replace": {


### PR DESCRIPTION
Version 1.7 introduces the GuzzleHttp\Psr7\Utils class
which is used since Flow 7.1

See #2525 and #2501 