### PR TITLE
BUGFIX: Do not run before and afterControllerInvocation signals in compile time

### DIFF
--- a/Neos.Flow/Classes/Cli/Dispatcher.php
+++ b/Neos.Flow/Classes/Cli/Dispatcher.php
@@ -5,6 +5,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\Exception\InfiniteLoopException;
 use Neos\Flow\Cli\Exception\InvalidCommandControllerException;
 use Neos\Flow\Cli\Exception\StopCommandException;
+use Neos\Flow\ObjectManagement\CompileTimeObjectManager;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 
 /**
@@ -80,6 +81,11 @@ class Dispatcher
      */
     protected function emitBeforeControllerInvocation(Request $request, Response $response, CommandControllerInterface $controller)
     {
+        // Before Flow 5.3 you could rely on this slot only being called during runtime
+        // There will be new slots in 7.x, which will run in compile time, too
+        if ($this->objectManager instanceof CompileTimeObjectManager) {
+            return;
+        }
         $this->signalDispatcher->dispatch(\Neos\Flow\Mvc\Dispatcher::class, 'beforeControllerInvocation', [
             'request' => $request,
             'response' => $response,
@@ -98,6 +104,11 @@ class Dispatcher
      */
     protected function emitAfterControllerInvocation(Request $request, Response $response, CommandControllerInterface $controller)
     {
+        // Before Flow 5.3 you could rely on this slot only being called during runtime
+        // There will be new slots in 7.x, which will run in compile time, too
+        if ($this->objectManager instanceof CompileTimeObjectManager) {
+            return;
+        }
         $this->signalDispatcher->dispatch(\Neos\Flow\Mvc\Dispatcher::class, 'afterControllerInvocation', [
             'request' => $request,
             'response' => $response,

--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -13,7 +13,6 @@ namespace Neos\Flow;
 
 use Neos\Flow\Core\Booting\Step;
 use Neos\Flow\Http\Helper\SecurityHelper;
-use Neos\Flow\ObjectManagement\CompileTimeObjectManager;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\Flow\Package\PackageManager;
 use Neos\Flow\ResourceManagement\ResourceManager;
@@ -61,10 +60,9 @@ class Package extends BasePackage
         $dispatcher = $bootstrap->getSignalSlotDispatcher();
 
         $dispatcher->connect(Mvc\Dispatcher::class, 'afterControllerInvocation', function ($request) use ($bootstrap) {
-            // No auto-persistence if there is no PersistenceManager registered or during compile time
+            // No auto-persistence if there is no PersistenceManager registered
             if (
                 $bootstrap->getObjectManager()->has(Persistence\PersistenceManagerInterface::class)
-                && !($bootstrap->getObjectManager() instanceof CompileTimeObjectManager)
             ) {
                 if (!$request instanceof Mvc\ActionRequest || SecurityHelper::hasSafeMethod($request->getHttpRequest()) !== true) {
                     $bootstrap->getObjectManager()->get(Persistence\PersistenceManagerInterface::class)->persistAll();


### PR DESCRIPTION
Together with Flow 6.x the Cli commands have been seperated from the Http ActionControllers.

Before these slots have been guaranteed to be executed during runtime only. This patch restores
that behavior. There will be another commit against master, which introduces new 4 new signals,
so in future you can even use compile time slots.

Fixes #2528
