### PR TITLE
BUGFIX: Properly encode error message in internal request header

### DIFF
--- a/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
+++ b/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
@@ -177,6 +177,6 @@ class InternalRequestEngine implements RequestEngineInterface
             ->withStatus($statusCode)
             ->withBody($this->contentFactory->createStream($content))
             ->withHeader('X-Flow-ExceptionCode', $exception->getCode())
-            ->withHeader('X-Flow-ExceptionMessage', $exception->getMessage());
+            ->withHeader('X-Flow-ExceptionMessage', base64_encode($exception->getMessage()));
     }
 }


### PR DESCRIPTION
According to the HTTP spec, characters like line breaks and some other are not allowed within a request header. Exception messages typically include those. Since guzzlehttp/psr7 1.8.4 it validates headers to this spec and makes our builds fail. This fixes that by base64 encoding the exception message we transfer via the `X-Flow-ExceptionMessage` header. Currently there is no code in the core that uses this header, but if you read this header at some obscure place, you need to `base64_decode()` the value first.

See https://github.com/guzzle/psr7/pull/486/files#diff-fb174524a7bba27ce140bc6ccd1c30811a6abeed9328e783b326189551ba7ed4R253