### PR TITLE
BUGFIX: Eel Helper `Array.push()` auto cast string to array. #2710

### DIFF
--- a/Neos.Eel/Classes/Helper/ArrayHelper.php
+++ b/Neos.Eel/Classes/Helper/ArrayHelper.php
@@ -342,14 +342,20 @@ class ArrayHelper implements ProtectedContextAwareInterface
      *
      *     Array.push(array, e1, e2)
      *
-     * @param iterable $array
+     * @param iterable|scalar $array
      * @param mixed $element
      * @return array The array with the inserted elements
      */
-    public function push(iterable $array, $element): array
+    public function push($array, $element): array
     {
         if ($array instanceof \Traversable) {
             $array = iterator_to_array($array);
+        }
+        if (is_scalar($array)) {
+            $array = [$array];
+        }
+        if (is_array($array) === false) {
+            throw new \InvalidArgumentException('$array must be of type iterable|scalar got: ' . gettype($array), 1647595715);
         }
         $elements = func_get_args();
         array_shift($elements);

--- a/Neos.Eel/Tests/Unit/Helper/ArrayHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/ArrayHelperTest.php
@@ -423,6 +423,9 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
             'string keys' => [['foo' => 'bar', 'baz' => 'foo', 'bar' => 'baz'], 42, 'foo', ['foo' => 'bar', 'baz' => 'foo', 'bar' => 'baz', 42, 'foo']],
             'mixed keys' => [['bar', '24' => 'foo', 'i' => 181.84, 'foo' => 'abc', '84216', 76, 'k' => 53], 42, 'foo', ['bar', '24' => 'foo', 'i' => 181.84, 'foo' => 'abc', '84216', 76, 'k' => 53, 42, 'foo']],
             'traversable' => [TestArrayIterator::fromArray(['a']), 'b', 'c', ['a', 'b', 'c']],
+            # expect cast scalar (as arg $array) to array
+            'string' => ['a', 'b', 'c', ['a', 'b', 'c']],
+            'int' => [123, 'b', 'c', [123, 'b', 'c']],
         ];
     }
 


### PR DESCRIPTION
fixes #2710

same lose behaviour exists already for `Array.concat()`
