### PR TITLE
BUGFIX: Use custom error view for rendering group independent of the configuration 'templatePathAndFilename'

### DIFF
--- a/Neos.Flow/Classes/Error/AbstractExceptionHandler.php
+++ b/Neos.Flow/Classes/Error/AbstractExceptionHandler.php
@@ -48,9 +48,18 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
     protected $options = [];
 
     /**
+     * Merged custom error view options from defaultRenderingOptions and of the first matching renderingGroup
+     *
      * @var array
      */
     protected $renderingOptions;
+
+    /**
+     * Should a custom error view be used
+     *
+     * @var bool
+     */
+    protected $useCustomErrorView;
 
     /**
      * @param LoggerInterface $logger
@@ -208,14 +217,18 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
     protected function resolveCustomRenderingOptions(\Throwable $exception): array
     {
         $renderingOptions = [];
+        $useCustomErrorView = false;
         if (isset($this->options['defaultRenderingOptions'])) {
             $renderingOptions = $this->options['defaultRenderingOptions'];
+            $useCustomErrorView = isset($renderingOptions['templatePathAndFilename']);
         }
         $renderingGroup = $this->resolveRenderingGroup($exception);
         if ($renderingGroup !== null) {
+            $useCustomErrorView = true;
             $renderingOptions = Arrays::arrayMergeRecursiveOverrule($renderingOptions, $this->options['renderingGroups'][$renderingGroup]['options']);
             $renderingOptions['renderingGroup'] = $renderingGroup;
         }
+        $this->useCustomErrorView = $useCustomErrorView;
         return $renderingOptions;
     }
 

--- a/Neos.Flow/Classes/Error/AbstractExceptionHandler.php
+++ b/Neos.Flow/Classes/Error/AbstractExceptionHandler.php
@@ -259,6 +259,23 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
     }
 
     /**
+     * If a renderingGroup was successfully resolved via @see resolveRenderingGroup
+     * We will use a custom error view.
+     *
+     * Also check for legacy 'templatePathAndFilename'
+     *
+     */
+    protected function useCustomErrorView(): bool
+    {
+        // for legacy reasons 'templatePathAndFilename' was enough to use the view,
+        // so it could theoretically be used without a 'renderingGroup' (will be deprecated!)
+        if (isset($this->renderingOptions['templatePathAndFilename'])) {
+            return true;
+        }
+        return isset($this->renderingOptions['renderingGroup']);
+    }
+
+    /**
      * Formats and echoes the exception and its previous exceptions (if any) for the command line
      *
      * @param \Throwable $exception

--- a/Neos.Flow/Classes/Error/AbstractExceptionHandler.php
+++ b/Neos.Flow/Classes/Error/AbstractExceptionHandler.php
@@ -50,16 +50,20 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
     /**
      * Merged custom error view options from defaultRenderingOptions and of the first matching renderingGroup
      *
-     * @var array
+     * @var array{
+     *      viewClassName: string,
+     *      viewOptions: array,
+     *      renderTechnicalDetails: bool,
+     *      logException: bool,
+     *      renderingGroup?: string,
+     *      variables?: array,
+     *      templatePathAndFilename?: string,
+     *      layoutRootPath?: string,
+     *      partialRootPath?: string,
+     *      format?: string
+     * }
      */
     protected $renderingOptions;
