### PR TITLE
TASK: Fix PhpUnit deprecation warnings

### DIFF
--- a/Neos.Flow/Tests/Unit/Fixtures/SessionlessTestToken.php
+++ b/Neos.Flow/Tests/Unit/Fixtures/SessionlessTestToken.php
@@ -1,0 +1,9 @@
+<?php
+namespace Neos\Flow\Fixtures;
+
+use Neos\Flow\Security\Authentication\Token\SessionlessTokenInterface;
+use Neos\Flow\Security\Authentication\TokenInterface;
+
+abstract class SessionlessTestToken implements TokenInterface, SessionlessTokenInterface
+{
+}

--- a/Neos.Flow/Tests/Unit/Http/Component/SecurityEntryPointComponentTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Component/SecurityEntryPointComponentTest.php
@@ -11,12 +11,12 @@ namespace Neos\Flow\Tests\Unit\Http\Component;
  * source code.
  */
 
+use Neos\Flow\Fixtures\SessionlessTestToken;
 use Neos\Flow\Http\Component\ComponentContext;
 use Neos\Flow\Http\Component\SecurityEntryPointComponent;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\DispatchComponent;
 use Neos\Flow\Security\Authentication\EntryPointInterface;
-use Neos\Flow\Security\Authentication\Token\SessionlessTokenInterface;
 use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Security\Exception\AuthenticationRequiredException;
@@ -25,6 +25,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
+
+require_once(__DIR__ . '/../../Fixtures/SessionlessTestToken.php');
 
 /**
  * Test case for the SecurityEntryPointComponent
@@ -218,11 +220,11 @@ class SecurityEntryPointComponentTest extends UnitTestCase
      */
     public function handleDoesNotSetInterceptedRequestIfAllAuthenticatedTokensAreSessionless(): void
     {
-        $mockAuthenticationToken1 = $this->getMockBuilder([TokenInterface::class, SessionlessTokenInterface::class])->getMock();
+        $mockAuthenticationToken1 = $this->getMockBuilder(SessionlessTestToken::class)->getMock();
         $mockEntryPoint1 = $this->getMockBuilder(EntryPointInterface::class)->getMock();
         $mockAuthenticationToken1->method('getAuthenticationEntryPoint')->willReturn($mockEntryPoint1);
 
-        $mockAuthenticationToken2 = $this->getMockBuilder([TokenInterface::class, SessionlessTokenInterface::class])->getMock();
+        $mockAuthenticationToken2 = $this->getMockBuilder(SessionlessTestToken::class)->getMock();
         $mockEntryPoint2 = $this->getMockBuilder(EntryPointInterface::class)->getMock();
         $mockAuthenticationToken2->method('getAuthenticationEntryPoint')->willReturn($mockEntryPoint2);
 

--- a/Neos.Flow/Tests/Unit/Http/Helper/RequestInformationHelperTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Helper/RequestInformationHelperTest.php
@@ -20,7 +20,7 @@ class RequestInformationHelperTest extends UnitTestCase
             ->withAddedHeader('Authorization', 'Bearer SomeToken');
 
         $renderedHeaders = RequestInformationHelper::renderRequestHeaders($request);
-        self::assertNotContains('SomePassword', $renderedHeaders);
-        self::assertNotContains('SomeToken', $renderedHeaders);
+        self::assertStringNotContainsString('SomePassword', $renderedHeaders);
+        self::assertStringNotContainsString('SomeToken', $renderedHeaders);
     }
 }

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/PersistenceManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/PersistenceManagerTest.php
@@ -104,7 +104,7 @@ class PersistenceManagerTest extends UnitTestCase
     public function persistAllThrowsExceptionIfTryingToPersistNonAllowedObjectsAndOnlyAllowedObjectsFlagIsTrue()
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageRegExp('/^Detected modified or new objects/');
+        $this->expectExceptionMessageMatches('/^Detected modified or new objects/');
         $mockObject = new \stdClass();
         $scheduledEntityUpdates = [spl_object_hash($mockObject) => $mockObject];
         $scheduledEntityDeletes = [];

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/CollectionConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/CollectionConverterTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
  * source code.
  */
 
