### PR TITLE
FEATURE: Add `Type.debugType` to Type EelHelper

### DIFF
--- a/Neos.Eel/Classes/Helper/TypeHelper.php
+++ b/Neos.Eel/Classes/Helper/TypeHelper.php
@@ -60,6 +60,17 @@ class TypeHelper implements ProtectedContextAwareInterface
     }
 
     /**
+     * Get the classname for objects or type for other values
+     *
+     * @param mixed $variable
+     * @return string
+     */
+    public function debugType($variable)
+    {
+        return get_debug_type($variable);
+    }
+
+    /**
      * Is the given variable an array.
      *
      * @param mixed $variable


### PR DESCRIPTION
As `php get_debug_type` this returns the classname for objects and otherwise the type of the value.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
