### PR TITLE
TASK: Remove support for Flow's custom class loader

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -81,23 +81,18 @@ class Scripts
                 'namespace' => 'Neos\\Flow\\',
                 'classPath' => FLOW_PATH_FLOW . 'Classes/',
                 'mappingType' => ClassLoader::MAPPING_TYPE_PSR4
-            ]
-        ];
-
-        if ($bootstrap->getContext()->isTesting()) {
-            $initialClassLoaderMappings[] = [
+            ],
+            [
                 'namespace' => 'Neos\\Flow\\Tests\\',
                 'classPath' => FLOW_PATH_FLOW . 'Tests/',
                 'mappingType' => ClassLoader::MAPPING_TYPE_PSR4
-            ];
-        }
+            ]
+        ];
 
         $classLoader = new ClassLoader($initialClassLoaderMappings);
         spl_autoload_register([$classLoader, 'loadClass'], true);
         $bootstrap->setEarlyInstance(ClassLoader::class, $classLoader);
-        if ($bootstrap->getContext()->isTesting()) {
-            $classLoader->setConsiderTestsNamespace(true);
-        }
+        $classLoader->setConsiderTestsNamespace(true);
     }
 
     /**
@@ -911,6 +906,6 @@ class Scripts
      */
     protected static function useClassLoader(Bootstrap $bootstrap)
     {
-        return !FLOW_ONLY_COMPOSER_LOADER;
+        return $bootstrap->getContext()->isTesting();
     }
 }

--- a/Neos.Flow/Classes/Core/Bootstrap.php
+++ b/Neos.Flow/Classes/Core/Bootstrap.php
@@ -540,14 +540,6 @@ class Bootstrap
             define('FLOW_PATH_TEMPORARY', $temporaryDirectoryPath);
         }
 
-        // Setting this flag to false will enable the custom Class Loader on top of the default autoloading provided by composer
-        // @deprecated since Version 4.3. Packages should use the default composer autoloading mechanism
-        $onlyUseComposerAutoLoaderForPackageClasses = true;
-        if (in_array(self::getEnvironmentConfigurationSetting('FLOW_ONLY_COMPOSER_LOADER'), [false, 'false', 0, '0'])) {
-            $onlyUseComposerAutoLoaderForPackageClasses = false;
-        }
-
-        define('FLOW_ONLY_COMPOSER_LOADER', $onlyUseComposerAutoLoaderForPackageClasses);
         define('FLOW_VERSION_BRANCH', 'master');
         define('FLOW_APPLICATION_CONTEXT', (string)$this->context);
     }

--- a/Neos.Flow/Classes/Core/ClassLoader.php
+++ b/Neos.Flow/Classes/Core/ClassLoader.php
@@ -16,7 +16,7 @@ use Neos\Flow\Package;
 use Neos\Utility\Files;
 
 /**
- * Class Loader implementation as fallback to the compoer loader and for test classes.
+ * Class Loader implementation for test classes.
  *
  * @Flow\Proxy(false)
  * @Flow\Scope("singleton")

--- a/Neos.Flow/Tests/Unit/Core/ClassLoaderTest.php
+++ b/Neos.Flow/Tests/Unit/Core/ClassLoaderTest.php
@@ -60,10 +60,6 @@ class ClassLoaderTest extends UnitTestCase
      */
     protected function setUp(): void
     {
-        if (FLOW_ONLY_COMPOSER_LOADER) {
-            $this->markTestSkipped('Not testing if composer-only loading is requested.');
-        }
-
         vfsStream::setup('Test');
 
         self::$testClassWasLoaded = false;


### PR DESCRIPTION
This drops support for the Flow ClassLoader – except for functional
testing. There it's still used to load test classes & fixtures.