### PR TITLE
BUGFIX: Use of undefined variable `$pathInfo['extension']`

### DIFF
--- a/Neos.Flow/Classes/ResourceManagement/Target/FileSystemSymlinkTarget.php
+++ b/Neos.Flow/Classes/ResourceManagement/Target/FileSystemSymlinkTarget.php
@@ -59,7 +59,7 @@ class FileSystemSymlinkTarget extends FileSystemTarget
     {
         $extension = strtolower(pathinfo($relativeTargetPathAndFilename, PATHINFO_EXTENSION));
         if ($extension !== '' && array_key_exists($extension, $this->excludedExtensions) && $this->excludedExtensions[$extension] === true) {
-            throw new TargetException(sprintf('Could not publish "%s" into resource publishing target "%s" because the filename extension "%s" is excluded.', $sourceStream, $this->name, strtolower($pathInfo['extension'])), 1447152230);
+            throw new TargetException(sprintf('Could not publish "%s" into resource publishing target "%s" because the filename extension "%s" is excluded.', $sourceStream, $this->name, $extension), 1447152230);
         }
 
         $streamMetaData = stream_get_meta_data($sourceStream);


### PR DESCRIPTION
Fixup for:
`TASK: Further clarify use of only "extension" from pathinfo`
https://github.com/neos/flow-development-collection/pull/2729

commit https://github.com/neos/flow-development-collection/commit/e1e9f006f491effe88111f92368810bf6e3d4bb7

noticed because psalm failed: https://github.com/neos/flow-development-collection/runs/5632499130?check_suite_focus=true
