### PR TITLE
FEATURE: Command line can parse associative array arguments

### DIFF
--- a/Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php
@@ -464,6 +464,22 @@ class RequestBuilderTest extends UnitTestCase
                 '--a1 1 --a1 x foo bar',
                 ['a1' => ['1', 'x']],
                 ['foo', 'bar']
+            ],
+            [
+                '--a1.k1.k2 1 --a1.k1.k3=x --a2.l1 a --a2 n foo bar',
+                [
+                    'a1' => [
+                        'k1' => [
+                            'k2' => 1,
+                            'k3' => 'x'
+                        ]
+                    ],
+                    'a2' => [
+                        'l1' => 'a',
+                        0 => 'n'
+                    ]
+                ],
+                ['foo', 'bar']
             ]
         ];
     }

--- a/Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php
@@ -466,7 +466,7 @@ class RequestBuilderTest extends UnitTestCase
                 ['foo', 'bar']
             ],
             [
-                '--a1.k1.k2 1 --a1.k1.k3=x --a2.l1 a --a2 n foo bar',
+                '--a1.k1.k2 1 --a1.k1.k3=x --a2.\\"l.1\\".2 a --a2 n foo bar',
                 [
                     'a1' => [
                         'k1' => [
@@ -475,7 +475,9 @@ class RequestBuilderTest extends UnitTestCase
                         ]
                     ],
                     'a2' => [
-                        'l1' => 'a',
+                        'l.1' => [
+                            2 => 'a'
+                        ],
                         0 => 'n'
                     ]
                 ],

--- a/Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php
@@ -466,7 +466,7 @@ class RequestBuilderTest extends UnitTestCase
                 ['foo', 'bar']
             ],
             [
-                '--a1.k1.k2 1 --a1.k1.k3=x --a2.\\"l.1\\".2 a --a2 n foo bar',
+                '--a1.k1.k2 1 --a1.k1.k3=x --a2.l.1.2 a --a2 n foo bar',
                 [
                     'a1' => [
                         'k1' => [
@@ -475,8 +475,10 @@ class RequestBuilderTest extends UnitTestCase
                         ]
                     ],
                     'a2' => [
-                        'l.1' => [
-                            2 => 'a'
+                        'l' => [
+                            1 => [
+                                2 => 'a'
+                            ]
                         ],
                         0 => 'n'
                     ]


### PR DESCRIPTION
**What I did**

The command line RequestBuilder can now parse arguments for associative arrays like
```
./flow my.pckg:index --dimension.language=en --dimension.country de --dimension.\"key.with.a.dot\" mindblown
```

The result is, that the command line controller like
```
public function indexCommand(array $dimension){
```
will receive an associative array as described with a dot syntax in the cli arguments.

I also tried to beautify the code a bit.