### PR TITLE
FEATURE: node migration kickstart command

### DIFF
--- a/Neos.Kickstarter/Classes/Command/KickstartCommandController.php
+++ b/Neos.Kickstarter/Classes/Command/KickstartCommandController.php
@@ -326,6 +326,28 @@ class KickstartCommandController extends CommandController
     }
 
     /**
+     *  Kickstart a node migration
+     *
+     * Creates a new node migration with the given $nodeMigrationName, and $packageKey
+     *
+     * @param string $packageKey The packageKey for the given package
+     * @param string $nodeMigrationName The name for the created node migration, with the current timeStamp in YmdHis format
+     * @return string
+     */
+    public function nodeMigrationCommand(string $packageKey, string $nodeMigrationName)
+    {
+        $this->validatePackageKey($packageKey);
+        if (!$this->packageManager->isPackageAvailable($packageKey)) {
+            $this->outputLine('Package "%s" is not available.', [$packageKey]);
+            exit(2);
+        }
+
+        $generatedFiles = $this->generatorService->generateNodeMigration($packageKey, $nodeMigrationName);
+        $this->outputLine(implode(PHP_EOL, $generatedFiles));
+        $this->outputLine('Your node migration has been created successfully.');
+    }
+
+    /**
      * Checks the syntax of the given $packageKey and quits with an error message if it's not valid
      *
      * @param string $packageKey

--- a/Neos.Kickstarter/Classes/Command/KickstartCommandController.php
+++ b/Neos.Kickstarter/Classes/Command/KickstartCommandController.php
@@ -332,7 +332,7 @@ class KickstartCommandController extends CommandController
      *
      * @param string $packageKey The packageKey for the given package
      * @param string $nodeMigrationName The name for the created node migration, with the current timeStamp in YmdHis format
-     * @return string
+     * @return void
      */
     public function nodeMigrationCommand(string $packageKey, string $nodeMigrationName)
     {

--- a/Neos.Kickstarter/Classes/Command/KickstartCommandController.php
+++ b/Neos.Kickstarter/Classes/Command/KickstartCommandController.php
@@ -328,13 +328,12 @@ class KickstartCommandController extends CommandController
     /**
      *  Kickstart a node migration
      *
-     * Creates a new node migration with the given $nodeMigrationName, and $packageKey
+     * Creates a new node migration for the given $packageKey
      *
      * @param string $packageKey The packageKey for the given package
-     * @param string $nodeMigrationName The name for the created node migration, with the current timeStamp in YmdHis format
      * @return void
      */
-    public function nodeMigrationCommand(string $packageKey, string $nodeMigrationName)
+    public function nodeMigrationCommand(string $packageKey)
     {
         $this->validatePackageKey($packageKey);
         if (!$this->packageManager->isPackageAvailable($packageKey)) {
@@ -342,7 +341,7 @@ class KickstartCommandController extends CommandController
             exit(2);
         }
 
-        $generatedFiles = $this->generatorService->generateNodeMigration($packageKey, $nodeMigrationName);
+        $generatedFiles = $this->generatorService->generateNodeMigration($packageKey);
         $this->outputLine(implode(PHP_EOL, $generatedFiles));
         $this->outputLine('Your node migration has been created successfully.');
     }

--- a/Neos.Kickstarter/Classes/Service/GeneratorService.php
+++ b/Neos.Kickstarter/Classes/Service/GeneratorService.php
@@ -514,6 +514,35 @@ class GeneratorService
     }
 
     /**
+     * Generate a node migration for the given $packageKey
+     *
+     * @param string $packageKey the package key
+     * @param string $nodeMigrationName the node migration name
+     * @return array
+     */
+    public function generateNodeMigration(string $packageKey, string $nodeMigrationName): array
+    {
+        $nodeMigrationName = ucfirst($nodeMigrationName);
+
+        $templatePathAndFilename = 'resource://Neos.Kickstarter/Private/Generator/Migrations/ContentRepository/NodeMigrationTemplate.yaml.tmpl';
+        $nodeMigrationPath = Files::concatenatePaths([$this->packageManager->getPackage($packageKey)->getPackagePath(), 'Migrations/ContentRepository']) . '/';
+
+        $contextVariables = [];
+        $contextVariables['packageKey'] = $packageKey;
+        $contextVariables['nodeMigrationName'] = $nodeMigrationName;
+
+        $timeStamp = (new \DateTimeImmutable())->format('YmdHis');
+
+        $nodeMigrationFileName = $nodeMigrationName . $timeStamp . '.yaml';
+        $fileContent = $this->renderTemplate($templatePathAndFilename, $contextVariables);
+
+        $targetPathAndFilename = $nodeMigrationPath . $nodeMigrationFileName;
+        $this->generateFile($targetPathAndFilename, $fileContent);
+
+        return $this->generatedFiles;
+    }
+
+    /**
      * Normalize types and prefix types with namespaces
      *
      * @param array $fieldDefinitions The field definitions

--- a/Neos.Kickstarter/Classes/Service/GeneratorService.php
+++ b/Neos.Kickstarter/Classes/Service/GeneratorService.php
@@ -517,23 +517,19 @@ class GeneratorService
      * Generate a node migration for the given $packageKey
      *
      * @param string $packageKey the package key
-     * @param string $nodeMigrationName the node migration name
      * @return array
      */
