### PR TITLE
FEATURE: Create ValueObjects from simple types by calling `from$TYPE` for objects and JsonArray properties

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/DataTypes/JsonArrayType.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/DataTypes/JsonArrayType.php
@@ -215,6 +215,7 @@ class JsonArrayType extends DoctrineJsonArrayType
             }
             if ($value instanceof \JsonSerializable && DenormalizingObjectConverter::isDenormalizable(get_class($value))) {
                 $value = self::serializeValueObject($value);
+                continue;
             }
 
             $propertyClassName = TypeHandling::getTypeForValue($value);

--- a/Neos.Flow/Classes/Persistence/Doctrine/DataTypes/JsonArrayType.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/DataTypes/JsonArrayType.php
@@ -213,10 +213,7 @@ class JsonArrayType extends DoctrineJsonArrayType
             if (!is_object($value) || (is_object($value) && $value instanceof DependencyProxy)) {
                 continue;
             }
-            if ($value instanceof \JsonSerializable && DenormalizingObjectConverter::isDenormalizable(get_class($value))) {
-                $value = self::serializeValueObject($value);
-                continue;
-            }
+
 
             $propertyClassName = TypeHandling::getTypeForValue($value);
 
@@ -243,6 +240,10 @@ class JsonArrayType extends DoctrineJsonArrayType
                     '__flow_object_type' => $propertyClassName,
                     '__identifier' => $this->persistenceManager->getIdentifierByObject($value)
                 ];
+            } elseif ($value instanceof \JsonSerializable
+                && DenormalizingObjectConverter::isDenormalizable(get_class($value))
+            ) {
+                $value = self::serializeValueObject($value);
             }
         }
     }

--- a/Neos.Flow/Classes/Persistence/Doctrine/DataTypes/JsonArrayType.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/DataTypes/JsonArrayType.php
@@ -9,6 +9,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\ObjectManagement\DependencyInjection\DependencyProxy;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Flow\Property\TypeConverter\DenormalizingObjectConverter;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Utility\TypeHandling;
 
@@ -165,12 +166,34 @@ class JsonArrayType extends DoctrineJsonArrayType
                 continue;
             }
 
-            if (isset($value['__flow_object_type'])) {
+            if (isset($value['__value_object_value']) && isset($value['__value_object_type'])) {
+                $value = self::deserializeValueObject($value);
+            } elseif (isset($value['__flow_object_type'])) {
                 $value = $this->persistenceManager->getObjectByIdentifier($value['__identifier'], $value['__flow_object_type'], true);
             } else {
                 $this->decodeObjectReferences($value);
             }
         }
