### PR TITLE
TASK: improve request information in exception logfiles

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -303,7 +303,7 @@ class Scripts
 
             $request = $requestHandler->getHttpRequest();
             if ($renderRequestInformation) {
-                $output .= PHP_EOL . 'HTTP REQUEST:' . PHP_EOL . ($request instanceof RequestInterface ? RequestInformationHelper::renderRequestInfo($request) : '[request was empty]') . PHP_EOL;
+                $output .= PHP_EOL . 'HTTP REQUEST:' . PHP_EOL . ($request instanceof RequestInterface ? RequestInformationHelper::renderRequestInformation($request) : '[request was empty]') . PHP_EOL;
             }
             $output .= PHP_EOL . 'PHP PROCESS:' . PHP_EOL . 'Inode: ' . getmyinode() . PHP_EOL . 'PID: ' . getmypid() . PHP_EOL . 'UID: ' . getmyuid() . PHP_EOL . 'GID: ' . getmygid() . PHP_EOL . 'User: ' . get_current_user() . PHP_EOL;
 

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -303,7 +303,7 @@ class Scripts
 
             $request = $requestHandler->getHttpRequest();
             if ($renderRequestInformation) {
-                $output .= PHP_EOL . 'HTTP REQUEST:' . PHP_EOL . ($request instanceof RequestInterface ? RequestInformationHelper::renderRequestHeaders($request) : '[request was empty]') . PHP_EOL;
+                $output .= PHP_EOL . 'HTTP REQUEST:' . PHP_EOL . ($request instanceof RequestInterface ? RequestInformationHelper::renderRequestInfo($request) : '[request was empty]') . PHP_EOL;
             }
             $output .= PHP_EOL . 'PHP PROCESS:' . PHP_EOL . 'Inode: ' . getmyinode() . PHP_EOL . 'PID: ' . getmypid() . PHP_EOL . 'UID: ' . getmyuid() . PHP_EOL . 'GID: ' . getmygid() . PHP_EOL . 'User: ' . get_current_user() . PHP_EOL;
 

--- a/Neos.Flow/Classes/Http/Helper/RequestInformationHelper.php
+++ b/Neos.Flow/Classes/Http/Helper/RequestInformationHelper.php
@@ -107,7 +107,7 @@ abstract class RequestInformationHelper
      * @param RequestInterface $request
      * @return string
      */
