### PR TITLE
TASK: Adjust docblock typehint to TYPO3Fluid change

### DIFF
--- a/Neos.FluidAdaptor/Classes/View/TemplatePaths.php
+++ b/Neos.FluidAdaptor/Classes/View/TemplatePaths.php
@@ -546,6 +546,7 @@ class TemplatePaths extends \TYPO3Fluid\Fluid\View\TemplatePaths
      */
     protected function createIdentifierForFile($pathAndFilename, $prefix)
     {
+        $pathAndFilename = (string)$pathAndFilename;
         $templateModifiedTimestamp = 0;
         $isStandardInput = $pathAndFilename === 'php://stdin';
         $isFile = is_file($pathAndFilename);

--- a/Neos.FluidAdaptor/Classes/View/TemplatePaths.php
+++ b/Neos.FluidAdaptor/Classes/View/TemplatePaths.php
@@ -539,7 +539,7 @@ class TemplatePaths extends \TYPO3Fluid\Fluid\View\TemplatePaths
      * <PackageKey>_<SubPackageKey>_<ControllerName>_<prefix>_<SHA1>
      * The SH1 hash is a checksum that is based on the file path and last modification date
      *
-     * @param string $pathAndFilename
+     * @param string|null $pathAndFilename
      * @param string $prefix
      * @return string
      * @throws InvalidTemplateResourceException


### PR DESCRIPTION
The $pathAndFilename argument has been declared nullable in upstream 2.7.1+ and psalm was notifying about this.

See https://github.com/TYPO3/Fluid/commit/2d28324f02b384bb4e1983cbd72813d31e8493c7

