### PR TITLE
TASK: Update .phpstorm.meta.php syntax

### DIFF
--- a/Neos.Flow/.phpstorm.meta.php
+++ b/Neos.Flow/.phpstorm.meta.php
@@ -1,15 +1,18 @@
 <?php
 /*
  * This file configures dynamic return type support for factory methods in PhpStorm
+ * see https://www.jetbrains.com/help/phpstorm/ide-advanced-metadata.html
  */
 
 namespace PHPSTORM_META {
-	$STATIC_METHOD_TYPES = [
-		\Neos\Flow\ObjectManagement\ObjectManagerInterface::get('') => [
-			'' == '@',
-		],
-		\Neos\Flow\Core\Bootstrap::getEarlyInstance('') => [
-			'' == '@',
-		]
-	];
+
+    override(
+        \Neos\Flow\ObjectManagement\ObjectManagerInterface::get(),
+        map(['' => '@'])
+    );
+
+    override(
+        \Neos\Flow\Core\Bootstrap::getEarlyInstance(),
+        map(['' => '@'])
+    );
 }


### PR DESCRIPTION
The old .phpstorm.meta.php syntax is deprecated, see
https://www.jetbrains.com/help/phpstorm/ide-advanced-metadata.html#legacy-metadata-format-deprecated

**Review instructions**

Code completion in PhpStorm should still "know" about these:

```php
// $environment is Environment|obect
$environment = $bootstrap->getEarlyInstance(Environment::class);

// $environment is Environment|obect
$environment = $objectManager->get(Environment::class);
```

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
