### PR TITLE
FEATURE: Optimised Redis cache backend

### DIFF
--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -631,8 +631,9 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
         if (!$this->entryIterator) {
             $prefix = $this->getPrefixedIdentifier('entry:');
             $prefixLength = strlen($prefix);
-            $keys = array_map(static fn (string $key) => substr($key, $prefixLength), $this->redis->keys($prefix . '*'));
-            $this->entryIterator = new \ArrayIterator($keys);
+            $keys = $this->redis->keys($prefix . '*') ?? [];
+            $entryIdentifiers = array_map(static fn (string $key) => substr($key, $prefixLength), $keys);
+            $this->entryIterator = new \ArrayIterator($entryIdentifiers);
         }
         return $this->entryIterator;
     }

--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -254,11 +254,11 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
         // language=lua
         $script = "
         local keys = redis.call('KEYS', ARGV[1] .. '*')
-		for k1,key in ipairs(keys) do
-			redis.call('DEL', key)
-		end
-		";
-        $this->redis->eval($script, [$this->getPrefixedIdentifier('')], 0);
+        for k1,key in ipairs(keys) do
+            redis.call('DEL', key)
+        end
+        ";
+        $this->redis->eval($script, [$this->getPrefixedIdentifier('')], 2);
 
         $this->frozen = null;
     }
@@ -287,14 +287,14 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
         }
 
         $script = "
-		local entries = redis.call('SMEMBERS', KEYS[1])
-		for k1,entryIdentifier in ipairs(entries) do
-			redis.call('DEL', ARGV[1]..'entry:'..entryIdentifier)
-			redis.call('DEL', ARGV[1]..'tags:'..entryIdentifier)
-		end
-		redis.call('DEL', KEYS[1])
-		return #entries
-		";
+        local entries = redis.call('SMEMBERS', KEYS[1])
+        for k1,entryIdentifier in ipairs(entries) do
+            redis.call('DEL', ARGV[1]..'entry:'..entryIdentifier)
+            redis.call('DEL', ARGV[1]..'tags:'..entryIdentifier)
+        end
+        redis.call('DEL', KEYS[1])
+        return #entries
+        ";
         return $this->redis->eval($script, [$this->getPrefixedIdentifier('tag:' . $tag), $this->getPrefixedIdentifier('')], 1);
     }
 

--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -290,6 +290,12 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
         local entries = redis.call('SMEMBERS', KEYS[1])
         for k1,entryIdentifier in ipairs(entries) do
             redis.call('DEL', ARGV[1]..'entry:'..entryIdentifier)
+
+            local tags = redis.call('SMEMBERS', ARGV[1]..'tags:'..entryIdentifier)
+            for k2,tagName in ipairs(tags) do
+                redis.call('SREM', ARGV[1]..'tag:'..tagName, entryIdentifier)
+            end
+
             redis.call('DEL', ARGV[1]..'tags:'..entryIdentifier)
         end
         redis.call('DEL', KEYS[1])
@@ -319,6 +325,12 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
             local entries = redis.call('SMEMBERS', KEYS[i])
             for k1,entryIdentifier in ipairs(entries) do
                 redis.call('UNLINK', ARGV[i]..'entry:'..entryIdentifier)
+
+                local tags = redis.call('SMEMBERS', ARGV[i]..'tags:'..entryIdentifier)
+                for k2,tagName in ipairs(tags) do
+                    redis.call('SREM', ARGV[i]..'tag:'..tagName, entryIdentifier)
+                end
+
                 redis.call('UNLINK', ARGV[i]..'tags:'..entryIdentifier)
             end
             redis.call('UNLINK', KEYS[i])

