### PR TITLE
BUGFIX: Declare properties in proxy classes to prevent PHP 8.2 deprecations

### DIFF
--- a/Neos.Flow/Classes/Aop/Builder/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/Aop/Builder/ProxyClassBuilder.php
@@ -452,7 +452,7 @@ class ProxyClassBuilder
             $proxyClass->addProperty($propertyName, var_export($propertyIntroduction->getInitialValue(), true), $propertyIntroduction->getPropertyVisibility(), $propertyIntroduction->getPropertyDocComment());
         }
 
-        $proxyClass->getMethod('Flow_Aop_Proxy_buildMethodsAndAdvicesArray')->addPreParentCallCode("        if (method_exists(get_parent_class(), 'Flow_Aop_Proxy_buildMethodsAndAdvicesArray') && is_callable('parent::Flow_Aop_Proxy_buildMethodsAndAdvicesArray')) parent::Flow_Aop_Proxy_buildMethodsAndAdvicesArray();\n");
+        $proxyClass->getMethod('Flow_Aop_Proxy_buildMethodsAndAdvicesArray')->addPreParentCallCode("        if (method_exists(get_parent_class(), 'Flow_Aop_Proxy_buildMethodsAndAdvicesArray') && is_callable([parent::class, 'Flow_Aop_Proxy_buildMethodsAndAdvicesArray'])) parent::Flow_Aop_Proxy_buildMethodsAndAdvicesArray();\n");
         $proxyClass->getMethod('Flow_Aop_Proxy_buildMethodsAndAdvicesArray')->addPreParentCallCode($this->buildMethodsAndAdvicesArrayCode($interceptedMethods));
         $proxyClass->getMethod('Flow_Aop_Proxy_buildMethodsAndAdvicesArray')->overrideMethodVisibility('protected');
 
@@ -462,7 +462,7 @@ class ProxyClassBuilder
         $proxyClass->getMethod('__clone')->addPreParentCallCode($callBuildMethodsAndAdvicesArrayCode);
 
         if (!$this->reflectionService->hasMethod($targetClassName, '__wakeup')) {
-            $proxyClass->getMethod('__wakeup')->addPostParentCallCode("        if (method_exists(get_parent_class(), '__wakeup') && is_callable('parent::__wakeup')) parent::__wakeup();\n");
+            $proxyClass->getMethod('__wakeup')->addPostParentCallCode("        if (method_exists(get_parent_class(), '__wakeup') && is_callable([parent::class, '__wakeup'])) parent::__wakeup();\n");
         }
 
         $proxyClass->addTraits(['\\' . AdvicesTrait::class]);
@@ -531,7 +531,7 @@ class ProxyClassBuilder
             return $treatedSubClasses;
         }
 
-        $callBuildMethodsAndAdvicesArrayCode = "        if (method_exists(get_parent_class(), 'Flow_Aop_Proxy_buildMethodsAndAdvicesArray') && is_callable('parent::Flow_Aop_Proxy_buildMethodsAndAdvicesArray')) parent::Flow_Aop_Proxy_buildMethodsAndAdvicesArray();\n";
+        $callBuildMethodsAndAdvicesArrayCode = "        if (method_exists(get_parent_class(), 'Flow_Aop_Proxy_buildMethodsAndAdvicesArray') && is_callable([parent::class, 'Flow_Aop_Proxy_buildMethodsAndAdvicesArray'])) parent::Flow_Aop_Proxy_buildMethodsAndAdvicesArray();\n";
         $proxyClass->getConstructor()->addPreParentCallCode($callBuildMethodsAndAdvicesArrayCode);
         $proxyClass->getMethod('__wakeup')->addPreParentCallCode($callBuildMethodsAndAdvicesArrayCode);
 

