### PR TITLE
BUGFIX: Widgets can't be nested in For (Fluid)

### DIFF
--- a/Neos.FluidAdaptor/Classes/Core/Widget/AbstractWidgetViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/Core/Widget/AbstractWidgetViewHelper.php
@@ -17,6 +17,7 @@ use Neos\Flow\Mvc\Exception\ForwardException;
 use Neos\Flow\Mvc\Exception\InfiniteLoopException;
 use Neos\Flow\Mvc\Exception\StopActionException;
 use Neos\Flow\ObjectManagement\DependencyInjection\DependencyProxy;
+use Neos\FluidAdaptor\Core\Rendering\RenderingContext;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 use Neos\FluidAdaptor\Core\ViewHelper\Facets\ChildNodeAccessInterface;
 use TYPO3Fluid\Fluid\Core\Compiler\TemplateCompiler;
@@ -118,9 +119,20 @@ abstract class AbstractWidgetViewHelper extends AbstractViewHelper implements Ch
      * Initialize the Widget Context, before the Render method is called.
      *
      * @return void
+     * @throws \Exception
      */
     private function initializeWidgetContext()
     {
+        /*
+         * We reset the state of the ViewHelper by generating a new WidgetContext to handle multiple occurrences of one instance (e.g. in a ForViewHelper).
+         *
+         * By only calling $this->resetState() we would end in a situation where the RenderChildrenViewHelper could not find its children therefore we move the original children to the new WidgetContext.
+         * We create new instances of RootNode and RenderingContext in case we got null because setViewHelperChildNodes requires its parameters to be corresponding instances.
+         */
+        $rootNode = $this->widgetContext->getViewHelperChildNodes() ?? new RootNode();
+        $renderingContext = $this->widgetContext->getViewHelperChildNodeRenderingContext() ?? new RenderingContext();
+        $this->resetState();
+        $this->widgetContext->setViewHelperChildNodes($rootNode, $renderingContext);
         if ($this->ajaxWidget === true) {
             if ($this->storeConfigurationInSession === true) {
                 $this->ajaxWidgetContextHolder->store($this->widgetContext);

--- a/Neos.FluidAdaptor/Resources/Private/Templates/Tests/Functional/Core/Fixtures/AjaxTest/ForIndex.html
+++ b/Neos.FluidAdaptor/Resources/Private/Templates/Tests/Functional/Core/Fixtures/AjaxTest/ForIndex.html
@@ -1,0 +1,3 @@
+{namespace test=Neos\FluidAdaptor\Tests\Functional\Core\Fixtures\ViewHelpers}<f:for each="{0: 0, 1: 1}" as="value">
+    <test:someAjax option1="first{value}" option2="second{value}" />
+</f:for>

--- a/Neos.FluidAdaptor/Resources/Private/Templates/Tests/Functional/Core/Fixtures/ViewHelpers/SomeAjax/Index.html
+++ b/Neos.FluidAdaptor/Resources/Private/Templates/Tests/Functional/Core/Fixtures/ViewHelpers/SomeAjax/Index.html
@@ -1,3 +1,3 @@
-SomeAjaxController::indexAction()
+SomeAjaxController::indexAction(option1: "{option1}", option2: "{option2}")
 {f:widget.uri(action: 'ajax', ajax: true, arguments: {option1: 'xyz'}) -> f:format.raw()}
 {f:widget.uri(action: 'ajaxWithCustomView', ajax: true, arguments: {option1: 'xyz'}) -> f:format.raw()}

--- a/Neos.FluidAdaptor/Tests/Functional/Core/Fixtures/Controller/AjaxTestController.php
+++ b/Neos.FluidAdaptor/Tests/Functional/Core/Fixtures/Controller/AjaxTestController.php
@@ -30,6 +30,10 @@ class AjaxTestController extends ActionController
     {
     }
 
+    public function forIndexAction()
+    {
+    }
+
     /**
      * Renders and returns the URI pointing to the widget for an AJAX call.
      *

--- a/Neos.FluidAdaptor/Tests/Functional/Core/Fixtures/ViewHelpers/Controller/SomeAjaxController.php
+++ b/Neos.FluidAdaptor/Tests/Functional/Core/Fixtures/ViewHelpers/Controller/SomeAjaxController.php
@@ -34,6 +34,10 @@ class SomeAjaxController extends AbstractWidgetController
      */
     public function indexAction()
     {
+        $this->view->assignMultiple([
+            'option1' => $this->widgetConfiguration['option1'],
+            'option2' => $this->widgetConfiguration['option2'],
+        ]);
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Functional/Core/WidgetTest.php
+++ b/Neos.FluidAdaptor/Tests/Functional/Core/WidgetTest.php
@@ -51,7 +51,7 @@ class WidgetTest extends FunctionalTestCase
     {
         $response = $this->browser->request('http://localhost/test/widget/ajaxtest');
         [$confirmation,] = explode(chr(10), $response->getBody()->getContents());
-        self::assertSame('SomeAjaxController::indexAction()', $confirmation);
+        self::assertSame('SomeAjaxController::indexAction(option1: "value1", option2: "value2")', $confirmation);
     }
 
     /**
@@ -71,6 +71,23 @@ class WidgetTest extends FunctionalTestCase
 
         $response = $this->browser->request('http://localhost/' . $ajaxWidgetUri);
         self::assertSame('SomeAjaxController::ajaxAction("value1", "value2")', trim($response->getBody()->getContents()));
+    }
+
+    /**
+     * @test
+     */
+    public function ifIncludedInAForViewHelperTheWidgetsKeepTheirDifferentContext(): void
+    {
+        $response = $this->browser->request('http://localhost/test/widget/ajaxtest/forIndex');
+        [$_, $confirmation, $ajaxWidgetUri, $_, $_, $_, $secondConfirmation, $secondAjaxWidgetUri, ] = explode(chr(10), $response->getBody());
+        self::assertSame('SomeAjaxController::indexAction(option1: "first0", option2: "second0")', \trim($confirmation));
+        self::assertSame('SomeAjaxController::indexAction(option1: "first1", option2: "second1")', \trim($secondConfirmation));
+
+        self::assertNotEquals($ajaxWidgetUri, $secondAjaxWidgetUri);
+        $response = $this->browser->request('http://localhost/' . $ajaxWidgetUri);
+        self::assertSame('SomeAjaxController::ajaxAction("first0", "second0")', trim($response->getBody()->getContents()));
+        $response = $this->browser->request('http://localhost/' . $secondAjaxWidgetUri);
+        self::assertSame('SomeAjaxController::ajaxAction("first1", "second1")', trim($response->getBody()->getContents()));
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetViewHelperTest.php
@@ -65,6 +65,7 @@ class AbstractWidgetViewHelperTest extends \Neos\Flow\Tests\UnitTestCase
         $this->viewHelper->injectWidgetContext($this->widgetContext);
 
         $this->objectManager = $this->createMock(\Neos\Flow\ObjectManagement\ObjectManagerInterface::class);
+        $this->objectManager->expects(self::any())->method('get')->with(\Neos\FluidAdaptor\Core\Widget\WidgetContext::class)->will(self::returnValue($this->widgetContext));
         $this->viewHelper->injectObjectManager($this->objectManager);
 
         $this->controllerContext = $this->getMockBuilder(\Neos\Flow\Mvc\Controller\ControllerContext::class)->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
* introduces a test with an AjaxWidgetViewHelper in a ForViewHelper which tests the indexAction and the ajaxAction
* resolved: https://github.com/neos/flow-development-collection/issues/1214

**Upgrade instructions**

**Review instructions**

The crucial part has a comment in code (AbstractWidgetViewHelper).

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
