### PR TITLE
BUGFIX: PDOBackend ignores missing tables in flush

### DIFF
--- a/Neos.Cache/Classes/Backend/PdoBackend.php
+++ b/Neos.Cache/Classes/Backend/PdoBackend.php
@@ -295,6 +295,11 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
     {
         $this->connect();
 
+        // Flushes can happen due to filemonitoring before setup can be called, so you might not be able to reach the setup command without this.
+        if (!$this->tableExists($this->cacheTableName) && !$this->tableExists($this->tagsTableName)) {
+            return;
+        }
+
         $this->databaseHandle->beginTransaction();
         try {
             $statementHandle = $this->databaseHandle->prepare('DELETE FROM "' . $this->tagsTableName . '" WHERE "context"=? AND "cache"=?');


### PR DESCRIPTION
This prevents errors for cache setup with PDOBackends for caches that are flushed early on eg. due to file monitors.

Fixes: #2634