### PR TITLE
FEATURE: Skip unhealthy cache backends in MultiBackend

### DIFF
--- a/Neos.Cache/Classes/Backend/MultiBackend.php
+++ b/Neos.Cache/Classes/Backend/MultiBackend.php
@@ -81,7 +81,7 @@ class MultiBackend extends AbstractBackend
             $backend = $this->instantiateBackend($backendClassName, $backendOptions, $this->environmentConfiguration);
             $backend->setCache($this->cache);
         } catch (Throwable $throwable) {
-            $this->logger && $this->throwableStorage && $this->logger->error(sprintf('Failed creating sub backend %s for %s: %s', $backendClassName, get_class($this), $this->throwableStorage->logThrowable($throwable)), LogEnvironment::fromMethodName(__METHOD__));
+            $this->logger?->error('Failed creating sub backend ' . $backendClassName . ' for ' . get_class($this) . ': ' . $this->throwableStorage?->logThrowable($throwable), LogEnvironment::fromMethodName(__METHOD__));
             $this->handleError($throwable);
             $backend = null;
         }
@@ -98,7 +98,7 @@ class MultiBackend extends AbstractBackend
             try {
                 $backend->set($entryIdentifier, $data, $tags, $lifetime);
             } catch (Throwable $throwable) {
-                $this->logger && $this->throwableStorage && $this->logger->error(sprintf('Failed setting cache entry using backend %s in %s: %s', get_class($backend), get_class($this), $this->throwableStorage->logThrowable($throwable)), LogEnvironment::fromMethodName(__METHOD__));
+                $this->logger?->error('Failed setting cache entry using backend ' . get_class($backend) . ' in ' . get_class($this) . ': ' . $this->throwableStorage?->logThrowable($throwable), LogEnvironment::fromMethodName(__METHOD__));
                 $this->handleError($throwable);
                 $this->removeUnhealthyBackend($backend);
                 if (!$this->setInAllBackends) {
@@ -118,7 +118,7 @@ class MultiBackend extends AbstractBackend
             try {
                 return $backend->get($entryIdentifier);
             } catch (Throwable $throwable) {
-                $this->logger && $this->throwableStorage && $this->logger->error(sprintf('Failed retrieving cache entry using backend %s in %s: %s', get_class($backend), get_class($this), $this->throwableStorage->logThrowable($throwable)), LogEnvironment::fromMethodName(__METHOD__));
+                $this->logger?->error('Failed retrieving cache entry using backend ' . get_class($backend) . ' in ' . get_class($this) . ': ' . $this->throwableStorage?->logThrowable($throwable), LogEnvironment::fromMethodName(__METHOD__));
                 $this->handleError($throwable);
                 $this->removeUnhealthyBackend($backend);
             }
@@ -136,7 +136,7 @@ class MultiBackend extends AbstractBackend
             try {
                 return $backend->has($entryIdentifier);
             } catch (Throwable $throwable) {
-                $this->logger && $this->throwableStorage && $this->logger->error(sprintf('Failed checking if cache entry exists using backend %s in %s: %s', get_class($backend), get_class($this), $this->throwableStorage->logThrowable($throwable)), LogEnvironment::fromMethodName(__METHOD__));
+                $this->logger?->error('Failed checking if cache entry exists using backend ' . get_class($backend) . ' in ' . get_class($this) . ': ' . $this->throwableStorage?->logThrowable($throwable), LogEnvironment::fromMethodName(__METHOD__));
                 $this->handleError($throwable);
                 $this->removeUnhealthyBackend($backend);
             }
@@ -155,7 +155,7 @@ class MultiBackend extends AbstractBackend
             try {
                 $result = $result || $backend->remove($entryIdentifier);
             } catch (Throwable $throwable) {
-                $this->logger && $this->throwableStorage && $this->logger->error(sprintf('Failed removing cache entry using backend %s in %s: %s', get_class($backend), get_class($this), $this->throwableStorage->logThrowable($throwable)), LogEnvironment::fromMethodName(__METHOD__));
+                $this->logger?->error('Failed removing cache entry using backend ' . get_class($backend) . ' in ' . get_class($this) . ': ' . $this->throwableStorage?->logThrowable($throwable), LogEnvironment::fromMethodName(__METHOD__));
                 $this->handleError($throwable);
                 $this->removeUnhealthyBackend($backend);
             }
@@ -173,7 +173,7 @@ class MultiBackend extends AbstractBackend
             try {
                 $backend->flush();
             } catch (Throwable $throwable) {
-                $this->logger && $this->throwableStorage && $this->logger->error(sprintf('Failed flushing cache using backend %s in %s: %s', get_class($backend), get_class($this), $this->throwableStorage->logThrowable($throwable)), LogEnvironment::fromMethodName(__METHOD__));
+                $this->logger?->error('Failed flushing cache using backend ' . get_class($backend) . ' in ' . get_class($this) . ': ' . $this->throwableStorage?->logThrowable($throwable), LogEnvironment::fromMethodName(__METHOD__));
                 $this->handleError($throwable);
                 $this->removeUnhealthyBackend($backend);
             }
@@ -190,7 +190,7 @@ class MultiBackend extends AbstractBackend
             try {
                 $backend->collectGarbage();
             } catch (Throwable $throwable) {
-                $this->logger && $this->throwableStorage && $this->logger->error(sprintf('Failed collecting garbage using cache backend %s in %s: %s', get_class($backend), get_class($this), $this->throwableStorage->logThrowable($throwable)), LogEnvironment::fromMethodName(__METHOD__));
+                $this->logger?->error('Failed collecting garbage using cache backend ' . get_class($backend) . ' in ' . get_class($this) . ': ' . $this->throwableStorage?->logThrowable($throwable), LogEnvironment::fromMethodName(__METHOD__));
                 $this->handleError($throwable);
                 $this->removeUnhealthyBackend($backend);
             }
@@ -255,7 +255,7 @@ class MultiBackend extends AbstractBackend
         $i = array_search($unhealthyBackend, $this->backends, true);
         if ($i !== false) {
             unset($this->backends[$i]);
-            $this->logger && $this->throwableStorage && $this->logger->warning(sprintf('Removing unhealthy cache backend %s from backends used by %s', get_class($unhealthyBackend), get_class($this)), LogEnvironment::fromMethodName(__METHOD__));
+            $this->logger?->warning(sprintf('Removing unhealthy cache backend %s from backends used by %s', get_class($unhealthyBackend), get_class($this)), LogEnvironment::fromMethodName(__METHOD__));
         }
     }
 }

