### PR TITLE
BUGFIX: ObjectSerialization does not create dynamic properties

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
@@ -230,7 +230,7 @@ class ProxyClassBuilder
                 $propertyVarTags[$propertyName] = isset($varTagValues[0]) ? $varTagValues[0] : null;
             }
             $code = "        \$this->Flow_Object_PropertiesToSerialize = array();
-        unset(\$this->Flow_Persistence_RelatedEntities);
+        \$this->Flow_Persistence_RelatedEntities = null;
 
         \$transientProperties = " . var_export($transientProperties, true) . ";
         \$propertyVarTags = " . var_export($propertyVarTags, true) . ";


### PR DESCRIPTION
The `ObjectSerializationTrait` used dynamically created properties on classes it is used in, to keep track of injected properties, entities and relations. These now lead to deprecations in PHP 8.2 and thus we should get rid of them. The change declares those properties now and additionally makes some minimal code improvements throughout the trait, but leaves the general way it works intact.

Fixes: #2946
