### PR TITLE
TASK: Run checks against current database versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,9 @@ jobs:
           - "3306:3306"
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
       postgres:
-        image: postgres:9.5-alpine
+        # see https://www.postgresql.org/support/versioning/
+        # this should be a current release
+        image: postgres:14-alpine
         env:
           POSTGRES_USER: neos
           POSTGRES_PASSWORD: neos

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mariadb:
-        image: mariadb:10.2
+        # see https://mariadb.com/kb/en/mariadb-server-release-dates/
+        # this should be a current release, e.g. the LTS version
+        image: mariadb:10.6
         env:
           MYSQL_USER: neos
           MYSQL_PASSWORD: neos

--- a/.github/workflows/postgresql-versions.yml
+++ b/.github/workflows/postgresql-versions.yml
@@ -20,7 +20,7 @@ jobs:
         # Use https://hub.docker.com/_/postgres for available versions
         postgresql-versions: ['14-alpine', '13-alpine', '12-alpine', '11-alpine', '10-alpine']
         dependencies: ['highest']
-        composer-arguments: ['--ignore-platform-reqs'] # to run --ignore-platform-reqs in experimental builds
+        composer-arguments: [''] # to run --ignore-platform-reqs in experimental builds
         experimental: [true]
         include:
           # Build for minimum dependencies.

--- a/.github/workflows/postgresql-versions.yml
+++ b/.github/workflows/postgresql-versions.yml
@@ -41,6 +41,15 @@ jobs:
         image: memcached:alpine
         ports:
           - "11211:11211"
+      postgres:
+        image: postgres:${{ matrix.postgresql-versions }}
+        env:
+          POSTGRES_USER: neos
+          POSTGRES_PASSWORD: neos
+          POSTGRES_DB: flow_functional_testing
+        ports:
+          - "5432:5432"
+        options:  --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
 
     env:
       FLOW_CONTEXT: Testing
@@ -69,14 +78,6 @@ jobs:
           coverage: xdebug #optional
           ini-values: date.timezone="Africa/Tunis", opcache.fast_shutdown=0, apc.enable_cli=on
 
-      - name: Setup PostgreSQL
-        uses: harmon758/postgresql-action@v1
-        with:
-          postgresql version: ${{ matrix.postgresql-versions }}
-          postgresql db: flow_functional_testing
-          postgresql user: neos
-          postgresql password: neos
-
       - name: Checkout development distribution
         uses: actions/checkout@v2
         with:
@@ -85,7 +86,12 @@ jobs:
           path: ${{ env.FLOW_DIST_FOLDER }}
 
       - name: Set alias branch name
-        run: if [ "${FLOW_TARGET_VERSION}" == "master" ]; then echo "FLOW_BRANCH_ALIAS=dev-master"; else echo "FLOW_BRANCH_ALIAS=${FLOW_TARGET_VERSION}.x-dev"; fi >> $GITHUB_ENV
+        run: |
+            if [ "${{ env.FLOW_TARGET_VERSION }}" == "master" ]; then
+                echo "FLOW_BRANCH_ALIAS=dev-master";
+            else
+                echo "FLOW_BRANCH_ALIAS=${{ env.FLOW_TARGET_VERSION }}.x-dev";
+            fi >> $GITHUB_ENV
 
       - name: Update composer.json
         run: |

