### PR TITLE
BUGFIX: Fix UriConstraints port constraints for default ports

### DIFF
--- a/Neos.Flow/Classes/Mvc/Routing/Dto/UriConstraints.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Dto/UriConstraints.php
@@ -86,8 +86,8 @@ final class UriConstraints
         if ($uri->getPort() !== null) {
             $constraints[self::CONSTRAINT_PORT] = $uri->getPort();
         }
-        if ($uri->getPath() !== '') {
-            $constraints[self::CONSTRAINT_PATH] = $uri->getPath();
+        if ($uri->getPort() !== null || $uri->getScheme() !== '') {
+            $constraints[self::CONSTRAINT_PORT] = $uri->getPort() ?? UriHelper::getDefaultPortForScheme($uri->getScheme());
         }
         if ($uri->getQuery() !== '') {
             $constraints[self::CONSTRAINT_QUERY_STRING] = $uri->getQuery();

--- a/Neos.Flow/Classes/Mvc/Routing/Dto/UriConstraints.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Dto/UriConstraints.php
@@ -83,11 +83,11 @@ final class UriConstraints
             $constraints[self::CONSTRAINT_SCHEME] = $uri->getScheme();
             $constraints[self::CONSTRAINT_HOST] = $uri->getHost();
         }
-        if ($uri->getPort() !== null) {
-            $constraints[self::CONSTRAINT_PORT] = $uri->getPort();
-        }
         if ($uri->getPort() !== null || $uri->getScheme() !== '') {
             $constraints[self::CONSTRAINT_PORT] = $uri->getPort() ?? UriHelper::getDefaultPortForScheme($uri->getScheme());
+        }
+        if ($uri->getPath() !== '') {
+            $constraints[self::CONSTRAINT_PATH] = $uri->getPath();
         }
         if ($uri->getQuery() !== '') {
             $constraints[self::CONSTRAINT_QUERY_STRING] = $uri->getQuery();

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/UriConstraintsTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/UriConstraintsTest.php
@@ -362,7 +362,8 @@ class UriConstraintsTest extends UnitTestCase
     {
         return [
             ['uri' => '', 'expectedConstraints' => []],
-            ['uri' => 'https://neos.io', 'expectedConstraints' => [UriConstraints::CONSTRAINT_SCHEME => 'https', UriConstraints::CONSTRAINT_HOST => 'neos.io']],
+            ['uri' => 'https://neos.io', 'expectedConstraints' => [UriConstraints::CONSTRAINT_SCHEME => 'https', UriConstraints::CONSTRAINT_HOST => 'neos.io', UriConstraints::CONSTRAINT_PORT => 443]],
+            ['uri' => 'http://www.neos.io', 'expectedConstraints' => [UriConstraints::CONSTRAINT_SCHEME => 'http', UriConstraints::CONSTRAINT_HOST => 'www.neos.io', UriConstraints::CONSTRAINT_PORT => 80]],
             ['uri' => 'http://localhost:8080', 'expectedConstraints' => [UriConstraints::CONSTRAINT_SCHEME => 'http', UriConstraints::CONSTRAINT_HOST => 'localhost', UriConstraints::CONSTRAINT_PORT => 8080]],
             ['uri' => '/some/path', 'expectedConstraints' => [UriConstraints::CONSTRAINT_PATH => '/some/path']],
             ['uri' => '?some&query=string', 'expectedConstraints' => [UriConstraints::CONSTRAINT_QUERY_STRING => 'some&query=string']],


### PR DESCRIPTION
Previously, if `UriConstraints` were applied to an URL with a non-default
port (e.g. "8080") this port constraint was applied to the target URL even
if no explicit port constraint was set.

Fixes: #2714