### PR TITLE
BUGFIX: Properly proxy methods with a `static` or `parent` return type

### DIFF
--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1381,7 +1381,7 @@ class ReflectionService
         }
 
         $returnType = $method->getDeclaredReturnType();
-        if ($returnType !== null && !in_array($returnType, ['self', 'null', 'callable', 'void', 'iterable', 'object', 'mixed']) && !TypeHandling::isSimpleType($returnType)) {
+        if ($returnType !== null && !in_array($returnType, ['self', 'static', 'parent', 'callable', 'void', 'iterable', 'object', 'mixed']) && !TypeHandling::isSimpleType($returnType)) {
             $returnType = '\\' . $returnType;
         }
         if ($method->isDeclaredReturnTypeNullable()) {


### PR DESCRIPTION
Previously classes that contained a method that returned `static` or `parent` could not be proxied properly, because the generated proxy class would prepend the return typehint with `\`, which makes PHP error out.
This fixes that by adding those return type declarations to the list to ignore for fully qualifying.