### PR TITLE
FEATURE: Add method `askQuestion` to console output that accepts a `Question` object

### DIFF
--- a/Neos.Flow/Classes/Cli/ConsoleOutput.php
+++ b/Neos.Flow/Classes/Cli/ConsoleOutput.php
@@ -191,6 +191,18 @@ class ConsoleOutput
     }
 
     /**
+     * Asks a question to the user
+     *
+     * @param Question $question The question to ask as an Object.
+     * @return mixed The user answer
+     * @throws \RuntimeException If there is no data to read in the input stream
+     */
+    public function askQuestion(Question $question)
+    {
+        return $this->getQuestionHelper()->ask($this->input, $this->output, $question);
+    }
+
+    /**
      * Asks a confirmation to the user.
      *
      * The question will be asked until the user answers by nothing, yes, or no.
@@ -359,7 +371,7 @@ class ConsoleOutput
      *
      * @return QuestionHelper
      */
-    protected function getQuestionHelper(): QuestionHelper
+    public function getQuestionHelper(): QuestionHelper
     {
         if ($this->questionHelper === null) {
             $this->questionHelper = new QuestionHelper();


### PR DESCRIPTION
The other question methods take arrays or strings as arguments which is easy and convenient however the underlying symfony console offers more flexibility.
This pr adds the method `askQestion` that accepts a smfony console question object and thus allows the full flexibility at the price of complexity.

In addition the method `getQuestionHelper` is made public to make this as accessible as the `getProgressBar` method.

**Review instructions**

I chose not to allow Question objects in the `ask` method because this method has a default argument that only makes sense when the question is passed as array or string.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
