### PR TITLE
BUGFIX: Don't rely on doctrine using spl_object_hash

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/ObjectValidationAndDeDuplicationListener.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/ObjectValidationAndDeDuplicationListener.php
@@ -104,8 +104,6 @@ class ObjectValidationAndDeDuplicationListener
                 $knownValueObjects[$className][$identifier] = true;
             }
         }
-
-        ObjectAccess::setProperty($unitOfWork, 'entityInsertions', $entityInsertions, true);
     }
 
     /**

--- a/Neos.Flow/Classes/Persistence/Doctrine/ObjectValidationAndDeDuplicationListener.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/ObjectValidationAndDeDuplicationListener.php
@@ -97,7 +97,7 @@ class ObjectValidationAndDeDuplicationListener
                 $identifier = $this->persistenceManager->getIdentifierByObject($entity);
 
                 if (isset($knownValueObjects[$className][$identifier]) || $unitOfWork->getEntityPersister($className)->exists($entity)) {
-                    unset($entityInsertions[spl_object_hash($entity)]);
+                    $unitOfWork->scheduleForDelete($entity);
                     continue;
                 }
 


### PR DESCRIPTION
Doctrine 2.10 switched spl_object_hash for spl_object_id which breaks the deduplication listener. Thanks @dlubitz.
We should use `scheduleForDelete` instead of manually unsetting the to be inserted entity via the object hash.

See https://github.com/doctrine/orm/commit/84ad007de39bc0947be838c8efcf1455513cbdca