### PR TITLE
!!!TASK: Remove legacy fluid custom error view options and migrate to `viewOptions`

### DIFF
--- a/Neos.Flow/Classes/Error/AbstractExceptionHandler.php
+++ b/Neos.Flow/Classes/Error/AbstractExceptionHandler.php
@@ -23,7 +23,6 @@ use Neos\Flow\Mvc\Controller\Arguments;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\Flow\Mvc\View\ViewInterface;
-use Neos\Utility\ObjectAccess;
 use Neos\Utility\Arrays;
 use Psr\Log\LoggerInterface;
 
@@ -161,7 +160,6 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
         });
         /** @var ViewInterface $view */
         $view = $viewClassName::createWithOptions($viewOptions);
-        $view = $this->applyLegacyViewOptions($view, $renderingOptions);
 
         $httpRequest = ServerRequest::fromGlobals();
         $request = ActionRequest::fromHttpRequest($httpRequest);
@@ -186,31 +184,6 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
             'statusMessage' => $statusMessage,
             'referenceCode' => $referenceCode
         ]);
-
-        return $view;
-    }
-
-    /**
-     * Sets legacy "option" properties to the view for backwards compatibility.
-     *
-     * @param ViewInterface $view
-     * @param array $renderingOptions
-     * @return ViewInterface
-     */
-    protected function applyLegacyViewOptions(ViewInterface $view, array $renderingOptions): ViewInterface
-    {
-        if (isset($renderingOptions['templatePathAndFilename'])) {
-            ObjectAccess::setProperty($view, 'templatePathAndFilename', $renderingOptions['templatePathAndFilename']);
-        }
-        if (isset($renderingOptions['layoutRootPath'])) {
-            ObjectAccess::setProperty($view, 'layoutRootPath', $renderingOptions['layoutRootPath']);
-        }
-        if (isset($renderingOptions['partialRootPath'])) {
-            ObjectAccess::setProperty($view, 'partialRootPath', $renderingOptions['partialRootPath']);
-        }
-        if (isset($renderingOptions['format'])) {
-            ObjectAccess::setProperty($view, 'format', $renderingOptions['format']);
-        }
 
         return $view;
     }
@@ -264,17 +237,9 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
     /**
      * If a renderingGroup was successfully resolved via @see resolveRenderingGroup
      * We will use a custom error view.
-     *
-     * Also check for legacy 'templatePathAndFilename'
-     *
      */
     protected function useCustomErrorView(): bool
     {
-        // for legacy reasons 'templatePathAndFilename' was enough to use the view,
-        // so it could theoretically be used without a 'renderingGroup' (will be deprecated!)
-        if (isset($this->renderingOptions['templatePathAndFilename'])) {
-            return true;
-        }
         return isset($this->renderingOptions['renderingGroup']);
     }
 

--- a/Neos.Flow/Classes/Error/AbstractExceptionHandler.php
+++ b/Neos.Flow/Classes/Error/AbstractExceptionHandler.php
@@ -55,11 +55,7 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
      *      renderTechnicalDetails: bool,
      *      logException: bool,
      *      renderingGroup?: string,
-     *      variables?: array,
-     *      templatePathAndFilename?: string,
-     *      layoutRootPath?: string,
-     *      partialRootPath?: string,
-     *      format?: string
+     *      variables?: array
      * }
      */
     protected $renderingOptions;

--- a/Neos.Flow/Configuration/Settings.Error.yaml
+++ b/Neos.Flow/Configuration/Settings.Error.yaml
@@ -26,14 +26,16 @@ Neos:
             matchingStatusCodes: [404, 410]
             options:
               logException: false
-              templatePathAndFilename: 'resource://Neos.Flow/Private/Templates/Error/Default.html'
+              viewOptions:
+                templatePathAndFilename: 'resource://Neos.Flow/Private/Templates/Error/Default.html'
               variables:
                 errorDescription: 'Sorry, the page you requested was not found.'
 
           databaseConnectionExceptions:
             matchingExceptionClassNames: ['Neos\Flow\Persistence\Doctrine\Exception\DatabaseException']
             options:
-              templatePathAndFilename: 'resource://Neos.Flow/Private/Templates/Error/Default.html'
+              viewOptions:
+                templatePathAndFilename: 'resource://Neos.Flow/Private/Templates/Error/Default.html'
               variables:
                 errorDescription: 'Sorry, the database connection couldn''t be established.'
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ErrorAndExceptionHandling.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ErrorAndExceptionHandling.rst
@@ -176,22 +176,6 @@ key names, their actual naming has no further implications.
     ``viewOptions``:
         an array of options handed to the view. See ``$supportedOptions`` of the used view
 
