### PR TITLE
BUGFIX: Move access to objectAccess of TemplateObjectAccessInterface into getByPath

### DIFF
--- a/Neos.FluidAdaptor/Classes/Core/ViewHelper/TemplateVariableContainer.php
+++ b/Neos.FluidAdaptor/Classes/Core/ViewHelper/TemplateVariableContainer.php
@@ -11,8 +11,6 @@ namespace Neos\FluidAdaptor\Core\ViewHelper;
  * source code.
  */
 
-use Neos\Utility\Exception\PropertyNotAccessibleException;
-use Neos\Utility\ObjectAccess;
 use Neos\FluidAdaptor\Core\Parser\SyntaxTree\TemplateObjectAccessInterface;
 use TYPO3Fluid\Fluid\Core\Variables\StandardVariableProvider;
 use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
@@ -24,25 +22,23 @@ use TYPO3Fluid\Fluid\Core\Variables\VariableProviderInterface;
  */
 class TemplateVariableContainer extends StandardVariableProvider implements VariableProviderInterface
 {
-    const ACCESSOR_OBJECT_ACCESS = 'object_access';
-
     /**
      * Get a variable by dotted path expression, retrieving the
      * variable from nested arrays/objects one segment at a time.
-     * If the second argument is provided, it must be an array of
-     * accessor names which can be used to extract each value in
-     * the dotted path.
      *
      * @param string $path
-     * @param array $accessors
      * @return mixed
      */
-    public function getByPath($path, array $accessors = [])
+    public function getByPath($path)
     {
-        $subject = parent::getByPath($path, $accessors);
+        $subject = parent::getByPath($path);
 
         if ($subject === null) {
             $subject = $this->getBooleanValue($path);
+        }
+
+        if ($subject instanceof TemplateObjectAccessInterface) {
+            return $subject->objectAccess();
         }
 
         return $subject;
@@ -63,42 +59,6 @@ class TemplateVariableContainer extends StandardVariableProvider implements Vari
             }
         }
         return $propertyPath;
-    }
-
-    /**
-     * @param mixed $subject
-     * @param string $propertyName
-     * @return NULL|string
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     */
-    protected function detectAccessor($subject, $propertyName)
-    {
-        return TemplateVariableContainer::ACCESSOR_OBJECT_ACCESS;
-    }
-
-    /**
-     * @param mixed $subject
-     * @param string $propertyName
-     * @param string $accessor
-     * @return mixed|null
-     */
-    protected function extractWithAccessor($subject, $propertyName, $accessor)
-    {
-        if (TemplateVariableContainer::ACCESSOR_OBJECT_ACCESS === $accessor) {
-            try {
-                $subject = ObjectAccess::getProperty($subject, $propertyName);
-            } catch (PropertyNotAccessibleException $e) {
-                $subject = null;
-            }
-        } else {
-            $subject = parent::extractWithAccessor($subject, $propertyName, $accessor);
-        }
-
-        if ($subject instanceof TemplateObjectAccessInterface) {
-            return $subject->objectAccess();
-        }
-
-        return $subject;
     }
 
     /**


### PR DESCRIPTION
... as accessors are not used anymore for variable provider within fluid, starting v2.8.0.

Due to the missing accessors the `objectAccess` of `TemplateObjectAccessInterface` didn't get called anymore, so the result of the `getByPath` method was an object of `FusionPathProxy` instead of an rendered string.

See: 
https://github.com/TYPO3/Fluid/compare/2.7.4...2.8.0#diff-a0aa72aa19d9eb57cdb9a4dcd344c3706d75ae7ca408286f91a846e495b3c766L122
https://github.com/TYPO3/Fluid/compare/2.7.4...2.8.0#diff-a0aa72aa19d9eb57cdb9a4dcd344c3706d75ae7ca408286f91a846e495b3c766L341
https://github.com/TYPO3/Fluid/compare/2.7.4...2.8.0#diff-a0aa72aa19d9eb57cdb9a4dcd344c3706d75ae7ca408286f91a846e495b3c766L312