--- a/Neos.Cache/Classes/Backend/MultiBackend.php
+++ b/Neos.Cache/Classes/Backend/MultiBackend.php
@@ -44,8 +44,7 @@ class MultiBackend extends AbstractBackend
     {
         parent::__construct($environmentConfiguration, $options);
 
-        /** @noinspection ClassConstantCanBeUsedInspection */
-        if ($this->logErrors && class_exists('Neos\Flow\Core\Bootstrap') && Bootstrap::$staticObjectManager instanceof ObjectManagerInterface) {
+        if ($this->logErrors && class_exists(Bootstrap::class) && Bootstrap::$staticObjectManager instanceof ObjectManagerInterface) {
             $logger = Bootstrap::$staticObjectManager->get(LoggerInterface::class);
             assert($logger instanceof LoggerInterface);
             $this->logger = $logger;

--- a/Neos.Cache/Classes/Backend/MultiBackend.php
+++ b/Neos.Cache/Classes/Backend/MultiBackend.php
@@ -33,6 +33,7 @@ class MultiBackend extends AbstractBackend
     protected array $backends = [];
     protected bool $setInAllBackends = true;
     protected bool $debug = false;
+    protected bool $logErrors = true;
     protected bool $removeUnhealthyBackends = true;
     protected bool $initialized = false;
 
@@ -44,7 +45,7 @@ class MultiBackend extends AbstractBackend
         parent::__construct($environmentConfiguration, $options);
 
         /** @noinspection ClassConstantCanBeUsedInspection */
-        if (class_exists('Neos\Flow\Core\Bootstrap') && Bootstrap::$staticObjectManager instanceof ObjectManagerInterface && class_exists('Neos\Flow\Log\ThrowableStorageInterface')) {
+        if ($this->logErrors && class_exists('Neos\Flow\Core\Bootstrap') && Bootstrap::$staticObjectManager instanceof ObjectManagerInterface) {
             $logger = Bootstrap::$staticObjectManager->get(LoggerInterface::class);
             assert($logger instanceof LoggerInterface);
             $this->logger = $logger;
@@ -227,6 +228,14 @@ class MultiBackend extends AbstractBackend
     public function setRemoveUnhealthyBackends(bool $removeUnhealthyBackends): void
     {
         $this->removeUnhealthyBackends = $removeUnhealthyBackends;
+    }
+
+    /**
+     * This setter is used by AbstractBackend::setProperties()
+     */
+    public function setLogErrors(bool $logErrors): void
+    {
+        $this->logErrors = $logErrors;
     }
 
     /**

--- a/Neos.Cache/Classes/Backend/MultiBackend.php
+++ b/Neos.Cache/Classes/Backend/MultiBackend.php
@@ -253,12 +253,10 @@ class MultiBackend extends AbstractBackend
         if ($this->removeUnhealthyBackends === false || count($this->backends) <= 1) {
             return;
         }
-        foreach ($this->backends as $i => $backend) {
-            if ($backend === $unhealthyBackend) {
-                unset($this->backends[$i]);
-                $this->logger && $this->throwableStorage && $this->logger->warning(sprintf('Removing unhealthy cache backend %s from backends used by %s', get_class($unhealthyBackend), get_class($this)), LogEnvironment::fromMethodName(__METHOD__));
-                return;
-            }
+        $i = array_search($unhealthyBackend, $this->backends, true);
+        if ($i !== false) {
+            unset($this->backends[$i]);
+            $this->logger && $this->throwableStorage && $this->logger->warning(sprintf('Removing unhealthy cache backend %s from backends used by %s', get_class($unhealthyBackend), get_class($this)), LogEnvironment::fromMethodName(__METHOD__));
         }
     }
 }

--- a/Neos.Cache/Classes/Backend/MultiBackend.php
+++ b/Neos.Cache/Classes/Backend/MultiBackend.php
@@ -14,7 +14,6 @@ namespace Neos\Cache\Backend;
  */
 
 use Neos\Cache\BackendInstantiationTrait;
-use Neos\Cache\Exception as CacheException;
 use Throwable;
 
 /**
@@ -71,7 +70,7 @@ class MultiBackend extends AbstractBackend
         $this->prepareBackends();
         foreach ($this->backends as $backend) {
             try {
-                $this->setInBackend($backend, $entryIdentifier, $data, $tags, $lifetime);
+                $backend->set($entryIdentifier, $data, $tags, $lifetime);
             } catch (Throwable $t) {
                 $this->handleError($t);
                 if (!$this->setInAllBackends) {
@@ -89,7 +88,7 @@ class MultiBackend extends AbstractBackend
         $this->prepareBackends();
         foreach ($this->backends as $backend) {
             try {
-                return $this->getFromBackend($backend, $entryIdentifier);
+                return $backend->get($entryIdentifier);
             } catch (Throwable $t) {
                 $this->handleError($t);
             }
@@ -105,7 +104,7 @@ class MultiBackend extends AbstractBackend
         $this->prepareBackends();
         foreach ($this->backends as $backend) {
             try {
-                return $this->backendHas($backend, $entryIdentifier);
+                return $backend->has($entryIdentifier);
             } catch (Throwable $t) {
                 $this->handleError($t);
             }
@@ -122,7 +121,7 @@ class MultiBackend extends AbstractBackend
         $result = false;
         foreach ($this->backends as $backend) {
             try {
-                $result = $result || $this->removeFromBackend($backend, $entryIdentifier);
+                $result = $result || $backend->remove($entryIdentifier);
             } catch (Throwable $t) {
                 $this->handleError($t);
             }
@@ -138,7 +137,7 @@ class MultiBackend extends AbstractBackend
         $this->prepareBackends();
         foreach ($this->backends as $backend) {
             try {
-                $this->flushBackend($backend);
+                $backend->flush();
             } catch (Throwable $t) {
                 $this->handleError($t);
             }
@@ -182,34 +181,6 @@ class MultiBackend extends AbstractBackend
     protected function setDebug(bool $debug): void
     {
         $this->debug = $debug;
-    }
-
-    /**
-     * @throws CacheException
-     */
-    protected function setInBackend(BackendInterface $backend, string $entryIdentifier, string $data, array $tags = [], int $lifetime = null): void
-    {
-        $backend->set($entryIdentifier, $data, $tags, $lifetime);
-    }
-
-    protected function getFromBackend(BackendInterface $backend, string $entryIdentifier): mixed
-    {
-        return $backend->get($entryIdentifier);
-    }
-
-    protected function backendHas(BackendInterface $backend, string $entryIdentifier): bool
-    {
-        return $backend->has($entryIdentifier);
-    }
-
-    protected function removeFromBackend(BackendInterface $backend, string $entryIdentifier): bool
-    {
-        return $backend->remove($entryIdentifier);
-    }
-
-    protected function flushBackend(BackendInterface $backend): void
-    {
-        $backend->flush();
     }
 
     /**

--- a/Neos.Cache/Classes/Backend/TaggableMultiBackend.php
+++ b/Neos.Cache/Classes/Backend/TaggableMultiBackend.php
@@ -45,6 +45,7 @@ class TaggableMultiBackend extends MultiBackend implements TaggableBackendInterf
             } catch (Throwable $throwable) {
                 $this->logger && $this->logger->error(sprintf('Failed flushing cache by tag using backend %s in %s: %s', get_class($backend), get_class($this), $this->throwableStorage->logThrowable($throwable)), LogEnvironment::fromMethodName(__METHOD__));
                 $this->handleError($throwable);
+                $this->removeUnhealthyBackend($backend);
             }
         }
         return $count;
@@ -76,6 +77,7 @@ class TaggableMultiBackend extends MultiBackend implements TaggableBackendInterf
             } catch (Throwable $throwable) {
                 $this->logger && $this->logger->error(sprintf('Failed finding identifiers by tag using backend %s in %s: %s', get_class($backend), get_class($this), $this->throwableStorage->logThrowable($throwable)), LogEnvironment::fromMethodName(__METHOD__));
                 $this->handleError($throwable);
+                $this->removeUnhealthyBackend($backend);
             }
         }
         // avoid array_merge in the loop, this trades memory for speed

--- a/Neos.Cache/Classes/Backend/TaggableMultiBackend.php
+++ b/Neos.Cache/Classes/Backend/TaggableMultiBackend.php
@@ -84,7 +84,6 @@ class TaggableMultiBackend extends MultiBackend implements TaggableBackendInterf
             }
         }
         // avoid array_merge in the loop, this trades memory for speed
-        // the empty array covers cases when no loops were made
-        return array_values(array_unique(array_merge([], ...$identifiers)));
+        return array_values(array_unique(array_merge(...$identifiers)));
     }
 }

--- a/Neos.Cache/Classes/Backend/TaggableMultiBackend.php
+++ b/Neos.Cache/Classes/Backend/TaggableMultiBackend.php
@@ -43,7 +43,7 @@ class TaggableMultiBackend extends MultiBackend implements TaggableBackendInterf
             try {
                 $count |= $backend->flushByTag($tag);
             } catch (Throwable $throwable) {
-                $this->logger && $this->throwableStorage && $this->logger->error(sprintf('Failed flushing cache by tag using backend %s in %s: %s', get_class($backend), get_class($this), $this->throwableStorage->logThrowable($throwable)), LogEnvironment::fromMethodName(__METHOD__));
+                $this->logger?->error('Failed flushing cache by tag using backend ' . get_class($backend) . ' in ' . get_class($this) . ': ' . $this->throwableStorage?->logThrowable($throwable), LogEnvironment::fromMethodName(__METHOD__));
                 $this->handleError($throwable);
                 $this->removeUnhealthyBackend($backend);
             }
@@ -55,6 +55,7 @@ class TaggableMultiBackend extends MultiBackend implements TaggableBackendInterf
      * @param array<string> $tags The tags the entries must have
      * @return integer The number of entries which have been affected by this flush
      * @throws Throwable
+     * @psalm-suppress MethodSignatureMismatch
      */
     public function flushByTags(array $tags): int
     {
@@ -77,7 +78,7 @@ class TaggableMultiBackend extends MultiBackend implements TaggableBackendInterf
             try {
                 $identifiers[] = $backend->findIdentifiersByTag($tag);
             } catch (Throwable $throwable) {
-                $this->logger && $this->throwableStorage && $this->logger->error(sprintf('Failed finding identifiers by tag using backend %s in %s: %s', get_class($backend), get_class($this), $this->throwableStorage->logThrowable($throwable)), LogEnvironment::fromMethodName(__METHOD__));
+                $this->logger?->error('Failed finding identifiers by tag using backend ' . get_class($backend) . ' in ' . get_class($this) . ': ' . $this->throwableStorage?->logThrowable($throwable), LogEnvironment::fromMethodName(__METHOD__));
                 $this->handleError($throwable);
                 $this->removeUnhealthyBackend($backend);
             }

--- a/Neos.Cache/Classes/Backend/TaggableMultiBackend.php
+++ b/Neos.Cache/Classes/Backend/TaggableMultiBackend.php
@@ -43,7 +43,7 @@ class TaggableMultiBackend extends MultiBackend implements TaggableBackendInterf
             try {
                 $count |= $backend->flushByTag($tag);
             } catch (Throwable $throwable) {
-                $this->logger && $this->logger->error(sprintf('Failed flushing cache by tag using backend %s in %s: %s', get_class($backend), get_class($this), $this->throwableStorage->logThrowable($throwable)), LogEnvironment::fromMethodName(__METHOD__));
+                $this->logger && $this->throwableStorage && $this->logger->error(sprintf('Failed flushing cache by tag using backend %s in %s: %s', get_class($backend), get_class($this), $this->throwableStorage->logThrowable($throwable)), LogEnvironment::fromMethodName(__METHOD__));
                 $this->handleError($throwable);
                 $this->removeUnhealthyBackend($backend);
             }
@@ -52,6 +52,8 @@ class TaggableMultiBackend extends MultiBackend implements TaggableBackendInterf
     }
 
     /**
+     * @param array<string> $tags The tags the entries must have
+     * @return integer The number of entries which have been affected by this flush
      * @throws Throwable
      */
     public function flushByTags(array $tags): int
@@ -75,7 +77,7 @@ class TaggableMultiBackend extends MultiBackend implements TaggableBackendInterf
             try {
                 $identifiers[] = $backend->findIdentifiersByTag($tag);
             } catch (Throwable $throwable) {
-                $this->logger && $this->logger->error(sprintf('Failed finding identifiers by tag using backend %s in %s: %s', get_class($backend), get_class($this), $this->throwableStorage->logThrowable($throwable)), LogEnvironment::fromMethodName(__METHOD__));
+                $this->logger && $this->throwableStorage && $this->logger->error(sprintf('Failed finding identifiers by tag using backend %s in %s: %s', get_class($backend), get_class($this), $this->throwableStorage->logThrowable($throwable)), LogEnvironment::fromMethodName(__METHOD__));
                 $this->handleError($throwable);
                 $this->removeUnhealthyBackend($backend);
             }

--- a/Neos.Cache/Readme.md
+++ b/Neos.Cache/Readme.md
@@ -51,7 +51,7 @@ Install latest version via composer:
 The first argument given to either factory is a unique identifier for the specific cache instance.
 If you need different caches you should give them separate identifiers.
 
-## Documenatation
+## Documentation
 
 Both the PSR-6 CachePool and the PSR-16 SimpleCache are separate implementations with their respective factories,
 but both use the existing [backends](https://flowframework.readthedocs.io/en/stable/TheDefinitiveGuide/PartIII/Caching.html#cache-backends)

--- a/Neos.Cache/Tests/Unit/Backend/MultiBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/MultiBackendTest.php
@@ -10,7 +10,6 @@ use Neos\Cache\Backend\NullBackend;
 use Neos\Cache\Backend\RedisBackend;
 use Neos\Cache\EnvironmentConfiguration;
 use Neos\Cache\Tests\BaseTestCase;
-use PHPUnit\Framework\MockObject\MockObject;
 
 class MultiBackendTest extends BaseTestCase
 {
@@ -126,9 +125,9 @@ class MultiBackendTest extends BaseTestCase
     }
 
     /**
-     * @return EnvironmentConfiguration|MockObject
+     * @return EnvironmentConfiguration
      */
-    public function getEnvironmentConfiguration(): EnvironmentConfiguration|MockObject
+    public function getEnvironmentConfiguration(): EnvironmentConfiguration
     {
         return new EnvironmentConfiguration(
             __DIR__ . '~Testing',

--- a/Neos.Cache/Tests/Unit/Backend/MultiBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/MultiBackendTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Cache\Tests\Unit\Backend;
 
 include_once(__DIR__ . '/../../BaseTestCase.php');
@@ -76,7 +78,7 @@ class MultiBackendTest extends BaseTestCase
         $this->inject($multiBackend, 'backends', [$firstNullBackendMock, $secondNullBackendMock]);
         $this->inject($multiBackend, 'initialized', true);
 
-        $multiBackend->set('foo', 1);
+        $multiBackend->set('foo', 'data');
     }
 
     /**

--- a/Neos.Cache/composer.json
+++ b/Neos.Cache/composer.json
@@ -8,6 +8,7 @@
         "php": "^8.0",
         "psr/simple-cache": "^2.0 || ^3.0",
         "psr/cache": "^2.0 || ^3.0",
+        "psr/log": "^2.0 || ^3.0",
         "neos/utility-files": "*",
         "neos/utility-pdo": "*",
         "neos/utility-opcodecache": "*"

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
@@ -752,48 +752,61 @@ The null backend has no options.
 Neos\\Cache\\Backend\\MultiBackend
 ----------------------------------
 
-This backend accepts several backend configurations
-to be used in order of appareance as a fallback mechanismn
-shoudl one of them not be available.
-If `backendConfigurations` is an empty array this will act
-just like the NullBackend.
+This backend accepts several backend configurations to be used in order of appearance as a
+fallback mechanism should one of them not be available. For example, you might want to
+configure the first backend be a `RedisBackend` and, as a fallback, configure a second
+cache backend based on the `FileBackend`, which steps in if Redis is unavailable.
+
+If `backendConfigurations` is an empty array this will act just like the NullBackend.
 
 .. warning::
 
-   Due to the nature of this backend as fallback it will swallow all
-   errors on creating and using the sub backends. So configuration
-   errors won't show up. See `debug` option.
+   Due to the nature of this backend as fallback it will swallow all errors on creating
+   and using the sub backends. So configuration errors won't show up. See `debug` option.
+
+Whenever an error occurs while using a configured backend, the error will be caught,
+logged, and the backend is flagged as "unhealthy" for the remainder of the request.
+The next operation (for example, a "get()" or "set()" call) will use the next healthy
+backend. If there is only one backend left and it causes an error, MultiBackend will
+still try to use it on the next operation.
+
+You can disable the the removal of unhealthy backends with a backend option.
 
 Options
 ~~~~~~~
 
 :title:`Multi cache backend options`
 
-+-----------------------+------------------------------------------+-----------+---------+---------+
-| Option                | Description                              | Mandatory | Type    | Default |
-+=======================+==========================================+===========+=========+=========+
-| setInAllBackends      | Should values given to the backend be    | No        | bool    | true    |
-|                       | replicated into all configured and       |           |         |         |
-|                       | available backends?                      |           |         |         |
-|                       | Generally that is desirable for          |           |         |         |
-|                       | fallback purposes, but to avoid too much |           |         |         |
-|                       | duplication at the cost of performance on|           |         |         |
-|                       | fallbacks this can be disabled.          |           |         |         |
-|                       |                                          |           |         |         |
-+-----------------------+------------------------------------------+-----------+---------+---------+
-| backendConfigurations | A list of backends to be used in order   | Yes       | array   | []      |
-|                       | of appearance. Each entry in that list   |           |         |         |
-|                       | should have the keys "backend" and       |           |         |         |
-|                       | "backendOptions" just as a top level     |           |         |         |
-|                       | backend configuration.                   |           |         |         |
-|                       |                                          |           |         |         |
-+-----------------------+------------------------------------------+-----------+---------+---------+
-| debug                 | Switch on debug mode which will throw    | No        | bool    | false   |
-|                       | any errors happening in sub backends.    |           |         |         |
-|                       | Use this in development to make sure     |           |         |         |
-|                       | everything works as expected.            |           |         |         |
-|                       |                                          |           |         |         |
-+-----------------------+------------------------------------------+-----------+---------+---------+
++-------------------------+------------------------------------------+-----------+---------+---------+
+| Option                  | Description                              | Mandatory | Type    | Default |
++=========================+==========================================+===========+=========+=========+
+| setInAllBackends        | Should values given to the backend be    | No        | bool    | true    |
+|                         | replicated into all configured and       |           |         |         |
+|                         | available backends?                      |           |         |         |
+|                         | Generally that is desirable for          |           |         |         |
+|                         | fallback purposes, but to avoid too much |           |         |         |
+|                         | duplication at the cost of performance on|           |         |         |
+|                         | fallbacks this can be disabled.          |           |         |         |
+|                         |                                          |           |         |         |
++-------------------------+------------------------------------------+-----------+---------+---------+
+| backendConfigurations   | A list of backends to be used in order   | Yes       | array   | []      |
+|                         | of appearance. Each entry in that list   |           |         |         |
+|                         | should have the keys "backend" and       |           |         |         |
+|                         | "backendOptions" just as a top level     |           |         |         |
+|                         | backend configuration.                   |           |         |         |
+|                         |                                          |           |         |         |
++-------------------------+------------------------------------------+-----------+---------+---------+
+| debug                   | Switch on debug mode which will throw    | No        | bool    | false   |
+|                         | any errors happening in sub backends.    |           |         |         |
+|                         | Use this in development to make sure     |           |         |         |
+|                         | everything works as expected.            |           |         |         |
+|                         |                                          |           |         |         |
++-------------------------+------------------------------------------+-----------+---------+---------+
+| removeUnhealthyBackends | Automatically remove a sub backend from  | No        | bool    | true    |
+|                         | the list of cache backends, in case it   |           |         |         |
+|                         | any errors. The sub backend will be used |           |         |         |
+|                         | again at the next CLI / web request.     |           |         |         |
++-------------------------+------------------------------------------+-----------+---------+---------+
 
 
 Neos\\Cache\\Backend\\TaggableMultiBackend

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
@@ -802,6 +802,11 @@ Options
 |                         | everything works as expected.            |           |         |         |
 |                         |                                          |           |         |         |
 +-------------------------+------------------------------------------+-----------+---------+---------+
+| logErrors               | Log errors reported by the individual    | No        | bool    | true    |
+|                         | sub backends and when a backend is       |           |         |         |
+|                         | flagged as unhealthy.                    |           |         |         |
+|                         |                                          |           |         |         |
++-------------------------+------------------------------------------+-----------+---------+---------+
 | removeUnhealthyBackends | Automatically remove a sub backend from  | No        | bool    | true    |
 |                         | the list of cache backends, in case it   |           |         |         |
 |                         | any errors. The sub backend will be used |           |         |         |

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -41,11 +41,6 @@
       <code>'-'</code>
     </RedundantPropertyInitializationCheck>
   </file>
-  <file src="Packages/Framework/Neos.Cache/Classes/Backend/TaggableMultiBackend.php">
-    <NonInvariantDocblockPropertyType occurrences="1">
-      <code>$backends</code>
-    </NonInvariantDocblockPropertyType>
-  </file>
   <file src="Packages/Framework/Neos.Cache/Classes/Frontend/PhpFrontend.php">
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>string|bool</code>
@@ -61,14 +56,6 @@
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$string</code>
     </MoreSpecificImplementedParamType>
-  </file>
-  <file src="Packages/Framework/Neos.Cache/Classes/Psr/Cache/CacheFactory.php">
-    <InvalidArgument occurrences="1">
-      <code>$backend</code>
-    </InvalidArgument>
-    <UndefinedDocblockClass occurrences="1">
-      <code>BackendInterface</code>
-    </UndefinedDocblockClass>
   </file>
   <file src="Packages/Framework/Neos.Cache/Classes/Psr/Cache/CacheItem.php">
     <PropertyTypeCoercion occurrences="1">
@@ -203,8 +190,7 @@
       <code>$x</code>
       <code>$x</code>
     </InvalidScalarArgument>
-    <RedundantCastGivenDocblockType occurrences="23">
-      <code>(float)$subject</code>
+    <RedundantCastGivenDocblockType occurrences="22">
       <code>(float)$x</code>
       <code>(float)$x</code>
       <code>(float)$x</code>
@@ -529,30 +515,6 @@
       <code>FLOW_PATH_ROOT</code>
     </UndefinedConstant>
   </file>
-  <file src="Packages/Framework/Neos.Flow/Classes/Command/CoreCommandController.php">
-    <FalsableReturnStatement occurrences="1">
-      <code>($subProcessStatus['running'] === true) ? [$subProcess, $pipes] : false</code>
-    </FalsableReturnStatement>
-    <InvalidFalsableReturnType occurrences="1">
-      <code>array</code>
-    </InvalidFalsableReturnType>
-    <MissingDocblockType occurrences="1">
-      <code>$command</code>
-    </MissingDocblockType>
-    <PossiblyFalseOperand occurrences="1">
-      <code>getenv('HOME')</code>
-    </PossiblyFalseOperand>
-    <TypeDoesNotContainType occurrences="2">
-      <code>$command-&gt;getCommandIdentifier() === false</code>
-      <code>$request === false</code>
-    </TypeDoesNotContainType>
-    <UndefinedConstant occurrences="4">
-      <code>FLOW_PATH_FLOW</code>
-      <code>FLOW_PATH_ROOT</code>
-      <code>FLOW_PATH_ROOT</code>
-      <code>FLOW_PATH_TEMPORARY_BASE</code>
-    </UndefinedConstant>
-  </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Command/DoctrineCommandController.php">
     <PossiblyInvalidArrayOffset occurrences="1">
       <code>$packages[$selectedPackage]</code>
@@ -742,9 +704,6 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Core/Bootstrap.php">
-    <NullableReturnStatement occurrences="1">
-      <code>null</code>
-    </NullableReturnStatement>
     <PossiblyUndefinedVariable occurrences="1">
       <code>$suitableRequestHandlers</code>
     </PossiblyUndefinedVariable>
@@ -1547,9 +1506,6 @@
     </PossiblyNullReference>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Persistence/Doctrine/CountWalker.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
-      <code>void</code>
-    </ImplementedReturnTypeMismatch>
     <PossiblyNullArgument occurrences="1">
       <code>$parentName</code>
     </PossiblyNullArgument>
@@ -1559,6 +1515,10 @@
     <PossiblyNullReference occurrences="1">
       <code>getSingleIdentifierFieldName</code>
     </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset occurrences="2">
+      <code>$parent['metadata']</code>
+      <code>$qComp['parent']</code>
+    </PossiblyUndefinedArrayOffset>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Persistence/Doctrine/DataTypes/JsonArrayType.php">
     <LessSpecificImplementedReturnType occurrences="1">
@@ -1648,6 +1608,12 @@
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$this-&gt;queryBuilder-&gt;getParameters()</code>
     </InvalidPropertyAssignmentValue>
+    <InvalidReturnStatement occurrences="1">
+      <code>$this-&gt;queryBuilder-&gt;getQuery()-&gt;getSQL()</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>array</code>
+    </InvalidReturnType>
     <InvalidScalarArgument occurrences="3">
       <code>$pdoException-&gt;getCode()</code>
       <code>$pdoException-&gt;getCode()</code>
@@ -2455,23 +2421,6 @@
       <code>$sourceTypes</code>
     </NonInvariantDocblockPropertyType>
   </file>
-  <file src="Packages/Framework/Neos.Flow/Classes/Session/Aspect/LoggingAspect.php">
-    <InvalidReturnType occurrences="3">
-      <code>mixed</code>
-      <code>mixed</code>
-      <code>mixed</code>
-    </InvalidReturnType>
-    <UndefinedInterfaceMethod occurrences="8">
-      <code>getId</code>
-      <code>getId</code>
-      <code>getId</code>
-      <code>getId</code>
-      <code>isStarted</code>
-      <code>isStarted</code>
-      <code>isStarted</code>
-      <code>isStarted</code>
-    </UndefinedInterfaceMethod>
-  </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Session/Session.php">
     <FalsableReturnStatement occurrences="1">
       <code>false</code>
@@ -2526,9 +2475,6 @@
       <code>null</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(string)Bootstrap::getEnvironmentConfigurationSetting('FLOW_REWRITEURLS')</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Utility/Ip.php">
     <PossiblyInvalidOperand occurrences="2">
@@ -2639,12 +2585,6 @@
     </PossiblyFalseArgument>
   </file>
   <file src="Packages/Framework/Neos.FluidAdaptor/Classes/Core/Cache/CacheAdaptor.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
-      <code>bool|void</code>
-    </ImplementedReturnTypeMismatch>
-    <InvalidReturnStatement occurrences="1">
-      <code>$this-&gt;flowCache-&gt;set($name, substr($value, strpos($value, "\n") + 1))</code>
-    </InvalidReturnStatement>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$value</code>
     </MoreSpecificImplementedParamType>


### PR DESCRIPTION
This introduces a new feature for the MultiBackend and the TaggableMultiBackend which automatically removes unhealthy sub backends from the list of backends for the remainder of a request.

If a sub backend throws any error, the error will be caught, logged and the backend removed from the list of sub backends. If the sub backend causing trouble is the last one configured for the MultiBackend, it will not be removed.

The feature can be disabled by setting the option `removeUnhealthyBackends` to `false`.

Resolves #2890