### PR TITLE
BUGFIX: AroundAdvice emits adviceInvoked signal

### DIFF
--- a/Neos.Flow/Classes/Aop/Advice/AroundAdvice.php
+++ b/Neos.Flow/Classes/Aop/Advice/AroundAdvice.php
@@ -32,6 +32,10 @@ class AroundAdvice extends AbstractAdvice implements AdviceInterface
 
         $adviceObject = $this->objectManager->get($this->aspectObjectName);
         $methodName = $this->adviceMethodName;
-        return $adviceObject->$methodName($joinPoint);
+        $result = $adviceObject->$methodName($joinPoint);
+
+        $this->emitAdviceInvoked($adviceObject, $methodName, $joinPoint);
+
+        return $result;
     }
 }

--- a/Neos.Flow/Tests/Unit/Aop/Advice/AroundAdviceTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Advice/AroundAdviceTest.php
@@ -13,6 +13,7 @@ namespace Neos\Flow\Tests\Unit\Aop\Advice;
 
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\SignalSlot;
 use Neos\Flow\Aop;
 
 /**
@@ -34,11 +35,16 @@ class AroundAdviceTest extends UnitTestCase
         $mockObjectManager = $this->getMockBuilder(ObjectManagerInterface::class)->disableOriginalConstructor()->getMock();
         $mockObjectManager->expects(self::once())->method('get')->with('aspectObjectName')->will(self::returnValue($mockAspect));
 
+        $mockDispatcher = $this->createMock(SignalSlot\Dispatcher::class);
+
         $advice = new Aop\Advice\AroundAdvice('aspectObjectName', 'someMethod', $mockObjectManager, function (Aop\JoinPointInterface $joinPoint) {
             if ($joinPoint !== null) {
                 return true;
             }
         });
+
+        $this->inject($advice, 'dispatcher', $mockDispatcher);
+
         $result = $advice->invoke($mockJoinPoint);
 
         self::assertEquals($result, 'result', 'The around advice did not return the result value as expected.');


### PR DESCRIPTION
The [documentation](https://neos.readthedocs.io/en/stable/References/Signals/Flow.html#aroundadvice-neos-flow-aop-advice-aroundadvice) mentions, that the `AroundAdvice` emit's the `adviceInvoked` signal. This is not the case, because `AroundAdvice` overrides the `invoke(JoinPointInterface $joinPoint)` method from `AbstractAdvice`.

**What I did**

This bugfix, just add's the missing signal, thus every advice should be easier to log using a slot for `adviceInvoked`.