### PR TITLE
BUGFIX: Fix getTagValues with comments on same line as an annotation

### DIFF
--- a/Neos.Flow/Classes/Reflection/DocCommentParser.php
+++ b/Neos.Flow/Classes/Reflection/DocCommentParser.php
@@ -115,7 +115,7 @@ class DocCommentParser
     protected function parseTag($line)
     {
         $tagAndValue = [];
-        if (preg_match('/@[A-Za-z0-9\\\\]+\\\\([A-Za-z0-9]+)(?:\\((.*)\\))?$/', $line, $tagAndValue) === 0) {
+        if (preg_match('/(@[A-Za-z0-9\\\\]+\\\\[A-Za-z0-9]+)(?:(?:\\(|\s)([^\)]*))?/', $line, $tagAndValue) === 0) {
             $tagAndValue = preg_split('/\s/', $line, 2);
         } else {
             array_shift($tagAndValue);

--- a/Neos.Flow/Tests/Unit/Reflection/Fixture/ClassWithAnnotatedMethod.php
+++ b/Neos.Flow/Tests/Unit/Reflection/Fixture/ClassWithAnnotatedMethod.php
@@ -7,12 +7,42 @@ use Neos\Flow\Annotations as Flow;
 class ClassWithAnnotatedMethod
 {
     /**
-     * @Flow\SkipCsrfProtection Some comment
+     * @skipcsrfprotection
      */
-    public function methodWithComment() {}
+    public function methodWithTag() {}
+
+    /**
+     * @skipcsrfprotection with some comment
+     */
+    public function methodWithTagAndComment() {}
 
     /**
      * @Flow\SkipCsrfProtection
      */
-    public function methodWithoutComment() {}
+    public function methodWithAnnotation() {}
+
+    /**
+     * @Flow\SkipCsrfProtection Some comment
+     */
+    public function methodWithAnnotationAndComment() {}
+
+    /**
+     * @Flow\Validate("foo")
+     */
+    public function methodWithAnnotationArgument(string $foo) {}
+
+    /**
+     * @Flow\Validate("foo") Some comment
+     */
+    public function methodWithAnnotationArgumentAndComment(string $foo) {}
+
+    /**
+     * @Flow\IgnoreValidation(argumentName="foo", evaluate=true)
+     */
+    public function methodWithMultipleAnnotationArguments(string $foo) {}
+
+    /**
+     * @Flow\IgnoreValidation(argumentName="foo", evaluate=true) Some comment
+     */
+    public function methodWithMultipleAnnotationArgumentsAndComment(string $foo) {}
 }

--- a/Neos.Flow/Tests/Unit/Reflection/Fixture/ClassWithAnnotatedMethod.php
+++ b/Neos.Flow/Tests/Unit/Reflection/Fixture/ClassWithAnnotatedMethod.php
@@ -9,40 +9,56 @@ class ClassWithAnnotatedMethod
     /**
      * @skipcsrfprotection
      */
-    public function methodWithTag() {}
+    public function methodWithTag()
+    {
+    }
 
     /**
      * @skipcsrfprotection with some comment
      */
-    public function methodWithTagAndComment() {}
+    public function methodWithTagAndComment()
+    {
+    }
 
     /**
      * @Flow\SkipCsrfProtection
      */
-    public function methodWithAnnotation() {}
+    public function methodWithAnnotation()
+    {
+    }
 
     /**
      * @Flow\SkipCsrfProtection Some comment
      */
-    public function methodWithAnnotationAndComment() {}
+    public function methodWithAnnotationAndComment()
+    {
+    }
 
     /**
      * @Flow\Validate("foo")
      */
-    public function methodWithAnnotationArgument(string $foo) {}
+    public function methodWithAnnotationArgument(string $foo)
+    {
+    }
 
     /**
      * @Flow\Validate("foo") Some comment
      */
-    public function methodWithAnnotationArgumentAndComment(string $foo) {}
+    public function methodWithAnnotationArgumentAndComment(string $foo)
+    {
+    }
 
     /**
      * @Flow\IgnoreValidation(argumentName="foo", evaluate=true)
      */
-    public function methodWithMultipleAnnotationArguments(string $foo) {}
+    public function methodWithMultipleAnnotationArguments(string $foo)
+    {
+    }
 
     /**
      * @Flow\IgnoreValidation(argumentName="foo", evaluate=true) Some comment
      */
-    public function methodWithMultipleAnnotationArgumentsAndComment(string $foo) {}
+    public function methodWithMultipleAnnotationArgumentsAndComment(string $foo)
+    {
+    }
 }

--- a/Neos.Flow/Tests/Unit/Reflection/Fixture/ClassWithAnnotatedMethod.php
+++ b/Neos.Flow/Tests/Unit/Reflection/Fixture/ClassWithAnnotatedMethod.php
@@ -14,7 +14,7 @@ class ClassWithAnnotatedMethod
     }
 
     /**
-     * @skipcsrfprotection with some comment
+     * @skipcsrfprotection Some comment
      */
     public function methodWithTagAndComment()
     {

--- a/Neos.Flow/Tests/Unit/Reflection/Fixture/ClassWithAnnotatedMethod.php
+++ b/Neos.Flow/Tests/Unit/Reflection/Fixture/ClassWithAnnotatedMethod.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Neos\Flow\Tests\Unit\Reflection\Fixture;
+
+use Neos\Flow\Annotations as Flow;
+
+class ClassWithAnnotatedMethod
+{
+    /**
+     * @Flow\SkipCsrfProtection Some comment
+     */
+    public function methodWithComment() {}
+
+    /**
+     * @Flow\SkipCsrfProtection
+     */
+    public function methodWithoutComment() {}
+}

--- a/Neos.Flow/Tests/Unit/Reflection/MethodReflectionTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/MethodReflectionTest.php
@@ -67,6 +67,6 @@ class MethodReflectionTest extends UnitTestCase
     public function commentsAfterAnnotationShouldBeIgnored($class, $method, $expected)
     {
         $method = new Reflection\MethodReflection($class, $method);
-        self::assertEquals($method->getTagValues());
+        self::assertEquals($method->getTagsValues());
     }
 }

--- a/Neos.Flow/Tests/Unit/Reflection/MethodReflectionTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/MethodReflectionTest.php
@@ -53,8 +53,8 @@ class MethodReflectionTest extends UnitTestCase
             [ClassWithAnnotatedMethod::class, 'methodWithTagAndComment', ['skipcsrfprotection' => ['Some comment']]],
             [ClassWithAnnotatedMethod::class, 'methodWithAnnotation', ['flow\skipcsrfprotection' => []]],
             [ClassWithAnnotatedMethod::class, 'methodWithAnnotationAndComment', ['flow\skipcsrfprotection' => ['Some comment']]],
-            [ClassWithAnnotatedMethod::class, 'methodWithAnnotationArgument', ['flow\validate' => ['"foo"']]],
-            [ClassWithAnnotatedMethod::class, 'methodWithAnnotationArgumentAndComment', ['flow\validate' => ['"foo"']]],
+            [ClassWithAnnotatedMethod::class, 'methodWithAnnotationArgument', ['flow\validate' => ['foo']]],
+            [ClassWithAnnotatedMethod::class, 'methodWithAnnotationArgumentAndComment', ['flow\validate' => ['foo']]],
             [ClassWithAnnotatedMethod::class, 'methodWithMultipleAnnotationArguments', ['flow\ignorevalidation' => ['argumentName="foo", evaluate=true']]],
             [ClassWithAnnotatedMethod::class, 'methodWithMultipleAnnotationArgumentsAndComment', ['flow\ignorevalidation' => ['argumentName="foo", evaluate=true']]],
         ];

