### PR TITLE
TASK: Drop tests checking notices/warnings are not supressed

### DIFF
--- a/Neos.Cache/Tests/Unit/Backend/FileBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/FileBackendTest.php
@@ -566,40 +566,6 @@ class FileBackendTest extends BaseTestCase
     /**
      * @test
      */
-    public function requireOnceDoesNotSwallowPhpWarningsOfTheIncludedFile()
-    {
-        $this->expectWarning();
-        $mockCache = $this->createMock(AbstractFrontend::class);
-        $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
-
-        $backend = $this->prepareDefaultBackend();
-        $backend->setCache($mockCache);
-
-        $entryIdentifier = 'SomePhpEntryWithPhpWarning';
-        $backend->set($entryIdentifier, '<?php trigger_error("Warning!", E_USER_WARNING); ?>');
-        $backend->requireOnce($entryIdentifier);
-    }
-
-    /**
-     * @test
-     */
-    public function requireOnceDoesNotSwallowPhpNoticesOfTheIncludedFile()
-    {
-        $this->expectNotice();
-        $mockCache = $this->createMock(AbstractFrontend::class);
-        $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
-
-        $backend = $this->prepareDefaultBackend();
-        $backend->setCache($mockCache);
-
-        $entryIdentifier = 'SomePhpEntryWithPhpNotice';
-        $backend->set($entryIdentifier, '<?php trigger_error("Notice!", E_USER_NOTICE); ?>');
-        $backend->requireOnce($entryIdentifier);
-    }
-
-    /**
-     * @test
-     */
     public function findIdentifiersByTagFindsCacheEntriesWithSpecifiedTag()
     {
         $mockCache = $this->createMock(AbstractFrontend::class);

--- a/Neos.Cache/Tests/Unit/Backend/SimpleFileBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/SimpleFileBackendTest.php
@@ -445,32 +445,6 @@ class SimpleFileBackendTest extends BaseTestCase
     /**
      * @test
      */
-    public function requireOnceDoesNotSwallowPhpWarningsOfTheIncludedFile()
-    {
-        $this->expectWarning();
-        $entryIdentifier = 'SomePhpEntryWithPhpWarning';
-
-        $simpleFileBackend = $this->getSimpleFileBackend();
-        $simpleFileBackend->set($entryIdentifier, '<?php trigger_error("Warning!", E_USER_WARNING); ?>');
-        $simpleFileBackend->requireOnce($entryIdentifier);
-    }
-
-    /**
-     * @test
-     */
-    public function requireOnceDoesNotSwallowPhpNoticesOfTheIncludedFile()
-    {
-        $this->expectNotice();
-        $entryIdentifier = 'SomePhpEntryWithPhpNotice';
-
-        $simpleFileBackend = $this->getSimpleFileBackend();
-        $simpleFileBackend->set($entryIdentifier, '<?php trigger_error("Notice!", E_USER_NOTICE); ?>');
-        $simpleFileBackend->requireOnce($entryIdentifier);
-    }
-
-    /**
-     * @test
-     */
     public function flushRemovesAllCacheEntries()
     {
         $this->mockCacheFrontend->expects(self::any())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));


### PR DESCRIPTION
These were added years ago to make sure the suppression of notices and warnings when including cached PHP files does not come back.

Since the way to check for those  will be removed in PhpUnit 10, and does not come back, I decided to completely remove the tests.

**Review instructions**

With PhpUnit 9 the deprecation warning on those tests should go away, and the tests should no longer fail on PhpUnit 10.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
