### PR TITLE
BUGFIX: FunctionalTestCase doesn't reset PrivilegeManager on setup

### DIFF
--- a/Neos.Flow/Tests/FunctionalTestCase.php
+++ b/Neos.Flow/Tests/FunctionalTestCase.php
@@ -144,6 +144,9 @@ abstract class FunctionalTestCase extends \Neos\Flow\Tests\BaseTestCase
             $session->destroy(sprintf('assure that session is fresh, in setUp() method of functional test %s.', get_class($this) . '::' . $this->getName()));
         }
 
+        $privilegeManager = $this->objectManager->get(\Neos\Flow\Security\Authorization\TestingPrivilegeManager::class);
+        $privilegeManager->reset();
+
         if ($this->testableSecurityEnabled === true || static::$testablePersistenceEnabled === true) {
             if (is_callable([self::$bootstrap->getObjectManager()->get(\Neos\Flow\Persistence\PersistenceManagerInterface::class), 'compile'])) {
                 $result = self::$bootstrap->getObjectManager()->get(\Neos\Flow\Persistence\PersistenceManagerInterface::class)->compile();
@@ -153,7 +156,6 @@ abstract class FunctionalTestCase extends \Neos\Flow\Tests\BaseTestCase
             }
             $this->persistenceManager = $this->objectManager->get(\Neos\Flow\Persistence\PersistenceManagerInterface::class);
         } else {
-            $privilegeManager = $this->objectManager->get(\Neos\Flow\Security\Authorization\TestingPrivilegeManager::class);
             $privilegeManager->setOverrideDecision(true);
         }
 


### PR DESCRIPTION
When extending the `FunctionalTestCase` without either `$testableSecurityEnabled` or `$testablePersistenceEnabled` set to `true`, the `privilegeManager` will get `overrideDecision` set to `true`.

All test classes executed later will now also have `overrideDecision` set to `true` instead of the expected `null`.

This fix ensures that `privilegeManager->reset()` is called no matter what.