### PR TITLE
BUGFIX: Relax CachePool key check

### DIFF
--- a/Neos.Cache/Classes/Psr/Cache/CachePool.php
+++ b/Neos.Cache/Classes/Psr/Cache/CachePool.php
@@ -27,7 +27,7 @@ class CachePool implements CacheItemPoolInterface
     /**
      * Pattern an entry identifier must match.
      */
-    const PATTERN_ENTRYIDENTIFIER = '/^[a-zA-Z0-9_%\-&]{1,250}$/';
+    const PATTERN_ENTRYIDENTIFIER = '/^[a-zA-Z0-9_%\-&\.]{1,250}$/';
 
     /**
      * @var BackendInterface

--- a/Neos.Cache/Tests/Unit/Psr/Cache/CachePoolTest.php
+++ b/Neos.Cache/Tests/Unit/Psr/Cache/CachePoolTest.php
@@ -12,6 +12,7 @@ namespace Neos\Cache\Tests\Unit\Psr\Cache;
  */
 
 use Neos\Cache\Backend\AbstractBackend;
+use Neos\Cache\Backend\BackendInterface;
 use Neos\Cache\Psr\Cache\CachePool;
 use Neos\Cache\Psr\Cache\CacheItem;
 use Neos\Cache\Psr\InvalidArgumentException;
@@ -23,6 +24,57 @@ use Neos\Cache\Tests\BaseTestCase;
  */
 class CachePoolTest extends BaseTestCase
 {
+    public function validIdentifiersDataProvider(): array
+    {
+        return [
+            ['short'],
+            ['SomeValidIdentifier'],
+            ['withNumbers0123456789'],
+            ['withUnder_score'],
+            ['with.dot'],
+
+            // The following tests exceed the minimum requirements of the PSR-6 keys (@see https://www.php-fig.org/psr/psr-6/#definitions)
+            ['dashes-are-allowed'],
+            ['percent%sign'],
+            ['amper&sand'],
+            ['a-string-that-exceeds-the-psr-minimum-maxlength-of-sixtyfour-but-is-shorter-than-twohundredandfifty-characters'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider validIdentifiersDataProvider
+     */
+    public function validIdentifiers(string $identifier): void
+    {
+        $mockBackend = $this->getMockBuilder(BackendInterface::class)->getMock();
+        $cachePool = new CachePool($identifier, $mockBackend);
+        self::assertInstanceOf(CachePool::class, $cachePool);
+    }
+
+    public function invalidIdentifiersDataProvider(): array
+    {
+        return [
+            [''],
+            ['späcialcharacters'],
+            ['a-string-that-exceeds-the-maximum-allowed-length-of-twohundredandfifty-characters-which-is-pretty-large-as-it-turns-out-so-i-repeat-a-string-that-exceeds-the-maximum-allowed-length-of-twohundredandfifty-characters-still-not-there-wow-crazy-flow-rocks-though'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidIdentifiersDataProvider
+     */
+    public function invalidIdentifiers(string $identifier): void
+    {
+        $mockBackend = $this->getMockBuilder(BackendInterface::class)->getMock();
+
+        $this->expectException(\InvalidArgumentException::class);
+        new CachePool($identifier, $mockBackend);
+    }
+
+    
+    
     /**
      * @test
      */


### PR DESCRIPTION
Adjusts the `CachePool` regex that checks the key (aka entry identifier) such that it allows "." as character.

*Note:* According to https://www.php-fig.org/psr/psr-6/#definitions the regex should be changed to `/^[a-zA-Z0-9_\.]{1,64}$/` (like done in the [SimpleCache implementation](https://github.com/neos/flow-development-collection/blob/d11ff78a9e419c5b215d6e951e4fb9eed63e4ffa/Neos.Cache/Classes/Psr/SimpleCache/SimpleCache.php#L30) – But this is out of scope of this bugfix since it would be a breaking change

Fixes: #2922