### PR TITLE
TASK: Raise minimal phpunit to 9.1 

### DIFF
--- a/Neos.Cache/composer.json
+++ b/Neos.Cache/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "mikey179/vfsstream": "^1.6.1",
-        "phpunit/phpunit": "~9.0"
+        "phpunit/phpunit": "~9.1"
     },
     "autoload": {
         "psr-4": {

--- a/Neos.Error.Messages/composer.json
+++ b/Neos.Error.Messages/composer.json
@@ -8,7 +8,7 @@
         "php": "^7.3 || ^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~9.0"
+        "phpunit/phpunit": "~9.1"
     },
     "autoload": {
         "psr-4": {

--- a/Neos.Flow.Log/composer.json
+++ b/Neos.Flow.Log/composer.json
@@ -12,7 +12,7 @@
         "psr/log": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~9.0"
+        "phpunit/phpunit": "~9.1"
     },
     "autoload": {
         "psr-4": {

--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -55,7 +55,7 @@
     "require-dev": {
         "vimeo/psalm": "~4.1.1",
         "mikey179/vfsstream": "^1.6.1",
-        "phpunit/phpunit": "~7.1"
+        "phpunit/phpunit": "~9.1"
     },
     "replace": {
         "symfony/polyfill-php70": "*",

--- a/Neos.Utility.Arrays/composer.json
+++ b/Neos.Utility.Arrays/composer.json
@@ -10,7 +10,7 @@
   },
   "require-dev": {
     "mikey179/vfsstream": "^1.6.1",
-    "phpunit/phpunit": "~9.0"
+    "phpunit/phpunit": "~9.1"
   },
   "autoload": {
     "psr-4": {

--- a/Neos.Utility.Files/composer.json
+++ b/Neos.Utility.Files/composer.json
@@ -10,7 +10,7 @@
   },
   "require-dev": {
     "mikey179/vfsstream": "^1.6.1",
-    "phpunit/phpunit": "~9.0"
+    "phpunit/phpunit": "~9.1"
   },
   "autoload": {
     "psr-4": {

--- a/Neos.Utility.MediaTypes/composer.json
+++ b/Neos.Utility.MediaTypes/composer.json
@@ -9,7 +9,7 @@
   },
   "require-dev": {
     "mikey179/vfsstream": "^1.6.1",
-    "phpunit/phpunit": "~9.0"
+    "phpunit/phpunit": "~9.1"
   },
   "autoload": {
     "psr-4": {

--- a/Neos.Utility.ObjectHandling/composer.json
+++ b/Neos.Utility.ObjectHandling/composer.json
@@ -8,7 +8,7 @@
     "php": "^7.3 || ^8.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~9.0",
+    "phpunit/phpunit": "~9.1",
     "doctrine/orm": "^2.6",
     "doctrine/common": "^2.13.1 || ^3.0"
   },

--- a/Neos.Utility.Schema/composer.json
+++ b/Neos.Utility.Schema/composer.json
@@ -10,7 +10,7 @@
   },
   "require-dev": {
     "mikey179/vfsstream": "^1.6.1",
-    "phpunit/phpunit": "~9.0"
+    "phpunit/phpunit": "~9.1"
   },
   "autoload": {
     "psr-4": {

--- a/Neos.Utility.Unicode/composer.json
+++ b/Neos.Utility.Unicode/composer.json
@@ -13,7 +13,7 @@
   },
   "require-dev": {
     "mikey179/vfsstream": "^1.6.1",
-    "phpunit/phpunit": "~9.0"
+    "phpunit/phpunit": "~9.1"
   },
   "replace": {
     "symfony/polyfill-mbstring": "*"

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,6 @@
         "egulias/email-validator": "^2.1",
         "typo3fluid/fluid": "~2.5.11 || ^2.6.10",
         "guzzlehttp/psr7": "^1.4.1, !=1.8.0",
-        "neos/fusion-afx": "*",
-        "neos/fusion-form": "*",
         "ext-mbstring": "*"
     },
     "replace": {

--- a/composer.json
+++ b/composer.json
@@ -119,7 +119,7 @@
     },
     "require-dev": {
         "mikey179/vfsstream": "^1.6.1",
-        "phpunit/phpunit": "~9.0",
+        "phpunit/phpunit": "^9.1",
         "vimeo/psalm": "~4.1.1"
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,8 @@
         "egulias/email-validator": "^2.1",
         "typo3fluid/fluid": "~2.5.11 || ^2.6.10",
         "guzzlehttp/psr7": "^1.4.1, !=1.8.0",
+        "neos/fusion-afx": "*",
+        "neos/fusion-form": "*",
         "ext-mbstring": "*"
     },
     "replace": {
@@ -119,7 +121,7 @@
     },
     "require-dev": {
         "mikey179/vfsstream": "^1.6.1",
-        "phpunit/phpunit": "^9.1",
+        "phpunit/phpunit": "~9.1",
         "vimeo/psalm": "~4.1.1"
     },
     "autoload-dev": {


### PR DESCRIPTION
Version 9.1 introduces the method `assertFileDoesNotExist()`
which is used since Flow 7.0 (#2310)