+    }
+
+    /**
+     * @param array<mixed> $serializedValueObject
+     * @return \JsonSerializable
+     * @throws \InvalidArgumentException
+     */
+    public static function deserializeValueObject(array $serializedValueObject): \JsonSerializable
+    {
+        if (isset($serializedValueObject['__value_object_value']) && isset($serializedValueObject['__value_object_type'])) {
+            return DenormalizingObjectConverter::convertFromSource(
+                $serializedValueObject['__value_object_value'],
+                $serializedValueObject['__value_object_type']
+            );
+        }
+
+        throw new \InvalidArgumentException(
+            '$serializedValueObject must contain keys "__value_object_value" and "__value_object_type"',
+            1621332088
+        );
     }
 
     /**
@@ -189,6 +212,9 @@ class JsonArrayType extends DoctrineJsonArrayType
             }
             if (!is_object($value) || (is_object($value) && $value instanceof DependencyProxy)) {
                 continue;
+            }
+            if ($value instanceof \JsonSerializable && DenormalizingObjectConverter::isDenormalizable(get_class($value))) {
+                $value = self::serializeValueObject($value);
             }
 
             $propertyClassName = TypeHandling::getTypeForValue($value);
@@ -218,6 +244,30 @@ class JsonArrayType extends DoctrineJsonArrayType
                 ];
             }
         }
+    }
+
+    /**
+     * @param \JsonSerializable $valueObject
+     * @return array<mixed>
+     * @throws \RuntimeException
+     */
+    public static function serializeValueObject(\JsonSerializable $valueObject): array
+    {
+        if ($json = json_encode($valueObject)) {
+            return [
+                '__value_object_type' => get_class($valueObject),
+                '__value_object_value' =>
+                    json_decode($json, true)
+            ];
+        }
+
+        throw new \RuntimeException(
+            sprintf(
+                'Could not serialize $valueObject due to: %s',
+                json_last_error_msg()
+            ),
+            1621333154
+        );
     }
 
     /**

--- a/Neos.Flow/Classes/Property/TypeConverter/DenormalizingObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/DenormalizingObjectConverter.php
@@ -1,0 +1,182 @@
+<?php
+namespace Neos\Flow\Property\TypeConverter;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Property\Exception\TypeConverterException;
+use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+use Neos\Flow\Property\TypeConverterInterface;
+
+final class DenormalizingObjectConverter implements TypeConverterInterface
+{
+    /**
+     * @return array<string>
+     */
+    public function getSupportedSourceTypes()
+    {
+        return ['array', 'string', 'bool', 'int', 'float'];
+    }
+
+    /**
+     * @return string
+     */
+    public function getSupportedTargetType()
+    {
+        return 'object';
+    }
+
+    /**
+     * @param mixed $source the source data
+     * @param string $originalTargetType the type we originally want to convert to
+     * @param PropertyMappingConfigurationInterface $configuration
+     * @return string
+     * @api
+     */
+    public function getTargetTypeForSource($source, $originalTargetType, PropertyMappingConfigurationInterface $configuration = null)
+    {
+        return $originalTargetType;
+    }
+
+    /**
+     * Return the priority of this TypeConverter. TypeConverters with a high priority are chosen before low priority.
+     *
+     * @return integer
+     * @api
+     */
+    public function getPriority()
+    {
+        return 100;
+    }
+
+    /**
+     * @param mixed $source the source data
+     * @param string $targetType the type to convert to.
+     * @return boolean true if this TypeConverter can convert from $source to $targetType, false otherwise.
+     * @api
+     */
+    public function canConvertFrom($source, $targetType)
+    {
+        return self::canConvertFromSourceType(gettype($source), $targetType);
+    }
+
+    /**
+     * @param string $sourceType
+     * @param string $targetType
+     * @return boolean
+     */
+    public static function canConvertFromSourceType(string $sourceType, string $targetType): bool
+    {
+        if (class_exists($targetType)) {
+            switch ($sourceType) {
+                case 'array':
+                    return method_exists($targetType, 'fromArray');
+                case 'string':
+                    return method_exists($targetType, 'fromString');
+                case 'bool':
+                case 'boolean':
+                    return method_exists($targetType, 'fromBool');
+                case 'int':
+                case 'integer':
+                    return method_exists($targetType, 'fromInt');
+                case 'double':
+                case 'float':
+                    return method_exists($targetType, 'fromFloat');
+                default:
+                    break;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $targetType
+     * @return boolean
+     */
+    public static function isDenormalizable(string $targetType): bool
+    {
+        return self::canConvertFromSourceType('array', $targetType)
+            || self::canConvertFromSourceType('string', $targetType)
+            || self::canConvertFromSourceType('boolean', $targetType)
+            || self::canConvertFromSourceType('integer', $targetType)
+            || self::canConvertFromSourceType('double', $targetType)
+        ;
+    }
+
+    /**
+     * @param mixed $source
+     * @return array<mixed>
+     * @api
+     */
+    public function getSourceChildPropertiesToBeConverted($source)
+    {
+        return [];
+    }
+
+    /**
+     * @param string $targetType
+     * @param string $propertyName
+     * @param PropertyMappingConfigurationInterface $configuration
+     * @return string the type of $propertyName in $targetType
+     * @api
+     */
+    public function getTypeOfChildProperty($targetType, $propertyName, PropertyMappingConfigurationInterface $configuration)
+    {
+        throw new \LogicException(self::class . '::getTypeOfChildProperty should never be called.');
+    }
+
+    /**
+     * @param mixed $source
+     * @param string $targetType
+     * @param array<mixed> $convertedChildProperties
+     * @param PropertyMappingConfigurationInterface|null $configuration
+     * @return mixed|null|Error the target type, or an error object if a user-error occurred
+     * @throws TypeConverterException thrown in case a developer error occurred
+     * @api
+     */
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    {
+        return self::convertFromSource($source, $targetType);
+    }
+
+    /**
+     * @param mixed $source
+     * @param string $targetType
+     * @return mixed
+     * @throws TypeConverterException thrown in case a developer error occurred
+     */
+    public static function convertFromSource($source, string $targetType)
+    {
+        switch (gettype($source)) {
+            case 'array':
+                return $targetType::fromArray($source);
+            case 'string':
+                return $targetType::fromString($source);
+            case 'boolean':
+                return $targetType::fromBool($source);
+            case 'integer':
+                return $targetType::fromInt($source);
+            case 'double':
+                return $targetType::fromFloat($source);
+            default:
+                break;
+        }
+
+        throw new TypeConverterException(
+            sprintf(
+                'Unable to convert "%s" to "%s"',
+                gettype($source),
+                $targetType
+            ),
+            1621322742
+        );
+    }
+}

--- a/Neos.Flow/Classes/Property/TypeConverter/DenormalizingObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/DenormalizingObjectConverter.php
@@ -138,7 +138,7 @@ final class DenormalizingObjectConverter implements TypeConverterInterface
      * @param string $targetType
      * @param array<mixed> $convertedChildProperties
      * @param PropertyMappingConfigurationInterface|null $configuration
-     * @return mixed|null|Error the target type, or an error object if a user-error occurred
+     * @return mixed
      * @throws TypeConverterException thrown in case a developer error occurred
      * @api
      */

--- a/Neos.Flow/Classes/Property/TypeConverter/DenormalizingObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/DenormalizingObjectConverter.php
@@ -82,10 +82,10 @@ final class DenormalizingObjectConverter implements TypeConverterInterface
                     return method_exists($targetType, 'fromString');
                 case 'bool':
                 case 'boolean':
-                    return method_exists($targetType, 'fromBoolean');
+                    return method_exists($targetType, 'fromBool');
                 case 'int':
                 case 'integer':
-                    return method_exists($targetType, 'fromInteger');
+                    return method_exists($targetType, 'fromInt');
                 case 'double':
                 case 'float':
                     return method_exists($targetType, 'fromFloat');
@@ -161,9 +161,9 @@ final class DenormalizingObjectConverter implements TypeConverterInterface
             case 'string':
                 return $targetType::fromString($source);
             case 'boolean':
-                return $targetType::fromBoolean($source);
+                return $targetType::fromBool($source);
             case 'integer':
-                return $targetType::fromInteger($source);
+                return $targetType::fromInt($source);
             case 'double':
                 return $targetType::fromFloat($source);
             default:

--- a/Neos.Flow/Classes/Property/TypeConverter/DenormalizingObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/DenormalizingObjectConverter.php
@@ -161,9 +161,9 @@ final class DenormalizingObjectConverter implements TypeConverterInterface
             case 'string':
                 return $targetType::fromString($source);
             case 'boolean':
-                return $targetType::fromBool($source);
+                return $targetType::fromBoolean($source);
             case 'integer':
-                return $targetType::fromInt($source);
+                return $targetType::fromInteger($source);
             case 'double':
                 return $targetType::fromFloat($source);
             default:

--- a/Neos.Flow/Classes/Property/TypeConverter/DenormalizingObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/DenormalizingObjectConverter.php
@@ -82,10 +82,10 @@ final class DenormalizingObjectConverter implements TypeConverterInterface
                     return method_exists($targetType, 'fromString');
                 case 'bool':
                 case 'boolean':
-                    return method_exists($targetType, 'fromBool');
+                    return method_exists($targetType, 'fromBoolean');
                 case 'int':
                 case 'integer':
-                    return method_exists($targetType, 'fromInt');
+                    return method_exists($targetType, 'fromInteger');
                 case 'double':
                 case 'float':
                     return method_exists($targetType, 'fromFloat');

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/DataTypes/JsonArrayTypeTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/DataTypes/JsonArrayTypeTest.php
@@ -12,6 +12,11 @@ namespace Neos\Flow\Tests\Unit\Persistence\Doctrine\DataTypes;
 */
 
 use Neos\Flow\Persistence\Doctrine\DataTypes\JsonArrayType;
+use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\ArrayBasedValueObject;
+use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\BooleanBasedValueObject;
+use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\FloatBasedValueObject;
+use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\IntegerBasedValueObject;
+use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\StringBasedValueObject;
 use Neos\Flow\Tests\UnitTestCase;
 
 class JsonArrayTypeTest extends UnitTestCase
@@ -55,5 +60,161 @@ class JsonArrayTypeTest extends UnitTestCase
     {
         $json = $this->jsonArrayTypeMock->convertToDatabaseValue(['simplestring',1,['nestedArray']], $this->abstractPlatformMock);
         self::assertEquals("{\n    \"0\": \"simplestring\",\n    \"1\": 1,\n    \"2\": {\n        \"0\": \"nestedArray\"\n    }\n}", $json);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function convertsValueObjectsToSerializableArrayStructures(): void
+    {
+        $this->assertEquals(
+            [
+                '__value_object_type' => ArrayBasedValueObject::class,
+                '__value_object_value' => [
+                    'key' => 'value'
+                ]
+            ],
+            JsonArrayType::serializeValueObject(
+                ArrayBasedValueObject::fromArray([
+                    'key' => 'value'
+                ])
+            )
+        );
+
+        $this->assertEquals(
+            [
+                '__value_object_type' => StringBasedValueObject::class,
+                '__value_object_value' => 'Hello World'
+            ],
+            JsonArrayType::serializeValueObject(
+                StringBasedValueObject::fromString('Hello World')
+            )
+        );
+
+        $this->assertEquals(
+            [
+                '__value_object_type' => BooleanBasedValueObject::class,
+                '__value_object_value' => true
+            ],
+            JsonArrayType::serializeValueObject(
+                BooleanBasedValueObject::fromBool(true)
+            )
+        );
+
+        $this->assertEquals(
+            [
+                '__value_object_type' => IntegerBasedValueObject::class,
+                '__value_object_value' => 12
+            ],
+            JsonArrayType::serializeValueObject(
+                IntegerBasedValueObject::fromInt(12)
+            )
+        );
+
+        $this->assertEquals(
+            [
+                '__value_object_type' => FloatBasedValueObject::class,
+                '__value_object_value' => 55.55
+            ],
+            JsonArrayType::serializeValueObject(
+                FloatBasedValueObject::fromFloat(55.55)
+            )
+        );
+
+        $this->assertEquals(
+            [
+                '__value_object_type' => ArrayBasedValueObject::class,
+                '__value_object_value' => [
+                    'array' => [
+                        'key' => 'value'
+                    ],
+                    'string' => 'string value',
+                    'boolean' => false,
+                    'integer' => 23,
+                    'float' => 22.22
+                ]
+            ],
+            JsonArrayType::serializeValueObject(
+                ArrayBasedValueObject::fromArray([
+                    'array' => ArrayBasedValueObject::fromArray([
+                        'key' => 'value'
+                    ]),
+                    'boolean' => BooleanBasedValueObject::fromBool(false),
+                    'string' => StringBasedValueObject::fromString('string value'),
+                    'integer' => IntegerBasedValueObject::fromInt(23),
+                    'float' => FloatBasedValueObject::fromFloat(22.22)
+                ])
+            )
+        );
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function deserializesValueObjectsFromSerializableArrayStructures(): void
+    {
+        //
+        // Array
+        //
+        $valueObject = JsonArrayType::deserializeValueObject([
+            '__value_object_type' => ArrayBasedValueObject::class,
+            '__value_object_value' => [
+                'key' => 'value'
+            ]
+        ]);
+
+        $this->assertInstanceOf(ArrayBasedValueObject::class, $valueObject);
+        /** @var ArrayBasedValueObject $valueObject */
+        $this->assertEquals(['key' => 'value'], $valueObject->getValue());
+
+        //
+        // String
+        //
+        $valueObject = JsonArrayType::deserializeValueObject([
+            '__value_object_type' => StringBasedValueObject::class,
+            '__value_object_value' => 'Hello World!'
+        ]);
+
+        $this->assertInstanceOf(StringBasedValueObject::class, $valueObject);
+        /** @var StringBasedValueObject $valueObject */
+        $this->assertEquals('Hello World!', $valueObject->getValue());
+
+        //
+        // Boolean
+        //
+        $valueObject = JsonArrayType::deserializeValueObject([
+            '__value_object_type' => BooleanBasedValueObject::class,
+            '__value_object_value' => false
+        ]);
+
+        $this->assertInstanceOf(BooleanBasedValueObject::class, $valueObject);
+        /** @var BooleanBasedValueObject $valueObject */
+        $this->assertEquals(false, $valueObject->getValue());
+
+        //
+        // Integer
+        //
+        $valueObject = JsonArrayType::deserializeValueObject([
+            '__value_object_type' => IntegerBasedValueObject::class,
+            '__value_object_value' => 87
+        ]);
+
+        $this->assertInstanceOf(IntegerBasedValueObject::class, $valueObject);
+        /** @var IntegerBasedValueObject $valueObject */
+        $this->assertEquals(87, $valueObject->getValue());
+
+        //
+        // Float
+        //
+        $valueObject = JsonArrayType::deserializeValueObject([
+            '__value_object_type' => FloatBasedValueObject::class,
+            '__value_object_value' => 17.777
+        ]);
+
+        $this->assertInstanceOf(FloatBasedValueObject::class, $valueObject);
+        /** @var FloatBasedValueObject $valueObject */
+        $this->assertEquals(17.777, $valueObject->getValue());
     }
 }

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/DataTypes/JsonArrayTypeTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/DataTypes/JsonArrayTypeTest.php
@@ -98,7 +98,7 @@ class JsonArrayTypeTest extends UnitTestCase
                 '__value_object_value' => true
             ],
             JsonArrayType::serializeValueObject(
-                BooleanBasedValueObject::fromBoolean(true)
+                BooleanBasedValueObject::fromBool(true)
             )
         );
 
@@ -108,7 +108,7 @@ class JsonArrayTypeTest extends UnitTestCase
                 '__value_object_value' => 12
             ],
             JsonArrayType::serializeValueObject(
-                IntegerBasedValueObject::fromInteger(12)
+                IntegerBasedValueObject::fromInt(12)
             )
         );
 
