### PR TITLE
BUGFIX: Bring back RenderingContext view argument, pin Fluid version

### DIFF
--- a/Neos.FluidAdaptor/Classes/Core/Rendering/RenderingContext.php
+++ b/Neos.FluidAdaptor/Classes/Core/Rendering/RenderingContext.php
@@ -87,7 +87,7 @@ class RenderingContext extends FluidRenderingContext implements FlowAwareRenderi
      */
     public function __construct(ViewInterface $view, array $options = [])
     {
-        parent::__construct();
+        parent::__construct($view);
         $this->setTemplateParser(new TemplateParser());
         $this->setViewHelperResolver(new ViewHelperResolver());
         $this->setTemplateProcessors([

--- a/Neos.FluidAdaptor/composer.json
+++ b/Neos.FluidAdaptor/composer.json
@@ -11,7 +11,7 @@
     "neos/cache": "*",
     "neos/utility-files": "*",
     "neos/utility-objecthandling": "*",
-    "typo3fluid/fluid": "~2.5.11 || ^2.6.10",
+    "typo3fluid/fluid": "~2.5.11 || ~2.6.10",
     "psr/log": "^1.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony/console": "^4.2",
         "neos/composer-plugin": "^2.0",
         "composer/composer": "^1.10.22 || ^2.0.13",
-        "typo3fluid/fluid": "~2.5.11 || ^2.6.10",
+        "typo3fluid/fluid": "~2.5.11 || ~2.6.10",
         "guzzlehttp/psr7": "^1.4, !=1.8.0",
         "ext-mbstring": "*"
     },


### PR DESCRIPTION
With `typo3fluid/fluid` 2.7.0 the `$view` constructor argument to
`RenderingContext` is gone, but we support lower versions, thus things
break.

This brings back the argument in our code and pins Fluid to < 2.7.0
for Flow below 7.2.0.

See https://github.com/neos/flow-development-collection/issues/2541
See https://github.com/TYPO3/Fluid/pull/548
