### PR TITLE
FEATURE: Add methods getSimpleCache PSR-16 and getCacheItemPool PSR-6 to the cacheManager

### DIFF
--- a/Neos.Flow/Classes/Cache/CacheManager.php
+++ b/Neos.Flow/Classes/Cache/CacheManager.php
@@ -22,7 +22,11 @@ use Neos\Flow\Log\Utility\LogEnvironment;
 use Neos\Flow\Utility\Environment;
 use Neos\Utility\Files;
 use Neos\Flow\Utility\PhpAnalyzer;
+use Neos\Cache\Psr\Cache\CachePool;
+use Neos\Cache\Psr\SimpleCache\SimpleCache;
 use Psr\Log\LoggerInterface;
+use Psr\SimpleCache\CacheInterface;
+use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * The Cache Manager
@@ -53,9 +57,19 @@ class CacheManager
     protected $environment;
 
     /**
-     * @var array
+     * @var FrontendInterface[]
      */
     protected $caches = [];
+
+    /**
+     * @var CacheInterface[]
+     */
+    protected $simpleCaches = [];
+
+    /**
+     * @var CacheItemPoolInterface[]
+     */
+    protected $cacheItemPools = [];
 
     /**
      * @var array
@@ -178,6 +192,42 @@ class CacheManager
         }
 
         return $this->caches[$identifier];
+    }
+
+    /**
+     * Return a SimpleCache frontend for the cache specified by $identifier
+     *
+     * @param string $identifier
+     * @return CacheInterface
+     */
+    public function getSimpleCache(string $identifier): CacheInterface
+    {
+        if (isset($this->simpleCaches[$identifier])) {
+            return $this->simpleCaches[$identifier];
+        }
+
+        $cache = $this->getCache($identifier);
+        $simpleCache = new SimpleCache($identifier, $cache->getBackend());
+        $this->simpleCaches[$identifier] = $simpleCache;
+        return $simpleCache;
+    }
+
+    /**
+     * Return a SimpleCache frontend for the cache specified by $identifier
+     *
+     * @param string $identifier
+     * @return CacheItemPoolInterface
+     */
+    public function getCacheItemPool(string $identifier): CacheItemPoolInterface
+    {
+        if (isset($this->cacheItemPools[$identifier])) {
+            return $this->cacheItemPools[$identifier];
+        }
+
+        $cache = $this->getCache($identifier);
+        $cacheItemPool = new CachePool($identifier, $cache->getBackend());
+        $this->cacheItemPools[$identifier] = $cacheItemPool;
+        return $cacheItemPool;
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Cache/CacheManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Cache/CacheManagerTest.php
@@ -19,6 +19,8 @@ use Neos\Flow\Monitor\ChangeDetectionStrategy\ChangeDetectionStrategyInterface;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\Utility\Environment;
 use Psr\Log\LoggerInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\SimpleCache\CacheInterface;
 
 /**
  * Testcase for the Cache Manager
@@ -106,6 +108,12 @@ class CacheManagerTest extends UnitTestCase
         $this->cacheManager->registerCache($cache2);
 
         self::assertSame($cache2, $this->cacheManager->getCache('cache2'), 'The cache returned by getCache() was not the same I registered.');
+
+        $cacheItemPool = $this->cacheManager->getCacheItemPool('cache2');
+        self::assertInstanceOf(CacheItemPoolInterface::class, $cacheItemPool);
+
+        $simpleCache = $this->cacheManager->getSimpleCache('cache2');
+        self::assertInstanceOf(CacheInterface::class, $simpleCache);
     }
 
     /**
@@ -121,6 +129,36 @@ class CacheManagerTest extends UnitTestCase
         $this->cacheManager->getCache('someidentifier');
 
         $this->cacheManager->getCache('doesnotexist');
+    }
+
+    /**
+     * @test
+     */
+    public function getCacheItemPoolThrowsExceptionForNonExistingIdentifier()
+    {
+        $this->expectException(Cache\Exception\NoSuchCacheException::class);
+        $cache = $this->getMockBuilder(Cache\Frontend\AbstractFrontend::class)->disableOriginalConstructor()->getMock();
+        $cache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('someidentifier'));
+
+        $this->cacheManager->registerCache($cache);
+        $this->cacheManager->getCacheItemPool('someidentifier');
+
+        $this->cacheManager->getCacheItemPool('doesnotexist');
+    }
+
+    /**
+     * @test
+     */
+    public function getSimpleCacheThrowsExceptionForNonExistingIdentifier()
+    {
+        $this->expectException(Cache\Exception\NoSuchCacheException::class);
+        $cache = $this->getMockBuilder(Cache\Frontend\AbstractFrontend::class)->disableOriginalConstructor()->getMock();
+        $cache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('someidentifier'));
+
+        $this->cacheManager->registerCache($cache);
+        $this->cacheManager->getSimpleCache('someidentifier');
+
+        $this->cacheManager->getSimpleCache('doesnotexist');
     }
 
     /**

--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -33,6 +33,8 @@
         "psr/log": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "psr/http-server-handler": "^1.0",
+        "psr/simple-cache": "^1.0",
+        "psr/cache": "~1.0",
 
         "ramsey/uuid": "^3.0 || ^4.0",
 


### PR DESCRIPTION
The methods create PSR Frontends for the cache with the given identifier. This allows to configure psr caches via
objects and caches yaml. This is an improvement as the included factories are not that easy to use.

The following settings in Objects.yaml allow to inject PSR Caches into Flow Classes:
```
Vendor\Site\Service:

  properties:
    simpleCacheProperty:
      object:
        factoryObjectName: Neos\Flow\Cache\CacheManager
        factoryMethodName: getSimpleCache
        arguments:
          1:
            value: Cache_Identifier_1

    cachePoolProperty:
      object:
        factoryObjectName: Neos\Flow\Cache\CacheManager
        factoryMethodName: getCacheItemPool
        arguments:
          1:
            value: Cache_Identifier_2
```

!!! While possible it is not advisible to access the same cache with multiple Interfaces as the storage formats may differ. !!!

Resolves: #2690 

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] Docs are adjusted
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
