### PR TITLE
BUGFIX: Address deprecation warnings from PHP 8.1

### DIFF
--- a/Neos.Flow/Classes/Core/Bootstrap.php
+++ b/Neos.Flow/Classes/Core/Bootstrap.php
@@ -620,7 +620,7 @@ class Bootstrap
      * - $_SERVER[REDIRECT_ . $variableName] (again for php cgi environments)
      *
      * @param string $variableName
-     * @return string or NULL if this variable was not set at all.
+     * @return string|null NULL if this variable was not set at all.
      */
     public static function getEnvironmentConfigurationSetting(string $variableName)
     {

--- a/Neos.Flow/Scripts/flow.php
+++ b/Neos.Flow/Scripts/flow.php
@@ -65,7 +65,7 @@ if (isset($argv[1]) && ($argv[1] === 'neos.flow:core:setfilepermissions' || $arg
         $_SERVER['FLOW_ROOTPATH'] = trim(getenv('FLOW_ROOTPATH'), '"\' ') ?: dirname($_SERVER['PHP_SELF']);
     }
 
-    $context = trim(\Neos\Flow\Core\Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT') ?: '', '"\' ') ?: 'Development';
+    $context = trim((string)\Neos\Flow\Core\Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT'), '"\' ') ?: 'Development';
 
     $bootstrap = new \Neos\Flow\Core\Bootstrap($context, $composerAutoloader);
     $bootstrap->run();

--- a/Neos.Flow/Scripts/flow.php
+++ b/Neos.Flow/Scripts/flow.php
@@ -65,7 +65,7 @@ if (isset($argv[1]) && ($argv[1] === 'neos.flow:core:setfilepermissions' || $arg
         $_SERVER['FLOW_ROOTPATH'] = trim(getenv('FLOW_ROOTPATH'), '"\' ') ?: dirname($_SERVER['PHP_SELF']);
     }
 
-    $context = trim(\Neos\Flow\Core\Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT'), '"\' ') ?: 'Development';
+    $context = trim(\Neos\Flow\Core\Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT') ?: '', '"\' ') ?: 'Development';
 
     $bootstrap = new \Neos\Flow\Core\Bootstrap($context, $composerAutoloader);
     $bootstrap->run();


### PR DESCRIPTION
The trim method did not like beeing called with a null argument when the FLOW_CONTEXT environment was not set.

```
PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in /Users/ficzel/PhpStormProjects/neos-development-distribution-8-0/Packages/Framework/Neos.Flow/Scripts/flow.php on line 68
```
