### PR TITLE
BUGFIX: Allow usage of doctrine attributes

### DIFF
--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1352,6 +1352,9 @@ class ReflectionService
             $this->classReflectionData[$className][self::DATA_CLASS_PROPERTIES][$propertyName][self::DATA_PROPERTY_ANNOTATIONS][get_class($annotation)][] = $annotation;
         }
         if (PHP_MAJOR_VERSION >= 8) {
+            if ($property->hasType() && !isset($this->classReflectionData[$className][self::DATA_CLASS_PROPERTIES][$propertyName][self::DATA_PROPERTY_TAGS_VALUES]['var'])) {
+                $this->classReflectionData[$className][self::DATA_CLASS_PROPERTIES][$propertyName][self::DATA_PROPERTY_TAGS_VALUES]['var'] = [trim((string)$property->getType(), '?')];
+            }
             foreach ($property->getAttributes() as $attribute) {
                 if ($this->isAttributeIgnored($attribute->getName())) {
                     continue;

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/AbstractEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/AbstractEntity.php
@@ -1,0 +1,24 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\Fixtures\Attributes;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A sample entity for tests
+ */
+#[Flow\Entity]
+#[ORM\InheritanceType("JOINED")]
+abstract class AbstractEntity
+{
+}

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/AnnotatedIdentitiesEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/AnnotatedIdentitiesEntity.php
@@ -1,0 +1,47 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\Fixtures\Attributes;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A sample entity that has properties with an Identity annotation
+ */
+#[Flow\Entity]
+class AnnotatedIdentitiesEntity
+{
+    #[Flow\Identity]
+    protected string $author;
+
+    #[Flow\Identity]
+    protected string $title;
+
+    public function getAuthor(): string
+    {
+        return $this->author;
+    }
+
+    public function setAuthor(string $author): void
+    {
+        $this->author = $author;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/CleanupObject.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/CleanupObject.php
@@ -1,0 +1,27 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\Fixtures\Attributes;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+class CleanupObject
+{
+    protected bool $state = false;
+
+    public function toggleState()
+    {
+        $this->state = !$this->state;
+    }
+
+    public function getState(): bool
+    {
+        return $this->state;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/Comment.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/Comment.php
@@ -1,0 +1,35 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\Fixtures\Attributes;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A sample entity for tests
+ */
+#[Flow\Entity]
+class Comment
+{
+    protected string $content = '';
+
+    #[ORM\PrePersist]
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    public function setContent(string $content): void
+    {
+        $this->content = $content;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/CompositeKeyTestEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/CompositeKeyTestEntity.php
@@ -1,0 +1,52 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\Fixtures\Attributes;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A simple entity for persistence tests
+ */
+#[ORM\Table(name: 'persistence_attributes_compsitekeytestentity')]
+#[Flow\Entity]
+class CompositeKeyTestEntity
+{
+    #[ORM\Id]
+    #[ORM\Column(length: 20)]
+    protected string $name = '';
+
+    #[ORM\Id]
+    #[ORM\ManyToOne]
+    protected TestEntity $relatedEntity;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getRelatedEntity(): TestEntity
+    {
+        return $this->relatedEntity;
+    }
+
+    public function setRelatedEntity(TestEntity $relatedEntity): void
+    {
+        $this->relatedEntity = $relatedEntity;
+    }
+
+}

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/CompositeKeyTestEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/CompositeKeyTestEntity.php
@@ -48,5 +48,4 @@ class CompositeKeyTestEntity
     {
         $this->relatedEntity = $relatedEntity;
     }
-
 }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/EntityWithIndexedRelation.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/EntityWithIndexedRelation.php
@@ -1,0 +1,64 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\Fixtures\Attributes;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A sample entity that has a property with an indexed relation
+ */
+#[Flow\Scope('prototype')]
+#[Flow\Entity]
+class EntityWithIndexedRelation
+{
+    #[ORM\ManyToMany(targetEntity: AnnotatedIdentitiesEntity::class, indexBy: 'author')]
+    protected Collection $annotatedIdentitiesEntities;
+
+    #[ORM\OneToMany(targetEntity: RelatedIndexEntity::class, indexBy: 'sorting', mappedBy: 'entityWithIndexedRelation')]
+    protected Collection $relatedIndexEntities;
+
+    public function __construct()
+    {
+        $this->annotatedIdentitiesEntities = new ArrayCollection();
+        $this->relatedIndexEntities = new ArrayCollection();
+    }
+
+    public function setAnnotatedIdentitiesEntities(Collection $annotatedIdentitiesEntities)
+    {
+        $this->annotatedIdentitiesEntities = $annotatedIdentitiesEntities;
+    }
+
+    public function getAnnotatedIdentitiesEntities(): Collection
+    {
+        return $this->annotatedIdentitiesEntities;
+    }
+
+    public function setRelatedIndexEntities(Collection $relatedIndexEntities)
+    {
+        $this->relatedIndexEntities = $relatedIndexEntities;
+    }
+
+    public function getRelatedIndexEntities(): Collection
+    {
+        return $this->relatedIndexEntities;
+    }
+
+    public function setRelatedIndexEntity(string $sorting, RelatedIndexEntity $relatedIndexEntity)
+    {
+        $relatedIndexEntity->setSorting($sorting);
+        $relatedIndexEntity->setEntityWithIndexedRelation($this);
+        $this->relatedIndexEntities->set($sorting, $relatedIndexEntity);
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/Image.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/Image.php
@@ -1,0 +1,55 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\Fixtures\Attributes;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A sample entity for tests
+ */
+#[Flow\Entity]
+class Image
+{
+    #[ORM\Column(nullable: true)]
+    protected string $data;
+
+    #[Flow\Transient]
+    protected CleanupObject $relatedObject;
+
+    public function getData(): string
+    {
+        return $this->data;
+    }
+
+    public function setData(string $data): void
+    {
+        $this->data = $data;
+    }
+
+    public function getRelatedObject(): CleanupObject
+    {
+        return $this->relatedObject;
+    }
+
+    public function setRelatedObject(CleanupObject $relatedObject = null)
+    {
+        $this->relatedObject = $relatedObject;
+    }
+
+    public function shutdownObject()
+    {
+        if ($this->relatedObject instanceof CleanupObject) {
+            $this->relatedObject->toggleState();
+        }
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/OneToOneEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/OneToOneEntity.php
@@ -24,7 +24,7 @@ class OneToOneEntity
     /**
      * Self-referencing
      */
-    #[ORM\OneToOne(targetEntity: OneToOneEntity::class,)]
+    #[ORM\OneToOne(targetEntity: OneToOneEntity::class)]
     protected OneToOneEntity $selfReferencing;
 
     /**

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/OneToOneEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/OneToOneEntity.php
@@ -1,0 +1,41 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\Fixtures\Attributes;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A simple entity for persistence tests of OneToOne relations.
+ */
+#[ORM\Table(name: 'persistence_attributes_onetooneentity')]
+#[Flow\Entity]
+class OneToOneEntity
+{
+    /**
+     * Self-referencing
+     */
+    #[ORM\OneToOne(targetEntity: OneToOneEntity::class,)]
+    protected OneToOneEntity $selfReferencing;
+
+    /**
+     * Bidirectional relation owning side
+     */
+    #[ORM\OneToOne(targetEntity: OneToOneEntity2::class, inversedBy: 'bidirectionalRelation')]
+    protected OneToOneEntity2 $bidirectionalRelation;
+
+    /**
+     * Unidirectional relation
+     */
+    #[ORM\OneToOne(targetEntity: OneToOneEntity2::class)]
+    protected OneToOneEntity2 $unidirectionalRelation;
+}

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/OneToOneEntity2.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/OneToOneEntity2.php
@@ -1,0 +1,29 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\Fixtures\Attributes;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A simple entity for persistence tests of OneToOne relations.
+ */
+#[ORM\Table(name: 'persistence_attributes_onetooneentity2')]
+#[Flow\Entity]
+class OneToOneEntity2
+{
+    /**
+     * Bidirectional relation inverse side
+     */
+    #[ORM\OneToOne(targetEntity: OneToOneEntity::class, mappedBy: 'bidirectionalRelation')]
+    protected OneToOneEntity $bidirectionalRelation;
+}

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/Post.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/Post.php
@@ -1,0 +1,117 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\Fixtures\Attributes;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Tests\Functional\Persistence\Fixtures\Attributes as Fixtures;
+
+#[Flow\Entity]
+#[ORM\HasLifecycleCallbacks]
+#[ORM\InheritanceType("JOINED")]
+class Post
+{
+    protected string $title = '';
+
+    #[ORM\OneToOne(targetEntity: Image::class)]
+    protected Image $image;
+
+    #[ORM\OneToOne(targetEntity: Image::class)]
+    protected Image $thumbnail;
+
+    /**
+     * Yeah, only one comment allowed for a post ;-)
+     * But that's the easiest option for our functional test.
+     */
+    #[ORM\OneToOne(targetEntity: Comment::class)]
+    #[ORM\JoinColumn(onDelete: "SET NULL")]
+    protected Comment $comment;
+
+    #[ORM\OneToMany(targetEntity: Fixtures\Tag::class)]
+    protected Collection $tags;
+
+    /**
+     * This attribute only works with php 8.1 or greater
+     * #[ORM\JoinTable(inverseJoinColumns: [new ORM\JoinColumn(name: "related_post_id")])]
+     *
+     * @ORM\JoinTable(inverseJoinColumns={@ORM\JoinColumn(name="related_post_id")})
+     */
+    #[ORM\ManyToMany(targetEntity: Fixtures\Post::class)]
+    protected Collection $related;
+
+    #[ORM\ManyToOne(targetEntity: TestValueObject::class)]
+    protected TestValueObject $author;
+
+    public function __construct()
+    {
+        $this->tags = new ArrayCollection();
+        $this->related = new ArrayCollection();
+    }
+
+    #[ORM\PrePersist]
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function setImage(Image $image): void
+    {
+        $this->image = $image;
+    }
+
+    public function getImage(): Image
+    {
+        return $this->image;
+    }
+
+    public function setComment(Comment $comment): void
+    {
+        $this->comment = $comment;
+    }
+
+    public function getComment(): Comment
+    {
+        return $this->comment;
+    }
+
+    public function addTag(Tag $tag): void
+    {
+        $this->tags->add($tag);
+    }
+
+    public function removeTag(Tag $tag): void
+    {
+        $this->tags->removeElement($tag);
+    }
+
+    public function getTags(): Collection
+    {
+        return $this->tags;
+    }
+
+    public function getAuthor(): TestValueObject
+    {
+        return $this->author;
+    }
+
+    public function setAuthor(TestValueObject $author): void
+    {
+        $this->author = $author;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/RelatedIndexEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/RelatedIndexEntity.php
@@ -1,0 +1,48 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\Fixtures\Attributes;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A test entity used by Entity with IndexedRelation
+ */
+#[Flow\Scope('prototype')]
+#[Flow\Entity]
+class RelatedIndexEntity
+{
+    protected string $sorting;
+
+    #[ORM\ManyToOne(targetEntity: EntityWithIndexedRelation::class)]
+    protected EntityWithIndexedRelation $entityWithIndexedRelation;
+
+    public function getSorting(): string
+    {
+        return $this->sorting;
+    }
+
+    public function setSorting(string $sorting): void
+    {
+        $this->sorting = $sorting;
+    }
+
+    public function getEntityWithIndexedRelation(): EntityWithIndexedRelation
+    {
+        return $this->entityWithIndexedRelation;
+    }
+
+    public function setEntityWithIndexedRelation(EntityWithIndexedRelation $entityWithIndexedRelation): void
+    {
+        $this->entityWithIndexedRelation = $entityWithIndexedRelation;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/Tag.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/Tag.php
@@ -1,0 +1,30 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\Fixtures\Attributes;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A sample entity for tests
+ */
+#[Flow\Entity]
+class Tag
+{
+    public function __construct(protected string $name)
+    {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/TestEmbeddable.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/TestEmbeddable.php
@@ -1,0 +1,30 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\Fixtures\Attributes;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * A simple Doctrine ORM 2.5 embeddable for persistence tests
+ */
+#[ORM\Embeddable]
+class TestEmbeddable
+{
+    public function __construct(protected string $value)
+    {
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/TestEmbeddedValueObject.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/TestEmbeddedValueObject.php
@@ -1,0 +1,31 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\Fixtures\Attributes;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A simple embedded value object for persistence tests
+ */
+#[Flow\ValueObject(embedded: true)]
+class TestEmbeddedValueObject
+{
+
+    public function __construct(protected string $value = '')
+    {
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/TestEmbeddedValueObject.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/TestEmbeddedValueObject.php
@@ -19,7 +19,6 @@ use Neos\Flow\Annotations as Flow;
 #[Flow\ValueObject(embedded: true)]
 class TestEmbeddedValueObject
 {
-
     public function __construct(protected string $value = '')
     {
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/TestEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/TestEntity.php
@@ -1,0 +1,150 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\Fixtures\Attributes;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Flow\Tests\Functional\Persistence\Fixtures\SubEntity as ImportedSubEntity;
+
+/**
+ * A simple entity for persistence tests
+ */
+#[ORM\Table(name: 'persistence_attributes_testentity')]
+#[Flow\Entity]
+class TestEntity
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    #[Flow\Inject]
+    protected $objectManager;
+
+    #[Flow\Validate(type: 'StringLength', options: ['minimum' => 3])]
+    protected string $name = '';
+
+    #[ORM\ManyToOne(targetEntity: TestEntity::class)]
+    protected TestEntity $relatedEntity;
+
+    #[ORM\OneToMany(targetEntity: ImportedSubEntity::class, mappedBy: 'parentEntity', cascade: ['all'])]
+    protected Collection $subEntities;
+
+    #[ORM\ManyToOne]
+    protected TestValueObject $relatedValueObject;
+
+    #[Flow\Validate(type: 'NotEmpty', validationGroups: ['SomeOther'])]
+    protected string $description = 'This is some text';
+
+    protected TestEmbeddedValueObject $embeddedValueObject;
+
+    protected array $arrayProperty = [];
+
+    #[ORM\Embedded(class: TestEmbeddable::class)]
+    protected TestEmbeddable $embedded;
+
+    public function __construct()
+    {
+        $this->subEntities = new ArrayCollection();
+        $this->embedded = new TestEmbeddable('');
+        $this->embeddedValueObject = new TestEmbeddedValueObject();
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): void
+    {
+        $this->description = $description;
+    }
+
+    public function getRelatedEntity(): TestEntity
+    {
+        return $this->relatedEntity;
+    }
+
+    public function setRelatedEntity(TestEntity $relatedEntity): void
+    {
+        $this->relatedEntity = $relatedEntity;
+    }
+
+    /**
+     * @return Collection<ImportedSubEntity>
+     */
+    public function getSubEntities(): Collection
+    {
+        return $this->subEntities;
+    }
+
+    public function setSubEntities(Collection $subEntities): void
+    {
+        $this->subEntities = $subEntities;
+    }
+
+    public function getRelatedValueObject(): TestValueObject
+    {
+        return $this->relatedValueObject;
+    }
+
+    public function setRelatedValueObject(TestValueObject $relatedValueObject): void
+    {
+        $this->relatedValueObject = $relatedValueObject;
+    }
+
+    public function getEmbeddedValueObject(): TestEmbeddedValueObject
+    {
+        return $this->embeddedValueObject;
+    }
+
+    public function setEmbeddedValueObject(TestEmbeddedValueObject $embeddedValueObject): void
+    {
+        $this->embeddedValueObject = $embeddedValueObject;
+    }
+
+    public function getArrayProperty(): array
+    {
+        return $this->arrayProperty;
+    }
+
+    public function sayHello(): string
+    {
+        return 'Hello';
+    }
+
+    public function setArrayProperty(array $arrayProperty): void
+    {
+        $this->arrayProperty = $arrayProperty;
+    }
+
+    public function getEmbedded(): TestEmbeddable
+    {
+        return $this->embedded;
+    }
+
+    public function setEmbedded(TestEmbeddable $embedded): void
+    {
+        $this->embedded = $embedded;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/TestValueObject.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/TestValueObject.php
@@ -1,0 +1,27 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\Fixtures\Attributes;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A simple value object for persistence tests
+ */
+#[ORM\Table(name: 'persistence_attributes_testvalueobject')]
+#[Flow\ValueObject(embedded: false)]
+class TestValueObject
+{
+    public function __construct(protected string $value)
+    {
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/UnproxiedTestEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes/UnproxiedTestEntity.php
@@ -1,0 +1,47 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\Fixtures\Attributes;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Utility\Algorithms;
+
+/**
+ * A simple entity for persistence tests that is not proxied (no AOP/DI)
+ */
+#[Flow\Entity]
+#[Flow\Proxy(false)]
+#[ORM\Table(name: "persistence_attributes_unproxiedtestentity")]
+class UnproxiedTestEntity
+{
+    #[ORM\Id]
+    #[ORM\Column(length: 40)]
+    protected string $uuid;
+
+    #[Flow\Validate(type: 'StringLength', options: [['minimum' => 3]])]
+    protected string $name = '';
+
+    public function __construct()
+    {
+        $this->uuid = Algorithms::generateUUID();
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+}


### PR DESCRIPTION
Currently, it is not possible to use modern php8 attributes for doctrine. As the ReflectionService already support both annotations and attributes, switching from reader to ReflectionService solves the problem.
I found this issue #2402 but changing the driver completely would be too breaking. I think we need a version that supports both attributes and annotations for a smooth migration.

** Target branch**
This PR currently targets the 8.0 branch, however I believe that it should be 7.3 instead, as that also has a PHP requirement with ^8.0 and is still supported. Is that correct?

**Review instructions**
I use the following `rector.php` to update the classes for the functional tests:
```
<?php

declare(strict_types=1);

use Neos\Flow\Annotations as Flow;
use Rector\Config\RectorConfig;
use Rector\Doctrine\Set\DoctrineSetList;
use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
use Rector\Php80\ValueObject\AnnotationToAttribute;
use Rector\Set\ValueObject\LevelSetList;

return static function (RectorConfig $rectorConfig): void {
    $rectorConfig->paths([
        __DIR__ . '/Packages/Framework/Neos.Flow/Tests/Functional/Persistence/Fixtures/Attributes',
        __FILE__,
    ]);

    $rectorConfig->import(LevelSetList::UP_TO_PHP_80);
    $rectorConfig->importNames();

    $rectorConfig->sets([
        DoctrineSetList::ANNOTATIONS_TO_ATTRIBUTES,
    ]);

    $rectorConfig->ruleWithConfiguration(AnnotationToAttributeRector::class, [
        new AnnotationToAttribute(Flow\After::class),
        new AnnotationToAttribute(Flow\AfterReturning::class),
        new AnnotationToAttribute(Flow\AfterThrowing::class),
        new AnnotationToAttribute(Flow\Around::class),
        new AnnotationToAttribute(Flow\Aspect::class),
        new AnnotationToAttribute(Flow\Autowiring::class),
        new AnnotationToAttribute(Flow\Before::class),
        new AnnotationToAttribute(Flow\CompileStatic::class),
        new AnnotationToAttribute(Flow\Entity::class),
        new AnnotationToAttribute(Flow\FlushesCaches::class),
        new AnnotationToAttribute(Flow\Identity::class),
        new AnnotationToAttribute(Flow\IgnoreValidation::class),
        new AnnotationToAttribute(Flow\Inject::class),
        new AnnotationToAttribute(Flow\InjectConfiguration::class),
        new AnnotationToAttribute(Flow\Internal::class),
        new AnnotationToAttribute(Flow\Introduce::class),
        new AnnotationToAttribute(Flow\Lazy::class),
        new AnnotationToAttribute(Flow\MapRequestBody::class),
        new AnnotationToAttribute(Flow\Pointcut::class),
        new AnnotationToAttribute(Flow\Proxy::class),
        new AnnotationToAttribute(Flow\Scope::class),
        new AnnotationToAttribute(Flow\Session::class),
        new AnnotationToAttribute(Flow\Signal::class),
        new AnnotationToAttribute(Flow\SkipCsrfProtection::class),
        new AnnotationToAttribute(Flow\Transient::class),
        new AnnotationToAttribute(Flow\Validate::class),
        new AnnotationToAttribute(Flow\ValidationGroups::class),
        new AnnotationToAttribute(Flow\ValueObject::class),
    ]);
};
```


**Checklist**

- [ x ] Code follows the PSR-2 coding style
- [ x ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ x ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
