### PR TITLE
TASK: Check if psalm errors disappear with composer < 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/dom-crawler": "^5.1",
         "symfony/console": "^5.1",
         "neos/composer-plugin": "^2.0",
-        "composer/composer": "^1.10.22 || ^2.0.13",
+        "composer/composer": "^1.10.22 || ^2.0.13, <2.2",
         "egulias/email-validator": "^2.1.17 || ^3.0",
         "typo3fluid/fluid": "^2.7.0",
         "guzzlehttp/psr7": "^1.7, !=1.8.0",


### PR DESCRIPTION
Checks if psalm build errors happening since https://github.com/neos/flow-development-collection/actions/runs/1652961637 are only related to composer 2.2