### PR TITLE
BUGFIX: Uncached ConfigurationManager

### DIFF
--- a/Neos.Flow/Classes/Configuration/ConfigurationManager.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationManager.php
@@ -382,6 +382,9 @@ class ConfigurationManager
      */
     protected function loadConfigurationsFromCache(): void
     {
+        if ($this->temporaryDirectoryPath === null) {
+            return;
+        }
         $cachePathAndFilename = $this->constructConfigurationCachePath();
         /** @noinspection UsingInclusionReturnValueInspection */
         $configurations = @include $cachePathAndFilename;
@@ -553,6 +556,7 @@ class ConfigurationManager
      */
     protected function constructConfigurationCachePath(): string
     {
+        assert($this->temporaryDirectoryPath !== null, 'ConfigurationManager::$temporaryDirectoryPath must not be null.');
         $configurationCachePath = $this->temporaryDirectoryPath . 'Configuration/';
         return $configurationCachePath . str_replace('/', '_', (string)$this->context) . 'Configurations.php';
     }

--- a/Neos.Flow/Classes/Configuration/ConfigurationManager.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationManager.php
@@ -252,7 +252,9 @@ class ConfigurationManager
                 return new ObjectsLoader(new YamlSource());
             case self::CONFIGURATION_PROCESSING_TYPE_POLICY:
                 $policyLoader = new PolicyLoader(new YamlSource());
-                $policyLoader->setTemporaryDirectoryPath($this->temporaryDirectoryPath);
+                if ($this->temporaryDirectoryPath) {
+                    $policyLoader->setTemporaryDirectoryPath($this->temporaryDirectoryPath);
+                }
                 return $policyLoader;
             case self::CONFIGURATION_PROCESSING_TYPE_ROUTES:
                 return new RoutesLoader(new YamlSource(), $this);

--- a/Neos.Flow/Classes/Configuration/ConfigurationManager.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationManager.php
@@ -154,7 +154,7 @@ class ConfigurationManager
     /**
      * An absolute file path to store configuration caches in. If not set, no cache will be active.
      *
-     * @var ?string
+     * @var string|null
      */
     protected $temporaryDirectoryPath = null;
 

--- a/Neos.Flow/Classes/Configuration/ConfigurationManager.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationManager.php
@@ -154,9 +154,9 @@ class ConfigurationManager
     /**
      * An absolute file path to store configuration caches in. If not set, no cache will be active.
      *
-     * @var string
+     * @var ?string
      */
-    protected $temporaryDirectoryPath;
+    protected $temporaryDirectoryPath = null;
 
     /**
      * @var array
@@ -400,7 +400,7 @@ class ConfigurationManager
     public function flushConfigurationCache(): void
     {
         $this->configurations = [self::CONFIGURATION_TYPE_SETTINGS => []];
-        if (!isset($this->temporaryDirectoryPath)) {
+        if ($this->temporaryDirectoryPath === null) {
             return;
         }
 
@@ -420,7 +420,7 @@ class ConfigurationManager
      */
     protected function processConfigurationType(string $configurationType)
     {
-        if (isset($this->temporaryDirectoryPath)) {
+        if ($this->temporaryDirectoryPath !== null) {
             // to avoid issues regarding concurrency and invalid filesystem characters
             // the configurationType is encoded as a uniqueid
             $configurationTypeId = \uniqid(\sprintf('%x', \crc32($configurationType)), true);
@@ -453,7 +453,7 @@ class ConfigurationManager
             }
         }
 
-        if (!isset($this->temporaryDirectoryPath)) {
+        if ($this->temporaryDirectoryPath === null) {
             return;
         }
 

--- a/Neos.Flow/Classes/Configuration/ConfigurationManager.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationManager.php
@@ -423,6 +423,11 @@ class ConfigurationManager
             $this->writeConfigurationCacheFile($cachePathAndFilename, $configurationType);
             $this->replaceConfigurationForConfigurationType($configurationType, $cachePathAndFilename);
             @unlink($cachePathAndFilename);
+        } else {
+            // in case the cache is disabled (implicitly, because temporaryDirectoryPath is null)
+            // we need to still handle replacing the environment variables like `%FLOW_PATH_ROOT%` in the configuration
+            $configuration = $this->unprocessedConfiguration[$configurationType];
+            $this->configurations[$configurationType] = eval('return ' . $this->replaceVariablesInPhpString(var_export($configuration, true)) . ';');
         }
     }
 

--- a/Neos.Flow/Classes/Configuration/ConfigurationManager.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationManager.php
@@ -152,7 +152,7 @@ class ConfigurationManager
     protected $cacheNeedsUpdate = false;
 
     /**
-     * An absolute file path to store configuration caches in. If null no cache will be active.
+     * An absolute file path to store configuration caches in. If not set, no cache will be active.
      *
      * @var string
      */
@@ -174,12 +174,18 @@ class ConfigurationManager
     }
 
     /**
-     * Set an absolute file path to store configuration caches in. If null no cache will be active.
+     * Set an absolute file path to store configuration caches in.
+     *
+     * If never called no cache will be active.
      *
      * @param string $temporaryDirectoryPath
      */
     public function setTemporaryDirectoryPath(string $temporaryDirectoryPath): void
     {
+        if (!is_dir($temporaryDirectoryPath)) {
+            throw new \RuntimeException(sprintf('Cannot set temporaryDirectoryPath to "%s" for the ConfigurationManager cache, as it must be a valid directory.', $temporaryDirectoryPath));
+        }
+
         $this->temporaryDirectoryPath = $temporaryDirectoryPath;
 
         $this->loadConfigurationsFromCache();
@@ -394,7 +400,7 @@ class ConfigurationManager
     public function flushConfigurationCache(): void
     {
         $this->configurations = [self::CONFIGURATION_TYPE_SETTINGS => []];
-        if ($this->temporaryDirectoryPath === null) {
+        if (!isset($this->temporaryDirectoryPath)) {
             return;
         }
 
@@ -414,7 +420,7 @@ class ConfigurationManager
      */
     protected function processConfigurationType(string $configurationType)
     {
-        if ($this->temporaryDirectoryPath !== null) {
+        if (isset($this->temporaryDirectoryPath)) {
             // to avoid issues regarding concurrency and invalid filesystem characters
             // the configurationType is encoded as a uniqueid
             $configurationTypeId = \uniqid(\sprintf('%x', \crc32($configurationType)), true);
@@ -447,7 +453,7 @@ class ConfigurationManager
             }
         }
 
-        if ($this->temporaryDirectoryPath === null) {
+        if (!isset($this->temporaryDirectoryPath)) {
             return;
         }
 

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -197,7 +197,7 @@ class Scripts
      * @return void
      * @throws FlowException
      */
-    public static function initializeConfiguration(Bootstrap $bootstrap)
+    public static function initializeConfiguration(Bootstrap $bootstrap, bool $enableCache = true)
     {
         $context = $bootstrap->getContext();
         $environment = new Environment($context);
@@ -209,7 +209,9 @@ class Scripts
 
         $configurationManager = new ConfigurationManager($context);
         $configurationManager->setPackages($packageManager->getFlowPackages());
-        $configurationManager->setTemporaryDirectoryPath($environment->getPathToTemporaryDirectory());
+        if ($enableCache) {
+            $configurationManager->setTemporaryDirectoryPath($environment->getPathToTemporaryDirectory());
+        }
 
         $yamlSource = new YamlSource();
         $configurationManager->registerConfigurationType(ConfigurationManager::CONFIGURATION_TYPE_CACHES, new MergeLoader($yamlSource, ConfigurationManager::CONFIGURATION_TYPE_CACHES));

--- a/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -1677,6 +1677,41 @@ class ConfigurationManagerTest extends UnitTestCase
     }
 
     /**
+     * Test the disabled cache and that we still replace env variables.
+     *
+     * {@see ConfigurationManager::$temporaryDirectoryPath} === null
+     *
+     * @test
+     */
+    public function configurationManagerWithDisabledCache(): void
+    {
+        $configurationManager = new ConfigurationManager(new ApplicationContext('Testing'));
+
+        // we don't invoke $configurationManager->setTemporaryDirectoryPath();, and thus the cache is disabled
+
+        $mockLoader = $this->getMockBuilder(LoaderInterface::class)->getMock();
+
+        $mockLoader->method('load')->willReturn(
+            [
+                'plainSetting' => '123',
+                'envSetting' => '%PHP_BINARY%'
+            ]
+        );
+
+        $configurationManager->registerConfigurationType('MockType', $mockLoader);
+
+        $configuration = $configurationManager->getConfiguration('MockType');
+
+        self::assertSame(
+            [
+                'plainSetting' => '123',
+                'envSetting' => PHP_BINARY
+            ],
+            $configuration
+        );
+    }
+
+    /**
      * A callback as stand in configruation source for above test.
      *
      * @param string $filenameAndPath


### PR DESCRIPTION
### BUGFIX: Proper uncached configurationManager mode

It is purposely not allowed to disable the cache at runtime (when you have a configuration manager at hand)

The usage to create a configuration manager without caching, you need to have your own request handler and boot only this step:

```php
Scripts::initializeConfiguration($this->bootstrap, false);
```

---

### BUGFIX: ConfigurationManager with disabled cache doesn't replace environment variables in setting

@kitsunet and me need this for building https://github.com/neos/setup/pull/59 at super early boot time - pre compile time.

We want to use the config manager without cache, which currently has a bug and you cant really disable the cache unless using reflection to set `temporaryDirectoryPath` to null.

The config manager with disabled cache doesnt replace environment variables in settings.


<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