-    public function generateNodeMigration(string $packageKey, string $nodeMigrationName): array
+    public function generateNodeMigration(string $packageKey): array
     {
-        $nodeMigrationName = ucfirst($nodeMigrationName);
-
         $templatePathAndFilename = 'resource://Neos.Kickstarter/Private/Generator/Migrations/ContentRepository/NodeMigrationTemplate.yaml.tmpl';
         $nodeMigrationPath = Files::concatenatePaths([$this->packageManager->getPackage($packageKey)->getPackagePath(), 'Migrations/ContentRepository']) . '/';
 
         $contextVariables = [];
         $contextVariables['packageKey'] = $packageKey;
-        $contextVariables['nodeMigrationName'] = $nodeMigrationName;
 
         $timeStamp = (new \DateTimeImmutable())->format('YmdHis');
 
-        $nodeMigrationFileName = $nodeMigrationName . $timeStamp . '.yaml';
+        $nodeMigrationFileName = 'Version' . $timeStamp . '.yaml';
         $fileContent = $this->renderTemplate($templatePathAndFilename, $contextVariables);
 
         $targetPathAndFilename = $nodeMigrationPath . $nodeMigrationFileName;

--- a/Neos.Kickstarter/Classes/Service/GeneratorService.php
+++ b/Neos.Kickstarter/Classes/Service/GeneratorService.php
@@ -582,13 +582,8 @@ class GeneratorService
             \Neos\Utility\Files::createDirectoryRecursively(dirname($targetPathAndFilename));
         }
 
-        if (substr($targetPathAndFilename, 0, 11) === 'resource://') {
-            list($packageKey, $resourcePath) = explode('/', substr($targetPathAndFilename, 11), 2);
-            $relativeTargetPathAndFilename = $packageKey . '/Resources/' . $resourcePath;
-        } elseif (strpos($targetPathAndFilename, 'Tests') !== false) {
-            $relativeTargetPathAndFilename = substr($targetPathAndFilename, strrpos(substr($targetPathAndFilename, 0, strpos($targetPathAndFilename, 'Tests/') - 1), '/') + 1);
-        } else {
-            $relativeTargetPathAndFilename = substr($targetPathAndFilename, strrpos(substr($targetPathAndFilename, 0, strpos($targetPathAndFilename, 'Classes/') - 1), '/') + 1);
+        if (strpos($targetPathAndFilename, FLOW_PATH_PACKAGES) === 0) {
+            $relativeTargetPathAndFilename = substr($targetPathAndFilename, strlen(FLOW_PATH_PACKAGES));
         }
 
         if (!file_exists($targetPathAndFilename) || $force === true) {

--- a/Neos.Kickstarter/Resources/Private/Generator/Migrations/ContentRepository/NodeMigrationTemplate.yaml.tmpl
+++ b/Neos.Kickstarter/Resources/Private/Generator/Migrations/ContentRepository/NodeMigrationTemplate.yaml.tmpl
@@ -1,0 +1,12 @@
+#############################################################################################################################################################################
+# For more information about node migrations in Neos, checkout the documentation: https://neos.readthedocs.io/en/stable/References/NodeMigrations.html?highlight=migrations#
+#############################################################################################################################################################################
+up:
+  comments: 'Migration description'
+  migration:
+    -
+      filters:
+        -
+
+down:
+  comments: 'No down migration available'

--- a/Neos.Kickstarter/Resources/Private/Generator/Migrations/ContentRepository/NodeMigrationTemplate.yaml.tmpl
+++ b/Neos.Kickstarter/Resources/Private/Generator/Migrations/ContentRepository/NodeMigrationTemplate.yaml.tmpl
@@ -1,5 +1,5 @@
 #############################################################################################################################################################################
-# For more information about node migrations in Neos, checkout the documentation: https://neos.readthedocs.io/en/stable/References/NodeMigrations.html?highlight=migrations#
+# For more information about node migrations in Neos, checkout the documentation: https://neos.readthedocs.io/en/stable/References/NodeMigrations.html?highlight=migrations #
 #############################################################################################################################################################################
 up:
   comments: 'Migration description'


### PR DESCRIPTION
**Review instructions**

This pull request contains a new feature for the `Neos.Kickstarter` package. The new command is: `./flow kickstart:nodemigration`. I can provide a `$packageKey`. The `$packageKey` is the respective site package. It also appends the current `$timeStamp` in the format: `YmdHis` to the generated migration.

## Demo:

![create-migration-demo](https://user-images.githubusercontent.com/39345336/188981987-0dc59bf5-f946-42e0-a8f3-5fe4f6dd94a2.gif)


The node migration is displayed as usual when running: `./flow node:migrationstatus`:

![Bildschirmfoto 2022-09-07 um 23 17 20](https://user-images.githubusercontent.com/39345336/188982473-f098a7c9-20e1-45ef-9cd5-244ce81acf4b.png)



The created node migration comes also with a template, which can be customized directly. The template also contains information about the node migration part in the Neos documentation.

### Template

```yaml
#############################################################################################################################################################################
# For more information about node migrations in Neos, checkout the documentation: https://neos.readthedocs.io/en/stable/References/NodeMigrations.html?highlight=migrations #
#############################################################################################################################################################################
up:
  comments: 'Migration description'
  migration:
    -
      filters:
        -

down:
  comments: 'No down migration available'
```

### Related information:
- https://github.com/neos/neos-development-collection/issues/3881

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
