### PR TITLE
TASK: Only add constructor injection code if needed

### DIFF
--- a/Neos.Flow/Classes/Aop/Pointcut/PointcutExpressionParser.php
+++ b/Neos.Flow/Classes/Aop/Pointcut/PointcutExpressionParser.php
@@ -13,8 +13,8 @@ namespace Neos\Flow\Aop\Pointcut;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Aop\Builder\ProxyClassBuilder;
-use Neos\Flow\Aop\Exception\InvalidPointcutExpressionException;
 use Neos\Flow\Aop\Exception as AopException;
+use Neos\Flow\Aop\Exception\InvalidPointcutExpressionException;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Log\PsrLoggerFactoryInterface;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
@@ -237,7 +237,7 @@ class PointcutExpressionParser
      */
     protected function parseAnnotationPattern(string &$annotationPattern, array &$annotationPropertyConstraints): void
     {
-        if (strpos($annotationPattern, '(') !== false) {
+        if (str_contains($annotationPattern, '(')) {
             $matches = [];
             preg_match(self::PATTERN_MATCHMETHODNAMEANDARGUMENTS, $annotationPattern, $matches);
 
@@ -450,11 +450,11 @@ class PointcutExpressionParser
     }
 
     /**
-    * Parses the method arguments pattern and returns the corresponding constraints array
-    *
-    * @param string $methodArgumentsPattern The arguments pattern defined in the pointcut expression
-    * @return array The corresponding constraints array
-    */
+     * Parses the method arguments pattern and returns the corresponding constraints array
+     *
+     * @param string $methodArgumentsPattern The arguments pattern defined in the pointcut expression
+     * @return array The corresponding constraints array
+     */
     protected function getArgumentConstraintsFromMethodArgumentsPattern(string $methodArgumentsPattern): array
     {
         $matches = [];

--- a/Neos.Flow/Classes/Aop/Pointcut/PointcutMethodNameFilter.php
+++ b/Neos.Flow/Classes/Aop/Pointcut/PointcutMethodNameFilter.php
@@ -56,7 +56,7 @@ class PointcutMethodNameFilter implements PointcutFilterInterface
      * Constructor - initializes the filter with the name filter pattern
      *
      * @param string $methodNameFilterExpression A regular expression which filters method names
-     * @param string $methodVisibility The method visibility modifier (public, protected or private). Specify NULL if you don't care.
+     * @param string|null $methodVisibility The method visibility modifier (public, protected or private). Specify NULL if you don't care.
      * @param array $methodArgumentConstraints array of method constraints
      * @throws InvalidPointcutExpressionException
      */

--- a/Neos.Flow/Classes/Cache/CacheFactory.php
+++ b/Neos.Flow/Classes/Cache/CacheFactory.php
@@ -57,18 +57,20 @@ class CacheFactory extends \Neos\Cache\CacheFactory
 
     /**
      * @param CacheManager $cacheManager
-     * @Flow\Autowiring(enabled=false)
+     *
+     * @Flow\Autowiring (enabled=false)
      */
-    public function injectCacheManager(CacheManager $cacheManager)
+    public function injectCacheManager(CacheManager $cacheManager): void
     {
         $this->cacheManager = $cacheManager;
     }
 
     /**
      * @param EnvironmentConfiguration $environmentConfiguration
-     * @Flow\Autowiring(enabled=false)
+     *
+     * @Flow\Autowiring (enabled=false)
      */
-    public function injectEnvironmentConfiguration(EnvironmentConfiguration $environmentConfiguration)
+    public function injectEnvironmentConfiguration(EnvironmentConfiguration $environmentConfiguration): void
     {
         $this->environmentConfiguration = $environmentConfiguration;
     }

--- a/Neos.Flow/Classes/Mvc/Routing/IdentityRoutePart.php
+++ b/Neos.Flow/Classes/Mvc/Routing/IdentityRoutePart.php
@@ -105,8 +105,7 @@ class IdentityRoutePart extends DynamicRoutePart
     public function getUriPattern()
     {
         if ($this->uriPattern === null) {
-            $classSchema = $this->reflectionService->getClassSchema($this->objectType);
-            $identityProperties = $classSchema->getIdentityProperties();
+            $identityProperties = $this->reflectionService->getClassSchema($this->objectType)?->getIdentityProperties() ?? [];
             if (count($identityProperties) === 0) {
                 $this->uriPattern = '';
             } else {
@@ -145,9 +144,10 @@ class IdentityRoutePart extends DynamicRoutePart
      * If no matching ObjectPathMapping was found or the given $pathSegment is no valid identifier NULL is returned.
      *
      * @param string $pathSegment the query path segment to convert
-     * @return string|integer the technical identifier of the object or NULL if it couldn't be found
+     *
+     * @return null|string the technical identifier of the object or NULL if it couldn't be found
      */
-    protected function getObjectIdentifierFromPathSegment($pathSegment)
+    protected function getObjectIdentifierFromPathSegment($pathSegment): string|null
     {
         if ($this->getUriPattern() === '') {
             $identifier = rawurldecode($pathSegment);

--- a/Neos.Flow/Classes/Mvc/Routing/ObjectPathMapping.php
+++ b/Neos.Flow/Classes/Mvc/Routing/ObjectPathMapping.php
@@ -65,7 +65,7 @@ class ObjectPathMapping
     /**
      * @param string $pathSegment
      */
-    public function setPathSegment($pathSegment)
+    public function setPathSegment($pathSegment): void
     {
         $this->pathSegment = $pathSegment;
     }
@@ -81,7 +81,7 @@ class ObjectPathMapping
     /**
      * @param string $uriPattern
      */
-    public function setUriPattern($uriPattern)
+    public function setUriPattern($uriPattern): void
     {
         $this->uriPattern = $uriPattern;
     }
@@ -97,7 +97,7 @@ class ObjectPathMapping
     /**
      * @param string $identifier
      */
-    public function setIdentifier($identifier)
+    public function setIdentifier($identifier): void
     {
         $this->identifier = $identifier;
     }
@@ -112,9 +112,10 @@ class ObjectPathMapping
 
     /**
      * @param string $objectType
+     *
      * @psalm-param class-string $objectType
      */
-    public function setObjectType($objectType)
+    public function setObjectType($objectType): void
     {
         $this->objectType = $objectType;
     }

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
@@ -183,7 +183,7 @@ class ConfigurationBuilder
      * @param array $rawObjectConfiguration
      * @return array
      */
-    protected function enhanceRawConfigurationWithAnnotationOptions($className, array $rawObjectConfiguration)
+    protected function enhanceRawConfigurationWithAnnotationOptions($className, array $rawObjectConfiguration): array
     {
         if ($this->reflectionService->isClassAnnotatedWith($className, Flow\Scope::class)) {
             $annotation = $this->reflectionService->getClassAnnotation($className, Flow\Scope::class);

--- a/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
@@ -273,9 +273,14 @@ class ObjectManager implements ObjectManagerInterface
      * Returns the object name corresponding to a given class name.
      *
      * @param string $className The class name
-     * @return string The object name corresponding to the given class name or false if no object is configured to use that class
+     *
+     * @return (int|string)|false The object name corresponding to the given class name or false if no object is configured to use that class
+     *
      * @throws \InvalidArgumentException
+     *
      * @api
+     *
+     * @psalm-return array-key|false
      */
     public function getObjectNameByClassName($className)
     {

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
@@ -141,12 +141,11 @@ class Compiler
             return false;
         }
 
-        $proxyAnnotation = $this->reflectionService->getClassAnnotation($fullClassName, Flow\Proxy::class);
-        if ($proxyAnnotation !== null && $proxyAnnotation->enabled === false) {
+        if ($this->reflectionService->getClassAnnotation($fullClassName, Flow\Proxy::class)?->enabled === false) {
             return false;
         }
 
-        if (in_array(substr($fullClassName, 0, $this->excludedSubPackagesLength), $this->excludedSubPackages)) {
+        if (in_array(substr($fullClassName, 0, $this->excludedSubPackagesLength), $this->excludedSubPackages, true)) {
             return false;
         }
         // Annotation classes (like \Neos\Flow\Annotations\Entity) must never be proxied because that would break the Doctrine AnnotationParser
@@ -210,9 +209,10 @@ class Compiler
 
     /**
      * @param array<string> $classNames
+     *
      * @Flow\Signal
      */
-    public function emitCompiledClasses(array $classNames)
+    public function emitCompiledClasses(array $classNames): void
     {
     }
 

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethod.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethod.php
@@ -184,7 +184,7 @@ class ProxyMethod
                             $code .= '            ' . $callParentMethodCode;
                         }
                     } else {
-                        $code .= '            $result = ' . ($callParentMethodCode === '' ? "NULL;\n" : $callParentMethodCode);
+                        $code .= '        $result = ' . ($callParentMethodCode === '' ? "NULL;\n" : $callParentMethodCode);
                     }
                     $code .= $this->addedPostParentCallCode;
                     if (!$returnTypeIsVoid) {

--- a/Neos.Flow/Classes/Persistence/Aspect/EmbeddedValueObjectPointcutFilter.php
+++ b/Neos.Flow/Classes/Persistence/Aspect/EmbeddedValueObjectPointcutFilter.php
@@ -43,17 +43,12 @@ class EmbeddedValueObjectPointcutFilter implements \Neos\Flow\Aop\Pointcut\Point
      * @param string $methodName Name of the method to check against
      * @param string $methodDeclaringClassName Name of the class the method was originally declared in
      * @param mixed $pointcutQueryIdentifier Some identifier for this query - must at least differ from a previous identifier. Used for circular reference detection.
-     * @return boolean true if the class / method match, otherwise false
+     * @return bool true if the class / method match, otherwise false
      */
-    public function matches($className, $methodName, $methodDeclaringClassName, $pointcutQueryIdentifier)
+    public function matches($className, $methodName, $methodDeclaringClassName, $pointcutQueryIdentifier): bool
     {
-        $valueObjectAnnotation = $this->reflectionService->getClassAnnotation($className, Flow\ValueObject::class);
-
-        if ($valueObjectAnnotation !== null && $valueObjectAnnotation->embedded === true) {
-            return true;
-        }
-
-        return false;
+        $annotation = $this->reflectionService->getClassAnnotation($className, Flow\ValueObject::class);
+        return ($annotation->embedded ?? false) === true;
     }
 
     /**

--- a/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -1046,7 +1046,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
         }
 
         $proxyAnnotation = $this->reader->getClassAnnotation($class, Flow\Proxy::class);
-        if ($proxyAnnotation === null || $proxyAnnotation->enabled !== false) {
+        if (($proxyAnnotation === null || $proxyAnnotation->enabled !== false) && method_exists($class->getName(), '__wakeup')) {
             $metadata->addLifecycleCallback('__wakeup', Events::postLoad);
         }
     }

--- a/Neos.Flow/Classes/Reflection/ReflectionServiceFactory.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionServiceFactory.php
@@ -51,7 +51,7 @@ class ReflectionServiceFactory
     /**
      * Get reflection service instance
      */
-    public function create()
+    public function create(): ReflectionService
     {
         if ($this->reflectionService !== null) {
             return $this->reflectionService;

--- a/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
@@ -12,21 +12,22 @@ namespace Neos\Flow\Tests\Functional\ObjectManagement;
  */
 
 use Neos\Flow\Configuration\ConfigurationManager;
+use Neos\Flow\ObjectManagement\Proxy\ProxyInterface;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\FinalClassWithDependencies;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\Flow175\ClassWithTransitivePrototypeDependency;
+use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassA;
+use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassH;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\SingletonClassA;
+use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ValueObjectClassA;
+use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ValueObjectClassB;
 use Neos\Flow\Tests\FunctionalTestCase;
 
 /**
  * Functional tests for the Dependency Injection features
- *
  */
 class DependencyInjectionTest extends FunctionalTestCase
 {
-    /**
-     * @var ConfigurationManager
-     */
-    protected $configurationManager;
+    protected ConfigurationManager $configurationManager;
 
     protected function setUp(): void
     {
@@ -38,7 +39,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function singletonObjectsCanBeInjectedIntoConstructorsOfSingletonObjects()
+    public function singletonObjectsCanBeInjectedIntoConstructorsOfSingletonObjects(): void
     {
         $objectA = $this->objectManager->get(Fixtures\SingletonClassA::class);
         $objectB = $this->objectManager->get(Fixtures\SingletonClassB::class);
@@ -49,7 +50,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function constructorInjectionCanHandleCombinationsOfRequiredAutowiredAndOptionalArguments()
+    public function constructorInjectionCanHandleCombinationsOfRequiredAutowiredAndOptionalArguments(): void
     {
         $objectC = $this->objectManager->get(Fixtures\SingletonClassC::class);
 
@@ -61,7 +62,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function propertiesOfVariousPrimitiveTypeAreSetInSingletonPropertiesIfConfigured()
+    public function propertiesOfVariousPrimitiveTypeAreSetInSingletonPropertiesIfConfigured(): void
     {
         $objectC = $this->objectManager->get(Fixtures\SingletonClassC::class);
 
@@ -76,7 +77,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function ifItExistsASetterIsUsedToInjectPrimitiveTypePropertiesFromConfiguration()
+    public function ifItExistsASetterIsUsedToInjectPrimitiveTypePropertiesFromConfiguration(): void
     {
         $objectC = $this->objectManager->get(Fixtures\SingletonClassC::class);
 
@@ -87,7 +88,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function propertiesAreReinjectedIfTheObjectIsUnserialized()
+    public function propertiesAreReinjectedIfTheObjectIsUnserialized(): void
     {
         $className = Fixtures\PrototypeClassA::class;
 
@@ -100,7 +101,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function virtualObjectsDefinedInObjectsYamlCanUseAFactoryForTheirActualImplementation()
+    public function virtualObjectsDefinedInObjectsYamlCanUseAFactoryForTheirActualImplementation(): void
     {
         $prototypeA = $this->objectManager->get(Fixtures\PrototypeClassAishInterface::class);
 
@@ -111,7 +112,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function constructorInjectionInSingletonCanHandleArgumentDefinedInSettings()
+    public function constructorInjectionInSingletonCanHandleArgumentDefinedInSettings(): void
     {
         $objectC = $this->objectManager->get(Fixtures\SingletonClassC::class);
 
@@ -122,7 +123,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function singletonCanHandleInjectedPrototypeWithSettingArgument()
+    public function singletonCanHandleInjectedPrototypeWithSettingArgument(): void
     {
         $objectD = $this->objectManager->get(Fixtures\SingletonClassD::class);
 
@@ -133,7 +134,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function singletonCanHandleInjectedPrototypeWithCustomFactory()
+    public function singletonCanHandleInjectedPrototypeWithCustomFactory(): void
     {
         $objectD = $this->objectManager->get(Fixtures\SingletonClassD::class);
 
@@ -145,7 +146,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function singletonCanHandleConstructorArgumentWithCustomFactory()
+    public function singletonCanHandleConstructorArgumentWithCustomFactory(): void
     {
         $objectG = $this->objectManager->get(Fixtures\SingletonClassG::class);
 
@@ -157,7 +158,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function onCreationOfObjectInjectionInParentClassIsDoneOnlyOnce()
+    public function onCreationOfObjectInjectionInParentClassIsDoneOnlyOnce(): void
     {
         $prototypeDsub = $this->objectManager->get(Fixtures\PrototypeClassDsub::class);
         self::assertSame(1, $prototypeDsub->injectionRuns);
@@ -168,7 +169,7 @@ class DependencyInjectionTest extends FunctionalTestCase
      *
      * @test
      */
-    public function injectedPropertiesAreAvailableInInitializeObjectEvenIfTheClassHasBeenExtended()
+    public function injectedPropertiesAreAvailableInInitializeObjectEvenIfTheClassHasBeenExtended(): void
     {
         $prototypeDsub = $this->objectManager->get(Fixtures\PrototypeClassDsub::class);
         self::assertFalse($prototypeDsub->injectedPropertyWasUnavailable);
@@ -177,7 +178,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function constructorsOfSingletonObjectsAcceptNullArguments()
+    public function constructorsOfSingletonObjectsAcceptNullArguments(): void
     {
         $objectF = $this->objectManager->get(Fixtures\SingletonClassF::class);
 
@@ -187,7 +188,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function constructorsOfPrototypeObjectsAcceptNullArguments()
+    public function constructorsOfPrototypeObjectsAcceptNullArguments(): void
     {
         $objectE = $this->objectManager->get(Fixtures\PrototypeClassE::class, null);
 
@@ -197,7 +198,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function injectionOfObjectFromSameNamespace()
+    public function injectionOfObjectFromSameNamespace(): void
     {
         $nonNamespacedDependencies = new Fixtures\ClassWithNonNamespacedDependencies();
         $classB = $this->objectManager->get(Fixtures\SingletonClassB::class);
@@ -207,7 +208,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function injectionOfObjectFromSubNamespace()
+    public function injectionOfObjectFromSubNamespace(): void
     {
         $nonNamespacedDependencies = new Fixtures\ClassWithNonNamespacedDependencies();
         $aClassFromSubNamespace = $this->objectManager->get(Fixtures\SubNamespace\AnotherClass::class);
@@ -217,7 +218,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function injectionOfAllSettings()
+    public function injectionOfAllSettings(): void
     {
         $classWithInjectedConfiguration = new Fixtures\ClassWithInjectedConfiguration();
         $actualSettings = $this->configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.Flow');
@@ -228,7 +229,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function injectionOfSpecifiedPackageSettings()
+    public function injectionOfSpecifiedPackageSettings(): void
     {
         $classWithInjectedConfiguration = new Fixtures\ClassWithInjectedConfiguration();
 
@@ -239,7 +240,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function injectionOfCurrentPackageSettings()
+    public function injectionOfCurrentPackageSettings(): void
     {
         $classWithInjectedConfiguration = new Fixtures\ClassWithInjectedConfiguration();
 
@@ -250,7 +251,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function injectionOfNonExistingSettingsOverridesDefaultValue()
+    public function injectionOfNonExistingSettingsOverridesDefaultValue(): void
     {
         $classWithInjectedConfiguration = new Fixtures\ClassWithInjectedConfiguration();
         self::assertNull($classWithInjectedConfiguration->getNonExistingSetting());
@@ -259,7 +260,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function injectionOfSingleSettings()
+    public function injectionOfSingleSettings(): void
     {
         $classWithInjectedConfiguration = new Fixtures\ClassWithInjectedConfiguration();
         self::assertSame('injected setting', $classWithInjectedConfiguration->getInjectedSettingA());
@@ -268,7 +269,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function injectionOfSingleSettingsFromSpecificPackage()
+    public function injectionOfSingleSettingsFromSpecificPackage(): void
     {
         $classWithInjectedConfiguration = new Fixtures\ClassWithInjectedConfiguration();
         self::assertSame('injected setting', $classWithInjectedConfiguration->getInjectedSettingB());
@@ -277,7 +278,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function injectionOfConfigurationCallsRespectiveSetterIfItExists()
+    public function injectionOfConfigurationCallsRespectiveSetterIfItExists(): void
     {
         $classWithInjectedConfiguration = new Fixtures\ClassWithInjectedConfiguration();
         self::assertSame('INJECTED SETTING', $classWithInjectedConfiguration->getInjectedSettingWithSetter());
@@ -286,7 +287,7 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function injectionOfOtherConfigurationTypes()
+    public function injectionOfOtherConfigurationTypes(): void
     {
         $classWithInjectedConfiguration = new Fixtures\ClassWithInjectedConfiguration();
         self::assertSame($this->configurationManager->getConfiguration('Views'), $classWithInjectedConfiguration->getInjectedViewsConfiguration());
@@ -303,7 +304,7 @@ class DependencyInjectionTest extends FunctionalTestCase
      * @test
      * @see https://jira.neos.io/browse/FLOW-175
      */
-    public function transitivePrototypeDependenciesWithExplicitObjectConfigurationAreConstructedCorrectly()
+    public function transitivePrototypeDependenciesWithExplicitObjectConfigurationAreConstructedCorrectly(): void
     {
         $classWithTransitivePrototypeDependency = new ClassWithTransitivePrototypeDependency();
         self::assertEquals('Hello World!', $classWithTransitivePrototypeDependency->getTestValue());
@@ -312,9 +313,24 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function dependencyInjectionWorksForFinalClasses()
+    public function dependencyInjectionWorksForFinalClasses(): void
     {
         $object = $this->objectManager->get(FinalClassWithDependencies::class);
         self::assertInstanceOf(SingletonClassA::class, $object->dependency);
+    }
+
+    /**
+     * @test
+     */
+    public function noProxyClassIsGeneratedForPrototypeClassesWithOnlyPrototypeConstructorArguments(): void
+    {
+        $object = new PrototypeClassH(
+            new ValueObjectClassA('foo'),
+            new ValueObjectClassB('bar')
+        );
+        self::assertNotInstanceOf(ProxyInterface::class, $object);
+
+        $object = new PrototypeClassA();
+        self::assertInstanceOf(ProxyInterface::class, $object);
     }
 }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassToBeSerialized.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassToBeSerialized.php
@@ -14,7 +14,9 @@ namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
 use Neos\Flow\Annotations as Flow;
 
 /**
- * A class to serialize and check if all dependencies are reinjected on unserialize.
+ * A class to serialize and check if all dependencies are re-injected on unserialize.
+ *
+ * @Flow\Entity()
  */
 class ClassToBeSerialized
 {

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassF.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassF.php
@@ -15,6 +15,8 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A class of scope prototype (but without explicit scope annotation)
+ *
+ * @Flow\Entity
  */
 class PrototypeClassF
 {

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassH.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassH.php
@@ -1,0 +1,24 @@
+<?php
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A class of scope prototype in the style of a read model
+ */
+class PrototypeClassH
+{
+    public function __construct(
+        readonly public ValueObjectClassA $classA,
+        readonly public ValueObjectClassB $classB,
+    ) {
+    }
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ValueObjectClassA.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ValueObjectClassA.php
@@ -1,0 +1,36 @@
+<?php
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A class in the style of a value object
+ */
+class ValueObjectClassA implements \JsonSerializable
+{
+    public function __construct(
+        readonly public string $value,
+    ) {
+        if ($value === '') {
+            throw new \InvalidArgumentException('Value must not be empty', 1684151596);
+        }
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+
+    public function jsonSerialize(): string
+    {
+        return $this->value;
+    }
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ValueObjectClassB.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ValueObjectClassB.php
@@ -1,0 +1,36 @@
+<?php
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A class in the style of a value object
+ */
+class ValueObjectClassB implements \JsonSerializable
+{
+    public function __construct(
+        readonly public string $value,
+    ) {
+        if ($value === '') {
+            throw new \InvalidArgumentException('Value must not be empty', 1684166315);
+        }
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+
+    public function jsonSerialize(): string
+    {
+        return $this->value;
+    }
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ObjectSerializationTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ObjectSerializationTest.php
@@ -53,7 +53,8 @@ class ObjectSerializationTest extends FunctionalTestCase
         $propertiesToBeSerialized = $object->__sleep();
 
         // Note that the privateProperty is not serialized as it was declared in the parent class of the proxy.
-        self::assertCount(2, $propertiesToBeSerialized);
+        self::assertCount(3, $propertiesToBeSerialized);
+        self::assertContains('Persistence_Object_Identifier', $propertiesToBeSerialized); # Introduced due to "Entity" annotation
         self::assertContains('someProperty', $propertiesToBeSerialized);
         self::assertContains('protectedProperty', $propertiesToBeSerialized);
     }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
@@ -195,16 +195,17 @@ class ProxyCompilerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function complexPropertyTypesArePreserved()
+    public function complexPropertyTypesArePreserved(): void
     {
         if (PHP_MAJOR_VERSION < 8) {
             $this->markTestSkipped('Only for PHP 8 with UnionTypes');
         }
         $reflectionClass = new ClassReflection(Fixtures\PHP8\ClassWithUnionTypes::class);
-        /** @var PropertyReflection $property */
+
         foreach ($reflectionClass->getProperties() as $property) {
-            if ($property->getName() !== 'propertyA' && $property->getName() !== 'propertyB') {
-                self::assertInstanceOf(\ReflectionUnionType::class, $property->getType(), $property->getName() . ': ' . $property->getType());
+            assert($property instanceof PropertyReflection);
+            if ($property->getName() !== 'propertyA' && $property->getName() !== 'propertyB' && !str_starts_with($property->getName(), 'Flow_')) {
+                self::assertInstanceOf(\ReflectionUnionType::class, $property->getType(), sprintf('Property "%s" is of type "%s"', $property->getName(), $property->getType()));
             }
         }
         self::assertEquals(


### PR DESCRIPTION
The proxy class builder now skips code generation for constructor injection code if the given original class is prototype, no user-defined object configuration exists and all potentially autowired constructor arguments are prototypes or simple values. This change should result in a significantly less amount of proxy classes generated in most modern Flow projects.

resolves: #3049
resolves: #1539