### PR TITLE
BUGFIX: Don't access uninitialized property in Debugger

### DIFF
--- a/Neos.Flow/Classes/Error/Debugger.php
+++ b/Neos.Flow/Classes/Error/Debugger.php
@@ -290,7 +290,11 @@ class Debugger
                     $dump .= chr(10);
                     $dump .= str_repeat(' ', $level) . ($plaintext ? '' : '<span class="debug-property">') . self::ansiEscapeWrap($property->getName(), '36', $ansiColors) . ($plaintext ? '' : '</span>') . ' => ';
                     $property->setAccessible(true);
-                    $value = $property->getValue($object);
+                    if (PHP_VERSION_ID >= 70400 && $property->isInitialized($object) === false) {
+                        $value = null;
+                    } else {
+                        $value = $property->getValue($object);
+                    }
                     if (is_array($value)) {
                         $dump .= self::renderDump($value, $level + 1, $plaintext, $ansiColors);
                     } elseif (is_object($value)) {

--- a/Neos.Flow/Tests/Unit/Error/DebuggerTest.php
+++ b/Neos.Flow/Tests/Unit/Error/DebuggerTest.php
@@ -62,4 +62,25 @@ class DebuggerTest extends UnitTestCase
         $object = new ApplicationContext('Development');
         self::assertEquals('Neos\Flow\Core\ApplicationContext object', Debugger::renderDump($object, 0, true));
     }
+
+    /**
+     * @test
+     */
+    public function uninitializedTypedPropertiesAreNotAccessed()
+    {
+        if (PHP_VERSION_ID < 70400) {
+            self::markTestSkipped('Test only works on PHP 7.4 and above');
+        }
+        // if the test fails, an exception raises an error, no assertion needed
+        $this->expectNotToPerformAssertions();
+
+        $className = 'TestClass' . md5(uniqid(mt_rand(), true));
+        eval('
+            class ' . $className . ' {
+                public string $stringProperty;
+            }
+        ');
+        $object = new $className();
+        Debugger::renderDump($object, 1, true);
+    }
 }


### PR DESCRIPTION
Fixes #2664