-
-    /**
-     * Should a custom error view be used
-     *
-     * @var bool
-     */
-    protected $useCustomErrorView;
 
     /**
      * @param LoggerInterface $logger
@@ -217,18 +221,14 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
     protected function resolveCustomRenderingOptions(\Throwable $exception): array
     {
         $renderingOptions = [];
-        $useCustomErrorView = false;
         if (isset($this->options['defaultRenderingOptions'])) {
             $renderingOptions = $this->options['defaultRenderingOptions'];
-            $useCustomErrorView = isset($renderingOptions['templatePathAndFilename']);
         }
         $renderingGroup = $this->resolveRenderingGroup($exception);
         if ($renderingGroup !== null) {
-            $useCustomErrorView = true;
             $renderingOptions = Arrays::arrayMergeRecursiveOverrule($renderingOptions, $this->options['renderingGroups'][$renderingGroup]['options']);
             $renderingOptions['renderingGroup'] = $renderingGroup;
         }
-        $this->useCustomErrorView = $useCustomErrorView;
         return $renderingOptions;
     }
 

--- a/Neos.Flow/Classes/Error/DebugExceptionHandler.php
+++ b/Neos.Flow/Classes/Error/DebugExceptionHandler.php
@@ -64,7 +64,7 @@ EOD;
             header(sprintf('HTTP/1.1 %s %s', $statusCode, $statusMessage));
         }
 
-        if (!isset($this->renderingOptions['templatePathAndFilename'])) {
+        if ($this->useCustomErrorView === false) {
             $this->renderStatically($statusCode, $exception);
             return;
         }

--- a/Neos.Flow/Classes/Error/DebugExceptionHandler.php
+++ b/Neos.Flow/Classes/Error/DebugExceptionHandler.php
@@ -64,8 +64,7 @@ EOD;
             header(sprintf('HTTP/1.1 %s %s', $statusCode, $statusMessage));
         }
 
-        $useCustomErrorView = isset($this->renderingOptions['templatePathAndFilename']) || isset($this->renderingOptions['renderingGroup']);
-        if ($useCustomErrorView === false) {
+        if ($this->useCustomErrorView() === false) {
             $this->renderStatically($statusCode, $exception);
             return;
         }

--- a/Neos.Flow/Classes/Error/DebugExceptionHandler.php
+++ b/Neos.Flow/Classes/Error/DebugExceptionHandler.php
@@ -64,7 +64,8 @@ EOD;
             header(sprintf('HTTP/1.1 %s %s', $statusCode, $statusMessage));
         }
 
-        if ($this->useCustomErrorView === false) {
+        $useCustomErrorView = isset($this->renderingOptions['templatePathAndFilename']) || isset($this->renderingOptions['renderingGroup']);
+        if ($useCustomErrorView === false) {
             $this->renderStatically($statusCode, $exception);
             return;
         }

--- a/Neos.Flow/Classes/Error/ProductionExceptionHandler.php
+++ b/Neos.Flow/Classes/Error/ProductionExceptionHandler.php
@@ -37,8 +37,7 @@ class ProductionExceptionHandler extends AbstractExceptionHandler
         }
 
         try {
-            $useCustomErrorView = isset($this->renderingOptions['templatePathAndFilename']) || isset($this->renderingOptions['renderingGroup']);
-            if ($useCustomErrorView) {
+            if ($this->useCustomErrorView()) {
                 try {
                     echo $this->buildView($exception, $this->renderingOptions)->render();
                 } catch (\Throwable $throwable) {

--- a/Neos.Flow/Classes/Error/ProductionExceptionHandler.php
+++ b/Neos.Flow/Classes/Error/ProductionExceptionHandler.php
@@ -37,7 +37,7 @@ class ProductionExceptionHandler extends AbstractExceptionHandler
         }
 
         try {
-            if (isset($this->renderingOptions['templatePathAndFilename'])) {
+            if ($this->useCustomErrorView === true) {
                 try {
                     echo $this->buildView($exception, $this->renderingOptions)->render();
                 } catch (\Throwable $throwable) {

--- a/Neos.Flow/Classes/Error/ProductionExceptionHandler.php
+++ b/Neos.Flow/Classes/Error/ProductionExceptionHandler.php
@@ -37,7 +37,8 @@ class ProductionExceptionHandler extends AbstractExceptionHandler
         }
 
         try {
-            if ($this->useCustomErrorView === true) {
+            $useCustomErrorView = isset($this->renderingOptions['templatePathAndFilename']) || isset($this->renderingOptions['renderingGroup']);
+            if ($useCustomErrorView) {
                 try {
                     echo $this->buildView($exception, $this->renderingOptions)->render();
                 } catch (\Throwable $throwable) {


### PR DESCRIPTION
resolves: #1108

previously, a custom error view is for rendering groups only used if `templatePathAndFilename` is set. See #1108

**A custom view will now be used if ...**
-  ... there is a matching rendering group (no further checks. It *could* be also a rendering group with empty options (no viewClassName or viewOptions) ... what would then trow an error probably - depending on the view)
- ... `defaultRenderingOptions.templatePathAndFilename` passes isset() (to not change previous working behaviour - should get depreceated sometime)

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
