### PR TITLE
TASK: Allow installing psr/log 3.0 and provide implementation for it

### DIFF
--- a/Neos.Flow.Log/composer.json
+++ b/Neos.Flow.Log/composer.json
@@ -9,7 +9,7 @@
     "require": {
         "php": "^8.0",
         "neos/utility-files": "*",
-        "psr/log": "^2.0"
+        "psr/log": "^2.0 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~9.1"
@@ -25,7 +25,7 @@
         }
     },
     "provide": {
-        "psr/log-implementation": "2.0.0"
+        "psr/log-implementation": "2.0.0 || 3.0.0"
     },
     "extra": {
         "neos": {

--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -30,7 +30,7 @@
         "psr/http-message": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/container": "^1.0",
-        "psr/log": "^2.0",
+        "psr/log": "^2.0 || ^3.0",
         "psr/http-server-middleware": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-client": "^1.0",

--- a/Neos.FluidAdaptor/composer.json
+++ b/Neos.FluidAdaptor/composer.json
@@ -12,7 +12,7 @@
     "neos/utility-files": "*",
     "neos/utility-objecthandling": "*",
     "typo3fluid/fluid": "^2.7.0",
-    "psr/log": "^2.0"
+    "psr/log": "^2.0 || ^3.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": "^8.0",
         "psr/simple-cache": "^2.0 || ^3.0",
         "psr/cache": "^2.0 || ^3.0",
-        "psr/log": "^2.0",
+        "psr/log": "^2.0 || ^3.0",
         "ext-zlib": "*",
         "ext-SPL": "*",
         "ext-json": "*",


### PR DESCRIPTION
The change in https://github.com/neos/flow-development-collection/pull/2792 did only allow for psr/log 2.0 while already adding the return type hints that are only part of 3.0. This change allows installing both 2.0 || 3.0 like we do for the other psr interfaces and provides implementations for both versions. Thanks @jonnitto for bringing this up
See also https://github.com/neos/flow-development-collection/pull/2805