### PR TITLE
!!! TASK: Add `persistAllowedObjects()` deprecate flag argument for `persistAll()` in PersistenceManager

### DIFF
--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -71,7 +71,7 @@ class Package extends BasePackage
                 if (!$request instanceof Mvc\ActionRequest || SecurityHelper::hasSafeMethod($request->getHttpRequest()) !== true) {
                     $bootstrap->getObjectManager()->get(Persistence\PersistenceManagerInterface::class)->persistAll();
                 } elseif (SecurityHelper::hasSafeMethod($request->getHttpRequest())) {
-                    $bootstrap->getObjectManager()->get(Persistence\PersistenceManagerInterface::class)->persistAll(true);
+                    $bootstrap->getObjectManager()->get(Persistence\PersistenceManagerInterface::class)->persistAllowedObjects();
                 }
             }
         });

--- a/Neos.Flow/Classes/Persistence/Doctrine/PersistenceManager.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/PersistenceManager.php
@@ -84,7 +84,7 @@ class PersistenceManager extends AbstractPersistenceManager
      * Commits new objects and changes to objects in the current persistence
      * session into the backend
      *
-     * @param boolean $onlyAllowedObjects If true an exception will be thrown if there are scheduled updates/deletes or insertions for objects that are not "allowed" (see AbstractPersistenceManager::allowObject()). Deprecated: Use `persistOnlyAllowedObjects()` instead.
+     * @param boolean $onlyAllowedObjects If true an exception will be thrown if there are scheduled updates/deletes or insertions for objects that are not "allowed" (see AbstractPersistenceManager::allowObject()). Deprecated: Use `persistAllowedObjects()` instead.
      * @return void
      * @throws PersistenceException
      * @api
