### PR TITLE
BUGFIX: Documentation fix follow up to #1108 and #2638

### DIFF
--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ErrorAndExceptionHandling.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ErrorAndExceptionHandling.rst
@@ -130,14 +130,18 @@ An example configuration could look like in the following Settings.yaml excerpt:
               notFoundExceptions:
                 matchingStatusCodes: [404]
                 options:
-                  templatePathAndFilename: 'resource://Neos.Flow/Private/Templates/Error/Default.html'
+                  viewClassName: 'Neos\FluidAdaptor\View\StandaloneView'
+                  viewOptions:
+                    templatePathAndFilename: 'resource://Neos.Flow/Private/Templates/Error/Default.html'
                   variables:
                     errorDescription: 'Sorry, the page you requested was not found.'
 
               databaseConnectionExceptions:
                 matchingExceptionClassNames: ['Neos\Flow\Persistence\Doctrine\DatabaseConnectionException']
                 options:
-                  templatePathAndFilename: 'resource://Neos.Flow/Private/Templates/Error/Default.html'
+                  viewClassName: 'Neos\FluidAdaptor\View\StandaloneView'
+                  viewOptions:
+                    templatePathAndFilename: 'resource://Neos.Flow/Private/Templates/Error/Default.html'
                   variables:
                     errorDescription: 'Sorry, the database connection couldn''t be established.'
 
@@ -166,16 +170,26 @@ key names, their actual naming has no further implications.
         template to include more details on the error at hand. Defaults to FALSE but is set to TRUE
         for development context.
 
+    ``viewClassName``:
+        a class name of the view that should be used
+
+    ``viewOptions``:
+        an array of options handed to the view. See ``$supportedOptions`` of the used view
+
     ``templatePathAndFilename``:
-        a resource string to the (Fluid) filename to use
+        **@deprecated** (use ``viewOptions.templatePathAndFilename: 'file'``)
+        a resource string to the filename to use
 
     ``layoutRootPath``:
+        **@deprecated** (use ``viewOptions.layoutRootPaths: ['path']``)
         a resource string to the layout root path
 
     ``partialRootPath``:
+        **@deprecated** (use ``viewOptions.partialRootPaths: ['path']``)
         a resource string to the partial root path
 
     ``format``:
+        **@deprecated**
         the format to use, for example ``html`` or ``json``, if appropriate
 
     ``variables``


### PR DESCRIPTION
related #1108
related #2638 

Concerning:
`Neos.Flow.error.exceptionHandler.renderingGroups.{exampleGroup}.options`

include the overseen options:

`viewClassName`, and `viewOptions`

mark the legacy options as @deprecated and show alternative
