### PR TITLE
BUGFIX: Custom error view: skip 'viewOptions' that are 'null' #2738

### DIFF
--- a/Neos.Flow/Classes/Error/AbstractExceptionHandler.php
+++ b/Neos.Flow/Classes/Error/AbstractExceptionHandler.php
@@ -156,8 +156,11 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
 
         $statusMessage = ResponseInformationHelper::getStatusMessageByCode($statusCode);
         $viewClassName = $renderingOptions['viewClassName'];
+        $viewOptions = array_filter($renderingOptions['viewOptions'], static function ($optionValue) {
+            return $optionValue !== null;
+        });
         /** @var ViewInterface $view */
-        $view = $viewClassName::createWithOptions($renderingOptions['viewOptions']);
+        $view = $viewClassName::createWithOptions($viewOptions);
         $view = $this->applyLegacyViewOptions($view, $renderingOptions);
 
         $httpRequest = ServerRequest::fromGlobals();


### PR DESCRIPTION
fixes #2738