@@ -92,7 +92,7 @@ class PersistenceManager extends AbstractPersistenceManager
     public function persistAll(bool $onlyAllowedObjects = false): void
     {
         if ($onlyAllowedObjects === true) {
-            $this->persistOnlyAllowedObjects();
+            $this->persistAllowedObjects();
             return;
         }
         if (!$this->entityManager->isOpen()) {
@@ -115,7 +115,7 @@ class PersistenceManager extends AbstractPersistenceManager
      * @throws PersistenceException
      * @api
      */
-    public function persistOnlyAllowedObjects(): void
+    public function persistAllowedObjects(): void
     {
         if (!$this->entityManager->isOpen()) {
             $this->logger->error('persistAll() skipped flushing data, the Doctrine EntityManager is closed. Check the logs for error message.', LogEnvironment::fromMethodName(__METHOD__));

--- a/Neos.Flow/Classes/Persistence/Doctrine/PersistenceManager.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/PersistenceManager.php
@@ -84,19 +84,44 @@ class PersistenceManager extends AbstractPersistenceManager
      * Commits new objects and changes to objects in the current persistence
      * session into the backend
      *
-     * @param boolean $onlyAllowedObjects If true an exception will be thrown if there are scheduled updates/deletes or insertions for objects that are not "allowed" (see AbstractPersistenceManager::allowObject())
+     * @param boolean $onlyAllowedObjects If true an exception will be thrown if there are scheduled updates/deletes or insertions for objects that are not "allowed" (see AbstractPersistenceManager::allowObject()). Deprecated: Use `persistOnlyAllowedObjects()` instead.
      * @return void
      * @throws PersistenceException
      * @api
      */
     public function persistAll(bool $onlyAllowedObjects = false): void
     {
+        if ($onlyAllowedObjects === true) {
+            return $this->persistOnlyAllowedObjects();
+        }
         if (!$this->entityManager->isOpen()) {
             $this->logger->error('persistAll() skipped flushing data, the Doctrine EntityManager is closed. Check the logs for error message.', LogEnvironment::fromMethodName(__METHOD__));
             return;
         }
 
-        $this->allowedObjects->checkNext($onlyAllowedObjects);
+        $this->allowedObjects->checkNext(false);
+        $this->entityManager->flush();
+        $this->emitAllObjectsPersisted();
+    }
+
+    /**
+     * Commits new objects and changes to objects in the current persistence
+     * session into the backend.
+     * An exception will be thrown if there are scheduled updates/deletes or
+     * insertions for objects that are not "allowed" (see AbstractPersistenceManager::allowObject())
+     *
+     * @return void
+     * @throws PersistenceException
+     * @api
+     */
+    public function persistOnlyAllowedObjects(): void
+    {
+        if (!$this->entityManager->isOpen()) {
+            $this->logger->error('persistAll() skipped flushing data, the Doctrine EntityManager is closed. Check the logs for error message.', LogEnvironment::fromMethodName(__METHOD__));
+            return;
+        }
+
+        $this->allowedObjects->checkNext(true);
         $this->entityManager->flush();
         $this->emitAllObjectsPersisted();
     }

--- a/Neos.Flow/Classes/Persistence/Doctrine/PersistenceManager.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/PersistenceManager.php
@@ -92,7 +92,8 @@ class PersistenceManager extends AbstractPersistenceManager
     public function persistAll(bool $onlyAllowedObjects = false): void
     {
         if ($onlyAllowedObjects === true) {
-            return $this->persistOnlyAllowedObjects();
+            $this->persistOnlyAllowedObjects();
+            return;
         }
         if (!$this->entityManager->isOpen()) {
             $this->logger->error('persistAll() skipped flushing data, the Doctrine EntityManager is closed. Check the logs for error message.', LogEnvironment::fromMethodName(__METHOD__));

--- a/Neos.Flow/Classes/Persistence/PersistenceManagerInterface.php
+++ b/Neos.Flow/Classes/Persistence/PersistenceManagerInterface.php
@@ -162,7 +162,7 @@ interface PersistenceManagerInterface
     public function update($object): void;
 
     /**
-     * Adds the given object to a list of allowed objects which may be persisted when persistOnlyAllowedObjects() is called.
+     * Adds the given object to a list of allowed objects which may be persisted when persistAllowedObjects() is called.
      * This is the case if "safe" HTTP request methods are used.
      *
      * @param object $object The object

--- a/Neos.Flow/Classes/Persistence/PersistenceManagerInterface.php
+++ b/Neos.Flow/Classes/Persistence/PersistenceManagerInterface.php
@@ -162,8 +162,8 @@ interface PersistenceManagerInterface
     public function update($object): void;
 
     /**
-     * Adds the given object to a list of allowed objects which may be persisted when persistAll() is called with the
-     * $onlyAllowedObjects flag. This is the case if "safe" HTTP request methods are used.
+     * Adds the given object to a list of allowed objects which may be persisted when persistOnlyAllowedObjects() is called.
+     * This is the case if "safe" HTTP request methods are used.
      *
      * @param object $object The object
      * @return void

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/PersistenceManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/PersistenceManagerTest.php
@@ -112,7 +112,7 @@ class PersistenceManagerTest extends UnitTestCase
     /**
      * @test
      */
-    public function persistAllThrowsExceptionIfTryingToPersistNonAllowedObjectsAndOnlyAllowedObjectsFlagIsTrue()
+    public function persistAllowedObjectsThrowsExceptionIfTryingToPersistNonAllowedObjects()
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessageMatches('/^Detected modified or new objects/');
@@ -124,13 +124,13 @@ class PersistenceManagerTest extends UnitTestCase
         $this->mockUnitOfWork->expects(self::any())->method('getScheduledEntityDeletions')->willReturn($scheduledEntityDeletes);
         $this->mockUnitOfWork->expects(self::any())->method('getScheduledEntityInsertions')->willReturn($scheduledEntityInsertions);
 
-        $this->persistenceManager->persistAll(true);
+        $this->persistenceManager->persistAllowedObjects();
     }
 
     /**
      * @test
      */
-    public function persistAllRespectsObjectAllowedIfOnlyAllowedObjectsFlagIsTrue()
+    public function persistAllowedObjectsRespectsObjectAllowed()
     {
         $mockObject = new \stdClass();
         $scheduledEntityUpdates = [spl_object_hash($mockObject) => $mockObject];
@@ -143,7 +143,7 @@ class PersistenceManagerTest extends UnitTestCase
         $this->mockEntityManager->expects(self::once())->method('flush');
 
         $this->persistenceManager->allowObject($mockObject);
-        $this->persistenceManager->persistAll(true);
+        $this->persistenceManager->persistAllowedObjects();
     }
 
     /**


### PR DESCRIPTION
If you ever used `persistAll(true)` you should replace those invocations with `persistAllowedObjects()`.