### PR TITLE
BUGFIX: Reset cache backend iterator state on update

### DIFF
--- a/Neos.Cache/Classes/Backend/ApcuBackend.php
+++ b/Neos.Cache/Classes/Backend/ApcuBackend.php
@@ -58,7 +58,7 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
     protected $identifierPrefix;
 
     /**
-     * @var \APCUIterator
+     * @var \APCUIterator|null
      */
     protected $cacheEntriesIterator;
 
@@ -111,7 +111,7 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
      * @param string $entryIdentifier An identifier for this specific cache entry
      * @param string $data The data to be stored
      * @param array $tags Tags to associate with this cache entry
-     * @param integer $lifetime Lifetime of this cache entry in seconds. If NULL is specified, the default lifetime is used. "0" means unlimited lifetime.
+     * @param int|null $lifetime Lifetime of this cache entry in seconds. If NULL is specified, the default lifetime is used. "0" means unlimited lifetime.
      * @return void
      * @throws Exception if no cache frontend has been set.
      * @throws \InvalidArgumentException if the identifier is not valid

--- a/Neos.Cache/Classes/Backend/ApcuBackend.php
+++ b/Neos.Cache/Classes/Backend/ApcuBackend.php
@@ -133,6 +133,8 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
         } else {
             throw new Exception('Could not set value.', 1232986877);
         }
+
+        $this->cacheEntriesIterator = null;
     }
 
     /**
@@ -175,6 +177,7 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
     public function remove(string $entryIdentifier): bool
     {
         $this->removeIdentifierFromAllTags($entryIdentifier);
+        $this->cacheEntriesIterator = null;
         return apcu_delete($this->getPrefixedIdentifier($entryIdentifier));
     }
 
@@ -238,6 +241,7 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
         foreach ($identifiers as $identifier) {
             $this->remove($identifier);
         }
+        $this->cacheEntriesIterator = null;
         return count($identifiers);
     }
 

--- a/Neos.Cache/Classes/Backend/PdoBackend.php
+++ b/Neos.Cache/Classes/Backend/PdoBackend.php
@@ -186,6 +186,7 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
             }
 
             $this->databaseHandle->commit();
+            $this->cacheEntriesIterator = null;
         } catch (\Exception $exception) {
             $this->databaseHandle->rollBack();
 
@@ -240,7 +241,7 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
      *
      * @param string $entryIdentifier Specifies the cache entry to remove
      * @return boolean true if (at least) one entry could be removed or false if no entry was found
-     * @throws Exception
+     * @throws \Exception
      * @api
      */
     public function remove(string $entryIdentifier): bool
@@ -251,6 +252,7 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
         try {
             $rowsWereDeleted = $this->removeWithoutTransaction($entryIdentifier);
             $this->databaseHandle->commit();
+            $this->cacheEntriesIterator = null;
 
             return $rowsWereDeleted;
         } catch (\Exception $exception) {
@@ -286,7 +288,7 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
      * Removes all cache entries of this cache.
      *
      * @return void
-     * @throws Exception
+     * @throws \Exception
      * @api
      */
     public function flush(): void
@@ -307,6 +309,7 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
             $statementHandle->execute([$this->context(), $this->cacheIdentifier]);
 
             $this->databaseHandle->commit();
+            $this->cacheEntriesIterator = null;
         } catch (\Exception $exception) {
             $this->databaseHandle->rollBack();
 
@@ -319,7 +322,7 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
      *
      * @param string $tag The tag the entries must have
      * @return integer
-     * @throws Exception
+     * @throws \Exception
      * @api
      */
     public function flushByTag(string $tag): int
@@ -337,13 +340,14 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
             $statementHandle->execute([$this->context(), $this->cacheIdentifier, $tag]);
 
             $this->databaseHandle->commit();
+            $this->cacheEntriesIterator = null;
+
+            return $flushed;
         } catch (\Exception $exception) {
             $this->databaseHandle->rollBack();
 
             throw $exception;
         }
-
-        return $flushed;
     }
 
     /**
@@ -389,6 +393,7 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
 
             throw $exception;
         }
+        $this->cacheEntriesIterator = null;
     }
 
     /**

--- a/Neos.Cache/Classes/Backend/PdoBackend.php
+++ b/Neos.Cache/Classes/Backend/PdoBackend.php
@@ -73,9 +73,9 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
     protected $tagsTableName = 'tags';
 
     /**
-     * @var \ArrayIterator
+     * @var \ArrayIterator|null
      */
