### PR TITLE
BUGFIX: Prevent UriConstraints to generate invalid URIs

### DIFF
--- a/Neos.Flow/Classes/Mvc/Routing/Dto/UriConstraints.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Dto/UriConstraints.php
@@ -311,6 +311,7 @@ final class UriConstraints
     public function applyTo(UriInterface $baseUri, bool $forceAbsoluteUri): UriInterface
     {
         $uri = new Uri('');
+        $uriPath = '';
         if (isset($this->constraints[self::CONSTRAINT_SCHEME]) && $this->constraints[self::CONSTRAINT_SCHEME] !== $baseUri->getScheme()) {
             $forceAbsoluteUri = true;
             $uri = $uri->withScheme($this->constraints[self::CONSTRAINT_SCHEME]);
@@ -364,16 +365,16 @@ final class UriConstraints
         }
 
         if (isset($this->constraints[self::CONSTRAINT_PATH]) && $this->constraints[self::CONSTRAINT_PATH] !== $baseUri->getPath()) {
-            $uri = $uri->withPath($this->constraints[self::CONSTRAINT_PATH]);
+            $uriPath = $this->constraints[self::CONSTRAINT_PATH];
         }
         if (isset($this->constraints[self::CONSTRAINT_PATH_PREFIX])) {
             // we need to trim the leading "/" from $uri->getPath() (as it is always absolute); so
             // that the Path Prefix can build strings like <prepended><url>, or
             // <prepended>/<url>
-            $uri = $uri->withPath($this->constraints[self::CONSTRAINT_PATH_PREFIX] . ltrim($uri->getPath(), '/'));
+            $uriPath = $this->constraints[self::CONSTRAINT_PATH_PREFIX] . ltrim($uriPath, '/');
         }
         if (isset($this->constraints[self::CONSTRAINT_PATH_SUFFIX])) {
-            $uri = $uri->withPath($uri->getPath() . $this->constraints[self::CONSTRAINT_PATH_SUFFIX]);
+            $uriPath .= $this->constraints[self::CONSTRAINT_PATH_SUFFIX];
         }
         if (isset($this->constraints[self::CONSTRAINT_QUERY_STRING])) {
             $uri = $uri->withQuery($this->constraints[self::CONSTRAINT_QUERY_STRING]);
@@ -383,18 +384,16 @@ final class UriConstraints
         $baseUriPath = trim($baseUri->getPath(), '/');
         if ($baseUriPath !== '') {
             $mergedUriPath = $baseUriPath;
-            if ($uri->getPath() !== '') {
-                $mergedUriPath .= '/' . ltrim($uri->getPath(), '/');
+            if ($uriPath !== '') {
+                $mergedUriPath .= '/' . ltrim($uriPath, '/');
             }
-            $uri = $uri->withPath($mergedUriPath);
+            $uriPath = $mergedUriPath;
         }
 
         // Ensure the URL always starts with "/", no matter if it is empty of non-empty.
         // HINT: We need to enforce at least a "/" URL,a s otherwise e.g. linking to the root node of a Neos
         // site would not work.
-        if ($uri->getPath() === '' || $uri->getPath()[0] !== '/') {
-            $uri = $uri->withPath('/' . $uri->getPath());
-        }
+        $uri = $uri->withPath('/' . ltrim($uriPath, '/'));
 
         if ($forceAbsoluteUri) {
             if (empty($uri->getScheme())) {


### PR DESCRIPTION
Adjusts `UriConstraints::applyTo()` such that it never creates
an `Uri` instance with a path of `/` (which according to `guzzle/psr` was
deprecated since 1.x and invalid with 2.x)

Fixes: #2473