### PR TITLE
BUGFIX: Make Array.push accept `null` for array type casting

### DIFF
--- a/Neos.Eel/Classes/Helper/ArrayHelper.php
+++ b/Neos.Eel/Classes/Helper/ArrayHelper.php
@@ -351,8 +351,11 @@ class ArrayHelper implements ProtectedContextAwareInterface
         if ($array instanceof \Traversable) {
             $array = iterator_to_array($array);
         }
-        if (is_scalar($array) || $array === null) {
+        if (is_scalar($array)) {
             $array = [$array];
+        }
+        if ($array === null) {
+            $array = [];
         }
         if (is_array($array) === false) {
             throw new \InvalidArgumentException('$array must be of type iterable|scalar|null got: ' . gettype($array), 1647595715);

--- a/Neos.Eel/Classes/Helper/ArrayHelper.php
+++ b/Neos.Eel/Classes/Helper/ArrayHelper.php
@@ -342,7 +342,7 @@ class ArrayHelper implements ProtectedContextAwareInterface
      *
      *     Array.push(array, e1, e2)
      *
-     * @param iterable|scalar $array
+     * @param iterable|scalar|null $array
      * @param mixed $element
      * @return array The array with the inserted elements
      */
@@ -351,11 +351,11 @@ class ArrayHelper implements ProtectedContextAwareInterface
         if ($array instanceof \Traversable) {
             $array = iterator_to_array($array);
         }
-        if (is_scalar($array)) {
+        if (is_scalar($array) || $array === null) {
             $array = [$array];
         }
         if (is_array($array) === false) {
-            throw new \InvalidArgumentException('$array must be of type iterable|scalar got: ' . gettype($array), 1647595715);
+            throw new \InvalidArgumentException('$array must be of type iterable|scalar|null got: ' . gettype($array), 1647595715);
         }
         $elements = func_get_args();
         array_shift($elements);

--- a/Neos.Eel/Tests/Unit/Helper/ArrayHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/ArrayHelperTest.php
@@ -426,6 +426,7 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
             # expect cast scalar (as arg $array) to array
             'string' => ['a', 'b', 'c', ['a', 'b', 'c']],
             'int' => [123, 'b', 'c', [123, 'b', 'c']],
+            'null' => [null, 'b', 'c', [null, 'b', 'c']],
         ];
     }
 

--- a/Neos.Eel/Tests/Unit/Helper/ArrayHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/ArrayHelperTest.php
@@ -426,7 +426,8 @@ class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
             # expect cast scalar (as arg $array) to array
             'string' => ['a', 'b', 'c', ['a', 'b', 'c']],
             'int' => [123, 'b', 'c', [123, 'b', 'c']],
-            'null' => [null, 'b', 'c', [null, 'b', 'c']],
+            # ignore null (as arg $array)
+            'null' => [null, 'b', 'c', ['b', 'c']],
         ];
     }
 


### PR DESCRIPTION
related: https://github.com/neos/neos-development-collection/pull/3658
fixes: https://github.com/neos/neos-development-collection/issues/3657