### PR TITLE
!!! BUGFIX: Prefix RedisBackend keys with application context

### DIFF
--- a/Neos.Cache/Classes/Backend/AbstractBackend.php
+++ b/Neos.Cache/Classes/Backend/AbstractBackend.php
@@ -38,6 +38,12 @@ abstract class AbstractBackend implements BackendInterface
     protected $cacheIdentifier;
 
     /**
+     * A prefix to seperate stored by appliaction context and cache
+     * @var string
+     */
+    protected $identifierPrefix;
+
+    /**
      * Default lifetime of a cache entry in seconds
      * @var integer
      */
@@ -111,27 +117,7 @@ abstract class AbstractBackend implements BackendInterface
     {
         $this->cache = $cache;
         $this->cacheIdentifier = $this->cache->getIdentifier();
-    }
-
-    /**
-     * Returns the internally used, prefixed entry identifier for the given public
-     * entry identifier.
-     *
-     * While Flow applications will mostly refer to the simple entry identifier, it
-     * may be necessary to know the actual identifier used by the cache backend
-     * in order to share cache entries with other applications. This method allows
-     * for retrieving it.
-     *
-     * Note that, in case of the AbstractBackend, this method is returns just the
-     * given entry identifier.
-     *
-     * @param string $entryIdentifier The short entry identifier, for example "NumberOfPostedArticles"
-     * @return string The prefixed identifier, for example "Flow694a5c7a43a4_NumberOfPostedArticles"
-     * @api
-     */
-    public function getPrefixedIdentifier(string $entryIdentifier): string
-    {
-        return $entryIdentifier;
+        $this->identifierPrefix = md5($this->environmentConfiguration->getApplicationIdentifier()) . ':' . $this->cacheIdentifier . ':';
     }
 
     /**
@@ -167,5 +153,26 @@ abstract class AbstractBackend implements BackendInterface
             $lifetime = $this->defaultLifetime;
         }
         return new \DateTime('now +' . $lifetime . ' seconds', new \DateTimeZone('UTC'));
+    }
+
+    /**
+     * Returns the internally used, prefixed entry identifier for the given public
+     * entry identifier.
+     *
+     * While Flow applications will mostly refer to the simple entry identifier, it
+     * may be necessary to know the actual identifier used by the cache backend
+     * in order to share cache entries with other applications. This method allows
+     * for retrieving it.
+     *
+     * Note that, in case of the AbstractBackend, this method is returns just the
+     * given entry identifier.
+     *
+     * @param string $entryIdentifier The short entry identifier, for example "NumberOfPostedArticles"
+     * @return string The prefixed identifier, for example "d59b7012de96aecf8171f8760323fe0a:Flow_Fusion_Content:NumberOfPostedArticles:"
+     * @api
+     */
+    public function getPrefixedIdentifier(string $entryIdentifier): string
+    {
+        return $this->identifierPrefix . $entryIdentifier;
     }
 }

