### PR TITLE
BUGFIX: Require psr/log ^2.0 in FluidAdapter

### DIFF
--- a/Neos.FluidAdaptor/composer.json
+++ b/Neos.FluidAdaptor/composer.json
@@ -12,7 +12,7 @@
     "neos/utility-files": "*",
     "neos/utility-objecthandling": "*",
     "typo3fluid/fluid": "^2.7.0",
-    "psr/log": "^1.0"
+    "psr/log": "^2.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Fixes #2801
