### PR TITLE
BUGFIX: Correctly set up TestingProvider for "testable security"

### DIFF
--- a/Neos.Flow/Classes/Security/Authentication/Provider/TestingProvider.php
+++ b/Neos.Flow/Classes/Security/Authentication/Provider/TestingProvider.php
@@ -11,7 +11,6 @@ namespace Neos\Flow\Security\Authentication\Provider;
  * source code.
  */
 
-use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Security\Account;
 use Neos\Flow\Security\Authentication\Token\TestingToken;
 use Neos\Flow\Security\Authentication\TokenInterface;
@@ -19,8 +18,6 @@ use Neos\Flow\Security\Authentication\TokenInterface;
 /**
  * A singleton authentication provider for functional tests with
  * mockable authentication.
- *
- * @Flow\Scope("singleton")
  */
 class TestingProvider extends AbstractProvider
 {

--- a/Neos.Flow/Tests/FunctionalTestCase.php
+++ b/Neos.Flow/Tests/FunctionalTestCase.php
@@ -14,6 +14,7 @@ namespace Neos\Flow\Tests;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Security\Authentication\TokenAndProviderFactory;
 use Neos\Flow\Http\Component\ComponentContext;
 use Neos\Http\Factories\ResponseFactory;
 use Neos\Http\Factories\ServerRequestFactory;
@@ -113,6 +114,11 @@ abstract class FunctionalTestCase extends \Neos\Flow\Tests\BaseTestCase
     protected $policyService;
 
     /**
+     * @var TokenAndProviderFactory
+     */
+    protected $tokenAndProviderFactory;
+
+    /**
      * @var \Neos\Flow\Security\Authentication\Provider\TestingProvider
      */
     protected $testingProvider;
@@ -190,8 +196,8 @@ abstract class FunctionalTestCase extends \Neos\Flow\Tests\BaseTestCase
 
             $this->authenticationManager = $this->objectManager->get(\Neos\Flow\Security\Authentication\AuthenticationProviderManager::class);
 
-            $this->testingProvider = $this->objectManager->get(\Neos\Flow\Security\Authentication\Provider\TestingProvider::class);
-            $this->testingProvider->setName('TestingProvider');
+            $this->tokenAndProviderFactory = $this->objectManager->get(TokenAndProviderFactory::class);
+            $this->testingProvider = $this->tokenAndProviderFactory->getProviders()['TestingProvider'];
 
             $this->registerRoute('functionaltestroute', 'neos/flow/test', [
                 '@package' => 'Neos.Flow',


### PR DESCRIPTION
As of https://github.com/neos/flow-development-collection/pull/1213
the authentication providers are created using a factory method, this
breaks the assumption the `TestingProvider` is a singleton.

The result is that e.g. ´authenticateRoles([])` no longer works as
expected in functional tests.

This fixes the issue by fetching the provider from the factory instead
of the object manager.

Fixes #2386
