### PR TITLE
BUGFIX: Prevent type hint errors with latest Fluid minor release

### DIFF
--- a/Neos.FluidAdaptor/composer.json
+++ b/Neos.FluidAdaptor/composer.json
@@ -11,7 +11,7 @@
     "neos/cache": "*",
     "neos/utility-files": "*",
     "neos/utility-objecthandling": "*",
-    "typo3fluid/fluid": "^2.7.0",
+    "typo3fluid/fluid": "~2.7.0",
     "psr/log": "^1.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "neos/composer-plugin": "^2.0",
         "composer/composer": "^1.10.22 || ^2.0.13",
         "egulias/email-validator": "^2.1.17 || ^3.0",
-        "typo3fluid/fluid": "^2.7.0",
+        "typo3fluid/fluid": "~2.7.0",
         "guzzlehttp/psr7": "^1.8.4",
         "ext-mbstring": "*"
     },


### PR DESCRIPTION
The 2.8.0 release of Fluid introduced breaking changes (type declarations), thus this changes the dependency to allow only 2.7.x.

Resolves: #3037

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
