### PR TITLE
Revert "TASK: Run post-update scripts only once"

### DIFF
--- a/Neos.Flow/Classes/Composer/InstallerScripts.php
+++ b/Neos.Flow/Classes/Composer/InstallerScripts.php
@@ -25,17 +25,6 @@ use Neos\Utility\Files;
  */
 class InstallerScripts
 {
-
-    /**
-     * @var bool
-     */
-    protected static $postPackageUpdateAndInstallAlreadyRun = false;
-
-    /**
-     * @var bool
-     */
-    protected static $postUpdateAndInstallAlreadyRun = false;
-
     /**
      * Make sure required paths and files are available outside of Package
      * Run on every Composer install or update - must be configured in root manifest
@@ -48,10 +37,6 @@ class InstallerScripts
      */
     public static function postUpdateAndInstall(Event $event): void
     {
-        if (self::$postUpdateAndInstallAlreadyRun) {
-            return;
-        }
-
         if (!defined('FLOW_PATH_ROOT')) {
             define('FLOW_PATH_ROOT', Files::getUnixStylePath(getcwd()) . '/');
         }
@@ -76,8 +61,6 @@ class InstallerScripts
         $packageManager->rescanPackages();
 
         chmod('flow', 0755);
-
-        self::$postUpdateAndInstallAlreadyRun = true;
     }
 
     /**
@@ -91,10 +74,6 @@ class InstallerScripts
      */
     public static function postPackageUpdateAndInstall(PackageEvent $event): void
     {
-        if (self::$postPackageUpdateAndInstallAlreadyRun) {
-            return;
-        }
-
         $operation = $event->getOperation();
         if (!$operation instanceof InstallOperation && !$operation instanceof UpdateOperation) {
             throw new Exception\UnexpectedOperationException('Handling of operation of type "' . get_class($operation) . '" not supported', 1348750840);
@@ -116,8 +95,6 @@ class InstallerScripts
         if ($operation instanceof UpdateOperation && isset($packageExtraConfig['neos/flow']['post-update'])) {
             self::runPackageScripts($packageExtraConfig['neos/flow']['post-update']);
         }
-
-        self::$postPackageUpdateAndInstallAlreadyRun = true;
     }
 
     /**


### PR DESCRIPTION
This reverts commit d79947442d7de8c59f0d6460e0affef30406148b.

Resolves: #2621

Original by @marcrobertscamao:

This fix resolves the issue of postPackageUpdateAndInstall not installing resources from all installed packages

What I did

Remove the single run code for the postPackageUpdateAndInstall function only

How to verify it

Clone git@github.com:marcrobertscamao/resource-test.git
Run composer install
See resource1.txt in the root and resource2.txt in the root
