### PR TITLE
BUGFIX: Fix PHP 8.1 compatibility of flow.php script

### DIFF
--- a/Neos.Flow/Scripts/flow.php
+++ b/Neos.Flow/Scripts/flow.php
@@ -55,8 +55,8 @@ if (isset($argv[1]) && ($argv[1] === 'neos.flow:core:setfilepermissions' || $arg
         $_SERVER['FLOW_ROOTPATH'] = trim(getenv('FLOW_ROOTPATH'), '"\' ') ?: dirname($_SERVER['PHP_SELF']);
     }
 
-    $context = trim(\Neos\Flow\Core\Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT'), '"\' ') ?: 'Development';
+    $context = \Neos\Flow\Core\Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT') ?: 'Development';
 
-    $bootstrap = new \Neos\Flow\Core\Bootstrap($context, $composerAutoloader);
+    $bootstrap = new \Neos\Flow\Core\Bootstrap(trim($context, '"\' '), $composerAutoloader);
     $bootstrap->run();
 }

--- a/Neos.Flow/Scripts/flow.php
+++ b/Neos.Flow/Scripts/flow.php
@@ -55,7 +55,7 @@ if (isset($argv[1]) && ($argv[1] === 'neos.flow:core:setfilepermissions' || $arg
         $_SERVER['FLOW_ROOTPATH'] = trim(getenv('FLOW_ROOTPATH'), '"\' ') ?: dirname($_SERVER['PHP_SELF']);
     }
 
-    $context = \Neos\Flow\Core\Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT') ?: 'Development';
+    $context = trim((string)\Neos\Flow\Core\Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT'), '"\' ') ?: 'Development';
 
     $bootstrap = new \Neos\Flow\Core\Bootstrap(trim($context, '"\' '), $composerAutoloader);
     $bootstrap->run();

--- a/Neos.Flow/Scripts/flow.php
+++ b/Neos.Flow/Scripts/flow.php
@@ -57,6 +57,6 @@ if (isset($argv[1]) && ($argv[1] === 'neos.flow:core:setfilepermissions' || $arg
 
     $context = trim((string)\Neos\Flow\Core\Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT'), '"\' ') ?: 'Development';
 
-    $bootstrap = new \Neos\Flow\Core\Bootstrap(trim($context, '"\' '), $composerAutoloader);
+    $bootstrap = new \Neos\Flow\Core\Bootstrap($context, $composerAutoloader);
     $bootstrap->run();
 }


### PR DESCRIPTION
Without this fix, every interaction with Flow/Neos on PHP 8.1 will lead to a Deprecation warning:

```
PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in /Packages/Framework/Neos.Flow/Scripts/flow.php on line 68

Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /Packages/Framework/Neos.Flow/Scripts/flow.php on line 68
```
