### PR TITLE
FEATURE: Allow optimization of proxy building

### DIFF
--- a/Neos.Flow/Classes/Aop/AspectContainer.php
+++ b/Neos.Flow/Classes/Aop/AspectContainer.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\Aop;
  */
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Aop\Builder\ClassNameIndex;
 use Neos\Flow\Aop\Pointcut\Pointcut;
 
 /**
@@ -40,42 +41,42 @@ class AspectContainer
     /**
      * @var string
      */
-    protected $className;
+    protected string $className;
 
     /**
      * An array of \Neos\Flow\Aop\Advisor objects
      * @var array
      */
-    protected $advisors = [];
+    protected array $advisors = [];
 
     /**
      * An array of \Neos\Flow\Aop\InterfaceIntroduction objects
      * @var array
      */
-    protected $interfaceIntroductions = [];
+    protected array $interfaceIntroductions = [];
 
     /**
      * An array of \Neos\Flow\Aop\PropertyIntroduction objects
      * @var array
      */
-    protected $propertyIntroductions = [];
+    protected array $propertyIntroductions = [];
 
     /**
      * An array of \Neos\Flow\Aop\TraitIntroduction objects
      * @var array
      */
-    protected $traitIntroductions = [];
+    protected array $traitIntroductions = [];
 
     /**
      * An array of explicitly declared \Neos\Flow\Pointcut objects
      * @var array
      */
-    protected $pointcuts = [];
+    protected array $pointcuts = [];
 
     /**
      * @var Builder\ClassNameIndex
      */
-    protected $cachedTargetClassNameCandidates;
+    protected ClassNameIndex $cachedTargetClassNameCandidates;
 
     /**
      * The constructor
@@ -100,7 +101,7 @@ class AspectContainer
     /**
      * Returns the advisors which were defined in the aspect
      *
-     * @return array Array of \Neos\Flow\Aop\Advisor objects
+     * @return Advisor[] Array of \Neos\Flow\Aop\Advisor objects
      */
     public function getAdvisors(): array
     {
@@ -110,7 +111,7 @@ class AspectContainer
     /**
      * Returns the interface introductions which were defined in the aspect
      *
-     * @return array Array of \Neos\Flow\Aop\InterfaceIntroduction objects
+     * @return InterfaceIntroduction[] Array of \Neos\Flow\Aop\InterfaceIntroduction objects
      */
     public function getInterfaceIntroductions(): array
     {
@@ -120,7 +121,7 @@ class AspectContainer
     /**
      * Returns the property introductions which were defined in the aspect
      *
-     * @return array Array of \Neos\Flow\Aop\PropertyIntroduction objects
+     * @return PropertyIntroduction[] Array of \Neos\Flow\Aop\PropertyIntroduction objects
      */
     public function getPropertyIntroductions(): array
     {
@@ -130,7 +131,7 @@ class AspectContainer
     /**
      * Returns the trait introductions which were defined in the aspect
      *
-     * @return array Array of \Neos\Flow\Aop\TraitIntroduction objects
+     * @return TraitIntroduction[] Array of \Neos\Flow\Aop\TraitIntroduction objects
      */
     public function getTraitIntroductions(): array
     {
@@ -142,7 +143,7 @@ class AspectContainer
      * does not contain the pointcuts which were made out of the pointcut
      * expressions for the advisors!
      *
-     * @return array Array of \Neos\Flow\Aop\Pointcut\Pointcut objects
+     * @return Pointcut[] Array of \Neos\Flow\Aop\Pointcut\Pointcut objects
      */
     public function getPointcuts(): array
     {

--- a/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
@@ -11,7 +11,6 @@ namespace Neos\Flow\ObjectManagement\DependencyInjection;
  * source code.
  */
 
-use Neos\Eel\FlowQuery\Operations\AddOperation;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\ObjectManagement\CompileTimeObjectManager;

--- a/Neos.Flow/Configuration/Settings.Object.yaml
+++ b/Neos.Flow/Configuration/Settings.Object.yaml
@@ -23,3 +23,8 @@ Neos:
       # by specifying corresponding regular expressions that don't match classes to exclude.
       #
       includeClasses: []
+
+      # 0 means no optimizations get enabled, the higher the number the more optimizations but the more it _could_ be breaking in special use cases.
+      # 1 excludes object serialization helpers for classes that only have simple type properties and have no injections, should be very safe
+      # 2 excludes object serialization helpers for classes that only have simple type properties (but still injections, so configuration injections will get serialized)
+      proxyOptimizationLevel: 1

--- a/Neos.Utility.Arrays/Classes/Arrays.php
+++ b/Neos.Utility.Arrays/Classes/Arrays.php
@@ -199,7 +199,7 @@ abstract class Arrays
      * @return mixed The value found, NULL if the path didn't exist (note there is no way to distinguish between a found NULL value and "path not found")
      * @throws \InvalidArgumentException
      */
-    public static function getValueByPath(array &$array, $path)
+    public static function getValueByPath(array $array, $path)
     {
         if (is_string($path)) {
             $path = explode('.', $path);


### PR DESCRIPTION
Adds the new configuration setting

Neos.Flow.object.proxyOptimizationLevel

which defaults to 1, as a base line for safe optimizations that will be added in the future. 0 means no optimization and results in the same as before this change. Everything over 1 will increasingly add optimizations that could be breaking in special use cases. See comments in the `Settings.Object.yaml` of Neos.Flow.

Resolves: #1539

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
