### PR TITLE
TASK: Avoid deprecated Doctrine ORM proxy

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
@@ -561,7 +561,7 @@ class ProxyClassBuilder
         if ($cause === ObjectManagerInterface::INITIALIZATIONCAUSE_RECREATED) {
             $code .= "\n" . '        $classParents = class_parents($this);';
             $code .= "\n" . '        $classImplements = class_implements($this);';
-            $code .= "\n" . '        $isClassProxy = array_search(\'' . $className . '\', $classParents) !== false && array_search(\'Doctrine\ORM\Proxy\Proxy\', $classImplements) !== false;' . "\n";
+            $code .= "\n" . '        $isClassProxy = array_search(\'' . $className . '\', $classParents) !== false && array_search(\'Doctrine\Persistence\Proxy\', $classImplements) !== false;' . "\n";
             $code .= "\n" . '        if ($isSameClass || $isClassProxy) {' . "\n";
         } else {
             $code .= "\n" . '        if ($isSameClass) {' . "\n";
@@ -589,7 +589,7 @@ class ProxyClassBuilder
         if ($cause === ObjectManagerInterface::INITIALIZATIONCAUSE_RECREATED) {
             $code .= "\n" . '        $classParents = class_parents($this);';
             $code .= "\n" . '        $classImplements = class_implements($this);';
-            $code .= "\n" . '        $isClassProxy = array_search(\'' . $className . '\', $classParents) !== false && array_search(\'Doctrine\ORM\Proxy\Proxy\', $classImplements) !== false;' . "\n";
+            $code .= "\n" . '        $isClassProxy = array_search(\'' . $className . '\', $classParents) !== false && array_search(\'Doctrine\Persistence\Proxy\', $classImplements) !== false;' . "\n";
             $code .= "\n" . '        if ($isSameClass || $isClassProxy) {' . "\n";
         } else {
             $code .= "\n" . '        if ($isSameClass) {' . "\n";

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ObjectSerializationTrait.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ObjectSerializationTrait.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\ObjectManagement\Proxy;
  */
 
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\Proxy\Proxy as OrmProxy;
+use Doctrine\Persistence\Proxy as DoctrineProxy;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\ObjectManagement\Configuration\Configuration;
 use Neos\Flow\ObjectManagement\DependencyInjection\DependencyProxy;
@@ -61,7 +61,7 @@ trait ObjectSerializationTrait
                 }
             }
             if (is_object($this->$propertyName) && !$this->$propertyName instanceof Collection) {
-                if ($this->$propertyName instanceof OrmProxy) {
+                if ($this->$propertyName instanceof DoctrineProxy) {
                     $className = get_parent_class($this->$propertyName);
                 } else {
                     if (isset($propertyVarTags[$propertyName])) {
@@ -71,13 +71,13 @@ trait ObjectSerializationTrait
                         $className = Bootstrap::$staticObjectManager->getObjectNameByClassName(get_class($this->$propertyName));
                     }
                 }
-                if ($this->$propertyName instanceof PersistenceMagicInterface && !Bootstrap::$staticObjectManager->get(PersistenceManagerInterface::class)->isNewObject($this->$propertyName) || $this->$propertyName instanceof OrmProxy) {
+                if ($this->$propertyName instanceof PersistenceMagicInterface && !Bootstrap::$staticObjectManager->get(PersistenceManagerInterface::class)->isNewObject($this->$propertyName) || $this->$propertyName instanceof DoctrineProxy) {
                     if (!property_exists($this, 'Flow_Persistence_RelatedEntities') || !is_array($this->Flow_Persistence_RelatedEntities)) {
                         $this->Flow_Persistence_RelatedEntities = [];
                         $this->Flow_Object_PropertiesToSerialize[] = 'Flow_Persistence_RelatedEntities';
                     }
                     $identifier = Bootstrap::$staticObjectManager->get(PersistenceManagerInterface::class)->getIdentifierByObject($this->$propertyName);
-                    if (!$identifier && $this->$propertyName instanceof OrmProxy) {
+                    if (!$identifier && $this->$propertyName instanceof DoctrineProxy) {
                         $identifier = current(ObjectAccess::getProperty($this->$propertyName, '_identifier', true));
                     }
                     $this->Flow_Persistence_RelatedEntities[$propertyName] = [
@@ -111,18 +111,18 @@ trait ObjectSerializationTrait
             foreach ($propertyValue as $key => $value) {
                 $this->Flow_searchForEntitiesAndStoreIdentifierArray($path . '.' . $key, $value, $originalPropertyName);
             }
-        } elseif ($propertyValue instanceof PersistenceMagicInterface && !Bootstrap::$staticObjectManager->get(PersistenceManagerInterface::class)->isNewObject($propertyValue) || $propertyValue instanceof OrmProxy) {
+        } elseif ($propertyValue instanceof PersistenceMagicInterface && !Bootstrap::$staticObjectManager->get(PersistenceManagerInterface::class)->isNewObject($propertyValue) || $propertyValue instanceof DoctrineProxy) {
             if (!property_exists($this, 'Flow_Persistence_RelatedEntities') || !is_array($this->Flow_Persistence_RelatedEntities)) {
                 $this->Flow_Persistence_RelatedEntities = [];
                 $this->Flow_Object_PropertiesToSerialize[] = 'Flow_Persistence_RelatedEntities';
             }
-            if ($propertyValue instanceof OrmProxy) {
+            if ($propertyValue instanceof DoctrineProxy) {
                 $className = get_parent_class($propertyValue);
             } else {
                 $className = Bootstrap::$staticObjectManager->getObjectNameByClassName(get_class($propertyValue));
             }
             $identifier = Bootstrap::$staticObjectManager->get(PersistenceManagerInterface::class)->getIdentifierByObject($propertyValue);
-            if (!$identifier && $propertyValue instanceof OrmProxy) {
+            if (!$identifier && $propertyValue instanceof DoctrineProxy) {
                 $identifier = current(ObjectAccess::getProperty($propertyValue, '_identifier', true));
             }
             $this->Flow_Persistence_RelatedEntities[$originalPropertyName . '.' . $path] = [

--- a/Neos.Flow/Classes/Property/TypeConverter/ArrayFromObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ArrayFromObjectConverter.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Property\TypeConverter;
  * source code.
  */
 
+use Doctrine\Persistence\Proxy as DoctrineProxy;
 use Neos\Flow\Annotations as Flow;
 use Neos\Error\Messages\Error;
 use Neos\Flow\Persistence\Aspect\PersistenceMagicInterface;
@@ -97,7 +98,7 @@ class ArrayFromObjectConverter extends AbstractTypeConverter
     public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
     {
         $properties = ObjectAccess::getGettableProperties($source);
-        if ($source instanceof \Doctrine\ORM\Proxy\Proxy) {
+        if ($source instanceof DoctrineProxy) {
             $className = get_parent_class($source);
         } else {
             $className = get_class($source);

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -14,6 +14,7 @@ namespace Neos\Flow\Reflection;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\PhpParser;
 use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Persistence\Proxy as DoctrineProxy;
 use Neos\Flow\Annotations as Flow;
 use Neos\Cache\Frontend\FrontendInterface;
 use Neos\Cache\Frontend\StringFrontend;
@@ -1236,7 +1237,7 @@ class ReflectionService
         $this->log(sprintf('Reflecting class %s', $className), LogLevel::DEBUG);
 
         $className = $this->cleanClassName($className);
-        if (strpos($className, 'Neos\Flow\Persistence\Doctrine\Proxies') === 0 && in_array(\Doctrine\ORM\Proxy\Proxy::class, class_implements($className))) {
+        if (strpos($className, 'Neos\Flow\Persistence\Doctrine\Proxies') === 0 && in_array(DoctrineProxy::class, class_implements($className))) {
             // Somebody tried to reflect a doctrine proxy, which will have severe side effects.
             // see bug http://forge.typo3.org/issues/29449 for details.
             throw new Exception\InvalidClassException('The class with name "' . $className . '" is a Doctrine proxy. It is not supported to reflect doctrine proxy classes.', 1314944681);

--- a/Neos.Flow/Classes/Validation/Validator/GenericObjectValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/GenericObjectValidator.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Validation\Validator;
  * source code.
  */
 
+use Doctrine\Persistence\Proxy as DoctrineProxy;
 use Neos\Utility\ObjectAccess;
 use Neos\Error\Messages\Result as ErrorResult;
 
@@ -87,7 +88,7 @@ class GenericObjectValidator extends AbstractValidator implements ObjectValidato
      */
     protected function isUninitializedProxy($object)
     {
-        return ($object instanceof \Doctrine\ORM\Proxy\Proxy && $object->__isInitialized() === false);
+        return ($object instanceof DoctrineProxy && $object->__isInitialized() === false);
     }
 
     /**
@@ -119,7 +120,7 @@ class GenericObjectValidator extends AbstractValidator implements ObjectValidato
      */
     protected function getPropertyValue($object, $propertyName)
     {
-        if ($object instanceof \Doctrine\ORM\Proxy\Proxy) {
+        if ($object instanceof DoctrineProxy) {
             $object->__load();
         }
 

--- a/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
+++ b/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
@@ -12,7 +12,7 @@ namespace Neos\Utility;
  */
 
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\Proxy\Proxy;
+use Doctrine\Persistence\Proxy;
 use Neos\Utility\Exception\InvalidTypeException;
 
 /**


### PR DESCRIPTION
The `Doctrine\ORM\Proxy\Proxy` is deprecated and extends the
`Doctrine\Persistence\Proxy`.
