### PR TITLE
BUGFIX: Remove includeClasses for typo3fluid/fluid

### DIFF
--- a/Neos.FluidAdaptor/Configuration/Settings.yaml
+++ b/Neos.FluidAdaptor/Configuration/Settings.yaml
@@ -17,9 +17,7 @@ Neos:
         # default options for all rendering groups (see below). Options can be overridden in the respective rendering group
         defaultRenderingOptions:
           viewClassName: Neos\FluidAdaptor\View\StandaloneView
-    object:
-      includeClasses:
-        'typo3fluid.fluid': ['.*']
+
   # DocTools is a tool used by Flow Developers to help with a variety of documentation tasks.
   # These settings are only used in generating Documentation.
   DocTools:


### PR DESCRIPTION
This was added in https://github.com/neos/flow-development-collection/commit/8452db4edd082b8de7fcb13038e61458e2f5d288

As of `typo3fluid/fluid` v2.7.3 this leads to an error, as the package now has a non-class PHP file in the `src/Tools` folder now.

Drawback: The generation of XSD schema for the TYPO3 Fluid default ViewHelpers will no longer work.

Fixes #2993

**Review instructions**

With `typo3fluid/fluid` installed try to run `./flow`, it should work with this PR applied and fail without.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
