### PR TITLE
BUGFIX: Web-Exception messages preserve whitespace (ASCII Art)

### DIFF
--- a/Neos.Flow/Classes/Error/DebugExceptionHandler.php
+++ b/Neos.Flow/Classes/Error/DebugExceptionHandler.php
@@ -96,11 +96,17 @@ EOD;
         while (true) {
             $filepaths = Debugger::findProxyAndShortFilePath($exception->getFile());
             $filePathAndName = $filepaths['proxy'] !== '' ? $filepaths['proxy'] : $filepaths['short'];
-            $exceptionMessageParts = $this->splitExceptionMessage($exception->getMessage());
 
-            $exceptionHeader .= '<h1 class="ExceptionSubject">' . htmlspecialchars($exceptionMessageParts['subject']) . '</h1>';
-            if ($exceptionMessageParts['body'] !== '') {
-                $exceptionHeader .= '<p class="ExceptionBody">' . nl2br(htmlspecialchars($exceptionMessageParts['body'])) . '</p>';
+            ['subject' => $exceptionMessageSubject, 'body' => $exceptionMessageBody] = $this->splitExceptionMessage($exception->getMessage());
+
+            $exceptionHeader .= '<h1 class="ExceptionSubject">' . htmlspecialchars($exceptionMessageSubject) . '</h1>';
+            if ($exceptionMessageBody !== '') {
+                if (str_contains($exceptionMessageBody, '  ')) {
+                    // contents with multiple spaces will be pre-served
+                    $exceptionHeader .= '<p class="ExceptionBodyPre">' . htmlspecialchars($exceptionMessageBody) . '</p>';
+                } else {
+                    $exceptionHeader .= '<p class="ExceptionBody">' . nl2br(htmlspecialchars($exceptionMessageBody)) . '</p>';
+                }
             }
 
             $exceptionHeader .= '<table class="Flow-Debug-Exception-Meta"><tbody>';

--- a/Neos.Flow/Resources/Public/Error/Exception.css
+++ b/Neos.Flow/Resources/Public/Error/Exception.css
@@ -47,6 +47,14 @@ h1, h2, h3 {
     color: #000000;
 }
 
+.ExceptionBodyPre {
+  padding: 10px;
+  margin: 10px;
+  color: #000000;
+  white-space: pre;
+  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+}
+
 .ExceptionProperty {
     color: #34363C;
 }


### PR DESCRIPTION
Closes #2696

Exceptions which have multiple spaces in their $message where previously not as expected displayed.
Exceptions outputted to the CLI or logged did preserve multiple whitespaces naturally, but since they are collapsed in HTML by default, they are not shown in the browser.

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
