### PR TITLE
TASK: Raise guzzlehttp/psr7 to ^1.8.4 (security fix)

### DIFF
--- a/Neos.Http.Factories/composer.json
+++ b/Neos.Http.Factories/composer.json
@@ -9,7 +9,7 @@
     "require": {
         "php": "^7.1",
         "psr/http-factory": "^1.0",
-        "guzzlehttp/psr7": "^1.4.1, !=1.8.0"
+        "guzzlehttp/psr7": "^1.8.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This makes sure `guzzlehttp/psr7` is will not be used in version with a known
security issue.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
