### PR TITLE
FEATURE: CLI command to list all connected signals with their slots

### DIFF
--- a/Neos.Flow/Classes/Command/SignalCommandController.php
+++ b/Neos.Flow/Classes/Command/SignalCommandController.php
@@ -56,14 +56,14 @@ class SignalCommandController extends CommandController
                 }
 
                 $this->outputFormatted('<b>%s</b>', [$signalMethodName], 2);
-                for ($i = 0; count($slots) > $i; $i++) {
-                    $slotClassName = $slots[$i]['class'];
-                    $slotMethodName = $slots[$i]['method'];
+                foreach ($slots as $slot) {
+                    $slotClassName = $slot['class'];
+                    $slotMethodName = $slot['method'];
 
                     if ($slotClassName !== null) {
-                        $this->outputFormatted('[%d] %s::%s', [$i, $slotClassName, $slotMethodName], 4);
+                        $this->outputFormatted('%s::%s', [$slotClassName, $slotMethodName], 4);
                     } else {
-                        $this->outputFormatted('[%d] <i>Closure</i>', [$i], 4);
+                        $this->outputFormatted('<i>Closure</i>', [], 4);
                     }
                 }
             }

--- a/Neos.Flow/Classes/Command/SignalCommandController.php
+++ b/Neos.Flow/Classes/Command/SignalCommandController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Neos\Flow\Command;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Cli\CommandController;
+use Neos\Flow\SignalSlot\Dispatcher;
+
+/**
+ * Signal command controller for the Neos.Flow package
+ *
+ * @Flow\Scope("singleton")
+ */
+class SignalCommandController extends CommandController
+{
+    /**
+     * @Flow\Inject
+     * @var Dispatcher
+     */
+    protected $dispatcher;
+
+    /**
+     * Lists all connected signals with their slots.
+     *
+     * @param string $className
+     * @param string $methodName
+     * @return void
+     */
+    public function listConnectedCommand(string $className = null,string $methodName = null)
+    {
+        $this->outputFormatted('<b>Connected signals with their slots.</b>');
+        $this->outputLine();
+
+        $connectedSignals = $this->dispatcher->getSignals();
+        foreach ($connectedSignals as $signalClassName => $signalsByClass) {
+
+            if ($className !== null && $signalClassName !== $className) {
+                continue;
+            }
+
+            $this->outputFormatted('<b>%s</b>', [$signalClassName]);
+            foreach ($signalsByClass as $signalMethodName => $slots) {
+
+                if ($methodName !== null && $signalMethodName !== $methodName) {
+                    continue;
+                }
+
+                $this->outputFormatted('<b>%s</b>', [$signalMethodName], 2);
+                for ($i = 0; count($slots) > $i; $i++) {
+                    $slotClassName = $slots[$i]['class'];
+                    $slotMethodName = $slots[$i]['method'];
+
+                    if ($slotClassName !== null) {
+                        $this->outputFormatted('[%d] %s::%s', [$i, $slotClassName, $slotMethodName], 4);
+                    } else {
+                        $this->outputFormatted('[%d] <i>Closure</i>', [$i], 4);
+                    }
+                }
+            }
+            $this->outputLine();
+        }
+    }
+}

--- a/Neos.Flow/Classes/Command/SignalCommandController.php
+++ b/Neos.Flow/Classes/Command/SignalCommandController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Neos\Flow\Command;
 

--- a/Neos.Flow/Classes/Command/SignalCommandController.php
+++ b/Neos.Flow/Classes/Command/SignalCommandController.php
@@ -44,14 +44,12 @@ class SignalCommandController extends CommandController
 
         $connectedSignals = $this->dispatcher->getSignals();
         foreach ($connectedSignals as $signalClassName => $signalsByClass) {
-
             if ($className !== null && $signalClassName !== $className) {
                 continue;
             }
 
             $this->outputFormatted('<b>%s</b>', [$signalClassName]);
             foreach ($signalsByClass as $signalMethodName => $slots) {
-
                 if ($methodName !== null && $signalMethodName !== $methodName) {
                     continue;
                 }

--- a/Neos.Flow/Classes/Command/SignalCommandController.php
+++ b/Neos.Flow/Classes/Command/SignalCommandController.php
@@ -32,11 +32,11 @@ class SignalCommandController extends CommandController
     /**
      * Lists all connected signals with their slots.
      *
-     * @param string $className
-     * @param string $methodName
+     * @param string $className if specified, only signals matching the given fully qualified class name will be shown. Note: escape namespace separators or wrap the value in quotes, e.g. "--class-name Neos\\Flow\\Core\\Bootstrap".
+     * @param string $methodName if specified, only signals matching the given method name will be shown. This is only useful in conjunction with the "--class-name" option.
      * @return void
      */
-    public function listConnectedCommand(string $className = null,string $methodName = null)
+    public function listConnectedCommand(string $className = null, string $methodName = null): void
     {
         $this->outputFormatted('<b>Connected signals with their slots.</b>');
         $this->outputLine();


### PR DESCRIPTION
The CLI command lists all signals with their slots. As parameter it accepts the class name and method name of the signal to filter the output.

Help output:
```
Lists all connected signals with their slots.

COMMAND:
  neos.flow:signal:listconnected

USAGE:
  ./flow signal:listconnected [<options>]

OPTIONS:
  --class-name
  --method-name
```

Example output:
```
$ ./flow signal:listconnected 
Connected signals with their slots.

Neos\Flow\Mvc\Dispatcher
  afterControllerInvocation
    [0] Closure

Neos\Flow\Cli\SlaveRequestHandler
  dispatchedCommandLineSlaveRequest
    [0] Neos\Flow\Persistence\PersistenceManagerInterface::persistAll

Neos\Flow\Core\Booting\Sequence
  afterInvokeStep
    [0] Closure
    [1] Closure
    [2] Closure
    [3] Closure

Neos\Flow\Monitor\FileMonitor
  filesHaveChanged
    [0] Closure
    [1] Neos\Flow\Cache\CacheManager::flushSystemCachesByChangedFiles
    [2] Closure
    [3] Closure
    [4] Closure
    [5] Closure

Neos\Flow\Core\Bootstrap
  bootstrapShuttingDown
    [0] Neos\Flow\ObjectManagement\ObjectManagerInterface::shutdown
    [1] Neos\Flow\Configuration\ConfigurationManager::shutdown
    [2] Neos\Flow\Reflection\ReflectionService::saveToCache

...
```

```
$ ./flow signal:listconnected --class-name "Neos\Media\Domain\Service\AssetService" --method-name assetRemoved
Connected signals with their slots.

Neos\Media\Domain\Service\AssetService
  assetRemoved
    [0] Neos\Media\Domain\Model\ImportedAssetManager::registerRemovedAsset
```

Fixes: #535 