### PR TITLE
BUGFIX: Store cache content in BLOB field with PdoBackend

### DIFF
--- a/Neos.Cache/Classes/Backend/PdoBackend.php
+++ b/Neos.Cache/Classes/Backend/PdoBackend.php
@@ -160,18 +160,19 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
 
         $lifetime = ($lifetime === null) ? $this->defaultLifetime : $lifetime;
 
-        // Convert binary data into hexadecimal representation,
-        // because it is not allowed to store null bytes in PostgreSQL.
-        if ($this->pdoDriver === 'pgsql') {
-            $data = bin2hex($data);
-        }
 
         $this->databaseHandle->beginTransaction();
         try {
             $this->removeWithoutTransaction($entryIdentifier);
 
             $statementHandle = $this->databaseHandle->prepare('INSERT INTO "' . $this->cacheTableName . '" ("identifier", "context", "cache", "created", "lifetime", "content") VALUES (?, ?, ?, ?, ?, ?)');
-            $result = $statementHandle->execute([$entryIdentifier, $this->context(), $this->cacheIdentifier, time(), $lifetime, $data]);
+            $statementHandle->bindValue(1, $entryIdentifier);
+            $statementHandle->bindValue(2, $this->context());
+            $statementHandle->bindValue(3, $this->cacheIdentifier);
+            $statementHandle->bindValue(4, time(), \PDO::PARAM_INT);
+            $statementHandle->bindValue(5, $lifetime, \PDO::PARAM_INT);
+            $statementHandle->bindValue(6, $data, \PDO::PARAM_LOB);
+            $result = $statementHandle->execute();
             if ($result === false) {
                 throw new Exception('The cache entry "' . $entryIdentifier . '" could not be written.', 1259530791);
             }
@@ -206,16 +207,13 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
 
         $statementHandle = $this->databaseHandle->prepare('SELECT "content" FROM "' . $this->cacheTableName . '" WHERE "identifier"=? AND "context"=? AND "cache"=?' . $this->getNotExpiredStatement());
         $statementHandle->execute([$entryIdentifier, $this->context(), $this->cacheIdentifier]);
-        /** @var false|string|null $fetchedColumn */
-        $fetchedColumn = $statementHandle->fetchColumn();
+        $statementHandle->bindColumn(1, $content, \PDO::PARAM_LOB);
+        $statementHandle->fetch(\PDO::FETCH_BOUND);
 
-        // Convert hexadecimal data into binary string,
-        // because it is not allowed to store null bytes in PostgreSQL.
-        if ($this->pdoDriver === 'pgsql' && is_string($fetchedColumn)) {
-            $fetchedColumn = hex2bin($fetchedColumn);
+        if ($content === null) {
+            return false;
         }
-
-        return $fetchedColumn;
+        return is_resource($content) ? stream_get_contents($content) : $content;
     }
 
     /**

--- a/Neos.Cache/Resources/Private/mysql.DDL.sql
+++ b/Neos.Cache/Resources/Private/mysql.DDL.sql
@@ -6,7 +6,7 @@ CREATE TABLE "cache" (
   "context" VARCHAR(150) NOT NULL,
   "created" INTEGER UNSIGNED NOT NULL,
   "lifetime" INTEGER UNSIGNED DEFAULT '0' NOT NULL,
-  "content" MEDIUMTEXT,
+  "content" MEDIUMBLOB,
   PRIMARY KEY ("identifier", "cache", "context")
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 

--- a/Neos.Cache/Resources/Private/pgsql.DDL.sql
+++ b/Neos.Cache/Resources/Private/pgsql.DDL.sql
@@ -4,9 +4,9 @@ CREATE TABLE "cache" (
   "identifier" VARCHAR(250) NOT NULL,
   "cache" VARCHAR(250) NOT NULL,
   "context" VARCHAR(150) NOT NULL,
-  "created" INTEGER UNSIGNED NOT NULL,
-  "lifetime" INTEGER UNSIGNED DEFAULT '0' NOT NULL,
-  "content" TEXT,
+  "created" INTEGER NOT NULL,
+  "lifetime" INTEGER DEFAULT '0' NOT NULL,
+  "content" BYTEA,
   PRIMARY KEY ("identifier", "cache", "context")
 );
 

--- a/Neos.Cache/Tests/Functional/Backend/PdoBackendTest.php
+++ b/Neos.Cache/Tests/Functional/Backend/PdoBackendTest.php
@@ -1,0 +1,123 @@
+<?php
+namespace Neos\Cache\Tests\Functional\Backend;
+
+include_once(__DIR__ . '/../../BaseTestCase.php');
+
+/*
+ * This file is part of the Neos.Cache package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Cache\Backend\PdoBackend;
+use Neos\Cache\EnvironmentConfiguration;
+use Neos\Cache\Tests\BaseTestCase;
+use Neos\Cache\Frontend\FrontendInterface;
+
+/**
+ * Testcase for the PDO cache backend
+ *
+ * These tests use actual database servers and will place and remove keys in the db!
+ * Since all keys have the 'TestCache:' prefix, running the tests should have
+ * no side effects on non-related cache entries.
+ *
+ * @requires extension pdo
+ */
+class PdoBackendTest extends BaseTestCase
+{
+    /**
+     * @var PdoBackend[]
+     */
+    private $backends = [];
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|FrontendInterface
+     */
+    private $cache;
+
+    protected function tearDown(): void
+    {
+        foreach ($this->backends as $backend) {
+            $backend->flush();
+        }
+    }
+
+    public function backendsToTest(): array
+    {
+        $this->cache = $this->createMock(FrontendInterface::class);
+        $this->cache->method('getIdentifier')->willReturn('TestCache');
+        $this->setupBackends();
+        return $this->backends;
+    }
+
+    /**
+     * @test
+     * @dataProvider backendsToTest
+     */
+    public function setAddsCacheEntry($backend)
+    {
+        // use data that contains binary junk
+        $data = random_bytes(2048);
+        $backend->set('some_entry', $data);
+        self::assertEquals($data, $backend->get('some_entry'));
+    }
+
+    private function setupBackends(): void
+    {
+        try {
+            $backend = new PdoBackend(
+                new EnvironmentConfiguration('PdoBackend a wonderful color Testing', '/some/path', PHP_MAXPATHLEN),
+                [
+                    'dataSourceName' => 'sqlite::memory:',
+                    'defaultLifetime' => 0
+                ]
+            );
+            $backend->setup();
+            $backend->setCache($this->cache);
+            $backend->flush();
+            $this->backends['sqlite'] = [$backend];
+        } catch (\Exception $e) {
+            $this->addWarning('SQLite DB is not reachable: ' . $e->getMessage());
+        }
+
+        try {
+            $backend = new PdoBackend(
+                new EnvironmentConfiguration('PdoBackend a wonderful color Testing', '/some/path', PHP_MAXPATHLEN),
+                [
+                    'dataSourceName' => 'mysql:host=127.0.0.1;dbname=flow_functional_testing',
+                    'username' => 'neos',
+                    'password' => 'neos',
+                    'defaultLifetime' => 0
+                ]
+            );
+            $backend->setup();
+            $backend->setCache($this->cache);
+            $backend->flush();
+            $this->backends['mysql'] = [$backend];
+        } catch (\Exception $e) {
+            $this->addWarning('MySQL DB server is not reachable: ' . $e->getMessage());
+        }
+
+        try {
+            $backend = new PdoBackend(
+                new EnvironmentConfiguration('PdoBackend a wonderful color Testing', '/some/path', PHP_MAXPATHLEN),
+                [
+                    'dataSourceName' => 'pgsql:host=127.0.0.1;dbname=flow_functional_testing',
+                    'username' => 'neos',
+                    'password' => 'neos',
+                    'defaultLifetime' => 0
+                ]
+            );
+            $backend->setup();
+            $backend->setCache($this->cache);
+            $backend->flush();
+            $this->backends['pgsql'] = [$backend];
+        } catch (\Exception $e) {
+            $this->addWarning('PostgreSQL DB server is not reachable: ' . $e->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
The cache `PdoBackend` used a `MEDIUMTEXT` column for the content, with
some special handling for PostgreSQL to fix null bytes in the content.

When using igbinary, even with MariadDB problems can occur, since the
written content is garbled when fetched back and cannot be unserialized
anymore, leading to cache misses / read errors.

This change fixes it by using a `MEDIUMBLOB` (`BYTEA` on PostgreSQL)
field for the content.

See #2830

**Upgrade instructions**

To make use of the new field, drop the `cache` table and run the cache setup again.

Another option is to switch the column type manually using a DB management tool
of your choice.

If you keep the old DB structure, aside from not having the fixed bug fixed:

- MariaDB doesn't care at all, the new code with the old DB structure works just fine.
- PostgreSQL will "work" but need a cache flush, as previously cached content shows wrong.

**Review instructions**

Hard to say, but you definitely need igbinary to run into the issue. Probably also a
specific kind of data that cannot be stored in MariaDB `MEDIUMTEXT`.

For PostgreSQL some code that used to do bin2hex/hex2bin on the data has been
removed, so if things still work as before, this is good.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
