### PR TITLE
BUGFIX: Use expanded pattern as cache key for dateTime format

### DIFF
--- a/Neos.Flow/Classes/I18n/Cldr/Reader/DatesReader.php
+++ b/Neos.Flow/Classes/I18n/Cldr/Reader/DatesReader.php
@@ -296,10 +296,15 @@ class DatesReader
         if ($formatType === 'dateTime') {
             // DateTime is a simple format like this: '{0} {1}' which denotes where to insert date and time
             $parsedFormat = $this->prepareDateAndTimeFormat($format, $locale, $formatLength);
+
+            // Therefore, we need to change the format which is used as cache key to the expanded pattern
+            $format = '';
+            array_walk_recursive($parsedFormat, function ($element) use (&$format) {
+                $format .= $element;
+            });
         } else {
             $parsedFormat = $this->parseFormat($format);
         }
-
         $this->parsedFormatsIndices[(string)$locale][$formatType][$formatLength] = $format;
         return $this->parsedFormats[$format] = $parsedFormat;
     }

--- a/Neos.Flow/Tests/Functional/I18n/Cldr/Reader/DatesReaderTest.php
+++ b/Neos.Flow/Tests/Functional/I18n/Cldr/Reader/DatesReaderTest.php
@@ -36,13 +36,23 @@ class DatesReaderTest extends FunctionalTestCase
      */
     public function parseFormatFromCldrCachesDateTimePatternsForEachLanguageIndependently(): void
     {
+        $convertFormatToString = function (array $formatArray) {
+            $format = '';
+            array_walk_recursive($formatArray, function ($element) use (&$format) {
+                $format .= $element;
+            });
+            return $format;
+        };
+
         // Warms the cache with parsed formats for en_US and de
         $this->datesReader->parseFormatFromCldr(new Locale('en_US'), DatesReader::FORMAT_TYPE_DATETIME, DatesReader::FORMAT_LENGTH_SHORT);
         $this->datesReader->parseFormatFromCldr(new Locale('de'), DatesReader::FORMAT_TYPE_DATETIME, DatesReader::FORMAT_LENGTH_SHORT);
 
         // Reads two different cache entries
         $enUSFormat = $this->datesReader->parseFormatFromCldr(new Locale('en_US'), DatesReader::FORMAT_TYPE_DATETIME, DatesReader::FORMAT_LENGTH_SHORT);
+        self::assertEquals('M/d/yy h:mm a', $convertFormatToString($enUSFormat));
+
         $deFormat = $this->datesReader->parseFormatFromCldr(new Locale('de'), DatesReader::FORMAT_TYPE_DATETIME, DatesReader::FORMAT_LENGTH_SHORT);
-        self::assertNotEquals($enUSFormat, $deFormat);
+        self::assertEquals('dd.MM.yy HH:mm', $convertFormatToString($deFormat));
     }
 }

--- a/Neos.Flow/Tests/Functional/I18n/Cldr/Reader/DatesReaderTest.php
+++ b/Neos.Flow/Tests/Functional/I18n/Cldr/Reader/DatesReaderTest.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Tests\Functional\I18n\Cldr\Reader;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\I18n\Cldr\Reader\DatesReader;
+use Neos\Flow\I18n\Locale;
+use Neos\Flow\Tests\FunctionalTestCase;
+
+class DatesReaderTest extends FunctionalTestCase
+{
+
+    /**
+     * @var DatesReader
+     */
+    protected $datesReader;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->datesReader = $this->objectManager->get(DatesReader::class);
+    }
+
+    /**
+     * @test
+     */
+    public function parseFormatFromCldrCachesDateTimePatternsForEachLanguageIndependently(): void
+    {
+        // Warms the cache with parsed formats for en_US and de
+        $this->datesReader->parseFormatFromCldr(new Locale('en_US'), DatesReader::FORMAT_TYPE_DATETIME, DatesReader::FORMAT_LENGTH_SHORT);
+        $this->datesReader->parseFormatFromCldr(new Locale('de'), DatesReader::FORMAT_TYPE_DATETIME, DatesReader::FORMAT_LENGTH_SHORT);
+
+        // Reads two different cache entries
+        $enUSFormat = $this->datesReader->parseFormatFromCldr(new Locale('en_US'), DatesReader::FORMAT_TYPE_DATETIME, DatesReader::FORMAT_LENGTH_SHORT);
+        $deFormat = $this->datesReader->parseFormatFromCldr(new Locale('de'), DatesReader::FORMAT_TYPE_DATETIME, DatesReader::FORMAT_LENGTH_SHORT);
+        self::assertNotEquals($enUSFormat, $deFormat);
+    }
+}


### PR DESCRIPTION
Closes: #2849

The cache key for a dateTime format is now the expanded format pattern instead of `{0} {1}`.