### PR TITLE
BUGFIX: disable invisible composer interaction in `./flow package:create`

### DIFF
--- a/Neos.Flow/Classes/Package/PackageManager.php
+++ b/Neos.Flow/Classes/Package/PackageManager.php
@@ -24,7 +24,6 @@ use Neos\Utility\OpcodeCacheHelper;
 use Neos\Flow\Package\Exception as PackageException;
 use Composer\Console\Application as ComposerApplication;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Output\NullOutput;
 
 /**
  * The default Flow Package Manager
@@ -401,12 +400,13 @@ class PackageManager
             $composerRequireArguments = new ArrayInput([
                 'command' => 'require',
                 'packages' => [$manifest['name'] . ' @dev'],
-                '--working-dir' => FLOW_PATH_ROOT
+                '--working-dir' => FLOW_PATH_ROOT,
+                '--quiet'
             ]);
 
             $composerApplication = new ComposerApplication();
             $composerApplication->setAutoExit(false);
-            $composerErrorCode = $composerApplication->run($composerRequireArguments, new NullOutput());
+            $composerErrorCode = $composerApplication->run($composerRequireArguments);
 
             if ($composerErrorCode !== 0) {
                 throw new Exception("The installation was not successful. Composer returned the error code: $composerErrorCode", 1572187932);


### PR DESCRIPTION
closes #2757

with #2571 was introduced, that the composer subcommand used by `./flow package:create` hides its output. But using the `new NullOutput()` doesn't prevent any interaction initiated by composer such as the infamous:

> neos/composer-plugin contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
> Do you trust "neos/composer-plugin" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?]

the current problem is that composer asks this question but shows not output. So one has to blind input `y` without even knowing the question. This is perceived as bug but clearly a feature see #2757.

With this bugfix we use the official supported cli flag `--quiet` to archive the same as the NullOutput and furthermore disable any invisible requested interactivity.

in the above case instead of a question - an error will be thrown, which is understandable and fixable by the user:

> In PluginManager.php line 768:
> neos/composer-plugin contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.
> ...
> The installation was not successful.
> Composer returned the error code: 1
>
>  Type: Neos\Flow\Package\Exception
>  Code: 1572187932
>  File: Packages/Framework/Neos.Flow/Classes/Package/PackageManager.php
>  Line: 391
>
> Open Data/Logs/Exceptions/202210221257240bfbde.txt for a full stack trace.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
