### PR TITLE
TASK: Fix setup error handling in PdoBackendTest

### DIFF
--- a/Neos.Cache/Tests/Functional/Backend/PdoBackendTest.php
+++ b/Neos.Cache/Tests/Functional/Backend/PdoBackendTest.php
@@ -80,8 +80,8 @@ class PdoBackendTest extends BaseTestCase
             $backend->setCache($this->cache);
             $backend->flush();
             $this->backends['sqlite'] = [$backend];
-        } catch (\Exception $e) {
-            $this->addWarning('SQLite DB is not reachable: ' . $e->getMessage());
+        } catch (\Throwable $t) {
+            $this->addWarning('SQLite DB is not reachable: ' . $t->getMessage());
         }
 
         try {
@@ -98,8 +98,8 @@ class PdoBackendTest extends BaseTestCase
             $backend->setCache($this->cache);
             $backend->flush();
             $this->backends['mysql'] = [$backend];
-        } catch (\Exception $e) {
-            $this->addWarning('MySQL DB server is not reachable: ' . $e->getMessage());
+        } catch (\Throwable $t) {
+            $this->addWarning('MySQL DB server is not reachable: ' . $t->getMessage());
         }
 
         try {
@@ -116,8 +116,8 @@ class PdoBackendTest extends BaseTestCase
             $backend->setCache($this->cache);
             $backend->flush();
             $this->backends['pgsql'] = [$backend];
-        } catch (\Exception $e) {
-            $this->addWarning('PostgreSQL DB server is not reachable: ' . $e->getMessage());
+        } catch (\Throwable $t) {
+            $this->addWarning('PostgreSQL DB server is not reachable: ' . $t->getMessage());
         }
     }
 }


### PR DESCRIPTION
If the database setup fails, catching a `Throwable` is needed to skip
correctly.

**Review instructions**

The tests should pass, as opposed to https://github.com/neos/flow-development-collection/actions/runs/2346671349

See https://github.com/neos/flow-development-collection/pull/2838 for the "source" of this.
