### PR TITLE
TASK: Return 400 response if required argument is missing

### DIFF
--- a/Neos.Flow/Classes/Mvc/Controller/ActionController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ActionController.php
@@ -153,10 +153,9 @@ class ActionController extends AbstractController
     protected $logger;
 
     /**
-     * @Flow\Inject
      * @var ThrowableStorageInterface
      */
-    protected $throwableStorage;
+    private $throwableStorage;
 
     /**
      * @param array $settings
@@ -176,6 +175,17 @@ class ActionController extends AbstractController
     public function injectLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
+    }
+
+    /**
+     * Injects the throwable storage.
+     *
+     * @param ThrowableStorageInterface $throwableStorage
+     * @return void
+     */
+    public function injectThrowableStorage(ThrowableStorageInterface $throwableStorage)
+    {
+        $this->throwableStorage = $throwableStorage;
     }
 
     /**

--- a/Neos.Flow/Classes/Mvc/Controller/ActionController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ActionController.php
@@ -223,7 +223,7 @@ class ActionController extends AbstractController
         } catch (InvalidArgumentForHashGenerationException|InvalidHashException $e) {
             $message = $this->throwableStorage->logThrowable($e);
             $this->logger->notice('Property mapping configuration failed due to HMAC errors. ' . $message, LogEnvironment::fromMethodName(__METHOD__));
-            $this->throwStatus(400, '400 Bad Request', 'Invalid HMAC submitted');
+            $this->throwStatus(400, null, 'Invalid HMAC submitted');
         }
 
         try {
@@ -231,7 +231,7 @@ class ActionController extends AbstractController
         } catch (RequiredArgumentMissingException $e) {
             $message = $this->throwableStorage->logThrowable($e);
             $this->logger->notice('Request argument mapping failed due to a missing required argument. ' . $message, LogEnvironment::fromMethodName(__METHOD__));
-            $this->throwStatus(400, '400 Bad Request', 'Required argument is missing');
+            $this->throwStatus(400, null, 'Required argument is missing');
         }
 
         if ($this->view === null) {

--- a/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
@@ -398,46 +398,43 @@ class ActionControllerTest extends FunctionalTestCase
      */
     public function argumentTestsDataProvider()
     {
-        $requiredArgumentExceptionText = 'Uncaught Exception in Flow #1298012500: Required argument "argument" is not set.';
-        $data = [
-            'required string            '       => ['requiredString', 'some String', '\'some String\''],
-            'required string - missing value'   => ['requiredString', null, $requiredArgumentExceptionText],
-            'optional string'                   => ['optionalString', '123', '\'123\''],
-            'optional string - default'         => ['optionalString', null, '\'default\''],
-            'optional string - nullable'        => ['optionalNullableString', null, 'NULL'],
-            'required integer'                  => ['requiredInteger', '234', 234],
-            'required integer - missing value'  => ['requiredInteger', null, $requiredArgumentExceptionText],
-            'required integer - mapping error'  => ['requiredInteger', 'not an integer', 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->requiredIntegerAction().'],
-            'required integer - empty value'    => ['requiredInteger', '', 'NULL'],
-            'optional integer'                  => ['optionalInteger', 456, 456],
-            'optional integer - default value'  => ['optionalInteger', null, 123],
-            'optional integer - mapping error'  => ['optionalInteger', 'not an integer', 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->optionalIntegerAction().'],
-            'optional integer - empty value'    => ['optionalInteger', '', 123],
-            'optional integer - nullable'       => ['optionalNullableInteger', null, 'NULL'],
-            'required float'                    => ['requiredFloat', 34.56, 34.56],
-            'required float - integer'          => ['requiredFloat', 485, '485'],
-            'required float - integer2'         => ['requiredFloat', '888', '888'],
-            'required float - missing value'    => ['requiredFloat', null, $requiredArgumentExceptionText],
-            'required float - mapping error'    => ['requiredFloat', 'not a float', 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->requiredFloatAction().'],
-            'required float - empty value'      => ['requiredFloat', '', 'NULL'],
-            'optional float'                    => ['optionalFloat', 78.90, 78.9],
-            'optional float - default value'    => ['optionalFloat', null, 112.34],
-            'optional float - mapping error'    => ['optionalFloat', 'not a float', 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->optionalFloatAction().'],
-            'optional float - empty value'      => ['optionalFloat', '', 112.34],
-            'optional float - nullable'         => ['optionalNullableFloat', null, 'NULL'],
-            'required date'                     => ['requiredDate', ['date' => '1980-12-13', 'dateFormat' => 'Y-m-d'], '1980-12-13'],
-            'required date string'              => ['requiredDate', '1980-12-13T14:22:12+02:00', '1980-12-13'],
-            'required date - missing value'     => ['requiredDate', null, $requiredArgumentExceptionText],
-            'required date - mapping error'     => ['requiredDate', 'no date', 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->requiredDateAction().'],
-            'required date - empty value'       => ['requiredDate', '', 'Uncaught Exception in Flow Argument 1 passed to Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController_Original::requiredDateAction() must be an instance of DateTime, null given'],
-            'optional date string'              => ['optionalDate', '1980-12-13T14:22:12+02:00', '1980-12-13'],
-            'optional date - default value'     => ['optionalDate', null, 'null'],
-            'optional date - mapping error'     => ['optionalDate', 'no date', 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->optionalDateAction().'],
-            'optional date - missing value'     => ['optionalDate', null, 'null'],
-            'optional date - empty value'       => ['optionalDate', '', 'null'],
+        return [
+            'required string            '       => ['requiredString', 'some String', '\'some String\'', 200],
+            'required string - missing value'   => ['requiredString', null, 'Required argument is missing', 400],
+            'optional string'                   => ['optionalString', '123', '\'123\'', 200],
+            'optional string - default'         => ['optionalString', null, '\'default\'', 200],
+            'optional string - nullable'        => ['optionalNullableString', null, 'NULL', 200],
+            'required integer'                  => ['requiredInteger', '234', 234, 200],
+            'required integer - missing value'  => ['requiredInteger', null, 'Required argument is missing', 400],
+            'required integer - mapping error'  => ['requiredInteger', 'not an integer', 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->requiredIntegerAction().', 200],
+            'required integer - empty value'    => ['requiredInteger', '', 'NULL', 200],
+            'optional integer'                  => ['optionalInteger', 456, 456, 200],
+            'optional integer - default value'  => ['optionalInteger', null, 123, 200],
+            'optional integer - mapping error'  => ['optionalInteger', 'not an integer', 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->optionalIntegerAction().', 200],
+            'optional integer - empty value'    => ['optionalInteger', '', 123, 200],
+            'optional integer - nullable'       => ['optionalNullableInteger', null, 'NULL', 200],
+            'required float'                    => ['requiredFloat', 34.56, 34.56, 200],
+            'required float - integer'          => ['requiredFloat', 485, '485', 200],
+            'required float - integer2'         => ['requiredFloat', '888', '888', 200],
+            'required float - missing value'    => ['requiredFloat', null, 'Required argument is missing', 400],
+            'required float - mapping error'    => ['requiredFloat', 'not a float', 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->requiredFloatAction().', 200],
+            'required float - empty value'      => ['requiredFloat', '', 'NULL', 200],
+            'optional float'                    => ['optionalFloat', 78.90, 78.9, 200],
+            'optional float - default value'    => ['optionalFloat', null, 112.34, 200],
+            'optional float - mapping error'    => ['optionalFloat', 'not a float', 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->optionalFloatAction().', 200],
+            'optional float - empty value'      => ['optionalFloat', '', 112.34, 200],
+            'optional float - nullable'         => ['optionalNullableFloat', null, 'NULL', 200],
+            'required date'                     => ['requiredDate', ['date' => '1980-12-13', 'dateFormat' => 'Y-m-d'], '1980-12-13', 200],
+            'required date string'              => ['requiredDate', '1980-12-13T14:22:12+02:00', '1980-12-13', 200],
+            'required date - missing value'     => ['requiredDate', null, 'Required argument is missing', 400],
+            'required date - mapping error'     => ['requiredDate', 'no date', 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->requiredDateAction().', 200],
+            'required date - empty value'       => ['requiredDate', '', 'Uncaught Exception in Flow Argument 1 passed to Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController_Original::requiredDateAction() must be an instance of DateTime, null given', 500],
+            'optional date string'              => ['optionalDate', '1980-12-13T14:22:12+02:00', '1980-12-13', 200],
+            'optional date - default value'     => ['optionalDate', null, 'null', 200],
+            'optional date - mapping error'     => ['optionalDate', 'no date', 'Validation failed while trying to call Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController->optionalDateAction().', 200],
+            'optional date - missing value'     => ['optionalDate', null, 'null', 200],
+            'optional date - empty value'       => ['optionalDate', '', 'null', 200],
         ];
-
-        return $data;
     }
 
     /**
@@ -446,10 +443,11 @@ class ActionControllerTest extends FunctionalTestCase
      * @param string $action
      * @param mixed $argument
      * @param string $expectedResult
+     * @param int $expectedStatusCode
      * @test
      * @dataProvider argumentTestsDataProvider
      */
-    public function argumentTests($action, $argument, $expectedResult)
+    public function argumentTests($action, $argument, $expectedResult, $expectedStatusCode)
     {
         $arguments = [
             'argument' => $argument,
@@ -457,7 +455,8 @@ class ActionControllerTest extends FunctionalTestCase
 
         $uri = str_replace('{@action}', strtolower($action), 'http://localhost/test/mvc/actioncontrollertestb/{@action}');
         $response = $this->browser->request($uri, 'POST', $arguments);
-        self::assertTrue(strpos(trim($response->getBody()->getContents()), (string)$expectedResult) === 0, sprintf('The resulting string did not start with the expected string. Expected: "%s", Actual: "%s"', $expectedResult, $response->getBody()->getContents()));
+        self::assertEquals($expectedStatusCode, $response->getStatusCode());
+        self::assertStringStartsWith((string)$expectedResult, trim($response->getBody()->getContents()));
     }
 
     /**


### PR DESCRIPTION
When a required argument is missing request processing, the controller
will return a response with a status code of 400, as that is caused
by a bad request. The exception is logged with a notice to the log,
to aid in debugging errors.

Previously the uncaught exception would cause a status 500 response
and log a critical error.

Fixes #2682
