### PR TITLE
BUGFIX: IgnoreValidation can be used without arguments on a property

### DIFF
--- a/Neos.Flow/Classes/Annotations/IgnoreValidation.php
+++ b/Neos.Flow/Classes/Annotations/IgnoreValidation.php
@@ -28,7 +28,7 @@ final class IgnoreValidation
 {
     /**
      * Name of the argument to skip validation for. (Can be given as anonymous argument.)
-     * @var string
+     * @var string|null
      */
     public $argumentName;
 
@@ -38,9 +38,9 @@ final class IgnoreValidation
      */
     public $evaluate = false;
 
-    public function __construct(string $argumentName, bool $evaluate = false)
+    public function __construct(string $argumentName = null, bool $evaluate = false)
     {
-        $this->argumentName = ltrim($argumentName, '$');
+        $this->argumentName = $argumentName ? ltrim($argumentName, '$') : null;
         $this->evaluate = $evaluate;
     }
 }

--- a/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/NestedObject.php
+++ b/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/NestedObject.php
@@ -1,0 +1,26 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A nested object with validation
+ */
+class NestedObject
+{
+    /**
+     * @var string
+     * @Flow\Validate(type="NotEmpty")
+     */
+    protected $name;
+}

--- a/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/TestObjectArgument.php
+++ b/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/TestObjectArgument.php
@@ -44,9 +44,16 @@ class TestObjectArgument implements TestObjectInterface
      */
     protected $related;
 
+    /**
+     * @var NestedObject
+     * @Flow\IgnoreValidation
+     */
+    protected $nested;
+
     public function __construct()
     {
         $this->collection = new ArrayCollection();
+        $this->nested = new NestedObject();
     }
 
     /**


### PR DESCRIPTION
It should be possible to annotate a property with just `@Flow\IgnoreValidation` without any arguments.

This was a regression from #2468.

Related to https://github.com/neos/neos-development-collection/issues/3515 and https://github.com/neos/neos-development-collection/pull/3411