### PR TITLE
BUGFIX: Reimplement request method override via middleware

### DIFF
--- a/Neos.Flow/Classes/Http/Middleware/MethodOverrideMiddleware.php
+++ b/Neos.Flow/Classes/Http/Middleware/MethodOverrideMiddleware.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Neos\Flow\Http\Middleware;
 
-use Neos\Flow\Annotations as Flow;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -20,13 +19,14 @@ class MethodOverrideMiddleware implements MiddlewareInterface
     /**
      * Process an incoming server request and overwrite the request method of a POST based on a __method argument or either
      * the X-Http-Method-Override or X-Http-Method header.
+     * @noinspection CallableParameterUseCaseInTypeContextInspection
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $next): ResponseInterface
     {
         if ($request->getMethod() === 'POST') {
-            $arguments = $request->getParsedBody();
-            if (isset($arguments['__method'])) {
-                $request = $request->withMethod($arguments['__method']);
+            $parsedBody = $request->getParsedBody();
+            if (isset($parsedBody['__method'])) {
+                $request = $request->withMethod($parsedBody['__method']);
             } elseif ($request->hasHeader('X-Http-Method-Override')) {
                 $request = $request->withMethod($request->getHeaderLine('X-Http-Method-Override'));
             } elseif ($request->hasHeader('X-Http-Method')) {

--- a/Neos.Flow/Classes/Http/Middleware/MethodOverrideMiddleware.php
+++ b/Neos.Flow/Classes/Http/Middleware/MethodOverrideMiddleware.php
@@ -35,5 +35,4 @@ class MethodOverrideMiddleware implements MiddlewareInterface
         }
         return $next->handle($request);
     }
-
 }

--- a/Neos.Flow/Classes/Http/Middleware/MethodOverrideMiddleware.php
+++ b/Neos.Flow/Classes/Http/Middleware/MethodOverrideMiddleware.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Http\Middleware;
+
+use Neos\Flow\Annotations as Flow;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Allows to override the request HTTP Method via different overrides in this order:
+ * - a "__method" argument passes in via request body
+ * - X-Http-Method-Override header
+ * - X-Http-Method header
+ */
+class MethodOverrideMiddleware implements MiddlewareInterface
+{
+    /**
+     * Process an incoming server request and overwrite the request method of a POST based on a __method argument or either
+     * the X-Http-Method-Override or X-Http-Method header.
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $next): ResponseInterface
+    {
+        if ($request->getMethod() === 'POST') {
+            $arguments = $request->getParsedBody();
+            if (isset($arguments['__method'])) {
+                $request = $request->withMethod($arguments['__method']);
+            } elseif ($request->hasHeader('X-Http-Method-Override')) {
+                $request = $request->withMethod($request->getHeaderLine('X-Http-Method-Override'));
+            } elseif ($request->hasHeader('X-Http-Method')) {
+                $request = $request->withMethod($request->getHeaderLine('X-Http-Method'));
+            }
+        }
+        return $next->handle($request);
+    }
+
+}

--- a/Neos.Flow/Configuration/Settings.Http.yaml
+++ b/Neos.Flow/Configuration/Settings.Http.yaml
@@ -33,6 +33,9 @@ Neos:
         'trustedProxies':
           position: 'start 50'
           middleware: 'Neos\Flow\Http\Middleware\TrustedProxiesMiddleware'
+        'methodOverride':
+          position: 'start 30'
+          middleware: 'Neos\Flow\Http\Middleware\MethodOverrideMiddleware'
         'session':
           position: 'start 10'
           middleware: 'Neos\Flow\Http\Middleware\SessionMiddleware'

--- a/Neos.Flow/Tests/Functional/Http/Client/BrowserTest.php
+++ b/Neos.Flow/Tests/Functional/Http/Client/BrowserTest.php
@@ -97,5 +97,4 @@ class BrowserTest extends FunctionalTestCase
         $response = $this->browser->request('http://localhost/test/http/request/method', 'POST', ['__method' => 'DELETE']);
         self::assertSame('DELETE', $response->getBody()->getContents());
     }
-
 }

--- a/Neos.Flow/Tests/Functional/Http/Client/BrowserTest.php
+++ b/Neos.Flow/Tests/Functional/Http/Client/BrowserTest.php
@@ -86,4 +86,16 @@ class BrowserTest extends FunctionalTestCase
         self::assertEquals(303, $response->getStatusCode());
         self::assertEquals('http://localhost/test/http/redirecting/tohere', $response->getHeaderLine('Location'));
     }
+
+    /**
+     * Check if request method can be overridden (@see https://github.com/neos/flow-development-collection/issues/2856)
+     *
+     * @test
+     */
+    public function methodCanBeOverriddenInPostRequests(): void
+    {
+        $response = $this->browser->request('http://localhost/test/http/request/method', 'POST', ['__method' => 'DELETE']);
+        self::assertSame('DELETE', $response->getBody()->getContents());
+    }
+
 }

