### PR TITLE
TASK: Adding labels to PRs

### DIFF
--- a/.github/workflows/add-pr-labels.yml
+++ b/.github/workflows/add-pr-labels.yml
@@ -1,0 +1,38 @@
+name: Add Labels to Pull Request
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+
+jobs:
+  add-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Maybe remove base branch label
+        if: github.event.action == 'edited' && github.event.changes.base.ref.from != ''
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: ${{ github.event.changes.base.ref.from }}
+      - name: Add feature label
+        if: startsWith(github.event.pull_request.title, 'FEATURE:')
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: 'Feature'
+      - name: Add bugfix label
+        if: startsWith(github.event.pull_request.title, 'BUGFIX:')
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: 'Bug'
+      - name: Add task label
+        if: startsWith(github.event.pull_request.title, 'TASK:')
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: 'Task'
+      - name: Add target branch label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: ${{ github.base_ref }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
With this task, we add automatically labels to the PRs. That makes the maintaining easier, as we did that manually all the time.

*What I did*
We always add the target branch as label, so we see directly which version the PR targets. And if the Commit message is following our rules, we also add the bugfix, task or feature label.

*How I did it*
I use the runner from https://github.com/actions-ecosystem They use node 12 which leads to a warning as actions are running node 16 but an issue is created and it runs anyways.

*How to verify it*
Checkout how it works in the neos-ui.
https://github.com/neos/neos-ui/pull/3387

**Checklist**

- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions