### PR TITLE
Fix #2620

### DIFF
--- a/Neos.Flow/Classes/Composer/InstallerScripts.php
+++ b/Neos.Flow/Classes/Composer/InstallerScripts.php
@@ -29,11 +29,6 @@ class InstallerScripts
     /**
      * @var bool
      */
-    protected static $postPackageUpdateAndInstallAlreadyRun = false;
-
-    /**
-     * @var bool
-     */
     protected static $postUpdateAndInstallAlreadyRun = false;
 
     /**
@@ -91,10 +86,6 @@ class InstallerScripts
      */
     public static function postPackageUpdateAndInstall(PackageEvent $event): void
     {
-        if (self::$postPackageUpdateAndInstallAlreadyRun) {
-            return;
-        }
-
         $operation = $event->getOperation();
         if (!$operation instanceof InstallOperation && !$operation instanceof UpdateOperation) {
             throw new Exception\UnexpectedOperationException('Handling of operation of type "' . get_class($operation) . '" not supported', 1348750840);
@@ -116,8 +107,6 @@ class InstallerScripts
         if ($operation instanceof UpdateOperation && isset($packageExtraConfig['neos/flow']['post-update'])) {
             self::runPackageScripts($packageExtraConfig['neos/flow']['post-update']);
         }
-
-        self::$postPackageUpdateAndInstallAlreadyRun = true;
     }
 
     /**


### PR DESCRIPTION
This fix resolves the issue of postPackageUpdateAndInstall not installing resources from all installed packages

**What I did**

Remove the single run code for the postPackageUpdateAndInstall function only

**How to verify it**

1. Clone git@github.com:marcrobertscamao/resource-test.git
2. Run composer install
3. See resource1.txt in the root and resource2.txt in the root

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
