### PR TITLE
TASK: Support promoted properties in validator

### DIFF
--- a/Neos.Flow/Classes/Validation/ValidatorResolver.php
+++ b/Neos.Flow/Classes/Validation/ValidatorResolver.php
@@ -307,7 +307,10 @@ class ValidatorResolver
                     if (!$propertyReflection->hasType()) {
                         throw new \InvalidArgumentException(sprintf('Failed building base validator conjunction for property %s in class %s because there is no @var annotation and no type declaration.', $classPropertyName, $targetClassName), 1363778104);
                     }
-                    $classPropertyTagsValues['var'][] = $propertyReflection->getType()->getName();
+                    /** @var \ReflectionNamedType $type */
+                    $type = $propertyReflection->getType();
+                    $classPropertyTagsValues['var'][] = $type->getName();
+
                 }
                 try {
                     $parsedType = TypeHandling::parseType(trim(implode('', $classPropertyTagsValues['var']), ' \\'));

--- a/Neos.Flow/Classes/Validation/ValidatorResolver.php
+++ b/Neos.Flow/Classes/Validation/ValidatorResolver.php
@@ -14,6 +14,7 @@ namespace Neos\Flow\Validation;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\Configuration\Configuration;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Flow\Reflection\PropertyReflection;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Validation\Validator\PolyTypeObjectValidatorInterface;
 use Neos\Utility\Exception\InvalidTypeException;
@@ -296,9 +297,17 @@ class ValidatorResolver
             $conjunctionValidator->addValidator($objectValidator);
             foreach ($this->reflectionService->getClassPropertyNames($targetClassName) as $classPropertyName) {
                 $classPropertyTagsValues = $this->reflectionService->getPropertyTagsValues($targetClassName, $classPropertyName);
-
                 if (!isset($classPropertyTagsValues['var'])) {
-                    throw new \InvalidArgumentException(sprintf('There is no @var annotation for property "%s" in class "%s".', $classPropertyName, $targetClassName), 1363778104);
+                    try {
+                        $propertyReflection = new PropertyReflection($targetClassName, $classPropertyName);
+                    } catch (\ReflectionException $e) {
+                        throw new \RuntimeException(sprintf('Failed reflecting property %s from class %s while building base a validator conjunction: %s', $classPropertyName, $targetClassName, $e->getMessage()), 1651570561);
+                    }
+
+                    if (!$propertyReflection->hasType()) {
+                        throw new \InvalidArgumentException(sprintf('Failed building base validator conjunction for property %s in class %s because there is no @var annotation and no type declaration.', $classPropertyName, $targetClassName), 1363778104);
+                    }
+                    $classPropertyTagsValues['var'][] = $propertyReflection->getType()->getName();
                 }
                 try {
                     $parsedType = TypeHandling::parseType(trim(implode('', $classPropertyTagsValues['var']), ' \\'));

--- a/Neos.Flow/Classes/Validation/ValidatorResolver.php
+++ b/Neos.Flow/Classes/Validation/ValidatorResolver.php
@@ -310,7 +310,6 @@ class ValidatorResolver
                     /** @var \ReflectionNamedType $type */
                     $type = $propertyReflection->getType();
                     $classPropertyTagsValues['var'][] = $type->getName();
-
                 }
                 try {
                     $parsedType = TypeHandling::parseType(trim(implode('', $classPropertyTagsValues['var']), ' \\'));


### PR DESCRIPTION
This change adds logic to the ValidatorResolver to accept properties which were promoted in a constructor (PHP 8.1 promoted properties) and thus do not have a @var annoation in a doc comment.

At the same time, @var annotations are not necessary anymore if a type declaration was provided.

Note that there was already [a PR for 5.3](https://github.com/neos/flow-development-collection/pull/2836) but since that is a stale branch, which won't be upmerged anymore, this PR now targets 8.0. Flow versions earlier than 8.0 are not supported, because this PR requires PHP 7.4 or higher.

Resolves https://github.com/neos/flow-development-collection/issues/2835