### PR TITLE
fixed $offset in XliffReader #2569

### DIFF
--- a/Neos.Flow/Classes/I18n/Xliff/Service/XliffReader.php
+++ b/Neos.Flow/Classes/I18n/Xliff/Service/XliffReader.php
@@ -48,9 +48,9 @@ class XliffReader
             $iterator($reader, $offset, $version);
             while ($reader->next()) {
                 if ($this->isFileNode($reader)) {
+                    $offset++;
                     $iterator($reader, $offset, $version);
                 }
-                $offset++;
             }
         } else {
             $this->i18nLogger->log('Given source "' . $sourcePath . '" is not a valid XLIFF file');


### PR DESCRIPTION
**What I did**
Fixed problem with the $offset value described in #2569

**How I did it**
$offset must be incremented in the while loop before the itterator. The first element is already handled before the loop. 

**How to verify it**
Create a .xlf File with at least 3 file blocks. 



Tested with the latest Flow Version. 

4.2 is the first version where I could find the problem. 
