### PR TITLE
TASK: Include the application context in cache keys

### DIFF
--- a/Neos.Cache/Classes/Backend/AbstractBackend.php
+++ b/Neos.Cache/Classes/Backend/AbstractBackend.php
@@ -35,6 +35,11 @@ abstract class AbstractBackend implements BackendInterface
     /**
      * @var string
      */
+    protected $applicationContextHash;
+
+    /**
+     * @var string
+     */
     protected $cacheIdentifier;
 
     /**
@@ -58,6 +63,8 @@ abstract class AbstractBackend implements BackendInterface
     public function __construct(EnvironmentConfiguration $environmentConfiguration = null, array $options = [])
     {
         $this->environmentConfiguration = $environmentConfiguration;
+
+        $this->applicationContextHash = md5($environmentConfiguration->getApplicationIdentifier());
 
         if (is_array($options) || $options instanceof \Iterator) {
             $this->setProperties($options);

--- a/Neos.Cache/Classes/Backend/AbstractBackend.php
+++ b/Neos.Cache/Classes/Backend/AbstractBackend.php
@@ -35,7 +35,7 @@ abstract class AbstractBackend implements BackendInterface
     /**
      * @var string
      */
-    protected $applicationContextHash;
+    protected $applicationContextHash = '';
 
     /**
      * @var string
@@ -64,7 +64,9 @@ abstract class AbstractBackend implements BackendInterface
     {
         $this->environmentConfiguration = $environmentConfiguration;
 
-        $this->applicationContextHash = md5($environmentConfiguration->getApplicationIdentifier());
+        if ($environmentConfiguration instanceof EnvironmentConfiguration) {
+            $this->applicationContextHash = md5($environmentConfiguration->getApplicationIdentifier());
+        }
 
         if (is_array($options) || $options instanceof \Iterator) {
             $this->setProperties($options);

--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -257,7 +257,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      */
     private function buildKey(string $identifier): string
     {
-        return $this->cacheIdentifier . ':' . $identifier;
+        return $this->applicationContextHash . ':' . $this->cacheIdentifier . ':' . $identifier;
     }
 
     /**


### PR DESCRIPTION
resolves: #2618

- Refactors the applicationContextHash to be available for all backends
- Use the application context in pdo and redis backend