### PR TITLE
TASK: Return 400 response when HMAC validation fails

### DIFF
--- a/Neos.Flow/Classes/Mvc/Controller/ActionController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ActionController.php
@@ -154,10 +154,9 @@ class ActionController extends AbstractController
     protected $logger;
 
     /**
-     * @Flow\Inject
      * @var ThrowableStorageInterface
      */
-    protected $throwableStorage;
+    private $throwableStorage;
 
     /**
      * @param array $settings
@@ -177,6 +176,17 @@ class ActionController extends AbstractController
     public function injectLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
+    }
+
+    /**
+     * Injects the throwable storage.
+     *
+     * @param ThrowableStorageInterface $throwableStorage
+     * @return void
+     */
+    public function injectThrowableStorage(ThrowableStorageInterface $throwableStorage)
+    {
+        $this->throwableStorage = $throwableStorage;
     }
 
     /**

--- a/Neos.Flow/Classes/Mvc/Controller/ActionController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ActionController.php
@@ -15,6 +15,7 @@ use Neos\Error\Messages\Result;
 use Neos\Flow\Annotations as Flow;
 use Neos\Error\Messages as Error;
 use Neos\Flow\Http\Component\ReplaceHttpResponseComponent;
+use Neos\Flow\Log\ThrowableStorageInterface;
 use Neos\Flow\Log\Utility\LogEnvironment;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\ActionResponse;
@@ -30,6 +31,8 @@ use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Property\Exception\TargetNotFoundException;
 use Neos\Flow\Property\TypeConverter\Error\TargetNotFoundError;
 use Neos\Flow\Reflection\ReflectionService;
+use Neos\Flow\Security\Exception\InvalidArgumentForHashGenerationException;
+use Neos\Flow\Security\Exception\InvalidHashException;
 use Neos\Utility\TypeHandling;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -151,6 +154,12 @@ class ActionController extends AbstractController
     protected $logger;
 
     /**
+     * @Flow\Inject
+     * @var ThrowableStorageInterface
+     */
+    protected $throwableStorage;
+
+    /**
      * @param array $settings
      * @return void
      */
@@ -198,7 +207,13 @@ class ActionController extends AbstractController
         if (method_exists($this, $actionInitializationMethodName)) {
             call_user_func([$this, $actionInitializationMethodName]);
         }
-        $this->mvcPropertyMappingConfigurationService->initializePropertyMappingConfigurationFromRequest($this->request, $this->arguments);
+        try {
+            $this->mvcPropertyMappingConfigurationService->initializePropertyMappingConfigurationFromRequest($this->request, $this->arguments);
+        } catch (InvalidArgumentForHashGenerationException|InvalidHashException $e) {
+            $message = $this->throwableStorage->logThrowable($e);
+            $this->logger->notice('Property mapping configuration failed due to HMAC errors. ' . $message, LogEnvironment::fromMethodName(__METHOD__));
+            $this->throwStatus(400, '400 Bad Request', 'Invalid HMAC submitted');
+        }
 
         $this->mapRequestArgumentsToControllerArguments();
 

--- a/Neos.Flow/Classes/Mvc/Controller/MvcPropertyMappingConfigurationService.php
+++ b/Neos.Flow/Classes/Mvc/Controller/MvcPropertyMappingConfigurationService.php
@@ -17,6 +17,7 @@ use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
 use Neos\Flow\Security\Cryptography\HashService;
 use Neos\Flow\Security\Exception\InvalidArgumentForHashGenerationException;
+use Neos\Flow\Security\Exception\InvalidHashException;
 
 /**
  * This is a Service which can generate a request hash and check whether the currently given arguments
@@ -106,7 +107,6 @@ class MvcPropertyMappingConfigurationService
         return $this->hashService->appendHmac($serializedFormFieldArray);
     }
 
-
     /**
      * Initialize the property mapping configuration in $controllerArguments if
      * the trusted properties are set inside the request.
@@ -114,6 +114,9 @@ class MvcPropertyMappingConfigurationService
      * @param ActionRequest $request
      * @param Arguments $controllerArguments
      * @return void
+     * @throws InvalidArgumentForHashGenerationException
+     * @throws InvalidHashException
+     * @throws \Neos\Flow\Mvc\Exception\NoSuchArgumentException
      */
     public function initializePropertyMappingConfigurationFromRequest(ActionRequest $request, Arguments $controllerArguments)
     {

--- a/Neos.FluidAdaptor/Tests/Functional/Form/FormObjectsTest.php
+++ b/Neos.FluidAdaptor/Tests/Functional/Form/FormObjectsTest.php
@@ -181,7 +181,7 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
         $form['__trustedProperties']->setValue($form['__trustedProperties']->getValue() . 'a');
         $this->browser->submit($form);
 
-        self::assertSame(500, $this->browser->getLastResponse()->getStatusCode());
+        self::assertSame(400, $this->browser->getLastResponse()->getStatusCode());
     }
 
     /**
@@ -306,7 +306,7 @@ class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
         $form['__trustedProperties']->setValue($form['__trustedProperties']->getValue() . 'a');
         $this->browser->submit($form);
 
-        self::assertSame(500, $this->browser->getLastResponse()->getStatusCode());
+        self::assertSame(400, $this->browser->getLastResponse()->getStatusCode());
     }
 
     /**


### PR DESCRIPTION
When HMAC validation fails during request processing, the controller
will return a response with a status code of 400, as that is caused
by a bad request. The exception is logged with a notice to the log,
to aid in debugging errors

Previously the uncaught exception would cause a status 500 response
and log a critical error.

Fixes #2681
