### PR TITLE
FEATURE: Type declaration support for property injection

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
@@ -561,7 +561,13 @@ class ConfigurationBuilder
                 if (!array_key_exists($propertyName, $properties)) {
                     /** @var Inject $injectAnnotation */
                     $injectAnnotation = $this->reflectionService->getPropertyAnnotation($className, $propertyName, Inject::class);
-                    $objectName = $injectAnnotation->name !== null ? $injectAnnotation->name : trim(implode('', $this->reflectionService->getPropertyTagValues($className, $propertyName, 'var')), ' \\');
+                    $objectName = $injectAnnotation->name;
+                    if ($objectName === null) {
+                        $objectName = $this->reflectionService->getPropertyType($className, $propertyName);
+                    }
+                    if ($objectName === null) {
+                        $objectName = trim(implode('', $this->reflectionService->getPropertyTagValues($className, $propertyName, 'var')), ' \\');
+                    }
                     $configurationProperty =  new ConfigurationProperty($propertyName, $objectName, ConfigurationProperty::PROPERTY_TYPES_OBJECT, null, $injectAnnotation->lazy);
                     $properties[$propertyName] = $configurationProperty;
                 }

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
@@ -561,14 +561,18 @@ class ConfigurationBuilder
                 if (!array_key_exists($propertyName, $properties)) {
                     /** @var Inject $injectAnnotation */
                     $injectAnnotation = $this->reflectionService->getPropertyAnnotation($className, $propertyName, Inject::class);
+                    $enableLazyInjection = $injectAnnotation->lazy;
                     $objectName = $injectAnnotation->name;
                     if ($objectName === null) {
                         $objectName = $this->reflectionService->getPropertyType($className, $propertyName);
+                        if ($objectName !== null) {
+                            $enableLazyInjection = false; # See:  https://github.com/neos/flow-development-collection/issues/2114
+                        }
                     }
                     if ($objectName === null) {
                         $objectName = trim(implode('', $this->reflectionService->getPropertyTagValues($className, $propertyName, 'var')), ' \\');
                     }
-                    $configurationProperty =  new ConfigurationProperty($propertyName, $objectName, ConfigurationProperty::PROPERTY_TYPES_OBJECT, null, $injectAnnotation->lazy);
+                    $configurationProperty =  new ConfigurationProperty($propertyName, $objectName, ConfigurationProperty::PROPERTY_TYPES_OBJECT, null, $enableLazyInjection);
                     $properties[$propertyName] = $configurationProperty;
                 }
             }