-    ``templatePathAndFilename``:
-        **@deprecated** (use ``viewOptions.templatePathAndFilename: 'file'``)
-        a resource string to the filename to use
-
-    ``layoutRootPath``:
-        **@deprecated** (use ``viewOptions.layoutRootPaths: ['path']``)
-        a resource string to the layout root path
-
-    ``partialRootPath``:
-        **@deprecated** (use ``viewOptions.partialRootPaths: ['path']``)
-        a resource string to the partial root path
-
-    ``format``:
-        **@deprecated**
-        the format to use, for example ``html`` or ``json``, if appropriate
-
     ``variables``
         an array of additional, arbitrary variables which can be accessed in the template
 

--- a/Neos.Flow/Migrations/Code/Version20220318174300.php
+++ b/Neos.Flow/Migrations/Code/Version20220318174300.php
@@ -1,0 +1,132 @@
+<?php
+namespace Neos\Flow\Core\Migrations;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Configuration\ConfigurationManager;
+use Neos\Utility\Arrays;
+
+/**
+ * Adjust "Settings.yaml" to remove legacy fluid custom error view options (see https://github.com/neos/flow-development-collection/issues/2742)
+ *
+ * concerning Neos.Flow.error.exceptionHandler.renderingGroups.{exampleGroup}.options
+ *
+ * options:
+ * -  templatePathAndFilename: 'file'
+ * -  layoutRootPath: 'path'
+ * -  partialRootPath: 'path'
+ * -  format: 'html'
+ * +  viewOptions:
+ * +    templatePathAndFilename: 'file'
+ * +    layoutRootPaths: ['path']
+ * +    partialRootPaths: ['path']
+ *
+ */
+class Version20220318174300 extends AbstractMigration
+{
+    public function getIdentifier(): string
+    {
+        return 'Neos.Flow-20220318174300';
+    }
+
+    public function up(): void
+    {
+        $this->processConfiguration(
+            ConfigurationManager::CONFIGURATION_TYPE_SETTINGS,
+            fn (array &$configuration) => $this->processErrorViewSettings($configuration),
+            true
+        );
+    }
+
+    /**
+     * Adjust legacy fluid view options: Neos.Flow.error.exceptionHandler.renderingGroups.{exampleGroup}.options
+     */
+    public function processErrorViewSettings(array &$configuration): void
+    {
+        if (self::arrayValueByPathIsArray($configuration, 'Neos.Flow.error.exceptionHandler.renderingGroups') === false) {
+            return;
+        }
+        $renderingGroups = &$configuration['Neos']['Flow']['error']['exceptionHandler']['renderingGroups'];
+
+        foreach ($renderingGroups as $renderingGroupName => &$renderingGroupConfig) {
+            if (self::arrayValueByPathIsArray($renderingGroupConfig, 'options') === false) {
+                continue;
+            }
+            $options = &$renderingGroupConfig['options'];
+
+            // config path for logs:
+            $renderingGroupPath = "Neos.Flow.error.exceptionHandler.renderingGroups.$renderingGroupName";
+
+            if (self::arrayValueByPathIsArray($options, 'viewOptions') === false) {
+                $options['viewOptions'] = [];
+            }
+            $viewOptions = &$options['viewOptions'];
+
+            //
+            // templatePathAndFilename
+            //
+            if (isset($options['templatePathAndFilename'])) {
+                $value = $options['templatePathAndFilename'];
+                unset($options['templatePathAndFilename']);
+                $viewOptions['templatePathAndFilename'] = $value;
+                $this->showNote("Moved 'templatePathAndFilename' to 'viewOptions.templatePathAndFilename' subkey:\n $renderingGroupPath.options.templatePathAndFilename = $value");
+            }
+
+            //
+            // layoutRootPath
+            //
+            if (isset($options['layoutRootPath'])) {
+                $value = $options['layoutRootPath'];
+                unset($options['layoutRootPath']);
+                if (self::arrayValueByPathIsArray($viewOptions, 'layoutRootPaths') === false) {
+                    $viewOptions['layoutRootPaths'] = [];
+                }
+                $viewOptions['layoutRootPaths'][] = $value;
+                $this->showNote("Moved 'layoutRootPath' to 'viewOptions.layoutRootPaths' subkey:\n $renderingGroupPath.options.layoutRootPath = $value");
+            }
+
+            //
+            // partialRootPath
+            //
+            if (isset($options['partialRootPath'])) {
+                $value = $options['partialRootPath'];
+                unset($options['partialRootPath']);
+                if (self::arrayValueByPathIsArray($viewOptions, 'partialRootPaths') === false) {
+                    $viewOptions['partialRootPaths'] = [];
+                }
+                $viewOptions['partialRootPaths'][] = $value;
+                $this->showNote("Moved 'layoutRootPath' to 'viewOptions.layoutRootPaths' subkey:\n $renderingGroupPath.options.layoutRootPath = $value");
+            }
+
+            //
+            // format
+            //
+            if (isset($options['format'])) {
+                $value = $options['format'];
+                if ($value === 'html') {
+                    unset($options['format']);
+                    $this->showNote("Unnecessary format option removed:\n $renderingGroupPath.options.format = $value");
+                } else {
+                    $this->showWarning("There is no replacement for the legacy fluid option format:\n $renderingGroupPath.options.format = $value");
+                }
+            }
+        }
+    }
+
+    /**
+     * checks if (isset($array['path']) && is_array($array['path']))
+     */
+    protected static function arrayValueByPathIsArray(array $array, string $path): bool
+    {
+        $value = Arrays::getValueByPath($array, $path);
+        return is_array($value);
+    }
+}

