### PR TITLE
BUGFIX: Support empty data in SimpleFileBackend

### DIFF
--- a/Neos.Cache/Classes/Backend/SimpleFileBackend.php
+++ b/Neos.Cache/Classes/Backend/SimpleFileBackend.php
@@ -503,7 +503,16 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
                     if ($offset !== null) {
                         fseek($file, $offset);
                     }
-                    $data = fread($file, $maxlen !== null ? $maxlen : filesize($cacheEntryPathAndFilename) - (int)$offset);
+
+                    $length = $maxlen !== null ? $maxlen : filesize($cacheEntryPathAndFilename) - (int)$offset;
+
+                    // fread requires a positive length. If the file is empty, we just return an empty string.
+                    if ($length === 0) {
+                        $data = '';
+                    } else {
+                        $data = fread($file, $length);
+                    }
+
                     flock($file, LOCK_UN);
                 }
                 fclose($file);

--- a/Neos.Cache/Tests/Unit/Backend/SimpleFileBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/SimpleFileBackendTest.php
@@ -225,6 +225,22 @@ class SimpleFileBackendTest extends BaseTestCase
     /**
      * @test
      */
+    public function getSupportsEmptyData()
+    {
+        $this->mockCacheFrontend->expects(self::any())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
+
+        $data = '';
+        $entryIdentifier = 'SimpleFileBackendTest';
+
+        $simpleFileBackend = $this->getSimpleFileBackend();
+        $simpleFileBackend->set($entryIdentifier, $data);
+
+        self::assertSame($data, $simpleFileBackend->get($entryIdentifier));
+    }
+
+    /**
+     * @test
+     */
     public function getReturnsFalseForDeletedFiles()
     {
         $this->mockCacheFrontend->expects(self::any())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));


### PR DESCRIPTION
In newer versions of PHP, calling `fread` with non-positive length raises an error:
`fread(): Argument #2 ($length) must be greater than 0`

Since SimpleFileBackend supports saving an empty file, it should also support reading one.

I've added a test that fails without these changes.

Fixes #2929 

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
