### PR TITLE
TASK: FlowQuery: Add magic methods with params and return types for IDE autocompletion

### DIFF
--- a/Neos.Eel/Classes/FlowQuery/FlowQuery.php
+++ b/Neos.Eel/Classes/FlowQuery/FlowQuery.php
@@ -11,6 +11,7 @@ namespace Neos\Eel\FlowQuery;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Eel\Exception;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
@@ -69,6 +70,34 @@ use Neos\Flow\Annotations as Flow;
  * ----------------
  *
  * If an operation is final, it should return the resulting value directly.
+ *
+ * @method int cacheLifetime()
+ * @method self children(?string $filter = null)
+ * @method self closest(?string $filter = null)
+ * @method self context(array $properties)
+ * @method self filter(string $filter)
+ * @method self find(string $filter)
+ * @method self has($argument)
+ * @method self nextAll(string $filter)
+ * @method self next(?string $filter = null)
+ * @method self nextUntil(?string $filter = null)
+ * @method self parent(?string $filter = null)
+ * @method self parents(?string $filter = null)
+ * @method self parentsUntil(?string $filter = null)
+ * @method self prevAll(?string $filter = null)
+ * @method self prev(?string $filter = null)
+ * @method self prevUntil(?string $filter = null)
+ * @method self property(?string $filter = null)
+ * @method self siblings(?string $filter = null)
+ * @method void add($argument)
+ * @method NodeInterface first()
+ * @method self|NodeInterface get(?int $index = null)
+ * @method NodeInterface is(array $arguments)
+ * @method NodeInterface last()
+ * @method NodeInterface remove($argument)
+ * @method NodeInterface search(?string $term = null, ?string $filterNodeTypeName = null)
+ * @method NodeInterface slice($context = null)
+ * @method NodeInterface sort(string $nodeProperty, string $direction)
  */
 class FlowQuery implements ProtectedContextAwareInterface, \IteratorAggregate, \Countable
 {


### PR DESCRIPTION
FlowQuery methods are built on magic methods. That is why there is no autocompletion available
in IDEs. Available methods are added as doc header which provide autocompletion.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
