### PR TITLE
TASK: Only add serialization entities code if needed

### DIFF
--- a/Neos.Flow/Classes/Aop/Pointcut/PointcutExpressionParser.php
+++ b/Neos.Flow/Classes/Aop/Pointcut/PointcutExpressionParser.php
@@ -13,8 +13,8 @@ namespace Neos\Flow\Aop\Pointcut;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Aop\Builder\ProxyClassBuilder;
-use Neos\Flow\Aop\Exception\InvalidPointcutExpressionException;
 use Neos\Flow\Aop\Exception as AopException;
+use Neos\Flow\Aop\Exception\InvalidPointcutExpressionException;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Log\PsrLoggerFactoryInterface;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
@@ -237,7 +237,7 @@ class PointcutExpressionParser
      */
     protected function parseAnnotationPattern(string &$annotationPattern, array &$annotationPropertyConstraints): void
     {
-        if (strpos($annotationPattern, '(') !== false) {
+        if (str_contains($annotationPattern, '(')) {
             $matches = [];
             preg_match(self::PATTERN_MATCHMETHODNAMEANDARGUMENTS, $annotationPattern, $matches);
 
@@ -450,11 +450,11 @@ class PointcutExpressionParser
     }
 
     /**
-    * Parses the method arguments pattern and returns the corresponding constraints array
-    *
-    * @param string $methodArgumentsPattern The arguments pattern defined in the pointcut expression
-    * @return array The corresponding constraints array
-    */
+     * Parses the method arguments pattern and returns the corresponding constraints array
+     *
+     * @param string $methodArgumentsPattern The arguments pattern defined in the pointcut expression
+     * @return array The corresponding constraints array
+     */
     protected function getArgumentConstraintsFromMethodArgumentsPattern(string $methodArgumentsPattern): array
     {
         $matches = [];

--- a/Neos.Flow/Classes/Aop/Pointcut/PointcutMethodNameFilter.php
+++ b/Neos.Flow/Classes/Aop/Pointcut/PointcutMethodNameFilter.php
@@ -56,7 +56,7 @@ class PointcutMethodNameFilter implements PointcutFilterInterface
      * Constructor - initializes the filter with the name filter pattern
      *
      * @param string $methodNameFilterExpression A regular expression which filters method names
-     * @param string $methodVisibility The method visibility modifier (public, protected or private). Specify NULL if you don't care.
+     * @param string|null $methodVisibility The method visibility modifier (public, protected or private). Specify NULL if you don't care.
      * @param array $methodArgumentConstraints array of method constraints
      * @throws InvalidPointcutExpressionException
      */

--- a/Neos.Flow/Classes/Cache/CacheFactory.php
+++ b/Neos.Flow/Classes/Cache/CacheFactory.php
@@ -57,18 +57,20 @@ class CacheFactory extends \Neos\Cache\CacheFactory
 
     /**
      * @param CacheManager $cacheManager
-     * @Flow\Autowiring(enabled=false)
+     *
+     * @Flow\Autowiring (enabled=false)
      */
-    public function injectCacheManager(CacheManager $cacheManager)
+    public function injectCacheManager(CacheManager $cacheManager): void
     {
         $this->cacheManager = $cacheManager;
     }
 
     /**
      * @param EnvironmentConfiguration $environmentConfiguration
-     * @Flow\Autowiring(enabled=false)
+     *
+     * @Flow\Autowiring (enabled=false)
      */
-    public function injectEnvironmentConfiguration(EnvironmentConfiguration $environmentConfiguration)
+    public function injectEnvironmentConfiguration(EnvironmentConfiguration $environmentConfiguration): void
     {
         $this->environmentConfiguration = $environmentConfiguration;
     }

--- a/Neos.Flow/Classes/Mvc/Routing/IdentityRoutePart.php
+++ b/Neos.Flow/Classes/Mvc/Routing/IdentityRoutePart.php
@@ -105,8 +105,7 @@ class IdentityRoutePart extends DynamicRoutePart
     public function getUriPattern()
     {
         if ($this->uriPattern === null) {
-            $classSchema = $this->reflectionService->getClassSchema($this->objectType);
-            $identityProperties = $classSchema->getIdentityProperties();
+            $identityProperties = $this->reflectionService->getClassSchema($this->objectType)?->getIdentityProperties() ?? [];
             if (count($identityProperties) === 0) {
                 $this->uriPattern = '';
             } else {
@@ -145,9 +144,10 @@ class IdentityRoutePart extends DynamicRoutePart
      * If no matching ObjectPathMapping was found or the given $pathSegment is no valid identifier NULL is returned.
      *
      * @param string $pathSegment the query path segment to convert
-     * @return string|integer the technical identifier of the object or NULL if it couldn't be found
+     *
+     * @return null|string the technical identifier of the object or NULL if it couldn't be found
      */
-    protected function getObjectIdentifierFromPathSegment($pathSegment)
+    protected function getObjectIdentifierFromPathSegment($pathSegment): string|null
     {
         if ($this->getUriPattern() === '') {
             $identifier = rawurldecode($pathSegment);

--- a/Neos.Flow/Classes/Mvc/Routing/ObjectPathMapping.php
+++ b/Neos.Flow/Classes/Mvc/Routing/ObjectPathMapping.php
@@ -65,7 +65,7 @@ class ObjectPathMapping
     /**
      * @param string $pathSegment
      */
-    public function setPathSegment($pathSegment)
+    public function setPathSegment($pathSegment): void
     {
         $this->pathSegment = $pathSegment;
     }
@@ -81,7 +81,7 @@ class ObjectPathMapping
     /**
      * @param string $uriPattern
      */
-    public function setUriPattern($uriPattern)
+    public function setUriPattern($uriPattern): void
     {
         $this->uriPattern = $uriPattern;
     }
@@ -97,7 +97,7 @@ class ObjectPathMapping
     /**
      * @param string $identifier
      */
-    public function setIdentifier($identifier)
+    public function setIdentifier($identifier): void
     {
         $this->identifier = $identifier;
     }
@@ -112,9 +112,10 @@ class ObjectPathMapping
 
     /**
      * @param string $objectType
+     *
      * @psalm-param class-string $objectType
      */
-    public function setObjectType($objectType)
+    public function setObjectType($objectType): void
     {
         $this->objectType = $objectType;
     }

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
@@ -183,7 +183,7 @@ class ConfigurationBuilder
      * @param array $rawObjectConfiguration
      * @return array
      */
-    protected function enhanceRawConfigurationWithAnnotationOptions($className, array $rawObjectConfiguration)
+    protected function enhanceRawConfigurationWithAnnotationOptions($className, array $rawObjectConfiguration): array
     {
         if ($this->reflectionService->isClassAnnotatedWith($className, Flow\Scope::class)) {
             $annotation = $this->reflectionService->getClassAnnotation($className, Flow\Scope::class);

--- a/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
@@ -273,9 +273,14 @@ class ObjectManager implements ObjectManagerInterface
      * Returns the object name corresponding to a given class name.
      *
      * @param string $className The class name
-     * @return string The object name corresponding to the given class name or false if no object is configured to use that class
+     *
+     * @return (int|string)|false The object name corresponding to the given class name or false if no object is configured to use that class
+     *
      * @throws \InvalidArgumentException
+     *
      * @api
+     *
+     * @psalm-return array-key|false
      */
     public function getObjectNameByClassName($className)
     {

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
@@ -141,12 +141,11 @@ class Compiler
             return false;
         }
 
-        $proxyAnnotation = $this->reflectionService->getClassAnnotation($fullClassName, Flow\Proxy::class);
-        if ($proxyAnnotation !== null && $proxyAnnotation->enabled === false) {
+        if ($this->reflectionService->getClassAnnotation($fullClassName, Flow\Proxy::class)?->enabled === false) {
             return false;
         }
 
-        if (in_array(substr($fullClassName, 0, $this->excludedSubPackagesLength), $this->excludedSubPackages)) {
+        if (in_array(substr($fullClassName, 0, $this->excludedSubPackagesLength), $this->excludedSubPackages, true)) {
             return false;
         }
         // Annotation classes (like \Neos\Flow\Annotations\Entity) must never be proxied because that would break the Doctrine AnnotationParser
@@ -210,9 +209,10 @@ class Compiler
 
     /**
      * @param array<string> $classNames
+     *
      * @Flow\Signal
      */
-    public function emitCompiledClasses(array $classNames)
+    public function emitCompiledClasses(array $classNames): void
     {
     }
 

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethod.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethod.php
@@ -184,7 +184,7 @@ class ProxyMethod
                             $code .= '            ' . $callParentMethodCode;
                         }
                     } else {
-                        $code .= '            $result = ' . ($callParentMethodCode === '' ? "NULL;\n" : $callParentMethodCode);
+                        $code .= '        $result = ' . ($callParentMethodCode === '' ? "NULL;\n" : $callParentMethodCode);
                     }
                     $code .= $this->addedPostParentCallCode;
                     if (!$returnTypeIsVoid) {

--- a/Neos.Flow/Classes/Persistence/Aspect/EmbeddedValueObjectPointcutFilter.php
+++ b/Neos.Flow/Classes/Persistence/Aspect/EmbeddedValueObjectPointcutFilter.php
@@ -43,17 +43,12 @@ class EmbeddedValueObjectPointcutFilter implements \Neos\Flow\Aop\Pointcut\Point
      * @param string $methodName Name of the method to check against
      * @param string $methodDeclaringClassName Name of the class the method was originally declared in
      * @param mixed $pointcutQueryIdentifier Some identifier for this query - must at least differ from a previous identifier. Used for circular reference detection.
-     * @return boolean true if the class / method match, otherwise false
+     * @return bool true if the class / method match, otherwise false
      */
-    public function matches($className, $methodName, $methodDeclaringClassName, $pointcutQueryIdentifier)
+    public function matches($className, $methodName, $methodDeclaringClassName, $pointcutQueryIdentifier): bool
     {
-        $valueObjectAnnotation = $this->reflectionService->getClassAnnotation($className, Flow\ValueObject::class);
-
-        if ($valueObjectAnnotation !== null && $valueObjectAnnotation->embedded === true) {
-            return true;
-        }
-
-        return false;
+        $annotation = $this->reflectionService->getClassAnnotation($className, Flow\ValueObject::class);
+        return ($annotation->embedded ?? false) === true;
     }
 
     /**

--- a/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -1046,7 +1046,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
         }
 
         $proxyAnnotation = $this->reader->getClassAnnotation($class, Flow\Proxy::class);
-        if ($proxyAnnotation === null || $proxyAnnotation->enabled !== false) {
+        if (($proxyAnnotation === null || $proxyAnnotation->enabled !== false) && method_exists($class->getName(), '__wakeup')) {
             $metadata->addLifecycleCallback('__wakeup', Events::postLoad);
         }
     }

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1926,7 +1926,7 @@ class ReflectionService
     /**
      * Filter an array of entries where keys are class names by being in the given package namespace.
      *
-     * @param (int|string) $packageKey
+     * @param int|string $packageKey
      *
      * @psalm-param array-key $packageKey
      */

--- a/Neos.Flow/Classes/Reflection/ReflectionServiceFactory.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionServiceFactory.php
@@ -51,7 +51,7 @@ class ReflectionServiceFactory
     /**
      * Get reflection service instance
      */
-    public function create()
+    public function create(): ReflectionService
     {
         if ($this->reflectionService !== null) {
             return $this->reflectionService;

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassToBeSerialized.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassToBeSerialized.php
@@ -14,7 +14,9 @@ namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
 use Neos\Flow\Annotations as Flow;
 
 /**
- * A class to serialize and check if all dependencies are reinjected on unserialize.
+ * A class to serialize and check if all dependencies are re-injected on unserialize.
+ *
+ * @Flow\Entity()
  */
 class ClassToBeSerialized
 {

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassF.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassF.php
@@ -15,6 +15,8 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A class of scope prototype (but without explicit scope annotation)
+ *
+ * @Flow\Entity
  */
 class PrototypeClassF
 {

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ObjectSerializationTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ObjectSerializationTest.php
@@ -53,7 +53,8 @@ class ObjectSerializationTest extends FunctionalTestCase
         $propertiesToBeSerialized = $object->__sleep();
 
         // Note that the privateProperty is not serialized as it was declared in the parent class of the proxy.
-        self::assertCount(2, $propertiesToBeSerialized);
+        self::assertCount(3, $propertiesToBeSerialized);
+        self::assertContains('Persistence_Object_Identifier', $propertiesToBeSerialized); # Introduced due to "Entity" annotation
         self::assertContains('someProperty', $propertiesToBeSerialized);
         self::assertContains('protectedProperty', $propertiesToBeSerialized);
     }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
@@ -195,16 +195,17 @@ class ProxyCompilerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function complexPropertyTypesArePreserved()
+    public function complexPropertyTypesArePreserved(): void
     {
         if (PHP_MAJOR_VERSION < 8) {
             $this->markTestSkipped('Only for PHP 8 with UnionTypes');
         }
         $reflectionClass = new ClassReflection(Fixtures\PHP8\ClassWithUnionTypes::class);
-        /** @var PropertyReflection $property */
+
         foreach ($reflectionClass->getProperties() as $property) {
-            if ($property->getName() !== 'propertyA' && $property->getName() !== 'propertyB') {
-                self::assertInstanceOf(\ReflectionUnionType::class, $property->getType(), $property->getName() . ': ' . $property->getType());
+            assert($property instanceof PropertyReflection);
+            if ($property->getName() !== 'propertyA' && $property->getName() !== 'propertyB' && !str_starts_with($property->getName(), 'Flow_')) {
+                self::assertInstanceOf(\ReflectionUnionType::class, $property->getType(), sprintf('Property "%s" is of type "%s"', $property->getName(), $property->getType()));
             }
         }
         self::assertEquals(


### PR DESCRIPTION
Proxy classes created by the Dependency Injection Proxy Class Builder now only contain code related to serialization and deserialization of related entities if needed.

The code is only rendered if one of the following conditions is met:

- The class is annotated with Entity
- The class is annotated with Scope("session")

Despite the previous condition, the code will not be rendered if the following condition is true:

- The class already has a __sleep() method (we assume that the developer wants to take care of serialization themself)

As part of this change, the generated code related to serialization was slightly adjusted for stricter type handling.

related: #1539

**Review instructions**

- try to find an existing application which relies on serialization of related entities, for example a Flow application which uses ORM with relations or uses entities in a session scope.
- remove all caches and then access your application in a browser using the current Flow 9 branch (without this patch)
- create a backup of the Cache/Code/Flow_Object_Classes directory
- switch to a branch with this change, remove all caches and access the application again in a browser
- use a diff tool (e.g. Kaleidoscope) to compare both cache directories to see what is now different
- check if your application still works