### PR TITLE
BUGFIX: Validate schema only for flow packages

### DIFF
--- a/Neos.Flow/Classes/Command/SchemaCommandController.php
+++ b/Neos.Flow/Classes/Command/SchemaCommandController.php
@@ -58,8 +58,8 @@ class SchemaCommandController extends CommandController
 
         if (is_null($configurationFile)) {
             $result = new Result();
-            $activePackages = $this->packageManager->getAvailablePackages();
-            foreach ($activePackages as $package) {
+            $activeFlowPackages = $this->packageManager->getFlowPackages();
+            foreach ($activeFlowPackages as $package) {
                 $packageKey = $package->getPackageKey();
                 $packageSchemaPath = Files::concatenatePaths([$package->getResourcesPath(), 'Private/Schema']);
                 if (is_dir($packageSchemaPath) && $packageKey !== 'Neos.Utility.Schema') {


### PR DESCRIPTION
`getAvailablePackages()` fetches all packages extending `Neos\Flow\Package\GenericPackage`. But `GenericPackage` does not implement `Neos\Flow\Package\FlowPackageInterface` which provides `getResourcesPath()`.

So the command fails, if generic packages are loaded with `Call to undefined method Neos\Flow\Package\GenericPackage::getResourcesPath()`.

`getFlowPackages()` filters the packages if the have implemented `Neos\Flow\Package\FlowPackageInterface`, which ensures `getResourcesPath()` is defined and implemented.