@@ -140,9 +140,9 @@ class JsonArrayTypeTest extends UnitTestCase
                     'array' => ArrayBasedValueObject::fromArray([
                         'key' => 'value'
                     ]),
-                    'boolean' => BooleanBasedValueObject::fromBoolean(false),
+                    'boolean' => BooleanBasedValueObject::fromBool(false),
                     'string' => StringBasedValueObject::fromString('string value'),
-                    'integer' => IntegerBasedValueObject::fromInteger(23),
+                    'integer' => IntegerBasedValueObject::fromInt(23),
                     'float' => FloatBasedValueObject::fromFloat(22.22)
                 ])
             )

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/DataTypes/JsonArrayTypeTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/DataTypes/JsonArrayTypeTest.php
@@ -98,7 +98,7 @@ class JsonArrayTypeTest extends UnitTestCase
                 '__value_object_value' => true
             ],
             JsonArrayType::serializeValueObject(
-                BooleanBasedValueObject::fromBool(true)
+                BooleanBasedValueObject::fromBoolean(true)
             )
         );
 
@@ -108,7 +108,7 @@ class JsonArrayTypeTest extends UnitTestCase
                 '__value_object_value' => 12
             ],
             JsonArrayType::serializeValueObject(
-                IntegerBasedValueObject::fromInt(12)
+                IntegerBasedValueObject::fromInteger(12)
             )
         );
 