--- a/Neos.Flow/Tests/Unit/Reflection/MethodReflectionTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/MethodReflectionTest.php
@@ -67,6 +67,6 @@ class MethodReflectionTest extends UnitTestCase
     public function commentsAfterAnnotationShouldBeIgnored($class, $method, $expected)
     {
         $method = new Reflection\MethodReflection($class, $method);
-        self::assertEquals($method->getTagsValues());
+        self::assertEquals($expected, $method->getTagsValues());
     }
 }

--- a/Neos.Flow/Tests/Unit/Reflection/MethodReflectionTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/MethodReflectionTest.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\Tests\Unit\Reflection;
  */
 
 use Neos\Flow\Reflection;
+use Neos\Flow\Tests\Unit\Reflection\Fixture\ClassWithAnnotatedMethod;
 use Neos\Flow\Tests\UnitTestCase;
 
 /**
@@ -43,5 +44,23 @@ class MethodReflectionTest extends UnitTestCase
             self::assertInstanceOf(Reflection\ParameterReflection::class, $parameter);
             self::assertEquals(__CLASS__, $parameter->getDeclaringClass()->getName());
         }
+    }
+
+    public function classAndMethodWithAnnotations()
+    {
+        return [
+            [ClassWithAnnotatedMethod::class, 'methodWithComment'],
+            [ClassWithAnnotatedMethod::class, 'methodWithoutComment']
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider classAndMethodWithAnnotations
+     */
+    public function commentsAfterAnnotationShouldBeIgnored($class, $method)
+    {
+        $method = new Reflection\MethodReflection($class, $method);
+        self::assertTrue($method->isTaggedWith('skipcsrfprotection'));
     }
 }

