### PR TITLE
!!! FEATURE: Introduce flushByTags to taggable cache backends

### DIFF
--- a/Neos.Cache/Classes/Backend/ApcuBackend.php
+++ b/Neos.Cache/Classes/Backend/ApcuBackend.php
@@ -242,6 +242,20 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
     }
 
     /**
+     * Removes all cache entries of this cache which are tagged by any of the specified tags.
+     *
+     * @api
+     */
+    public function flushByTags(array $tags): int
+    {
+        $flushed = 0;
+        foreach ($tags as $tag) {
+            $flushed += $this->flushByTag($tag);
+        }
+        return $flushed;
+    }
+
+    /**
      * Associates the identifier with the given tags
      *
      * @param string $entryIdentifier

--- a/Neos.Cache/Classes/Backend/FileBackend.php
+++ b/Neos.Cache/Classes/Backend/FileBackend.php
@@ -311,6 +311,20 @@ class FileBackend extends SimpleFileBackend implements PhpCapableBackendInterfac
     }
 
     /**
+     * Removes all cache entries of this cache which are tagged by any of the specified tags.
+     *
+     * @api
+     */
+    public function flushByTags(array $tags): int
+    {
+        $flushed = 0;
+        foreach ($tags as $tag) {
+            $flushed += $this->flushByTag($tag);
+        }
+        return $flushed;
+    }
+
+    /**
      * Checks if the given cache entry files are still valid or if their
      * lifetime has exceeded.
      *

--- a/Neos.Cache/Classes/Backend/MemcachedBackend.php
+++ b/Neos.Cache/Classes/Backend/MemcachedBackend.php
@@ -366,6 +366,20 @@ class MemcachedBackend extends IndependentAbstractBackend implements TaggableBac
     }
 
     /**
+     * Removes all cache entries of this cache which are tagged by any of the specified tags.
+     *
+     * @api
+     */
+    public function flushByTags(array $tags): int
+    {
+        $flushed = 0;
+        foreach ($tags as $tag) {
+            $flushed += $this->flushByTag($tag);
+        }
+        return $flushed;
+    }
+
+    /**
      * Associates the identifier with the given tags
      *
      * @param string $entryIdentifier

--- a/Neos.Cache/Classes/Backend/NullBackend.php
+++ b/Neos.Cache/Classes/Backend/NullBackend.php
@@ -123,6 +123,18 @@ class NullBackend extends AbstractCacheBackend implements PhpCapableBackendInter
     /**
      * Does nothing
      *
+     * @param array<string> $tags ignored
+     * @return integer
+     * @api
+     */
+    public function flushByTags(array $tags): int
+    {
+        return 0;
+    }
+
+    /**
+     * Does nothing
+     *
      * @return void
      * @api
      */

--- a/Neos.Cache/Classes/Backend/PdoBackend.php
+++ b/Neos.Cache/Classes/Backend/PdoBackend.php
@@ -349,6 +349,21 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
     }
 
     /**
+     * Removes all cache entries of this cache which are tagged by any of the specified tags.
+     *
+     * @throws Exception
+     * @api
+     */
+    public function flushByTags(array $tags): int
+    {
+        $flushed = 0;
+        foreach ($tags as $tag) {
+            $flushed += $this->flushByTag($tag);
+        }
+        return $flushed;
+    }
+
+    /**
      * Finds and returns all cache entry identifiers which are tagged by the
      * specified tag.
      *

--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -281,6 +281,20 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
     }
 
     /**
+     * Removes all cache entries of this cache which are tagged by any of the specified tags.
+     *
+     * @api
+     */
+    public function flushByTags(array $tags): int
+    {
+        $flushed = 0;
+        foreach ($tags as $tag) {
+            $flushed += $this->flushByTag($tag);
+        }
+        return $flushed;
+    }
+
+    /**
      * Finds and returns all cache entry identifiers which are tagged by the
      * specified tag.
      *

--- a/Neos.Cache/Classes/Backend/TaggableBackendInterface.php
+++ b/Neos.Cache/Classes/Backend/TaggableBackendInterface.php
@@ -30,6 +30,15 @@ interface TaggableBackendInterface extends BackendInterface
     public function flushByTag(string $tag): int;
 
     /**
+     * Removes all cache entries of this cache which are tagged by any of the specified tags.
+     *
+     * @param array<string> $tags The tags the entries must have
+     * @return integer The number of entries which have been affected by this flush or NULL if the number is unknown
+     * @api
+     */
+    public function flushByTags(array $tags): int;
+
+    /**
      * Finds and returns all cache entry identifiers which are tagged by the
      * specified tag.
      *

--- a/Neos.Cache/Classes/Backend/TaggableBackendInterface.php
+++ b/Neos.Cache/Classes/Backend/TaggableBackendInterface.php
@@ -24,7 +24,7 @@ interface TaggableBackendInterface extends BackendInterface
      * Removes all cache entries of this cache which are tagged by the specified tag.
      *
      * @param string $tag The tag the entries must have
-     * @return integer The number of entries which have been affected by this flush or NULL if the number is unknown
+     * @return integer The number of entries which have been affected by this flush
      * @api
      */
     public function flushByTag(string $tag): int;
