### PR TITLE
TASK: Extract methods `set`, `get`, `getByTag`, `has`, and `remove` from `FrontendInterface` into `FlowCacheFrontendInterface`

### DIFF
--- a/Neos.Cache/Classes/Frontend/AbstractFrontend.php
+++ b/Neos.Cache/Classes/Frontend/AbstractFrontend.php
@@ -21,7 +21,7 @@ use Neos\Cache\Backend\TaggableBackendInterface;
  *
  * @api
  */
-abstract class AbstractFrontend implements FrontendInterface
+abstract class AbstractFrontend implements FlowCacheFrontendInterface
 {
     /**
      * Identifies this cache

--- a/Neos.Cache/Classes/Frontend/CacheEntryIterator.php
+++ b/Neos.Cache/Classes/Frontend/CacheEntryIterator.php
@@ -23,7 +23,7 @@ use Neos\Cache\Backend\IterableBackendInterface;
 class CacheEntryIterator implements \Iterator
 {
     /**
-     * @var FrontendInterface
+     * @var FlowCacheFrontendInterface
      */
     protected $frontend;
 
@@ -35,10 +35,10 @@ class CacheEntryIterator implements \Iterator
     /**
      * Constructs this Iterator
      *
-     * @param FrontendInterface $frontend Frontend of the cache to iterate over
+     * @param FlowCacheFrontendInterface $frontend Frontend of the cache to iterate over
      * @param IterableBackendInterface $backend Backend of the cache
      */
-    public function __construct(FrontendInterface $frontend, IterableBackendInterface $backend)
+    public function __construct(FlowCacheFrontendInterface $frontend, IterableBackendInterface $backend)
     {
         $this->frontend = $frontend;
         $this->backend = $backend;

--- a/Neos.Cache/Classes/Frontend/FlowCacheFrontendInterface.php
+++ b/Neos.Cache/Classes/Frontend/FlowCacheFrontendInterface.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Cache\Frontend;
+
+/*
+ * This file is part of the Neos.Cache package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Contract for a Flow Cache (frontend)
+ *
+ * @api
+ */
+interface FlowCacheFrontendInterface extends FrontendInterface
+{
+
+    /**
+     * Saves data in the cache.
+     *
+     * @param string $entryIdentifier Something which identifies the data - depends on concrete cache
+     * @param mixed $data The data to cache - also depends on the concrete cache implementation
+     * @param array $tags Tags to associate with this cache entry
+     * @param integer $lifetime Lifetime of this cache entry in seconds. If NULL is specified, the default lifetime is used. "0" means unlimited lifetime.
+     * @return void
+     * @api
+     */
+    public function set(string $entryIdentifier, $data, array $tags = [], int $lifetime = null);
+
+    /**
+     * Finds and returns data from the cache.
+     *
+     * @param string $entryIdentifier Something which identifies the cache entry - depends on concrete cache
+     * @return mixed
+     * @api
+     */
+    public function get(string $entryIdentifier);
+
+    /**
+     * Finds and returns all cache entries which are tagged by the specified tag.
+     *
+     * @param string $tag The tag to search for
+     * @return array An array with the identifier (key) and content (value) of all matching entries. An empty array if no entries matched
+     * @api
+     */
+    public function getByTag(string $tag): array;
+
+    /**
+     * Checks if a cache entry with the specified identifier exists.
+     *
+     * @param string $entryIdentifier An identifier specifying the cache entry
+     * @return boolean true if such an entry exists, false if not
+     * @api
+     */
+    public function has(string $entryIdentifier): bool;
+
+    /**
+     * Removes the given cache entry from the cache.
+     *
+     * @param string $entryIdentifier An identifier specifying the cache entry
+     * @return boolean true if such an entry exists, false if not
+     */
+    public function remove(string $entryIdentifier): bool;
+}

--- a/Neos.Cache/Classes/Frontend/FrontendInterface.php
+++ b/Neos.Cache/Classes/Frontend/FrontendInterface.php
@@ -47,53 +47,6 @@ interface FrontendInterface
     public function getBackend();
 
     /**
-     * Saves data in the cache.
-     *
-     * @param string $entryIdentifier Something which identifies the data - depends on concrete cache
-     * @param mixed $data The data to cache - also depends on the concrete cache implementation
-     * @param array $tags Tags to associate with this cache entry
-     * @param integer $lifetime Lifetime of this cache entry in seconds. If NULL is specified, the default lifetime is used. "0" means unlimited lifetime.
-     * @return void
-     * @api
-     */
-    public function set(string $entryIdentifier, $data, array $tags = [], int $lifetime = null);
-
-    /**
-     * Finds and returns data from the cache.
-     *
-     * @param string $entryIdentifier Something which identifies the cache entry - depends on concrete cache
-     * @return mixed
-     * @api
-     */
-    public function get(string $entryIdentifier);
-
-    /**
-     * Finds and returns all cache entries which are tagged by the specified tag.
-     *
-     * @param string $tag The tag to search for
-     * @return array An array with the identifier (key) and content (value) of all matching entries. An empty array if no entries matched
-     * @api
-     */
-    public function getByTag(string $tag): array;
-
-    /**
-     * Checks if a cache entry with the specified identifier exists.
-     *
-     * @param string $entryIdentifier An identifier specifying the cache entry
-     * @return boolean true if such an entry exists, false if not
-     * @api
-     */
-    public function has(string $entryIdentifier): bool;
-
-    /**
-     * Removes the given cache entry from the cache.
-     *
-     * @param string $entryIdentifier An identifier specifying the cache entry
-     * @return boolean true if such an entry exists, false if not
-     */
-    public function remove(string $entryIdentifier): bool;
-
-    /**
      * Removes all cache entries of this cache.
      *
      * @return void

--- a/Neos.Flow/Classes/Cache/CacheManager.php
+++ b/Neos.Flow/Classes/Cache/CacheManager.php
@@ -16,6 +16,7 @@ use Neos\Flow\Cache\Backend\FileBackend;
 use Neos\Cache\Exception\DuplicateIdentifierException;
 use Neos\Cache\Exception\NoSuchCacheException;
 use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\FlowCacheFrontendInterface;
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Log\Utility\LogEnvironment;
@@ -345,7 +346,13 @@ class CacheManager
      */
     protected function flushClassCachesByChangedFiles(array $changedFiles): void
     {
+        /**
+         * @var FlowCacheFrontendInterface $objectClassesCache
+         */
         $objectClassesCache = $this->getCache('Flow_Object_Classes');
+        /**
+         * @var FlowCacheFrontendInterface $objectConfigurationCache
+         */
         $objectConfigurationCache = $this->getCache('Flow_Object_Configuration');
         $modifiedAspectClassNamesWithUnderscores = [];
         $modifiedClassNamesWithUnderscores = [];
@@ -373,6 +380,9 @@ class CacheManager
         $flushDoctrineProxyCache = false;
         $flushPolicyCache = false;
         if (count($modifiedClassNamesWithUnderscores) > 0) {
+            /**
+             * @var FlowCacheFrontendInterface $reflectionStatusCache
+             */
             $reflectionStatusCache = $this->getCache('Flow_Reflection_Status');
             foreach (array_keys($modifiedClassNamesWithUnderscores) as $classNameWithUnderscores) {
                 $reflectionStatusCache->remove($classNameWithUnderscores);
@@ -414,7 +424,13 @@ class CacheManager
         $aopProxyClassRebuildIsNeeded = false;
         $aopProxyClassInfluencers = '/(?:Policy|Objects|Settings)(?:\..*)*\.yaml/';
 
+        /**
+         * @var FlowCacheFrontendInterface $objectConfigurationCache
+         */
         $objectClassesCache = $this->getCache('Flow_Object_Classes');
+        /**
+         * @var FlowCacheFrontendInterface $objectConfigurationCache
+         */
         $objectConfigurationCache = $this->getCache('Flow_Object_Configuration');
         $caches = [
             '/Policy\.yaml/' => ['Flow_Security_Authorization_Privilege_Method', 'Flow_Persistence_Doctrine', 'Flow_Persistence_Doctrine_Results', 'Flow_Aop_RuntimeExpressions'],

--- a/Neos.Flow/Classes/Persistence/Doctrine/CacheAdapter.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/CacheAdapter.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Persistence\Doctrine;
 
 use Doctrine\Common\Cache\Cache;
 use Neos\Flow\Annotations as Flow;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Security\Context;
 
 /**
@@ -22,7 +22,7 @@ use Neos\Flow\Security\Context;
 class CacheAdapter implements Cache
 {
     /**
-     * @var FrontendInterface
+     * @var VariableFrontend
      */
     protected $cache;
 
@@ -35,10 +35,10 @@ class CacheAdapter implements Cache
     /**
      * Set the cache this adapter should use.
      *
-     * @param FrontendInterface $cache
+     * @param VariableFrontend $cache
      * @return void
      */
-    public function setCache(FrontendInterface $cache)
+    public function setCache(VariableFrontend $cache)
     {
         $this->cache = $cache;
     }

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/Method/MethodPrivilege.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/Method/MethodPrivilege.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Security\Authorization\Privilege\Method;
  * source code.
  */
 
+use Neos\Cache\Frontend\FlowCacheFrontendInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Aop\Pointcut\PointcutFilter;
 use Neos\Flow\Aop\Pointcut\PointcutFilterComposite;
@@ -74,7 +75,11 @@ class MethodPrivilege extends AbstractPrivilege implements MethodPrivilegeInterf
         if (static::$methodPermissions !== null) {
             return;
         }
-        static::$methodPermissions = $cacheManager->getCache('Flow_Security_Authorization_Privilege_Method')->get('methodPermission');
+        /**
+         * @var FlowCacheFrontendInterface $cache
+         */
+        $cache = $cacheManager->getCache('Flow_Security_Authorization_Privilege_Method');
+        static::$methodPermissions = $cache->get('methodPermission');
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Cache/CacheManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Cache/CacheManagerTest.php
@@ -66,11 +66,11 @@ class CacheManagerTest extends UnitTestCase
      * Creates a mock cache with the given $cacheIdentifier and registers it with the cache manager
      *
      * @param $cacheIdentifier
-     * @return Cache\Frontend\FrontendInterface
+     * @return Cache\Frontend\FlowCacheFrontendInterface
      */
     protected function registerCache($cacheIdentifier)
     {
-        $cache = $this->createMock(Cache\Frontend\FrontendInterface::class);
+        $cache = $this->createMock(Cache\Frontend\FlowCacheFrontendInterface::class);
         $cache->expects(self::any())->method('getIdentifier')->will(self::returnValue($cacheIdentifier));
         $this->cacheManager->registerCache($cache);
 


### PR DESCRIPTION
The frontend interface now only describes method needed by the cache manager and the methods used for interaction with the cache are moved to the new `FlowCacheFrontendInterface`. This change will allow to implement frontends that provide a differrent api like PSR6, PSR16 directly.

About breakiness:
- Since code always use one of the concrete frontend implementations no changed are needed
- Cache Backends still get the same Frontend set and as long as the backends only use the getIdentifier
method which is common no changes are needed.

**Review instructions**

Stumbled upon this when i played with https://github.com/sitegeist/Sitegeist.StaleMate (Caches with Stale items and async udates) and was not able to implement those in an alternate CacheFrontend. Also this will allow to create PSR6, PSR16  compatible cache frontends that are handled like all the other frontends and 

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