--- a/.github/workflows/postgresql-versions.yml
+++ b/.github/workflows/postgresql-versions.yml
@@ -1,0 +1,145 @@
+name: PostgreSQL tests
+
+on:
+  workflow_dispatch: # allow manual runs
+  schedule:
+    - cron:  '0 0 * * *' # Runs every day at midnight
+
+jobs:
+  build:
+    name: "Experimental PostgreSQL ${{ matrix.postgresql-versions }} Test (PHP: ${{ matrix.php-versions }}, deps: ${{ matrix.dependencies }})"
+
+    continue-on-error: true
+
+    strategy:
+      fail-fast: false
+      matrix:
+        flow-versions: ['master']
+        php-versions: ['8.1', '8.0']
+        # See https://www.postgresql.org/support/versioning/
+        # Use https://hub.docker.com/_/postgres for available versions
+        postgresql-versions: ['14-alpine', '13-alpine', '12-alpine', '11-alpine', '10-alpine']
+        dependencies: ['highest']
+        composer-arguments: ['--ignore-platform-reqs'] # to run --ignore-platform-reqs in experimental builds
+        experimental: [true]
+        include:
+          # Build for minimum dependencies.
+          - flow-versions: 'master'
+            php-versions: '8.0'
+            postgresql-versions: '10-alpine'
+            experimental: true
+            dependencies: 'lowest'
+
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:alpine
+        ports:
+          - "6379:6379"
+        options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+      memcached:
+        image: memcached:alpine
+        ports:
+          - "11211:11211"
+
+    env:
+      FLOW_CONTEXT: Testing
+      FLOW_DIST_FOLDER: flow-development-distribution
+      FLOW_FOLDER: flow-development-collection
+
+    defaults:
+      run:
+        working-directory: ${{ env.FLOW_DIST_FOLDER }}
+
+    steps:
+      - name: Set Flow target branch name
+        run: echo "FLOW_TARGET_VERSION=${{ matrix.flow-versions }}" >> $GITHUB_ENV
+        working-directory: .
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: ${{ env.FLOW_FOLDER }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, xml, json, zlib, iconv, intl, pdo_sqlite, mysql, pgsql, redis, memcached, memcache, apcu
+          coverage: xdebug #optional
+          ini-values: date.timezone="Africa/Tunis", opcache.fast_shutdown=0, apc.enable_cli=on
+
+      - name: Setup PostgreSQL
+        uses: harmon758/postgresql-action@v1
+        with:
+          postgresql version: ${{ matrix.postgresql-versions }}
+          postgresql db: flow_functional_testing
+          postgresql user: neos
+          postgresql password: neos
+
+      - name: Checkout development distribution
+        uses: actions/checkout@v2
+        with:
+          repository: neos/flow-development-distribution
+          ref: ${{ env.FLOW_TARGET_VERSION }}
+          path: ${{ env.FLOW_DIST_FOLDER }}
+
+      - name: Set alias branch name
+        run: if [ "${FLOW_TARGET_VERSION}" == "master" ]; then echo "FLOW_BRANCH_ALIAS=dev-master"; else echo "FLOW_BRANCH_ALIAS=${FLOW_TARGET_VERSION}.x-dev"; fi >> $GITHUB_ENV
+
+      - name: Update composer.json
+        run: |
+          git -C ../${{ env.FLOW_FOLDER }} checkout -b build
+          composer config repositories.flow '{ "type": "path", "url": "../${{ env.FLOW_FOLDER }}", "options": { "symlink": false } }'
+          composer require --no-update neos/flow-development-collection:"dev-build as ${{ env.FLOW_BRANCH_ALIAS }}"
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/composer
+            ${{ env.FLOW_DIST_FOLDER }}/Packages
+          key: php-${{ matrix.php-versions }}-${{ matrix.dependencies }}${{ hashFiles('**/composer.json') }}
+          restore-keys: php-${{ matrix.php-versions }}-${{ matrix.dependencies }}
+
+      - name: Install dependencies
+        run: |
+          composer ${{ matrix.dependencies == 'locked' && 'install' || 'update' }} --no-progress --no-interaction ${{ matrix.dependencies == 'lowest' && '--prefer-lowest' || '' }} ${{ matrix.composer-arguments }}
+
+      - name: Set Flow Context
+        run: echo "FLOW_CONTEXT=${{ env.FLOW_CONTEXT }}" >> $GITHUB_ENV
+
+      - name: Setup Flow configuration
+        run: |
+          rm -f Configuration/Testing/Settings.yaml
+          cat <<EOF >> Configuration/Testing/Settings.yaml
+          Neos:
+            Flow:
+              persistence:
+                backendOptions:
+                  host: '127.0.0.1'
+                  port: 5432
+                  driver: pdo_pgsql
+                  user: 'neos'
+                  password: 'neos'
+                  dbname: 'flow_functional_testing'
+                  charset: 'utf8'
+                  defaultTableOptions:
+                    charset: 'utf8'
+              mvc:
+                routes:
+                  'Neos.Flow': TRUE
+          EOF
+
+      - name: Run unit tests
+        run: composer test-unit -- --verbose
+
+      - name: Run functional tests
+        run: composer test-func -- --verbose
+
+      - name: Run behat tests
+        if: ${{matrix.dependencies != 'lowest' }}
+        run: |
+          FLOW_CONTEXT=Testing/Behat ./flow behat:setup && ./flow doctrine:create && ./flow doctrine:migrationversion --add --version all
+          bin/behat --stop-on-failure -f progress -c Packages/Framework/Neos.Flow/Tests/Behavior/behat.yml.dist


### PR DESCRIPTION
This change

- updates the MariaDB version used for testing from 10.2 to 10.6. The former reaches EOL in May 2022 but 10.6 is the current LTS version supported until July 2026
- updates the PostgreSQL version used for testing from 9.5 (reached EOL in February 2021) to 10.x, the oldest still supported release
- adds a nighty test against all supported PostgreSQL versions (10.x to 14.x)