--- a/Neos.Flow/Tests/Unit/Reflection/MethodReflectionTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/MethodReflectionTest.php
@@ -49,8 +49,14 @@ class MethodReflectionTest extends UnitTestCase
     public function classAndMethodWithAnnotations()
     {
         return [
-            [ClassWithAnnotatedMethod::class, 'methodWithComment'],
-            [ClassWithAnnotatedMethod::class, 'methodWithoutComment']
+            [ClassWithAnnotatedMethod::class, 'methodWithTag', ['skipcsrfprotection' => []]],
+            [ClassWithAnnotatedMethod::class, 'methodWithTagAndComment', ['skipcsrfprotection' => ['Some comment']]],
+            [ClassWithAnnotatedMethod::class, 'methodWithAnnotation', ['flow\skipcsrfprotection' => []]],
+            [ClassWithAnnotatedMethod::class, 'methodWithAnnotationAndComment', ['flow\skipcsrfprotection' => ['Some comment']]],
+            [ClassWithAnnotatedMethod::class, 'methodWithAnnotationArgument', ['flow\validate' => ['"foo"']]],
+            [ClassWithAnnotatedMethod::class, 'methodWithAnnotationArgumentAndComment', ['flow\validate' => ['"foo"']]],
+            [ClassWithAnnotatedMethod::class, 'methodWithMultipleAnnotationArguments', ['flow\ignorevalidation' => ['argumentName="foo", evaluate=true']]],
+            [ClassWithAnnotatedMethod::class, 'methodWithMultipleAnnotationArgumentsAndComment', ['flow\ignorevalidation' => ['argumentName="foo", evaluate=true']]],
         ];
     }
 
@@ -58,9 +64,9 @@ class MethodReflectionTest extends UnitTestCase
      * @test
      * @dataProvider classAndMethodWithAnnotations
      */
-    public function commentsAfterAnnotationShouldBeIgnored($class, $method)
+    public function commentsAfterAnnotationShouldBeIgnored($class, $method, $expected)
     {
         $method = new Reflection\MethodReflection($class, $method);
-        self::assertTrue($method->isTaggedWith('skipcsrfprotection'));
+        self::assertEquals($method->getTagValues());
     }
 }


### PR DESCRIPTION
Related to #2612