### PR TITLE
BUGFIX: Do not pass signal information to persistAll

### DIFF
--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -71,7 +71,7 @@ class Package extends BasePackage
                 }
             }
         });
-        $dispatcher->connect(Cli\SlaveRequestHandler::class, 'dispatchedCommandLineSlaveRequest', Persistence\PersistenceManagerInterface::class, 'persistAll');
+        $dispatcher->connect(Cli\SlaveRequestHandler::class, 'dispatchedCommandLineSlaveRequest', Persistence\PersistenceManagerInterface::class, 'persistAll', false);
 
         if (!$context->isProduction()) {
             $dispatcher->connect(Core\Booting\Sequence::class, 'afterInvokeStep', function (Step $step) use ($bootstrap, $dispatcher) {


### PR DESCRIPTION
With PR #2448 the `shouldCheck()` was added, having a return type
declaration of `bool`. The value returned is set only by the argument
given to `persistAll()`, so having Behat tests fail when the value was
a string seemed strange.

The actual value was even stranger:

    Neos\\Flow\\Cli\\SlaveRequestHandler::dispatchedCommandLineSlaveRequest

Reason: The `Package` class in `Neos.Flow` connects a signal to the
`persistAll()` method, and the "signal information" is passed as an
argument…

This change fixes that.
