### PR TITLE
FEATURE: Add new validators `MediaType`, `FileExtension` and `FileSize`

### DIFF
--- a/Neos.Flow/Classes/Validation/Validator/FileExtensionValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/FileExtensionValidator.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Validation\Validator;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\ResourceManagement\ResourceMetaDataInterface;
+use Psr\Http\Message\UploadedFileInterface;
+
+/**
+ * The given $value is has one of the allowed file extensions
+ * Note: a value of NULL or empty string ('') are considered valid
+ */
+class FileExtensionValidator extends AbstractValidator
+{
+    /**
+     * This contains the supported options, each being an array of:
+     *
+     * 0 => default value
+     * 1 => description
+     * 2 => type
+     * 3 => required (boolean, optional)
+     *
+     * @var array
+     */
+    protected $supportedOptions = [
+        'allowedExtensions' => [[], 'Array of allowed file extensions', 'array', true]
+    ];
+
+    /**
+     * The given $value is valid media type matches one of the allowedTypes and
+     * none of the disallowedTypes
+     *
+     * Note: a value of NULL or empty string ('') is considered valid and was handled already
+     *
+     * @param mixed $value
+     * @return void
+     * @api
+     */
+    protected function isValid($value)
+    {
+        if ($value instanceof UploadedFileInterface) {
+            $filename = $value->getClientFilename();
+        } elseif ($value instanceof ResourceMetaDataInterface) {
+            $filename = $value->getFilename();
+        } else {
+            $this->addError('Only Uploads or Resources are supported.', 1677934927);
+            return;
+        }
+
+        $fileExtension =  pathinfo((string)$filename, PATHINFO_EXTENSION);
+
+        if ($fileExtension === null || $fileExtension === '') {
+            $this->addError('The file has no file extension.', 1677934932);
+            return;
+        }
+        if (!in_array($fileExtension, $this->options['allowedExtensions'])) {
+            $this->addError('The file extension "%s" is not allowed.', 1677934939, [$fileExtension]);
+            return;
+        }
+    }
+}

--- a/Neos.Flow/Classes/Validation/Validator/FileSizeValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/FileSizeValidator.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Validation\Validator;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\ResourceManagement\ResourceMetaDataInterface;
+use Psr\Http\Message\UploadedFileInterface;
+
+/**
+ * Validator for file sizes
+ * Note: a value of NULL or empty string ('') are considered valid
+ */
+class FileSizeValidator extends AbstractValidator
+{
+    /**
+     * This contains the supported options, each being an array of:
+     *
+     * 0 => default value
+     * 1 => description
+     * 2 => type
+     * 3 => required (boolean, optional)
+     *
+     * @var array
+     */
+    protected $supportedOptions = [
+        'minimum' => [null, 'Minimum allowed filesize in bytes', 'integer', false],
+        'maximum' => [null, 'Maximum allowed filesize in bytes', 'integer', false]
+    ];
+
+    /**
+     * The given $value is valid media type matches one of the allowedTypes and
+     * none of the disallowedTypes
+     *
+     * Note: a value of NULL or empty string ('') is considered valid and was handled already
+     *
+     * @param mixed $value
+     * @return void
+     * @api
+     */
+    protected function isValid($value)
+    {
+        if ($value instanceof UploadedFileInterface) {
+            $filesize = $value->getSize();
+        } elseif ($value instanceof ResourceMetaDataInterface) {
+            $filesize = $value->getFileSize();
+        } else {
+            $this->addError('Only Uploads or Resources are supported.', 1677934918);
+            return;
+        }
+
+        if ($filesize === null) {
+            $this->addError('The file has no size.', 1677934912);
+            return;
+        }
+        if ($this->options['minimum'] && $filesize < $this->options['minimum']) {
+            $this->addError('The file is larger than allowed.', 1677934908);
+            return;
+        }
+        if ($this->options['maximum'] && $filesize > $this->options['maximum']) {
+            $this->addError('The file is smaller than allowed.', 1677934903);
+            return;
+        }
+    }
+}