--- a/Neos.Cache/Classes/Backend/AbstractBackend.php
+++ b/Neos.Cache/Classes/Backend/AbstractBackend.php
@@ -117,7 +117,8 @@ abstract class AbstractBackend implements BackendInterface
     {
         $this->cache = $cache;
         $this->cacheIdentifier = $this->cache->getIdentifier();
-        $this->identifierPrefix = md5($this->environmentConfiguration->getApplicationIdentifier()) . ':' . $this->cacheIdentifier . ':';
+        $applicationIdentifier = $this->environmentConfiguration instanceof EnvironmentConfiguration ? $this->environmentConfiguration->getApplicationIdentifier() : '';
+        $this->identifierPrefix = md5($applicationIdentifier) . ':' . $this->cacheIdentifier . ':';
     }
 
     /**

--- a/Neos.Cache/Classes/Backend/ApcuBackend.php
+++ b/Neos.Cache/Classes/Backend/ApcuBackend.php
@@ -126,7 +126,7 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
         $tags[] = '%APCUBE%' . $this->cacheIdentifier;
         $expiration = $lifetime !== null ? $lifetime : $this->defaultLifetime;
 
-        $success = apcu_store($this->identifierPrefix . 'entry_' . $entryIdentifier, $data, $expiration);
+        $success = apcu_store($this->getPrefixedIdentifier($entryIdentifier), $data, $expiration);
         if ($success === true) {
             $this->removeIdentifierFromAllTags($entryIdentifier);
             $this->addIdentifierToTags($entryIdentifier, $tags);
@@ -145,7 +145,7 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
     public function get(string $entryIdentifier)
     {
         $success = false;
-        $value = apcu_fetch($this->identifierPrefix . 'entry_' . $entryIdentifier, $success);
+        $value = apcu_fetch($this->getPrefixedIdentifier($entryIdentifier), $success);
         return ($success ? $value : $success);
     }
 
@@ -159,7 +159,7 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
     public function has(string $entryIdentifier): bool
     {
         $success = false;
-        apcu_fetch($this->identifierPrefix . 'entry_' . $entryIdentifier, $success);
+        apcu_fetch($this->getPrefixedIdentifier($entryIdentifier), $success);
         return $success;
     }
 
@@ -175,7 +175,7 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
     public function remove(string $entryIdentifier): bool
     {
         $this->removeIdentifierFromAllTags($entryIdentifier);
-        return apcu_delete($this->identifierPrefix . 'entry_' . $entryIdentifier);
+        return apcu_delete($this->getPrefixedIdentifier($entryIdentifier));
     }
 
     /**

--- a/Neos.Cache/Tests/Unit/Backend/RedisBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/RedisBackendTest.php
@@ -80,7 +80,7 @@ class RedisBackendTest extends BaseTestCase
     {
         $this->redis->expects(self::once())
             ->method('sMembers')
-            ->with('Foo_Cache:tag:some_tag')
+            ->with('d41d8cd98f00b204e9800998ecf8427e:Foo_Cache:tag:some_tag')
             ->will(self::returnValue(['entry_1', 'entry_2']));
 
         $this->assertEquals(['entry_1', 'entry_2'], $this->backend->findIdentifiersByTag('some_tag'));
@@ -93,7 +93,7 @@ class RedisBackendTest extends BaseTestCase
     {
         $this->redis->expects(self::once())
             ->method('lRange')
-            ->with('Foo_Cache:entries', 0, -1)
+            ->with('d41d8cd98f00b204e9800998ecf8427e:Foo_Cache:entries', 0, -1)
             ->will(self::returnValue(['entry_1', 'entry_2']));
 
         $this->redis->expects(self::exactly(2))
@@ -101,7 +101,7 @@ class RedisBackendTest extends BaseTestCase
 
         $this->redis->expects(self::once())
             ->method('set')
-            ->with('Foo_Cache:frozen', true);
+            ->with('d41d8cd98f00b204e9800998ecf8427e:Foo_Cache:frozen', true);
 
         $this->backend->freeze();
     }
@@ -159,7 +159,7 @@ class RedisBackendTest extends BaseTestCase
 
         $this->redis->expects(self::once())
             ->method('set')
-            ->with('Foo_Cache:entry:entry_1', 'foo')
+            ->with('d41d8cd98f00b204e9800998ecf8427e:Foo_Cache:entry:entry_1', 'foo')
             ->willReturn($this->redis);
 
         $this->backend->set('entry_1', 'foo');
@@ -172,7 +172,7 @@ class RedisBackendTest extends BaseTestCase
     {
         $this->redis->expects(self::once())
             ->method('get')
-            ->with('Foo_Cache:entry:foo')
+            ->with('d41d8cd98f00b204e9800998ecf8427e:Foo_Cache:entry:foo')
             ->will(self::returnValue('bar'));
 
         self::assertEquals('bar', $this->backend->get('foo'));
@@ -185,7 +185,7 @@ class RedisBackendTest extends BaseTestCase
     {
         $this->redis->expects(self::once())
             ->method('exists')
-            ->with('Foo_Cache:entry:foo')
+            ->with('d41d8cd98f00b204e9800998ecf8427e:Foo_Cache:entry:foo')
             ->will(self::returnValue(true));
 
         self::assertEquals(true, $this->backend->has('foo'));
@@ -202,7 +202,7 @@ class RedisBackendTest extends BaseTestCase
         $this->inject($this->backend, 'frozen', null);
         $this->redis->expects(self::once())
             ->method('exists')
-            ->with('Foo_Cache:frozen')
+            ->with('d41d8cd98f00b204e9800998ecf8427e:Foo_Cache:frozen')
             ->will(self::returnValue(true));
 
         $this->backend->$method('foo', 'bar');


### PR DESCRIPTION
Also refactors MemCached and ApcuBackend to use the `getPrefixedIdentifier()` method.

Resolves: #2618