### PR TITLE
Make adjustments to support PHP8.1's stricter type system

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -598,7 +598,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
             $mapping['fieldName'] = $property->getName();
             $mapping['columnName'] = strtolower($property->getName());
             $mapping['targetEntity'] = $propertyMetaData['type'];
-            $mapping['nullable'] = $propertyMetaData['nullable'];
+            $mapping['nullable'] = $propertyMetaData['nullable'] ?? false;
 
             $joinColumns = $this->evaluateJoinColumnAnnotations($property);
 

--- a/Neos.Flow/Classes/Reflection/ClassReflection.php
+++ b/Neos.Flow/Classes/Reflection/ClassReflection.php
@@ -50,6 +50,7 @@ class ClassReflection extends \ReflectionClass
      *
      * @return MethodReflection Method reflection object of the constructor method
      */
+    #[\ReturnTypeWillChange]
     public function getConstructor()
     {
         $parentConstructor = parent::getConstructor();
@@ -63,6 +64,7 @@ class ClassReflection extends \ReflectionClass
      *
      * @return array<ClassReflection> Class reflection objects of the properties in this class
      */
+    #[\ReturnTypeWillChange]
     public function getInterfaces()
     {
         $extendedInterfaces = [];
@@ -81,6 +83,7 @@ class ClassReflection extends \ReflectionClass
      * @param string $name
      * @return MethodReflection Method reflection object of the named method
      */
+    #[\ReturnTypeWillChange]
     public function getMethod($name)
     {
         return new MethodReflection($this->getName(), $name);
@@ -94,6 +97,7 @@ class ClassReflection extends \ReflectionClass
      * @param integer|null $filter A filter mask
      * @return array<MethodReflection> Method reflection objects of the methods in this class
      */
+    #[\ReturnTypeWillChange]
     public function getMethods($filter = null)
     {
         $extendedMethods = [];
@@ -112,6 +116,7 @@ class ClassReflection extends \ReflectionClass
      *
      * @return ClassReflection|false Reflection of the parent class - if any
      */
+    #[\ReturnTypeWillChange]
     public function getParentClass()
     {
         $parentClass = parent::getParentClass();
@@ -144,6 +149,7 @@ class ClassReflection extends \ReflectionClass
      * @param string $name Name of the property
      * @return PropertyReflection Property reflection object of the specified property in this class
      */
+    #[\ReturnTypeWillChange]
     public function getProperty($name)
     {
         return new PropertyReflection($this->getName(), $name);
@@ -200,6 +206,7 @@ class ClassReflection extends \ReflectionClass
      * @see https://github.com/doctrine/doctrine2/commit/530c01b5e3ed7345cde564bd511794ac72f49b65
      * @return object
      */
+    #[\ReturnTypeWillChange]
     public function newInstanceWithoutConstructor()
     {
         $instance = parent::newInstanceWithoutConstructor();

--- a/Neos.Flow/Classes/Reflection/ClassReflection.php
+++ b/Neos.Flow/Classes/Reflection/ClassReflection.php
@@ -50,8 +50,7 @@ class ClassReflection extends \ReflectionClass
      *
      * @return MethodReflection Method reflection object of the constructor method
      */
-    #[\ReturnTypeWillChange]
-    public function getConstructor()
+    public function getConstructor(): MethodReflection
     {
         $parentConstructor = parent::getConstructor();
         return (!is_object($parentConstructor)) ? $parentConstructor : new MethodReflection($this->getName(), $parentConstructor->getName());
@@ -64,8 +63,7 @@ class ClassReflection extends \ReflectionClass
      *
      * @return array<ClassReflection> Class reflection objects of the properties in this class
      */
-    #[\ReturnTypeWillChange]
-    public function getInterfaces()
+    public function getInterfaces(): array
     {
         $extendedInterfaces = [];
         $interfaces = parent::getInterfaces();
@@ -83,8 +81,7 @@ class ClassReflection extends \ReflectionClass
      * @param string $name
      * @return MethodReflection Method reflection object of the named method
      */
-    #[\ReturnTypeWillChange]
-    public function getMethod($name)
+    public function getMethod($name): MethodReflection
     {
         return new MethodReflection($this->getName(), $name);
     }
@@ -97,8 +94,7 @@ class ClassReflection extends \ReflectionClass
      * @param integer|null $filter A filter mask
      * @return array<MethodReflection> Method reflection objects of the methods in this class
      */
-    #[\ReturnTypeWillChange]
-    public function getMethods($filter = null)
+    public function getMethods($filter = null): array
     {
         $extendedMethods = [];
 
@@ -131,7 +127,7 @@ class ClassReflection extends \ReflectionClass
      * @param integer $filter A filter mask
      * @return array<PropertyReflection> Property reflection objects of the properties in this class
      */
-    public function getProperties($filter = null)
+    public function getProperties($filter = null): array
     {
         $extendedProperties = [];
         $properties = ($filter === null ? parent::getProperties() : parent::getProperties($filter));
@@ -149,8 +145,7 @@ class ClassReflection extends \ReflectionClass
      * @param string $name Name of the property
      * @return PropertyReflection Property reflection object of the specified property in this class
      */
-    #[\ReturnTypeWillChange]
-    public function getProperty($name)
+    public function getProperty($name): PropertyReflection
     {
         return new PropertyReflection($this->getName(), $name);
     }
@@ -206,8 +201,7 @@ class ClassReflection extends \ReflectionClass
      * @see https://github.com/doctrine/doctrine2/commit/530c01b5e3ed7345cde564bd511794ac72f49b65
      * @return object
      */
-    #[\ReturnTypeWillChange]
-    public function newInstanceWithoutConstructor()
+    public function newInstanceWithoutConstructor(): object
     {
         $instance = parent::newInstanceWithoutConstructor();
 

--- a/Neos.Flow/Classes/Reflection/MethodReflection.php
+++ b/Neos.Flow/Classes/Reflection/MethodReflection.php
@@ -30,6 +30,7 @@ class MethodReflection extends \ReflectionMethod
      *
      * @return ClassReflection The declaring class
      */
+    #[\ReturnTypeWillChange]
     public function getDeclaringClass()
     {
         return new ClassReflection(parent::getDeclaringClass()->getName());
@@ -42,6 +43,7 @@ class MethodReflection extends \ReflectionMethod
      *
      * @return array<ParameterReflection> objects of the parameters of this method
      */
+    #[\ReturnTypeWillChange]
     public function getParameters()
     {
         $extendedParameters = [];

--- a/Neos.Flow/Classes/Reflection/MethodReflection.php
+++ b/Neos.Flow/Classes/Reflection/MethodReflection.php
@@ -30,8 +30,7 @@ class MethodReflection extends \ReflectionMethod
      *
      * @return ClassReflection The declaring class
      */
-    #[\ReturnTypeWillChange]
-    public function getDeclaringClass()
+    public function getDeclaringClass(): ClassReflection
     {
         return new ClassReflection(parent::getDeclaringClass()->getName());
     }
@@ -43,8 +42,7 @@ class MethodReflection extends \ReflectionMethod
      *
      * @return array<ParameterReflection> objects of the parameters of this method
      */
-    #[\ReturnTypeWillChange]
-    public function getParameters()
+    public function getParameters(): array
     {
         $extendedParameters = [];
         foreach (parent::getParameters() as $parameter) {

--- a/Neos.Flow/Classes/Reflection/ParameterReflection.php
+++ b/Neos.Flow/Classes/Reflection/ParameterReflection.php
@@ -30,6 +30,7 @@ class ParameterReflection extends \ReflectionParameter
      *
      * @return ClassReflection The declaring class
      */
+    #[\ReturnTypeWillChange]
     public function getDeclaringClass()
     {
         return new ClassReflection(parent::getDeclaringClass()->getName());
@@ -40,6 +41,7 @@ class ParameterReflection extends \ReflectionParameter
      *
      * @return ClassReflection|null The parameter class
      */
+    #[\ReturnTypeWillChange]
     public function getClass()
     {
         try {

--- a/Neos.Flow/Classes/Reflection/ParameterReflection.php
+++ b/Neos.Flow/Classes/Reflection/ParameterReflection.php
@@ -30,8 +30,7 @@ class ParameterReflection extends \ReflectionParameter
      *
      * @return ClassReflection The declaring class
      */
-    #[\ReturnTypeWillChange]
-    public function getDeclaringClass()
+    public function getDeclaringClass(): ClassReflection
     {
         return new ClassReflection(parent::getDeclaringClass()->getName());
     }
@@ -41,8 +40,7 @@ class ParameterReflection extends \ReflectionParameter
      *
      * @return ClassReflection|null The parameter class
      */
-    #[\ReturnTypeWillChange]
-    public function getClass()
+    public function getClass(): ?ClassReflection
     {
         try {
             $class = parent::getType();

--- a/Neos.Flow/Classes/Reflection/PropertyReflection.php
+++ b/Neos.Flow/Classes/Reflection/PropertyReflection.php
@@ -50,6 +50,7 @@ class PropertyReflection extends \ReflectionProperty
      *
      * @return ClassReflection The declaring class
      */
+    #[\ReturnTypeWillChange]
     public function getDeclaringClass()
     {
         return new ClassReflection(parent::getDeclaringClass()->getName());
@@ -93,6 +94,7 @@ class PropertyReflection extends \ReflectionProperty
      * @return mixed Value of the property
      * @throws Exception
      */
+    #[\ReturnTypeWillChange]
     public function getValue($object = null)
     {
         if (!is_object($object)) {
@@ -114,6 +116,7 @@ class PropertyReflection extends \ReflectionProperty
      * @return void
      * @throws Exception
      */
+    #[\ReturnTypeWillChange]
     public function setValue($object = null, $value = null)
     {
         if (!is_object($object)) {

--- a/Neos.Flow/Classes/Reflection/PropertyReflection.php
+++ b/Neos.Flow/Classes/Reflection/PropertyReflection.php
@@ -50,8 +50,7 @@ class PropertyReflection extends \ReflectionProperty
      *
      * @return ClassReflection The declaring class
      */
-    #[\ReturnTypeWillChange]
-    public function getDeclaringClass()
+    public function getDeclaringClass(): ClassReflection
     {
         return new ClassReflection(parent::getDeclaringClass()->getName());
     }
@@ -116,8 +115,7 @@ class PropertyReflection extends \ReflectionProperty
      * @return void
      * @throws Exception
      */
-    #[\ReturnTypeWillChange]
-    public function setValue($object = null, $value = null)
+    public function setValue($object = null, $value = null): void
     {
         if (!is_object($object)) {
             throw new Exception('$object is of type ' . gettype($object) . ', instance of class ' . $this->class . ' expected.', 1210859212);

--- a/Neos.Flow/Tests/Behavior/Features/Bootstrap/SecurityOperationsTrait.php
+++ b/Neos.Flow/Tests/Behavior/Features/Bootstrap/SecurityOperationsTrait.php
@@ -104,7 +104,7 @@ trait SecurityOperationsTrait
      */
     public static function cleanUpSecurity()
     {
-        if (file_exists(self::$testingPolicyPathAndFilename)) {
+        if (self::$testingPolicyPathAndFilename && file_exists(self::$testingPolicyPathAndFilename)) {
             unlink(self::$testingPolicyPathAndFilename);
         }
     }

--- a/Neos.Utility.Arrays/Classes/Arrays.php
+++ b/Neos.Utility.Arrays/Classes/Arrays.php
@@ -293,7 +293,9 @@ abstract class Arrays
                 }
             }
         }
-        return ksort($array, $sortFlags);
+        return is_int($sortFlags)
+            ? ksort($array, $sortFlags)
+            : ksort($array);
     }
 
     /**


### PR DESCRIPTION
This adds additional type hints where required in PHP 8.1 while maintaining support for 7.4.
These are only the adjustments required fir the ESCR test suite, more are to follow