### PR TITLE
TASK: Remove interactive shell and deprecate infrastructure

### DIFF
--- a/Neos.Flow/Classes/Cli/SlaveRequestHandler.php
+++ b/Neos.Flow/Classes/Cli/SlaveRequestHandler.php
@@ -25,6 +25,8 @@ use Psr\Log\LoggerInterface;
  *
  * @Flow\Proxy(false)
  * @Flow\Scope("singleton")
+ *
+ * @deprecated  This will probably move to a separate package and be renamed in a future version, you should not rely on it.
  */
 class SlaveRequestHandler implements RequestHandlerInterface
 {

--- a/Neos.Flow/Tests/Behavior/Features/Bootstrap/SubProcess/SubProcess.php
+++ b/Neos.Flow/Tests/Behavior/Features/Bootstrap/SubProcess/SubProcess.php
@@ -9,6 +9,8 @@ use Neos\Flow\Core\ApplicationContext;
  * Usage:
  *  $subProcess = new SubProcess($applicationContext);
  *  $subProcessResponse = $subProcess->execute('some:flow:command');
+ *
+ * @deprecated This will probably move to a separate package in a future version, you should not rely on it.
  */
 class SubProcess
 {
@@ -53,7 +55,7 @@ class SubProcess
             }
         };
         if (!is_resource($this->subProcess)) {
-            list($this->subProcess, $this->pipes) = $this->launchSubProcess();
+            [$this->subProcess, $this->pipes] = $this->launchSubProcess();
             if ($this->subProcess === false || !is_array($this->pipes)) {
                 throw new \Exception('Failed launching the shell sub process');
             }


### PR DESCRIPTION
This removes the interactive shell functionality and deeprecates
the support classes for this. Those are still used by the behat
tests and everything should be moved to a separate package at
which point we will reintroduce the interactive shell in that
new package. At that point renaming will likely happen, therefore
the respective classes are marked deprecated. None of it was public
API before so this is not marked breaking.