### PR TITLE
BUGFIX: Change type hint of returned security logger

### DIFF
--- a/Neos.Flow/Classes/Mvc/Dispatcher.php
+++ b/Neos.Flow/Classes/Mvc/Dispatcher.php
@@ -28,6 +28,7 @@ use Neos\Flow\Security\Context;
 use Neos\Flow\Security\Exception\AccessDeniedException;
 use Neos\Flow\Security\Exception\AuthenticationRequiredException;
 use Neos\Flow\Security\Exception\MissingConfigurationException;
+use Psr\Log\LoggerInterface;
 
 /**
  * Dispatches requests to the controller which was specified by the request and
@@ -112,7 +113,7 @@ class Dispatcher
             );
             return;
         } catch (AccessDeniedException $exception) {
-            /** @var PsrLoggerFactoryInterface $securityLogger */
+            /** @var LoggerInterface $securityLogger */
             $securityLogger = $this->objectManager->get(PsrLoggerFactoryInterface::class)->get('securityLogger');
             $securityLogger->warning('Access denied', LogEnvironment::fromMethodName(__METHOD__));
             throw $exception;


### PR DESCRIPTION
The type hint for the `$securityLogger` was referring to the `PsrLoggerFactoryInterface` instead of the correct `LoggerInterface`