@@ -33,7 +33,7 @@ interface TaggableBackendInterface extends BackendInterface
      * Removes all cache entries of this cache which are tagged by any of the specified tags.
      *
      * @param array<string> $tags The tags the entries must have
-     * @return integer The number of entries which have been affected by this flush or NULL if the number is unknown
+     * @return integer The number of entries which have been affected by this flush
      * @api
      */
     public function flushByTags(array $tags): int;

--- a/Neos.Cache/Classes/Backend/TaggableMultiBackend.php
+++ b/Neos.Cache/Classes/Backend/TaggableMultiBackend.php
@@ -68,6 +68,21 @@ class TaggableMultiBackend extends MultiBackend implements TaggableBackendInterf
     }
 
     /**
+     * Removes all cache entries of this cache which are tagged by any of the specified tags.
+     *
+     * @throws \Throwable
+     * @api
+     */
+    public function flushByTags(array $tags): int
+    {
+        $flushed = 0;
+        foreach ($tags as $tag) {
+            $flushed += $this->flushByTag($tag);
+        }
+        return $flushed;
+    }
+
+    /**
      * @param string $tag
      * @return string[]
      */

--- a/Neos.Cache/Classes/Backend/TransientMemoryBackend.php
+++ b/Neos.Cache/Classes/Backend/TransientMemoryBackend.php
@@ -153,6 +153,20 @@ class TransientMemoryBackend extends IndependentAbstractBackend implements Tagga
     }
 
     /**
+     * Removes all cache entries of this cache which are tagged by any of the specified tags.
+     *
+     * @api
+     */
+    public function flushByTags(array $tags): int
+    {
+        $flushed = 0;
+        foreach ($tags as $tag) {
+            $flushed += $this->flushByTag($tag);
+        }
+        return $flushed;
+    }
+
+    /**
      * Does nothing
      *
      * @return void

--- a/Neos.Cache/Classes/Frontend/AbstractFrontend.php
+++ b/Neos.Cache/Classes/Frontend/AbstractFrontend.php
@@ -153,6 +153,27 @@ abstract class AbstractFrontend implements FrontendInterface
     }
 
     /**
+     * Removes all cache entries of this cache which are tagged by any of the specified tags.
+     *
+     * @param array<string> $tags The tags the entries must have
+     * @return integer The number of entries which have been affected by this flush
+     * @throws \InvalidArgumentException
+     * @api
+     */
+    public function flushByTags(array $tags): int
+    {
+        foreach ($tags as $tag) {
+            if (!$this->isValidTag($tag)) {
+                throw new \InvalidArgumentException('"' . $tag . '" is not a valid tag for a cache entry.', 1646209443);
+            }
+        }
+        if ($this->backend instanceof TaggableBackendInterface) {
+            return $this->backend->flushByTags($tags);
+        }
+        return 0;
+    }
+
+    /**
      * Does garbage collection
      *
      * @return void

--- a/Neos.Cache/Classes/Frontend/FrontendInterface.php
+++ b/Neos.Cache/Classes/Frontend/FrontendInterface.php
@@ -104,7 +104,7 @@ interface FrontendInterface
      * Removes all cache entries of this cache which are tagged by the specified tag.
      *
      * @param string $tag The tag the entries must have
-     * @return integer The number of entries which have been affected by this flush or NULL if the number is unknown
+     * @return integer The number of entries which have been affected by this flush
      * @api
      */
     public function flushByTag(string $tag): int;
@@ -113,7 +113,7 @@ interface FrontendInterface
      * Removes all cache entries of this cache which are tagged by any of the specified tags.
      *
      * @param array<string> $tags The tags the entries must have
