### PR TITLE
TASK: use PHPs hash_pbkdf2

### DIFF
--- a/Neos.Flow/Classes/Security/Cryptography/Algorithms.php
+++ b/Neos.Flow/Classes/Security/Cryptography/Algorithms.php
@@ -16,17 +16,12 @@ namespace Neos\Flow\Security\Cryptography;
  *
  * Right now this class provides a PHP based PBKDF2 implementation.
  *
+ * @deprecated since 8.2, use PHPs `hash_pbkdf2`
  */
 class Algorithms
 {
     /**
      * Compute a derived key from a password based on PBKDF2
-     *
-     * See PKCS #5 v2.0 http://tools.ietf.org/html/rfc2898 for implementation details.
-     * The implementation is tested with test vectors from http://tools.ietf.org/html/rfc6070 .
-     *
-     * If https://wiki.php.net/rfc/hash_pbkdf2 is ever part of PHP we should check for the
-     * existence of hash_pbkdf2() and use it if available.
      *
      * @param string $password Input string / password
      * @param string $salt The salt
@@ -37,21 +32,6 @@ class Algorithms
      */
     public static function pbkdf2($password, $salt, $iterationCount, $derivedKeyLength, $algorithm = 'sha256')
     {
-        $hashLength = strlen(hash($algorithm, '', true));
-        $keyBlocksToCompute = ceil($derivedKeyLength / $hashLength);
-        $derivedKey = '';
-
-        for ($block = 1; $block <= $keyBlocksToCompute; $block++) {
-            $iteratedBlock = hash_hmac($algorithm, $salt . pack('N', $block), $password, true);
-
-            for ($iteration = 1, $iteratedHash = $iteratedBlock; $iteration < $iterationCount; $iteration++) {
-                $iteratedHash = hash_hmac($algorithm, $iteratedHash, $password, true);
-                $iteratedBlock ^= $iteratedHash;
-            }
-
-            $derivedKey .= $iteratedBlock;
-        }
-
-        return substr($derivedKey, 0, $derivedKeyLength);
+        return hash_pbkdf2($algorithm, $password, $salt, $iterationCount, $derivedKeyLength, true);
     }
 }

--- a/Neos.Flow/Classes/Security/Cryptography/Pbkdf2HashingStrategy.php
+++ b/Neos.Flow/Classes/Security/Cryptography/Pbkdf2HashingStrategy.php
@@ -12,7 +12,6 @@ namespace Neos\Flow\Security\Cryptography;
  */
 
 use Neos\Flow\Utility\Algorithms as UtilityAlgorithms;
-use Neos\Flow\Security\Cryptography\Algorithms as CryptographyAlgorithms;
 
 /**
  * A PBKDF2 based password hashing strategy
@@ -71,7 +70,7 @@ class Pbkdf2HashingStrategy implements PasswordHashingStrategyInterface
     public function hashPassword($password, $staticSalt = null)
     {
         $dynamicSalt = UtilityAlgorithms::generateRandomBytes($this->dynamicSaltLength);
-        $result = CryptographyAlgorithms::pbkdf2($password, $dynamicSalt . $staticSalt, $this->iterationCount, $this->derivedKeyLength, $this->algorithm);
+        $result = hash_pbkdf2($this->algorithm, $password, $dynamicSalt . $staticSalt, $this->iterationCount, $this->derivedKeyLength, true);
         return base64_encode($dynamicSalt) . ',' . base64_encode($result);
     }
 
@@ -94,6 +93,6 @@ class Pbkdf2HashingStrategy implements PasswordHashingStrategyInterface
         $dynamicSalt = base64_decode($parts[0]);
         $derivedKey = base64_decode($parts[1]);
         $derivedKeyLength = strlen($derivedKey);
-        return $derivedKey === CryptographyAlgorithms::pbkdf2($password, $dynamicSalt . $staticSalt, $this->iterationCount, $derivedKeyLength, $this->algorithm);
+        return $derivedKey === hash_pbkdf2($this->algorithm, $password, $dynamicSalt . $staticSalt, $this->iterationCount, $derivedKeyLength, true);
     }
 }


### PR DESCRIPTION
Use `hash_pbkdf2` provided by PHP (since 5.5) instead of own generation logic.

Fixes #2916

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
