### PR TITLE
BUGFIX: Prevent flush force error in production context

### DIFF
--- a/Neos.Flow/Classes/Core/LockManager.php
+++ b/Neos.Flow/Classes/Core/LockManager.php
@@ -133,7 +133,7 @@ class LockManager
         if (is_resource($this->lockResource)) {
             flock($this->lockResource, LOCK_UN);
             fclose($this->lockResource);
-            unlink($this->lockPathAndFilename);
+            @unlink($this->lockPathAndFilename);
         }
         @unlink($this->lockFlagPathAndFilename);
     }


### PR DESCRIPTION
**What I did**

The `flow:cache:flush --force` command runs `Files::emptyDirectoryRecursively($environment->getPathToTemporaryDirectory());` which removes the lock file in the temporary directory too. The call to `unlockSite()` then causes a PHP warning because of the missing lock file.

`Warning: unlink(/…/cbe856ff790c9ba5208811309bdf168b_Flow.lock): No such file or directory in /…/Core/LockManager.php line 145`

This PR just add's a bit of error handling to the corresponding unlink of the lock file.

**How to verify it**

Run `./flow flow:cache:flush --force` command in `Production` context.

**Question**

Since this is a bugfix, I used branch 6.3. In case of Flow 7, some PHP 8 compatiblity was added which would change the PR to 

```
            try {
                @unlink($this->lockPathAndFilename);
            } catch (\Throwable $e) {
                // PHP 8 apparently throws for unlink even with shutup operator, but we really don't care at this place. It's also the only way to handle this race-condition free.
            }
```

Should I create another PR if this one is merged to get PHP 8 compatibility?

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
