### PR TITLE
BUGFIX: Support PHP8 union and intersection types as method return value in reflection service

### DIFF
--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1414,7 +1414,6 @@ class ReflectionService
         $applyLeadingSlashIfNeeded = function (string $type): string {
             if (!in_array($type, ['self', 'null', 'callable', 'void', 'iterable', 'object', 'mixed'])
                 && !TypeHandling::isSimpleType($type)
-                && !TypeHandling::isLiteralType($type)
             ) {
                 return '\\' . $type;
             }

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1412,7 +1412,7 @@ class ReflectionService
 
         $returnType= $method->getDeclaredReturnType();
         $applyLeadingSlashIfNeeded = function (string $type): string {
-            if (!in_array($type, ['self', 'null', 'callable', 'void', 'iterable', 'object', 'mixed'])
+            if (!in_array($type, ['self', 'parent', 'static', 'null', 'callable', 'void', 'never', 'iterable', 'object', 'resource', 'mixed'])
                 && !TypeHandling::isSimpleType($type)
             ) {
                 return '\\' . $type;

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1411,7 +1411,7 @@ class ReflectionService
         }
 
         $returnType= $method->getDeclaredReturnType();
-        $applyLeadingSlashIfNeeded = function (string $type) {
+        $applyLeadingSlashIfNeeded = function (string $type): string {
             if (!in_array($type, ['self', 'null', 'callable', 'void', 'iterable', 'object', 'mixed'])
                 && !TypeHandling::isSimpleType($type)
                 && !TypeHandling::isLiteralType($type)

--- a/Neos.Flow/Tests/Functional/Reflection/Fixtures/DummyClassWithTypeHints.php
+++ b/Neos.Flow/Tests/Functional/Reflection/Fixtures/DummyClassWithTypeHints.php
@@ -31,4 +31,8 @@ class DummyClassWithTypeHints
     public function methodWithArrayTypeHintAndAnnotation(array $array)
     {
     }
+
+    public function methodWithUnionReturnType(): string|false
+    {
+    }
 }

--- a/Neos.Flow/Tests/Functional/Reflection/Fixtures/PHP8/DummyClassWithUnionTypeHints.php
+++ b/Neos.Flow/Tests/Functional/Reflection/Fixtures/PHP8/DummyClassWithUnionTypeHints.php
@@ -1,5 +1,5 @@
 <?php
-namespace Neos\Flow\Tests\Functional\Reflection\Fixtures;
+namespace Neos\Flow\Tests\Functional\Reflection\Fixtures\PHP8;
 
 /*
  * This file is part of the Neos.Flow package.
@@ -15,20 +15,17 @@ namespace Neos\Flow\Tests\Functional\Reflection\Fixtures;
  * Dummy class for the Reflection tests
  *
  */
-class DummyClassWithTypeHints
+class DummyClassWithUnionTypeHints
 {
-    public function methodWithScalarTypeHints(int $integer, string $string)
+    public function methodWithUnionReturnTypeA(): string|false
     {
     }
 
-    public function methodWithArrayTypeHint(array $array)
+    public function methodWithUnionReturnTypesB(): false|DummyClassWithUnionTypeHints
     {
     }
 
-    /**
-     * @param string[] $array
-     */
-    public function methodWithArrayTypeHintAndAnnotation(array $array)
+    public function methodWithUnionReturnTypesC(): null|DummyClassWithUnionTypeHints
     {
     }
 }

--- a/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
@@ -302,4 +302,13 @@ class ReflectionServiceTest extends FunctionalTestCase
         $methodWithTypeHintsParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\DummyClassWithTypeHints::class, 'methodWithArrayTypeHintAndAnnotation');
         self::assertEquals('array<string>', $methodWithTypeHintsParameters['array']['type']);
     }
+
+    /**
+     * @test
+     */
+    public function unionReturnTypesWorkCorrectly()
+    {
+        $returnType = $this->reflectionService->getMethodDeclaredReturnType(Reflection\Fixtures\DummyClassWithTypeHints::class, 'methodWithUnionReturnType');
+        self::assertEquals('string|false', $returnType);
+    }
 }

--- a/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
@@ -308,7 +308,15 @@ class ReflectionServiceTest extends FunctionalTestCase
      */
     public function unionReturnTypesWorkCorrectly()
     {
-        $returnType = $this->reflectionService->getMethodDeclaredReturnType(Reflection\Fixtures\DummyClassWithTypeHints::class, 'methodWithUnionReturnType');
-        self::assertEquals('string|false', $returnType);
+        if (PHP_MAJOR_VERSION < 8) {
+            $this->markTestSkipped('Only for PHP 8 with UnionTypes');
+        }
+        $returnTypeA = $this->reflectionService->getMethodDeclaredReturnType(Reflection\Fixtures\PHP8\DummyClassWithUnionTypeHints::class, 'methodWithUnionReturnTypeA');
+        $returnTypeB = $this->reflectionService->getMethodDeclaredReturnType(Reflection\Fixtures\PHP8\DummyClassWithUnionTypeHints::class, 'methodWithUnionReturnTypesB');
+        $returnTypeC = $this->reflectionService->getMethodDeclaredReturnType(Reflection\Fixtures\PHP8\DummyClassWithUnionTypeHints::class, 'methodWithUnionReturnTypesC');
+
+        self::assertEquals('string|false', $returnTypeA);
+        self::assertEquals('\Neos\Flow\Tests\Functional\Reflection\Fixtures\PHP8\DummyClassWithUnionTypeHints|false', $returnTypeB);
+        self::assertEquals('?\Neos\Flow\Tests\Functional\Reflection\Fixtures\PHP8\DummyClassWithUnionTypeHints', $returnTypeC);
     }
 }

--- a/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
+++ b/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
@@ -111,18 +111,7 @@ abstract class TypeHandling
      */
     public static function isSimpleType(string $type): bool
     {
-        return in_array(self::normalizeType($type), ['array', 'string', 'float', 'integer', 'boolean', 'null'], true);
-    }
-
-    /**
-     * Returns true if the $type is a literal type.
-     *
-     * @param string $type
-     * @return boolean
-     */
-    public static function isLiteralType(string $type): bool
-    {
-        return in_array($type, ['false', 'true'], true);
+        return in_array(self::normalizeType($type), ['array', 'string', 'float', 'integer', 'boolean', 'null', 'false', 'true'], true);
     }
 
     /**

--- a/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
+++ b/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
@@ -122,7 +122,7 @@ abstract class TypeHandling
      */
     public static function isLiteralType(string $type): bool
     {
-        return in_array(self::normalizeType($type), ['false', 'true'], true);
+        return in_array($type, ['false', 'true'], true);
     }
 
     /**

--- a/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
+++ b/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
@@ -111,7 +111,7 @@ abstract class TypeHandling
      */
     public static function isSimpleType(string $type): bool
     {
-        return in_array(self::normalizeType($type), ['array', 'string', 'float', 'integer', 'boolean'], true);
+        return in_array(self::normalizeType($type), ['array', 'string', 'float', 'integer', 'boolean', 'null'], true);
     }
 
     /**

--- a/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
+++ b/Neos.Utility.ObjectHandling/Classes/TypeHandling.php
@@ -115,6 +115,17 @@ abstract class TypeHandling
     }
 
     /**
+     * Returns true if the $type is a literal type.
+     *
+     * @param string $type
+     * @return boolean
+     */
+    public static function isLiteralType(string $type): bool
+    {
+        return in_array(self::normalizeType($type), ['false', 'true'], true);
+    }
+
+    /**
      * Returns true if the $type is a collection type.
      *
      * @param string $type
@@ -135,6 +146,28 @@ abstract class TypeHandling
         }
 
         return false;
+    }
+
+    /**
+     * Returns true if the $type is a union type.
+     *
+     * @param string $type
+     * @return boolean
+     */
+    public static function isUnionType(string $type): bool
+    {
+        return str_contains($type, '|');
+    }
+
+    /**
+     * Returns true if the $type is an intersection type.
+     *
+     * @param string $type
+     * @return boolean
+     */
+    public static function isIntersectionType(string $type): bool
+    {
+        return str_contains($type, '&');
     }
 
     /**

--- a/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
@@ -209,7 +209,13 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
             ['Doctrine\Common\Collections\Collection', false],
             ['Doctrine\Common\Collections\ArrayCollection', false],
             ['IteratorAggregate', false],
-            ['Iterator', false]
+            ['Iterator', false],
+            ['resource', false],
+            ['parent', false],
+            ['static', false],
+            ['self', false],
+            ['void', false],
+            ['never', false]
         ];
     }
 

--- a/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
@@ -43,6 +43,7 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
     public function types()
     {
         return [
+            ['null', ['type' => 'null', 'elementType' => null, 'nullable' => true]],
             ['int', ['type' => 'integer', 'elementType' => null, 'nullable' => false]],
             ['string', ['type' => 'string', 'elementType' => null, 'nullable' => false]],
             ['DateTime', ['type' => 'DateTime', 'elementType' => null, 'nullable' => false]],
@@ -142,6 +143,7 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
     public function nonLiteralTypes()
     {
         return [
+            ['null'],
             ['DateTime'],
             ['\Foo\Bar'],
             ['array'],
@@ -190,6 +192,7 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
     public function simpleTypes()
     {
         return [
+            ['null', true],
             ['integer', true],
             ['int', true],
             ['float', true],
@@ -225,6 +228,7 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
     public function literalTypes()
     {
         return [
+            ['null', false],
             ['integer', false],
             ['int', false],
             ['float', false],
@@ -260,6 +264,7 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
     public function collectionTypes()
     {
         return [
+            ['null', false],
             ['integer', false],
             ['int', false],
             ['float', false],
@@ -295,6 +300,7 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
     public function unionAndIntersectionTypes()
     {
         return [
+            ['null', false, false],
             ['integer', false, false],
             ['int', false, false],
             ['float', false, false],

--- a/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
@@ -160,9 +160,9 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * data provider for isLiteralReturnsTrueForLiteralType
+     * data provider for isLiteralReturnsTrueForLiterals
      */
-    public function literalTypes()
+    public function literals()
     {
         return [
             ['integer'],
@@ -177,11 +177,81 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @test
-     * @dataProvider literalTypes
+     * @dataProvider literals
      */
-    public function isLiteralReturnsTrueForLiteralType(string $type)
+    public function isLiteralReturnsTrueForLiterals(string $type)
     {
         self::assertTrue(TypeHandling::isLiteral($type), 'Failed for ' . $type);
+    }
+
+    /**
+     * data provider for isSimpleTypeReturnsTrueForSimpleType
+     */
+    public function simpleTypes()
+    {
+        return [
+            ['integer', true],
+            ['int', true],
+            ['float', true],
+            ['double', true],
+            ['boolean', true],
+            ['bool', true],
+            ['string', true],
+            ['true', false],
+            ['false', false],
+            ['SomeClassThatIsUnknownToPhpAtThisPoint', false],
+            ['array', true],
+            ['ArrayObject', false],
+            ['SplObjectStorage', false],
+            ['Doctrine\Common\Collections\Collection', false],
+            ['Doctrine\Common\Collections\ArrayCollection', false],
+            ['IteratorAggregate', false],
+            ['Iterator', false]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider simpleTypes
+     */
+    public function isSimpleTypeReturnsTrueForSimpleType(string $type, bool $expected)
+    {
+        self::assertSame($expected, TypeHandling::isSimpleType($type), 'Failed for ' . $type);
+    }
+
+    /**
+     * data provider for isLitaralTypeReturnsTrueForSimpleType
+     */
+    public function literalTypes()
+    {
+        return [
+            ['integer', false],
+            ['int', false],
+            ['float', false],
+            ['double', false],
+            ['boolean', false],
+            ['bool', false],
+            ['string', false],
+            ['true', true],
+            ['false', true],
+            ['SomeClassThatIsUnknownToPhpAtThisPoint', false],
+            ['array', false],
+            ['ArrayObject', false],
+            ['SplObjectStorage', false],
+            ['Doctrine\Common\Collections\Collection', false],
+            ['Doctrine\Common\Collections\ArrayCollection', false],
+            ['IteratorAggregate', false],
+            ['Iterator', false]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider literalTypes
+     */
+    public function isLiteralTypeReturnsTrueForLiteralType(string $type, bool $expected)
+    {
+        self::assertSame($expected, TypeHandling::isLiteralType($type), 'Failed for ' . $type);
     }
 
     /**
@@ -197,6 +267,8 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
             ['boolean', false],
             ['bool', false],
             ['string', false],
+            ['true', false],
+            ['false', false],
             ['SomeClassThatIsUnknownToPhpAtThisPoint', false],
             ['array', true],
             ['ArrayObject', true],
@@ -215,6 +287,45 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
     public function isCollectionTypeReturnsTrueForCollectionType(string $type, bool $expected)
     {
         self::assertSame($expected, TypeHandling::isCollectionType($type), 'Failed for ' . $type);
+    }
+
+    /**
+     * data provider for isUnionTypeReturnsTrueForUnionType
+     */
+    public function unionAndIntersectionTypes()
+    {
+        return [
+            ['integer', false, false],
+            ['int', false, false],
+            ['float', false, false],
+            ['double', false, false],
+            ['boolean', false, false],
+            ['integer|null', true, false],
+            ['integer|string', true, false],
+            ['integer|false', true, false],
+            ['SomeClassThatIsUnknownToPhpAtThisPoint|false', true, false],
+            ['SomeClassThatIsUnknownToPhpAtThisPoint', false, false],
+            ['ArrayObject', false, false],
+            ['Iterator&Traversable', false, true]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider unionAndIntersectionTypes
+     */
+    public function isUnionTypeReturnsTrueForUnionType(string $type, bool $expectUnionType, bool $expectIntersectionType)
+    {
+        self::assertSame($expectUnionType, TypeHandling::isUnionType($type), 'Failed for ' . $type);
+    }
+
+    /**
+     * @test
+     * @dataProvider unionAndIntersectionTypes
+     */
+    public function isIntersectionTypeReturnsTrueForIntersectionTypes(string $type,  bool $expectUnionType, bool $expectIntersectionType)
+    {
+        self::assertSame($expectIntersectionType, TypeHandling::isIntersectionType($type), 'Failed for ' . $type);
     }
 
     /**

--- a/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
@@ -200,8 +200,8 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
             ['boolean', true],
             ['bool', true],
             ['string', true],
-            ['true', false],
-            ['false', false],
+            ['true', true],
+            ['false', true],
             ['SomeClassThatIsUnknownToPhpAtThisPoint', false],
             ['array', true],
             ['ArrayObject', false],
@@ -220,42 +220,6 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
     public function isSimpleTypeReturnsTrueForSimpleType(string $type, bool $expected)
     {
         self::assertSame($expected, TypeHandling::isSimpleType($type), 'Failed for ' . $type);
-    }
-
-    /**
-     * data provider for isLitaralTypeReturnsTrueForSimpleType
-     */
-    public function literalTypes()
-    {
-        return [
-            ['null', false],
-            ['integer', false],
-            ['int', false],
-            ['float', false],
-            ['double', false],
-            ['boolean', false],
-            ['bool', false],
-            ['string', false],
-            ['true', true],
-            ['false', true],
-            ['SomeClassThatIsUnknownToPhpAtThisPoint', false],
-            ['array', false],
-            ['ArrayObject', false],
-            ['SplObjectStorage', false],
-            ['Doctrine\Common\Collections\Collection', false],
-            ['Doctrine\Common\Collections\ArrayCollection', false],
-            ['IteratorAggregate', false],
-            ['Iterator', false]
-        ];
-    }
-
-    /**
-     * @test
-     * @dataProvider literalTypes
-     */
-    public function isLiteralTypeReturnsTrueForLiteralType(string $type, bool $expected)
-    {
-        self::assertSame($expected, TypeHandling::isLiteralType($type), 'Failed for ' . $type);
     }
 
     /**

--- a/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/TypeHandlingTest.php
@@ -323,7 +323,7 @@ class TypeHandlingTest extends \PHPUnit\Framework\TestCase
      * @test
      * @dataProvider unionAndIntersectionTypes
      */
-    public function isIntersectionTypeReturnsTrueForIntersectionTypes(string $type,  bool $expectUnionType, bool $expectIntersectionType)
+    public function isIntersectionTypeReturnsTrueForIntersectionTypes(string $type, bool $expectUnionType, bool $expectIntersectionType)
     {
         self::assertSame($expectIntersectionType, TypeHandling::isIntersectionType($type), 'Failed for ' . $type);
     }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -62,14 +62,6 @@
       <code>$string</code>
     </MoreSpecificImplementedParamType>
   </file>
-  <file src="Packages/Framework/Neos.Cache/Classes/Psr/Cache/CacheFactory.php">
-    <InvalidArgument occurrences="1">
-      <code>$backend</code>
-    </InvalidArgument>
-    <UndefinedDocblockClass occurrences="1">
-      <code>BackendInterface</code>
-    </UndefinedDocblockClass>
-  </file>
   <file src="Packages/Framework/Neos.Cache/Classes/Psr/Cache/CacheItem.php">
     <PropertyTypeCoercion occurrences="1">
       <code>$expiration</code>
@@ -212,8 +204,7 @@
     <PossiblyNullArgument occurrences="1">
       <code>$x</code>
     </PossiblyNullArgument>
-    <RedundantCastGivenDocblockType occurrences="3">
-      <code>(float)$subject</code>
+    <RedundantCastGivenDocblockType occurrences="2">
       <code>(float)$x</code>
       <code>(float)$x</code>
     </RedundantCastGivenDocblockType>
@@ -740,9 +731,6 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Core/Bootstrap.php">
-    <NullableReturnStatement occurrences="1">
-      <code>null</code>
-    </NullableReturnStatement>
     <PossiblyUndefinedVariable occurrences="1">
       <code>$suitableRequestHandlers</code>
     </PossiblyUndefinedVariable>
@@ -1505,9 +1493,6 @@
     </UndefinedDocblockClass>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$annotation</code>
-    </ArgumentTypeCoercion>
     <PossiblyFalseArgument occurrences="1">
       <code>strrpos($fullOriginalClassName, '\\')</code>
     </PossiblyFalseArgument>
@@ -1521,9 +1506,6 @@
     </UndefinedMethod>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethod.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$annotation</code>
-    </ArgumentTypeCoercion>
     <UndefinedMethod occurrences="1">
       <code>getAttributes</code>
     </UndefinedMethod>
@@ -1593,9 +1575,6 @@
     </PossiblyNullReference>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Persistence/Doctrine/CountWalker.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
-      <code>void</code>
-    </ImplementedReturnTypeMismatch>
     <PossiblyNullArgument occurrences="1">
       <code>$parentName</code>
     </PossiblyNullArgument>
@@ -1605,6 +1584,13 @@
     <PossiblyNullReference occurrences="1">
       <code>getSingleIdentifierFieldName</code>
     </PossiblyNullReference>
+    <PossiblyUndefinedArrayOffset occurrences="2">
+      <code>$parent['metadata']</code>
+      <code>$qComp['parent']</code>
+    </PossiblyUndefinedArrayOffset>
+    <UndefinedDocblockClass occurrences="1">
+      <code>$this-&gt;_getQueryComponents()</code>
+    </UndefinedDocblockClass>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Persistence/Doctrine/DataTypes/JsonArrayType.php">
     <LessSpecificImplementedReturnType occurrences="1">
@@ -1655,10 +1641,13 @@
     </ArgumentTypeCoercion>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php">
-    <ArgumentTypeCoercion occurrences="3">
+    <ArgumentTypeCoercion occurrences="5">
+      <code>$className</code>
       <code>$className</code>
       <code>$classSchema-&gt;getRepositoryClassName()</code>
+      <code>$discriminatorColumn</code>
     </ArgumentTypeCoercion>
+    <InvalidArgument occurrences="1"/>
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>new IndexedReader(new AnnotationReader())</code>
     </InvalidPropertyAssignmentValue>
@@ -1694,6 +1683,12 @@
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$this-&gt;queryBuilder-&gt;getParameters()</code>
     </InvalidPropertyAssignmentValue>
+    <InvalidReturnStatement occurrences="1">
+      <code>$this-&gt;queryBuilder-&gt;getQuery()-&gt;getSQL()</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>array</code>
+    </InvalidReturnType>
     <InvalidScalarArgument occurrences="3">
       <code>$pdoException-&gt;getCode()</code>
       <code>$pdoException-&gt;getCode()</code>
@@ -1923,12 +1918,6 @@
     <LessSpecificImplementedReturnType occurrences="1">
       <code>array&lt;ParameterReflection&gt;</code>
     </LessSpecificImplementedReturnType>
-    <LessSpecificReturnStatement occurrences="1">
-      <code>$this-&gt;docCommentParser</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1">
-      <code>DocCommentParser</code>
-    </MoreSpecificReturnType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Reflection/ParameterReflection.php">
     <MissingImmutableAnnotation occurrences="3">
@@ -1942,14 +1931,6 @@
     <UndefinedMethod occurrences="1">
       <code>getName</code>
     </UndefinedMethod>
-  </file>
-  <file src="Packages/Framework/Neos.Flow/Classes/Reflection/PropertyReflection.php">
-    <LessSpecificReturnStatement occurrences="1">
-      <code>$this-&gt;docCommentParser</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1">
-      <code>DocCommentParser</code>
-    </MoreSpecificReturnType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Reflection/ReflectionService.php">
     <ArgumentTypeCoercion occurrences="3">
@@ -2533,23 +2514,6 @@
       <code>$sourceTypes</code>
     </NonInvariantDocblockPropertyType>
   </file>
-  <file src="Packages/Framework/Neos.Flow/Classes/Session/Aspect/LoggingAspect.php">
-    <InvalidReturnType occurrences="3">
-      <code>mixed</code>
-      <code>mixed</code>
-      <code>mixed</code>
-    </InvalidReturnType>
-    <UndefinedInterfaceMethod occurrences="8">
-      <code>getId</code>
-      <code>getId</code>
-      <code>getId</code>
-      <code>getId</code>
-      <code>isStarted</code>
-      <code>isStarted</code>
-      <code>isStarted</code>
-      <code>isStarted</code>
-    </UndefinedInterfaceMethod>
-  </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Session/Session.php">
     <FalsableReturnStatement occurrences="1">
       <code>false</code>
@@ -2604,9 +2568,6 @@
       <code>null</code>
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(string)Bootstrap::getEnvironmentConfigurationSetting('FLOW_REWRITEURLS')</code>
-    </RedundantCastGivenDocblockType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Utility/Ip.php">
     <PossiblyInvalidOperand occurrences="2">
@@ -2717,12 +2678,6 @@
     </PossiblyFalseArgument>
   </file>
   <file src="Packages/Framework/Neos.FluidAdaptor/Classes/Core/Cache/CacheAdaptor.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
-      <code>bool|void</code>
-    </ImplementedReturnTypeMismatch>
-    <InvalidReturnStatement occurrences="1">
-      <code>$this-&gt;flowCache-&gt;set($name, substr($value, strpos($value, "\n") + 1))</code>
-    </InvalidReturnStatement>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$value</code>
     </MoreSpecificImplementedParamType>


### PR DESCRIPTION
The change allows to use union types and intersection types in classes which are proxied by the flow framework. 
Offcourse the php version Flow is running on has to support the used features aswell.

In addition: 
- `true`, `false` and `null` are added to the list of simple types which are not prefixed by the reflection service
- `parent`, `static`, `never` and `resource` are added to the list of additional types that need no prefix during reflection aswell

Resolves: #2941 

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