--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -177,7 +177,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      */
     private function calculateExpires(string $tag, int $lifetime): int
     {
-        $ttl = $this->redis->ttl($tag);
+        $ttl = (int)$this->redis->ttl($tag);
         if ($ttl < 0 || $lifetime === self::UNLIMITED_LIFETIME) {
             return -1;
         }

--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -38,8 +38,8 @@ use Neos\Error\Messages\Result;
  *  - batchSize:       Maximum number of parameters per query for batch operations
  *
  * Requirements:
- *  - Redis 2.6.0+ (tested with 2.6.14 and 2.8.5)
- *  - phpredis with Redis 2.6 support, e.g. 2.2.4 (tested with 92782639b0329ff91658a0602a3d816446a3663d from 2014-01-06)
+ *  - Redis 6.0.0+
+ *  - phpredis with Redis 6.0 support
  *
  * Implementation based on ext:rediscache by Christopher Hlubek - networkteam GmbH
  *
@@ -56,7 +56,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
 {
     use RequireOnceFromValueTrait;
 
-    const MIN_REDIS_VERSION = '2.6.0';
+    const MIN_REDIS_VERSION = '6.0.0';
 
     /**
      * @var \Redis

--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -126,7 +126,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      * @param string $entryIdentifier An identifier for this specific cache entry
      * @param string $data The data to be stored
      * @param array $tags Tags to associate with this cache entry. If the backend does not support tags, this option can be ignored.
-     * @param integer $lifetime Lifetime of this cache entry in seconds. If NULL is specified, the default lifetime is used. "0" means unlimited lifetime.
+     * @param integer|null $lifetime Lifetime of this cache entry in seconds. If NULL is specified, the default lifetime is used. "0" means unlimited lifetime.
      * @throws \RuntimeException
      * @throws CacheException
      * @return void
@@ -225,7 +225,6 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      * in an atomic way.
      *
      * @throws \RuntimeException
-     * @return void
      * @api
      */
     public function flush(): void
@@ -251,7 +250,6 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
     /**
      * This backend does not need an externally triggered garbage collection
      *
-     * @return void
      * @api
      */
     public function collectGarbage(): void
@@ -472,9 +470,6 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
         $this->database = (int)$database;
     }
 
-    /**
-     * @param string $password
-     */
     public function setPassword(string $password): void
     {
         $this->password = $password;
@@ -498,10 +493,6 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
         $this->batchSize = $batchSize;
     }
 
-    /**
-     * @param \Redis $redis
-     * @return void
-     */
     public function setRedis(\Redis $redis = null): void
     {
         if ($redis !== null) {
@@ -515,31 +506,23 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      */
     private function uncompress($value)
     {
-        if ($value === false || empty($value)) {
+        if (empty($value)) {
             return $value;
         }
         return $this->useCompression() ? gzdecode((string) $value) : $value;
     }
 
-    /**
-     * @param string $value
-     * @return string
-     */
     private function compress(string $value): string
     {
         return $this->useCompression() ? gzencode($value, $this->compressionLevel) : $value;
     }
 
-    /**
-     * @return boolean
-     */
     private function useCompression(): bool
     {
         return $this->compressionLevel > 0;
     }
 
     /**
-     * @return \Redis
      * @throws CacheException
      */
     private function getRedisClient(): \Redis
@@ -549,7 +532,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
         try {
             $connected = false;
             // keep the assignment above! the connect calls below leaves the variable undefined, if an error occurs.
-            if (strpos($this->hostname, '/') !== false) {
+            if (str_contains($this->hostname, '/')) {
                 $connected = $redis->connect($this->hostname);
             } else {
                 $connected = $redis->connect($this->hostname, $this->port);
@@ -561,17 +544,14 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
             }
         }
 
-        if ($this->password !== '') {
-            if (!$redis->auth($this->password)) {
-                throw new CacheException('Redis authentication failed.', 1502366200);
-            }
+        if ($this->password !== '' && !$redis->auth($this->password)) {
+            throw new CacheException('Redis authentication failed.', 1502366200);
         }
         $redis->select($this->database);
         return $redis;
     }
 
     /**
-     * @return void
      * @throws CacheException
      */
     protected function verifyRedisVersionIsSupported(): void
@@ -591,7 +571,6 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
     /**
      * Validates that the configured redis backend is accessible and returns some details about its configuration if that's the case
      *
-     * @return Result
      * @api
      */
     public function getStatus(): Result

--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -101,7 +101,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
     protected $batchSize = 100000;
 
     /**
-     * @var \ArrayIterator
+     * @var \ArrayIterator|null
      */
     private $entryIterator;
 
@@ -631,8 +631,12 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
         if (!$this->entryIterator) {
             $prefix = $this->getPrefixedIdentifier('entry:');
             $prefixLength = strlen($prefix);
-            $keys = $this->redis->keys($prefix . '*') ?? [];
-            $entryIdentifiers = array_map(static fn (string $key) => substr($key, $prefixLength), $keys);
+            $keys = $this->redis->keys($prefix . '*');
+            if (is_array($keys)) {
+                $entryIdentifiers = array_map(static fn (string $key) => substr($key, $prefixLength), $keys);
+            } else {
+                $entryIdentifiers = [];
+            }
             $this->entryIterator = new \ArrayIterator($entryIdentifiers);
         }
         return $this->entryIterator;

--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -61,7 +61,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      */
     protected $redis;
 
-    protected ?bool $frozen;
+    protected ?bool $frozen = null;
 
     protected string $hostname = '127.0.0.1';
 

--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -258,7 +258,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
             redis.call('DEL', key)
         end
         ";
-        $this->redis->eval($script, [$this->getPrefixedIdentifier('')], 2);
+        $this->redis->eval($script, [$this->getPrefixedIdentifier('frozen'), $this->getPrefixedIdentifier('')], 1);
 
         $this->frozen = null;
     }

--- a/Neos.Cache/Classes/Backend/RequireOnceFromValueTrait.php
+++ b/Neos.Cache/Classes/Backend/RequireOnceFromValueTrait.php
@@ -32,7 +32,7 @@ trait RequireOnceFromValueTrait
      */
     public function requireOnce(string $entryIdentifier)
     {
-        $value = trim($this->get($entryIdentifier));
+        $value = trim((string)$this->get($entryIdentifier));
         if ($value === '') {
             return false;
         }

--- a/Neos.Cache/Tests/Functional/Backend/RedisBackendTest.php
+++ b/Neos.Cache/Tests/Functional/Backend/RedisBackendTest.php
@@ -49,8 +49,8 @@ class RedisBackendTest extends BaseTestCase
     protected function setUp(): void
     {
         $phpredisVersion = phpversion('redis');
-        if (version_compare($phpredisVersion, '1.2.0', '<')) {
-            $this->markTestSkipped(sprintf('phpredis extension version %s is not supported. Please update to verson 1.2.0+.', $phpredisVersion));
+        if (version_compare($phpredisVersion, '5.0.0', '<')) {
+            $this->markTestSkipped(sprintf('phpredis extension version %s is not supported. Please update to version 5.0.0+.', $phpredisVersion));
         }
         try {
             if (!@fsockopen('127.0.0.1', 6379)) {

--- a/Neos.Cache/Tests/Functional/Backend/RedisBackendTest.php
+++ b/Neos.Cache/Tests/Functional/Backend/RedisBackendTest.php
@@ -162,6 +162,18 @@ class RedisBackendTest extends BaseTestCase
     /**
      * @test
      */
+    public function flushUnfreezesTheCache()
+    {
+        self::assertFalse($this->backend->isFrozen());
+        $this->backend->freeze();
+        self::assertTrue($this->backend->isFrozen());
+        $this->backend->flush();
+        self::assertFalse($this->backend->isFrozen());
+    }
+
+    /**
+     * @test
+     */
     public function flushByTagFlushesEntryByTag()
     {
         for ($i = 0; $i < 10; $i++) {

--- a/Neos.Cache/Tests/Unit/Backend/RedisBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/RedisBackendTest.php
@@ -48,8 +48,8 @@ class RedisBackendTest extends BaseTestCase
     protected function setUp(): void
     {
         $phpredisVersion = phpversion('redis');
-        if (version_compare($phpredisVersion, '1.2.0', '<')) {
-            $this->markTestSkipped(sprintf('phpredis extension version %s is not supported. Please update to verson 1.2.0+.', $phpredisVersion));
+        if (version_compare($phpredisVersion, '5.0.0', '<')) {
+            $this->markTestSkipped(sprintf('phpredis extension version %s is not supported. Please update to version 5.0.0+.', $phpredisVersion));
         }
 
         $this->redis = $this->getMockBuilder(\Redis::class)->disableOriginalConstructor()->getMock();
@@ -92,8 +92,7 @@ class RedisBackendTest extends BaseTestCase
     public function freezeInvokesRedis()
     {
         $this->redis->expects(self::once())
-            ->method('lRange')
-            ->with('d41d8cd98f00b204e9800998ecf8427e:Foo_Cache:entries', 0, -1)
+            ->method('keys')
             ->will(self::returnValue(['entry_1', 'entry_2']));
 
         $this->redis->expects(self::exactly(2))

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
@@ -565,6 +565,15 @@ Options
 | compressionLevel | Set gzip compression level to a | No        | integer   | 0         |
 |                  | specific value.                 |           | (0 to 9)  |           |
 +------------------+---------------------------------+-----------+-----------+-----------+
+| batchSize        | Maximum number of parameters    | No        | int       | 100000    |
+|                  | per query for batch operations. |           |           |           |
+|                  |                                 |           |           |           |
+|                  | Redis supports up to            |           |           |           |
+|                  | 1.048.576 parameters, but a     |           |           |           |
+|                  | lower batch size allows other   |           |           |           |
+|                  | calls to Redis to be processed  |           |           |           |
+|                  | between each batch.             |           |           |           |
++------------------+---------------------------------+-----------+-----------+-----------+
 
 Neos\\Cache\\Backend\\MemcachedBackend
 --------------------------------------


### PR DESCRIPTION
**What I did**

With this change the `flushByTags` is optimised to run flush operations in batches. 
The maximum batch size can and should be configured based on the used data source.

This change relies on the interface changes in #2718

Additionally all optimisations from https://github.com/sandstorm/OptimizedRedisCacheBackend were added.

**How I did it**

Instead of uploading the flush Lua script and only flushing the entries for one tag.
The same is now done for batches of tags reducing the calls to Redis and the 
evaluation time Redis needs to parse the script.

**How to verify it**

#2718 includes updated tests for the Redis backend that will also check this method.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed -> see #2718 
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