--- a/Neos.Flow/Classes/Validation/Validator/MediaTypeValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/MediaTypeValidator.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Validation\Validator;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\ResourceManagement\ResourceMetaDataInterface;
+use Neos\Utility\MediaTypes;
+use Psr\Http\Message\UploadedFileInterface;
+
+/**
+ * The given $value is matches the defined medis types
+ * Note: a value of NULL or empty string ('') are considered valid
+ */
+class MediaTypeValidator extends AbstractValidator
+{
+    /**
+     * This contains the supported options, each being an array of:
+     *
+     * 0 => default value
+     * 1 => description
+     * 2 => type
+     * 3 => required (boolean, optional)
+     *
+     * @var array
+     */
+    protected $supportedOptions = [
+        'allowedTypes' => [[], 'Array of allowed media ranges', 'array', true],
+        'disallowedTypes' => [[], 'Array of disallowed media ranges', 'array', false],
+    ];
+
+    /**
+     * The given $value is valid media type matches one of the allowedTypes and
+     * none of the disallowedTypes
+     *
+     * Note: a value of NULL or empty string ('') is considered valid and was handled already
+     *
+     * @param mixed $value
+     * @return void
+     * @api
+     */
+    protected function isValid($value)
+    {
+        if ($value instanceof UploadedFileInterface) {
+            $mediaType = $value->getClientMediaType();
+        } elseif ($value instanceof ResourceMetaDataInterface) {
+            $mediaType = $value->getMediaType();
+        } else {
+            $this->addError('Only Uploads or Resources are supported.', 1677928909);
+            return;
+        }
+
+        if ($mediaType === null) {
+            $this->addError('No media type was found.', 1677938309);
+            return;
+        }
+
+        if ($this->options['allowedTypes']) {
+            $matched = false;
+            foreach ($this->options['allowedTypes'] as $allowedMediaRange) {
+                if (MediaTypes::mediaRangeMatches($allowedMediaRange, $mediaType)) {
+                    $matched = true;
+                    break;
+                }
+            }
+            if (!$matched) {
+                $this->addError('Media type %s is not allowed.', 1677929196, [$mediaType]);
+                return;
+            }
+        }
+
+        if ($this->options['disallowedTypes']) {
+            foreach ($this->options['disallowedTypes'] as $disAllowedMediaRange) {
+                if (MediaTypes::mediaRangeMatches($disAllowedMediaRange, $mediaType)) {
+                    $this->addError('Media type %s is forbidden.', 1677929309, [$mediaType, $disAllowedMediaRange]);
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/Neos.Flow/Tests/Unit/Validation/Validator/FileExtensionValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/FileExtensionValidatorTest.php
@@ -1,0 +1,103 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Validation\Validator;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\ResourceManagement\ResourceMetaDataInterface;
+use Neos\Flow\Validation\Validator\FileExtensionValidator;
+use Psr\Http\Message\UploadedFileInterface;
+
+/**
+ * Testcase for the file extension validator
+ *
+ */
+class FileExtensionValidatorTest extends AbstractValidatorTestcase
+{
+    protected $validatorClassName = FileExtensionValidator::class;
+
+    public function setUp(): void
+    {
+        $this->validatorOptions([
+            'allowedExtensions' => ['jpg','jpeg','png'],
+        ]);
+    }
+
+    protected function createResourceMetaDataInterfaceMock(string $filename): ResourceMetaDataInterface
+    {
+        $mock = $this->createMock(ResourceMetaDataInterface::class);
+        $mock->expects($this->once())->method('getFilename')->willReturn($filename);
+        return $mock;
+    }
+
+    protected function createUploadedFileInterfaceMock(string $filename): UploadedFileInterface
+    {
+        $mock = $this->createMock(UploadedFileInterface::class);
+        $mock->expects($this->once())->method('getClientFilename')->willReturn($filename);
+        return $mock;
+    }
+
+    public function emptyItems(): array
+    {
+        return [
+            [null],
+            ['']
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider emptyItems
+     */
+    public function validateAcceptsEmptyValue($item)
+    {
+        self::assertFalse($this->validator->validate($item)->hasErrors());
+    }
+
+    public function itemsWithAllowedExtension(): array
+    {
+        return [
+            [$this->createResourceMetaDataInterfaceMock('image.jpg')],
+            [$this->createResourceMetaDataInterfaceMock('image.jpeg')],
+            [$this->createResourceMetaDataInterfaceMock('image.png')],
+            [$this->createUploadedFileInterfaceMock('image.jpg')],
+            [$this->createUploadedFileInterfaceMock('image.jpeg')],
+            [$this->createUploadedFileInterfaceMock('image.png')]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider itemsWithAllowedExtension
+     */
+    public function validateAcceptsItemsWithAllowedExtension($item)
+    {
+        self::assertFalse($this->validator->validate($item)->hasErrors());
+    }
+
+    public function itemsWithDisallowedExtension(): array
+    {
+        return [
+            [$this->createResourceMetaDataInterfaceMock('evil.exe')],
+            [$this->createResourceMetaDataInterfaceMock('image.tiff')],
+            [$this->createUploadedFileInterfaceMock('evil.exe')],
+            [$this->createUploadedFileInterfaceMock('image.tiff')]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider itemsWithDisallowedExtension
+     */
+    public function validateRejectsItemsWithDisallowedExtension($item)
+    {
+        self::assertTrue($this->validator->validate($item)->hasErrors());
+    }
+}

--- a/Neos.Flow/Tests/Unit/Validation/Validator/FileSizeValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/FileSizeValidatorTest.php
@@ -1,0 +1,123 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Validation\Validator;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\ResourceManagement\ResourceMetaDataInterface;
+use Neos\Flow\Validation\Validator\FileSizeValidator;
+use Psr\Http\Message\UploadedFileInterface;
+
+/**
+ * Testcase for the file size validator
+ *
+ */
+class FileSizeValidatorTest extends AbstractValidatorTestcase
+{
+    protected $validatorClassName = FileSizeValidator::class;
+
+    public function setUp(): void
+    {
+        $this->validatorOptions([
+            'minimum' => 200,
+            'maximum' => 1000,
+        ]);
+    }
+
+    protected function createResourceMetaDataInterfaceMock(int $filesize): ResourceMetaDataInterface
+    {
+        $mock = $this->createMock(ResourceMetaDataInterface::class);
+        $mock->expects($this->once())->method('getFileSize')->willReturn($filesize);
+        return $mock;
+    }
+
+    protected function createUploadedFileInterfaceMock(string $filesize): UploadedFileInterface
+    {
+        $mock = $this->createMock(UploadedFileInterface::class);
+        $mock->expects($this->once())->method('getSize')->willReturn($filesize);
+        return $mock;
+    }
+
+    public function emptyItems(): array
+    {
+        return [
+            [null],
+            ['']
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider emptyItems
+     */
+    public function validateAcceptsEmptyValue($item)
+    {
+        self::assertFalse($this->validator->validate($item)->hasErrors());
+    }
+
+    public function itemsWithAllowedSize(): array
+    {
+        return [
+            [$this->createResourceMetaDataInterfaceMock(200)],
+            [$this->createResourceMetaDataInterfaceMock(800)],
+            [$this->createResourceMetaDataInterfaceMock(1000)],
+            [$this->createUploadedFileInterfaceMock(200)],
+            [$this->createUploadedFileInterfaceMock(800)],
+            [$this->createUploadedFileInterfaceMock(1000)]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider itemsWithAllowedSize
+     */
+    public function validateAcceptsItemsWithAllowedSize($item)
+    {
+        self::assertFalse($this->validator->validate($item)->hasErrors());
+    }
+
+    public function itemsWithLargerThanAllowedSize(): array
+    {
+        return [
+            [$this->createResourceMetaDataInterfaceMock(1001)],
+            [$this->createResourceMetaDataInterfaceMock(PHP_INT_MAX)],
+            [$this->createUploadedFileInterfaceMock(1001)],
+            [$this->createUploadedFileInterfaceMock(PHP_INT_MAX)]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider itemsWithLargerThanAllowedSize
+     */
+    public function validateRejectsItemsWithLargerThanAllowedSize($item)
+    {
+        self::assertTrue($this->validator->validate($item)->hasErrors());
+    }
+
+    public function itemsWithSmallerThanAllowedSize(): array
+    {
+        return [
+            [$this->createResourceMetaDataInterfaceMock(199)],
+            [$this->createResourceMetaDataInterfaceMock(0)],
+            [$this->createUploadedFileInterfaceMock(199)],
+            [$this->createUploadedFileInterfaceMock(0)]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider itemsWithSmallerThanAllowedSize
+     */
+    public function validateRejectsItemsWithSmallerThanAllowedSize($item)
+    {
+        self::assertTrue($this->validator->validate($item)->hasErrors());
+    }
+}

--- a/Neos.Flow/Tests/Unit/Validation/Validator/MediaTypeValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/MediaTypeValidatorTest.php
@@ -1,0 +1,141 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Validation\Validator;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\ResourceManagement\ResourceMetaDataInterface;
+use Neos\Flow\Validation\Validator\MediaTypeValidator;
+use Psr\Http\Message\UploadedFileInterface;
+
+/**
+ * Testcase for the media type validator
+ *
+ */
+class MediaTypeValidatorTest extends AbstractValidatorTestcase
+{
+    protected $validatorClassName = MediaTypeValidator::class;
+
+    public function setUp(): void
+    {
+        $this->validatorOptions([
+            'allowedTypes' => ['image/*', 'application/csv'],
+            'disallowedTypes' => ['video/*', 'application/pdf']
+        ]);
+    }
+
+    protected function createResourceMetaDataInterfaceMock(string $mediaType): ResourceMetaDataInterface
+    {
+        $mock = $this->createMock(ResourceMetaDataInterface::class);
+        $mock->expects($this->once())->method('getMediaType')->willReturn($mediaType);
+        return $mock;
+    }
+
+    protected function createUploadedFileInterfaceMock(string $mediaType): UploadedFileInterface
+    {
+        $mock = $this->createMock(UploadedFileInterface::class);
+        $mock->expects($this->once())->method('getClientMediaType')->willReturn($mediaType);
+        return $mock;
+    }
+
+    public function emptyItems(): array
+    {
+        return [
+            [null],
+            ['']
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider emptyItems
+     */
+    public function validateAcceptsEmptyValue($item)
+    {
+        self::assertFalse($this->validator->validate($item)->hasErrors());
+    }
+
+
+    public function itemsWithAllowedMediaType(): array
+    {
+        return [
+            [$this->createResourceMetaDataInterfaceMock('image/jpeg')],
+            [$this->createResourceMetaDataInterfaceMock('application/csv')],
+            [$this->createUploadedFileInterfaceMock('image/jpeg')],
+            [$this->createUploadedFileInterfaceMock('application/csv')]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider itemsWithAllowedMediaType
+     */
+    public function validateAcceptsItemsWithAllowedMediaType($item)
+    {
+        self::assertFalse($this->validator->validate($item)->hasErrors());
+    }
+
+    public function itemsWithUnhandledTypes(): array
+    {
+        return [
+            [12],
+            ['hello'],
+            [(object) []],
+            [new \DateTime()]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider itemsWithUnhandledTypes
+     */
+    public function validateRejectsItemsWithUnhandledTypes($item)
+    {
+        self::assertTrue($this->validator->validate($item)->hasErrors());
+    }
+
+
+
+    public function itemsWithDisallowedMediaType(): array
+    {
+        return [
+            [$this->createResourceMetaDataInterfaceMock('video/mp4')],
+            [$this->createResourceMetaDataInterfaceMock('application/pdf')],
+            [$this->createUploadedFileInterfaceMock('video/mp4')],
+            [$this->createUploadedFileInterfaceMock('application/pdf')],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider itemsWithDisallowedMediaType
+     */
+    public function validateRejectsItemsWithDisallowedMediaType($item)
+    {
+        self::assertTrue($this->validator->validate($item)->hasErrors());
+    }
+
+    public function itemsWithOtherMediaType(): array
+    {
+        return [
+            [$this->createResourceMetaDataInterfaceMock('text/plain')],
+            [$this->createUploadedFileInterfaceMock('text/plain')],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider itemsWithOtherMediaType
+     */
+    public function validateRejectsItemsWithOtherMediaType($item)
+    {
+        self::assertTrue($this->validator->validate($item)->hasErrors());
+    }
+}


### PR DESCRIPTION
The validators will validate both UploadedFileInterface (FlowUploadedFile) or ResourceMetaDataInterface (PersistentResource).

The `MediaType` validator supports the following options: 

- `allowedTypes`: Array of allowed media ranges
- `disallowedTypes`: Array of disallowed media ranges

The `FileSize` validator supports the following options: 

- `minimum`: Minimum allowed filesize in bytes
- `maximum`: Maximum allowed filesize in bytes

The `FileExtension` validator supports the following options: 

- `allowedExtensions`: Array of allowed file extensions

**Upgrade instructions**


**Review instructions**

The FileExtension validator is pretty much a clone of the FileType validator from the form package but is extended to support uploadedFiles aswell. The FileSize and MediaType validators were somehow missing before.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
