### PR TITLE
TASK: Test and Fix Utility::parseEelExpression

### DIFF
--- a/Neos.Eel/Classes/Package.php
+++ b/Neos.Eel/Classes/Package.php
@@ -21,22 +21,24 @@ use Neos\Flow\Annotations as Flow;
  */
 class Package extends BasePackage
 {
-    const EelExpressionRecognizer = '/
-			^\${(?P<exp>
-				(?:
-					{ (?P>exp) }			# match object literal expression recursively
-					|[^{}"\']+				# simple eel expression without quoted strings
-					|"[^"\\\\]*				# double quoted strings with possibly escaped double quotes
-						(?:
-							\\\\.			# escaped character (quote)
-							[^"\\\\]*		# unrolled loop following Jeffrey E.F. Friedl
-						)*"
-					|\'[^\'\\\\]*			# single quoted strings with possibly escaped single quotes
-						(?:
-							\\\\.			# escaped character (quote)
-							[^\'\\\\]*		# unrolled loop following Jeffrey E.F. Friedl
-						)*\'
-				)*
-			)}
-			$/x';
+    public const EelExpressionRecognizer = <<<'REGEX'
+    /
+      ^\${(?P<exp>
+        (?>
+          { (?P>exp) }          # match object literal expression recursively
+          |[^{}"']+	            # simple eel expression without quoted strings
+          |"[^"\\]*			    # double quoted strings with possibly escaped double quotes
+            (?:
+              \\.			# escaped character (quote)
+              [^"\\]*		# unrolled loop following Jeffrey E.F. Friedl
+            )*"
+          |'[^'\\]*			# single quoted strings with possibly escaped single quotes
+            (?:
+              \\.			# escaped character (quote)
+              [^'\\]*		# unrolled loop following Jeffrey E.F. Friedl
+            )*'
+        )*
+      )}$
+    /x
+    REGEX;
 }

--- a/Neos.Eel/Classes/Utility.php
+++ b/Neos.Eel/Classes/Utility.php
@@ -18,14 +18,17 @@ namespace Neos\Eel;
 class Utility
 {
     /**
-     * Return the expression if it is an valid EEL expression, otherwise return null.
-     *
-     * @param string $expression
-     * @return string|null
+     * Return the expression if it is a valid EEL expression, null otherwise.
      */
-    public static function parseEelExpression($expression)
+    public static function parseEelExpression(string $expression): ?string
     {
-        return preg_match(Package::EelExpressionRecognizer, $expression, $matches) === 1 ? $matches['exp'] : null;
+        if (!str_starts_with($expression, '${')) {
+            return null;
+        }
+        return match (preg_match(Package::EelExpressionRecognizer, $expression, $matches)) {
+            1 => $matches['exp'],
+            default => null
+        };
     }
 
     /**

--- a/Neos.Eel/Tests/Unit/EelExpressionRecognizerTest.php
+++ b/Neos.Eel/Tests/Unit/EelExpressionRecognizerTest.php
@@ -12,6 +12,7 @@ namespace Neos\Eel\Tests\Unit;
  * source code.
  */
 
+use Neos\Eel\Package;
 use Neos\Eel\Utility;
 
 class EelExpressionRecognizerTest extends \Neos\Flow\Tests\UnitTestCase
@@ -69,6 +70,14 @@ class EelExpressionRecognizerTest extends \Neos\Flow\Tests\UnitTestCase
             '${"foo + bar}',
         ];
 
+        yield "space on start" => [
+            '   ${foo + bar}',
+        ];
+
+        yield "space on end" => [
+            '${foo + bar}   ',
+        ];
+
         yield "unwrapped" => [
             'foo + bar',
         ];
@@ -83,5 +92,14 @@ class EelExpressionRecognizerTest extends \Neos\Flow\Tests\UnitTestCase
         self::assertNull(
             Utility::parseEelExpression($expression)
         );
+    }
+
+    /** @test */
+    public function leftOpenEelDoesntResultInCatastrophicBacktracking()
+    {
+        $malformedExpression = '${abc abc abc abc abc abc abc abc abc abc abc ...';
+        $return = preg_match(Package::EelExpressionRecognizer, $malformedExpression);
+        self::assertNotSame(false, $return, "Regex not efficient");
+        self::assertEquals($return, 0, "Regex should not match");
     }
 }

--- a/Neos.Eel/Tests/Unit/EelExpressionRecognizerTest.php
+++ b/Neos.Eel/Tests/Unit/EelExpressionRecognizerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Neos\Eel\Tests\Unit;
+
+/*
+ * This file is part of the Neos.Eel package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Eel\Utility;
+
+class EelExpressionRecognizerTest extends \Neos\Flow\Tests\UnitTestCase
+{
+    public function wrappedEelExpressionProvider()
+    {
+        yield "simple" => [
+            "wrapped" => '${foo + bar}',
+            "unwrapped" => 'foo + bar',
+        ];
+
+        yield "string" => [
+            "wrapped" => '${"foo" + bar}',
+            "unwrapped" => '"foo" + bar',
+        ];
+
+        yield "string with escaping and special chars" => [
+            "wrapped" => <<<'EEL'
+            ${"fo\"o{" + bar}
+            EEL,
+            "unwrapped" => <<<'EEL'
+            "fo\"o{" + bar
+            EEL,
+        ];
+
+        yield "nested object" => [
+            "wrapped" => <<<'EEL'
+            ${{foo: {hi: "lol"}}}
+            EEL,
+            "unwrapped" => <<<'EEL'
+            {foo: {hi: "lol"}}
+            EEL,
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider wrappedEelExpressionProvider
+     */
+    public function unwrapEelExpression(string $wrapped, string $unwrapped)
+    {
+        self::assertEquals(
+            Utility::parseEelExpression($wrapped),
+            $unwrapped
+        );
+    }
+
+    public function notAnExpressionProvider()
+    {
+        yield "missing object brace" => [
+            '${{foo: {}}',
+        ];
+
+        yield "left open string" => [
+            '${"foo + bar}',
+        ];
+
+        yield "unwrapped" => [
+            'foo + bar',
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider notAnExpressionProvider
+     */
+    public function notAnExpression(string $expression)
+    {
+        self::assertNull(
+            Utility::parseEelExpression($expression)
+        );
+    }
+}


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**
- make parseEelExpression faster, by checking first if the string starts with `${` via str_starts_with
- fix catastrophic backtrace in regex: add atomic group `(?>)`
  - same was done with the new fusion parser: https://github.com/neos/neos-development-collection/blob/7fa4fc647a61f5023e74fe1639285a37934b9dbf/Neos.Fusion/Classes/Core/ObjectTreeParser/Lexer.php#L20
- make regex more readable by avoiding escaping via nowdoc
- add tests

see catastrophic backtrace here without atomic group: https://regex101.com/r/94MJGr/1

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
