### PR TITLE
BUGFIX: Don't convert numeric strings to numbers in proxy method argument defaults

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethod.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethod.php
@@ -288,10 +288,10 @@ class ProxyMethod
                             $defaultValue = ' = NULL';
                         } elseif (is_bool($rawDefaultValue)) {
                             $defaultValue = ($rawDefaultValue ? ' = true' : ' = false');
-                        } elseif (is_numeric($rawDefaultValue)) {
-                            $defaultValue = ' = ' . $rawDefaultValue;
                         } elseif (is_string($rawDefaultValue)) {
                             $defaultValue = " = '" . $rawDefaultValue . "'";
+                        } elseif (is_numeric($rawDefaultValue)) {
+                            $defaultValue = ' = ' . $rawDefaultValue;
                         } elseif (is_array($rawDefaultValue)) {
                             $defaultValue = ' = ' . $this->buildArraySetupCode($rawDefaultValue);
                         }
@@ -344,10 +344,10 @@ class ProxyMethod
                 $code .= 'NULL';
             } elseif (is_bool($value)) {
                 $code .= ($value ? 'true' : 'false');
-            } elseif (is_numeric($value)) {
-                $code .= $value;
             } elseif (is_string($value)) {
                 $code .= "'" . $value . "'";
+            } elseif (is_numeric($value)) {
+                $code .= $value;
             }
             $code .= ', ';
         }


### PR DESCRIPTION
The check `is_numeric` evaluates to true for strings like `"1"` therefore the generated code would be missing the quotes
necessary to keep the default argument a string. This causes type errors in the proxy class when the arguments type is `string`.
Therefore the check whether an argument value is a string should be done first.

This change could be breaking if no type is used and a method somehow relies on the proxy class turning the argument default into a number.

Resolves: #2864