### PR TITLE
BUGFIX: Add missing method to Generic\PersistenceManager

### DIFF
--- a/Neos.Flow/Classes/Persistence/Generic/PersistenceManager.php
+++ b/Neos.Flow/Classes/Persistence/Generic/PersistenceManager.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Persistence\Generic;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\AbstractPersistenceManager;
+use Neos\Flow\Persistence\Exception as PersistenceException;
 use Neos\Flow\Persistence\Exception\UnknownObjectException;
 use Neos\Flow\Persistence\Generic\Exception\MissingBackendException;
 use Neos\Flow\Persistence\QueryInterface;
@@ -354,6 +355,25 @@ class PersistenceManager extends AbstractPersistenceManager
         return $this->backend->isConnected();
     }
 
+    /**
+     * Checks if the given object is allowed and if not, throws an exception
+     *
+     * @param object $object
+     * @return void
+     * @throws \Neos\Flow\Persistence\Exception
+     */
+    protected function throwExceptionIfObjectIsNotAllowed($object)
+    {
+        if (!$this->allowedObjects->contains($object)) {
+            $message = 'Detected modified or new objects (' . get_class($object) . ', uuid:' . $this->getIdentifierByObject($object) . ') to be persisted which is not allowed for "safe requests"' . chr(10) .
+                'According to the HTTP 1.1 specification, so called "safe request" (usually GET or HEAD requests)' . chr(10) .
+                'should not change your data on the server side and should be considered read-only. If you need to add,' . chr(10) .
+                'modify or remove data, you should use the respective request methods (POST, PUT, DELETE and PATCH).' . chr(10) . chr(10) .
+                'If you need to store some data during a safe request (for example, logging some data for your analytics),' . chr(10) .
+                'you are still free to call PersistenceManager->persistAll() manually.';
+            throw new PersistenceException($message, 1377788621);
+        }
+    }
     /**
      * Signals that all persistAll() has been executed successfully.
      *


### PR DESCRIPTION
With https://github.com/neos/flow-development-collection/pull/2448
the method `throwExceptionIfObjectIsNotAllowed()` was removed, but
the `Generic\PersistenceManager` was not adjusted. This fixes that in
the simplest possible way…
