### PR TITLE
!!! TASK: Modernized code style in ReflectionService

### DIFF
--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -17,7 +17,6 @@ use Doctrine\Common\Annotations\PhpParser;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Persistence\Proxy as DoctrineProxy;
-use InvalidArgumentException;
 use Neos\Cache\Exception;
 use Neos\Cache\Frontend\StringFrontend;
 use Neos\Cache\Frontend\VariableFrontend;
@@ -188,7 +187,7 @@ class ReflectionService
     {
         $this->statusCache = $cache;
         $backend = $this->statusCache->getBackend();
-        if (is_callable(['initializeObject', $backend])) {
+        if (is_callable([$backend, 'initializeObject'])) {
             $backend->initializeObject();
         }
     }
@@ -336,7 +335,7 @@ class ReflectionService
         $interfaceName = $this->cleanClassName($interfaceName);
 
         if (interface_exists($interfaceName) === false) {
-            throw new InvalidArgumentException('"' . $interfaceName . '" does not exist or is not the name of an interface.', 1238769559);
+            throw new \InvalidArgumentException('"' . $interfaceName . '" does not exist or is not the name of an interface.', 1238769559);
         }
         $this->loadOrReflectClassIfNecessary($interfaceName);
 
@@ -374,7 +373,7 @@ class ReflectionService
         $interfaceName = $this->cleanClassName($interfaceName);
 
         if (interface_exists($interfaceName) === false) {
-            throw new InvalidArgumentException('"' . $interfaceName . '" does not exist or is not the name of an interface.', 1238769560);
+            throw new \InvalidArgumentException('"' . $interfaceName . '" does not exist or is not the name of an interface.', 1238769560);
         }
         $this->loadOrReflectClassIfNecessary($interfaceName);
 
@@ -397,7 +396,7 @@ class ReflectionService
         $className = $this->cleanClassName($className);
 
         if (class_exists($className) === false) {
-            throw new InvalidArgumentException('"' . $className . '" does not exist or is not the name of a class.', 1257168042);
+            throw new \InvalidArgumentException('"' . $className . '" does not exist or is not the name of a class.', 1257168042);
         }
         $this->loadOrReflectClassIfNecessary($className);
 
@@ -1438,7 +1437,7 @@ class ReflectionService
 
     /**
      * @throws InvalidPropertyTypeException
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      * @throws ClassSchemaConstraintViolationException
      */
     protected function evaluateClassPropertyAnnotationsForSchema(ClassSchema $classSchema, string $propertyName): bool

--- a/Neos.Flow/Tests/Unit/Cli/CommandManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/CommandManagerTest.php
@@ -11,8 +11,8 @@ namespace Neos\Flow\Tests\Unit\Cli;
  * source code.
  */
 
-use Neos\Flow\Cli\CommandManager;
 use Neos\Flow\Cli;
+use Neos\Flow\Cli\CommandManager;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Mvc\Exception\AmbiguousCommandIdentifierException;
 use Neos\Flow\Mvc\Exception\NoSuchCommandException;
@@ -54,17 +54,18 @@ class CommandManagerTest extends UnitTestCase
     /**
      * @test
      */
-    public function getAvailableCommandsReturnsAllAvailableCommands()
+    public function getAvailableCommandsReturnsAllAvailableCommands(): void
     {
         $commandManager = new CommandManager();
         $mockCommandControllerClassNames = [Fixtures\Command\MockACommandController::class, Fixtures\Command\MockBCommandController::class];
-        $this->mockReflectionService->expects(self::once())->method('getAllSubClassNamesForClass')->with(Cli\CommandController::class)->will(self::returnValue($mockCommandControllerClassNames));
+        $this->mockReflectionService->expects(self::once())->method('getAllSubClassNamesForClass')->with(Cli\CommandController::class)->willReturn($mockCommandControllerClassNames);
         $mockObjectManager = $this->createMock(ObjectManagerInterface::class);
-        $mockObjectManager->expects(self::any())->method('get')->with(ReflectionService::class)->willReturn($this->mockReflectionService);
+        $mockObjectManager->method('get')->with(ReflectionService::class)->willReturn($this->mockReflectionService);
+        $mockObjectManager->method('getObjectNameByClassName')->willReturnArgument(0);
         $commandManager->injectObjectManager($mockObjectManager);
 
         $commands = $commandManager->getAvailableCommands();
-        self::assertEquals(3, count($commands));
+        self::assertCount(3, $commands);
         self::assertEquals('neos.flow.tests.unit.cli.fixtures:mocka:foo', $commands[0]->getCommandIdentifier());
         self::assertEquals('neos.flow.tests.unit.cli.fixtures:mocka:bar', $commands[1]->getCommandIdentifier());
         self::assertEquals('neos.flow.tests.unit.cli.fixtures:mockb:baz', $commands[2]->getCommandIdentifier());

--- a/Neos.Flow/Tests/Unit/Cli/CommandTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/CommandTest.php
@@ -16,6 +16,7 @@ use Neos\Flow\Command\CacheCommandController;
 use Neos\Flow\Reflection\MethodReflection;
 use Neos\Flow\Reflection\ParameterReflection;
 use Neos\Flow\Reflection\ReflectionService;
+use Neos\Flow\Tests\Unit\Cli\Fixtures\Command\MockACommandController;
 use Neos\Flow\Tests\UnitTestCase;
 
 /**
@@ -40,7 +41,7 @@ class CommandTest extends UnitTestCase
     {
         $this->command = $this->getAccessibleMock(Cli\Command::class, ['getCommandMethodReflection'], [], '', false);
         $this->methodReflection = $this->createMock(MethodReflection::class, [], [__CLASS__, 'dummyMethod']);
-        $this->command->expects(self::any())->method('getCommandMethodReflection')->will(self::returnValue($this->methodReflection));
+        $this->command->method('getCommandMethodReflection')->willReturn($this->methodReflection);
     }
 
     /**
@@ -104,15 +105,18 @@ class CommandTest extends UnitTestCase
     /**
      * @test
      */
-    public function getArgumentDefinitionsReturnsArrayOfArgumentDefinitionIfCommandExpectsArguments()
+    public function getArgumentDefinitionsReturnsArrayOfArgumentDefinitionIfCommandExpectsArguments(): void
     {
         $parameterReflection = $this->createMock(ParameterReflection::class, [], [[__CLASS__, 'dummyMethod'], 'arg']);
         $mockReflectionService = $this->createMock(ReflectionService::class);
         $mockMethodParameters = ['argument1' => ['optional' => false], 'argument2' => ['optional' => true]];
-        $mockReflectionService->expects(self::atLeastOnce())->method('getMethodParameters')->will(self::returnValue($mockMethodParameters));
+        $mockReflectionService->expects(self::atLeastOnce())->method('getMethodParameters')->willReturn($mockMethodParameters);
+
         $this->command->injectReflectionService($mockReflectionService);
-        $this->methodReflection->expects(self::atLeastOnce())->method('getParameters')->will(self::returnValue([$parameterReflection]));
-        $this->methodReflection->expects(self::atLeastOnce())->method('getTagsValues')->will(self::returnValue(['param' => ['@param $argument1 argument1 description', '@param $argument2 argument2 description']]));
+        $this->inject($this->command, 'controllerClassName', MockACommandController::class);
+
+        $this->methodReflection->expects(self::atLeastOnce())->method('getParameters')->willReturn([$parameterReflection]);
+        $this->methodReflection->expects(self::atLeastOnce())->method('getTagsValues')->willReturn(['param' => ['@param $argument1 argument1 description', '@param $argument2 argument2 description']]);
 
         $expectedResult = [
             new Cli\CommandArgumentDefinition('argument1', true, 'argument1 description'),
@@ -125,15 +129,16 @@ class CommandTest extends UnitTestCase
     /**
      * @test
      */
-    public function getArgumentDefinitionsReturnsArrayOfArgumentDefinitionIfCommandExpectsArgumentsEvenWhenDocblocksAreMissing()
+    public function getArgumentDefinitionsReturnsArrayOfArgumentDefinitionIfCommandExpectsArgumentsEvenWhenDocBlocksAreMissing(): void
     {
         $parameterReflection = $this->createMock(ParameterReflection::class, [], [[__CLASS__, 'dummyMethod'], 'arg']);
         $mockReflectionService = $this->createMock(ReflectionService::class);
         $mockMethodParameters = ['argument1' => ['optional' => false], 'argument2' => ['optional' => true]];
-        $mockReflectionService->expects(self::atLeastOnce())->method('getMethodParameters')->will(self::returnValue($mockMethodParameters));
+        $mockReflectionService->expects(self::atLeastOnce())->method('getMethodParameters')->willReturn($mockMethodParameters);
         $this->command->injectReflectionService($mockReflectionService);
-        $this->methodReflection->expects(self::atLeastOnce())->method('getParameters')->will(self::returnValue([$parameterReflection]));
-        $this->methodReflection->expects(self::atLeastOnce())->method('getTagsValues')->will(self::returnValue([]));
+        $this->inject($this->command, 'controllerClassName', MockACommandController::class);
+        $this->methodReflection->expects(self::atLeastOnce())->method('getParameters')->willReturn([$parameterReflection]);
+        $this->methodReflection->expects(self::atLeastOnce())->method('getTagsValues')->willReturn([]);
 
         $expectedResult = [
             new Cli\CommandArgumentDefinition('argument1', true, 'argument1'),

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/ObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/ObjectConverterTest.php
@@ -11,12 +11,12 @@ namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
  * source code.
  */
 
+use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\Property\TypeConverter\ObjectConverter;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Tests\UnitTestCase;
-use Neos\Flow\Annotations as Flow;
 
 /**
  * Testcase for the ObjectConverter
@@ -73,15 +73,20 @@ class ObjectConverterTest extends UnitTestCase
      * @test
      * @dataProvider dataProviderForCanConvert
      */
-    public function canConvertFromReturnsTrueIfClassIsTaggedWithEntityOrValueObject($isEntity, $isValueObject, $expected)
+    public function canConvertFromReturnsTrueIfClassIsTaggedWithEntityOrValueObject(bool $isEntity, bool $isValueObject, bool $expected): void
     {
-        if ($isEntity) {
-            $this->mockReflectionService->expects(self::once())->method('isClassAnnotatedWith')->with('TheTargetType', Flow\Entity::class)->will(self::returnValue($isEntity));
-        } else {
-            $this->mockReflectionService->expects(self::atLeast(2))->method('isClassAnnotatedWith')->withConsecutive(['TheTargetType', Flow\Entity::class], ['TheTargetType', Flow\ValueObject::class])->willReturnOnConsecutiveCalls($isEntity, $isValueObject);
-        }
-
-        self::assertEquals($expected, $this->converter->canConvertFrom('myInputData', 'TheTargetType'));
+        $this->mockReflectionService->method('isClassAnnotatedWith')->willReturnCallback(
+            function ($source, $targetType) use ($isEntity, $isValueObject): bool {
+                if ($targetType === Flow\Entity::class) {
+                    return $isEntity;
+                }
+                if ($targetType === Flow\ValueObject::class) {
+                    return $isValueObject;
+                }
+                return false;
+            }
+        );
+        self::assertSame($expected, $this->converter->canConvertFrom('myInputData', 'TheTargetType'));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/PersistentObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/PersistentObjectConverterTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
  * source code.
  */
 
+use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Fixtures\ClassWithSetters;
 use Neos\Flow\Fixtures\ClassWithSettersAndConstructor;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
@@ -26,7 +27,6 @@ use Neos\Flow\Property\TypeConverterInterface;
 use Neos\Flow\Reflection\ClassSchema;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Tests\UnitTestCase;
-use Neos\Flow\Annotations as Flow;
 
 require_once(__DIR__ . '/../../Fixtures/ClassWithSetters.php');
 require_once(__DIR__ . '/../../Fixtures/ClassWithSettersAndConstructor.php');
@@ -93,18 +93,21 @@ class PersistentObjectConverterTest extends UnitTestCase
 
     /**
      * @test
-     * @param boolean $isEntity
-     * @param boolean $isValueObject
-     * @param boolean $expected
      * @dataProvider dataProviderForCanConvert
      */
-    public function canConvertFromReturnsTrueIfClassIsTaggedWithEntityOrValueObject($isEntity, $isValueObject, $expected)
+    public function canConvertFromReturnsTrueIfClassIsTaggedWithEntityOrValueObject(bool $isEntity, bool $isValueObject, bool $expected): void
     {
-        if ($isEntity) {
-            $this->mockReflectionService->expects(self::once())->method('isClassAnnotatedWith')->with('TheTargetType', Flow\Entity::class)->will(self::returnValue($isEntity));
-        } else {
-            $this->mockReflectionService->expects(self::atLeast(2))->method('isClassAnnotatedWith')->withConsecutive(['TheTargetType', Flow\Entity::class], ['TheTargetType', Flow\ValueObject::class])->willReturnOnConsecutiveCalls($isEntity, $isValueObject);
-        }
+        $this->mockReflectionService->method('isClassAnnotatedWith')->willReturnCallback(
+            function ($source, $targetType) use ($isEntity, $isValueObject): bool {
+                if ($targetType === Flow\Entity::class) {
+                    return $isEntity;
+                }
+                if ($targetType === Flow\ValueObject::class) {
+                    return $isValueObject;
+                }
+                return false;
+            }
+        );
 
         self::assertEquals($expected, $this->converter->canConvertFrom('myInputData', 'TheTargetType'));
     }


### PR DESCRIPTION
Code in the reflection service was adjusted to the current code style best practices. 

The method arguments in the Reflection Service are now strictly typed. Therefore, third-party code which relied on loose types and passes invalid types, need to be adjusted. Tests in the Flow package were adjusted were necessary.

As part of the clean up, the setStatusCache() method in ReflectionService was fixed which used a wrong order of parameters in its is_callable() call.

Preparation for #2913