### PR TITLE
BUGFIX: Add doctrine/annotation as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "doctrine/migrations": "^3.0",
         "doctrine/dbal": "^2.12",
         "doctrine/common": "^2.13.1 || ^3.0",
+        "doctrine/annotations": "^1.12",
         "symfony/yaml": "^5.1",
         "symfony/dom-crawler": "^5.1",
         "symfony/console": "^5.1",


### PR DESCRIPTION
Prevents exception in booting flow, as it is requiring the 'Doctrine\Common\Annotations\AnnotationRegistry'

fixes: #2673