### PR TITLE
TASK: Improve ThrowableStorage docblocks

### DIFF
--- a/Neos.Flow/Classes/Log/ThrowableStorage/FileStorage.php
+++ b/Neos.Flow/Classes/Log/ThrowableStorage/FileStorage.php
@@ -112,6 +112,13 @@ class FileStorage implements ThrowableStorageInterface
     }
 
     /**
+     * Stores information about the given exception and returns information about
+     * the exception and where the details have been stored. The returned message
+     * can be logged or displayed as needed.
+     *
+     * The returned message follows this pattern:
+     * Exception #<code> in <line> of <file>: <message> - See also: <dumpFilename>
+     *
      * @param \Throwable $throwable
      * @param array $additionalData
      * @return string Informational message about the stored throwable

--- a/Neos.Flow/Classes/Log/ThrowableStorageInterface.php
+++ b/Neos.Flow/Classes/Log/ThrowableStorageInterface.php
@@ -2,15 +2,15 @@
 namespace Neos\Flow\Log;
 
 /**
- * An interface for storages that can log full exceptions and their stacktraces.
+ * An interface for storages that can store full exceptions and their stack traces.
  *
  * @api
  */
 interface ThrowableStorageInterface
 {
     /**
-     *
      * A factory method to create an instance of the throwable storage.
+     *
      * Note that throwable storages must work without proxy so all dependencies need to be resolved manually or via options.
      *
      * @param array $options
@@ -20,7 +20,9 @@ interface ThrowableStorageInterface
 
 
     /**
-     * Writes information about the given exception into the log.
+     * Stores information about the given exception and returns information about
+     * the exception and where the details have been stored. The returned message
+     * can be logged or displayed as needed.
      *
      * @param \Throwable $throwable The throwable to log
      * @param array $additionalData Additional data to log


### PR DESCRIPTION
This clarifies the use of `logThrowable()` from `ThrowableStorage` and
`ThrowableStorageInterface`.