-    protected $cacheEntriesIterator = null;
+    protected $cacheEntriesIterator;
 
     /**
      * Sets the DSN to use
@@ -143,7 +143,7 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
      * @param string $entryIdentifier An identifier for this specific cache entry
      * @param string $data The data to be stored
      * @param array $tags Tags to associate with this cache entry
-     * @param integer $lifetime Lifetime of this cache entry in seconds. If NULL is specified, the default lifetime is used. "0" means unlimited lifetime.
+     * @param int|null $lifetime Lifetime of this cache entry in seconds. If NULL is specified, the default lifetime is used. "0" means unlimited lifetime.
      * @return void
      * @throws Exception if no cache frontend has been set.
      * @throws \InvalidArgumentException if the identifier is not valid

--- a/Neos.Cache/Classes/Backend/SimpleFileBackend.php
+++ b/Neos.Cache/Classes/Backend/SimpleFileBackend.php
@@ -161,6 +161,7 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
             if ($this->cacheEntryFileExtension === '.php') {
                 OpcodeCacheHelper::clearAllActive($cacheEntryPathAndFilename);
             }
+            $this->cacheFilesIterator = null;
             return;
         }
 
@@ -259,7 +260,8 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
 
                 if ($result === true) {
                     clearstatcache(true, $cacheEntryPathAndFilename);
-                    return $result;
+                    $this->cacheFilesIterator = null;
+                    return true;
                 }
             } catch (\Exception $e) {
             }
@@ -279,6 +281,7 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
     public function flush(): void
     {
         Files::emptyDirectoryRecursively($this->cacheDirectory);
+        $this->cacheFilesIterator = null;
     }
 
     /**

--- a/Neos.Cache/Classes/Backend/SimpleFileBackend.php
+++ b/Neos.Cache/Classes/Backend/SimpleFileBackend.php
@@ -73,7 +73,7 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
     protected $useIgBinary = false;
 
     /**
-     * @var \DirectoryIterator
+     * @var \DirectoryIterator|null
      */
     protected $cacheFilesIterator;
 
@@ -99,7 +99,7 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
      * Sets a reference to the cache frontend which uses this backend and
      * initializes the default cache directory.
      *
-     * @param \Neos\Cache\Frontend\FrontendInterface $cache The cache frontend
+     * @param FrontendInterface $cache The cache frontend
      * @return void
      * @throws Exception
      */
@@ -139,7 +139,7 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
      * @param string $entryIdentifier An identifier for this specific cache entry
      * @param string $data The data to be stored
      * @param array $tags Ignored in this type of cache backend
-     * @param integer $lifetime Ignored in this type of cache backend
+     * @param int|null $lifetime Ignored in this type of cache backend
      * @return void
      * @throws Exception if the directory does not exist or is not writable or exceeds the maximum allowed path length, or if no cache frontend has been set.
      * @throws \InvalidArgumentException

