### PR TITLE
FEATURE: Add support for secrets stored in a file for the configuration

### DIFF
--- a/Neos.Flow/Classes/Configuration/ConfigurationManager.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationManager.php
@@ -494,7 +494,7 @@ class ConfigurationManager
     }
 
     /**
-     * Replaces variables (in the format %CONSTANT% or %env:ENVIRONMENT_VARIABLE%)
+     * Replaces variables (in the format %CONSTANT%, %env:ENVIRONMENT_VARIABLE% or %file:/path/to/file%)
      * in the given php exported configuration string.
      *
      * This is applied before caching to allow runtime evaluation of constants and environment variables.
@@ -510,13 +510,17 @@ class ConfigurationManager
             (?P<expression>
             (?:(?:\\\?[\d\w_\\\]+\:\:)             # either a class name followed by ::
             |                                      # or
-            (?:(?P<prefix>[a-z]+)                  # a prefix (like "env")
+            (?:(?P<prefix>[a-z]+)                  # a prefix (like "env" or "file")
             (\((?P<type>int|bool|float|string)\))? # optional type (like "(int)")
             \:))?                                  # followed by ":"
-            (?P<name>[A-Z_0-9]+))                  # the actual variable name in all upper
+            (?P<name>[A-Za-z_0-9\/]+))             # the actual variable name in all upper or path to a file
             %)                                     # concluded by %
             (?<endString>[^%]*?(?:\',\n)?)?        # optionally concluding a string
         /mx', static function ($matchGroup) {
+            if ($matchGroup['prefix'] === 'env' && strtoupper($matchGroup['name']) !== $matchGroup['name']) {
+                return $matchGroup[0];
+            }
+
             $replacement = "";
             $constantDoesNotStartAsBeginning = false;
             if ($matchGroup['startString'] !== "=> '") {
@@ -532,6 +536,8 @@ class ConfigurationManager
                 } else {
                     $replacement .= "getenv('" . $matchGroup['name'] . "')";
                 }
+            } elseif (isset($matchGroup['prefix']) && $matchGroup['prefix'] === 'file') {
+                $replacement .= "trim(file_get_contents('" . $matchGroup['name'] . "'))";
             } elseif (isset($matchGroup['expression'])) {
                 $replacement .= "(defined('" . $matchGroup['expression'] . "') ? constant('" . $matchGroup['expression'] . "') : null)";
             }

--- a/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -839,6 +839,34 @@ class ConfigurationManagerTest extends UnitTestCase
         }
     }
 
+    public function replaceVariablesInPhpStringReplacesFileMarkersDataProvider(): \Traversable
+    {
+        yield ['fileName' => 'test1', 'content' => 'foobar'];
+    }
+
+    /**
+     * @test
+     * @dataProvider replaceVariablesInPhpStringReplacesFileMarkersDataProvider
+     */
+    public function replaceVariablesInPhpStringReplacesFileMarkersTests(string $fileName, string $content): void
+    {
+        // create a temporary file with the content
+        $tempFile = tempnam(sys_get_temp_dir(), $fileName);
+        file_put_contents($tempFile, $content);
+
+        // create the setting dynamically since the file path is not known before
+        $setting = '%file:' . $tempFile . '%';
+
+        $settingsPhpString = var_export(['setting' => $setting], true);
+        $configurationManager = $this->getAccessibleConfigurationManager(['dummy']);
+        $processedPhpString = $configurationManager->_call('replaceVariablesInPhpString', $settingsPhpString);
+        $settings = eval('return ' . $processedPhpString . ';');
+
+        self::assertSame($content, $settings['setting']);
+
+        unlink($tempFile);
+    }
+
     /**
      * We expect that the context specific routes are loaded *first*
      *


### PR DESCRIPTION
Adds the support of secrets stored in files for configurations

Resolves: #2935

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
