### PR TITLE
BUGFIX: Check if variable is an array before accessing it as such

### DIFF
--- a/Neos.Flow/Classes/Mvc/Controller/Argument.php
+++ b/Neos.Flow/Classes/Mvc/Controller/Argument.php
@@ -223,7 +223,7 @@ class Argument
         $configuredType = $configuration->getConfigurationValue(ObjectConverter::class, ObjectConverter::CONFIGURATION_TARGET_TYPE);
         if ($configuredType !== null) {
             $this->dataType = $configuredType;
-        } elseif (isset($rawValue['__type']) && $configuration->getConfigurationValue(ObjectConverter::class, ObjectConverter::CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED) === true) {
+        } elseif (is_array($rawValue) && isset($rawValue['__type']) && $configuration->getConfigurationValue(ObjectConverter::class, ObjectConverter::CONFIGURATION_OVERRIDE_TARGET_TYPE_ALLOWED) === true) {
             $this->dataType = $rawValue['__type'];
         }
         $this->value = $this->propertyMapper->convert($rawValue, $this->dataType, $this->getPropertyMappingConfiguration());


### PR DESCRIPTION
The current code lead to an error when an argument is of type `Neos\Http\Factories\FlowUploadedFile`, trying to access an array property on it. This fixes it by checking for `is_array`.

Fixes neos/neos-development-collection#3467