### PR TITLE
Revert "TASK: Add type declarations in PersistenceManagerInterface"

### DIFF
--- a/Neos.Flow/Classes/Persistence/AbstractPersistenceManager.php
+++ b/Neos.Flow/Classes/Persistence/AbstractPersistenceManager.php
@@ -91,7 +91,7 @@ abstract class AbstractPersistenceManager implements PersistenceManagerInterface
      * @return void
      * @api
      */
-    public function allowObject($object): void
+    public function allowObject($object)
     {
         $this->allowedObjects->attach($object);
     }
@@ -103,7 +103,7 @@ abstract class AbstractPersistenceManager implements PersistenceManagerInterface
      * @return array The identity array in the format array('__identity' => '...')
      * @throws Exception\UnknownObjectException if the given object is not known to the Persistence Manager
      */
-    public function convertObjectToIdentityArray(object $object): array
+    public function convertObjectToIdentityArray($object): array
     {
         $identifier = $this->getIdentifierByObject($object);
         if ($identifier === null) {

--- a/Neos.Flow/Classes/Persistence/Doctrine/PersistenceManager.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/PersistenceManager.php
@@ -122,7 +122,7 @@ class PersistenceManager extends AbstractPersistenceManager
      * @return boolean true if the object is new, false if the object exists in the repository
      * @api
      */
-    public function isNewObject(object $object): bool
+    public function isNewObject($object): bool
     {
         return ($this->entityManager->getUnitOfWork()->getEntityState($object, UnitOfWork::STATE_NEW) === UnitOfWork::STATE_NEW);
     }
@@ -141,7 +141,7 @@ class PersistenceManager extends AbstractPersistenceManager
      * @todo improve try/catch block
      * @api
      */
-    public function getIdentifierByObject(object $object)
+    public function getIdentifierByObject($object)
     {
         if (property_exists($object, 'Persistence_Object_Identifier')) {
             $identifierCandidate = ObjectAccess::getProperty($object, 'Persistence_Object_Identifier', true);
@@ -207,7 +207,7 @@ class PersistenceManager extends AbstractPersistenceManager
      * @throws PropertyNotAccessibleException
      * @api
      */
-    public function add(object $object): void
+    public function add($object): void
     {
         if (!$this->isNewObject($object)) {
             throw new KnownObjectException('The object of type "' . get_class($object) . '" (identifier: "' . $this->getIdentifierByObject($object) . '") which was passed to EntityManager->add() is not a new object. Check the code which adds this entity to the repository and make sure that only objects are added which were not persisted before. Alternatively use update() for updating existing objects."', 1337934295);
@@ -227,7 +227,7 @@ class PersistenceManager extends AbstractPersistenceManager
      * @return void
      * @api
      */
-    public function remove(object $object): void
+    public function remove($object): void
     {
         $this->entityManager->remove($object);
     }
@@ -242,7 +242,7 @@ class PersistenceManager extends AbstractPersistenceManager
      * @throws PropertyNotAccessibleException
      * @api
      */
-    public function update(object $object): void
+    public function update($object): void
     {
         if ($this->isNewObject($object)) {
             throw new UnknownObjectException('The object of type "' . get_class($object) . '" (identifier: "' . $this->getIdentifierByObject($object) . '") which was passed to EntityManager->update() is not a previously persisted object. Check the code which updates this entity and make sure that only objects are updated which were persisted before. Alternatively use add() for persisting new objects."', 1313663277);

--- a/Neos.Flow/Classes/Persistence/PersistenceManagerInterface.php
+++ b/Neos.Flow/Classes/Persistence/PersistenceManagerInterface.php
@@ -58,7 +58,7 @@ interface PersistenceManagerInterface
      * @return boolean true if the object is new, false if the object exists in the repository
      * @api
      */
-    public function isNewObject(object $object): bool;
+    public function isNewObject($object): bool;
 
     /**
      * Registers an object which has been created or cloned during this request.
@@ -87,7 +87,7 @@ interface PersistenceManagerInterface
      * @return mixed The identifier for the object if it is known, or NULL
      * @api
      */
-    public function getIdentifierByObject(object $object);
+    public function getIdentifierByObject($object);
 
     /**
      * Returns the object with the (internal) identifier, if it is known to the
@@ -110,7 +110,7 @@ interface PersistenceManagerInterface
      * @throws UnknownObjectException if the given object is not known to the Persistence Manager
      * @api
      */
-    public function convertObjectToIdentityArray(object $object): array;
+    public function convertObjectToIdentityArray($object): array;
 
     /**
      * Recursively iterates through the given array and turns objects
@@ -140,7 +140,7 @@ interface PersistenceManagerInterface
      * @return void
      * @api
      */
-    public function add(object $object): void;
+    public function add($object): void;
 
     /**
      * Removes an object to the persistence.
@@ -149,7 +149,7 @@ interface PersistenceManagerInterface
      * @return void
      * @api
      */
-    public function remove(object $object): void;
+    public function remove($object): void;
 
     /**
      * Update an object in the persistence.
@@ -159,7 +159,7 @@ interface PersistenceManagerInterface
      * @throws UnknownObjectException
      * @api
      */
-    public function update(object $object): void;
+    public function update($object): void;
 
     /**
      * Adds the given object to a list of allowed objects which may be persisted when persistAll() is called with the
@@ -169,7 +169,7 @@ interface PersistenceManagerInterface
      * @return void
      * @api
      */
-    public function allowObject(object $object): void;
+    public function allowObject($object);
 
     /**
      * Returns true, if an active connection to the persistence


### PR DESCRIPTION
This reverts commit 18386878d77b5d93ff976769f967a3713ce2d7e6. 

The return type `object` is not handled properly yet in proxy class building which causes trouble on the neos side. We are reverting this now as hotfix. The proper handling of `object` types can be added as bugfix. The type annotations for the PersistenceManagerInterface will have to wait until next major.

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
