### PR TITLE
TASK: Fix step to automatically update psalm baseline on merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,11 +155,13 @@ jobs:
           ./flow routing:list
 
       - name: Static analysis
+        id: psalm
         if: matrix.static-analysis == 'psalm'
+        continue-on-error: true
         run: composer test-static
 
       - name: Update psalm baseline
-        if: ${{ failure() && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true }}
+        if: ${{ steps.psalm.outcome != 'success' && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true }}
         run: |
           composer psalm-baseline-update
           cd ./Packages/Framework


### PR DESCRIPTION
🤞 still the force push will not work like that - see https://github.community/t/how-to-push-to-protected-branches-in-a-github-action/16101/47 - we'd need a bot user with a personal access token and force-push rights that we make accessible to this workflow via GH secrets. That in turn means anyone with rights to edit this workflow can potentially force-push to protected branches via scripting.