### PR TITLE
BUGFIX: InternalRequestEngine should behave like HttpRequestEngine

### DIFF
--- a/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
+++ b/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
@@ -116,6 +116,9 @@ class InternalRequestEngine implements RequestEngineInterface
 
         $objectManager = $this->bootstrap->getObjectManager();
         $middlewaresChain = $objectManager->get(Http\Middleware\MiddlewaresChain::class);
+        $middlewaresChain->onStep(function (ServerRequestInterface $request) use ($requestHandler) {
+            $requestHandler->setHttpRequest($request);
+        });
 
         try {
             $response = $middlewaresChain->handle($httpRequest);


### PR DESCRIPTION
The `HttpRequestEngine` holds a reference to the "current" http request in each step of the middleware chain.
The internal request engine does not, making it hard to write tests, that predict system behavior.

With this patch you can fetch the current request (and not only the outer most) even in `InternalRequestEngine`

See `\Neos\Flow\Http\RequestHandler::handleRequest()`

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