-    public static function renderRequestInfo(RequestInterface $request): string
+    public static function renderRequestInformation(RequestInterface $request): string
     {
         $info = [
             sprintf('target: %s', $request->getRequestTarget()),

--- a/Neos.Flow/Classes/Http/Helper/RequestInformationHelper.php
+++ b/Neos.Flow/Classes/Http/Helper/RequestInformationHelper.php
@@ -102,6 +102,22 @@ abstract class RequestInformationHelper
     }
 
     /**
+     * Renders information about the request
+     *
+     * @param RequestInterface $request
+     * @return string
+     */
+    public static function renderRequestInfo(RequestInterface $request): string
+    {
+        $info = [
+            sprintf('target: %s', $request->getRequestTarget()),
+            self::renderRequestHeaders($request)
+        ];
+
+        return implode(PHP_EOL, $info);
+    }
+
+    /**
      * Renders the HTTP headers - EXCLUDING the status header - of the given request
      *
      * @param RequestInterface $request
@@ -109,17 +125,17 @@ abstract class RequestInformationHelper
      */
     public static function renderRequestHeaders(RequestInterface $request): string
     {
-        $renderedHeaders = '';
-        $headers = $request->getHeaders();
-        foreach (array_keys($headers) as $name) {
+        $renderedHeaders = [];
+        foreach (array_keys($request->getHeaders()) as $name) {
             if ($name === 'Authorization') {
-                $renderedHeaders .= 'Authorization: ****';
+                $value = '****';
             } else {
-                $renderedHeaders .= $request->getHeaderLine($name);
+                $value = $request->getHeaderLine($name);
             }
+            $renderedHeaders[] = sprintf('%s: %s', $name, $value);
         }
 
-        return $renderedHeaders;
+        return implode(PHP_EOL, $renderedHeaders);
     }
 
     /**

--- a/Neos.Flow/Classes/Log/ThrowableStorage/FileStorage.php
+++ b/Neos.Flow/Classes/Log/ThrowableStorage/FileStorage.php
@@ -74,7 +74,6 @@ class FileStorage implements ThrowableStorageInterface
             }
 
             $request = $requestHandler->getHttpRequest();
-            // TODO: Sensible error output
             $output .= PHP_EOL . 'HTTP REQUEST:' . PHP_EOL . ($request instanceof RequestInterface ? RequestInformationHelper::renderRequestInformation($request) : '[request was empty]') . PHP_EOL;
             $output .= PHP_EOL . 'PHP PROCESS:' . PHP_EOL . 'Inode: ' . getmyinode() . PHP_EOL . 'PID: ' . getmypid() . PHP_EOL . 'UID: ' . getmyuid() . PHP_EOL . 'GID: ' . getmygid() . PHP_EOL . 'User: ' . get_current_user() . PHP_EOL;
 

--- a/Neos.Flow/Classes/Log/ThrowableStorage/FileStorage.php
+++ b/Neos.Flow/Classes/Log/ThrowableStorage/FileStorage.php
@@ -75,7 +75,7 @@ class FileStorage implements ThrowableStorageInterface
 
             $request = $requestHandler->getHttpRequest();
             // TODO: Sensible error output
-            $output .= PHP_EOL . 'HTTP REQUEST:' . PHP_EOL . ($request instanceof RequestInterface ? RequestInformationHelper::renderRequestHeaders($request) : '[request was empty]') . PHP_EOL;
+            $output .= PHP_EOL . 'HTTP REQUEST:' . PHP_EOL . ($request instanceof RequestInterface ? RequestInformationHelper::renderRequestInfo($request) : '[request was empty]') . PHP_EOL;
             $output .= PHP_EOL . 'PHP PROCESS:' . PHP_EOL . 'Inode: ' . getmyinode() . PHP_EOL . 'PID: ' . getmypid() . PHP_EOL . 'UID: ' . getmyuid() . PHP_EOL . 'GID: ' . getmygid() . PHP_EOL . 'User: ' . get_current_user() . PHP_EOL;
 
             return $output;

--- a/Neos.Flow/Classes/Log/ThrowableStorage/FileStorage.php
+++ b/Neos.Flow/Classes/Log/ThrowableStorage/FileStorage.php
@@ -75,7 +75,7 @@ class FileStorage implements ThrowableStorageInterface
 
             $request = $requestHandler->getHttpRequest();
             // TODO: Sensible error output
-            $output .= PHP_EOL . 'HTTP REQUEST:' . PHP_EOL . ($request instanceof RequestInterface ? RequestInformationHelper::renderRequestInfo($request) : '[request was empty]') . PHP_EOL;
+            $output .= PHP_EOL . 'HTTP REQUEST:' . PHP_EOL . ($request instanceof RequestInterface ? RequestInformationHelper::renderRequestInformation($request) : '[request was empty]') . PHP_EOL;
             $output .= PHP_EOL . 'PHP PROCESS:' . PHP_EOL . 'Inode: ' . getmyinode() . PHP_EOL . 'PID: ' . getmypid() . PHP_EOL . 'UID: ' . getmyuid() . PHP_EOL . 'GID: ' . getmygid() . PHP_EOL . 'User: ' . get_current_user() . PHP_EOL;
 
             return $output;


### PR DESCRIPTION
**Motivation**
According to https://github.com/neos/flow-development-collection/issues/2548 this is my suggestion for better request information in the exception txt files.
The goal is better readability of the request information for humans and the chance to parse them with scripts. 

**What I did**
- Add the name of the request headers
- Seperate each header (name: value) into an own line
- Add the request target (requested url)
