### PR TITLE
BUGFIX:  Avoid errors when  `./flow help` is shown for an action without docblock

### DIFF
--- a/Neos.Flow/Classes/Cli/Command.php
+++ b/Neos.Flow/Classes/Cli/Command.php
@@ -184,10 +184,14 @@ class Command
         $commandParameters = $this->reflectionService->getMethodParameters($this->controllerClassName, $this->controllerCommandName . 'Command');
         $i = 0;
         foreach ($commandParameters as $commandParameterName => $commandParameterDefinition) {
-            $explodedAnnotation = explode(' ', $annotations['param'][$i]);
-            array_shift($explodedAnnotation);
-            array_shift($explodedAnnotation);
-            $description = implode(' ', $explodedAnnotation);
+            if (isset($annotations['param'][$i])) {
+                $explodedAnnotation = explode(' ', $annotations['param'][$i]);
+                array_shift($explodedAnnotation);
+                array_shift($explodedAnnotation);
+                $description = implode(' ', $explodedAnnotation);
+            } else {
+                $description = $commandParameterName;
+            }
             $required = $commandParameterDefinition['optional'] !== true;
             $commandArgumentDefinitions[] = new CommandArgumentDefinition($commandParameterName, $required, $description);
             $i ++;


### PR DESCRIPTION
The `./flow help` command currently throws errors when rendering details for command that has no doc-block.
Since modern php and flow need those doc-blocks less and less this should be supported aswell.

This change will return the argument name as description when no @param annotation is found for a parameter.
This is not as helpful as a description but shows the parameter and avoids an unnecessary error.

**Upgrade instructions**

**Review instructions**

To verify this you can remove the docblock from a cli-command method and run `./flow help your:command` afterwards.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
