### PR TITLE
BUGFIX: NullBackend ignores configured properties

### DIFF
--- a/Neos.Cache/Classes/Backend/NullBackend.php
+++ b/Neos.Cache/Classes/Backend/NullBackend.php
@@ -25,6 +25,18 @@ use Neos\Cache\Backend\TaggableBackendInterface;
 class NullBackend extends AbstractCacheBackend implements PhpCapableBackendInterface, TaggableBackendInterface
 {
     /**
+     * Successfully ignore every configured property
+     *
+     * @param string $propertyName
+     * @param mixed $propertyValue
+     * @return boolean TRUE
+     */
+    protected function setProperty(string $propertyName, $propertyValue) : bool
+    {
+        return true;
+    }
+
+    /**
      * Acts as if it would save data
      *
      * @param string $entryIdentifier ignored


### PR DESCRIPTION
**What I did**

The `NullBackend` just return's `true` in `setProperty()` for all configured properties.

**What does this solve**

I'm using split sources Objects.local.yaml to disable caches in my local setup where I only change the `backend:` configuration to `Neos\Cache\Backend\NullBackend`.

The problem I have is, that the Objects.yaml merge strategy also includes the `backendOptions` and thus by just using
```
Neos_Fusion_Content:
  backend: Neos\Cache\Backend\NullBackend
```
in my `Objects.local.yaml` I get an Exception, thrown by AbstractBackend, that the `NullBackend` doesn't accept the backendOption `hostname` - from my default redis configuration.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
