### PR TITLE
TASK: Render API docs (again)

### DIFF
--- a/.doctum.php
+++ b/.doctum.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+use Doctum\Doctum;
+use Doctum\RemoteRepository\GitHubRemoteRepository;
+use Symfony\Component\Finder\Finder;
+
+$iterator = Finder::create()
+    ->files()
+    ->name('*.php')
+    ->path('/Classes/')
+    ->in(__DIR__);
+
+return new Doctum($iterator, [
+    'title' => 'Flow Framework',
+    'base_url' => 'https://neos.github.io/',
+    'favicon' => 'https://www.neos.io/favicon-32x32.png',
+    'language' => 'en',
+    'remote_repository' => new GitHubRemoteRepository('neos/flow-development-collection', __DIR__),
+    'footer_link' => [
+        'href' => 'https://flow.neos.io',
+        'rel' => 'noreferrer noopener',
+        'target' => '_blank',
+        'before_text' => 'Learn more about the',
+        'link_text' => 'Flow Framework',
+        'after_text' => 'if you like!',
+    ]
+]);

--- a/.github/workflows/doctum.yml
+++ b/.github/workflows/doctum.yml
@@ -27,9 +27,9 @@ jobs:
 
       - name: Move rendered docs to site
         run: |
-          rm -rf docs-site/${{ github.ref_name }}
-          mkdir -p docs-site/${{ github.ref_name }}
-          mv build/* docs-site/${{ github.ref_name }}/
+          rm -rf docs-site/flow/${{ github.ref_name }}
+          mkdir -p docs-site/flow/${{ github.ref_name }}
+          mv build/* docs-site/flow/${{ github.ref_name }}/
 
       - name: Commit update
         run: |

--- a/.github/workflows/doctum.yml
+++ b/.github/workflows/doctum.yml
@@ -1,0 +1,49 @@
+name: Build API documentation
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ '[0-9]+.[0-9]' ]
+
+jobs:
+  build-api-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build API documentation
+        uses: sudo-bot/action-doctum@v5
+        with:
+          config-file: .doctum.php
+          method: "update"
+          # use of --only-version fixes branch name in "View source" links to GitHub
+          cli-args: "--output-format=github --no-ansi --no-progress --ignore-parse-errors --only-version=${{ github.ref_name }}"
+
+      - name: Check out documentation site
+        uses: actions/checkout@v3
+        with:
+          repository: neos/neos.github.io
+          path: docs-site
+
+      - name: Move rendered docs to site
+        run: |
+          rm -rf docs-site/${{ github.ref_name }}
+          mkdir -p docs-site/${{ github.ref_name }}
+          mv build/* docs-site/${{ github.ref_name }}/
+
+      - name: Commit update
+        run: |
+          cd docs-site
+          git config --local --unset-all "http.https://github.com/.extraheader"
+          git config --global user.email "ops@neos.io"
+          git config --global user.name "Neos Bot"
+          git add .
+          git commit -m "TASK: Update API docs from ${{ github.ref_name }}"
+
+      - name: Push to git
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.NEOS_BOT_TOKEN }}
+          repository: neos/neos.github.io
+          directory: docs-site
+          branch: main

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -811,7 +811,7 @@ class Scripts
      * Compares the realpath of the configured PHP binary (if any) with the one flow was called with in a CLI request.
      * This avoids config errors where users forget to set Neos.Flow.core.phpBinaryPathAndFilename in CLI.
      *
-     * @param string phpBinaryPathAndFilename
+     * @param string $phpBinaryPathAndFilename
      * @throws FlowException
      */
     protected static function ensureCLISubrequestsUseCurrentlyRunningPhpBinary($phpBinaryPathAndFilename)

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/Configuration.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/Configuration.php
@@ -127,7 +127,7 @@ class Configuration
     /**
      * Sets the object name
      *
-     * @param string object name
+     * @param string $objectName
      * @return void
      */
     public function setObjectName($objectName)

--- a/Neos.Flow/Classes/Persistence/QueryInterface.php
+++ b/Neos.Flow/Classes/Persistence/QueryInterface.php
@@ -160,7 +160,6 @@ interface QueryInterface
     /**
      * Returns the maximum size of the result set to limit.
      *
-     * @param integer
      * @api
      */
     public function getLimit();

--- a/Neos.Flow/Classes/Reflection/MethodReflection.php
+++ b/Neos.Flow/Classes/Reflection/MethodReflection.php
@@ -21,7 +21,7 @@ use Neos\Flow\Annotations as Flow;
 class MethodReflection extends \ReflectionMethod
 {
     /**
-     * @var DocCommentParser: An instance of the doc comment parser
+     * @var DocCommentParser An instance of the doc comment parser
      */
     protected $docCommentParser;
 

--- a/Neos.Flow/Classes/Reflection/PropertyReflection.php
+++ b/Neos.Flow/Classes/Reflection/PropertyReflection.php
@@ -21,7 +21,7 @@ use Neos\Flow\Annotations as Flow;
 class PropertyReflection extends \ReflectionProperty
 {
     /**
-     * @var DocCommentParser: An instance of the doc comment parser
+     * @var DocCommentParser An instance of the doc comment parser
      */
     protected $docCommentParser;
 

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Format/DateViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Format/DateViewHelper.php
@@ -119,11 +119,6 @@ class DateViewHelper extends AbstractLocaleAwareViewHelper
     /**
      * Render the supplied DateTime object as a formatted date.
      *
-     * @param mixed $date either a \DateTime object or a string that is accepted by \DateTime constructor
-     * @param string $format Format String which is taken to format the Date/Time if none of the locale options are set.
-     * @param string $localeFormatType Whether to format (according to locale set in $forceLocale) date, time or dateTime. Must be one of Neos\Flow\I18n\Cldr\Reader\DatesReader::FORMAT_TYPE_*'s constants.
-     * @param string $localeFormatLength Format length if locale set in $forceLocale. Must be one of Neos\Flow\I18n\Cldr\Reader\DatesReader::FORMAT_LENGTH_*'s constants.
-     * @param string $cldrFormat Format string in CLDR format (see http://cldr.unicode.org/translation/date-time)
      * @throws ViewHelperException
      * @return string Formatted date
      * @api


### PR DESCRIPTION
This renders API docs (again), using Doctum via GH Actions.

The results are pushed to https://neos.github.io for consumption.

**Review instructions**

A test run result can be seen at https://neos.github.io/flow/8.2/index.html already. The workflow run is visible at https://github.com/kdambekalns/flow-development-collection/actions/runs/3233003582/jobs/5294292366

See also kdambekalns/apigenerator.org#1

**TODO**

- [x] Links to GitHub are wrong (`workspace` must go and branch is wrong)
- [ ] Maybe add a theme to make it look more Neos-y?

**Checklist**

- [ ] ~~Code follows the PSR-2 coding style~~
- [ ] ~~Tests have been created, run and adjusted as needed~~
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~~Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions~~
