### PR TITLE
TASK: Handle ReflectionUnionType & ReflectionIntersectionType

### DIFF
--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1798,8 +1798,18 @@ class ReflectionService
 
         $parameterType = $parameter->getType();
         if ($parameterType !== null) {
-            // TODO: This needs to handle ReflectionUnionType
-            $parameterType = ($parameterType instanceof \ReflectionNamedType) ? $parameterType->getName() : $parameterType->__toString();
+            if ($parameterType instanceof \ReflectionUnionType || $parameterType instanceof \ReflectionIntersectionType) {
+                // ReflectionUnionType as of PHP 8, ReflectionIntersectionType as of PHP 8.1
+                $parameterType = implode('|', array_map(
+                    static function (\ReflectionNamedType $type) {
+                        return $type->getName();
+                    },
+                    $parameterType->getTypes()
+                ));
+            } else {
+                // ReflectionNamedType as of PHP 7.1
+                $parameterType = $parameterType->getName();
+            }
         }
         if ($parameterType !== null && !TypeHandling::isSimpleType($parameterType)) {
             // We use parameter type here to make class_alias usage work and return the hinted class name instead of the alias

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1798,9 +1798,17 @@ class ReflectionService
 
         $parameterType = $parameter->getType();
         if ($parameterType !== null) {
-            if ($parameterType instanceof \ReflectionUnionType || $parameterType instanceof \ReflectionIntersectionType) {
-                // ReflectionUnionType as of PHP 8, ReflectionIntersectionType as of PHP 8.1
+            if ($parameterType instanceof \ReflectionUnionType) {
+                // ReflectionUnionType as of PHP 8
                 $parameterType = implode('|', array_map(
+                    static function (\ReflectionNamedType $type) {
+                        return $type->getName();
+                    },
+                    $parameterType->getTypes()
+                ));
+            } elseif ($parameterType instanceof \ReflectionIntersectionType) {
+                // ReflectionIntersectionType as of PHP 8.1
+                $parameterType = implode('&', array_map(
                     static function (\ReflectionNamedType $type) {
                         return $type->getName();
                     },

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1970,6 +1970,9 @@
     <TooManyArguments occurrences="1">
       <code>getPropertyAnnotations</code>
     </TooManyArguments>
+    <UndefinedClass occurrences="1">
+      <code>\ReflectionUnionType</code>
+    </UndefinedClass>
     <UndefinedInterfaceMethod occurrences="3">
       <code>freeze</code>
       <code>freeze</code>


### PR DESCRIPTION
This adds explicit handling of `ReflectionUnionType` & `ReflectionIntersectionType` instead of falling back to the deprecated `__toString()` method on `ReflectionType`.

Since we do no longer suppport PHP < 7.1 only the two mentioned types as well as `ReflectionNamedType` are supported, a "pure" `ReflectionType` can no longer be present at this point.