--- a/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
@@ -446,7 +446,7 @@ class ProxyClassBuilder
         if (!isset($this->objectConfigurations[$propertyObjectName])) {
             $configurationSource = $objectConfiguration->getConfigurationSourceHint();
             if (!isset($propertyObjectName[0])) {
-                throw new ObjectException\UnknownObjectException('Malformed DocComent block for a property in class "' . $className . '".', 1360171313);
+                throw new ObjectException\UnknownObjectException(sprintf('Malformed DocComment block for property %s in class %s.', $propertyName, $className), 1360171313);
             }
             if ($propertyObjectName[0] === '\\') {
                 throw new ObjectException\UnknownObjectException('The object name "' . $propertyObjectName . '" which was specified as a property in the object configuration of object "' . $objectConfiguration->getObjectName() . '" (' . $configurationSource . ') starts with a leading backslash.', 1277827579);
@@ -466,11 +466,12 @@ class ProxyClassBuilder
             return $result;
         }
 
-        if ($propertyConfiguration->isLazyLoading() && $this->objectConfigurations[$propertyObjectName]->getScope() !== Configuration::SCOPE_PROTOTYPE) {
-            return $this->buildLazyPropertyInjectionCode($propertyObjectName, $propertyClassName, $propertyName, $preparedSetterArgument);
-        } else {
+        # Disable lazy property injection, see https://github.com/neos/flow-development-collection/issues/2114
+//        if ($propertyConfiguration->isLazyLoading() && $this->objectConfigurations[$propertyObjectName]->getScope() !== Configuration::SCOPE_PROTOTYPE) {
+//            return $this->buildLazyPropertyInjectionCode($propertyObjectName, $propertyClassName, $propertyName, $preparedSetterArgument);
+//        } else {
             return ['    $this->' . $propertyName . ' = ' . $preparedSetterArgument . ';'];
-        }
+//        }
     }
 
     /**

--- a/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
@@ -467,11 +467,11 @@ class ProxyClassBuilder
         }
 
         # Disable lazy property injection, see https://github.com/neos/flow-development-collection/issues/2114
-//        if ($propertyConfiguration->isLazyLoading() && $this->objectConfigurations[$propertyObjectName]->getScope() !== Configuration::SCOPE_PROTOTYPE) {
-//            return $this->buildLazyPropertyInjectionCode($propertyObjectName, $propertyClassName, $propertyName, $preparedSetterArgument);
-//        } else {
+        if ($propertyConfiguration->isLazyLoading() && $this->objectConfigurations[$propertyObjectName]->getScope() !== Configuration::SCOPE_PROTOTYPE) {
+            return $this->buildLazyPropertyInjectionCode($propertyObjectName, $propertyClassName, $propertyName, $preparedSetterArgument);
+        } else {
             return ['    $this->' . $propertyName . ' = ' . $preparedSetterArgument . ';'];
-//        }
+        }
     }
 
     /**

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -91,6 +91,7 @@ class ReflectionService
     const DATA_PROPERTY_TAGS_VALUES = 14;
     const DATA_PROPERTY_ANNOTATIONS = 15;
     const DATA_PROPERTY_VISIBILITY = 24;
+    const DATA_PROPERTY_TYPE = 26;
     const DATA_PARAMETER_POSITION = 16;
     const DATA_PARAMETER_OPTIONAL = 17;
     const DATA_PARAMETER_TYPE = 18;
@@ -997,6 +998,18 @@ class ReflectionService
     }
 
     /**
+     * Returns the property type
+     *
+     * @param $className
+     * @param $propertyName
+     * @return string|null
+     */
+    public function getPropertyType($className, $propertyName)
+    {
+        return $this->classReflectionData[$className][self::DATA_CLASS_PROPERTIES][$propertyName][self::DATA_PROPERTY_TYPE] ?? null;
+    }
+
+    /**
      * Tells if the specified property is private
      *
      * @param string $className Name of the class containing the method
@@ -1303,6 +1316,9 @@ class ReflectionService
     {
         $propertyName = $property->getName();
         $this->classReflectionData[$className][self::DATA_CLASS_PROPERTIES][$propertyName] = [];
+        if ($property->hasType()) {
+            $this->classReflectionData[$className][self::DATA_CLASS_PROPERTIES][$propertyName][self::DATA_PROPERTY_TYPE] = trim((string)$property->getType(), '?');
+        }
 
         $visibility = $property->isPublic() ? self::VISIBILITY_PUBLIC : ($property->isProtected() ? self::VISIBILITY_PROTECTED : self::VISIBILITY_PRIVATE);
         $this->classReflectionData[$className][self::DATA_CLASS_PROPERTIES][$propertyName][self::DATA_PROPERTY_VISIBILITY] = $visibility;
@@ -1315,7 +1331,7 @@ class ReflectionService
             $this->classReflectionData[$className][self::DATA_CLASS_PROPERTIES][$propertyName][self::DATA_PROPERTY_TAGS_VALUES][$tagName] = $tagValues;
         }
 
-        foreach ($this->annotationReader->getPropertyAnnotations($property, $propertyName) as $annotation) {
+        foreach ($this->annotationReader->getPropertyAnnotations($property) as $annotation) {
             $this->classReflectionData[$className][self::DATA_CLASS_PROPERTIES][$propertyName][self::DATA_PROPERTY_ANNOTATIONS][get_class($annotation)][] = $annotation;
         }
         if (PHP_MAJOR_VERSION >= 8) {

--- a/Neos.Flow/Tests/Functional/ObjectManagement/LazyDependencyInjectionTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/LazyDependencyInjectionTest.php
@@ -25,6 +25,7 @@ class LazyDependencyInjectionTest extends FunctionalTestCase
      */
     public function lazyDependencyIsOnlyInjectedIfMethodOnDependencyIsCalledForTheFirstTime()
     {
+        $this->markTestSkipped('Lazy dependency injection is currently disabled.'); # See https://github.com/neos/flow-development-collection/issues/2114
         $this->objectManager->forgetInstance(Fixtures\SingletonClassA::class);
 
         $object = $this->objectManager->get(Fixtures\ClassWithLazyDependencies::class);
@@ -53,6 +54,7 @@ class LazyDependencyInjectionTest extends FunctionalTestCase
      */
     public function lazyDependencyIsInjectedIntoAllClassesWhichNeedItIfItIsUsedTheFirstTime()
     {
+        $this->markTestSkipped('Lazy dependency injection is currently disabled.'); # See https://github.com/neos/flow-development-collection/issues/2114
         $this->objectManager->forgetInstance(Fixtures\SingletonClassA::class);
         $this->objectManager->forgetInstance(Fixtures\SingletonClassB::class);
 

--- a/Neos.Flow/Tests/Functional/ObjectManagement/LazyDependencyInjectionTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/LazyDependencyInjectionTest.php
@@ -25,7 +25,6 @@ class LazyDependencyInjectionTest extends FunctionalTestCase
      */
     public function lazyDependencyIsOnlyInjectedIfMethodOnDependencyIsCalledForTheFirstTime()
     {
-        $this->markTestSkipped('Lazy dependency injection is currently disabled.'); # See https://github.com/neos/flow-development-collection/issues/2114
         $this->objectManager->forgetInstance(Fixtures\SingletonClassA::class);
 
         $object = $this->objectManager->get(Fixtures\ClassWithLazyDependencies::class);
@@ -54,7 +53,6 @@ class LazyDependencyInjectionTest extends FunctionalTestCase
      */
     public function lazyDependencyIsInjectedIntoAllClassesWhichNeedItIfItIsUsedTheFirstTime()
     {
-        $this->markTestSkipped('Lazy dependency injection is currently disabled.'); # See https://github.com/neos/flow-development-collection/issues/2114
         $this->objectManager->forgetInstance(Fixtures\SingletonClassA::class);
         $this->objectManager->forgetInstance(Fixtures\SingletonClassB::class);
 


### PR DESCRIPTION
This change introduces basic support for PHP 7.4 class property types
for property injection.

It allows for using types as follows:

```php
/**
 * @Flow\Inject
 **/
protected LoggerInterface $logger;
```

In order to allow this syntax, Lazy Property Injection is disabled
when a type is declared. To still use Lazy Property Injection, don't
use a PHP type declaration but a `@var` annotation:

```php
/**
 * @Flow\Inject
 * @var LoggerInterface
 **/
protected $logger;
```

If using both (type declaration _and_ `@var`), it is handled non-lazily.

Lazy Property Injection on properties with type declarations may 
be re-implemented as part of a future release.

#2114
