### PR TITLE
BUGFIX: Handle required array arguments and exceeding arguments properly together

### DIFF
--- a/Neos.Flow/Classes/Cli/RequestBuilder.php
+++ b/Neos.Flow/Classes/Cli/RequestBuilder.php
@@ -183,6 +183,7 @@ class RequestBuilder
         $commandMethodName = $controllerCommandName . 'Command';
         $commandMethodParameters = $this->commandManager->getCommandMethodParameters($controllerObjectName, $commandMethodName);
 
+        $requiredArgumentNames = [];
         $requiredArguments = [];
         $optionalArguments = [];
         foreach ($commandMethodParameters as $parameterName => $parameterInfo) {
@@ -191,6 +192,7 @@ class RequestBuilder
                     'parameterName' => $parameterName,
                     'type' => $parameterInfo['type']
                 ];
+                $requiredArgumentNames[strtolower($parameterName)] = $parameterName;
             } else {
                 $optionalArguments[strtolower($parameterName)] = [
                     'parameterName' => $parameterName,
@@ -229,16 +231,16 @@ class RequestBuilder
                         $commandLineArguments[$requiredArguments[$argumentName]['parameterName']][] = $argumentValue;
                     } else {
                         $commandLineArguments[$requiredArguments[$argumentName]['parameterName']] = $argumentValue;
-                        unset($requiredArguments[$argumentName]);
                     }
+                    unset($requiredArgumentNames[strtolower($requiredArguments[$argumentName]['parameterName'])]);
                 }
             } else {
-                if (count($requiredArguments) > 0) {
+                if (count($requiredArgumentNames) > 0) {
                     if ($decidedToUseNamedArguments) {
                         throw new InvalidArgumentMixingException(sprintf('Unexpected unnamed argument "%s". If you use named arguments, all required arguments must be passed named.', $rawArgument), 1309971820);
                     }
-                    $argument = array_shift($requiredArguments);
-                    $commandLineArguments[$argument['parameterName']] = $rawArgument;
+                    $argumentName = array_shift($requiredArgumentNames);
+                    $commandLineArguments[strtolower($argumentName)] = $rawArgument;
                     $decidedToUseUnnamedArguments = true;
                 } else {
                     $exceedingArguments[] = $rawArgument;


### PR DESCRIPTION
When a cli argument of type array was used it was not removed from the list of required arguments and thus
later when unnamed arguments where checked ended up as still missing.

This is solved by having an explicit list of required argumentNames instead of removing the configuration of a
required argument after it was set.

**How to verify it**

Create a cli controller that has array arguments and pass exceeding arguments.

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
