### PR TITLE
BUGFIX: Wrong port assigned in applyTo()

### DIFF
--- a/Neos.Flow/Classes/Mvc/Routing/Dto/UriConstraints.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Dto/UriConstraints.php
@@ -337,7 +337,7 @@ final class UriConstraints
                 $uri = $uri->withHost($baseUri->getHost());
             }
             if (empty($uri->getPort()) && !isset($this->constraints[self::CONSTRAINT_PORT])) {
-                $port = $baseUri->getPort() ?? UriHelper::getDefaultPortForScheme($baseUri->getScheme());
+                $port = $baseUri->getPort() ?? UriHelper::getDefaultPortForScheme($uri->getScheme());
                 $uri = $uri->withPort($port);
             }
         }

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/UriConstraintsTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/UriConstraintsTest.php
@@ -37,7 +37,8 @@ class UriConstraintsTest extends UnitTestCase
     {
         return [
             ['constraints' => [UriConstraints::CONSTRAINT_SCHEME => 'http'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => '/'],
-            ['constraints' => [UriConstraints::CONSTRAINT_SCHEME => 'https'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => 'https://some-domain.tld:80/'],
+            ['constraints' => [UriConstraints::CONSTRAINT_SCHEME => 'https'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => 'https://some-domain.tld/'],
+            ['constraints' => [UriConstraints::CONSTRAINT_SCHEME => 'https', UriConstraints::CONSTRAINT_PORT => 80], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => 'https://some-domain.tld:80/'],
 
             ['constraints' => [UriConstraints::CONSTRAINT_HOST => 'some-domain.tld'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => '/'],
             ['constraints' => [UriConstraints::CONSTRAINT_HOST => 'some-other-domain.tld'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => 'http://some-other-domain.tld/'],


### PR DESCRIPTION
This fixes the following:

- given an HTTPS connection to a proxy that passes the request handling to a server via HTTP
- given a shortcut node pointing to `http://www.acme.com`
- will result in `http://www.acme.com:443` leading to errors

This fixes it by using the (at this point already set!) scheme of the `$uri` to fill in the standard
port.
