### PR TITLE
BUGFIX: Catch Warning for rmdir in PHP 8.0

### DIFF
--- a/Neos.Utility.Files/Classes/Files.php
+++ b/Neos.Utility.Files/Classes/Files.php
@@ -196,7 +196,9 @@ abstract class Files
                     // PHP 8 apparently throws for unlink even with shutup operator, but we really don't care at this place. It's also the only way to handle this race-condition free.
                 }
             }
-            if (@rmdir($path) === false) {
+            try {
+                rmdir($path);
+            } catch (\Throwable $e) {
                 break;
             }
             $path = substr($path, 0, -(strlen($currentSegment) + 1));

--- a/Neos.Utility.Files/Classes/Files.php
+++ b/Neos.Utility.Files/Classes/Files.php
@@ -197,8 +197,11 @@ abstract class Files
                 }
             }
             try {
-                rmdir($path);
+                if (@rmdir($path) === false) {
+                    throw new FilesException(sprintf('Could not remove directory "%s".', $path), 1634928640);
+                }
             } catch (\Throwable $e) {
+                // PHP 8 throws for rmdir even with a shutup operator set. To ensure the loop gets correctly ended in PHP 8 and below, an additional FilesException is used.
                 break;
             }
             $path = substr($path, 0, -(strlen($currentSegment) + 1));


### PR DESCRIPTION
When a resource is deleted the method `removeEmptyDirectoriesOnPath` is used, which cause an E_WARNING with PHP 8.0. Even if the shutup operator is used. This bugfix catch the E_WARNING to break the foreach at the right time.
