### PR TITLE
FEATURE: Add ArrayObjectConverter

### DIFF
--- a/Neos.Flow/Classes/Property/TypeConverter/ArrayObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ArrayObjectConverter.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Property\TypeConverter;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Property\Exception\InvalidSourceException;
+use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+
+/**
+ * Converter which transforms ArrayObjects to arrays.
+ *
+ * @api
+ * @Flow\Scope("singleton")
+ */
+class ArrayObjectConverter extends AbstractTypeConverter
+{
+    /**
+     * @var array<string>
+     */
+    protected $sourceTypes = [\ArrayObject::class];
+
+    /**
+     * @var string
+     */
+    protected $targetType = 'array';
+
+    /**
+     * @var integer
+     */
+    protected $priority = 1;
+
+    /**
+     * Convert from $source to $targetType.
+     *
+     * @param mixed $source
+     * @param string $targetType
+     * @param array $convertedChildProperties
+     * @param PropertyMappingConfigurationInterface|null $configuration
+     * @return array
+     * @throws InvalidSourceException
+     * @api
+     */
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null): array
+    {
+        if (!($source instanceof \ArrayObject)) {
+            throw new InvalidSourceException('Source was not an instance of ArrayObject.', 1648456200);
+        }
+
+        return $source->getArrayCopy();
+    }
+}

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/ArrayObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/ArrayObjectConverterTest.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Property\PropertyMappingConfiguration;
+use Neos\Flow\Property\TypeConverter\ArrayConverter;
+use Neos\Flow\Property\TypeConverter\ArrayObjectConverter;
+use Neos\Flow\Tests\UnitTestCase;
+
+/**
+ * Testcase for the ArrayObject converter
+ */
+class ArrayObjectConverterTest extends UnitTestCase
+{
+    /**
+     * @var ArrayConverter
+     */
+    protected $converter;
+
+    protected function setUp(): void
+    {
+        $this->converter = new ArrayObjectConverter();
+    }
+
+    /**
+     * @test
+     */
+    public function checkMetadata(): void
+    {
+        self::assertEquals([\ArrayObject::class], $this->converter->getSupportedSourceTypes(), 'Source types do not match');
+        self::assertEquals('array', $this->converter->getSupportedTargetType(), 'Target type does not match');
+        self::assertEquals(1, $this->converter->getPriority(), 'Priority does not match');
+    }
+
+    public function arrayObjectDataProvider(): array
+    {
+        return [
+            [new \ArrayObject(['Foo', 1, true, 'Bar']), ['Foo', 1, true, 'Bar']],
+            [new \ArrayObject(), []]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider arrayObjectDataProvider
+     */
+    public function canConvertToArray(\ArrayObject $source, array $expectedResult): void
+    {
+        $propertyMappingConfiguration = $this->createMock(PropertyMappingConfiguration::class);
+        self::assertEquals($expectedResult, $this->converter->convertFrom($source, 'array', [], $propertyMappingConfiguration));
+    }
+}


### PR DESCRIPTION
This adds an ArrayObjectConverter that allows to convert to a plain
array. It uses `getArrayCopy()` to get the job done.

Fixes #2041
