### PR TITLE
BUGFIX: Correctly reflect builtin types in method arguments

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethod.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethod.php
@@ -224,7 +224,7 @@ class ProxyMethod
             $methodTags = $this->reflectionService->getMethodTagsValues($className, $methodName);
             $allowedTags = ['param', 'return', 'throws'];
             foreach ($methodTags as $tag => $values) {
-                if (in_array($tag, $allowedTags)) {
+                if (in_array($tag, $allowedTags, true)) {
                     if (count($values) === 0) {
                         $methodDocumentation .= '     * @' . $tag . "\n";
                     } else {
@@ -285,7 +285,7 @@ class ProxyMethod
                     if ($methodParameterInfo['optional'] === true) {
                         $rawDefaultValue = $methodParameterInfo['defaultValue'] ?? null;
                         if ($rawDefaultValue === null) {
-                            $defaultValue = ' = NULL';
+                            $defaultValue = ' = null';
                         } elseif (is_bool($rawDefaultValue)) {
                             $defaultValue = ($rawDefaultValue ? ' = true' : ' = false');
                         } elseif (is_numeric($rawDefaultValue)) {
@@ -341,7 +341,7 @@ class ProxyMethod
             $code .= (is_string($key)) ? "'" . $key . "'" : $key;
             $code .= ' => ';
             if ($value === null) {
-                $code .= 'NULL';
+                $code .= 'null';
             } elseif (is_bool($value)) {
                 $code .= ($value ? 'true' : 'false');
             } elseif (is_numeric($value)) {
@@ -368,7 +368,8 @@ class ProxyMethod
         }
         if ($this->reflectionService->isMethodProtected($this->fullOriginalClassName, $this->methodName)) {
             return 'protected';
-        } elseif ($this->reflectionService->isMethodPrivate($this->fullOriginalClassName, $this->methodName)) {
+        }
+        if ($this->reflectionService->isMethodPrivate($this->fullOriginalClassName, $this->methodName)) {
             return 'private';
         }
         return 'public';

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1381,7 +1381,7 @@ class ReflectionService
         }
 
         $returnType = $method->getDeclaredReturnType();
-        if ($returnType !== null && !in_array($returnType, ['self', 'null', 'callable', 'void', 'iterable', 'object', 'mixed']) && !TypeHandling::isSimpleType($returnType)) {
+        if ($returnType !== null && !in_array($returnType, ['self', 'static', 'parent']) && !$method->getReturnType()->isBuiltin()) {
             $returnType = '\\' . $returnType;
         }
         if ($method->isDeclaredReturnTypeNullable()) {

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1809,7 +1809,11 @@ class ReflectionService
             $parameterInformation[self::DATA_PARAMETER_ARRAY] = true;
         } else {
             $parameterInformation[self::DATA_PARAMETER_TYPE] = $builtinType;
-            $parameterInformation[self::DATA_PARAMETER_SCALAR_DECLARATION] = true;
+            // The isSimpleType() check is needed to avoid a problem with AOP proxy building, see
+            // https://github.com/neos/flow-development-collection/pull/2786#issuecomment-1084450139
+            if ($parameterType !== null && !TypeHandling::isSimpleType($parameterType)) {
+                $parameterInformation[self::DATA_PARAMETER_SCALAR_DECLARATION] = true;
+            }
         }
         if ($parameter->isOptional() && $parameter->isDefaultValueAvailable()) {
             $parameterInformation[self::DATA_PARAMETER_DEFAULT_VALUE] = $parameter->getDefaultValue();

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1801,17 +1801,15 @@ class ReflectionService
             // TODO: This needs to handle ReflectionUnionType
             $parameterType = ($parameterType instanceof \ReflectionNamedType) ? $parameterType->getName() : $parameterType->__toString();
         }
-        if ($parameterType !== null && !TypeHandling::isSimpleType($parameterType)) {
+        $builtinType = $parameter->getBuiltinType();
+        if ($parameterType !== null && $builtinType === null) {
             // We use parameter type here to make class_alias usage work and return the hinted class name instead of the alias
             $parameterInformation[self::DATA_PARAMETER_CLASS] = $parameterType;
         } elseif ($parameterType === 'array') {
             $parameterInformation[self::DATA_PARAMETER_ARRAY] = true;
         } else {
-            $builtinType = $parameter->getBuiltinType();
-            if ($builtinType !== null) {
-                $parameterInformation[self::DATA_PARAMETER_TYPE] = $builtinType;
-                $parameterInformation[self::DATA_PARAMETER_SCALAR_DECLARATION] = true;
-            }
+            $parameterInformation[self::DATA_PARAMETER_TYPE] = $builtinType;
+            $parameterInformation[self::DATA_PARAMETER_SCALAR_DECLARATION] = true;
         }
         if ($parameter->isOptional() && $parameter->isDefaultValueAvailable()) {
             $parameterInformation[self::DATA_PARAMETER_DEFAULT_VALUE] = $parameter->getDefaultValue();

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1381,7 +1381,7 @@ class ReflectionService
         }
 
         $returnType = $method->getDeclaredReturnType();
-        if ($returnType !== null && !in_array($returnType, ['self', 'static', 'parent']) && !$method->getReturnType()->isBuiltin()) {
+        if ($returnType !== null && !in_array($returnType, ['self', 'static', 'parent']) && $method->getReturnType() !== null && !$method->getReturnType()->isBuiltin()) {
             $returnType = '\\' . $returnType;
         }
         if ($method->isDeclaredReturnTypeNullable()) {

--- a/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
+++ b/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
@@ -98,7 +98,7 @@ class ScriptsTest extends UnitTestCase
     public function initializeConfigurationInjectsSettingsToPackageManager()
     {
         $mockSignalSlotDispatcher = $this->createMock(Dispatcher::class);
-        $mockPackageManager = $this->createMock(PackageManager::class, ['injectSettings'], [], '', false, true);
+        $mockPackageManager = $this->createMock(PackageManager::class);
 
         $bootstrap = new Bootstrap('Testing');
         $bootstrap->setEarlyInstance(Dispatcher::class, $mockSignalSlotDispatcher);

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyMethodTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyMethodTest.php
@@ -62,7 +62,7 @@ class ProxyMethodTest extends \Neos\Flow\Tests\UnitTestCase
              * @param string $arg1 Arg1
              */
             class ' . $className . ' {
-                public function foo($arg1, array $arg2, \ArrayObject $arg3, $arg4= "foo", $arg5 = true, array $arg6 = array(true, \'foo\' => \'bar\', NULL, 3 => 1, 2.3)) {}
+                public function foo($arg1, array $arg2, \ArrayObject $arg3, $arg4= "foo", $arg5 = true, array $arg6 = array(true, \'foo\' => \'bar\', null, 3 => 1, 2.3)) {}
             }
         ');
         $methodParameters = [
@@ -128,7 +128,7 @@ class ProxyMethodTest extends \Neos\Flow\Tests\UnitTestCase
         $mockReflectionService = $this->createMock(ReflectionService::class);
         $mockReflectionService->expects(self::atLeastOnce())->method('getMethodParameters')->will(self::returnValue($methodParameters));
 
-        $expectedCode = '$arg1, array $arg2, \ArrayObject $arg3, $arg4 = \'foo\', $arg5 = true, array $arg6 = array(0 => true, \'foo\' => \'bar\', 1 => NULL, 3 => 1, 4 => 2.3)';
+        $expectedCode = '$arg1, array $arg2, \ArrayObject $arg3, $arg4 = \'foo\', $arg5 = true, array $arg6 = array(0 => true, \'foo\' => \'bar\', 1 => null, 3 => 1, 4 => 2.3)';
 
         $builder = $this->getMockBuilder(ProxyMethod::class)->disableOriginalConstructor()->setMethods(['dummy'])->getMock();
         $builder->injectReflectionService($mockReflectionService);

--- a/Neos.Flow/Tests/Unit/Reflection/Fixture/ClassWithBuiltinTypes.php
+++ b/Neos.Flow/Tests/Unit/Reflection/Fixture/ClassWithBuiltinTypes.php
@@ -27,4 +27,12 @@ class ClassWithBuiltinTypes
     public function doCoolStuffWithClass(\stdClass $firstArgument)
     {
     }
+
+    public function doCoolStuffWithString(string $firstArgument)
+    {
+    }
+
+    public function doCoolStuffWithNullableString(?string $firstArgument)
+    {
+    }
 }

--- a/Neos.Flow/Tests/Unit/Reflection/Fixture/ClassWithBuiltinTypes.php
+++ b/Neos.Flow/Tests/Unit/Reflection/Fixture/ClassWithBuiltinTypes.php
@@ -1,0 +1,30 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Reflection\Fixture;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Dummy class for the Reflection tests, with a method that has a builtin type method argument
+ */
+class ClassWithBuiltinTypes
+{
+    public function doCoolStuffWithObject(object $firstArgument)
+    {
+    }
+
+    public function doCoolStuffWithIterable(iterable $firstArgument)
+    {
+    }
+
+    public function doCoolStuffWithClass(\stdClass $firstArgument)
+    {
+    }
+}

--- a/Neos.Flow/Tests/Unit/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/ReflectionServiceTest.php
@@ -98,7 +98,6 @@ class ReflectionServiceTest extends UnitTestCase
     {
         $this->reflectionService->_call('reflectClass', Fixture\ClassWithBuiltinTypes::class);
         $parameters = $this->reflectionService->getMethodParameters(Fixture\ClassWithBuiltinTypes::class, 'doCoolStuffWithIterable');
-        var_dump($parameters);
         $this->assertEquals('iterable', $parameters['firstArgument']['type']);
         $this->assertTrue($parameters['firstArgument']['scalarDeclaration']);
     }

--- a/Neos.Flow/Tests/Unit/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/ReflectionServiceTest.php
@@ -83,6 +83,39 @@ class ReflectionServiceTest extends UnitTestCase
     /**
      * @test
      */
+    public function getMethodParametersReturnsCorrectTypeForObjectType()
+    {
+        $this->reflectionService->_call('reflectClass', Fixture\ClassWithAliasDependency::class);
+        $parameters = $this->reflectionService->getMethodParameters(Fixture\ClassWithBuiltinTypes::class, 'doCoolStuffWithObject');
+        $this->assertEquals('object', $parameters['firstArgument']['type']);
+        $this->assertTrue($parameters['firstArgument']['scalarDeclaration']);
+    }
+
+    /**
+     * @test
+     */
+    public function getMethodParametersReturnsCorrectTypeForIterableType()
+    {
+        $this->reflectionService->_call('reflectClass', Fixture\ClassWithAliasDependency::class);
+        $parameters = $this->reflectionService->getMethodParameters(Fixture\ClassWithBuiltinTypes::class, 'doCoolStuffWithIterable');
+        $this->assertEquals('iterable', $parameters['firstArgument']['type']);
+        $this->assertTrue($parameters['firstArgument']['scalarDeclaration']);
+    }
+
+    /**
+     * @test
+     */
+    public function getMethodParametersReturnsCorrectTypeForClassType()
+    {
+        $this->reflectionService->_call('reflectClass', Fixture\ClassWithAliasDependency::class);
+        $parameters = $this->reflectionService->getMethodParameters(Fixture\ClassWithBuiltinTypes::class, 'doCoolStuffWithClass');
+        $this->assertEquals('stdClass', $parameters['firstArgument']['class']);
+        $this->assertEmpty($parameters['firstArgument']['scalarDeclaration']);
+    }
+
+    /**
+     * @test
+     */
     public function isTagIgnoredReturnsTrueForIgnoredTags()
     {
         $settings = ['reflection' => ['ignoredTags' => ['ignored' => true]]];

--- a/Neos.Flow/Tests/Unit/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/ReflectionServiceTest.php
@@ -85,7 +85,7 @@ class ReflectionServiceTest extends UnitTestCase
      */
     public function getMethodParametersReturnsCorrectTypeForObjectType()
     {
-        $this->reflectionService->_call('reflectClass', Fixture\ClassWithAliasDependency::class);
+        $this->reflectionService->_call('reflectClass', Fixture\ClassWithBuiltinTypes::class);
         $parameters = $this->reflectionService->getMethodParameters(Fixture\ClassWithBuiltinTypes::class, 'doCoolStuffWithObject');
         $this->assertEquals('object', $parameters['firstArgument']['type']);
         $this->assertTrue($parameters['firstArgument']['scalarDeclaration']);
@@ -96,8 +96,9 @@ class ReflectionServiceTest extends UnitTestCase
      */
     public function getMethodParametersReturnsCorrectTypeForIterableType()
     {
-        $this->reflectionService->_call('reflectClass', Fixture\ClassWithAliasDependency::class);
+        $this->reflectionService->_call('reflectClass', Fixture\ClassWithBuiltinTypes::class);
         $parameters = $this->reflectionService->getMethodParameters(Fixture\ClassWithBuiltinTypes::class, 'doCoolStuffWithIterable');
+        var_dump($parameters);
         $this->assertEquals('iterable', $parameters['firstArgument']['type']);
         $this->assertTrue($parameters['firstArgument']['scalarDeclaration']);
     }
@@ -107,7 +108,7 @@ class ReflectionServiceTest extends UnitTestCase
      */
     public function getMethodParametersReturnsCorrectTypeForClassType()
     {
-        $this->reflectionService->_call('reflectClass', Fixture\ClassWithAliasDependency::class);
+        $this->reflectionService->_call('reflectClass', Fixture\ClassWithBuiltinTypes::class);
         $parameters = $this->reflectionService->getMethodParameters(Fixture\ClassWithBuiltinTypes::class, 'doCoolStuffWithClass');
         $this->assertEquals('stdClass', $parameters['firstArgument']['class']);
         $this->assertEmpty($parameters['firstArgument']['scalarDeclaration']);

--- a/Neos.Flow/Tests/Unit/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/ReflectionServiceTest.php
@@ -111,7 +111,32 @@ class ReflectionServiceTest extends UnitTestCase
         $this->reflectionService->_call('reflectClass', Fixture\ClassWithBuiltinTypes::class);
         $parameters = $this->reflectionService->getMethodParameters(Fixture\ClassWithBuiltinTypes::class, 'doCoolStuffWithClass');
         $this->assertEquals('stdClass', $parameters['firstArgument']['class']);
-        $this->assertEmpty($parameters['firstArgument']['scalarDeclaration']);
+        $this->assertFalse($parameters['firstArgument']['scalarDeclaration']);
+    }
+
+    /**
+     * @test
+     */
+    public function getMethodParametersReturnsCorrectTypeForStringType()
+    {
+        $this->reflectionService->_call('reflectClass', Fixture\ClassWithBuiltinTypes::class);
+        $parameters = $this->reflectionService->getMethodParameters(Fixture\ClassWithBuiltinTypes::class, 'doCoolStuffWithString');
+        $this->assertEquals('string', $parameters['firstArgument']['type']);
+        $this->assertFalse($parameters['firstArgument']['scalarDeclaration']);
+        $this->assertFalse($parameters['firstArgument']['allowsNull']);
+    }
+
+    /**
+     * @test
+     */
+    public function getMethodParametersReturnsCorrectTypeForNullableStringType()
+    {
+        $this->reflectionService->_call('reflectClass', Fixture\ClassWithBuiltinTypes::class);
+        $parameters = $this->reflectionService->getMethodParameters(Fixture\ClassWithBuiltinTypes::class, 'doCoolStuffWithNullableString');
+        $this->assertEquals('string', $parameters['firstArgument']['type']);
+        $this->assertFalse($parameters['firstArgument']['scalarDeclaration']);
+        $this->assertFalse($parameters['firstArgument']['optional']);
+        $this->assertTrue($parameters['firstArgument']['allowsNull']);
     }
 
     /**

--- a/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
+++ b/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
@@ -52,7 +52,6 @@ abstract class TypeHandling
         }
 
         $typeWithoutNull = self::stripNullableType($matches['type']);
-        $isNullable = $typeWithoutNull !== $matches['type'];
         $type = self::normalizeType($typeWithoutNull);
         $elementType = isset($matches['elementType']) ? self::normalizeType($matches['elementType']) : null;
 


### PR DESCRIPTION
Before builtin types like `object` or `iterable` in method arguments would lead to being reflected as if they were class types, leading to the AOP proxy builder prefixing those types with `\` which results in a PHP error "Type declaration 'object' must be unqualified". Only "simple" types were handled correctly as they had a separate check.
This adds a test that verifies that builtin types like `object` and `iterable` are correctly reflected as non-class types in the ReflectionService.