### PR TITLE
FEATURE: Doctrine rollback command

### DIFF
--- a/Neos.Flow/Classes/Command/DoctrineCommandController.php
+++ b/Neos.Flow/Classes/Command/DoctrineCommandController.php
@@ -527,7 +527,7 @@ class DoctrineCommandController extends CommandController
     public function rollbackCommand(): void
     {
         $executedMigrations = $this->doctrineService->getExecutedMigrations()->getItems();
-        uasort($executedMigrations, function(ExecutedMigration $a, ExecutedMigration $b) {
+        uasort($executedMigrations, function (ExecutedMigration $a, ExecutedMigration $b) {
             return $a->getExecutedAt() > $b->getExecutedAt();
         });
 

--- a/Neos.Flow/Classes/Command/DoctrineCommandController.php
+++ b/Neos.Flow/Classes/Command/DoctrineCommandController.php
@@ -12,7 +12,9 @@ namespace Neos\Flow\Command;
  */
 
 use Doctrine\Common\Util\Debug;
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\Migrations\Exception\MigrationException;
+use Doctrine\Migrations\Metadata\ExecutedMigration;
 use Doctrine\ORM\Tools\ToolsException;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Neos\Flow\Annotations as Flow;
@@ -509,6 +511,39 @@ class DoctrineCommandController extends CommandController
             }
             $this->outputLine('- Review and adjust the generated migration.');
             $this->outputLine('- (optional) execute the migration using <comment>%s doctrine:migrate</comment>', [$this->getFlowInvocationString()]);
+        }
+    }
+
+    /**
+     * Rollback latest executed migration
+     *
+     * Based on the executedAt property of executed migrations,
+     * the latest migration will be executed, using the `down`
+     * direction.
+     *
+     * @see neos.flow:doctrine:migrate
+     * @return void
+     */
+    public function rollbackCommand(): void
+    {
+        $executedMigrations = $this->doctrineService->getExecutedMigrations()->getItems();
+        uasort($executedMigrations, function(ExecutedMigration $a, ExecutedMigration $b) {
+            return $a->getExecutedAt() > $b->getExecutedAt();
+        });
+
+        $last = end($executedMigrations);
+        if (!$last) {
+            $this->outputLine('No migration to rollback');
+            $this->quit(1);
+        }
+
+        try {
+            $result = $this->doctrineService->executeMigration((string) $last->getVersion(), 'down');
+            $this->output($result);
+        } catch (DBALException $exception) {
+            $this->outputLine('<error>Rollback failed</error>');
+            $this->outputLine($exception->getMessage());
+            $this->quit(1);
         }
     }
 

--- a/Neos.Flow/Classes/Command/DoctrineCommandController.php
+++ b/Neos.Flow/Classes/Command/DoctrineCommandController.php
@@ -524,17 +524,22 @@ class DoctrineCommandController extends CommandController
      * @see neos.flow:doctrine:migrate
      * @return void
      */
-    public function rollbackCommand(): void
+    public function rollbackCommand(bool $dryRun = false): void
     {
         $executedMigrations = $this->doctrineService->getExecutedMigrations()->getItems();
         uasort($executedMigrations, function (ExecutedMigration $a, ExecutedMigration $b) {
-            return $a->getExecutedAt() > $b->getExecutedAt();
+            return ($a->getExecutedAt() === $b->getExecutedAt()) ? 0 : (($a->getExecutedAt() > $b->getExecutedAt()) ? 1 : -1);
         });
 
         $last = end($executedMigrations);
         if (!$last) {
             $this->outputLine('No migration to rollback');
             $this->quit(1);
+        }
+
+        if ($dryRun) {
+            $this->outputLine('DRY RUN: Rollback migration "%s"', [(string) $last->getVersion()]);
+            $this->quit();
         }
 
         try {

--- a/Neos.Flow/Classes/Persistence/Doctrine/Service.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Service.php
@@ -637,6 +637,11 @@ class Service
         return ucfirst($this->entityManager->getConnection()->getDatabasePlatform()->getName());
     }
 
+    public function getExecutedMigrations(): ExecutedMigrationsList
+    {
+        return $this->getDependencyFactory()->getMetadataStorage()->getExecutedMigrations();
+    }
+
     /**
      * This serves a rather strange use case: renaming columns used in FK constraints.
      *


### PR DESCRIPTION
With this change, you can now execute 

`./flow doctrine:rollback`

to rollback latest executed migration

Resolves #2937 

**Upgrade instructions**

No changes needed

**Review instructions**

 * Set up a Flow installation
 * Migrate all tables
 * Use the `doctrine:rollback` to see only the latest migration is rolledback
 * Further: Run a migration with a older timestamp
 * See that the rollback is solely depended on the executedAt property

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
