### PR TITLE
BUGFIX: Don't create proxy classes for PHP enums

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,6 +1,6 @@
 preset: psr2
 
-version: 8
+version: 8.1
 
 finder:
   path:

--- a/Neos.Flow/Classes/ObjectManagement/CompileTimeObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/CompileTimeObjectManager.php
@@ -228,7 +228,10 @@ class CompileTimeObjectManager extends ObjectManager
                 }
                 if ($package instanceof FlowPackageInterface && $shouldRegisterFunctionalTestClasses) {
                     foreach ($package->getFunctionalTestsClassFiles() as $fullClassName => $path) {
-                        if (PHP_MAJOR_VERSION < 8 && strpos($fullClassName, '\\PHP8\\') !== false) {
+                        if (version_compare(PHP_VERSION, '8.0', '<=') && strpos($fullClassName, '\\PHP8\\') !== false) {
+                            continue;
+                        }
+                        if (version_compare(PHP_VERSION, '8.1', '<=') && strpos($fullClassName, '\\PHP81\\') !== false) {
                             continue;
                         }
                         if (substr($fullClassName, -9, 9) !== 'Exception') {

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
@@ -116,12 +116,13 @@ class Compiler
      * If no such proxy class has been created yet by this renderer,
      * this function will create one and register it for later use.
      *
-     * If the class is not proxable, false will be returned
+     * If the class is not proxyable, or is not a real class at all,
+     * false will be returned
      *
      * @param string $fullClassName Name of the original class
      * @return ProxyClass|boolean
      */
-    public function getProxyClass($fullClassName)
+    public function getProxyClass(string $fullClassName)
     {
         if (interface_exists($fullClassName) || in_array(BaseTestCase::class, class_parents($fullClassName))) {
             return false;
@@ -133,6 +134,10 @@ class Compiler
 
         $classReflection = new \ReflectionClass($fullClassName);
         if ($classReflection->isInternal() === true) {
+            return false;
+        }
+
+        if (method_exists($classReflection, 'isEnum') && $classReflection->isEnum()) {
             return false;
         }
 

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PHP8/BackedEnumWithMethod.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PHP8/BackedEnumWithMethod.php
@@ -1,0 +1,38 @@
+<?php
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations\Proxy;
+
+/**
+ * A PHP 8.1 value-backed enum with methods
+ */
+enum BackedEnumWithMethod: string
+{
+    case ESPRESSO = 'esp';
+    case RISTRETTO = 'ris';
+    case FLAT_WHITE = 'flw';
+
+    public function label(): string
+    {
+        return BackedEnumWithMethod::getLabel($this);
+    }
+
+    public static function getLabel(self $value): string
+    {
+        return match ($value) {
+            self::ESPRESSO => 'Espresso',
+            self::RISTRETTO => 'Ristretto',
+            self::FLAT_WHITE => 'Flat White'
+        };
+    }
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PHP81/BackedEnumWithMethod.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PHP81/BackedEnumWithMethod.php
@@ -1,5 +1,5 @@
 <?php
-namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PHP8;
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PHP81;
 
 /*
  * This file is part of the Neos.Flow package.

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PHP81/BackedEnumWithMethod.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PHP81/BackedEnumWithMethod.php
@@ -11,8 +11,6 @@ namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PHP81;
  * source code.
  */
 
-use Neos\Flow\Annotations\Proxy;
-
 /**
  * A PHP 8.1 value-backed enum with methods
  */

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
@@ -19,7 +19,7 @@ use Neos\Flow\Reflection\MethodReflection;
 use Neos\Flow\Reflection\PropertyReflection;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ClassImplementingInterfaceWithConstructor;
-use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PHP8\BackedEnumWithMethod;
+use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PHP81\BackedEnumWithMethod;
 use Neos\Flow\Tests\FunctionalTestCase;
 
 /**

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
@@ -19,6 +19,7 @@ use Neos\Flow\Reflection\MethodReflection;
 use Neos\Flow\Reflection\PropertyReflection;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ClassImplementingInterfaceWithConstructor;
+use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PHP8\BackedEnumWithMethod;
 use Neos\Flow\Tests\FunctionalTestCase;
 
 /**
@@ -92,6 +93,24 @@ class ProxyCompilerTest extends FunctionalTestCase
     {
         $singletonB = $this->objectManager->get(Fixtures\SingletonClassB::class);
         $this->assertNotInstanceOf(ProxyInterface::class, $singletonB);
+    }
+
+    /**
+     * This test would fail with a fatal error, if Flow would try to build a proxy class for the given Enum:
+     *
+     * PHP Fatal error:  Cannot declare class Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PHP8\BackedEnumWithMethod,
+     * because the name is already in use in …/Flow_Object_Classes/Neos_Flow_Tests_Functional_ObjectManagement_Fixtures_PHP8_BackedEnumWithMethod.php on line 47
+     *
+     * @test
+     */
+    public function enumsAreNotProxied()
+    {
+        if (version_compare(PHP_VERSION, '8.1', '<=')) {
+            $this->markTestSkipped('Only for PHP.1 8 with Enums');
+        }
+
+        # PHP < 8.1 would fail compiling this test case if we used the syntax BackedEnumWithMethod::ESPRESSO->label()
+        $this->assertSame('Espresso', BackedEnumWithMethod::getLabel(BackedEnumWithMethod::ESPRESSO));
     }
 
     /**


### PR DESCRIPTION
This change introduces a check in the proxy class compiler which makes sure that PHP 8.1 enums are not considered as regular classes and are removed from the list of proxyable classes.

How to reproduce:

1. create an enum, for example in `Packages/Acme/Classes/ExampleEnum.php`:
```php
namespace Acme;
enum ExampleEnum
{
    case FOO;
    case BAR;
}
```

2. let Flow compile classes, the following error will appear:

> PHP Fatal error:  Cannot declare class Acme\ExampleEnum, because the name is already in use in /application/Data/Temporary/Development/Cache/Code/Flow_Object_Classes/Acme_ExampleEnum.php on line 23

Addresses #2698