### PR TITLE
!!! FEATURE: Implement Psr-18 HTTP\Client

### DIFF
--- a/Neos.Flow/Classes/Http/Client/Browser.php
+++ b/Neos.Flow/Classes/Http/Client/Browser.php
@@ -16,7 +16,9 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\Headers;
 use Neos\Flow\Http\Helper\RequestInformationHelper;
 use Neos\Flow\Http\Helper\UploadedFilesHelper;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
@@ -30,7 +32,7 @@ use Symfony\Component\DomCrawler\Form;
  *
  * @api
  */
-class Browser
+class Browser implements ClientInterface
 {
     /**
      * @var ServerRequestInterface
@@ -202,11 +204,12 @@ class Browser
     /**
      * Sends a prepared request and returns the respective response.
      *
-     * @param ServerRequestInterface $request
+     * @param RequestInterface $request
      * @return ResponseInterface
+     * @throws \Psr\Http\Client\ClientExceptionInterface
      * @api
      */
-    public function sendRequest(ServerRequestInterface $request)
+    public function sendRequest(RequestInterface $request): ResponseInterface
     {
         foreach ($this->automaticRequestHeaders->getAll() as $name => $values) {
             $request = $request->withAddedHeader($name, $values);

--- a/Neos.Flow/Classes/Http/Client/Browser.php
+++ b/Neos.Flow/Classes/Http/Client/Browser.php
@@ -73,6 +73,7 @@ class Browser implements ClientInterface
     protected $automaticRequestHeaders;
 
     /**
+     * @Flow\Inject
      * @var RequestEngineInterface
      */
     protected $requestEngine;

--- a/Neos.Flow/Classes/Http/Client/CurlEngine.php
+++ b/Neos.Flow/Classes/Http/Client/CurlEngine.php
@@ -15,7 +15,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http;
 use Neos\Flow\Http\InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\RequestInterface;
 use GuzzleHttp\Psr7\Message;
 
 /**
@@ -55,13 +55,13 @@ class CurlEngine implements RequestEngineInterface
     /**
      * Sends the given HTTP request
      *
-     * @param ServerRequestInterface $request
+     * @param RequestInterface $request
      * @return ResponseInterface The response or false
      * @api
      * @throws Http\Exception
      * @throws CurlEngineException
      */
-    public function sendRequest(ServerRequestInterface $request): ResponseInterface
+    public function sendRequest(RequestInterface $request): ResponseInterface
     {
         if (!extension_loaded('curl')) {
             throw new Http\Exception('CurlEngine requires the PHP CURL extension to be installed and loaded.', 1346319808);

--- a/Neos.Flow/Classes/Http/Client/CurlEngine.php
+++ b/Neos.Flow/Classes/Http/Client/CurlEngine.php
@@ -57,7 +57,6 @@ class CurlEngine implements RequestEngineInterface
      *
      * @param RequestInterface $request
      * @return ResponseInterface The response or false
-     * @api
      * @throws Http\Exception
      * @throws CurlEngineException
      */

--- a/Neos.Flow/Classes/Http/Client/Exception.php
+++ b/Neos.Flow/Classes/Http/Client/Exception.php
@@ -12,10 +12,10 @@ namespace Neos\Flow\Http\Client;
  */
 
 /**
- * An exception for the Curl Engine
+ * A generic HTTP exception
  *
  * @api
  */
-class CurlEngineException extends Exception
+class Exception extends \Neos\Flow\Http\Exception implements \Psr\Http\Client\ClientExceptionInterface
 {
 }

--- a/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
+++ b/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
@@ -30,6 +30,8 @@ use Neos\Flow\Validation\ValidatorResolver;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestFactoryInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 
 /**
@@ -84,6 +86,12 @@ class InternalRequestEngine implements RequestEngineInterface
 
     /**
      * @Flow\Inject
+     * @var ServerRequestFactoryInterface
+     */
+    protected $serverRequestFactory;
+
+    /**
+     * @Flow\Inject
      * @var ResponseFactoryInterface
      */
     protected $responseFactory;
@@ -105,6 +113,19 @@ class InternalRequestEngine implements RequestEngineInterface
      */
     public function sendRequest(RequestInterface $httpRequest): ResponseInterface
     {
+        // convert RequestInterface to ServerRequestInterface if needed
+        if (!$httpRequest instanceof ServerRequestInterface) {
+            $serverRequest = $this->serverRequestFactory->createServerRequest(
+                $httpRequest->getMethod(),
+                $httpRequest->getUri()
+            );
+            foreach ($httpRequest->getHeaders() as $header => $value) {
+                $serverRequest = $serverRequest->withHeader($header, $value);
+            }
+            $serverRequest = $serverRequest->withBody($httpRequest->getBody());
+            $httpRequest = $serverRequest;
+        }
+
         $requestHandler = $this->bootstrap->getActiveRequestHandler();
         if (!$requestHandler instanceof FunctionalTestRequestHandler) {
             throw new Http\Exception('The browser\'s internal request engine has only been designed for use within functional tests.', 1335523749);
@@ -115,6 +136,10 @@ class InternalRequestEngine implements RequestEngineInterface
         $this->validatorResolver->reset();
 
         $objectManager = $this->bootstrap->getObjectManager();
+
+        /**
+         * @var Http\Middleware\MiddlewaresChain $middlewaresChain
+         */
         $middlewaresChain = $objectManager->get(Http\Middleware\MiddlewaresChain::class);
 
         try {

--- a/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
+++ b/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
@@ -109,7 +109,6 @@ class InternalRequestEngine implements RequestEngineInterface
      * @return ResponseInterface
      * @throws FlowException
      * @throws Http\Exception
-     * @api
      */
     public function sendRequest(RequestInterface $httpRequest): ResponseInterface
     {

--- a/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
+++ b/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
@@ -29,7 +29,7 @@ use Neos\Flow\Tests\FunctionalTestRequestHandler;
 use Neos\Flow\Validation\ValidatorResolver;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 
 /**
@@ -97,13 +97,13 @@ class InternalRequestEngine implements RequestEngineInterface
     /**
      * Sends the given HTTP request
      *
-     * @param ServerRequestInterface $httpRequest
+     * @param RequestInterface $httpRequest
      * @return ResponseInterface
      * @throws FlowException
      * @throws Http\Exception
      * @api
      */
-    public function sendRequest(ServerRequestInterface $httpRequest): ResponseInterface
+    public function sendRequest(RequestInterface $httpRequest): ResponseInterface
     {
         $requestHandler = $this->bootstrap->getActiveRequestHandler();
         if (!$requestHandler instanceof FunctionalTestRequestHandler) {

--- a/Neos.Flow/Classes/Http/Client/RequestEngineInterface.php
+++ b/Neos.Flow/Classes/Http/Client/RequestEngineInterface.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Http\Client;
 
 use Neos\Flow\Http;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * Interface for a Request Engine which can be used by a HTTP Client implementation
@@ -24,9 +24,9 @@ interface RequestEngineInterface
     /**
      * Sends the given HTTP request
      *
-     * @param ServerRequestInterface $request
+     * @param RequestInterface $request
      * @return ResponseInterface
-     * @throws Http\Exception
+     * @throws Http\Client\Exception
      */
-    public function sendRequest(ServerRequestInterface $request): ResponseInterface;
+    public function sendRequest(RequestInterface $request): ResponseInterface;
 }

--- a/Neos.Flow/Configuration/Objects.yaml
+++ b/Neos.Flow/Configuration/Objects.yaml
@@ -212,6 +212,11 @@ Neos\Flow\Monitor\FileMonitor:
 #                                                                          #
 # HTTP                                                                     #
 #                                                                          #
+Psr\Http\Client\ClientInterface:
+  className: Neos\Flow\Http\Client\Browser
+
+Neos\Flow\Http\Client\RequestEngineInterface:
+  className: Neos\Flow\Http\Client\CurlEngine
 
 Psr\Http\Message\ServerRequestFactoryInterface:
   className: Neos\Http\Factories\ServerRequestFactory

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
@@ -569,10 +569,11 @@ You are encouraged to use the ``Uri`` class for your own purposes – you'll get
 Virtual Browser
 ---------------
 
-The HTTP foundation comes with a virtual browser which allows for sending and receiving HTTP requests and responses.
-The browser's API basically follows the functions of a typical web browser. The requests and responses are used in form
-of ``Http\Request`` and ``Http\Response`` instances, similar to the requests and responses used by Flow's request
-handling mechanism.
+The HTTP foundation comes with a virtual browser that implements the ``Psr\Http\Client\ClientInterface`` which allows
+for sending and receiving HTTP requests and responses. The browser's API basically follows the functions of a typical
+web browser. The requests and responses are used in form of ``Psr\Http\Message\RequestInterface`` and
+``\Psr\Http\Message\ResponseInterface`` instances, similar to the requests and responses used by Flow's
+request handling mechanism.
 
 Request Engines
 ~~~~~~~~~~~~~~~
@@ -580,8 +581,8 @@ Request Engines
 The engine responsible for actually sending the request is pluggable. Currently there are two engines delivered with
 Flow:
 
+* ``CurlEngine`` (Default) uses the cURL extension to send real requests to other servers
 * ``InternalRequestEngine`` simulates requests for use in functional tests
-* ``CurlEngine`` uses the cURL extension to send real requests to other servers
 
 Sending a request and processing the response is a matter of a few lines::
 
@@ -598,24 +599,45 @@ Sending a request and processing the response is a matter of a few lines::
 		protected $browser;
 
 		/**
-		 * @Flow\Inject
-		 * @var \Neos\Flow\Http\Client\CurlEngine
+		 * Some action
 		 */
-		protected $browserRequestEngine;
+		public function testAction(): string
+		{
+			$response = $this->browser->request('https://www.flowframework.io');
+			return ($response->hasHeader('X-Flow-Powered') ? 'yes' : 'no');
+		}
+	}
+
+The same request can also be performed by purely relying on psr interfaces implemented by Neos::
+
+	/**
+	 * A sample controller
+	 */
+	class MyController extends ActionController
+	{
+
+		/**
+		 * @Flow\Inject
+		 * @var \Psr\Http\Client\ClientInterface
+		 */
+		protected $client;
+
+		/**
+		 * @Flow\Inject
+		 * @var \Psr\Http\Message\RequestFactoryInterface
+		 */
+		protected $requestFactory;
 
 		/**
 		 * Some action
 		 */
 		public function testAction(): string
 		{
-			$this->browser->setRequestEngine($this->browserRequestEngine);
-			$response = $this->browser->request('https://www.flowframework.io');
+		  $request = $this->requestFactory->createRequest('get', 'https://www.flowframework.io');
+			$response = $this->client->request($request);
 			return ($response->hasHeader('X-Flow-Powered') ? 'yes' : 'no');
 		}
 	}
-
-As there is no default engine selected for the browser, you need to set one yourself. Of course you can use the advanced
-Dependency Injection techniques (through Objects.yaml) for injecting an engine into the browser you use.
 
 Also note that the virtual browser is of scope Prototype in order to support multiple browsers with possibly different
 request engines.

--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -33,6 +33,7 @@
         "psr/log": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "psr/http-server-handler": "^1.0",
+        "psr/http-client": "^1.0",
 
         "ramsey/uuid": "^3.0 || ^4.0",
 

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "psr/container": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "psr/http-server-handler": "^1.0",
+        "psr/http-client": "^1.0",
         "ramsey/uuid": "^3.0 || ^4.0",
         "doctrine/orm": "^2.9.3",
         "doctrine/migrations": "^3.0",


### PR DESCRIPTION
The `Neos\Flow\Http\Client\Browser` now implements the `Psr\Http\Client\ClientInterface` and works with dependency injection by default.

The signature of the method sendRequest is relaxed slightly from ServerRequestInterface to RequestInterface and the curl requestEngine is injected by default. That way any browser is ready for use from the start.

Internally the request engines now also use the RequestInterface instead of ServerRequestInterface.
This should be almost non breaky because changes ServerRequestInterface is still allowed as it extends the RequestInterface. The InternalRequestEngide will upcast the RequestInterfaces to ServerRequestInterface when needed.

!!!The PR removes the @api annotation from the requestEngines to allow us to remove or alter those in the future.

Resolves: #2691 

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] Docs are adjusted
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
