### PR TITLE
TASK: Update psalm to 4.9

### DIFF
--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -53,7 +53,7 @@
         "composer/composer": "^1.10.22 || ^2.0.13"
     },
     "require-dev": {
-        "vimeo/psalm": "~4.1.1",
+        "vimeo/psalm": "~4.9.3",
         "mikey179/vfsstream": "^1.6.1",
         "phpunit/phpunit": "~8.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,7 @@
     "require-dev": {
         "mikey179/vfsstream": "^1.6.1",
         "phpunit/phpunit": "~8.5",
-        "vimeo/psalm": "~4.1.1"
+        "vimeo/psalm": "~4.9.3"
     },
     "autoload-dev": {
         "psr-4": {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.1.1@16bfbd9224698bd738c665f33039fade2a1a3977">
+<files psalm-version="4.9.3@4c262932602b9bbab5020863d1eb22d49de0dbf4">
   <file src="Packages/Framework/Neos.Cache/Classes/Backend/AbstractBackend.php">
     <PossiblyInvalidArgument occurrences="1">
       <code>$options</code>
@@ -21,15 +21,32 @@
       <code>\APCUIterator</code>
     </UndefinedDocblockClass>
   </file>
+  <file src="Packages/Framework/Neos.Cache/Classes/Backend/FileBackend.php">
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$cacheEntryIdentifiers</code>
+    </NonInvariantDocblockPropertyType>
+  </file>
   <file src="Packages/Framework/Neos.Cache/Classes/Backend/PdoBackend.php">
     <PossiblyNullPropertyAssignmentValue occurrences="1">
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="Packages/Framework/Neos.Cache/Classes/Backend/RedisBackend.php">
-    <TypeDoesNotContainType occurrences="1">
-      <code>$transactionResult === false</code>
-    </TypeDoesNotContainType>
+    <RedundantCast occurrences="2">
+      <code>(array)$this-&gt;redis-&gt;info('SERVER')</code>
+      <code>(array)$this-&gt;redis-&gt;info('SERVER')</code>
+    </RedundantCast>
+  </file>
+  <file src="Packages/Framework/Neos.Cache/Classes/Backend/SimpleFileBackend.php">
+    <RedundantPropertyInitializationCheck occurrences="2">
+      <code>$this-&gt;baseDirectory</code>
+      <code>'-'</code>
+    </RedundantPropertyInitializationCheck>
+  </file>
+  <file src="Packages/Framework/Neos.Cache/Classes/Backend/TaggableMultiBackend.php">
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$backends</code>
+    </NonInvariantDocblockPropertyType>
   </file>
   <file src="Packages/Framework/Neos.Cache/Classes/Frontend/PhpFrontend.php">
     <ImplementedReturnTypeMismatch occurrences="1">
@@ -38,22 +55,14 @@
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$sourceCode</code>
     </MoreSpecificImplementedParamType>
-    <ParamNameMismatch occurrences="1">
-      <code>$sourceCode</code>
-    </ParamNameMismatch>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$backend</code>
+    </NonInvariantDocblockPropertyType>
   </file>
   <file src="Packages/Framework/Neos.Cache/Classes/Frontend/StringFrontend.php">
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$string</code>
     </MoreSpecificImplementedParamType>
-    <ParamNameMismatch occurrences="1">
-      <code>$string</code>
-    </ParamNameMismatch>
-  </file>
-  <file src="Packages/Framework/Neos.Cache/Classes/Frontend/VariableFrontend.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$variable</code>
-    </ParamNameMismatch>
   </file>
   <file src="Packages/Framework/Neos.Cache/Classes/Psr/Cache/CacheFactory.php">
     <InvalidArgument occurrences="1">
@@ -73,36 +82,6 @@
       <code>$lifetime</code>
       <code>$ttl</code>
     </MoreSpecificImplementedParamType>
-    <ParamNameMismatch occurrences="3">
-      <code>$defaultValue</code>
-      <code>$lifetime</code>
-      <code>$variable</code>
-    </ParamNameMismatch>
-  </file>
-  <file src="Packages/Framework/Neos.Eel/Classes/AbstractParser.php">
-    <UndefinedThisPropertyAssignment occurrences="10">
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-    </UndefinedThisPropertyAssignment>
-    <UndefinedThisPropertyFetch occurrences="9">
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;string</code>
-      <code>$this-&gt;string</code>
-      <code>$this-&gt;string</code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="Packages/Framework/Neos.Eel/Classes/CompilingEvaluator.php">
     <UndefinedPropertyFetch occurrences="1">
@@ -116,85 +95,6 @@
     <UnsafeInstantiation occurrences="1">
       <code>new static($value)</code>
     </UnsafeInstantiation>
-  </file>
-  <file src="Packages/Framework/Neos.Eel/Classes/EelParser.php">
-    <UndefinedThisPropertyAssignment occurrences="43">
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-    </UndefinedThisPropertyAssignment>
-    <UndefinedThisPropertyFetch occurrences="30">
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;pos</code>
-      <code>$this-&gt;string</code>
-      <code>$this-&gt;string</code>
-      <code>$this-&gt;string</code>
-      <code>$this-&gt;string</code>
-      <code>$this-&gt;string</code>
-      <code>$this-&gt;string</code>
-      <code>$this-&gt;string</code>
-      <code>$this-&gt;string</code>
-      <code>$this-&gt;string</code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="Packages/Framework/Neos.Eel/Classes/FlowQuery/FlowQuery.php">
     <InvalidPropertyAssignmentValue occurrences="1">
@@ -339,6 +239,48 @@
       <code>$fromIndex</code>
       <code>$limit</code>
     </PossiblyNullArgument>
+    <RedundantCast occurrences="2">
+      <code>(integer)$index</code>
+      <code>(integer)$index</code>
+    </RedundantCast>
+    <RedundantCastGivenDocblockType occurrences="36">
+      <code>(int)$value</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$string</code>
+      <code>(string)$unicodeString</code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="Packages/Framework/Neos.Eel/Classes/InterpretedEvaluator.php">
     <UndefinedPropertyFetch occurrences="1">
@@ -397,9 +339,6 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Aop/Builder/AdvicedConstructorInterceptorBuilder.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$interceptedMethods</code>
-    </ParamNameMismatch>
     <PossiblyInvalidMethodCall occurrences="1">
       <code>getConstructor</code>
     </PossiblyInvalidMethodCall>
@@ -408,9 +347,6 @@
     </UndefinedMethod>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Aop/Builder/AdvicedMethodInterceptorBuilder.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$interceptedMethods</code>
-    </ParamNameMismatch>
     <PossiblyInvalidMethodCall occurrences="1">
       <code>getMethod</code>
     </PossiblyInvalidMethodCall>
@@ -487,9 +423,8 @@
       <code>$matches[3][$i]</code>
       <code>$matches[3][$i]</code>
     </PossiblyInvalidArgument>
-    <TypeDoesNotContainType occurrences="2">
+    <TypeDoesNotContainType occurrences="1">
       <code>!is_string($pointcutExpression)</code>
-      <code>is_string($pointcutExpression)</code>
     </TypeDoesNotContainType>
     <UndefinedDocblockClass occurrences="1">
       <code>$logger</code>
@@ -499,11 +434,6 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$methodDeclaringClassName</code>
     </ArgumentTypeCoercion>
-  </file>
-  <file src="Packages/Framework/Neos.Flow/Classes/Aop/Pointcut/PointcutSettingFilter.php">
-    <PossiblyNullArrayAccess occurrences="1">
-      <code>$settingValue[$currentKey]</code>
-    </PossiblyNullArrayAccess>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Aop/Pointcut/RuntimeExpressionEvaluator.php">
     <InvalidPropertyAssignmentValue occurrences="1">
@@ -577,6 +507,9 @@
     </PossiblyUndefinedVariable>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Command/CacheCommandController.php">
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$objectManager</code>
+    </NonInvariantDocblockPropertyType>
     <PropertyTypeCoercion occurrences="1">
       <code>$objectManager</code>
     </PropertyTypeCoercion>
@@ -681,12 +614,12 @@
     <PossiblyNullIterator occurrences="1">
       <code>$methodNames</code>
     </PossiblyNullIterator>
-    <PossiblyUndefinedMethod occurrences="1">
-      <code>matchesMethod</code>
-    </PossiblyUndefinedMethod>
     <PropertyTypeCoercion occurrences="1">
       <code>$cacheManager-&gt;getCache('Flow_Security_Authorization_Privilege_Method')</code>
     </PropertyTypeCoercion>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>matchesMethod</code>
+    </UndefinedInterfaceMethod>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Command/ServerCommandController.php">
     <UndefinedConstant occurrences="2">
@@ -868,6 +801,9 @@
     <InvalidArgument occurrences="1">
       <code>[$this, 'handleError']</code>
     </InvalidArgument>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(array)$this-&gt;exceptionalErrors</code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Error/ProductionExceptionHandler.php">
     <ImplicitToStringCast occurrences="1">
@@ -884,6 +820,14 @@
     <PossiblyFalseOperand occurrences="1">
       <code>date('YmdHis', $_SERVER['REQUEST_TIME'])</code>
     </PossiblyFalseOperand>
+    <RedundantPropertyInitializationCheck occurrences="1">
+      <code>isset($this-&gt;referenceCode)</code>
+    </RedundantPropertyInitializationCheck>
+  </file>
+  <file src="Packages/Framework/Neos.Flow/Classes/Http/Client/Browser.php">
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(boolean)$flag</code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Http/Client/CurlEngine.php">
     <InvalidScalarArgument occurrences="1">
@@ -992,18 +936,20 @@
       <code>FLOW_SAPITYPE</code>
     </UndefinedConstant>
   </file>
+  <file src="Packages/Framework/Neos.Flow/Classes/Http/UriTemplate.php">
+    <RedundantCast occurrences="1">
+      <code>(string)$expressionPart</code>
+    </RedundantCast>
+  </file>
   <file src="Packages/Framework/Neos.Flow/Classes/I18n/Cldr/CldrModel.php">
     <PossiblyFalseOperand occurrences="1">
       <code>strpos($nodeString, '"]', $positionOfAttributeValue)</code>
     </PossiblyFalseOperand>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/I18n/Cldr/CldrParser.php">
-    <PossiblyNullArgument occurrences="1">
-      <code>$child-&gt;attributes()</code>
-    </PossiblyNullArgument>
-    <PossiblyNullIterator occurrences="1">
-      <code>$child-&gt;attributes()</code>
-    </PossiblyNullIterator>
+    <PossiblyNullReference occurrences="1">
+      <code>getName</code>
+    </PossiblyNullReference>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/I18n/Cldr/CldrRepository.php">
     <NullableReturnStatement occurrences="1">
@@ -1094,6 +1040,9 @@
     </InvalidScalarArgument>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/I18n/Formatter/NumberFormatter.php">
+    <PossiblyFalseArgument occurrences="1">
+      <code>$secondaryGroupsOfIntegerPart</code>
+    </PossiblyFalseArgument>
     <TypeDoesNotContainType occurrences="1">
       <code>$parsedFormat === false</code>
     </TypeDoesNotContainType>
@@ -1113,6 +1062,9 @@
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$source</code>
     </MoreSpecificImplementedParamType>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$sourceTypes</code>
+    </NonInvariantDocblockPropertyType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/I18n/Parser/DatetimeParser.php">
     <FalsableReturnStatement occurrences="6">
@@ -1129,10 +1081,6 @@
     <PossiblyFalseOperand occurrences="1">
       <code>strpos($datetimeToParse, $timezone)</code>
     </PossiblyFalseOperand>
-    <TypeDoesNotContainType occurrences="2">
-      <code>$numberStarted</code>
-      <code>$numberStarted</code>
-    </TypeDoesNotContainType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/I18n/Parser/NumberParser.php">
     <PossiblyFalseArgument occurrences="1">
@@ -1177,6 +1125,9 @@
     <PossiblyInvalidPropertyFetch occurrences="1">
       <code>$translationElement-&gt;{'trans-unit'}</code>
     </PossiblyInvalidPropertyFetch>
+    <PossiblyNullArgument occurrences="1">
+      <code>$file</code>
+    </PossiblyNullArgument>
     <UndefinedInterfaceMethod occurrences="1">
       <code>children</code>
     </UndefinedInterfaceMethod>
@@ -1193,9 +1144,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>rand()</code>
     </InvalidScalarArgument>
-    <PossiblyFalseOperand occurrences="1">
-      <code>date('YmdHis', $timestamp)</code>
-    </PossiblyFalseOperand>
     <PossiblyNullArgument occurrences="1">
       <code>$error</code>
     </PossiblyNullArgument>
@@ -1235,12 +1183,28 @@
     <NullableReturnStatement occurrences="1">
       <code>$this-&gt;internalArguments[$argumentName] ?? null</code>
     </NullableReturnStatement>
+    <RedundantCast occurrences="1">
+      <code>strtolower</code>
+    </RedundantCast>
+    <RedundantCastGivenDocblockType occurrences="2">
+      <code>(bool)$flag</code>
+      <code>(string)$this-&gt;controllerSubpackageKey</code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Mvc/ActionResponse.php">
     <PropertyTypeCoercion occurrences="2">
       <code>$content</code>
       <code>stream_for()</code>
     </PropertyTypeCoercion>
+    <RedundantPropertyInitializationCheck occurrences="2">
+      <code>$this-&gt;contentType</code>
+      <code>''</code>
+    </RedundantPropertyInitializationCheck>
+  </file>
+  <file src="Packages/Framework/Neos.Flow/Classes/Mvc/Controller/AbstractController.php">
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(int)$delay</code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Mvc/Controller/ActionController.php">
     <PossiblyNullPropertyAssignmentValue occurrences="2">
@@ -1378,6 +1342,10 @@
       <code>null</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
+    <RedundantCastGivenDocblockType occurrences="2">
+      <code>(boolean)$appendExceedingArguments</code>
+      <code>(boolean)$lowerCase</code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Mvc/Routing/Router.php">
     <ImplicitToStringCast occurrences="1">
@@ -1424,6 +1392,14 @@
       <code>null</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
+    <RedundantCast occurrences="1">
+      <code>(array)$subRequest-&gt;getArguments()</code>
+    </RedundantCast>
+    <RedundantCastGivenDocblockType occurrences="3">
+      <code>(boolean)$addQueryString</code>
+      <code>(boolean)$createAbsoluteUri</code>
+      <code>(string)$section</code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Mvc/View/AbstractView.php">
     <UnsafeInstantiation occurrences="1">
@@ -1436,9 +1412,6 @@
     </PossiblyNullIterator>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/ObjectManagement/CompileTimeObjectManager.php">
-    <ParamNameMismatch occurrences="1">
-      <code>$objectName</code>
-    </ParamNameMismatch>
     <PossiblyNullArgument occurrences="1">
       <code>$rawCustomObjectConfigurations</code>
     </PossiblyNullArgument>
@@ -1532,15 +1505,16 @@
     <NullableReturnStatement occurrences="1">
       <code>$this-&gt;objects[$objectName]['i'] ?? null</code>
     </NullableReturnStatement>
-    <ParamNameMismatch occurrences="1">
-      <code>$objectName</code>
-    </ParamNameMismatch>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php">
     <ArgumentTypeCoercion occurrences="2">
       <code>$optionValue</code>
       <code>$v</code>
     </ArgumentTypeCoercion>
+    <InvalidArrayOffset occurrences="1">
+      <code>$optionDefaults[$optionName]</code>
+    </InvalidArrayOffset>
+    <ParadoxicalCondition occurrences="1"/>
     <UndefinedClass occurrences="1">
       <code>BaseTestCase</code>
     </UndefinedClass>
@@ -1552,6 +1526,11 @@
     <PossiblyFalseArgument occurrences="1">
       <code>strrpos($fullOriginalClassName, '\\')</code>
     </PossiblyFalseArgument>
+    <RedundantPropertyInitializationCheck occurrences="3">
+      <code>''</code>
+      <code>isset($this-&gt;constructor)</code>
+      <code>isset($this-&gt;constructor)</code>
+    </RedundantPropertyInitializationCheck>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethod.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -1583,6 +1562,10 @@
     <PossiblyFalseOperand occurrences="1">
       <code>strrpos(trim($packagePath, '/'), '/')</code>
     </PossiblyFalseOperand>
+    <PossiblyInvalidArgument occurrences="2">
+      <code>$composerManifest</code>
+      <code>$composerManifest</code>
+    </PossiblyInvalidArgument>
     <PossiblyNullArgument occurrences="1">
       <code>$packagePath</code>
     </PossiblyNullArgument>
@@ -1636,30 +1619,16 @@
     <LessSpecificImplementedReturnType occurrences="1">
       <code>array</code>
     </LessSpecificImplementedReturnType>
-    <ParamNameMismatch occurrences="2">
-      <code>$array</code>
-      <code>$fieldDeclaration</code>
-    </ParamNameMismatch>
     <PropertyTypeCoercion occurrences="2">
       <code>Bootstrap::$staticObjectManager-&gt;get(PersistenceManagerInterface::class)</code>
       <code>Bootstrap::$staticObjectManager-&gt;get(ReflectionService::class)</code>
     </PropertyTypeCoercion>
-    <ReferenceConstraintViolation occurrences="1">
-      <code>$value</code>
-    </ReferenceConstraintViolation>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Persistence/Doctrine/DataTypes/ObjectArray.php">
-    <ParamNameMismatch occurrences="2">
-      <code>$array</code>
-      <code>$fieldDeclaration</code>
-    </ParamNameMismatch>
     <PropertyTypeCoercion occurrences="2">
       <code>Bootstrap::$staticObjectManager-&gt;get(PersistenceManagerInterface::class)</code>
       <code>Bootstrap::$staticObjectManager-&gt;get(ReflectionService::class)</code>
     </PropertyTypeCoercion>
-    <ReferenceConstraintViolation occurrences="1">
-      <code>$value</code>
-    </ReferenceConstraintViolation>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Persistence/Doctrine/EntityManagerConfiguration.php">
     <PossiblyNullReference occurrences="2">
@@ -1735,6 +1704,9 @@
     <PropertyTypeCoercion occurrences="1">
       <code>$entityManager</code>
     </PropertyTypeCoercion>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(array)$this-&gt;joins</code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Persistence/Doctrine/Repository.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -1818,6 +1790,9 @@
     <InvalidArgument occurrences="1">
       <code>$this-&gt;mapToObject($arrayValue['value'])</code>
     </InvalidArgument>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(integer) $timestamp</code>
+    </RedundantCastGivenDocblockType>
     <UndefinedInterfaceMethod occurrences="1">
       <code>getObjectDataByIdentifier</code>
     </UndefinedInterfaceMethod>
@@ -1915,10 +1890,9 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Property/PropertyMapper.php">
-    <TypeDoesNotContainType occurrences="3">
+    <TypeDoesNotContainType occurrences="2">
       <code>!($typeConverter instanceof TypeConverterInterface)</code>
       <code>!is_object($typeConverter)</code>
-      <code>is_object($typeConverter)</code>
     </TypeDoesNotContainType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Property/PropertyMappingConfiguration.php">
@@ -1981,6 +1955,9 @@
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$source</code>
     </MoreSpecificImplementedParamType>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$sourceTypes</code>
+    </NonInvariantDocblockPropertyType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Property/TypeConverter/ObjectConverter.php">
     <ArgumentTypeCoercion occurrences="1">
@@ -1990,6 +1967,9 @@
       <code>self::CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED</code>
       <code>self::CONFIGURATION_TARGET_TYPE</code>
     </InvalidScalarArgument>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$sourceTypes</code>
+    </NonInvariantDocblockPropertyType>
     <NullableReturnStatement occurrences="1">
       <code>null</code>
     </NullableReturnStatement>
@@ -2002,6 +1982,9 @@
       <code>self::CONFIGURATION_MODIFICATION_ALLOWED</code>
       <code>self::CONFIGURATION_TARGET_TYPE</code>
     </InvalidScalarArgument>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$sourceTypes</code>
+    </NonInvariantDocblockPropertyType>
     <NullableReturnStatement occurrences="1">
       <code>null</code>
     </NullableReturnStatement>
@@ -2014,17 +1997,26 @@
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$source</code>
     </MoreSpecificImplementedParamType>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$sourceTypes</code>
+    </NonInvariantDocblockPropertyType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Property/TypeConverter/ScalarTypeToObjectConverter.php">
     <MoreSpecificImplementedParamType occurrences="2">
       <code>$source</code>
       <code>$source</code>
     </MoreSpecificImplementedParamType>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$sourceTypes</code>
+    </NonInvariantDocblockPropertyType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Property/TypeConverter/SessionConverter.php">
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$source</code>
     </MoreSpecificImplementedParamType>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$sourceTypes</code>
+    </NonInvariantDocblockPropertyType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Property/TypeConverter/TypedArrayConverter.php">
     <MoreSpecificImplementedParamType occurrences="1">
@@ -2091,6 +2083,11 @@
       <code>ClassReflection</code>
       <code>string</code>
     </InvalidNullableReturnType>
+    <MissingImmutableAnnotation occurrences="3">
+      <code>\ReflectionParameter</code>
+      <code>public function getClass()</code>
+      <code>public function getDeclaringClass()</code>
+    </MissingImmutableAnnotation>
     <NullableReturnStatement occurrences="3">
       <code>is_object($class) ? new ClassReflection($class-&gt;getName()) : null</code>
       <code>null</code>
@@ -2114,11 +2111,6 @@
       <code>$className</code>
       <code>$this-&gt;cleanClassName($className)</code>
     </ArgumentTypeCoercion>
-    <InvalidNullableReturnType occurrences="3">
-      <code>object</code>
-      <code>object</code>
-      <code>object</code>
-    </InvalidNullableReturnType>
     <LessSpecificReturnStatement occurrences="1">
       <code>is_object($this-&gt;classSchemata[$className]) ? $this-&gt;classSchemata[$className] : null</code>
     </LessSpecificReturnStatement>
@@ -2132,10 +2124,7 @@
     <MoreSpecificReturnType occurrences="1">
       <code>ClassSchema</code>
     </MoreSpecificReturnType>
-    <NullableReturnStatement occurrences="6">
-      <code>$annotations === [] ? null : current($annotations)</code>
-      <code>$annotations === [] ? null : current($annotations)</code>
-      <code>$annotations === [] ? null : current($annotations)</code>
+    <NullableReturnStatement occurrences="3">
       <code>is_object($this-&gt;classSchemata[$className]) ? $this-&gt;classSchemata[$className] : null</code>
       <code>null</code>
       <code>null</code>
@@ -2666,9 +2655,6 @@
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Security/Cryptography/Algorithms.php">
-    <InvalidOperand occurrences="1">
-      <code>$iteratedBlock</code>
-    </InvalidOperand>
     <NullArgument occurrences="1">
       <code>null</code>
     </NullArgument>
@@ -2710,9 +2696,6 @@
     <NullArgument occurrences="1">
       <code>null</code>
     </NullArgument>
-    <ParamNameMismatch occurrences="1">
-      <code>$cipher</code>
-    </ParamNameMismatch>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Security/DummyContext.php">
     <PossiblyNullPropertyAssignmentValue occurrences="5">
@@ -2744,6 +2727,11 @@
     <NullableReturnStatement occurrences="1">
       <code>null</code>
     </NullableReturnStatement>
+  </file>
+  <file src="Packages/Framework/Neos.Flow/Classes/Security/Policy/RoleConverter.php">
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$sourceTypes</code>
+    </NonInvariantDocblockPropertyType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Session/Aspect/LoggingAspect.php">
     <InvalidLiteralArgument occurrences="1">
@@ -2789,13 +2777,13 @@
     <LessSpecificImplementedReturnType occurrences="1">
       <code>mixed</code>
     </LessSpecificImplementedReturnType>
-    <PossiblyFalseArgument occurrences="1">
-      <code>strrchr($this-&gt;garbageCollectionProbability, '.')</code>
-    </PossiblyFalseArgument>
     <PossiblyNullPropertyAssignmentValue occurrences="2">
       <code>null</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(integer)strlen(strrchr($this-&gt;garbageCollectionProbability, '.'))</code>
+    </RedundantCastGivenDocblockType>
     <UndefinedThisPropertyAssignment occurrences="1">
       <code>$this-&gt;request</code>
     </UndefinedThisPropertyAssignment>
@@ -2819,11 +2807,6 @@
       <code>$data</code>
     </MoreSpecificImplementedParamType>
   </file>
-  <file src="Packages/Framework/Neos.Flow/Classes/Utility/Algorithms.php">
-    <UndefinedConstant occurrences="1">
-      <code>UUID_TYPE_RANDOM</code>
-    </UndefinedConstant>
-  </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Utility/Environment.php">
     <PossiblyNullPropertyAssignmentValue occurrences="2">
       <code>null</code>
@@ -2840,6 +2823,9 @@
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>1201447005</code>
     </InvalidPropertyAssignmentValue>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$code</code>
+    </NonInvariantDocblockPropertyType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Validation/Validator/AbstractCompositeValidator.php">
     <NoInterfaceProperties occurrences="1">
@@ -2890,9 +2876,6 @@
     </PossiblyFalseOperand>
   </file>
   <file src="Packages/Framework/Neos.Flow/Scripts/Migrations/AbstractMigration.php">
-    <PossiblyFalseArgument occurrences="1">
-      <code>strrchr(get_class($this), 'Version')</code>
-    </PossiblyFalseArgument>
     <PossiblyInvalidArgument occurrences="1">
       <code>$configuration</code>
     </PossiblyInvalidArgument>
@@ -2962,14 +2945,21 @@
     </InvalidReturnType>
   </file>
   <file src="Packages/Framework/Neos.FluidAdaptor/Classes/Core/Parser/SyntaxTree/ResourceUriNode.php">
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$arguments</code>
+    </NonInvariantDocblockPropertyType>
     <UndefinedInterfaceMethod occurrences="1">
       <code>setViewHelperNode</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="Packages/Framework/Neos.FluidAdaptor/Classes/Core/Rendering/RenderingContext.php">
-    <TooManyArguments occurrences="1">
-      <code>parent::__construct($view)</code>
-    </TooManyArguments>
+    <NonInvariantDocblockPropertyType occurrences="2">
+      <code>$cache</code>
+      <code>$viewHelperResolver</code>
+    </NonInvariantDocblockPropertyType>
+    <RedundantCast occurrences="1">
+      <code>(string)$request-&gt;getControllerPackageKey()</code>
+    </RedundantCast>
   </file>
   <file src="Packages/Framework/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractConditionViewHelper.php">
     <LessSpecificImplementedReturnType occurrences="1">
@@ -3172,9 +3162,6 @@
     <NullArrayAccess occurrences="1">
       <code>$arguments['privilegeTarget']</code>
     </NullArrayAccess>
-    <TypeDoesNotContainType occurrences="1">
-      <code>$arguments['parameters'] ?? []</code>
-    </TypeDoesNotContainType>
     <UndefinedInterfaceMethod occurrences="1">
       <code>getObjectManager</code>
     </UndefinedInterfaceMethod>
@@ -3214,6 +3201,9 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="Packages/Framework/Neos.FluidAdaptor/Classes/ViewHelpers/TranslateViewHelper.php">
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(string)$this-&gt;translator-&gt;translateByOriginalLabel($originalLabel, $arguments, $quantity, $localeObject, $source, $package)</code>
+    </RedundantCastGivenDocblockType>
     <UndefinedInterfaceMethod occurrences="1">
       <code>getControllerContext</code>
     </UndefinedInterfaceMethod>
@@ -3252,16 +3242,26 @@
       <code>$validationResults</code>
     </MissingDocblockType>
   </file>
+  <file src="Packages/Framework/Neos.FluidAdaptor/Classes/ViewHelpers/Widget/AutocompleteViewHelper.php">
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$controller</code>
+    </NonInvariantDocblockPropertyType>
+  </file>
   <file src="Packages/Framework/Neos.FluidAdaptor/Classes/ViewHelpers/Widget/Controller/AutocompleteController.php">
     <MissingDocblockType occurrences="1">
       <code>$queryResult</code>
     </MissingDocblockType>
   </file>
   <file src="Packages/Framework/Neos.FluidAdaptor/Classes/ViewHelpers/Widget/Controller/PaginateController.php">
-    <InvalidPropertyAssignmentValue occurrences="2">
+    <InvalidPropertyAssignmentValue occurrences="4">
       <code>$this-&gt;currentPage + $delta + ($maximumNumberOfLinks % 2 === 0 ? 1 : 0)</code>
       <code>$this-&gt;currentPage - $delta</code>
+      <code>$this-&gt;displayRangeEnd -= $this-&gt;displayRangeStart - 1</code>
+      <code>$this-&gt;displayRangeStart -= ($this-&gt;displayRangeEnd - $this-&gt;numberOfPages)</code>
     </InvalidPropertyAssignmentValue>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(integer)$currentPage</code>
+    </RedundantCastGivenDocblockType>
   </file>
   <file src="Packages/Framework/Neos.FluidAdaptor/Classes/ViewHelpers/Widget/LinkViewHelper.php">
     <InvalidScalarArgument occurrences="1">
@@ -3273,6 +3273,11 @@
     <NullArgument occurrences="1">
       <code>null</code>
     </NullArgument>
+  </file>
+  <file src="Packages/Framework/Neos.FluidAdaptor/Classes/ViewHelpers/Widget/PaginateViewHelper.php">
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$controller</code>
+    </NonInvariantDocblockPropertyType>
   </file>
   <file src="Packages/Framework/Neos.FluidAdaptor/Classes/ViewHelpers/Widget/UriViewHelper.php">
     <InvalidScalarArgument occurrences="1">
@@ -3305,15 +3310,15 @@
     </PossiblyFalseArgument>
   </file>
   <file src="Packages/Framework/Neos.Kickstarter/Classes/Service/GeneratorService.php">
+    <NullArgument occurrences="1">
+      <code>$namespace</code>
+    </NullArgument>
     <PossiblyFalseOperand occurrences="4">
       <code>strpos($targetPathAndFilename, 'Classes/')</code>
       <code>strpos($targetPathAndFilename, 'Tests/')</code>
       <code>strrpos(substr($targetPathAndFilename, 0, strpos($targetPathAndFilename, 'Classes/') - 1), '/')</code>
       <code>strrpos(substr($targetPathAndFilename, 0, strpos($targetPathAndFilename, 'Tests/') - 1), '/')</code>
     </PossiblyFalseOperand>
-    <TypeDoesNotContainType occurrences="1">
-      <code>is_array($autoloadPaths)</code>
-    </TypeDoesNotContainType>
   </file>
   <file src="Packages/Framework/Neos.Utility.Arrays/Classes/Arrays.php">
     <PossiblyNullArgument occurrences="1">
@@ -3336,10 +3341,19 @@
     <PossiblyInvalidArrayOffset occurrences="1">
       <code>self::$sizeUnits[$pow]</code>
     </PossiblyInvalidArrayOffset>
+    <PossiblyInvalidMethodCall occurrences="4">
+      <code>getPathname</code>
+      <code>getPathname</code>
+      <code>getPathname</code>
+      <code>isDir</code>
+    </PossiblyInvalidMethodCall>
     <PossiblyNullArgument occurrences="2">
       <code>$offset</code>
       <code>$offset</code>
     </PossiblyNullArgument>
+    <RedundantCast occurrences="1">
+      <code>(float)round($size)</code>
+    </RedundantCast>
     <TypeDoesNotContainType occurrences="1">
       <code>$flags === true</code>
     </TypeDoesNotContainType>
@@ -3380,6 +3394,9 @@
     <InvalidScalarArgument occurrences="1">
       <code>$enc</code>
     </InvalidScalarArgument>
+    <RedundantCast occurrences="1">
+      <code>(integer)$componentsFromUrl['port']</code>
+    </RedundantCast>
   </file>
   <file src="Packages/Framework/Neos.Utility.Unicode/Classes/TextIterator.php">
     <InvalidReturnStatement occurrences="3">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -9,17 +9,9 @@
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="Packages/Framework/Neos.Cache/Classes/Backend/ApcuBackend.php">
-    <UndefinedClass occurrences="1">
-      <code>\APCUIterator</code>
-    </UndefinedClass>
-    <UndefinedDocblockClass occurrences="6">
-      <code>$this-&gt;cacheEntriesIterator</code>
-      <code>$this-&gt;cacheEntriesIterator</code>
-      <code>$this-&gt;cacheEntriesIterator</code>
-      <code>$this-&gt;cacheEntriesIterator</code>
-      <code>$this-&gt;cacheEntriesIterator</code>
-      <code>\APCUIterator</code>
-    </UndefinedDocblockClass>
+    <RedundantCast occurrences="1">
+      <code>(string)$this-&gt;cacheEntriesIterator-&gt;key()</code>
+    </RedundantCast>
   </file>
   <file src="Packages/Framework/Neos.Cache/Classes/Backend/FileBackend.php">
     <NonInvariantDocblockPropertyType occurrences="1">

--- a/psalm.xml
+++ b/psalm.xml
@@ -13,6 +13,8 @@
             <directory name="Packages/Framework/**/Tests" />
             <directory name="Packages/Framework/**/Resources" />
             <file name="Packages/Framework/Neos.Eel/Classes/FlowQuery/FizzleParser.php" />
+            <file name="Packages/Framework/Neos.Eel/Classes/AbstractParser.php" />
+            <file name="Packages/Framework/Neos.Eel/Classes/EelParser.php" />
             <file name="Packages/Framework/Neos.Flow/.phpstorm.meta.php" />
         </ignoreFiles>
     </projectFiles>
@@ -76,5 +78,7 @@
         <RawObjectIteration errorLevel="info" />
 
         <InvalidStringClass errorLevel="info" />
+
+        <ParamNameMismatch errorLevel="info" />
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
This updates psalm to 4.9 and also updates the baseline.
The new `ParamNameMismatch` error is lowered to `info` level.

Related to https://github.com/neos/flow-development-distribution/issues/74
Resolves #2515 