--- a/Neos.Cache/Tests/Unit/Backend/ApcuBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/ApcuBackendTest.php
@@ -274,6 +274,128 @@ class ApcuBackendTest extends BaseTestCase
     }
 
     /**
+     * @test
+     */
+    public function iterationOverEmptyCacheYieldsNoData()
+    {
+        $backend = $this->setUpBackend();
+        $cache = new VariableFrontend('UnitTestCache', $backend);
+        $data = \iterator_to_array(
+            $cache->getIterator()
+        );
+        self::assertEmpty($data);
+    }
+
+    /**
+     * @test
+     */
+    public function iterationOverNotEmptyCacheYieldsData()
+    {
+        $backend = $this->setUpBackend();
+        $cache = new VariableFrontend('UnitTestCache', $backend);
+
+        $cache->set('first', 'firstData');
+        $cache->set('second', 'secondData');
+
+        $data = \iterator_to_array(
+            $cache->getIterator()
+        );
+        self::assertEquals(
+            ['first' => 'firstData', 'second' => 'secondData'],
+            $data
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataIsSet()
+    {
+        $backend = $this->setUpBackend();
+        $cache = new VariableFrontend('UnitTestCache', $backend);
+
+        $cache->set('first', 'firstData');
+        $cache->set('second', 'secondData');
+
+        \iterator_to_array(
+            $cache->getIterator()
+        );
+
+        $cache->set('third', 'thirdData');
+
+        $data = \iterator_to_array(
+            $cache->getIterator()
+        );
+        self::assertEquals(
+            ['first' => 'firstData', 'second' => 'secondData', 'third' => 'thirdData'],
+            $data
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataFlushed()
+    {
+        $backend = $this->setUpBackend();
+        $cache = new VariableFrontend('UnitTestCache', $backend);
+
+        $cache->set('first', 'firstData');
+        \iterator_to_array(
+            $cache->getIterator()
+        );
+
+        $backend->flush();
+
+        $data = \iterator_to_array(
+            $cache->getIterator()
+        );
+        self::assertEmpty($data);
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataFlushedByTag()
+    {
+        $backend = $this->setUpBackend();
+        $cache = new VariableFrontend('UnitTestCache', $backend);
+
+        $cache->set('first', 'firstData', ['tag']);
+        \iterator_to_array(
+            $cache->getIterator()
+        );
+
+        $backend->flushByTag('tag');
+
+        $data = \iterator_to_array(
+            $cache->getIterator()
+        );
+        self::assertEmpty($data);
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataGetsRemoved()
+    {
+        $backend = $this->setUpBackend();
+        $cache = new VariableFrontend('UnitTestCache', $backend);
+
+        $cache->set('first', 'firstData');
+        \iterator_to_array(
+            $cache->getIterator()
+        );
+
+        $backend->remove('first');
+
+        $data = \iterator_to_array(
+            $cache->getIterator()
+        );
+        self::assertEmpty($data);
+    }
+
+    /**
      * Sets up the APCu backend used for testing
      *
      * @return ApcuBackend
@@ -284,6 +406,7 @@ class ApcuBackendTest extends BaseTestCase
         $cache = $this->createMock(FrontendInterface::class);
         $backend = new ApcuBackend($this->getEnvironmentConfiguration(), []);
         $backend->setCache($cache);
+        $backend->flush(); // I'd rather start with a clean directory in the first place, but I can't get the "vfs" thing to work
 
         return $backend;
     }

--- a/Neos.Cache/Tests/Unit/Backend/PdoBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/PdoBackendTest.php
@@ -218,6 +218,101 @@ class PdoBackendTest extends BaseTestCase
     }
 
     /**
+     * @test
+     */
+    public function iterationOverEmptyCacheYieldsNoData()
+    {
+        $backend = $this->setUpBackend();
+        $data = \iterator_to_array($backend);
+        self::assertEmpty($data);
+    }
+
+    /**
+     * @test
+     */
+    public function iterationOverNotEmptyCacheYieldsData()
+    {
+        $backend = $this->setUpBackend();
+
+        $backend->set('first', 'firstData');
+        $backend->set('second', 'secondData');
+
+        $data = \iterator_to_array($backend);
+        self::assertEquals(
+            ['first' => 'firstData', 'second' => 'secondData'],
+            $data
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataIsSet()
+    {
+        $backend = $this->setUpBackend();
+
+        $backend->set('first', 'firstData');
+        $backend->set('second', 'secondData');
+        \iterator_to_array($backend);
+
+        $backend->set('third', 'thirdData');
+
+        $data = \iterator_to_array($backend);
+        self::assertEquals(
+            ['first' => 'firstData', 'second' => 'secondData', 'third' => 'thirdData'],
+            $data
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataFlushed()
+    {
+        $backend = $this->setUpBackend();
+
+        $backend->set('first', 'firstData');
+        \iterator_to_array($backend);
+
+        $backend->flush();
+
+        $data = \iterator_to_array($backend);
+        self::assertEmpty($data);
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataFlushedByTag()
+    {
+        $backend = $this->setUpBackend();
+
+        $backend->set('first', 'firstData', ['tag']);
+        \iterator_to_array($backend);
+
+        $backend->flushByTag('tag');
+
+        $data = \iterator_to_array($backend);
+        self::assertEmpty($data);
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataGetsRemoved()
+    {
+        $backend = $this->setUpBackend();
+
+        $backend->set('first', 'firstData');
+        \iterator_to_array($backend);
+
+        $backend->remove('first');
+
+        $data = \iterator_to_array($backend);
+        self::assertEmpty($data);
+    }
+
+    /**
      * Sets up the APC backend used for testing
      *
      * @return PdoBackend

--- a/Neos.Cache/Tests/Unit/Backend/SimpleFileBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/SimpleFileBackendTest.php
@@ -479,4 +479,83 @@ class SimpleFileBackendTest extends BaseTestCase
         }
         self::assertEquals(100, $i);
     }
+
+    /**
+     * @test
+     */
+    public function iterationOverEmptyCacheYieldsNoData()
+    {
+        $backend = $this->getSimpleFileBackend();
+        $data = \iterator_to_array($backend);
+        self::assertEmpty($data);
+    }
+
+    /**
+     * @test
+     */
+    public function iterationOverNotEmptyCacheYieldsData()
+    {
+        $backend = $this->getSimpleFileBackend();
+
+        $backend->set('first', 'firstData');
+        $backend->set('second', 'secondData');
+
+        $data = \iterator_to_array($backend);
+        self::assertEquals(
+            ['first' => 'firstData', 'second' => 'secondData'],
+            $data
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataIsSet()
+    {
+        $backend = $this->getSimpleFileBackend();
+
+        $backend->set('first', 'firstData');
+        $backend->set('second', 'secondData');
+        \iterator_to_array($backend);
+
+        $backend->set('third', 'thirdData');
+
+        $data = \iterator_to_array($backend);
+        self::assertEquals(
+            ['first' => 'firstData', 'second' => 'secondData', 'third' => 'thirdData'],
+            $data
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataGetsRemoved()
+    {
+        $backend = $this->getSimpleFileBackend();
+
+        $backend->set('first', 'firstData');
+        \iterator_to_array($backend);
+
+        $backend->remove('first');
+
+        $data = \iterator_to_array($backend);
+        self::assertEmpty($data);
+    }
+
+    /**
+     * @test
+     */
+    public function iterationResetsWhenDataFlushed()
+    {
+        $backend = $this->getSimpleFileBackend();
+
+        $backend->set('first', 'firstData');
+        \iterator_to_array($backend);
+
+        $backend->flush();
+
+        $data = \iterator_to_array($backend);
+        self::assertEmpty($data);
+    }
 }


### PR DESCRIPTION
Some cache backends hold an internal state when used as an iterator.
This state needs to be reset whenever the source data is updated.

Fixes #2828 

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
