### PR TITLE
TASK: Add explicit doctrine annotations dependency

### DIFF
--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -40,6 +40,7 @@
         "doctrine/migrations": "^3.0",
         "doctrine/dbal": "^2.12",
         "doctrine/common": "^2.13.1 || ^3.0",
+        "doctrine/annotations": "^1.12",
 
         "symfony/yaml": "^5.1",
         "symfony/dom-crawler": "^5.1",

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "doctrine/migrations": "^3.0",
         "doctrine/dbal": "^2.12",
         "doctrine/common": "^2.13.1 || ^3.0",
+        "doctrine/annotations": "^1.12",
         "symfony/yaml": "^5.1",
         "symfony/dom-crawler": "^5.1",
         "symfony/console": "^5.1",


### PR DESCRIPTION
This also fixes onto ^1.12 to include the `@NamedConstructorAnnotation` we use since adding PHP8 attributes support