### PR TITLE
TASK: Remove unused parameter in Redis flush

### DIFF
--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -238,7 +238,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
             redis.call('DEL', key)
         end
         ";
-        $this->redis->eval($script, [$this->getPrefixedIdentifier('frozen'), $this->getPrefixedIdentifier('')], 1);
+        $this->redis->eval($script, [$this->getPrefixedIdentifier('')], 0);
 
         $this->frozen = null;
         $this->entryIterator = null;


### PR DESCRIPTION
The `frozen` key is already included in the prefixed argument in combination with the wildcard in the Lua script.
Therefore it can be safely removed. The script anyway didn’t use it.

The matching functional test works correctly.
