### PR TITLE
FEATURE: Add TypeConverters to convert `BackedEnum` back and forth to `string|int`

### DIFF
--- a/Neos.Flow/Classes/Property/TypeConverter/BackedEnumToIntegerConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/BackedEnumToIntegerConverter.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Property\TypeConverter;
+
+use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+use Neos\Flow\Property\TypeConverterInterface;
+
+class BackedEnumToIntegerConverter implements TypeConverterInterface
+{
+    public function getSupportedSourceTypes()
+    {
+        return ['object'];
+    }
+
+    public function getSupportedTargetType()
+    {
+        return 'integer';
+    }
+
+    public function getTargetTypeForSource($source, $originalTargetType, PropertyMappingConfigurationInterface $configuration = null)
+    {
+        return gettype($source->value);
+    }
+
+    public function getPriority()
+    {
+        return 200;
+    }
+
+    public function canConvertFrom($source, $targetType)
+    {
+        /* @todo once the min php version is raised to 8.1 use BackedEnum::class */
+        if (interface_exists("BackedEnum") && is_subclass_of($source, 'BackedEnum')) {
+            return (gettype($source->value) === $targetType);
+        }
+        return false;
+    }
+
+    public function getSourceChildPropertiesToBeConverted($source)
+    {
+        return [];
+    }
+
+    public function getTypeOfChildProperty($targetType, $propertyName, PropertyMappingConfigurationInterface $configuration)
+    {
+        return '';
+    }
+
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    {
+        /* @todo once the min php version is raised to 8.1 use BackedEnum::class */
+        if (interface_exists("BackedEnum") && is_subclass_of($source, 'BackedEnum')) {
+            return $source->value;
+        }
+    }
+}

--- a/Neos.Flow/Classes/Property/TypeConverter/BackedEnumToStringConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/BackedEnumToStringConverter.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Property\TypeConverter;
+
+use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+use Neos\Flow\Property\TypeConverterInterface;
+
+class BackedEnumToStringConverter implements TypeConverterInterface
+{
+    public function getSupportedSourceTypes()
+    {
+        return ['object'];
+    }
+
+    public function getSupportedTargetType()
+    {
+        return 'string';
+    }
+
+    public function getTargetTypeForSource($source, $originalTargetType, PropertyMappingConfigurationInterface $configuration = null)
+    {
+        return gettype($source->value);
+    }
+
+    public function getPriority()
+    {
+        return 200;
+    }
+
+    public function canConvertFrom($source, $targetType)
+    {
+        /* @todo once the min php version is raised to 8.1 use BackedEnum::class */
+        if (interface_exists("BackedEnum") && is_subclass_of($source, 'BackedEnum')) {
+            return (gettype($source->value) === $targetType);
+        }
+        return false;
+    }
+
+    public function getSourceChildPropertiesToBeConverted($source)
+    {
+        return [];
+    }
+
+    public function getTypeOfChildProperty($targetType, $propertyName, PropertyMappingConfigurationInterface $configuration)
+    {
+        return '';
+    }
+
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    {
+        /* @todo once the min php version is raised to 8.1 use BackedEnum::class */
+        if (interface_exists("BackedEnum") && is_subclass_of($source, 'BackedEnum')) {
+            return $source->value;
+        }
+    }
+}

--- a/Neos.Flow/Classes/Property/TypeConverter/ValueToBackedEnumConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ValueToBackedEnumConverter.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Property\TypeConverter;
+
+use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+use Neos\Flow\Property\TypeConverterInterface;
+
+class ValueToBackedEnumConverter implements TypeConverterInterface
+{
+    public function getSupportedSourceTypes()
+    {
+        return ['integer', 'string'];
+    }
+
+    public function getSupportedTargetType()
+    {
+        return 'object';
+    }
+
+    public function getTargetTypeForSource($source, $originalTargetType, PropertyMappingConfigurationInterface $configuration = null)
+    {
+        return $originalTargetType;
+    }
+
+    public function getPriority()
+    {
+        return 200;
+    }
+
+    public function canConvertFrom($source, $targetType)
+    {
+        /* @todo once the min php version is raised to 8.1 use BackedEnum::class */
+        if (interface_exists("BackedEnum") && is_subclass_of($targetType, 'BackedEnum')) {
+            return $targetType::tryFrom($source) ? true : false;
+        }
+        return false;
+    }
+
+    public function getSourceChildPropertiesToBeConverted($source)
+    {
+        return [];
+    }
+
+    public function getTypeOfChildProperty($targetType, $propertyName, PropertyMappingConfigurationInterface $configuration)
+    {
+        return '';
+    }
+
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    {
+        /* @todo once the min php version is raised to 8.1 use BackedEnum::class */
+        if (interface_exists("BackedEnum") && is_subclass_of($targetType, 'BackedEnum')) {
+            return $targetType::from($source);
+        }
+    }
+}


### PR DESCRIPTION
The change adds Enum Support to Flow property mapping which allows to use Enums as Node properties in Neos aswell. As enums will likely be used with the SelectBoxEditor a change on the Neos-Ui side is required aswell to support selecting the different cases of an enum on via select box.

The implementation checks the existence for the "BackedEnum" class first as this is only available from PHP 8.1.

**Upgrade instructions**


**Review instructions**


**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