+use Neos\Flow\Property\Exception\InvalidDataTypeException;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
 use Neos\Flow\Property\TypeConverter\CollectionConverter;
 use Neos\Flow\Tests\UnitTestCase;
@@ -50,10 +51,10 @@ class CollectionConverterTest extends UnitTestCase
 
     /**
      * @test
-     * @expectedException \Neos\Flow\Property\Exception\InvalidDataTypeException
      */
     public function getTypeOfChildPropertyThrowsExceptionForMissingElementType()
     {
+        $this->expectException(InvalidDataTypeException::class);
         $this->converter->getTypeOfChildProperty('array', 'collection', $this->createMock(PropertyMappingConfigurationInterface::class));
     }
 }

--- a/Neos.Flow/Tests/Unit/Security/ContextTest.php
+++ b/Neos.Flow/Tests/Unit/Security/ContextTest.php
@@ -12,11 +12,10 @@ namespace Neos\Flow\Tests\Unit\Security;
  */
 
 use Neos\Flow\Exception;
+use Neos\Flow\Fixtures\SessionlessTestToken;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Flow\Security\Authentication\AuthenticationManagerInterface;
 use Neos\Flow\Security\Account;
-use Neos\Flow\Security\Authentication\Token\SessionlessTokenInterface;
 use Neos\Flow\Security\Authentication\TokenAndProviderFactory;
 use Neos\Flow\Security\Authentication\TokenAndProviderFactoryInterface;
 use Neos\Flow\Security\Authentication\TokenInterface;
@@ -29,6 +28,8 @@ use Neos\Flow\Session\SessionManagerInterface;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\Security\Policy\Role;
 use Psr\Log\LoggerInterface;
+
+require_once(__DIR__ . '/../Fixtures/ClassWithBoolConstructor.php');
 
 /**
  * Testcase for the security context
@@ -234,7 +235,7 @@ class ContextTest extends UnitTestCase
         $activeToken->method('getAuthenticationProviderName')->willReturn('activeTokenProvider');
         $activeToken->method('getAuthenticationStatus')->willReturn(TokenInterface::AUTHENTICATION_NEEDED);
 
-        $sessionlessToken = $this->createMock([TokenInterface::class, SessionlessTokenInterface::class]);
+        $sessionlessToken = $this->createMock(SessionlessTestToken::class);
         $sessionlessToken->expects(self::once())->method('hasRequestPatterns')->willReturn(false);
         $sessionlessToken->method('getAuthenticationProviderName')->willReturn('sessionlessTokenProvider');
         $sessionlessToken->method('getAuthenticationStatus')->willReturn(TokenInterface::AUTHENTICATION_NEEDED);

--- a/Neos.Flow/Tests/Unit/Security/SessionDataContainerTest.php
+++ b/Neos.Flow/Tests/Unit/Security/SessionDataContainerTest.php
@@ -11,11 +11,13 @@ namespace Neos\Flow\Tests\Unit\Security;
  * source code.
  */
 
+use Neos\Flow\Fixtures\SessionlessTestToken;
 use Neos\Flow\Mvc\ActionRequest;
-use Neos\Flow\Security\Authentication\Token\SessionlessTokenInterface;
 use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\SessionDataContainer;
 use Neos\Flow\Tests\UnitTestCase;
+
+require_once(__DIR__ . '/../Fixtures/ClassWithBoolConstructor.php');
 
 /**
  * Testcase for the SessionDataContainer
@@ -66,7 +68,7 @@ class SessionDataContainerTest extends UnitTestCase
     public function setSecurityTokensThrowsExceptionWhenTryingToAddSessionlessTokens(): void
     {
         $mockSecurityTokens = [
-            'someProvider' => $this->getMockBuilder([TokenInterface::class, SessionlessTokenInterface::class])->getMock()
+            'someProvider' => $this->getMockBuilder(SessionlessTestToken::class)->getMock()
         ];
         $this->expectException(\InvalidArgumentException::class);
         $this->sessionDataContainer->setSecurityTokens($mockSecurityTokens);


### PR DESCRIPTION
The new `SessionlessTestToken` class is needed to replace the mocking of two interfaces (`TokenInterface` and `SessionlessTokeInterface`) in one call.