### PR TITLE
FEATURE: Multiple shorthand identifiers in one translation id string

### DIFF
--- a/Neos.Flow/Classes/I18n/EelHelper/TranslationHelper.php
+++ b/Neos.Flow/Classes/I18n/EelHelper/TranslationHelper.php
@@ -136,8 +136,7 @@ class TranslationHelper implements ProtectedContextAwareInterface
      */
     protected function translateByShortHandString(string $shortHandString, $locale = null, $fallbackLocale = null)
     {
-        return preg_replace_callback(self::I18N_LABEL_ID_PATTERN, function ($matches) use ($locale, $fallbackLocale){
-
+        return preg_replace_callback(self::I18N_LABEL_ID_PATTERN, function ($matches) use ($locale, $fallbackLocale) {
             $shortHandStringParts = explode(':', $matches[0]);
             if (count($shortHandStringParts) === 3) {
                 list($package, $source, $id) = $shortHandStringParts;


### PR DESCRIPTION
Refactored to handle multiple shorthand identifiers in one translation id string.
Does match the functionality in https://github.com/neos/neos-ui/pull/3326

And added an optional fallbackLocale to handle needs from https://github.com/neos/neos-development-collection/pull/4180
