### PR TITLE
TASK: extending phpstorm autocomplete information, focused on attributes

### DIFF
--- a/Neos.Flow/.phpstorm.meta.php
+++ b/Neos.Flow/.phpstorm.meta.php
@@ -15,4 +15,20 @@ namespace PHPSTORM_META {
         \Neos\Flow\Core\Bootstrap::getEarlyInstance(),
         map(['' => '@'])
     );
+
+    expectedArguments(\Neos\Flow\Annotations\Validate::__construct(), 1, 'AggregateBoundary', 'Alphanumeric', 'Boolean', 'Collection', 'Conjunction', 'Count', 'DateTimeRange', 'DateTime', 'Disjunction', 'EmailAddress', 'Float', 'GenericObject', 'Integer', 'Label', 'LocaleIdentifier', 'NotEmpty', 'NumberRange', 'Number', 'Raw', 'RegularExpresion', 'StringLength', 'Text', 'UniqueEntity', 'Uuid');
+
+    expectedArguments(\Neos\Flow\Annotations\Scope::__construct(), 0, 'prototype', 'session', 'singleton');
+
+    registerArgumentsSet(
+        'flowSettingsTypes',
+        \Neos\Flow\Configuration\ConfigurationManager::CONFIGURATION_TYPE_CACHES,
+        \Neos\Flow\Configuration\ConfigurationManager::CONFIGURATION_TYPE_OBJECTS,
+        \Neos\Flow\Configuration\ConfigurationManager::CONFIGURATION_TYPE_POLICY,
+        \Neos\Flow\Configuration\ConfigurationManager::CONFIGURATION_TYPE_ROUTES,
+        \Neos\Flow\Configuration\ConfigurationManager::CONFIGURATION_TYPE_SETTINGS
+    );
+    expectedArguments(\Neos\Flow\Annotations\InjectConfiguration::__construct(), 2, argumentsSet('flowSettingsTypes'));
+    expectedArguments(\Neos\Flow\Configuration\ConfigurationManager::getConfiguration(), 0, argumentsSet('flowSettingsTypes'));
+    expectedArguments(\Neos\Flow\Configuration\ConfigurationManager::loadConfiguration(), 0, argumentsSet('flowSettingsTypes'));
 }


### PR DESCRIPTION
This only adds some autocomplete hints to PHP-Storm, especially the Validate and Scope - Attributes.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
