### PR TITLE
BUGFIX: Support custom table names for PdoBackend

### DIFF
--- a/Neos.Cache/Classes/Backend/PdoBackend.php
+++ b/Neos.Cache/Classes/Backend/PdoBackend.php
@@ -453,7 +453,7 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
     {
         $this->connect();
         try {
-            PdoHelper::importSql($this->databaseHandle, $this->pdoDriver, __DIR__ . '/../../Resources/Private/DDL.sql');
+            PdoHelper::importSql($this->databaseHandle, $this->pdoDriver, __DIR__ . '/../../Resources/Private/DDL.sql', ['###CACHE_TABLE_NAME###' => $this->cacheTableName, '###TAGS_TABLE_NAME###' => $this->tagsTableName]);
         } catch (\PDOException $exception) {
             throw new Exception('Could not create cache tables with DSN "' . $this->dataSourceName . '". PDO error: ' . $exception->getMessage(), 1259576985);
         }
@@ -575,6 +575,7 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
             $this->connect();
         } catch (Exception $exception) {
             $result->addError(new Error($exception->getMessage(), (int)$exception->getCode(), [], 'Failed'));
+            return $result;
         }
         if ($this->pdoDriver === 'sqlite') {
             $result->addNotice(new Notice('SQLite database tables are created automatically and don\'t need to be set up'));

--- a/Neos.Cache/Resources/Private/DDL.sql
+++ b/Neos.Cache/Resources/Private/DDL.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-CREATE TABLE "cache" (
+CREATE TABLE "###CACHE_TABLE_NAME###" (
   "identifier" VARCHAR(250) NOT NULL,
   "cache" VARCHAR(250) NOT NULL,
   "context" VARCHAR(150) NOT NULL,
@@ -10,13 +10,13 @@ CREATE TABLE "cache" (
   PRIMARY KEY ("identifier", "cache", "context")
 );
 
-CREATE TABLE "tags" (
+CREATE TABLE "###TAGS_TABLE_NAME###" (
   "identifier" VARCHAR(250) NOT NULL,
   "cache" VARCHAR(250) NOT NULL,
   "context" VARCHAR(150) NOT NULL,
   "tag" VARCHAR(250) NOT NULL
 );
-CREATE INDEX "identifier" ON "tags" ("identifier", "cache", "context");
-CREATE INDEX "tag" ON "tags" ("tag");
+CREATE INDEX "identifier" ON "###TAGS_TABLE_NAME###" ("identifier", "cache", "context");
+CREATE INDEX "tag" ON "###TAGS_TABLE_NAME###" ("tag");
 
 COMMIT;

--- a/Neos.Cache/Resources/Private/mysql.DDL.sql
+++ b/Neos.Cache/Resources/Private/mysql.DDL.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-CREATE TABLE "cache" (
+CREATE TABLE "###CACHE_TABLE_NAME###" (
   "identifier" VARCHAR(250) NOT NULL,
   "cache" VARCHAR(250) NOT NULL,
   "context" VARCHAR(150) NOT NULL,
@@ -10,7 +10,7 @@ CREATE TABLE "cache" (
   PRIMARY KEY ("identifier", "cache", "context")
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-CREATE TABLE "tags" (
+CREATE TABLE "###TAGS_TABLE_NAME###" (
   "pk" INT NOT NULL AUTO_INCREMENT,
   "identifier" VARCHAR(250) NOT NULL,
   "cache" VARCHAR(250) NOT NULL,
@@ -18,7 +18,7 @@ CREATE TABLE "tags" (
   "tag" VARCHAR(250) NOT NULL,
   PRIMARY KEY ("pk")
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-CREATE INDEX "identifier" ON tags ("identifier", "cache", "context");
-CREATE INDEX "tag" ON "tags" ("tag");
+CREATE INDEX "identifier" ON ###TAGS_TABLE_NAME### ("identifier", "cache", "context");
+CREATE INDEX "tag" ON "###TAGS_TABLE_NAME###" ("tag");
 
 COMMIT;

--- a/Neos.Cache/Resources/Private/pgsql.DDL.sql
+++ b/Neos.Cache/Resources/Private/pgsql.DDL.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-CREATE TABLE "cache" (
+CREATE TABLE "###CACHE_TABLE_NAME###" (
   "identifier" VARCHAR(250) NOT NULL,
   "cache" VARCHAR(250) NOT NULL,
   "context" VARCHAR(150) NOT NULL,
@@ -10,13 +10,13 @@ CREATE TABLE "cache" (
   PRIMARY KEY ("identifier", "cache", "context")
 );
 
-CREATE TABLE "tags" (
+CREATE TABLE "###TAGS_TABLE_NAME###" (
   "identifier" VARCHAR(250) NOT NULL,
   "cache" VARCHAR(250) NOT NULL,
   "context" VARCHAR(150) NOT NULL,
   "tag" VARCHAR(250) NOT NULL
 );
-CREATE INDEX "identifier" ON "tags" ("identifier", "cache", "context");
-CREATE INDEX "tag" ON "tags" ("tag");
+CREATE INDEX "identifier" ON "###TAGS_TABLE_NAME###" ("identifier", "cache", "context");
+CREATE INDEX "tag" ON "###TAGS_TABLE_NAME###" ("tag");
 
 COMMIT;

--- a/Neos.Utility.Pdo/Classes/PdoHelper.php
+++ b/Neos.Utility.Pdo/Classes/PdoHelper.php
@@ -33,9 +33,10 @@ abstract class PdoHelper
      * @param \PDO $databaseHandle
      * @param string $pdoDriver
      * @param string $pathAndFilename
+     * @param array $replacePairs every key in this array will be replaced with the corresponding value in the loaded SQL (example: ['###CACHE_TABLE_NAME###' => 'caches', '###TAGS_TABLE_NAME###' => 'tags'])
      * @return void
      */
-    public static function importSql(\PDO $databaseHandle, string $pdoDriver, string $pathAndFilename)
+    public static function importSql(\PDO $databaseHandle, string $pdoDriver, string $pathAndFilename, array $replacePairs = [])
     {
         $path = dirname($pathAndFilename);
         $filename = basename($pathAndFilename);
@@ -52,7 +53,7 @@ abstract class PdoHelper
 
         $statement = '';
         foreach ($sql as $line) {
-            $statement .= ' ' . trim($line);
+            $statement .= ' ' . trim(strtr($line, $replacePairs));
             if (substr($statement, -1) === ';') {
                 $databaseHandle->exec($statement);
                 $statement = '';


### PR DESCRIPTION
Fixes the `PdoBackend::setup()` to actually respect any configured `cacheTableName` and/or `tagsTableName`.

Fixes: #2958