--- a/Neos.Flow/Migrations/Code/Version20220318174300.php
+++ b/Neos.Flow/Migrations/Code/Version20220318174300.php
@@ -48,9 +48,21 @@ class Version20220318174300 extends AbstractMigration
 
     /**
      * Adjust legacy fluid view options: Neos.Flow.error.exceptionHandler.renderingGroups.{exampleGroup}.options
+     * show warning if Neos.Flow.error.exceptionHandler.defaultRenderingOptions was used with legacy fluid view options
      */
     public function processErrorViewSettings(array &$configuration): void
     {
+        if (self::arrayValueByPathIsArray($configuration, 'Neos.Flow.error.exceptionHandler.defaultRenderingOptions')) {
+            $defaultRenderingOptions = $configuration['Neos']['Flow']['error']['exceptionHandler']['defaultRenderingOptions'];
+            if (isset($defaultRenderingOptions['templatePathAndFilename'])
+                || isset($defaultRenderingOptions['layoutRootPath'])
+                || isset($defaultRenderingOptions['partialRootPath'])
+                || isset($defaultRenderingOptions['format'])) {
+                // moving these options globally to the 'viewOptions' subkey would lead to that every view (not only fluid) will get them applied and not supported options view errors will occur.
+                $this->showWarning("No automatic migration can be done for the global legacy fluid error view options:\nNeos.Flow.error.exceptionHandler.defaultRenderingOptions");
+            }
+        }
+
         if (self::arrayValueByPathIsArray($configuration, 'Neos.Flow.error.exceptionHandler.renderingGroups') === false) {
             return;
         }
@@ -76,8 +88,15 @@ class Version20220318174300 extends AbstractMigration
             if (isset($options['templatePathAndFilename'])) {
                 $value = $options['templatePathAndFilename'];
                 unset($options['templatePathAndFilename']);
-                $viewOptions['templatePathAndFilename'] = $value;
-                $this->showNote("Moved 'templatePathAndFilename' to 'viewOptions.templatePathAndFilename' subkey:\n $renderingGroupPath.options.templatePathAndFilename = $value");
+                if (is_string($value) && $value !== '') {
+                    $viewOptions['templatePathAndFilename'] = $value;
+                    $this->showNote("Moved 'templatePathAndFilename' to 'viewOptions.templatePathAndFilename' subkey:\n $renderingGroupPath.options.templatePathAndFilename = $value");
+                } else {
+                    // templatePathAndFilename: true
+                    // was a workaround:
+                    // https://github.com/neos/flow-development-collection/issues/1108
+                    $this->showNote("Old 'templatePathAndFilename' workaround removed:\n  $renderingGroupPath.options.templatePathAndFilename = $value");
+                }
             }
 
             //

--- a/Neos.Flow/Tests/Unit/Error/AbstractExceptionHandlerTest.php
+++ b/Neos.Flow/Tests/Unit/Error/AbstractExceptionHandlerTest.php
@@ -65,7 +65,9 @@ class AbstractExceptionHandlerTest extends UnitTestCase
                     'matchingStatusCodes' => [404],
                     'options' => [
                         'logException' => false,
-                        'templatePathAndFilename' => 'resource://Neos.Flow/Private/Templates/Error/Default.html',
+                        'viewOptions' => [
+                            'templatePathAndFilename' => 'resource://Neos.Flow/Private/Templates/Error/Default.html',
+                        ],
                         'variables' => [
                             'errorDescription' => 'Sorry, the page you requested was not found.'
                         ]


### PR DESCRIPTION
resolves: #2742

Concerning:
`Neos.Flow.error.exceptionHandler.renderingGroups.{exampleGroup}.options`

remove the legacy way of passing

* templatePathAndFilename
* layoutRootPath
* partialRootPath
* format

to a fluid view.

migrate those options to the equivalent `viewOptions`

migration see: https://github.com/neos/flow-development-collection/pull/2748

### How to test:

(Make sure youre on flow only - or comment out the neos.neos error view settings or also use https://github.com/neos/neos-development-collection/pull/3637)

throw some of these at your favorite places and marvel at the great exceptions:

```php
throw new DatabaseException();
throw new TargetNotFoundException(); // provokes a 404
```
