### PR TITLE
TASK: Drop nullability of $propertyPath on getPropertyPath()

### DIFF
--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Form/AbstractFormFieldViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Form/AbstractFormFieldViewHelper.php
@@ -204,7 +204,7 @@ abstract class AbstractFormFieldViewHelper extends AbstractFormViewHelper
         }
         $formObject = $this->viewHelperVariableContainer->get(FormViewHelper::class, 'formObject');
         $propertyNameOrPath = $this->arguments['property'];
-        return ObjectAccess::getPropertyPath($formObject, $propertyNameOrPath);
+        return $propertyNameOrPath === null ? null : ObjectAccess::getPropertyPath($formObject, $propertyNameOrPath);
     }
 
     /**

--- a/Neos.Utility.ObjectHandling/Classes/ObjectAccess.php
+++ b/Neos.Utility.ObjectHandling/Classes/ObjectAccess.php
@@ -192,13 +192,8 @@ abstract class ObjectAccess
      * @param string $propertyPath
      * @return mixed Value of the property
      */
-    public static function getPropertyPath($subject, string $propertyPath = null)
+    public static function getPropertyPath($subject, string $propertyPath)
     {
-        // TODO: This default value handling is only in place for b/c to have this method accept nulls.
-        //       It can be removed with Flow 5.0 and other breaking typehint changes.
-        if ($propertyPath === null) {
-            return null;
-        }
         $propertyPathSegments = explode('.', $propertyPath);
         foreach ($propertyPathSegments as $pathSegment) {
             $propertyExists = false;


### PR DESCRIPTION
That has been deprecated for ages and was to be dropped with 5.0
already.
