### PR TITLE
TASK: Raise minimum egulias/email-validator version to 2.1.17

### DIFF
--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -50,7 +50,7 @@
 
         "composer/composer": "^1.9 || ^2.0",
 
-        "egulias/email-validator": "^2.1"
+        "egulias/email-validator": "^2.1.17"
     },
     "require-dev": {
         "vimeo/psalm": "~4.1.1",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/console": "^5.1",
         "neos/composer-plugin": "^2.0",
         "composer/composer": "^1.9 || ^2.0",
-        "egulias/email-validator": "^2.1",
+        "egulias/email-validator": "^2.1.17",
         "typo3fluid/fluid": "~2.5.11 || ^2.6.10",
         "guzzlehttp/psr7": "^1.4.1, !=1.8.0",
         "ext-mbstring": "*"


### PR DESCRIPTION
This is required to pass emailAddressValidatorUsingStrictHasErrorsForAnEmailAddressWithWarnings with data set #0

See https://github.com/egulias/EmailValidator/pull/233