--- a/Neos.Flow/Classes/ObjectManagement/DependencyInjection/PropertyInjectionTrait.php
+++ b/Neos.Flow/Classes/ObjectManagement/DependencyInjection/PropertyInjectionTrait.php
@@ -16,6 +16,8 @@ namespace Neos\Flow\ObjectManagement\DependencyInjection;
  */
 trait PropertyInjectionTrait
 {
+    protected array $Flow_Injected_Properties = [];
+
     /**
      * Does a property injection lazily with fallbacks.
      * Used in proxy classes.

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ObjectSerializationTrait.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ObjectSerializationTrait.php
@@ -27,6 +27,10 @@ use Neos\Utility\Arrays;
  */
 trait ObjectSerializationTrait
 {
+    protected array $Flow_Object_PropertiesToSerialize = [];
+
+    protected ?array $Flow_Persistence_RelatedEntities = null;
+
     /**
      * Code to find and serialize entities on sleep
      *
@@ -43,11 +47,14 @@ trait ObjectSerializationTrait
             if (in_array($propertyName, [
                 'Flow_Aop_Proxy_targetMethodsAndGroupedAdvices',
                 'Flow_Aop_Proxy_groupedAdviceChains',
-                'Flow_Aop_Proxy_methodIsInAdviceMode'
+                'Flow_Aop_Proxy_methodIsInAdviceMode',
+                'Flow_Persistence_RelatedEntities',
+                'Flow_Object_PropertiesToSerialize',
+                'Flow_Injected_Properties',
             ])) {
                 continue;
             }
-            if (isset($this->Flow_Injected_Properties) && is_array($this->Flow_Injected_Properties) && in_array($propertyName, $this->Flow_Injected_Properties)) {
+            if (property_exists($this, 'Flow_Injected_Properties') && is_array($this->Flow_Injected_Properties) && in_array($propertyName, $this->Flow_Injected_Properties)) {
                 continue;
             }
             if ($reflectionProperty->isStatic() || in_array($propertyName, $transientProperties)) {
@@ -72,7 +79,7 @@ trait ObjectSerializationTrait
                     }
                 }
                 if ($this->$propertyName instanceof PersistenceMagicInterface && !Bootstrap::$staticObjectManager->get(PersistenceManagerInterface::class)->isNewObject($this->$propertyName) || $this->$propertyName instanceof OrmProxy) {
-                    if (!property_exists($this, 'Flow_Persistence_RelatedEntities') || !is_array($this->Flow_Persistence_RelatedEntities)) {
+                    if (!isset($this->Flow_Persistence_RelatedEntities)) {
                         $this->Flow_Persistence_RelatedEntities = [];
                         $this->Flow_Object_PropertiesToSerialize[] = 'Flow_Persistence_RelatedEntities';
                     }
@@ -112,7 +119,7 @@ trait ObjectSerializationTrait
                 $this->Flow_searchForEntitiesAndStoreIdentifierArray($path . '.' . $key, $value, $originalPropertyName);
             }
         } elseif ($propertyValue instanceof PersistenceMagicInterface && !Bootstrap::$staticObjectManager->get(PersistenceManagerInterface::class)->isNewObject($propertyValue) || $propertyValue instanceof OrmProxy) {
-            if (!property_exists($this, 'Flow_Persistence_RelatedEntities') || !is_array($this->Flow_Persistence_RelatedEntities)) {
+            if (!isset($this->Flow_Persistence_RelatedEntities)) {
                 $this->Flow_Persistence_RelatedEntities = [];
                 $this->Flow_Object_PropertiesToSerialize[] = 'Flow_Persistence_RelatedEntities';
             }
@@ -146,7 +153,7 @@ trait ObjectSerializationTrait
      */
     private function Flow_setRelatedEntities()
     {
-        if (property_exists($this, 'Flow_Persistence_RelatedEntities') && is_array($this->Flow_Persistence_RelatedEntities)) {
+        if (isset($this->Flow_Persistence_RelatedEntities)) {
             $persistenceManager = Bootstrap::$staticObjectManager->get(PersistenceManagerInterface::class);
             foreach ($this->Flow_Persistence_RelatedEntities as $entityInformation) {
                 $entity = $persistenceManager->getObjectByIdentifier($entityInformation['identifier'], $entityInformation['entityType'], true);

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
@@ -194,7 +194,7 @@ class ProxyCompilerTest extends FunctionalTestCase
         $reflectionClass = new ClassReflection(Fixtures\PHP8\ClassWithUnionTypes::class);
         /** @var PropertyReflection $property */
         foreach ($reflectionClass->getProperties() as $property) {
-            if ($property->getName() !== 'propertyA' && $property->getName() !== 'propertyB') {
+            if (str_starts_with($property->getName(), 'property') && $property->getName() !== 'propertyA' && $property->getName() !== 'propertyB') {
                 self::assertInstanceOf(\ReflectionUnionType::class, $property->getType(), $property->getName() . ': ' . $property->getType());
             }
         }


### PR DESCRIPTION
This patch resolves deprecation notices on PHP 8.2:

## Dynamic properties in proxy classes
There are some properties that are dynamically declared in proxy classes:
* `Flow_Injected_Properties`
* `Flow_Object_PropertiesToSerialize`
* `Flow_Persistence_RelatedEntities`: this is mostly used inside of the `ObjectSerializationTrait`, so I thought it might make more sense to declare it there instead of adding a property using the `ProxyClassBuilder`

Resolves #2946

## `parent` inside of closures
There are some methods that will be checked against `is_callable` with `parent::`:
* `parent::Flow_Aop_Proxy_buildMethodsAndAdvicesArray`
* `parent::__wakeup`

**Review instructions**
* Set up a flow distribution on PHP 8.2
* Run tests and make sure no deprecation warnings are thrown

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
