### PR TITLE
TASK: Improve command documentation

### DIFF
--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/CommandLine.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/CommandLine.rst
@@ -480,6 +480,7 @@ Here's an example showing of some of those functions:
 				usleep(5000);
 			}
 			$this->output->progressFinish();
+			$this->output->outputLine();
 		}
 	}
 


### PR DESCRIPTION
Update the cli command example in the documentation to follow best practices.
In commands, when showing a progress bar, using ->progressFinish() does not output a newline. This is intended, as it allows adding further text in the same line. However, the full command output - unless empty - should end with a newline.

See https://github.com/neos/neos-development-collection/issues/3894

**Checklist**

- [ ] ~~Code follows the PSR-2 coding style~~ (adheres to the existing example code)
- [ ] ~~Tests have been created, run and adjusted as needed~~
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