-     * @return integer The number of entries which have been affected by this flush or NULL if the number is unknown
+     * @return integer The number of entries which have been affected by this flush
      * @api
      */
     public function flushByTags(array $tags): int;

--- a/Neos.Cache/Classes/Frontend/FrontendInterface.php
+++ b/Neos.Cache/Classes/Frontend/FrontendInterface.php
@@ -110,6 +110,15 @@ interface FrontendInterface
     public function flushByTag(string $tag): int;
 
     /**
+     * Removes all cache entries of this cache which are tagged by any of the specified tags.
+     *
+     * @param array<string> $tags The tags the entries must have
+     * @return integer The number of entries which have been affected by this flush or NULL if the number is unknown
+     * @api
+     */
+    public function flushByTags(array $tags): int;
+
+    /**
      * Does garbage collection
      *
      * @return void

--- a/Neos.Cache/Tests/Unit/Backend/AbstractBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/AbstractBackendTest.php
@@ -43,6 +43,7 @@ class AbstractBackendTest extends BaseTestCase
                 public function remove(string $entryIdentifier): bool {}
                 public function flush(): void {}
                 public function flushByTag(string $tag): int {}
+                public function flushByTags(array $tags): int {}
                 public function findIdentifiersByTag(string $tag): array {}
                 public function collectGarbage(): void {}
                 public function setSomeOption($value) {

--- a/Neos.Cache/Tests/Unit/Backend/ApcuBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/ApcuBackendTest.php
@@ -187,6 +187,25 @@ class ApcuBackendTest extends BaseTestCase
     /**
      * @test
      */
+    public function flushByTagsRemovesCacheEntriesWithSpecifiedTags()
+    {
+        $backend = $this->setUpBackend();
+
+        $data = 'some data' . microtime();
+        $backend->set('BackendAPCUTest1', $data, ['UnitTestTag%test', 'UnitTestTag%boring']);
+        $backend->set('BackendAPCUTest2', $data, ['UnitTestTag%test', 'UnitTestTag%special']);
+        $backend->set('BackendAPCUTest3', $data, ['UnitTestTag%test']);
+
+        $backend->flushByTags(['UnitTestTag%boring', 'UnitTestTag%special']);
+
+        self::assertFalse($backend->has('BackendAPCUTest1'), 'BackendAPCUTest1');
+        self::assertFalse($backend->has('BackendAPCUTest2'), 'BackendAPCUTest2');
+        self::assertTrue($backend->has('BackendAPCUTest3'), 'BackendAPCUTest3');
+    }
+
+    /**
+     * @test
+     */
     public function flushRemovesAllCacheEntries()
     {
         $backend = $this->setUpBackend();

--- a/Neos.Cache/Tests/Unit/Backend/FileBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/FileBackendTest.php
@@ -677,6 +677,19 @@ class FileBackendTest extends BaseTestCase
     /**
      * @test
      */
+    public function flushByTagsRemovesCacheEntriesWithSpecifiedTags()
+    {
+        $backend = $this->prepareDefaultBackend(['findIdentifiersByTag', 'remove']);
+
+        $backend->expects(self::once())->method('findIdentifiersByTag')->with('UnitTestTag%special')->will(self::returnValue(['foo', 'bar', 'baz']));
+        $backend->expects(self::atLeast(3))->method('remove')->withConsecutive(['foo'], ['bar'], ['baz']);
+
+        $backend->flushByTags(['UnitTestTag%special']);
+    }
+
+    /**
+     * @test
+     */
     public function collectGarbageRemovesExpiredCacheEntries()
     {
         $mockCache = $this->createMock(AbstractFrontend::class);

--- a/Neos.Cache/Tests/Unit/Backend/PdoBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/PdoBackendTest.php
@@ -178,6 +178,25 @@ class PdoBackendTest extends BaseTestCase
     /**
      * @test
      */
+    public function flushByTagsRemovesCacheEntriesWithSpecifiedTags()
+    {
+        $backend = $this->setUpBackend();
+
+        $data = 'some data' . microtime();
+        $backend->set('PdoBackendTest1', $data, ['UnitTestTag%test', 'UnitTestTag%boring']);
+        $backend->set('PdoBackendTest2', $data, ['UnitTestTag%test', 'UnitTestTag%special']);
+        $backend->set('PdoBackendTest3', $data, ['UnitTestTag%test']);
+
+        $backend->flushByTags(['UnitTestTag%boring', 'UnitTestTag%special']);
+
+        self::assertFalse($backend->has('PdoBackendTest1'), 'PdoBackendTest1');
+        self::assertFalse($backend->has('PdoBackendTest2'), 'PdoBackendTest2');
+        self::assertTrue($backend->has('PdoBackendTest3'), 'PdoBackendTest3');
+    }
+
+    /**
+     * @test
+     */
     public function flushRemovesAllCacheEntries()
     {
         $backend = $this->setUpBackend();

--- a/Neos.Cache/Tests/Unit/Backend/RedisBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/RedisBackendTest.php
@@ -209,6 +209,23 @@ class RedisBackendTest extends BaseTestCase
     }
 
     /**
+     * @test
+     * @dataProvider batchWritingOperationsProvider
+     * @param string $method
+     */
+    public function batchWritingOperationsThrowAnExceptionIfCacheIsFrozen($method)
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->inject($this->backend, 'frozen', null);
+        $this->redis->expects(self::once())
+            ->method('exists')
+            ->with('d41d8cd98f00b204e9800998ecf8427e:Foo_Cache:frozen')
+            ->will(self::returnValue(true));
+
+        $this->backend->$method(['foo', 'bar']);
+    }
+
+    /**
      * @return array
      */
     public static function writingOperationsProvider()
@@ -218,6 +235,16 @@ class RedisBackendTest extends BaseTestCase
             ['remove'],
             ['flushByTag'],
             ['freeze']
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public static function batchWritingOperationsProvider()
+    {
+        return [
+            ['flushByTags'],
         ];
     }
 }

