### PR TITLE
TASK: Add type hints and minimal cleanup in configuration builder

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Configuration/Configuration.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/Configuration.php
@@ -11,7 +11,6 @@ namespace Neos\Flow\ObjectManagement\Configuration;
  * source code.
  */
 
-use InvalidArgumentException;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Configuration\Exception\InvalidConfigurationException;
 
@@ -127,7 +126,7 @@ class Configuration
         }
 
         $this->objectName = $objectName;
-        $this->className = ($className ?? $objectName);
+        $this->className = $className;
     }
 
     /**
@@ -224,12 +223,12 @@ class Configuration
      *
      * @param string $methodName The factory method name
      * @return void
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      */
     public function setFactoryMethodName(string $methodName): void
     {
         if ($methodName === '') {
-            throw new InvalidArgumentException('No valid factory method name specified.', 1229700126);
+            throw new \InvalidArgumentException('No valid factory method name specified.', 1229700126);
         }
         $this->factoryMethodName = $methodName;
     }

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/Configuration.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/Configuration.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\ObjectManagement\Configuration;
  * source code.
  */
 
+use InvalidArgumentException;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Configuration\Exception\InvalidConfigurationException;
 
@@ -21,89 +22,94 @@ use Neos\Flow\Configuration\Exception\InvalidConfigurationException;
  */
 class Configuration
 {
-    const AUTOWIRING_MODE_OFF = 0;
-    const AUTOWIRING_MODE_ON = 1;
+    public const AUTOWIRING_MODE_OFF = 0;
 
-    const SCOPE_PROTOTYPE = 1;
-    const SCOPE_SINGLETON = 2;
-    const SCOPE_SESSION = 3;
+    public const AUTOWIRING_MODE_ON = 1;
+
+    public const SCOPE_PROTOTYPE = 1;
+
+    public const SCOPE_SINGLETON = 2;
+
+    public const SCOPE_SESSION = 3;
 
     /**
      * Name of the object
+     *
      * @var string $objectName
      */
-    protected $objectName;
+    protected string $objectName;
 
     /**
      * Name of the class the object is based on
+     *
      * @var string $className
      */
-    protected $className;
+    protected string $className;
 
     /**
      * Key of the package the specified object is part of
      * @var string
      */
-    protected $packageKey;
+    protected string $packageKey = '';
 
     /**
      * If set, specifies the factory object name used to create this object
      * @var string
      */
-    protected $factoryObjectName = '';
+    protected string $factoryObjectName = '';
 
     /**
      * Name of the factory method.
      * @var string
      */
-    protected $factoryMethodName = '';
+    protected string $factoryMethodName = '';
 
     /**
      * Arguments of the factory method
      * @var array
      */
-    protected $factoryArguments = [];
+    protected array $factoryArguments = [];
 
     /**
-     * @var string
+     * @var int
      */
-    protected $scope = self::SCOPE_PROTOTYPE;
+    protected int $scope = self::SCOPE_PROTOTYPE;
 
     /**
      * Arguments of the constructor detected by reflection
      * @var array
      */
-    protected $arguments = [];
+    protected array $arguments = [];
 
     /**
      * Array of properties which are injected into the object
      * @var array
      */
-    protected $properties = [];
+    protected array $properties = [];
 
     /**
      * Mode of the autowiring feature. One of the AUTOWIRING_MODE_* constants
-     * @var integer
+     * @var int
      */
-    protected $autowiring = self::AUTOWIRING_MODE_ON;
+    protected int $autowiring = self::AUTOWIRING_MODE_ON;
 
     /**
      * Name of the method to call during the initialization of the object (after dependencies are injected)
      * @var string
      */
-    protected $lifecycleInitializationMethodName = 'initializeObject';
+    protected string $lifecycleInitializationMethodName = 'initializeObject';
 
     /**
      * Name of the method to call during the shutdown of the framework
      * @var string
      */
-    protected $lifecycleShutdownMethodName = 'shutdownObject';
+    protected string $lifecycleShutdownMethodName = 'shutdownObject';
 
     /**
      * Information about where this configuration has been created. Used in error messages to make debugging easier.
      * @var string
      */
-    protected $configurationSourceHint = '< unknown >';
+    protected string $configurationSourceHint = '< unknown >';
 
     /**
      * The constructor
@@ -111,7 +117,7 @@ class Configuration
      * @param string $objectName The unique identifier of the object
      * @param string $className Name of the class which provides the functionality of this object
      */
-    public function __construct($objectName, $className = null)
+    public function __construct(string $objectName, string $className)
     {
         $backtrace = debug_backtrace();
         if (isset($backtrace[1]['object'])) {
@@ -121,7 +127,7 @@ class Configuration
         }
 
         $this->objectName = $objectName;
-        $this->className = ($className === null ? $objectName : $className);
+        $this->className = ($className ?? $objectName);
     }
 
     /**
@@ -130,10 +136,9 @@ class Configuration
      * @param string $objectName
      * @return void
      */
-    public function setObjectName($objectName)
+    public function setObjectName(string $objectName): void
     {
         $this->objectName = $objectName;
-        ;
     }
 
     /**
@@ -141,7 +146,7 @@ class Configuration
      *
      * @return string object name
      */
-    public function getObjectName()
+    public function getObjectName(): string
     {
         return $this->objectName;
     }
@@ -152,7 +157,7 @@ class Configuration
      * @param string $className Name of the class which provides the functionality for this object
      * @return void
      */
-    public function setClassName($className)
+    public function setClassName(string $className): void
     {
         $this->className = $className;
     }
@@ -162,7 +167,7 @@ class Configuration
      *
      * @return string Name of the implementing class of this object
      */
-    public function getClassName()
+    public function getClassName(): string
     {
         return $this->className;
     }
@@ -173,7 +178,7 @@ class Configuration
      * @param string $packageKey Key of the package this object is part of
      * @return void
      */
-    public function setPackageKey($packageKey)
+    public function setPackageKey(string $packageKey): void
     {
         $this->packageKey = $packageKey;
     }
@@ -183,7 +188,7 @@ class Configuration
      *
      * @return string Key of the package this object is part of
      */
-    public function getPackageKey()
+    public function getPackageKey(): string
     {
         return $this->packageKey;
     }
@@ -194,7 +199,7 @@ class Configuration
      * @param string $objectName Valid object name of a factory
      * @return void
      */
-    public function setFactoryObjectName($objectName)
+    public function setFactoryObjectName(string $objectName): void
     {
         $this->factoryObjectName = $objectName;
         if ($this->factoryMethodName === '') {
@@ -209,7 +214,7 @@ class Configuration
      *
      * @return string The factory class name
      */
-    public function getFactoryObjectName()
+    public function getFactoryObjectName(): string
     {
         return $this->factoryObjectName;
     }
@@ -219,12 +224,12 @@ class Configuration
      *
      * @param string $methodName The factory method name
      * @return void
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
-    public function setFactoryMethodName($methodName)
+    public function setFactoryMethodName(string $methodName): void
     {
-        if (!is_string($methodName) || $methodName === '') {
-            throw new \InvalidArgumentException('No valid factory method name specified.', 1229700126);
+        if ($methodName === '') {
+            throw new InvalidArgumentException('No valid factory method name specified.', 1229700126);
         }
         $this->factoryMethodName = $methodName;
     }
@@ -234,7 +239,7 @@ class Configuration
      *
      * @return string The factory method name
      */
-    public function getFactoryMethodName()
+    public function getFactoryMethodName(): string
     {
         return $this->factoryMethodName;
     }
@@ -244,7 +249,7 @@ class Configuration
      *
      * @return boolean
      */
-    public function isCreatedByFactory()
+    public function isCreatedByFactory(): bool
     {
         return ($this->factoryObjectName !== '' || $this->factoryMethodName !== '');
     }
@@ -255,7 +260,7 @@ class Configuration
      * @param integer $scope Name of the scope
      * @return void
      */
-    public function setScope($scope)
+    public function setScope(int $scope): void
     {
         $this->scope = $scope;
     }
@@ -263,9 +268,9 @@ class Configuration
     /**
      * Returns the scope for this object
      *
-     * @return string The scope, one of the SCOPE constants
+     * @return int The scope, one of the SCOPE constants
      */
-    public function getScope()
+    public function getScope(): int
     {
         return $this->scope;
     }
@@ -276,7 +281,7 @@ class Configuration
      * @param integer $autowiring One of the AUTOWIRING_MODE_* constants
      * @return void
      */
-    public function setAutowiring($autowiring)
+    public function setAutowiring(int $autowiring): void
     {
         $this->autowiring = $autowiring;
     }
@@ -286,7 +291,7 @@ class Configuration
      *
      * @return integer Value of one of the AUTOWIRING_MODE_* constants
      */
-    public function getAutowiring()
+    public function getAutowiring(): int
     {
         return $this->autowiring;
     }
@@ -297,7 +302,7 @@ class Configuration
      * @param string $lifecycleInitializationMethodName Name of the method to call after setter injection
      * @return void
      */
-    public function setLifecycleInitializationMethodName($lifecycleInitializationMethodName)
+    public function setLifecycleInitializationMethodName(string $lifecycleInitializationMethodName): void
     {
         $this->lifecycleInitializationMethodName = $lifecycleInitializationMethodName;
     }
@@ -307,7 +312,7 @@ class Configuration
      *
      * @return string The name of the initialization method
      */
-    public function getLifecycleInitializationMethodName()
+    public function getLifecycleInitializationMethodName(): string
     {
         return $this->lifecycleInitializationMethodName;
     }
@@ -318,7 +323,7 @@ class Configuration
      * @param string $lifecycleShutdownMethodName Name of the method to call during shutdown of the framework
      * @return void
      */
-    public function setLifecycleShutdownMethodName($lifecycleShutdownMethodName)
+    public function setLifecycleShutdownMethodName(string $lifecycleShutdownMethodName): void
     {
         $this->lifecycleShutdownMethodName = $lifecycleShutdownMethodName;
     }
@@ -328,7 +333,7 @@ class Configuration
      *
      * @return string The name of the shutdown method
      */
-    public function getLifecycleShutdownMethodName()
+    public function getLifecycleShutdownMethodName(): string
     {
         return $this->lifecycleShutdownMethodName;
     }
@@ -341,7 +346,7 @@ class Configuration
      * @throws InvalidConfigurationException
      * @return void
      */
-    public function setProperties(array $properties)
+    public function setProperties(array $properties): void
     {
         if ($properties === []) {
             $this->properties = [];
@@ -350,7 +355,7 @@ class Configuration
                 if ($value instanceof ConfigurationProperty) {
                     $this->setProperty($value);
                 } else {
-                    throw new InvalidConfigurationException(sprintf('Only ConfigurationProperty instances are allowed, "%s" given', is_object($value) ? get_class($value) : gettype($value)), 1449217567);
+                    throw new InvalidConfigurationException(sprintf('Only ConfigurationProperty instances are allowed, "%s" given', get_debug_type($value)), 1449217567);
                 }
             }
         }
@@ -361,7 +366,7 @@ class Configuration
      *
      * @return array<ConfigurationProperty>
      */
-    public function getProperties()
+    public function getProperties(): array
     {
         return $this->properties;
     }
@@ -372,7 +377,7 @@ class Configuration
      * @param ConfigurationProperty $property
      * @return void
      */
-    public function setProperty(ConfigurationProperty $property)
+    public function setProperty(ConfigurationProperty $property): void
     {
         $this->properties[$property->getName()] = $property;
     }
@@ -385,7 +390,7 @@ class Configuration
      * @throws InvalidConfigurationException
      * @return void
      */
-    public function setArguments(array $arguments)
+    public function setArguments(array $arguments): void
     {
         if ($arguments === []) {
             $this->arguments = [];
@@ -394,7 +399,7 @@ class Configuration
                 if ($argument instanceof ConfigurationArgument) {
                     $this->setArgument($argument);
                 } else {
-                    throw new InvalidConfigurationException(sprintf('Only ConfigurationArgument instances are allowed, "%s" given', is_object($argument) ? get_class($argument) : gettype($argument)), 1449217803);
+                    throw new InvalidConfigurationException(sprintf('Only ConfigurationArgument instances are allowed, "%s" given', get_debug_type($argument)), 1449217803);
                 }
             }
         }
@@ -406,7 +411,7 @@ class Configuration
      * @param ConfigurationArgument $argument The argument
      * @return void
      */
-    public function setArgument(ConfigurationArgument $argument)
+    public function setArgument(ConfigurationArgument $argument): void
     {
         $this->arguments[$argument->getIndex()] = $argument;
     }
@@ -416,7 +421,7 @@ class Configuration
      *
      * @return array<ConfigurationArgument> A sorted array of ConfigurationArgument objects with the argument position as index
      */
-    public function getArguments()
+    public function getArguments(): array
     {
         if (count($this->arguments) < 1) {
             return [];
@@ -438,7 +443,7 @@ class Configuration
      * @param ConfigurationArgument $argument The argument
      * @return void
      */
-    public function setFactoryArgument(ConfigurationArgument $argument)
+    public function setFactoryArgument(ConfigurationArgument $argument): void
     {
         $this->factoryArguments[$argument->getIndex()] = $argument;
     }
@@ -448,7 +453,7 @@ class Configuration
      *
      * @return array<ConfigurationArgument> A sorted array of ConfigurationArgument objects with the argument position as index
      */
-    public function getFactoryArguments()
+    public function getFactoryArguments(): array
     {
         if (count($this->factoryArguments) < 1) {
             return [];
@@ -470,7 +475,7 @@ class Configuration
      * @param string $hint The hint - e.g. the filename of the configuration file
      * @return void
      */
-    public function setConfigurationSourceHint($hint)
+    public function setConfigurationSourceHint(string $hint): void
     {
         $this->configurationSourceHint = $hint;
     }
@@ -480,7 +485,7 @@ class Configuration
      *
      * @return string The hint - e.g. the filename of the configuration file
      */
-    public function getConfigurationSourceHint()
+    public function getConfigurationSourceHint(): string
     {
         return $this->configurationSourceHint;
     }

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationArgument.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationArgument.php
@@ -78,7 +78,7 @@ class ConfigurationArgument
     /**
      * Returns the index (position) of the argument
      *
-     * @return string Index of the argument
+     * @return int Index of the argument
      */
     public function getIndex(): int
     {

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationArgument.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationArgument.php
@@ -20,40 +20,42 @@ use Neos\Flow\Annotations as Flow;
  */
 class ConfigurationArgument
 {
-    const ARGUMENT_TYPES_STRAIGHTVALUE = 0;
-    const ARGUMENT_TYPES_OBJECT = 1;
-    const ARGUMENT_TYPES_SETTING = 2;
+    public const ARGUMENT_TYPES_STRAIGHTVALUE = 0;
+
+    public const ARGUMENT_TYPES_OBJECT = 1;
+
+    public const ARGUMENT_TYPES_SETTING = 2;
 
     /**
      * The position of the constructor argument. Counting starts at "1".
      * @var integer
      */
-    protected $index;
+    protected int $index;
 
     /**
      * @var mixed The argument's value
      */
-    protected $value;
+    protected mixed $value;
 
     /**
      * Argument type, one of the ARGUMENT_TYPES_* constants
      * @var integer
      */
-    protected $type;
+    protected int $type;
 
     /**
      * @var integer
      */
-    protected $autowiring = Configuration::AUTOWIRING_MODE_ON;
+    protected int $autowiring = Configuration::AUTOWIRING_MODE_ON;
 
     /**
      * Constructor - sets the index, value and type of the argument
      *
-     * @param string $index Index of the argument
+     * @param int $index Index of the argument
      * @param mixed $value Value of the argument
      * @param integer $type Type of the argument - one of the argument_TYPE_* constants
      */
-    public function __construct($index, $value, $type = self::ARGUMENT_TYPES_STRAIGHTVALUE)
+    public function __construct(int $index, mixed $value, int $type = self::ARGUMENT_TYPES_STRAIGHTVALUE)
     {
         $this->set($index, $value, $type);
     }
@@ -66,7 +68,7 @@ class ConfigurationArgument
      * @param integer $type Type of the argument - one of the ARGUMENT_TYPE_* constants
      * @return void
      */
-    public function set($index, $value, $type = self::ARGUMENT_TYPES_STRAIGHTVALUE)
+    public function set(int $index, mixed $value, int $type = self::ARGUMENT_TYPES_STRAIGHTVALUE): void
     {
         $this->index = $index;
         $this->value = $value;
@@ -78,7 +80,7 @@ class ConfigurationArgument
      *
      * @return string Index of the argument
      */
-    public function getIndex()
+    public function getIndex(): int
     {
         return $this->index;
     }
@@ -88,7 +90,7 @@ class ConfigurationArgument
      *
      * @return mixed Value of the argument
      */
-    public function getValue()
+    public function getValue(): mixed
     {
         return $this->value;
     }
@@ -98,7 +100,7 @@ class ConfigurationArgument
      *
      * @return integer Type of the argument - one of the ARGUMENT_TYPES_* constants
      */
-    public function getType()
+    public function getType(): int
     {
         return $this->type;
     }
@@ -109,7 +111,7 @@ class ConfigurationArgument
      * @param integer $autowiring One of the Configuration::AUTOWIRING_MODE_* constants
      * @return void
      */
-    public function setAutowiring($autowiring)
+    public function setAutowiring(int $autowiring): void
     {
         $this->autowiring = $autowiring;
     }
@@ -119,7 +121,7 @@ class ConfigurationArgument
      *
      * @return integer Value of one of the Configuration::AUTOWIRING_MODE_* constants
      */
-    public function getAutowiring()
+    public function getAutowiring(): int
     {
         return $this->autowiring;
     }

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
@@ -166,7 +166,7 @@ class ConfigurationBuilder
                 }
 
                 $objectConfigurations[$objectName] = $newObjectConfiguration;
-                if ($objectConfigurations[$objectName]->getPackageKey() === null) {
+                if ($objectConfigurations[$objectName]->getPackageKey() === '') {
                     $objectConfigurations[$objectName]->setPackageKey($packageKey);
                 }
             }
@@ -220,7 +220,7 @@ class ConfigurationBuilder
      * @return Configuration The object configuration object
      * @throws InvalidObjectConfigurationException if errors occurred during parsing
      */
-    protected function parseConfigurationArray($objectName, array $rawConfigurationOptions, $configurationSourceHint = '', $existingObjectConfiguration = null)
+    protected function parseConfigurationArray(string $objectName, array $rawConfigurationOptions, string $configurationSourceHint = '', $existingObjectConfiguration = null): Configuration
     {
         $className = $rawConfigurationOptions['className'] ?? $objectName;
         $objectConfiguration = ($existingObjectConfiguration instanceof Configuration) ? $existingObjectConfiguration : new Configuration($objectName, $className);
@@ -353,7 +353,7 @@ class ConfigurationBuilder
                     $objectName = $annotations[0];
                 }
             }
-            $objectConfiguration = $this->parseConfigurationArray($objectName, $objectNameOrConfiguration, $parentObjectConfiguration->getConfigurationSourceHint() . ', property "' . $propertyName . '"');
+            $objectConfiguration = $this->parseConfigurationArray((string)$objectName, $objectNameOrConfiguration, $parentObjectConfiguration->getConfigurationSourceHint() . ', property "' . $propertyName . '"');
             $property = new ConfigurationProperty($propertyName, $objectConfiguration, ConfigurationProperty::PROPERTY_TYPES_OBJECT);
         } else {
             $property = new ConfigurationProperty($propertyName, $objectNameOrConfiguration, ConfigurationProperty::PROPERTY_TYPES_OBJECT);
@@ -383,7 +383,7 @@ class ConfigurationBuilder
                     throw new InvalidObjectConfigurationException('Object configuration for argument "' . $argumentName . '" contains neither object name nor factory object or method name in ' . $configurationSourceHint, 1417431742);
                 }
             }
-            $objectConfiguration = $this->parseConfigurationArray($objectName, $objectNameOrConfiguration, $configurationSourceHint . ', argument "' . $argumentName . '"');
+            $objectConfiguration = $this->parseConfigurationArray((string)$objectName, $objectNameOrConfiguration, $configurationSourceHint . ', argument "' . $argumentName . '"');
             $argument = new ConfigurationArgument($argumentName, $objectConfiguration, ConfigurationArgument::ARGUMENT_TYPES_OBJECT);
         } else {
             $argument = new ConfigurationArgument($argumentName, $objectNameOrConfiguration, ConfigurationArgument::ARGUMENT_TYPES_OBJECT);
@@ -431,9 +431,6 @@ class ConfigurationBuilder
                 }
                 $argumentObjectName = $objectConfiguration->getObjectName() . ':argument:' . $index;
                 $argumentValue->setObjectName($argumentObjectName);
-                if ($argumentValue->getClassName() === null) {
-                    $argumentValue->setClassName('');
-                }
                 $objectConfigurations[$argumentObjectName] = $argument->getValue();
                 $argument->set((int)$argument->getIndex(), $argumentObjectName, $argument->getType());
             }

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
@@ -24,7 +24,6 @@ use Neos\Flow\ObjectManagement\Exception\UnresolvedDependenciesException;
 use Neos\Flow\ObjectManagement\ObjectManager;
 use Neos\Flow\Reflection\ReflectionService;
 use Psr\Log\LoggerInterface;
-use TypeError;
 
 /**
  * Object Configuration Builder which can build object configuration objects
@@ -314,7 +313,7 @@ class ConfigurationBuilder
      * @return integer The autowiring option translated into one of Configuration::AUTOWIRING_MODE_*
      * @throws InvalidObjectConfigurationException if an invalid option has been specified
      */
-    protected static function parseAutowiring(bool|int $value): int
+    protected static function parseAutowiring(mixed $value): int
     {
         return match ($value) {
             true, Configuration::AUTOWIRING_MODE_ON => Configuration::AUTOWIRING_MODE_ON,
@@ -523,7 +522,7 @@ class ConfigurationBuilder
 
             try {
                 $classMethodNames = get_class_methods($className);
-            } catch (TypeError $error) {
+            } catch (\TypeError $error) {
                 throw new UnknownClassException(sprintf('The class "%s" defined in the object configuration for object "%s", defined in package: %s, does not exist.', $className, $objectConfiguration->getObjectName(), $objectConfiguration->getPackageKey()), 1352371372);
             }
             foreach ($classMethodNames as $methodName) {

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationProperty.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationProperty.php
@@ -20,43 +20,44 @@ use Neos\Flow\Annotations as Flow;
  */
 class ConfigurationProperty
 {
-    const PROPERTY_TYPES_STRAIGHTVALUE = 0;
-    const PROPERTY_TYPES_OBJECT = 1;
-    const PROPERTY_TYPES_CONFIGURATION = 2;
-    const PROPERTY_TYPES_CACHE = 3;
+    public const PROPERTY_TYPES_STRAIGHTVALUE = 0;
+    public const PROPERTY_TYPES_OBJECT = 1;
+    public const PROPERTY_TYPES_CONFIGURATION = 2;
+    public const PROPERTY_TYPES_CACHE = 3;
 
     /**
      * @var string Name of the property
      */
-    protected $name;
+    protected string $name;
 
     /**
      * @var mixed Value of the property
      */
-    protected $value;
+    protected mixed $value;
 
     /**
      * @var integer Type of the property - one of the PROPERTY_TYPE_* constants
      */
-    protected $type;
+    protected int $type = self::PROPERTY_TYPES_STRAIGHTVALUE;
 
     /**
      * If specified, this configuration is used for instantiating / retrieving an property of type object
-     * @var Configuration
+     *
+     * @var Configuration|null
      */
-    protected $objectConfiguration = null;
+    protected ?Configuration $objectConfiguration = null;
 
     /**
      * @var integer
      */
-    protected $autowiring = Configuration::AUTOWIRING_MODE_ON;
+    protected int $autowiring = Configuration::AUTOWIRING_MODE_ON;
 
     /**
      * Should this property be lazy loaded
      *
      * @var boolean
      */
-    protected $lazyLoading = true;
+    protected bool $lazyLoading = true;
 
     /**
      * Constructor - sets the name, type and value of the property
@@ -64,10 +65,10 @@ class ConfigurationProperty
      * @param string $name Name of the property
      * @param mixed $value Value of the property
      * @param integer $type Type of the property - one of the PROPERTY_TYPE_* constants
-     * @param Configuration $objectConfiguration If $type is OBJECT, a custom object configuration may be specified
+     * @param Configuration|null $objectConfiguration If $type is OBJECT, a custom object configuration may be specified
      * @param boolean $lazyLoading
      */
-    public function __construct($name, $value, $type = self::PROPERTY_TYPES_STRAIGHTVALUE, $objectConfiguration = null, $lazyLoading = true)
+    public function __construct(string $name, mixed $value, int $type = self::PROPERTY_TYPES_STRAIGHTVALUE, ?Configuration $objectConfiguration = null, bool $lazyLoading = true)
     {
         $this->set($name, $value, $type, $objectConfiguration, $lazyLoading);
     }
@@ -78,11 +79,11 @@ class ConfigurationProperty
      * @param string $name Name of the property
      * @param mixed $value Value of the property
      * @param integer $type Type of the property - one of the PROPERTY_TYPE_* constants
-     * @param Configuration $objectConfiguration If $type is OBJECT, a custom object configuration may be specified
+     * @param Configuration|null $objectConfiguration If $type is OBJECT, a custom object configuration may be specified
      * @param boolean $lazyLoading
      * @return void
      */
-    public function set($name, $value, $type = self::PROPERTY_TYPES_STRAIGHTVALUE, $objectConfiguration = null, $lazyLoading = true)
+    public function set(string $name, mixed $value, int $type = self::PROPERTY_TYPES_STRAIGHTVALUE, ?Configuration $objectConfiguration = null, bool $lazyLoading = true)
     {
         $this->name = $name;
         $this->value = $value;
@@ -96,7 +97,7 @@ class ConfigurationProperty
      *
      * @return string Name of the property
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -106,7 +107,7 @@ class ConfigurationProperty
      *
      * @return mixed Value of the property
      */
-    public function getValue()
+    public function getValue(): mixed
     {
         return $this->value;
     }
@@ -116,7 +117,7 @@ class ConfigurationProperty
      *
      * @return integer Type of the property
      */
-    public function getType()
+    public function getType(): int
     {
         return $this->type;
     }
@@ -126,7 +127,7 @@ class ConfigurationProperty
      *
      * @return Configuration|null The object configuration or NULL
      */
-    public function getObjectConfiguration()
+    public function getObjectConfiguration(): ?Configuration
     {
         return $this->objectConfiguration;
     }
@@ -137,7 +138,7 @@ class ConfigurationProperty
      * @param integer $autowiring One of the Configuration::AUTOWIRING_MODE_* constants
      * @return void
      */
-    public function setAutowiring($autowiring)
+    public function setAutowiring(int $autowiring): void
     {
         $this->autowiring = $autowiring;
     }
@@ -147,7 +148,7 @@ class ConfigurationProperty
      *
      * @return integer Value of one of the Configuration::AUTOWIRING_MODE_* constants
      */
-    public function getAutowiring()
+    public function getAutowiring(): int
     {
         return $this->autowiring;
     }
@@ -157,7 +158,7 @@ class ConfigurationProperty
      *
      * @return boolean
      */
-    public function isLazyLoading()
+    public function isLazyLoading(): bool
     {
         return $this->lazyLoading;
     }

--- a/Neos.Flow/Classes/ObjectManagement/DependencyInjection/DependencyProxy.php
+++ b/Neos.Flow/Classes/ObjectManagement/DependencyInjection/DependencyProxy.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\ObjectManagement\DependencyInjection;
  * source code.
  */
 
+use Closure;
 use Neos\Flow\Annotations as Flow;
 
 /**
@@ -24,25 +25,25 @@ class DependencyProxy
     /**
      * @var string
      */
-    protected $className;
+    protected string $className;
 
     /**
-     * @var \Closure
+     * @var Closure
      */
-    protected $builder;
+    protected Closure $builder;
 
     /**
      * @var array
      */
-    protected $propertyVariables = [];
+    protected array $propertyVariables = [];
 
     /**
      * Constructs this proxy
      *
      * @param string $className Implementation class name of the dependency to proxy
-     * @param \Closure $builder The closure which eventually builds the dependency
+     * @param Closure $builder The closure which eventually builds the dependency
      */
-    public function __construct($className, \Closure $builder)
+    public function __construct(string $className, Closure $builder)
     {
         $this->className = $className;
         $this->builder = $builder;
@@ -54,7 +55,7 @@ class DependencyProxy
      * @return object The real dependency object
      * @api
      */
-    public function _activateDependency()
+    public function _activateDependency(): object
     {
         $realDependency = $this->builder->__invoke();
         foreach ($this->propertyVariables as &$propertyVariable) {
@@ -69,7 +70,7 @@ class DependencyProxy
      * @return string Fully qualified class name of the proxied object
      * @api
      */
-    public function _getClassName()
+    public function _getClassName(): string
     {
         return $this->className;
     }
@@ -81,7 +82,7 @@ class DependencyProxy
      * @param mixed &$propertyVariable The variable to replace
      * @return void
      */
-    public function _addPropertyVariable(&$propertyVariable)
+    public function _addPropertyVariable(mixed &$propertyVariable): void
     {
         $this->propertyVariables[] = &$propertyVariable;
     }
@@ -94,7 +95,7 @@ class DependencyProxy
      * @param array $arguments An array of arguments to be passed to the method
      * @return mixed
      */
-    public function __call($methodName, array $arguments)
+    public function __call(string $methodName, array $arguments): mixed
     {
         return $this->_activateDependency()->$methodName(...$arguments);
     }

--- a/Neos.Flow/Classes/ObjectManagement/DependencyInjection/DependencyProxy.php
+++ b/Neos.Flow/Classes/ObjectManagement/DependencyInjection/DependencyProxy.php
@@ -11,7 +11,6 @@ namespace Neos\Flow\ObjectManagement\DependencyInjection;
  * source code.
  */
 
-use Closure;
 use Neos\Flow\Annotations as Flow;
 
 /**
@@ -28,9 +27,9 @@ class DependencyProxy
     protected string $className;
 
     /**
-     * @var Closure
+     * @var \Closure
      */
-    protected Closure $builder;
+    protected \Closure $builder;
 
     /**
      * @var array
@@ -41,9 +40,9 @@ class DependencyProxy
      * Constructs this proxy
      *
      * @param string $className Implementation class name of the dependency to proxy
-     * @param Closure $builder The closure which eventually builds the dependency
+     * @param \Closure $builder The closure which eventually builds the dependency
      */
-    public function __construct(string $className, Closure $builder)
+    public function __construct(string $className, \Closure $builder)
     {
         $this->className = $className;
         $this->builder = $builder;

--- a/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
@@ -13,8 +13,6 @@ namespace Neos\Flow\ObjectManagement;
  * source code.
  */
 
-use Closure;
-use InvalidArgumentException;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Configuration\Exception\InvalidConfigurationTypeException;
 use Neos\Flow\ObjectManagement\Configuration\Configuration as ObjectConfiguration;
@@ -23,7 +21,6 @@ use Neos\Flow\Core\ApplicationContext;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\DependencyInjection\DependencyProxy;
 use Neos\Flow\Security\Context;
-use SplObjectStorage;
 
 /**
  * Object Manager
@@ -81,17 +78,17 @@ class ObjectManager implements ObjectManagerInterface
      * A SplObjectStorage containing those objects which need to be shutdown when the container
      * shuts down. Each value of each entry is the respective shutdown method name.
      *
-     * @var SplObjectStorage
+     * @var \SplObjectStorage
      */
-    protected SplObjectStorage $shutdownObjects;
+    protected \SplObjectStorage $shutdownObjects;
 
     /**
      * A SplObjectStorage containing only those shutdown objects which have been registered for Flow.
      * These shutdown method will be called after all other shutdown methods have been called.
      *
-     * @var SplObjectStorage
+     * @var \SplObjectStorage
      */
-    protected SplObjectStorage $internalShutdownObjects;
+    protected \SplObjectStorage $internalShutdownObjects;
 
     /**
      * Constructor for this Object Container
@@ -101,8 +98,8 @@ class ObjectManager implements ObjectManagerInterface
     public function __construct(ApplicationContext $context)
     {
         $this->context = $context;
-        $this->shutdownObjects = new SplObjectStorage;
-        $this->internalShutdownObjects = new SplObjectStorage;
+        $this->shutdownObjects = new \SplObjectStorage;
+        $this->internalShutdownObjects = new \SplObjectStorage;
     }
 
     /**
@@ -145,7 +142,7 @@ class ObjectManager implements ObjectManagerInterface
      *
      * @param  string $objectName Name of the object
      * @return boolean true if the object has been registered, otherwise false
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      * @api
      */
     public function isRegistered($objectName): bool
@@ -155,7 +152,7 @@ class ObjectManager implements ObjectManagerInterface
         }
 
         if ($objectName[0] === '\\') {
-            throw new InvalidArgumentException('Object names must not start with a backslash ("' . $objectName . '")', 1270827335);
+            throw new \InvalidArgumentException('Object names must not start with a backslash ("' . $objectName . '")', 1270827335);
         }
         return false;
     }
@@ -199,14 +196,14 @@ class ObjectManager implements ObjectManagerInterface
      * @return T The object instance
      * @throws Exception\CannotBuildObjectException
      * @throws Exception\UnknownObjectException if an object with the given name does not exist
-     * @throws InvalidArgumentException
+     * @throws \InvalidArgumentException
      * @throws InvalidConfigurationTypeException
      * @api
      */
     public function get($objectName, ...$constructorArguments): object
     {
         if (!empty($constructorArguments) && isset($this->objects[$objectName]) && $this->objects[$objectName][self::KEY_SCOPE] !== ObjectConfiguration::SCOPE_PROTOTYPE) {
-            throw new InvalidArgumentException('You cannot provide constructor arguments for singleton objects via get(). If you need to pass arguments to the constructor, define them in the Objects.yaml configuration.', 1298049934);
+            throw new \InvalidArgumentException('You cannot provide constructor arguments for singleton objects via get(). If you need to pass arguments to the constructor, define them in the Objects.yaml configuration.', 1298049934);
         }
 
         if (isset($this->objects[$objectName][self::KEY_INSTANCE])) {
@@ -307,7 +304,7 @@ class ObjectManager implements ObjectManagerInterface
             }
         }
         if ($className[0] === '\\') {
-            throw new InvalidArgumentException('Class names must not start with a backslash ("' . $className . '")', 1270826088);
+            throw new \InvalidArgumentException('Class names must not start with a backslash ("' . $className . '")', 1270826088);
         }
 
         return false;
@@ -425,10 +422,10 @@ class ObjectManager implements ObjectManagerInterface
      * @param string $hash An md5 hash over the code needed to actually build the dependency instance
      * @param mixed &$propertyReferenceVariable A first variable where the dependency needs to be injected into
      * @param string $className Name of the class of the dependency which eventually will be instantiated
-     * @param Closure $builder An anonymous function which creates the instance to be injected
+     * @param \Closure $builder An anonymous function which creates the instance to be injected
      * @return DependencyProxy
      */
-    public function createLazyDependency(string $hash, mixed &$propertyReferenceVariable, string $className, Closure $builder): DependencyProxy
+    public function createLazyDependency(string $hash, mixed &$propertyReferenceVariable, string $className, \Closure $builder): DependencyProxy
     {
         $this->dependencyProxies[$hash] = new DependencyProxy($className, $builder);
         $this->dependencyProxies[$hash]->_addPropertyVariable($propertyReferenceVariable);
@@ -569,10 +566,10 @@ class ObjectManager implements ObjectManagerInterface
     /**
      * Executes the methods of the provided objects.
      *
-     * @param SplObjectStorage $shutdownObjects
+     * @param \SplObjectStorage $shutdownObjects
      * @return void
      */
-    protected function callShutdownMethods(SplObjectStorage $shutdownObjects): void
+    protected function callShutdownMethods(\SplObjectStorage $shutdownObjects): void
     {
         foreach ($shutdownObjects as $object) {
             $methodName = $shutdownObjects[$object];

--- a/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
@@ -13,6 +13,8 @@ namespace Neos\Flow\ObjectManagement;
  * source code.
  */
 
+use Closure;
+use InvalidArgumentException;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Configuration\Exception\InvalidConfigurationTypeException;
 use Neos\Flow\ObjectManagement\Configuration\Configuration as ObjectConfiguration;
@@ -21,6 +23,7 @@ use Neos\Flow\Core\ApplicationContext;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\DependencyInjection\DependencyProxy;
 use Neos\Flow\Security\Context;
+use SplObjectStorage;
 
 /**
  * Object Manager
@@ -30,55 +33,65 @@ use Neos\Flow\Security\Context;
  */
 class ObjectManager implements ObjectManagerInterface
 {
+    protected const KEY_INSTANCE = 'i';
+    protected const KEY_SCOPE = 's';
+    protected const KEY_FACTORY = 'f';
+    protected const KEY_FACTORY_ARGUMENTS = 'fa';
+    protected const KEY_ARGUMENT_TYPE = 't';
+    protected const KEY_ARGUMENT_VALUE = 'v';
+    protected const KEY_CLASS_NAME = 'c';
+    protected const KEY_PACKAGE = 'p';
+    protected const KEY_LOWERCASE_NAME = 'l';
+
     /**
      * The configuration context for this Flow run
      *
      * @var ApplicationContext
      */
-    protected $context;
+    protected ApplicationContext $context;
 
     /**
      * An array of settings of all packages, indexed by package key
      *
      * @var array
      */
-    protected $allSettings;
+    protected array $allSettings = [];
 
     /**
      * @var array
      */
-    protected $objects = [];
+    protected array $objects = [];
 
     /**
      * @var array<DependencyInjection\DependencyProxy>
      */
-    protected $dependencyProxies = [];
+    protected array $dependencyProxies = [];
 
     /**
      * @var array
      */
-    protected $classesBeingInstantiated = [];
+    protected array $classesBeingInstantiated = [];
 
     /**
      * @var array
      */
-    protected $cachedLowerCasedObjectNames = [];
+    protected array $cachedLowerCasedObjectNames = [];
 
     /**
      * A SplObjectStorage containing those objects which need to be shutdown when the container
      * shuts down. Each value of each entry is the respective shutdown method name.
      *
-     * @var \SplObjectStorage
+     * @var SplObjectStorage
      */
-    protected $shutdownObjects;
+    protected SplObjectStorage $shutdownObjects;
 
     /**
      * A SplObjectStorage containing only those shutdown objects which have been registered for Flow.
      * These shutdown method will be called after all other shutdown methods have been called.
      *
-     * @var \SplObjectStorage
+     * @var SplObjectStorage
      */
-    protected $internalShutdownObjects;
+    protected SplObjectStorage $internalShutdownObjects;
 
     /**
      * Constructor for this Object Container
@@ -88,8 +101,8 @@ class ObjectManager implements ObjectManagerInterface
     public function __construct(ApplicationContext $context)
     {
         $this->context = $context;
-        $this->shutdownObjects = new \SplObjectStorage;
-        $this->internalShutdownObjects = new \SplObjectStorage;
+        $this->shutdownObjects = new SplObjectStorage;
+        $this->internalShutdownObjects = new SplObjectStorage;
     }
 
     /**
@@ -101,8 +114,8 @@ class ObjectManager implements ObjectManagerInterface
     public function setObjects(array $objects): void
     {
         $this->objects = $objects;
-        $this->objects[ObjectManagerInterface::class]['i'] = $this;
-        $this->objects[get_class($this)]['i'] = $this;
+        $this->objects[ObjectManagerInterface::class][self::KEY_INSTANCE] = $this;
+        $this->objects[get_class($this)][self::KEY_INSTANCE] = $this;
     }
 
     /**
@@ -122,7 +135,7 @@ class ObjectManager implements ObjectManagerInterface
      *
      * @return ApplicationContext The context, for example "Development" or "Production"
      */
-    public function getContext()
+    public function getContext(): ApplicationContext
     {
         return $this->context;
     }
@@ -132,17 +145,17 @@ class ObjectManager implements ObjectManagerInterface
      *
      * @param  string $objectName Name of the object
      * @return boolean true if the object has been registered, otherwise false
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @api
      */
-    public function isRegistered($objectName)
+    public function isRegistered($objectName): bool
     {
         if (isset($this->objects[$objectName])) {
             return true;
         }
 
         if ($objectName[0] === '\\') {
-            throw new \InvalidArgumentException('Object names must not start with a backslash ("' . $objectName . '")', 1270827335);
+            throw new InvalidArgumentException('Object names must not start with a backslash ("' . $objectName . '")', 1270827335);
         }
         return false;
     }
@@ -154,7 +167,7 @@ class ObjectManager implements ObjectManagerInterface
      * @param string $objectName
      * @return bool
      */
-    public function has($objectName)
+    public function has($objectName): bool
     {
         return $this->isRegistered($objectName);
     }
@@ -167,9 +180,9 @@ class ObjectManager implements ObjectManagerInterface
      * @return void
      * @api
      */
-    public function registerShutdownObject($object, $shutdownLifecycleMethodName)
+    public function registerShutdownObject($object, $shutdownLifecycleMethodName): void
     {
-        if (strpos(get_class($object), 'Neos\Flow\\') === 0) {
+        if (str_starts_with(get_class($object), 'Neos\Flow\\')) {
             $this->internalShutdownObjects[$object] = $shutdownLifecycleMethodName;
         } else {
             $this->shutdownObjects[$object] = $shutdownLifecycleMethodName;
@@ -186,27 +199,27 @@ class ObjectManager implements ObjectManagerInterface
      * @return T The object instance
      * @throws Exception\CannotBuildObjectException
      * @throws Exception\UnknownObjectException if an object with the given name does not exist
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @throws InvalidConfigurationTypeException
      * @api
      */
-    public function get($objectName, ...$constructorArguments)
+    public function get($objectName, ...$constructorArguments): object
     {
-        if (!empty($constructorArguments) && isset($this->objects[$objectName]) && $this->objects[$objectName]['s'] !== ObjectConfiguration::SCOPE_PROTOTYPE) {
-            throw new \InvalidArgumentException('You cannot provide constructor arguments for singleton objects via get(). If you need to pass arguments to the constructor, define them in the Objects.yaml configuration.', 1298049934);
+        if (!empty($constructorArguments) && isset($this->objects[$objectName]) && $this->objects[$objectName][self::KEY_SCOPE] !== ObjectConfiguration::SCOPE_PROTOTYPE) {
+            throw new InvalidArgumentException('You cannot provide constructor arguments for singleton objects via get(). If you need to pass arguments to the constructor, define them in the Objects.yaml configuration.', 1298049934);
         }
 
-        if (isset($this->objects[$objectName]['i'])) {
-            return $this->objects[$objectName]['i'];
+        if (isset($this->objects[$objectName][self::KEY_INSTANCE])) {
+            return $this->objects[$objectName][self::KEY_INSTANCE];
         }
 
-        if (isset($this->objects[$objectName]['f'])) {
-            if ($this->objects[$objectName]['s'] === ObjectConfiguration::SCOPE_PROTOTYPE) {
+        if (isset($this->objects[$objectName][self::KEY_FACTORY])) {
+            if ($this->objects[$objectName][self::KEY_SCOPE] === ObjectConfiguration::SCOPE_PROTOTYPE) {
                 return $this->buildObjectByFactory($objectName);
             }
 
-            $this->objects[$objectName]['i'] = $this->buildObjectByFactory($objectName);
-            return $this->objects[$objectName]['i'];
+            $this->objects[$objectName][self::KEY_INSTANCE] = $this->buildObjectByFactory($objectName);
+            return $this->objects[$objectName][self::KEY_INSTANCE];
         }
 
         $className = $this->getClassNameByObjectName($objectName);
@@ -215,12 +228,12 @@ class ObjectManager implements ObjectManagerInterface
             throw new Exception\UnknownObjectException('Object "' . $objectName . '" is not registered.' . $hint, 1264589155);
         }
 
-        if (!isset($this->objects[$objectName]) || $this->objects[$objectName]['s'] === ObjectConfiguration::SCOPE_PROTOTYPE) {
+        if (!isset($this->objects[$objectName]) || $this->objects[$objectName][self::KEY_SCOPE] === ObjectConfiguration::SCOPE_PROTOTYPE) {
             return $this->instantiateClass($className, $constructorArguments);
         }
 
-        $this->objects[$objectName]['i'] = $this->instantiateClass($className, []);
-        return $this->objects[$objectName]['i'];
+        $this->objects[$objectName][self::KEY_INSTANCE] = $this->instantiateClass($className, []);
+        return $this->objects[$objectName][self::KEY_INSTANCE];
     }
 
     /**
@@ -231,13 +244,13 @@ class ObjectManager implements ObjectManagerInterface
      * @throws Exception\UnknownObjectException
      * @api
      */
-    public function getScope($objectName)
+    public function getScope($objectName): int
     {
         if (!isset($this->objects[$objectName])) {
             $hint = ($objectName[0] === '\\') ? ' Hint: You specified an object name with a leading backslash!' : '';
             throw new Exception\UnknownObjectException('Object "' . $objectName . '" is not registered.' . $hint, 1265367590);
         }
-        return $this->objects[$objectName]['s'];
+        return $this->objects[$objectName][self::KEY_SCOPE];
     }
 
     /**
@@ -262,7 +275,7 @@ class ObjectManager implements ObjectManagerInterface
         }
 
         foreach ($this->objects as $objectName => $information) {
-            if (isset($information['l']) && $information['l'] === $lowerCasedObjectName) {
+            if (isset($information[self::KEY_LOWERCASE_NAME]) && $information[self::KEY_LOWERCASE_NAME] === $lowerCasedObjectName) {
                 $this->cachedLowerCasedObjectNames[$lowerCasedObjectName] = $objectName;
                 return $objectName;
             }
@@ -282,19 +295,19 @@ class ObjectManager implements ObjectManagerInterface
      *
      * @api
      */
-    public function getObjectNameByClassName($className)
+    public function getObjectNameByClassName($className): string|false
     {
-        if (isset($this->objects[$className]) && (!isset($this->objects[$className]['c']) || $this->objects[$className]['c'] === $className)) {
+        if (isset($this->objects[$className]) && (!isset($this->objects[$className][self::KEY_CLASS_NAME]) || $this->objects[$className][self::KEY_CLASS_NAME] === $className)) {
             return $className;
         }
 
         foreach ($this->objects as $objectName => $information) {
-            if (isset($information['c']) && $information['c'] === $className) {
+            if (isset($information[self::KEY_CLASS_NAME]) && $information[self::KEY_CLASS_NAME] === $className) {
                 return $objectName;
             }
         }
         if ($className[0] === '\\') {
-            throw new \InvalidArgumentException('Class names must not start with a backslash ("' . $className . '")', 1270826088);
+            throw new InvalidArgumentException('Class names must not start with a backslash ("' . $className . '")', 1270826088);
         }
 
         return false;
@@ -304,27 +317,27 @@ class ObjectManager implements ObjectManagerInterface
      * Returns the implementation class name for the specified object
      *
      * @param string $objectName The object name
-     * @return string The class name corresponding to the given object name or false if no such object is registered
+     * @return string|false The class name corresponding to the given object name or false if no such object is registered
      * @api
      */
-    public function getClassNameByObjectName($objectName)
+    public function getClassNameByObjectName($objectName): string|false
     {
         if (!isset($this->objects[$objectName])) {
             return class_exists($objectName) ? $objectName : false;
         }
-        return $this->objects[$objectName]['c'] ?? $objectName;
+        return $this->objects[$objectName][self::KEY_CLASS_NAME] ?? $objectName;
     }
 
     /**
      * Returns the key of the package the specified object is contained in.
      *
      * @param string $objectName The object name
-     * @return string The package key or false if no such object exists
+     * @return string|false The package key or false if no such object exists
      * @internal
      */
-    public function getPackageKeyByObjectName($objectName)
+    public function getPackageKeyByObjectName($objectName): string|false
     {
-        return (isset($this->objects[$objectName]) ? $this->objects[$objectName]['p'] : false);
+        return (isset($this->objects[$objectName]) ? $this->objects[$objectName][self::KEY_PACKAGE] : false);
     }
 
     /**
@@ -339,19 +352,19 @@ class ObjectManager implements ObjectManagerInterface
      * @throws Exception\WrongScopeException
      * @throws Exception\UnknownObjectException
      */
-    public function setInstance($objectName, $instance)
+    public function setInstance($objectName, $instance): void
     {
         if (!isset($this->objects[$objectName])) {
             if (!class_exists($objectName, false)) {
                 throw new Exception\UnknownObjectException('Cannot set instance of object "' . $objectName . '" because the object or class name is unknown to the Object Manager.', 1265370539);
-            } else {
-                throw new Exception\WrongScopeException('Cannot set instance of class "' . $objectName . '" because no matching object configuration was found. Classes which exist but are not registered are considered to be of scope prototype. However, setInstance() only accepts "session" and "singleton" instances. Check your object configuration and class name spellings.', 12653705341);
             }
+
+            throw new Exception\WrongScopeException('Cannot set instance of class "' . $objectName . '" because no matching object configuration was found. Classes which exist but are not registered are considered to be of scope prototype. However, setInstance() only accepts "session" and "singleton" instances. Check your object configuration and class name spellings.', 12653705341);
         }
-        if ($this->objects[$objectName]['s'] === ObjectConfiguration::SCOPE_PROTOTYPE) {
+        if ($this->objects[$objectName][self::KEY_SCOPE] === ObjectConfiguration::SCOPE_PROTOTYPE) {
             throw new Exception\WrongScopeException('Cannot set instance of object "' . $objectName . '" because it is of scope prototype. Only session and singleton instances can be set.', 1265370540);
         }
-        $this->objects[$objectName]['i'] = $instance;
+        $this->objects[$objectName][self::KEY_INSTANCE] = $instance;
     }
 
     /**
@@ -361,9 +374,9 @@ class ObjectManager implements ObjectManagerInterface
      * @param string $objectName The object name
      * @return boolean true if an instance already exists
      */
-    public function hasInstance($objectName): bool
+    public function hasInstance(string $objectName): bool
     {
-        return isset($this->objects[$objectName]['i']);
+        return isset($this->objects[$objectName][self::KEY_INSTANCE]);
     }
 
     /**
@@ -375,9 +388,9 @@ class ObjectManager implements ObjectManagerInterface
      * @phpstan-return ($objectName is class-string<T> ? T|null : object|null) The object instance or null
      * @return T|null The object instance or null
      */
-    public function getInstance($objectName)
+    public function getInstance(string $objectName): ?object
     {
-        return $this->objects[$objectName]['i'] ?? null;
+        return $this->objects[$objectName][self::KEY_INSTANCE] ?? null;
     }
 
     /**
@@ -390,9 +403,9 @@ class ObjectManager implements ObjectManagerInterface
      *
      * @param string $hash
      * @param mixed &$propertyReferenceVariable Reference of the variable to inject into once the proxy is activated
-     * @return mixed
+     * @return object|null
      */
-    public function getLazyDependencyByHash($hash, &$propertyReferenceVariable)
+    public function getLazyDependencyByHash(string $hash, mixed &$propertyReferenceVariable): ?object
     {
         if (!isset($this->dependencyProxies[$hash])) {
             return null;
@@ -410,12 +423,12 @@ class ObjectManager implements ObjectManagerInterface
      * Internally used by the injectProperties method of generated proxy classes.
      *
      * @param string $hash An md5 hash over the code needed to actually build the dependency instance
-     * @param string &$propertyReferenceVariable A first variable where the dependency needs to be injected into
+     * @param mixed &$propertyReferenceVariable A first variable where the dependency needs to be injected into
      * @param string $className Name of the class of the dependency which eventually will be instantiated
-     * @param \Closure $builder An anonymous function which creates the instance to be injected
+     * @param Closure $builder An anonymous function which creates the instance to be injected
      * @return DependencyProxy
      */
-    public function createLazyDependency($hash, &$propertyReferenceVariable, $className, \Closure $builder): DependencyProxy
+    public function createLazyDependency(string $hash, mixed &$propertyReferenceVariable, string $className, Closure $builder): DependencyProxy
     {
         $this->dependencyProxies[$hash] = new DependencyProxy($className, $builder);
         $this->dependencyProxies[$hash]->_addPropertyVariable($propertyReferenceVariable);
@@ -433,9 +446,9 @@ class ObjectManager implements ObjectManagerInterface
      * @param string $objectName The object name
      * @return void
      */
-    public function forgetInstance($objectName)
+    public function forgetInstance($objectName): void
     {
-        unset($this->objects[$objectName]['i']);
+        unset($this->objects[$objectName][self::KEY_INSTANCE]);
     }
 
     /**
@@ -443,12 +456,12 @@ class ObjectManager implements ObjectManagerInterface
      *
      * @return array
      */
-    public function getSessionInstances()
+    public function getSessionInstances(): array
     {
         $sessionObjects = [];
         foreach ($this->objects as $information) {
-            if (isset($information['i']) && $information['s'] === ObjectConfiguration::SCOPE_SESSION) {
-                $sessionObjects[] = $information['i'];
+            if (isset($information[self::KEY_INSTANCE]) && $information[self::KEY_SCOPE] === ObjectConfiguration::SCOPE_SESSION) {
+                $sessionObjects[] = $information[self::KEY_INSTANCE];
             }
         }
         return $sessionObjects;
@@ -462,8 +475,9 @@ class ObjectManager implements ObjectManagerInterface
      * @throws Exception\CannotBuildObjectException
      * @throws Exception\UnknownObjectException
      * @throws InvalidConfigurationTypeException
+     * @throws \Exception
      */
-    public function shutdown()
+    public function shutdown(): void
     {
         $this->callShutdownMethods($this->shutdownObjects);
 
@@ -500,22 +514,22 @@ class ObjectManager implements ObjectManagerInterface
      * @throws InvalidConfigurationTypeException
      * @throws Exception\CannotBuildObjectException
      */
-    protected function buildObjectByFactory($objectName)
+    protected function buildObjectByFactory(string $objectName): object
     {
-        $factory = $this->objects[$objectName]['f'][0] ? $this->get($this->objects[$objectName]['f'][0]) : null;
-        $factoryMethodName = $this->objects[$objectName]['f'][1];
+        $factory = $this->objects[$objectName][self::KEY_FACTORY][0] ? $this->get($this->objects[$objectName][self::KEY_FACTORY][0]) : null;
+        $factoryMethodName = $this->objects[$objectName][self::KEY_FACTORY][1];
 
         $factoryMethodArguments = [];
-        foreach ($this->objects[$objectName]['fa'] as $index => $argumentInformation) {
-            switch ($argumentInformation['t']) {
+        foreach ($this->objects[$objectName][self::KEY_FACTORY_ARGUMENTS] as $index => $argumentInformation) {
+            switch ($argumentInformation[self::KEY_ARGUMENT_TYPE]) {
                 case ObjectConfigurationArgument::ARGUMENT_TYPES_SETTING:
-                    $factoryMethodArguments[$index] = $this->get(ConfigurationManager::class)->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, $argumentInformation['v']);
+                    $factoryMethodArguments[$index] = $this->get(ConfigurationManager::class)->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, $argumentInformation[self::KEY_ARGUMENT_VALUE]);
                     break;
                 case ObjectConfigurationArgument::ARGUMENT_TYPES_STRAIGHTVALUE:
-                    $factoryMethodArguments[$index] = $argumentInformation['v'];
+                    $factoryMethodArguments[$index] = $argumentInformation[self::KEY_ARGUMENT_VALUE];
                     break;
                 case ObjectConfigurationArgument::ARGUMENT_TYPES_OBJECT:
-                    $factoryMethodArguments[$index] = $this->get($argumentInformation['v']);
+                    $factoryMethodArguments[$index] = $this->get($argumentInformation[self::KEY_ARGUMENT_VALUE]);
                     break;
             }
         }
@@ -536,7 +550,7 @@ class ObjectManager implements ObjectManagerInterface
      * @throws Exception\CannotBuildObjectException
      * @throws \Exception
      */
-    protected function instantiateClass($className, array $arguments)
+    protected function instantiateClass(string $className, array $arguments): object
     {
         if (isset($this->classesBeingInstantiated[$className])) {
             throw new Exception\CannotBuildObjectException('Circular dependency detected while trying to instantiate class "' . $className . '".', 1168505928);
@@ -555,10 +569,10 @@ class ObjectManager implements ObjectManagerInterface
     /**
      * Executes the methods of the provided objects.
      *
-     * @param \SplObjectStorage $shutdownObjects
+     * @param SplObjectStorage $shutdownObjects
      * @return void
      */
-    protected function callShutdownMethods(\SplObjectStorage $shutdownObjects): void
+    protected function callShutdownMethods(SplObjectStorage $shutdownObjects): void
     {
         foreach ($shutdownObjects as $object) {
             $methodName = $shutdownObjects[$object];

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationBuilderTest.php
@@ -22,7 +22,6 @@ use Neos\Flow\ObjectManagement\Exception\UnresolvedDependenciesException;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\Annotations as Flow;
-use Psr\Log\LoggerInterface;
 
 /**
  * Testcase for the object configuration builder
@@ -56,7 +55,7 @@ class ConfigurationBuilderTest extends UnitTestCase
         $objectConfiguration->setLifecycleShutdownMethodName('shutdownMethod');
         $objectConfiguration->setAutowiring(Configuration::AUTOWIRING_MODE_OFF);
 
-        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy'], [], '', false);
+        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy']);
         $builtObjectConfiguration = $configurationBuilder->_call('parseConfigurationArray', 'TestObject', $configurationArray, __CLASS__);
         self::assertEquals($objectConfiguration, $builtObjectConfiguration, 'The manually created and the built object configuration don\'t match.');
     }
@@ -76,7 +75,7 @@ class ConfigurationBuilderTest extends UnitTestCase
         $objectConfiguration = new Configuration('TestObject', 'TestObject');
         $objectConfiguration->setArgument(new ConfigurationArgument(1, $argumentObjectConfiguration, ConfigurationArgument::ARGUMENT_TYPES_OBJECT));
 
-        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy'], [], '', false);
+        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy']);
         $builtObjectConfiguration = $configurationBuilder->_call('parseConfigurationArray', 'TestObject', $configurationArray, __CLASS__);
         self::assertEquals($objectConfiguration, $builtObjectConfiguration);
     }
@@ -96,7 +95,7 @@ class ConfigurationBuilderTest extends UnitTestCase
         $objectConfiguration = new Configuration('TestObject', 'TestObject');
         $objectConfiguration->setProperty(new ConfigurationProperty('theProperty', $propertyObjectConfiguration, ConfigurationProperty::PROPERTY_TYPES_OBJECT));
 
-        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy'], [], '', false);
+        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy']);
         $builtObjectConfiguration = $configurationBuilder->_call('parseConfigurationArray', 'TestObject', $configurationArray, __CLASS__);
         self::assertEquals($objectConfiguration, $builtObjectConfiguration);
     }
@@ -114,7 +113,7 @@ class ConfigurationBuilderTest extends UnitTestCase
         $objectConfiguration->setProperty(new ConfigurationProperty('straightValueProperty', ['foo' => 'bar', 'object' => 'nö']));
         $objectConfiguration->setArgument(new ConfigurationArgument(1, ['foo' => 'bar', 'object' => 'nö']));
 
-        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy'], [], '', false);
+        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy']);
         $builtObjectConfiguration = $configurationBuilder->_call('parseConfigurationArray', 'TestObject', $configurationArray, __CLASS__);
         self::assertEquals($objectConfiguration, $builtObjectConfiguration);
     }
@@ -126,7 +125,7 @@ class ConfigurationBuilderTest extends UnitTestCase
     {
         $this->expectException(InvalidObjectConfigurationException::class);
         $configurationArray = ['scoopy' => 'prototype'];
-        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy'], [], '', false);
+        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy']);
         $configurationBuilder->_call('parseConfigurationArray', 'TestObject', $configurationArray, __CLASS__);
     }
 
@@ -140,7 +139,9 @@ class ConfigurationBuilderTest extends UnitTestCase
         $configurationArray['arguments'][1]['setting'] = 'Neos.Foo.Bar';
         $configurationArray['properties']['someProperty']['setting'] = 'Neos.Bar.Baz';
 
-        $mockLogger = $this->createMock(LoggerInterface::class);
+        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy']);
+        $dummyObjectConfiguration = [$configurationBuilder->_call('parseConfigurationArray', __CLASS__, $configurationArray, __CLASS__)];
+
         $reflectionServiceMock = $this->createMock(ReflectionService::class);
         $reflectionServiceMock
                 ->expects(self::once())
@@ -154,8 +155,7 @@ class ConfigurationBuilderTest extends UnitTestCase
                 ->with(__CLASS__, 'dummyProperty')
                 ->will(self::returnValue(true));
 
-        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy'], [$reflectionServiceMock, $mockLogger], '');
-        $dummyObjectConfiguration = [$configurationBuilder->_call('parseConfigurationArray', __CLASS__, $configurationArray, __CLASS__)];
+        $configurationBuilder->injectReflectionService($reflectionServiceMock);
         $configurationBuilder->_call('autowireProperties', $dummyObjectConfiguration);
     }
 
@@ -169,7 +169,7 @@ class ConfigurationBuilderTest extends UnitTestCase
         $configurationArray['properties']['someProperty']['object']['name'] = 'Foo';
         $configurationArray['properties']['someProperty']['object']['className'] = 'foobar';
 
-        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy'], [], '', false);
+        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy']);
         $dummyObjectConfiguration = [$configurationBuilder->_call('parseConfigurationArray', 'Foo', $configurationArray, __CLASS__)];
 
         $configurationBuilder->_call('autowireProperties', $dummyObjectConfiguration);
@@ -184,7 +184,7 @@ class ConfigurationBuilderTest extends UnitTestCase
         $configurationArray['properties']['someProperty']['setting'] = 'Neos.Foo.Bar';
 
         /** @var ConfigurationBuilder $configurationBuilder */
-        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, null, [], '', false);
+        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, null);
         /** @var Configuration $builtObjectConfiguration */
         $builtObjectConfiguration = $configurationBuilder->_call('parseConfigurationArray', 'TestObject', $configurationArray, __CLASS__);
 
@@ -201,7 +201,7 @@ class ConfigurationBuilderTest extends UnitTestCase
         $configurationArray['arguments'][1]['setting'] = 'Neos.Foo.Bar';
 
         /** @var ConfigurationBuilder $configurationBuilder */
-        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, null, [], '', false);
+        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, null);
         /** @var Configuration $builtObjectConfiguration */
         $builtObjectConfiguration = $configurationBuilder->_call('parseConfigurationArray', 'TestObject', $configurationArray, __CLASS__);
 
@@ -219,8 +219,9 @@ class ConfigurationBuilderTest extends UnitTestCase
             'factoryObjectName' => 'TestFactory',
         ];
 
+        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy']);
+        $dummyObjectConfiguration = [$configurationBuilder->_call('parseConfigurationArray', __CLASS__, $configurationArray)];
 
-        $mockLogger = $this->createMock(LoggerInterface::class);
         $reflectionServiceMock = $this->createMock(ReflectionService::class);
 
         $reflectionServiceMock
@@ -240,9 +241,7 @@ class ConfigurationBuilderTest extends UnitTestCase
                 ]
             ]));
 
-        $configurationBuilder = $this->getAccessibleMock(ConfigurationBuilder::class, ['dummy'], [$reflectionServiceMock, $mockLogger], '');
-        $dummyObjectConfiguration = [$configurationBuilder->_call('parseConfigurationArray', __CLASS__, $configurationArray)];
-
+        $configurationBuilder->injectReflectionService($reflectionServiceMock);
         try {
             $configurationBuilder->_call('autowireArguments', $dummyObjectConfiguration);
         } catch (UnresolvedDependenciesException $e) {

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationTest.php
@@ -31,7 +31,7 @@ class ConfigurationTest extends UnitTestCase
      */
     protected function setUp(): void
     {
-        $this->objectConfiguration = new Configuration\Configuration('Neos\Foo\Bar');
+        $this->objectConfiguration = new Configuration\Configuration('Neos\Foo\Bar', 'Neos\Foo\Bar');
     }
 
     /**
@@ -121,7 +121,7 @@ class ConfigurationTest extends UnitTestCase
      */
     public function setFactoryMethodNameRejectsAnythingElseThanAString()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(\TypeError::class);
         $this->objectConfiguration->setFactoryMethodName([]);
     }
 


### PR DESCRIPTION
This is a minimal cleanup to the object management classes. Adding type hints, using more modern language constructs, and introducing constants for the cryptic array keys in the `ObjectManager` configuration.

**Checklist**

- [ x] Code follows the PSR-2 coding style
- [ x] Tests have been created, run and adjusted as needed
- [x ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
