### PR TITLE
!!!TASK: Make AbstractConditionViewHelper PHP 8.1 compatible

### DIFF
--- a/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractConditionViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractConditionViewHelper.php
@@ -71,7 +71,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
      * @return boolean
      * @api
      */
-    protected static function evaluateCondition($arguments, RenderingContextInterface $renderingContext)
+    protected static function evaluateCondition(RenderingContextInterface $renderingContext, ?array $arguments)
     {
         return (boolean)$arguments['condition'];
     }
@@ -84,7 +84,7 @@ abstract class AbstractConditionViewHelper extends AbstractViewHelper
      */
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
-        if (static::evaluateCondition($arguments, $renderingContext)) {
+        if (static::evaluateCondition($renderingContext, $arguments)) {
             if (isset($arguments['then'])) {
                 return $arguments['then'];
             }

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Security/IfAccessViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Security/IfAccessViewHelper.php
@@ -72,7 +72,7 @@ class IfAccessViewHelper extends AbstractConditionViewHelper
      */
     public function render()
     {
-        if (static::evaluateCondition($this->arguments, $this->renderingContext)) {
+        if (static::evaluateCondition($this->renderingContext, $this->arguments)) {
             return $this->renderThenChild();
         }
 
@@ -87,15 +87,15 @@ class IfAccessViewHelper extends AbstractConditionViewHelper
      */
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
-        return static::renderResult(static::evaluateCondition($arguments, $renderingContext), $arguments, $renderingContext);
+        return static::renderResult(static::evaluateCondition($renderingContext, $arguments), $arguments, $renderingContext);
     }
 
     /**
-     * @param null $arguments
+     * @param array|null $arguments
      * @param RenderingContextInterface $renderingContext
      * @return boolean
      */
-    protected static function evaluateCondition($arguments, RenderingContextInterface $renderingContext)
+    protected static function evaluateCondition(RenderingContextInterface $renderingContext, ?array $arguments)
     {
         $objectManager = $renderingContext->getObjectManager();
         /** @var Context $securityContext */

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Security/IfAuthenticatedViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Security/IfAuthenticatedViewHelper.php
@@ -57,7 +57,7 @@ class IfAuthenticatedViewHelper extends AbstractConditionViewHelper
      */
     public function render()
     {
-        if (static::evaluateCondition($this->arguments, $this->renderingContext)) {
+        if (static::evaluateCondition($this->renderingContext, $this->arguments)) {
             return $this->renderThenChild();
         }
 
@@ -65,11 +65,11 @@ class IfAuthenticatedViewHelper extends AbstractConditionViewHelper
     }
 
     /**
-     * @param null $arguments
+     * @param array|null $arguments
      * @param RenderingContextInterface $renderingContext
      * @return bool
      */
-    protected static function evaluateCondition($arguments, RenderingContextInterface $renderingContext)
+    protected static function evaluateCondition(RenderingContextInterface $renderingContext, ?array $arguments)
     {
         $objectManager = $renderingContext->getObjectManager();
         /** @var Context $securityContext */

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Security/IfHasRoleViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Security/IfHasRoleViewHelper.php
@@ -95,7 +95,7 @@ class IfHasRoleViewHelper extends AbstractConditionViewHelper
      */
     public function render()
     {
-        if (static::evaluateCondition($this->arguments, $this->renderingContext)) {
+        if (static::evaluateCondition($this->renderingContext, $this->arguments)) {
             return $this->renderThenChild();
         }
 
@@ -103,11 +103,11 @@ class IfHasRoleViewHelper extends AbstractConditionViewHelper
     }
 
     /**
-     * @param null $arguments
+     * @param array|null $arguments
      * @param RenderingContextInterface $renderingContext
      * @return boolean
      */
-    protected static function evaluateCondition($arguments, RenderingContextInterface $renderingContext)
+    protected static function evaluateCondition(RenderingContextInterface $renderingContext, ?array $arguments)
     {
         $objectManager = $renderingContext->getObjectManager();
         /** @var PolicyService $policyService */

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Validation/IfHasErrorsViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Validation/IfHasErrorsViewHelper.php
@@ -64,7 +64,7 @@ class IfHasErrorsViewHelper extends AbstractConditionViewHelper
      */
     public function render()
     {
-        if (self::evaluateCondition($this->arguments, $this->renderingContext)) {
+        if (self::evaluateCondition($this->renderingContext, $this->arguments)) {
             return $this->renderThenChild();
         } else {
             return $this->renderElseChild();
@@ -72,11 +72,11 @@ class IfHasErrorsViewHelper extends AbstractConditionViewHelper
     }
 
     /**
-     * @param null $arguments
+     * @param array|null $arguments
      * @param FlowAwareRenderingContextInterface|RenderingContextInterface $renderingContext
      * @return boolean
      */
-    protected static function evaluateCondition($arguments, RenderingContextInterface $renderingContext)
+    protected static function evaluateCondition(RenderingContextInterface $renderingContext, ?array $arguments)
     {
         /** @var ActionRequest $request */
         /** @var FlowAwareRenderingContextInterface $renderingContext */


### PR DESCRIPTION
Required parameters after optional parameters are deprecated since PHP 8.0

See https://php.watch/versions/8.0/deprecate-required-param-after-optional

Needs changes in the Neos project aswell.

**What I did**
Makes the AbstractConditionViewHelper compatible with PHP 8.1

**How I did it**
Changed order of parameters for the evaluateCondition method.

**How to verify it**
Run tests.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