--- a/Neos.Flow/Tests/Functional/Http/Fixtures/Controller/RequestController.php
+++ b/Neos.Flow/Tests/Functional/Http/Fixtures/Controller/RequestController.php
@@ -22,4 +22,9 @@ class RequestController extends ActionController
     {
         return json_encode($this->request->getHttpRequest()->getParsedBody());
     }
+
+    public function methodAction(): string
+    {
+        return $this->request->getHttpRequest()->getMethod();
+    }
 }

--- a/Neos.Flow/Tests/Unit/Http/Middleware/MethodOverrideMiddlewareTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Middleware/MethodOverrideMiddlewareTest.php
@@ -1,0 +1,107 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Http\Component;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Http\Middleware\MethodOverrideMiddleware;
+use Neos\Flow\Tests\UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class MethodOverrideMiddlewareTest extends UnitTestCase
+{
+
+    private MethodOverrideMiddleware $middleware;
+
+    /**
+     * @var ServerRequestInterface|MockObject
+     */
+    private $mockRequest;
+
+    /**
+     * @var RequestHandlerInterface|MockObject
+     */
+    private $mockRequestHandler;
+
+    /**
+     * @var ResponseInterface|MockObject
+     */
+    private $mockResponse;
+
+    public function setUp(): void
+    {
+        $this->middleware = new MethodOverrideMiddleware();
+
+        $this->mockRequest = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
+        $this->mockRequestHandler = $this->getMockBuilder(RequestHandlerInterface::class)->getMock();
+        $this->mockResponse = $this->getMockBuilder(ResponseInterface::class)->getMock();
+    }
+
+    public function process_matchingRequests_dataProvider(): \Traversable
+    {
+        yield 'parsedBody (__method)' => ['method' => 'POST', 'headers' => [], 'parsedBody' => ['__method' => 'PUT'], 'expectedMethod' => 'PUT'];
+        yield 'header (X-Http-Method-Override)' => ['method' => 'POST', 'headers' => ['X-Http-Method-Override' => 'PATCH'], 'parsedBody' => [], 'expectedMethod' => 'PATCH'];
+        yield 'header (X-Http-Method header)' => ['method' => 'POST', 'headers' => ['X-Http-Method' => 'DELETE'], 'parsedBody' => [], 'expectedMethod' => 'DELETE'];
+        yield 'parsedBody and X-Http-Method header' => ['method' => 'POST', 'headers' => ['X-Http-Method' => 'DELETE'], 'parsedBody' => ['__method' => 'PUT'], 'expectedMethod' => 'PUT'];
+        yield 'X-Http-Method-Override and X-Http-Method header' => ['method' => 'POST', 'headers' => ['X-Http-Method-Override' => 'PATCH', 'X-Http-Method' => 'DELETE'], 'parsedBody' => [], 'expectedMethod' => 'PATCH'];
+        yield 'parsedBody and both headers' => ['method' => 'POST', 'headers' => ['X-Http-Method-Override' => 'PATCH', 'X-Http-Method' => 'DELETE'], 'parsedBody' => ['__method' => 'PUT'], 'expectedMethod' => 'PUT'];
+    }
+
+    /**
+     * @test
+     * @dataProvider process_matchingRequests_dataProvider
+     */
+    public function process_matchingRequests(string $method, array $headers, $parsedBody, string $expectedMethod): void
+    {
+        $this->mockRequest->method('getMethod')->willReturn($method);
+        $this->mockRequest->method('getParsedBody')->willReturn($parsedBody);
+        $this->mockRequest->method('hasHeader')->willReturnCallback(fn($header) => isset($headers[$header]));
+        $this->mockRequest->method('getHeaderLine')->willReturnCallback(fn($header) => $headers[$header]);
+
+        $mockAlteredRequest = $this->getMockBuilder(ServerRequestInterface::class)->disableOriginalConstructor()->getMock();
+        $this->mockRequest->expects(self::once())->method('withMethod')->with($expectedMethod)->willReturn($mockAlteredRequest);
+        $this->mockRequestHandler->expects(self::once())->method('handle')->willReturnCallback(function($request) use ($mockAlteredRequest) {
+            self::assertSame($request, $mockAlteredRequest);
+            return $this->mockResponse;
+        });
+
+        $this->middleware->process($this->mockRequest, $this->mockRequestHandler);
+    }
+
+    public function process_nonMatchingRequests_dataProvider2(): \Traversable
+    {
+        yield 'POST request' => ['method' => 'POST', 'headers' => [], 'parsedBody' => ['foo' => 'bar']];
+        yield 'GET request with X-Http-Method-Override and X-Http-Method header' => ['method' => 'GET', 'headers' => ['X-Http-Method-Override' => 'PATCH', 'X-Http-Method' => 'DELETE'], 'parsedBody' => []];
+        yield 'DELETE request with parsedBody' => ['method' => 'DELETE', 'headers' => [], 'parsedBody' => ['__method' => 'PUT']];
+    }
+
+    /**
+     * @test
+     * @dataProvider process_nonMatchingRequests_dataProvider2
+     */
+    public function process_nonMatchingRequests(string $method, array $headers, $parsedBody): void
+    {
+        $this->mockRequest->method('getMethod')->willReturn($method);
+        $this->mockRequest->method('getParsedBody')->willReturn($parsedBody);
+        $this->mockRequest->method('hasHeader')->willReturnCallback(fn($header) => isset($headers[$header]));
+        $this->mockRequest->method('getHeaderLine')->willReturnCallback(fn($header) => $headers[$header]);
+
+        $this->mockRequest->expects(self::never())->method('withMethod');
+        $this->mockRequestHandler->expects(self::once())->method('handle')->willReturnCallback(function($request) {
+            self::assertSame($request, $this->mockRequest);
+            return $this->mockResponse;
+        });
+
+        $this->middleware->process($this->mockRequest, $this->mockRequestHandler);
+    }
+}

