### PR TITLE
TASK: Test count returned by TaggableMultiBackend.flushByTag

### DIFF
--- a/Neos.Cache/Classes/Backend/TaggableMultiBackend.php
+++ b/Neos.Cache/Classes/Backend/TaggableMultiBackend.php
@@ -55,16 +55,15 @@ class TaggableMultiBackend extends MultiBackend implements TaggableBackendInterf
     public function flushByTag(string $tag): int
     {
         $this->prepareBackends();
-        $count = 0;
+        $flushed = 0;
         foreach ($this->backends as $backend) {
             try {
-                $count |= $backend->flushByTag($tag);
+                $flushed += $backend->flushByTag($tag);
             } catch (\Throwable $t) {
                 $this->handleError($t);
             }
         }
-
-        return $count;
+        return $flushed;
     }
 
     /**

--- a/Neos.Cache/Tests/Unit/Backend/TaggableMultiBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/TaggableMultiBackendTest.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Cache\Tests\Unit\Backend;
+
+include_once(__DIR__ . '/../../BaseTestCase.php');
+
+use Neos\Cache\Backend\NullBackend;
+use Neos\Cache\Backend\TaggableMultiBackend;
+use Neos\Cache\EnvironmentConfiguration;
+use Neos\Cache\Tests\BaseTestCase;
+
+class TaggableMultiBackendTest extends BaseTestCase
+{
+    /**
+     * @test
+     */
+    public function flushByTagReturnsCountOfFlushedEntries(): void
+    {
+        $mockBuilder = $this->getMockBuilder(NullBackend::class);
+        $firstNullBackendMock = $mockBuilder->getMock();
+        $secondNullBackendMock = $mockBuilder->getMock();
+        $thirdNullBackendMock = $mockBuilder->getMock();
+
+        $firstNullBackendMock->expects(self::once())->method('flushByTag')->with('foo')->willReturn(2);
+        $secondNullBackendMock->expects(self::once())->method('flushByTag')->with('foo')->willThrowException(new \RuntimeException());
+        $thirdNullBackendMock->expects(self::once())->method('flushByTag')->with('foo')->willReturn(3);
+
+        $multiBackend = new TaggableMultiBackend($this->getEnvironmentConfiguration(), []);
+        $this->inject($multiBackend, 'backends', [$firstNullBackendMock, $secondNullBackendMock, $thirdNullBackendMock]);
+        $this->inject($multiBackend, 'initialized', true);
+
+        $result = $multiBackend->flushByTag('foo');
+        self::assertSame(5, $result);
+    }
+
+    /**
+     * @return EnvironmentConfiguration
+     */
+    public function getEnvironmentConfiguration(): EnvironmentConfiguration
+    {
+        return new EnvironmentConfiguration(
+            __DIR__ . '~Testing',
+            'vfs://Foo/',
+            255
+        );
+    }
+}


### PR DESCRIPTION
This makes sure the count of flushed entries returned by `flushByTag()` is calculated in a more readable way.

Fixes #2892 

**Review instructions**

The new test proves it…

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
