### PR TITLE
BUGFIX: Use env var for FLOW_LOCK_HOLDING_PAGE

### DIFF
--- a/Neos.Flow/Classes/Core/LockManager.php
+++ b/Neos.Flow/Classes/Core/LockManager.php
@@ -42,6 +42,11 @@ class LockManager
     protected $lockFlagPathAndFilename;
 
     /**
+     * @var string
+     */
+    protected $lockHoldingPage;
+
+    /**
      * @var resource
      */
     protected $lockResource;

--- a/Neos.Flow/Classes/Core/LockManager.php
+++ b/Neos.Flow/Classes/Core/LockManager.php
@@ -54,7 +54,8 @@ class LockManager
         $lockPath = $this->getLockPath();
         $this->lockPathAndFilename = $lockPath . md5(FLOW_PATH_ROOT) . '_Flow.lock';
         $this->lockFlagPathAndFilename = $lockPath . md5(FLOW_PATH_ROOT) . '_FlowIsLocked';
-        $this->lockHoldingPage = defined('FLOW_LOCKHOLDINGPAGE') ? FLOW_PATH_PACKAGES . FLOW_LOCKHOLDINGPAGE : FLOW_PATH_FLOW . 'Resources/Private/Core/LockHoldingStackPage.html';
+        $configuredLockHoldingPage = Bootstrap::getEnvironmentConfigurationSetting('FLOW_LOCKHOLDINGPAGE');
+        $this->lockHoldingPage = $configuredLockHoldingPage ? FLOW_PATH_PACKAGES . $configuredLockHoldingPage : FLOW_PATH_FLOW . 'Resources/Private/Core/LockHoldingStackPage.html';
         $this->removeExpiredLock();
     }
 

--- a/Neos.Flow/Classes/Core/LockManager.php
+++ b/Neos.Flow/Classes/Core/LockManager.php
@@ -54,7 +54,7 @@ class LockManager
         $lockPath = $this->getLockPath();
         $this->lockPathAndFilename = $lockPath . md5(FLOW_PATH_ROOT) . '_Flow.lock';
         $this->lockFlagPathAndFilename = $lockPath . md5(FLOW_PATH_ROOT) . '_FlowIsLocked';
-        $configuredLockHoldingPage = Bootstrap::getEnvironmentConfigurationSetting('FLOW_LOCKHOLDINGPAGE');
+        $configuredLockHoldingPage = Bootstrap::getEnvironmentConfigurationSetting('FLOW_LOCK_HOLDING_PAGE') ?? Bootstrap::getEnvironmentConfigurationSetting('FLOW_LOCKHOLDINGPAGE');
         $this->lockHoldingPage = $configuredLockHoldingPage ? FLOW_PATH_PACKAGES . $configuredLockHoldingPage : FLOW_PATH_FLOW . 'Resources/Private/Core/LockHoldingStackPage.html';
         $this->removeExpiredLock();
     }

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartII/Configuration.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartII/Configuration.rst
@@ -196,7 +196,7 @@ Variable                      Description
 ``FLOW_ROOTPATH``             Can be used to override the path to the Flow root.
 ``FLOW_CONTEXT``              Use to set the flow context (see above).
 ``FLOW_PATH_TEMPORARY_BASE``  Can be used to set a path for temporary data.
-``FLOW_LOCKHOLDINGPAGE``      Use to specify the html page shown when the site is
+``FLOW_LOCK_HOLDING_PAGE``    Use to specify the html page shown when the site is
                               locked. This is relative to the Packages directory.
                               Can be given as ``FLOW_LOCKHOLDINGPAGE``, too.
                               That is deprecated as of Flow 8.0.

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartII/Configuration.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartII/Configuration.rst
@@ -178,9 +178,9 @@ table structure needed by Flow:
 .. note::
   If you run into problems with the migrations, e.g. because the database does not allow dropping primary keys,
   there is another method to setup the database newly:
-  
+
     ./flow doctrine:create && ./flow doctrine:migrationversion --add --version all
-  
+
   This should only be used for initial creation of the database, as it is a destructive operation though! Also note
   that this will not solve the issue for future migrations.
 
@@ -190,16 +190,18 @@ Environment Variables
 
 Some specific flow behaviour can also be configured with a couple of environment variables.
 
-============================	==================================================
-Variable						Description
-============================	==================================================
-FLOW_ROOTPATH					Can be used to override the path to the Flow root.
-FLOW_CONTEXT					Use to set the flow context (see above).
-FLOW_PATH_TEMPORARY_BASE		Can be used to set a path for temporary data.
-FLOW_LOCKHOLDINGPAGE			Use to specify the html page shown when the site is locked.
-								This is relative to the Packages directory.
-FLOW_ONLY_COMPOSER_LOADER		Set to true (1) to only use composer autoloader.
-============================	==================================================
+============================= ==================================================
+Variable                      Description
+============================= ==================================================
+``FLOW_ROOTPATH``             Can be used to override the path to the Flow root.
+``FLOW_CONTEXT``              Use to set the flow context (see above).
+``FLOW_PATH_TEMPORARY_BASE``  Can be used to set a path for temporary data.
+``FLOW_LOCKHOLDINGPAGE``      Use to specify the html page shown when the site is
+                              locked. This is relative to the Packages directory.
+                              Can be given as ``FLOW_LOCKHOLDINGPAGE``, too.
+                              That is deprecated as of Flow 8.0.
+``FLOW_ONLY_COMPOSER_LOADER`` Set to true (1) to only use composer autoloader.
+============================= ==================================================
 
 
 -----

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -745,18 +745,14 @@
       <code>$this-&gt;lockResource</code>
       <code>$this-&gt;lockResource</code>
     </InvalidPropertyAssignmentValue>
-    <UndefinedConstant occurrences="4">
+    <UndefinedConstant occurrences="6">
+      <code>FLOW_PATH_FLOW</code>
+      <code>FLOW_PATH_PACKAGES</code>
       <code>FLOW_PATH_ROOT</code>
       <code>FLOW_PATH_ROOT</code>
       <code>FLOW_PATH_TEMPORARY</code>
       <code>FLOW_SAPITYPE</code>
     </UndefinedConstant>
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;lockHoldingPage</code>
-    </UndefinedThisPropertyAssignment>
-    <UndefinedThisPropertyFetch occurrences="1">
-      <code>$this-&gt;lockHoldingPage</code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Core/ProxyClassLoader.php">
     <UndefinedConstant occurrences="1">
@@ -3353,10 +3349,7 @@
     </NullableReturnStatement>
   </file>
   <file src="Packages/Framework/Neos.Utility.ObjectHandling/Classes/ObjectAccess.php">
-    <InvalidScalarArgument occurrences="4">
-      <code>$propertyName</code>
-      <code>$propertyName</code>
-      <code>$propertyName</code>
+    <InvalidScalarArgument occurrences="1">
       <code>$propertyName</code>
     </InvalidScalarArgument>
   </file>


### PR DESCRIPTION
The lock holding page was supposed to be customizable through
an environment variable, but that never worked…

Now it does, using the new variable name `FLOW_LOCK_HOLDING_PAGE`
as well as the (now deprecated) old name `FLOW_LOCKHOLDINGPAGE`.

Fixes #2798
