### PR TITLE
BUGFIX: LockManager catches PHP 8 Throwable during unlockSite

### DIFF
--- a/Neos.Flow/Classes/Core/LockManager.php
+++ b/Neos.Flow/Classes/Core/LockManager.php
@@ -140,7 +140,11 @@ class LockManager
         if (is_resource($this->lockResource)) {
             flock($this->lockResource, LOCK_UN);
             fclose($this->lockResource);
-            @unlink($this->lockPathAndFilename);
+            try {
+                @unlink($this->lockPathAndFilename);
+            } catch (\Throwable $e) {
+                // PHP 8 apparently throws for unlink even with shutup operator, but we really don't care at this place. It's also the only way to handle this race-condition free.
+            }
         }
         if ($this->isSiteLocked()) {
             try {


### PR DESCRIPTION
This is a followup PR to https://github.com/neos/flow-development-collection/pull/2716 to catch PHP 8 Throwables possibly thrown during `@unlink($this->lockPathAndFilename);`.