### PR TITLE
!!!TASK: Adjust security event log levels

### DIFF
--- a/Neos.Flow/Classes/Http/Middleware/SecurityEntryPointMiddleware.php
+++ b/Neos.Flow/Classes/Http/Middleware/SecurityEntryPointMiddleware.php
@@ -72,7 +72,7 @@ class SecurityEntryPointMiddleware implements MiddlewareInterface
                 }
 
                 $entryPoint = $token->getAuthenticationEntryPoint();
-                $this->securityLogger->info(sprintf('Starting authentication with entry point of type "%s"', \get_class($entryPoint)), LogEnvironment::fromMethodName(__METHOD__));
+                $this->securityLogger->debug(sprintf('Starting authentication with entry point of type "%s"', \get_class($entryPoint)), LogEnvironment::fromMethodName(__METHOD__));
 
                 // Only store the intercepted request if it is a GET request (otherwise it can't be resumed properly)
                 // We also don't store the request for "sessionless authentications" because that would implicitly start a session

--- a/Neos.Flow/Classes/Security/Aspect/LoggingAspect.php
+++ b/Neos.Flow/Classes/Security/Aspect/LoggingAspect.php
@@ -151,7 +151,7 @@ class LoggingAspect
         $subjectJoinPoint = $joinPoint->getMethodArgument('subject');
         $decision = $joinPoint->getResult() === true ? 'GRANTED' : 'DENIED';
         $message = sprintf('Decided "%s" on method call %s::%s().', $decision, $subjectJoinPoint->getClassName(), $subjectJoinPoint->getMethodName());
-        $this->securityLogger->info($message, $this->getLogEnvironmentFromJoinPoint($joinPoint));
+        $this->securityLogger->debug($message, $this->getLogEnvironmentFromJoinPoint($joinPoint));
     }
 
     /**
@@ -165,7 +165,7 @@ class LoggingAspect
     {
         $decision = $joinPoint->getResult() === true ? 'GRANTED' : 'DENIED';
         $message = sprintf('Decided "%s" on privilege "%s".', $decision, $joinPoint->getMethodArgument('privilegeTargetIdentifier'));
-        $this->securityLogger->info($message, $this->getLogEnvironmentFromJoinPoint($joinPoint));
+        $this->securityLogger->debug($message, $this->getLogEnvironmentFromJoinPoint($joinPoint));
     }
 
     /**

--- a/Neos.Flow/Classes/Session/Aspect/LoggingAspect.php
+++ b/Neos.Flow/Classes/Session/Aspect/LoggingAspect.php
@@ -25,13 +25,13 @@ use Psr\Log\LoggerInterface;
 class LoggingAspect
 {
     /**
-     * @Flow\Inject(name="Neos.Flow:SystemLogger")
+     * @Flow\Inject(name="Neos.Flow:SecurityLogger")
      * @var LoggerInterface
      */
     protected $logger;
 
     /**
-     * Injects the (system) logger based on PSR-3.
+     * Injects the (security) logger based on PSR-3.
      *
      * @param LoggerInterface $logger
      * @return void

--- a/Neos.Flow/Tests/Unit/Session/Aspect/LoggingAspectTest.php
+++ b/Neos.Flow/Tests/Unit/Session/Aspect/LoggingAspectTest.php
@@ -33,14 +33,14 @@ class LoggingAspectTest extends UnitTestCase
         $testSessionId = $testSession->getId();
 
         $mockJoinPoint = new JoinPoint($testSession, TransientSession::class, 'destroy', ['reason' => 'session timed out']);
-        $mockSystemLogger = $this->createMock(LoggerInterface::class);
-        $mockSystemLogger
+        $mockLogger = $this->createMock(LoggerInterface::class);
+        $mockLogger
             ->expects(self::once())
             ->method('debug')
             ->with(self::equalTo('TransientSession: Destroyed session with id ' . $testSessionId . ': session timed out'));
 
         $loggingAspect = new LoggingAspect();
-        $this->inject($loggingAspect, 'logger', $mockSystemLogger);
+        $this->inject($loggingAspect, 'logger', $mockLogger);
         $loggingAspect->logDestroy($mockJoinPoint);
     }
 
@@ -56,14 +56,14 @@ class LoggingAspectTest extends UnitTestCase
         $testSessionId = $testSession->getId();
 
         $mockJoinPoint = new JoinPoint($testSession, TransientSession::class, 'destroy', []);
-        $mockSystemLogger = $this->createMock(LoggerInterface::class);
-        $mockSystemLogger
+        $mockLogger = $this->createMock(LoggerInterface::class);
+        $mockLogger
             ->expects(self::once())
             ->method('debug')
             ->with(self::equalTo('TransientSession: Destroyed session with id ' . $testSessionId . ': no reason given'));
 
         $loggingAspect = new LoggingAspect();
-        $this->inject($loggingAspect, 'logger', $mockSystemLogger);
+        $this->inject($loggingAspect, 'logger', $mockLogger);
         $loggingAspect->logDestroy($mockJoinPoint);
     }
 }


### PR DESCRIPTION
This adjusts some security related log levels, specifically:

- Privilege decisions are now DEBUG (before INFO)
- Authentication starts are now DEBUG (before INFO)
- Session starts moved to the Security log but kept their level

It is marked breaking in case anyone is observing these log events.

<!--
Thanks for your contribution, we appreciate it!

Please read through our pull request guidelines, there are some interesting things there:
https://discuss.neos.io/t/creating-a-pull-request/506

And one more thing... Don't forget about the tests!
-->


**What I did**

**How I did it**

**How to verify it**

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
