### PR TITLE
!!! BUGFIX: Avoid broken proxy docblocks

### DIFF
--- a/Neos.Flow/Classes/Aop/Builder/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/Aop/Builder/ProxyClassBuilder.php
@@ -57,11 +57,6 @@ class ProxyClassBuilder
     protected $pointcutExpressionParser;
 
     /**
-     * @var ProxyClassBuilder
-     */
-    protected $proxyClassBuilder;
-
-    /**
      * @var VariableFrontend
      */
     protected $objectConfigurationCache;

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
@@ -243,7 +243,7 @@ return ' . var_export($this->storedProxyClasses, true) . ';';
         $classCode = $this->stripOpeningPhpTag($classCode);
 
         $classNameSuffix = self::ORIGINAL_CLASSNAME_SUFFIX;
-        $classCode = preg_replace_callback('/^([a-z\s]*?)(final\s+)?(interface|class)\s+([a-zA-Z0-9_]+)/m', function ($matches) use ($pathAndFilename, $classNameSuffix, $proxyClassCode) {
+        $classCode = preg_replace_callback('/^([a-z\s]*?)(final\s+)?(interface|class)\s+([a-zA-Z0-9_]+)/m', static function ($matches) use ($pathAndFilename, $classNameSuffix, $proxyClassCode) {
             $classNameAccordingToFileName = basename($pathAndFilename, '.php');
             if ($matches[4] !== $classNameAccordingToFileName) {
                 throw new Exception('The name of the class "' . $matches[4] . '" is not the same as the filename which is "' . basename($pathAndFilename) . '". Path: ' . $pathAndFilename, 1398356897);
@@ -253,7 +253,7 @@ return ' . var_export($this->storedProxyClasses, true) . ';';
 
         // comment out "final" keyword, if the method is final and if it is advised (= part of the $proxyClassCode)
         // Note: Method name regex according to http://php.net/manual/en/language.oop5.basic.php
-        $classCode = preg_replace_callback('/^(\s*)((public|protected)\s+)?final(\s+(public|protected))?(\s+function\s+)([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+\s*\()/m', function ($matches) use ($pathAndFilename, $classNameSuffix, $proxyClassCode) {
+        $classCode = preg_replace_callback('/^(\s*)((public|protected)\s+)?final(\s+(public|protected))?(\s+function\s+)([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+\s*\()/m', static function ($matches) use ($proxyClassCode) {
             // the method is not advised => don't remove the final keyword
             if (strpos($proxyClassCode, $matches[0]) === false) {
                 return $matches[0];
@@ -263,7 +263,7 @@ return ' . var_export($this->storedProxyClasses, true) . ';';
 
         $classCode = preg_replace('/\\?>[\n\s\r]*$/', '', $classCode);
 
-        $proxyClassCode .= "\n" . '# PathAndFilename: ' . $pathAndFilename;
+        $proxyClassCode .= PHP_EOL . '# PathAndFilename: ' . $pathAndFilename;
 
         $separator =
             PHP_EOL . '#' .
@@ -329,7 +329,7 @@ return ' . var_export($this->storedProxyClasses, true) . ';';
             $optionValueAsString = '';
             if (is_object($optionValue)) {
                 $optionValueAsString = self::renderAnnotation($optionValue);
-            } elseif (is_scalar($optionValue) && is_string($optionValue)) {
+            } elseif (is_string($optionValue)) {
                 $optionValueAsString = '"' . $optionValue . '"';
             } elseif (is_bool($optionValue)) {
                 $optionValueAsString = $optionValue ? 'true' : 'false';
@@ -370,7 +370,7 @@ return ' . var_export($this->storedProxyClasses, true) . ';';
                 $value .= self::renderAnnotation($v);
             } elseif (is_array($v)) {
                 $value .= self::renderOptionArrayValueAsString($v);
-            } elseif (is_scalar($v) && is_string($v)) {
+            } elseif (is_string($v)) {
                 $value .= '"' . $v . '"';
             } elseif (is_bool($v)) {
                 $value .= $v ? 'true' : 'false';

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php
@@ -229,11 +229,7 @@ class ProxyClass
         if ($methodsCode . $constantsCode === '') {
             return '';
         }
-        $classCode = ($namespace !== '' ? 'namespace ' . $namespace . ";\n\n" : '') .
-            "use Doctrine\\ORM\\Mapping as ORM;\n" .
-            "use Neos\\Flow\\Annotations as Flow;\n" .
-            "\n" .
-            $this->buildClassDocumentation() .
+        $classCode = $this->buildClassDocumentation() .
             $classModifier . 'class ' . $proxyClassName . ' extends ' . $originalClassName . ' implements ' . implode(', ', array_unique($this->interfaces)) . " {\n\n" .
             $traitsCode .
             $constantsCode .

--- a/Neos.Flow/Classes/Persistence/Aspect/PersistenceMagicAspect.php
+++ b/Neos.Flow/Classes/Persistence/Aspect/PersistenceMagicAspect.php
@@ -11,7 +11,6 @@ namespace Neos\Flow\Persistence\Aspect;
  * source code.
  */
 
-use Doctrine\ORM\Mapping as ORM;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Aop\JoinPointInterface;
 use Neos\Flow\Persistence\PersistenceManagerInterface;

--- a/Neos.Flow/Classes/Persistence/Aspect/PersistenceMagicAspect.php
+++ b/Neos.Flow/Classes/Persistence/Aspect/PersistenceMagicAspect.php
@@ -70,8 +70,8 @@ class PersistenceMagicAspect
 
     /**
      * @var string
-     * @ORM\Id
-     * @ORM\Column(length=40)
+     * @Doctrine\ORM\Mapping\Id
+     * @Doctrine\ORM\Mapping\Column(length=40)
      * @Flow\Introduce("Neos\Flow\Persistence\Aspect\PersistenceMagicAspect->isEntityOrValueObject && filter(Neos\Flow\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriver)")
      */
     protected $Persistence_Object_Identifier;

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/AspectOrientedProgramming.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/AspectOrientedProgramming.rst
@@ -293,7 +293,7 @@ aspect.
 	advice, introduction or pointcut has been defined.
 
 .. Note::
-	With Flow 4.0+ classes that are marked ``final`` can now be targeted by AOP advices
+	With Flow classes that are marked ``final`` can be targeted by AOP advices
 	by default.
 	This can be explicitly disabled with a ``@Flow\Proxy(false)`` annotation on the
 	class in question.
@@ -952,37 +952,36 @@ The following example introduces a new interface ``NewInterface`` to the class
 
 *Example: Interface introduction*::
 
-	namespace Example\MyPackage;
-	use Neos\Flow\AOP\JoinPointInterface;
+    namespace Example\MyPackage;
+    use Neos\Flow\AOP\JoinPointInterface;
 
-	/**
-	 * An aspect for demonstrating introductions
-	 *
-	 * Introduces Example\MyPackage\NewInterface to the class Example\MyPackage\OldClass:
-	 *
-	 * @Flow\Introduce("class(Example\MyPackage\OldClass)", interfaceName="Example\MyPackage\NewInterface")
-	 * @Flow\Aspect
-	 */
-	class IntroductionAspect
-	{
+    /**
+     * An aspect for demonstrating introductions
+     *
+     * Introduces Example\MyPackage\NewInterface to the class Example\MyPackage\OldClass:
+     *
+     * @Flow\Introduce("class(Example\MyPackage\OldClass)", interfaceName="Example\MyPackage\NewInterface")
+     * @Flow\Aspect
+     */
+    class IntroductionAspect
+    {
+        /**
+         * Around advice, implements the new method "newMethod" of the
+         * "NewInterface" interface
+         *
+         * @Flow\Around("method(Example\MyPackage\OldClass->newMethod())")
+         */
+        public function newMethodImplementation(JoinPointInterface $joinPoint): int
+        {
+                // We call the advice chain, in case any other advice is declared for
+                // this method, but we don't care about the result.
+            $someResult = $joinPoint->getAdviceChain()->proceed($joinPoint);
 
-		/**
-		 * Around advice, implements the new method "newMethod" of the
-		 * "NewInterface" interface
-		 *
-		 * @Flow\Around("method(Example\MyPackage\OldClass->newMethod())")
-		 */
-		public function newMethodImplementation(JoinPointInterface $joinPoint): int
-		{
-				// We call the advice chain, in case any other advice is declared for
-				// this method, but we don't care about the result.
-			$someResult = $joinPoint->getAdviceChain()->proceed($joinPoint);
-
-			$a = $joinPoint->getMethodArgument('a');
-			$b = $joinPoint->getMethodArgument('b');
-			return $a + $b;
-		}
-	}
+            $a = $joinPoint->getMethodArgument('a');
+            $b = $joinPoint->getMethodArgument('b');
+            return $a + $b;
+        }
+    }
 
 Trait introduction
 -------------------
@@ -999,19 +998,21 @@ The following example introduces a trait ``SomeTrait`` to the class ``MyClass``.
 
 *Example: Trait introduction*::
 
-	namespace Example\MyPackage;
+    namespace Example\MyPackage;
 
-	/**
-	 * An aspect for demonstrating trait introduction
-	 *
-	 * Introduces Example\MyPackage\SomeTrait to the class Example\MyPackage\MyClass:
-	 *
-	 * @Flow\Introduce("class(Example\MyPackage\MyClass)", traitName="Example\MyPackage\SomeTrait")
-	 * @Flow\Aspect
-	 */
-	class TraitIntroductionAspect
-	{
-	}
+    use Neos\Flow\Annotations as Flow;
+
+    /**
+     * An aspect for demonstrating trait introduction
+     *
+     * Introduces Example\MyPackage\SomeTrait to the class Example\MyPackage\MyClass:
+     *
+     * @Flow\Introduce("class(Example\MyPackage\MyClass)", traitName="Example\MyPackage\SomeTrait")
+     * @Flow\Aspect
+     */
+    class TraitIntroductionAspect
+    {
+    }
 
 Property introduction
 -----------------------
@@ -1020,11 +1021,11 @@ The declaration of a property introduction anchors to a property inside an aspec
 
 Form of the declaration::
 
-	/**
-	 * @var type
-	 * @Flow\Introduce("PointcutExpression")
-	 */
-	protected $propertyName;
+    /**
+     * @var type
+     * @Flow\Introduce("PointcutExpression")
+     */
+    protected $propertyName;
 
 The declared property will be added to the target classes matched by the pointcut.
 
@@ -1033,23 +1034,30 @@ The following example introduces a new property "subtitle" to the class
 
 *Example: Property introduction*::
 
-	namespace Example\MyPackage;
+    namespace Example\MyPackage;
 
-	/**
-	 * An aspect for demonstrating property introductions
-	 *
-	 * @Flow\Aspect
-	 */
-	class PropertyIntroductionAspect {
+    use Neos\Flow\Annotations as Flow;
 
-		/**
-		 * @var string
-		 * @Column(length=40)
-		 * @Flow\Introduce("class(Example\Blog\Domain\Model\Post)")
-		 */
-		protected $subtitle;
+    /**
+     * An aspect for demonstrating property introductions
+     *
+     * @Flow\Aspect
+     */
+    class PropertyIntroductionAspect
+    {
 
-	}
+        /**
+         * @var string
+         * @Doctrine\ORM\Mapping\Column(length=40)
+         * @Flow\Introduce("class(Example\Blog\Domain\Model\Post)")
+         */
+        protected $subtitle;
+    }
+
+.. note::
+    Any annotation on the introduced property (except the actual ``Introduce``)
+    **must use the fully qualified class name** for Flow to build working proxy
+    class code.
 
 Implementation details
 ======================

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyClassTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyClassTest.php
@@ -29,11 +29,7 @@ class ProxyClassTest extends UnitTestCase
                 'originalClassAnnotations' => [],
                 'originalClassDocumentation' => '',
                 'originalClassConstants' => [['name' => 'TEST_CONSTANT', 'value' => '1']],
-                'expectedProxyCode' => "namespace \\Acme\\Namespace;\n" .
-                    "\n" .
-                    "use Doctrine\\ORM\\Mapping as ORM;\n" .
-                    "use Neos\\Flow\\Annotations as Flow;\n" .
-                    "\n" .
+                'expectedProxyCode' =>
                     'class ClassName extends ClassName' . Compiler::ORIGINAL_CLASSNAME_SUFFIX . " implements \\Neos\\Flow\\ObjectManagement\\Proxy\\ProxyInterface {\n\n" .
                     "    const TEST_CONSTANT = 1;\n\n" .
                     '}',
@@ -44,9 +40,6 @@ class ProxyClassTest extends UnitTestCase
                 'originalClassDocumentation' => '',
                 'originalClassConstants' => [['name' => 'TEST_CONSTANT', 'value' => '1']],
                 'expectedProxyCode' =>
-                    "use Doctrine\\ORM\\Mapping as ORM;\n" .
-                    "use Neos\\Flow\\Annotations as Flow;\n" .
-                    "\n" .
                     'class ClassWithoutNamespace extends ClassWithoutNamespace' . Compiler::ORIGINAL_CLASSNAME_SUFFIX . " implements \\Neos\\Flow\\ObjectManagement\\Proxy\\ProxyInterface {\n\n" .
                     "    const TEST_CONSTANT = 1;\n\n" .
                     '}',
@@ -57,9 +50,6 @@ class ProxyClassTest extends UnitTestCase
                 'originalClassDocumentation' => '',
                 'originalClassConstants' => [['name' => 'TEST_CONSTANT', 'value' => '1']],
                 'expectedProxyCode' =>
-                    "use Doctrine\\ORM\\Mapping as ORM;\n" .
-                    "use Neos\\Flow\\Annotations as Flow;\n" .
-                    "\n" .
                     'class ClassWithoutNamespace extends ClassWithoutNamespace' . Compiler::ORIGINAL_CLASSNAME_SUFFIX . " implements \\Neos\\Flow\\ObjectManagement\\Proxy\\ProxyInterface {\n\n" .
                     "    const TEST_CONSTANT = 1;\n\n" .
                     '}',


### PR DESCRIPTION
With PR #2533 docblocks are copied from the original class to the proxy class. This breaks when using annotations without the "standard" imports `Flow` and `ORM`. One example is the ImportedAsset domain model.

This fixes that by some changes to the proxy building.

Note, if you use property introduction via AOP, those properties must from now on use fully-qualified classnames for annoatations on them!

Fixes #2564