### PR TITLE
TASK: ObjectManagement limit debugBacktrace

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Configuration/Configuration.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/Configuration.php
@@ -113,7 +113,7 @@ class Configuration
      */
     public function __construct($objectName, $className = null)
     {
-        $backtrace = debug_backtrace();
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
         if (isset($backtrace[1]['object'])) {
             $this->configurationSourceHint = get_class($backtrace[1]['object']);
         } elseif (isset($backtrace[1]['class'])) {


### PR DESCRIPTION
`debug_backtrace` is expensive, and we are only interested in the second callee.