### PR TITLE
TASK: Require fixed composer/composer packages

### DIFF
--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -46,7 +46,7 @@
         "neos/composer-plugin": "^2.0",
         "neos/utility-pdo": "~5.3.0",
 
-        "composer/composer": "^1.9 || ^2.0"
+        "composer/composer": "^1.10.22 || ^2.0.13"
     },
     "require-dev": {
         "mikey179/vfsstream": "^1.6.1",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/dom-crawler": "^4.2",
         "symfony/console": "^4.2",
         "neos/composer-plugin": "^2.0",
-        "composer/composer": "^1.9 || ^2.0",
+        "composer/composer": "^1.10.22 || ^2.0.13",
         "typo3fluid/fluid": "~2.5.11 || ^2.6.10",
         "ext-mbstring": "*"
     },


### PR DESCRIPTION
This makes sure the required `composer/composer` dependency is not
affected by CVE-2021-29472

https://github.com/composer/composer/security/advisories/GHSA-h5h8-pc6h-jvvx