--- a/Neos.Cache/Tests/Unit/Backend/TransientMemoryBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/TransientMemoryBackendTest.php
@@ -215,6 +215,27 @@ class TransientMemoryBackendTest extends BaseTestCase
     /**
      * @test
      */
+    public function flushByTagsRemovesCacheEntriesWithSpecifiedTags(): void
+    {
+        $cache = $this->createMock(FrontendInterface::class);
+        $backend = new TransientMemoryBackend($this->getEnvironmentConfiguration());
+        $backend->setCache($cache);
+
+        $data = 'some data' . microtime();
+        $backend->set('TransientMemoryBackendTest1', $data, ['UnitTestTag%test', 'UnitTestTag%boring']);
+        $backend->set('TransientMemoryBackendTest2', $data, ['UnitTestTag%test', 'UnitTestTag%special']);
+        $backend->set('TransientMemoryBackendTest3', $data, ['UnitTestTag%test']);
+
+        $backend->flushByTags(['UnitTestTag%boring', 'UnitTestTag%special']);
+
+        self::assertFalse($backend->has('TransientMemoryBackendTest1'), 'TransientMemoryBackendTest1');
+        self::assertFalse($backend->has('TransientMemoryBackendTest2'), 'TransientMemoryBackendTest2');
+        self::assertTrue($backend->has('TransientMemoryBackendTest3'), 'TransientMemoryBackendTest3');
+    }
+
+    /**
+     * @test
+     */
     public function flushRemovesAllCacheEntries(): void
     {
         $cache = $this->createMock(FrontendInterface::class);

--- a/Neos.Flow/Classes/Mvc/Routing/RouterCachingService.php
+++ b/Neos.Flow/Classes/Mvc/Routing/RouterCachingService.php
@@ -207,6 +207,17 @@ class RouterCachingService
     }
 
     /**
+     * Flushes 'findMatchResults' and 'resolve' caches for the given $tags
+     *
+     * @param array<string> $tags
+     */
+    public function flushCachesByTags(array $tags): void
+    {
+        $this->routeCache->flushByTags($tags);
+        $this->resolveCache->flushByTags($tags);
+    }
+
+    /**
      * Flushes 'findMatchResults' caches that are tagged with the given $uriPath
      *
      * @param string $uriPath

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
@@ -244,6 +244,9 @@ with these methods.
 ``flushByTag()``
 	Flush all cache entries which are tagged with the given tag.
 
+``flushByTags()``
+	Flush all cache entries which are tagged with any of the given tags.
+
 ``collectGarbage()``
 	Call the garbage collection method of the backend. This is important for backends
 	which are unable to do this internally.


### PR DESCRIPTION
**What I did**

This change introduces the `flushByTags` method to taggable cache backends. This allows each backend to be further optimised in the future to find the best way to flush multiple tags from its storage.

Resolves: #2717

**How I did it**

The `TaggableBackendInterface` and `FrontendInterface` were extended with the method `flushByTags` and each provided backend in the core got a simple implementation for it to fulfil the interface.