@@ -140,9 +140,9 @@ class JsonArrayTypeTest extends UnitTestCase
                     'array' => ArrayBasedValueObject::fromArray([
                         'key' => 'value'
                     ]),
-                    'boolean' => BooleanBasedValueObject::fromBool(false),
+                    'boolean' => BooleanBasedValueObject::fromBoolean(false),
                     'string' => StringBasedValueObject::fromString('string value'),
-                    'integer' => IntegerBasedValueObject::fromInt(23),
+                    'integer' => IntegerBasedValueObject::fromInteger(23),
                     'float' => FloatBasedValueObject::fromFloat(22.22)
                 ])
             )

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/DenormalizingObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/DenormalizingObjectConverterTest.php
@@ -1,0 +1,161 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Property\TypeConverter\DenormalizingObjectConverter;
+use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\ArrayBasedValueObject;
+use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\BooleanBasedValueObject;
+use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\FloatBasedValueObject;
+use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\IntegerBasedValueObject;
+use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\StringBasedValueObject;
+use Neos\Flow\Tests\UnitTestCase;
+
+final class DenormalizingObjectConverterTest extends UnitTestCase
+{
+    /**
+     * @test
+     * @return void
+     */
+    public function identifiesDenormalizableClasses(): void
+    {
+        $this->assertTrue(DenormalizingObjectConverter::isDenormalizable(ArrayBasedValueObject::class));
+        $this->assertTrue(DenormalizingObjectConverter::isDenormalizable(StringBasedValueObject::class));
+        $this->assertTrue(DenormalizingObjectConverter::isDenormalizable(BooleanBasedValueObject::class));
+        $this->assertTrue(DenormalizingObjectConverter::isDenormalizable(IntegerBasedValueObject::class));
+        $this->assertTrue(DenormalizingObjectConverter::isDenormalizable(FloatBasedValueObject::class));
+
+        $this->assertFalse(DenormalizingObjectConverter::isDenormalizable(UnitTestCase::class));
+        $this->assertFalse(DenormalizingObjectConverter::isDenormalizable(DenormalizingObjectConverter::class));
+        $this->assertFalse(DenormalizingObjectConverter::isDenormalizable(\stdClass::class));
+        $this->assertFalse(DenormalizingObjectConverter::isDenormalizable(\DateTimeInterface::class));
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function canConvertFromArray(): void
+    {
+        $typeConverter = new DenormalizingObjectConverter();
+        $this->assertTrue($typeConverter->canConvertFrom(['key' => 'value'], ArrayBasedValueObject::class));
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function convertsFromArray(): void
+    {
+        $typeConverter = new DenormalizingObjectConverter();
+        $result = $typeConverter->convertFrom(['key' => 'value'], ArrayBasedValueObject::class);
+
+        $this->assertInstanceOf(ArrayBasedValueObject::class, $result);
+        $this->assertEquals(['key' => 'value'], $result->getValue());
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function canConvertFromString(): void
+    {
+        $typeConverter = new DenormalizingObjectConverter();
+        $this->assertTrue($typeConverter->canConvertFrom('string', StringBasedValueObject::class));
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function convertsFromString(): void
+    {
+        $typeConverter = new DenormalizingObjectConverter();
+        $result = $typeConverter->convertFrom('string', StringBasedValueObject::class);
+
+        $this->assertInstanceOf(StringBasedValueObject::class, $result);
+        $this->assertEquals('string', $result->getValue());
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function canConvertFromBoolean(): void
+    {
+        $typeConverter = new DenormalizingObjectConverter();
+        $this->assertTrue($typeConverter->canConvertFrom(true, BooleanBasedValueObject::class));
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function convertsFromBoolean(): void
+    {
+        $typeConverter = new DenormalizingObjectConverter();
+        $resultFalse = $typeConverter->convertFrom(false, BooleanBasedValueObject::class);
+
+        $this->assertInstanceOf(BooleanBasedValueObject::class, $resultFalse);
+        $this->assertEquals(false, $resultFalse->getValue());
+
+        $resultTrue = $typeConverter->convertFrom(true, BooleanBasedValueObject::class);
+
+        $this->assertInstanceOf(BooleanBasedValueObject::class, $resultTrue);
+        $this->assertEquals(true, $resultTrue->getValue());
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function canConvertFromInteger(): void
+    {
+        $typeConverter = new DenormalizingObjectConverter();
+        $this->assertTrue($typeConverter->canConvertFrom(42, IntegerBasedValueObject::class));
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function convertsFromInteger(): void
+    {
+        $typeConverter = new DenormalizingObjectConverter();
+        $result = $typeConverter->convertFrom(12264, IntegerBasedValueObject::class);
+
+        $this->assertInstanceOf(IntegerBasedValueObject::class, $result);
+        $this->assertEquals(12264, $result->getValue());
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function canConvertFromFloat(): void
+    {
+        $typeConverter = new DenormalizingObjectConverter();
+        $this->assertTrue($typeConverter->canConvertFrom(23.3, FloatBasedValueObject::class));
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function convertsFromFloat(): void
+    {
+        $typeConverter = new DenormalizingObjectConverter();
+        $result = $typeConverter->convertFrom(12264.123, FloatBasedValueObject::class);
+
+        $this->assertInstanceOf(FloatBasedValueObject::class, $result);
+        $this->assertEquals(12264.123, $result->getValue());
+    }
+}

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/ArrayBasedValueObject.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/ArrayBasedValueObject.php
@@ -1,0 +1,53 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+final class ArrayBasedValueObject implements \JsonSerializable
+{
+    /**
+     * @var array
+     */
+    private $value;
+
+    /**
+     * @param array $value
+     */
+    private function __construct(array $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @param array $array
+     * @return self
+     */
+    public static function fromArray(array $array): self
+    {
+        return new self($array);
+    }
+
+    /**
+     * @return array
+     */
+    public function getValue(): array
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function jsonSerialize()
+    {
+        return $this->value;
+    }
+}

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/BooleanBasedValueObject.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/BooleanBasedValueObject.php
@@ -30,7 +30,7 @@ final class BooleanBasedValueObject implements \JsonSerializable
      * @param bool $bool
      * @return self
      */
-    public static function fromBoolean(bool $bool): self
+    public static function fromBool(bool $bool): self
     {
         return new self($bool);
     }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/BooleanBasedValueObject.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/BooleanBasedValueObject.php
@@ -30,7 +30,7 @@ final class BooleanBasedValueObject implements \JsonSerializable
      * @param bool $bool
      * @return self
      */
-    public static function fromBool(bool $bool): self
+    public static function fromBoolean(bool $bool): self
     {
         return new self($bool);
     }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/BooleanBasedValueObject.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/BooleanBasedValueObject.php
@@ -1,0 +1,53 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+final class BooleanBasedValueObject implements \JsonSerializable
+{
+    /**
+     * @var bool
+     */
+    private $value;
+
+    /**
+     * @param bool $value
+     */
+    private function __construct(bool $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @param bool $bool
+     * @return self
+     */
+    public static function fromBool(bool $bool): self
+    {
+        return new self($bool);
+    }
+
+    /**
+     * @return bool
+     */
+    public function getValue(): bool
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function jsonSerialize()
+    {
+        return $this->value;
+    }
+}

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/FloatBasedValueObject.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/FloatBasedValueObject.php
@@ -1,0 +1,53 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+final class FloatBasedValueObject implements \JsonSerializable
+{
+    /**
+     * @var float
+     */
+    private $value;
+
+    /**
+     * @param float $value
+     */
+    private function __construct(float $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @param float $float
+     * @return self
+     */
+    public static function fromFloat(float $float): self
+    {
+        return new self($float);
+    }
+
+    /**
+     * @return float
+     */
+    public function getValue(): float
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return float
+     */
+    public function jsonSerialize()
+    {
+        return $this->value;
+    }
+}

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/IntegerBasedValueObject.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/IntegerBasedValueObject.php
@@ -30,7 +30,7 @@ final class IntegerBasedValueObject implements \JsonSerializable
      * @param int $int
      * @return self
      */
-    public static function fromInt(int $int): self
+    public static function fromInteger(int $int): self
     {
         return new self($int);
     }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/IntegerBasedValueObject.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/IntegerBasedValueObject.php
@@ -30,7 +30,7 @@ final class IntegerBasedValueObject implements \JsonSerializable
      * @param int $int
      * @return self
      */
-    public static function fromInteger(int $int): self
+    public static function fromInt(int $int): self
     {
         return new self($int);
     }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/IntegerBasedValueObject.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/IntegerBasedValueObject.php
@@ -1,0 +1,53 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+final class IntegerBasedValueObject implements \JsonSerializable
+{
+    /**
+     * @var int
+     */
+    private $value;
+
+    /**
+     * @param int $value
+     */
+    private function __construct(int $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @param int $int
+     * @return self
+     */
+    public static function fromInt(int $int): self
+    {
+        return new self($int);
+    }
+
+    /**
+     * @return int
+     */
+    public function getValue(): int
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return int
+     */
+    public function jsonSerialize()
+    {
+        return $this->value;
+    }
+}

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/StringBasedValueObject.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/StringBasedValueObject.php
@@ -1,0 +1,53 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+final class StringBasedValueObject implements \JsonSerializable
+{
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @param string $value
+     */
+    private function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @param string $string
+     * @return self
+     */
+    public static function fromString(string $string): self
+    {
+        return new self($string);
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return string
+     */
+    public function jsonSerialize()
+    {
+        return $this->value;
+    }
+}


### PR DESCRIPTION
When converting from simple types the denormalizer now checks wether the target class has a method `from$TYPE` and uses this to create the object.  Supported method names are `fromArray`, `fromString`, `fromBool`, `fromInt` and `fromFloat`.

For example the following controller action would use the methods `BirthDate::fromString` or `BirthDate::fromArray` (depending on submitted data) to instantiate the $birthDate argument.
```
public function indexAction(BirthDate $birthDate) 
```

In addition the JsonArray Type is extended to support this aswell. The serialization as flow entities takes precedence over the serialization as value object flow objects that implement \JsonSerializable are still serialized as Flow Objects in JsonArray properties. While beeing a Flow feature this allows to store and restore ValueObjects in Neos Node properties aswell. 

Note: This is a rebased version of https://github.com/neos/flow-development-collection/pull/2703 from @nezaniel 

Resolves: #2763
Replaces:  #2703

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