--- a/Neos.Flow/Tests/Unit/Http/Middleware/MethodOverrideMiddlewareTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Middleware/MethodOverrideMiddlewareTest.php
@@ -71,13 +71,13 @@ class MethodOverrideMiddlewareTest extends UnitTestCase
         $this->mockRequest->method('hasHeader')->willReturnCallback(function ($header) use ($headers) {
             return isset($headers[$header]);
         });
-        $this->mockRequest->method('getHeaderLine')->willReturnCallback(function($header) use ($headers) {
+        $this->mockRequest->method('getHeaderLine')->willReturnCallback(function ($header) use ($headers) {
             return $headers[$header];
         });
 
         $mockAlteredRequest = $this->getMockBuilder(ServerRequestInterface::class)->disableOriginalConstructor()->getMock();
         $this->mockRequest->expects(self::once())->method('withMethod')->with($expectedMethod)->willReturn($mockAlteredRequest);
-        $this->mockRequestHandler->expects(self::once())->method('handle')->willReturnCallback(function($request) use ($mockAlteredRequest) {
+        $this->mockRequestHandler->expects(self::once())->method('handle')->willReturnCallback(function ($request) use ($mockAlteredRequest) {
             self::assertSame($request, $mockAlteredRequest);
             return $this->mockResponse;
         });
@@ -103,12 +103,12 @@ class MethodOverrideMiddlewareTest extends UnitTestCase
         $this->mockRequest->method('hasHeader')->willReturnCallback(function ($header) use ($headers) {
             return isset($headers[$header]);
         });
-        $this->mockRequest->method('getHeaderLine')->willReturnCallback(function($header) use ($headers) {
+        $this->mockRequest->method('getHeaderLine')->willReturnCallback(function ($header) use ($headers) {
             return $headers[$header];
         });
 
         $this->mockRequest->expects(self::never())->method('withMethod');
-        $this->mockRequestHandler->expects(self::once())->method('handle')->willReturnCallback(function($request) {
+        $this->mockRequestHandler->expects(self::once())->method('handle')->willReturnCallback(function ($request) {
             self::assertSame($request, $this->mockRequest);
             return $this->mockResponse;
         });

--- a/Neos.Flow/Tests/Unit/Http/Middleware/MethodOverrideMiddlewareTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Middleware/MethodOverrideMiddlewareTest.php
@@ -21,7 +21,10 @@ use Psr\Http\Server\RequestHandlerInterface;
 class MethodOverrideMiddlewareTest extends UnitTestCase
 {
 
-    private MethodOverrideMiddleware $middleware;
+    /**
+     * @var MethodOverrideMiddleware
+     */
+    private $middleware;
 
     /**
      * @var ServerRequestInterface|MockObject

--- a/Neos.Flow/Tests/Unit/Http/Middleware/MethodOverrideMiddlewareTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Middleware/MethodOverrideMiddlewareTest.php
@@ -68,8 +68,12 @@ class MethodOverrideMiddlewareTest extends UnitTestCase
     {
         $this->mockRequest->method('getMethod')->willReturn($method);
         $this->mockRequest->method('getParsedBody')->willReturn($parsedBody);
-        $this->mockRequest->method('hasHeader')->willReturnCallback(fn($header) => isset($headers[$header]));
-        $this->mockRequest->method('getHeaderLine')->willReturnCallback(fn($header) => $headers[$header]);
+        $this->mockRequest->method('hasHeader')->willReturnCallback(function ($header) use ($headers) {
+            return isset($headers[$header]);
+        });
+        $this->mockRequest->method('getHeaderLine')->willReturnCallback(function($header) use ($headers) {
+            return $headers[$header];
+        });
 
         $mockAlteredRequest = $this->getMockBuilder(ServerRequestInterface::class)->disableOriginalConstructor()->getMock();
         $this->mockRequest->expects(self::once())->method('withMethod')->with($expectedMethod)->willReturn($mockAlteredRequest);
@@ -96,8 +100,12 @@ class MethodOverrideMiddlewareTest extends UnitTestCase
     {
         $this->mockRequest->method('getMethod')->willReturn($method);
         $this->mockRequest->method('getParsedBody')->willReturn($parsedBody);
-        $this->mockRequest->method('hasHeader')->willReturnCallback(fn($header) => isset($headers[$header]));
-        $this->mockRequest->method('getHeaderLine')->willReturnCallback(fn($header) => $headers[$header]);
+        $this->mockRequest->method('hasHeader')->willReturnCallback(function ($header) use ($headers) {
+            return isset($headers[$header]);
+        });
+        $this->mockRequest->method('getHeaderLine')->willReturnCallback(function($header) use ($headers) {
+            return $headers[$header];
+        });
 
         $this->mockRequest->expects(self::never())->method('withMethod');
         $this->mockRequestHandler->expects(self::once())->method('handle')->willReturnCallback(function($request) {


### PR DESCRIPTION
The documented feature to override the request method with the POST argument `__method` or one of the HTTP headers X-Http-Method-Override or X-Http-Method was accidentally removed in the transition towards PSR-7. This adds it back in by adding a middleware that does the same logic that was removed with the previous Http\Request class.

Resolves #2856