### PR TITLE
TASK: Take __toString into account for resolving uri value

### DIFF
--- a/Neos.Flow/Classes/Mvc/Routing/DynamicRoutePart.php
+++ b/Neos.Flow/Classes/Mvc/Routing/DynamicRoutePart.php
@@ -227,7 +227,13 @@ class DynamicRoutePart extends AbstractRoutePart implements DynamicRoutePartInte
             return false;
         }
         if (is_object($value)) {
-            $value = $this->persistenceManager->getIdentifierByObject($value);
+            $identifier = $this->persistenceManager->getIdentifierByObject($value);
+
+            if ($identifier === null && method_exists($value, '__toString')) {
+                $identifier = (string) $value;
+            }
+            $value = $identifier;
+
             if ($value === null || (!is_string($value) && !is_integer($value))) {
                 return false;
             }

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/DynamicRoutePartTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/DynamicRoutePartTest.php
@@ -15,6 +15,7 @@ use Neos\Flow\Mvc\Routing\Dto\ResolveResult;
 use Neos\Flow\Mvc\Routing\DynamicRoutePart;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Tests\Unit\Mvc\Routing\Fixtures\UriArgumentObjectWithToString;
 
 /**
  * Testcase for the MVC Web Routing DynamicRoutePart Class
@@ -394,6 +395,15 @@ class DynamicRoutePartTest extends UnitTestCase
         $object = new \stdClass();
         $this->mockPersistenceManager->expects(self::once())->method('getIdentifierByObject')->with($object)->will(self::returnValue(null));
         self::assertFalse($this->dynamicRoutPart->_call('resolveValue', $object));
+    }
+
+    /**
+     * @test
+     */
+    public function resolveValueReturnsToStringValueOfObjectNotAvailableFromPersistenceManager()
+    {
+        $resolveResult = $this->dynamicRoutPart->_call('resolveValue', new UriArgumentObjectWithToString());
+        self::assertSame('string%20to%20identify%20object', $resolveResult->getResolvedValue());
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Fixtures/UriArgumentObjectWithToString.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Fixtures/UriArgumentObjectWithToString.php
@@ -1,0 +1,22 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Mvc\Routing\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+class UriArgumentObjectWithToString
+{
+    protected string $identifier = 'String To Identify Object';
+
+    public function __toString(): string
+    {
+        return $this->identifier;
+    }
+}


### PR DESCRIPTION
When resolving values for a route via DynamicRoutePart, object are only being looked up in the persistence manager.

With this change, we honour if a identifier is found, and if not, we look at the object to see, if it has a `__toString` method available, to give us a value.

This is backward compatible, since we respect the identifier, if given at first

Reolves #2658 