### PR TITLE
BUGFIX: Prevent proxies for classes with unsupported interfaces

### DIFF
--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassImplementingInterfaceWithConstructor.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassImplementingInterfaceWithConstructor.php
@@ -1,0 +1,22 @@
+<?php
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+class ClassImplementingInterfaceWithConstructor implements InterfaceWithConstructor
+{
+
+    public function __construct(array $someArgument = [])
+    {
+    }
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/InterfaceWithConstructor.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/InterfaceWithConstructor.php
@@ -1,0 +1,17 @@
+<?php
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+interface InterfaceWithConstructor
+{
+    public function __construct(array $someArgument = []);
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
@@ -11,8 +11,12 @@ namespace Neos\Flow\Tests\Functional\ObjectManagement;
  * source code.
  */
 
+use Neos\Flow\ObjectManagement\Exception\CannotBuildObjectException;
+use Neos\Flow\ObjectManagement\Proxy\ProxyClass;
 use Neos\Flow\ObjectManagement\Proxy\ProxyInterface;
 use Neos\Flow\Reflection\ClassReflection;
+use Neos\Flow\Reflection\ReflectionService;
+use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ClassImplementingInterfaceWithConstructor;
 use Neos\Flow\Tests\FunctionalTestCase;
 
 /**
@@ -128,5 +132,19 @@ class ProxyCompilerTest extends FunctionalTestCase
     {
         $reflectionClass = new ClassReflection(Fixtures\FinalClassWithDependencies::class);
         self::assertTrue($reflectionClass->isFinal());
+    }
+
+
+    /**
+     * @test
+     * @see https://github.com/neos/flow-development-collection/issues/2554
+     */
+    public function proxyingClassImplementingInterfacesWithParametrizedConstructorsLeadsToException()
+    {
+        $this->expectException(CannotBuildObjectException::class);
+        $proxyClass = new ProxyClass(ClassImplementingInterfaceWithConstructor::class);
+        $proxyClass->injectReflectionService($this->objectManager->get(ReflectionService::class));
+        $proxyClass->getConstructor()->addPreParentCallCode('// some code');
+        $proxyClass->render();
     }
 }


### PR DESCRIPTION
Adjusts the proxy building for classes such that it throws a more
helpful exception when trying to generate proxies for classes
implementing an interface with constructor and parameters.

Fixes: #2554