### PR TITLE
!!! TASK: Raise minimal supported PHP version to 8.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['8.0', '8.1']
         dependencies: ['highest']
         composer-arguments: [''] # to run --ignore-platform-reqs in experimental builds
         static-analysis: ['no']

--- a/Neos.Cache/composer.json
+++ b/Neos.Cache/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://flow.neos.io",
     "license": ["MIT"],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^8.0",
         "psr/simple-cache": "^1.0",
         "psr/cache": "~1.0",
         "neos/utility-files": "*",

--- a/Neos.Eel/composer.json
+++ b/Neos.Eel/composer.json
@@ -4,7 +4,7 @@
     "license": ["MIT"],
     "description": "The Embedded Expression Language (Eel) is a building block for creating Domain Specific Languages",
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^8.0",
         "neos/flow": "*",
         "neos/cache": "*",
         "neos/utility-unicode": "*",

--- a/Neos.Error.Messages/composer.json
+++ b/Neos.Error.Messages/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://flow.neos.io",
     "license": "MIT",
     "require": {
-        "php": "^7.3 || ^8.0"
+        "php": "^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~9.1"

--- a/Neos.Flow.Log/composer.json
+++ b/Neos.Flow.Log/composer.json
@@ -7,7 +7,7 @@
         "MIT"
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^8.0",
         "neos/utility-files": "*",
         "psr/log": "^1.0.1"
     },

--- a/Neos.Flow/Classes/Core/Bootstrap.php
+++ b/Neos.Flow/Classes/Core/Bootstrap.php
@@ -34,7 +34,7 @@ class Bootstrap
     /**
      * Required PHP version
      */
-    const MINIMUM_PHP_VERSION = '7.3.0';
+    const MINIMUM_PHP_VERSION = '8.0.0';
 
     const RUNLEVEL_COMPILETIME = 'Compiletime';
     const RUNLEVEL_RUNTIME = 'Runtime';

--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -6,7 +6,7 @@
     "license": ["MIT"],
 
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^8.0",
 
         "ext-zlib": "*",
         "ext-SPL": "*",

--- a/Neos.FluidAdaptor/composer.json
+++ b/Neos.FluidAdaptor/composer.json
@@ -6,7 +6,7 @@
     "MIT"
   ],
   "require": {
-    "php": "^7.3 || ^8.0",
+    "php": "^8.0",
     "neos/flow": "*",
     "neos/cache": "*",
     "neos/utility-files": "*",

--- a/Neos.Http.Factories/composer.json
+++ b/Neos.Http.Factories/composer.json
@@ -7,7 +7,7 @@
         "MIT"
     ],
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^8.0",
         "psr/http-factory": "^1.0",
         "guzzlehttp/psr7": "^1.7, !=1.8.0"
     },

--- a/Neos.Kickstarter/composer.json
+++ b/Neos.Kickstarter/composer.json
@@ -4,7 +4,7 @@
     "description": "A simple generator for controller and views.",
     "license": "MIT",
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^8.0",
         "neos/flow": "*",
         "neos/fluid-adaptor": "*",
         "neos/utility-arrays": "*"

--- a/Neos.Utility.Arrays/composer.json
+++ b/Neos.Utility.Arrays/composer.json
@@ -5,7 +5,7 @@
   "homepage": "http://flow.neos.io",
   "license": "MIT",
   "require": {
-    "php": "^7.3 || ^8.0",
+    "php": "^8.0",
     "neos/utility-objecthandling": "*"
   },
   "require-dev": {

--- a/Neos.Utility.Files/composer.json
+++ b/Neos.Utility.Files/composer.json
@@ -5,7 +5,7 @@
   "homepage": "http://flow.neos.io",
   "license": "MIT",
   "require": {
-    "php": "^7.3 || ^8.0",
+    "php": "^8.0",
     "neos/error-messages": "*"
   },
   "require-dev": {

--- a/Neos.Utility.MediaTypes/composer.json
+++ b/Neos.Utility.MediaTypes/composer.json
@@ -5,7 +5,7 @@
   "homepage": "http://flow.neos.io",
   "license": "MIT",
   "require": {
-    "php": "^7.3 || ^8.0"
+    "php": "^8.0"
   },
   "require-dev": {
     "mikey179/vfsstream": "^1.6.1",

--- a/Neos.Utility.ObjectHandling/composer.json
+++ b/Neos.Utility.ObjectHandling/composer.json
@@ -5,7 +5,7 @@
   "homepage": "http://flow.neos.io",
   "license": "MIT",
   "require": {
-    "php": "^7.3 || ^8.0"
+    "php": "^8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~9.1",

--- a/Neos.Utility.OpcodeCache/composer.json
+++ b/Neos.Utility.OpcodeCache/composer.json
@@ -5,7 +5,7 @@
   "homepage": "http://flow.neos.io",
   "license": "MIT",
   "require": {
-    "php": "^7.3 || ^8.0"
+    "php": "^8.0"
   },
   "autoload": {
     "psr-4": {

--- a/Neos.Utility.Pdo/composer.json
+++ b/Neos.Utility.Pdo/composer.json
@@ -5,7 +5,7 @@
   "homepage": "http://flow.neos.io",
   "license": "MIT",
   "require": {
-    "php": "^7.3 || ^8.0"
+    "php": "^8.0"
   },
   "autoload": {
     "psr-4": {

--- a/Neos.Utility.Schema/composer.json
+++ b/Neos.Utility.Schema/composer.json
@@ -5,7 +5,7 @@
   "homepage": "http://flow.neos.io",
   "license": "MIT",
   "require": {
-    "php": "^7.3 || ^8.0",
+    "php": "^8.0",
     "neos/error-messages": "*"
   },
   "require-dev": {

--- a/Neos.Utility.Unicode/composer.json
+++ b/Neos.Utility.Unicode/composer.json
@@ -8,7 +8,7 @@
     "bin-dir": "bin"
   },
   "require": {
-    "php": "^7.3 || ^8.0",
+    "php": "^8.0",
     "ext-mbstring": "*"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     ],
     "type": "neos-package-collection",
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^8.0",
         "psr/simple-cache": "^1.0",
         "psr/cache": "~1.0",
         "psr/log": "^1.0",


### PR DESCRIPTION
Neos 8 will depend on php 8. This change adjusts composer dependencies, the MINIMUM_PHP_VERSION in the flow bootstrap and adjusts the github actions to only run for supported php-versions.

Resolves: #2708