### PR TITLE
BUGFIX: Add behat @BeforeSuite and @AfterSuite to ignored annotation tags

### DIFF
--- a/Neos.Flow/Configuration/Settings.Reflection.yaml
+++ b/Neos.Flow/Configuration/Settings.Reflection.yaml
@@ -22,6 +22,8 @@ Neos:
         'Then': true
         'BeforeScenario': true
         'AfterScenario': true
+        'BeforeSuite': true
+        'AfterSuite': true
         'fixtures': true
         'Isolated': true
         'AfterFeature': true


### PR DESCRIPTION
**What I did**
This adds the missing behat annotations to ignored tags, so behat tests using those hooks can be reflected.

**How to verify it**
This is an example of the error that occurs currently when `@BeforeSuite` or `@AfterSuite` is used in any Behat Step class.
![image](https://user-images.githubusercontent.com/16836464/157476691-c5da169d-32d9-497f-b5ef-4806369a6600.png)
see also https://github.com/sandstorm/Sandstorm.E2ETestTools/pull/6
This can also be avoided when classes containing those annotations are *not reflected*, meaning if they are outside the psr classes directory.
When they are *inside* psr class directories, an error is thrown (see screenshot)