### PR TITLE
TASK: Replace "adviced" by "advised"

### DIFF
--- a/Neos.Flow/Classes/Aop/Builder/AdvisedConstructorInterceptorBuilder.php
+++ b/Neos.Flow/Classes/Aop/Builder/AdvisedConstructorInterceptorBuilder.php
@@ -15,14 +15,15 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Aop\Exception;
 
 /**
- * An AOP interceptor code builder for methods enriched by advices.
+ * A method interceptor build for constructors with advice.
  *
+ * @Flow\Proxy(false)
  * @Flow\Scope("singleton")
  */
-class AdvicedMethodInterceptorBuilder extends AbstractMethodInterceptorBuilder
+class AdvisedConstructorInterceptorBuilder extends AbstractMethodInterceptorBuilder
 {
     /**
-     * Builds interception PHP code for an adviced method
+     * Builds interception PHP code for an advised constructor
      *
      * @param string $methodName Name of the method to build an interceptor for
      * @param array $interceptedMethods An array of method names and their meta information, including advices for the method (if any)
@@ -32,23 +33,20 @@ class AdvicedMethodInterceptorBuilder extends AbstractMethodInterceptorBuilder
      */
     public function build(string $methodName, array $interceptedMethods, string $targetClassName): void
     {
-        if ($methodName === '__construct') {
-            throw new Exception('The ' . __CLASS__ . ' cannot build constructor interceptor code.', 1173107446);
+        if ($methodName !== '__construct') {
+            throw new Exception('The ' . __CLASS__ . ' can only build constructor interceptor code.', 1231789021);
         }
 
         $declaringClassName = $interceptedMethods[$methodName]['declaringClassName'];
-        $proxyMethod = $this->compiler->getProxyClass($targetClassName)->getMethod($methodName);
-        if ($proxyMethod->isPrivate()) {
-            throw new Exception(sprintf('The %s cannot build interceptor code for private method %s::%s(). Please change the scope to at least protected or adjust the pointcut expression in the corresponding aspect.', __CLASS__, $targetClassName, $methodName), 1593070574);
-        }
+        $proxyMethod = $this->compiler->getProxyClass($targetClassName)->getConstructor();
         if ($declaringClassName !== $targetClassName) {
-            $proxyMethod->setMethodParametersCode($proxyMethod->buildMethodParametersCode($declaringClassName, $methodName, true));
+            $proxyMethod->setMethodParametersCode($this->buildMethodParametersCode($declaringClassName, $methodName, true));
         }
 
         $groupedAdvices = $interceptedMethods[$methodName]['groupedAdvices'];
         $advicesCode = $this->buildAdvicesCode($groupedAdvices, $methodName, $targetClassName, $declaringClassName);
 
-        if ($methodName !== null || $methodName === '__wakeup') {
+        if ($methodName !== null) {
             $proxyMethod->addPreParentCallCode('
         if (isset($this->Flow_Aop_Proxy_methodIsInAdviceMode[\'' . $methodName . '\'])) {
 ');
@@ -62,6 +60,7 @@ class AdvicedMethodInterceptorBuilder extends AbstractMethodInterceptorBuilder
                 throw $exception;
             }
             unset($this->Flow_Aop_Proxy_methodIsInAdviceMode[\'' . $methodName . '\']);
+            return;
         }
 ');
         }

--- a/Neos.Flow/Classes/Aop/Builder/AdvisedMethodInterceptorBuilder.php
+++ b/Neos.Flow/Classes/Aop/Builder/AdvisedMethodInterceptorBuilder.php
@@ -15,15 +15,14 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Aop\Exception;
 
 /**
- * A method interceptor build for constructors with advice.
+ * An AOP interceptor code builder for methods enriched by advices.
  *
- * @Flow\Proxy(false)
  * @Flow\Scope("singleton")
  */
-class AdvicedConstructorInterceptorBuilder extends AbstractMethodInterceptorBuilder
+class AdvisedMethodInterceptorBuilder extends AbstractMethodInterceptorBuilder
 {
     /**
-     * Builds interception PHP code for an adviced constructor
+     * Builds interception PHP code for an advised method
      *
      * @param string $methodName Name of the method to build an interceptor for
      * @param array $interceptedMethods An array of method names and their meta information, including advices for the method (if any)
@@ -33,20 +32,23 @@ class AdvicedConstructorInterceptorBuilder extends AbstractMethodInterceptorBuil
      */
     public function build(string $methodName, array $interceptedMethods, string $targetClassName): void
     {
-        if ($methodName !== '__construct') {
-            throw new Exception('The ' . __CLASS__ . ' can only build constructor interceptor code.', 1231789021);
+        if ($methodName === '__construct') {
+            throw new Exception('The ' . __CLASS__ . ' cannot build constructor interceptor code.', 1173107446);
         }
 
         $declaringClassName = $interceptedMethods[$methodName]['declaringClassName'];
-        $proxyMethod = $this->compiler->getProxyClass($targetClassName)->getConstructor();
+        $proxyMethod = $this->compiler->getProxyClass($targetClassName)->getMethod($methodName);
+        if ($proxyMethod->isPrivate()) {
+            throw new Exception(sprintf('The %s cannot build interceptor code for private method %s::%s(). Please change the scope to at least protected or adjust the pointcut expression in the corresponding aspect.', __CLASS__, $targetClassName, $methodName), 1593070574);
+        }
         if ($declaringClassName !== $targetClassName) {
-            $proxyMethod->setMethodParametersCode($this->buildMethodParametersCode($declaringClassName, $methodName, true));
+            $proxyMethod->setMethodParametersCode($proxyMethod->buildMethodParametersCode($declaringClassName, $methodName, true));
         }
 
         $groupedAdvices = $interceptedMethods[$methodName]['groupedAdvices'];
         $advicesCode = $this->buildAdvicesCode($groupedAdvices, $methodName, $targetClassName, $declaringClassName);
 
-        if ($methodName !== null) {
+        if ($methodName !== null || $methodName === '__wakeup') {
             $proxyMethod->addPreParentCallCode('
         if (isset($this->Flow_Aop_Proxy_methodIsInAdviceMode[\'' . $methodName . '\'])) {
 ');
@@ -60,7 +62,6 @@ class AdvicedConstructorInterceptorBuilder extends AbstractMethodInterceptorBuil
                 throw $exception;
             }
             unset($this->Flow_Aop_Proxy_methodIsInAdviceMode[\'' . $methodName . '\']);
-            return;
         }
 ');
         }

--- a/Neos.Flow/Classes/Aop/Builder/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/Aop/Builder/ProxyClassBuilder.php
@@ -141,25 +141,25 @@ class ProxyClassBuilder
     }
 
     /**
-     * Injects the Adviced Constructor Interceptor Builder
+     * Injects the Advised Constructor Interceptor Builder
      *
-     * @param AdvicedConstructorInterceptorBuilder $builder
+     * @param AdvisedConstructorInterceptorBuilder $builder
      * @return void
      */
-    public function injectAdvicedConstructorInterceptorBuilder(AdvicedConstructorInterceptorBuilder $builder): void
+    public function injectAdvisedConstructorInterceptorBuilder(AdvisedConstructorInterceptorBuilder $builder): void
     {
-        $this->methodInterceptorBuilders['AdvicedConstructor'] = $builder;
+        $this->methodInterceptorBuilders['AdvisedConstructor'] = $builder;
     }
 
     /**
-     * Injects the Adviced Method Interceptor Builder
+     * Injects the Advised Method Interceptor Builder
      *
-     * @param AdvicedMethodInterceptorBuilder $builder
+     * @param AdvisedMethodInterceptorBuilder $builder
      * @return void
      */
-    public function injectAdvicedMethodInterceptorBuilder(AdvicedMethodInterceptorBuilder $builder): void
+    public function injectAdvisedMethodInterceptorBuilder(AdvisedMethodInterceptorBuilder $builder): void
     {
-        $this->methodInterceptorBuilders['AdvicedMethod'] = $builder;
+        $this->methodInterceptorBuilders['AdvisedMethod'] = $builder;
     }
 
     /**
@@ -222,7 +222,7 @@ class ProxyClassBuilder
             if ($rebuildEverything === true || $hasCacheEntry === false) {
                 $proxyBuildResult = $this->buildProxyClass($targetClassName, $this->aspectContainers);
                 if ($proxyBuildResult === false) {
-                    // In case the proxy was not build because there was nothing adviced,
+                    // In case the proxy was not build because there was nothing advised,
                     // it might be an advice in the parent and so we need to try to treat this class.
                     $treatedSubClasses = $this->addBuildMethodsAndAdvicesCodeToClass($targetClassName, $treatedSubClasses);
                 }
@@ -422,7 +422,7 @@ class ProxyClassBuilder
         $methodsFromIntroducedInterfaces = $this->getIntroducedMethodsFromInterfaceIntroductions($interfaceIntroductions);
 
         $interceptedMethods = [];
-        $this->addAdvicedMethodsToInterceptedMethods($interceptedMethods, array_merge($methodsFromTargetClass, $methodsFromIntroducedInterfaces), $targetClassName, $aspectContainers);
+        $this->addAdvisedMethodsToInterceptedMethods($interceptedMethods, array_merge($methodsFromTargetClass, $methodsFromIntroducedInterfaces), $targetClassName, $aspectContainers);
         $this->addIntroducedMethodsToInterceptedMethods($interceptedMethods, $methodsFromIntroducedInterfaces);
 
         if (count($interceptedMethods) < 1 && count($introducedInterfaces) < 1 && count($introducedTraits) < 1 && count($propertyIntroductions) < 1) {
@@ -480,9 +480,9 @@ class ProxyClassBuilder
     }
 
     /**
-     * Makes sure that any sub classes of an adviced class also build the advices array on construction.
+     * Makes sure that any sub classes of an advised class also build the advices array on construction.
      *
-     * @param string $className The adviced class name
+     * @param string $className The advised class name
      * @param ClassNameIndex $targetClassNameCandidates target class names for advices
      * @param ClassNameIndex $treatedSubClasses Already treated (sub) classes to avoid duplication
      * @return ClassNameIndex The new collection of already treated classes
@@ -625,7 +625,7 @@ class ProxyClassBuilder
             if (count($methodMetaInformation['groupedAdvices']) === 0) {
                 throw new Aop\Exception\VoidImplementationException(sprintf('Refuse to introduce method %s into target class %s because it has no implementation code. You might want to create an around advice which implements this method.', $methodName, $targetClassName), 1303224472);
             }
-            $builderType = 'Adviced' . ($methodName === '__construct' ? 'Constructor' : 'Method');
+            $builderType = 'Advised' . ($methodName === '__construct' ? 'Constructor' : 'Method');
             $this->methodInterceptorBuilders[$builderType]->build($methodName, $interceptedMethods, $targetClassName);
         }
     }
@@ -640,7 +640,7 @@ class ProxyClassBuilder
      * @param array &$aspectContainers All aspects to take into consideration
      * @return void
      */
-    protected function addAdvicedMethodsToInterceptedMethods(array &$interceptedMethods, array $methods, string $targetClassName, array &$aspectContainers): void
+    protected function addAdvisedMethodsToInterceptedMethods(array &$interceptedMethods, array $methods, string $targetClassName, array &$aspectContainers): void
     {
         $pointcutQueryIdentifier = 0;
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/AspectOrientedProgramming.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/AspectOrientedProgramming.rst
@@ -169,7 +169,7 @@ Pointcut expression
 	pointcut- and advice declarations.
 
 Target
-	A class or method being adviced by one or more aspects is referred to as a
+	A class or method being advised by one or more aspects is referred to as a
 	target class /-method.
 
 Introduction
@@ -250,10 +250,10 @@ Manager to fulfill its task.
 Flow uses PHP's reflection capabilities to analyze declarations of aspects,
 pointcuts and advices and implements method interceptors as a dynamic proxy. In
 accordance to the GoF patterns [#]_, the proxy classes act as a placeholders for
-the target object. They are true subclasses of the original and override adviced
+the target object. They are true subclasses of the original and override advised
 methods by implementing an interceptor method. The proxy classes are generated
 automatically by the AOP framework and cached for further use. If a class has
-been adviced by some aspect, the Object Manager will only deliver instances of
+been advised by some aspect, the Object Manager will only deliver instances of
 the proxy class instead of the original.
 
 The approach of storing generated proxy classes in files provides the whole

--- a/Neos.Flow/Tests/Functional/Aop/AopProxyTest.php
+++ b/Neos.Flow/Tests/Functional/Aop/AopProxyTest.php
@@ -30,7 +30,7 @@ class AopProxyTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function anAdvicedParentMethodIsCalledCorrectlyIfANonAdvicedOverridingMethodCallsIt(): void
+    public function anAdvisedParentMethodIsCalledCorrectlyIfANonAdvisedOverridingMethodCallsIt(): void
     {
         $targetClass = new Fixtures\ChildClassOfTargetClass01();
         self::assertEquals('Two plus two makes five! For big twos and small fives! That was smart, eh?', $targetClass->saySomethingSmart());
@@ -60,7 +60,7 @@ class AopProxyTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function canCallAdvicedParentMethodNotDeclaredInChild(): void
+    public function canCallAdvisedParentMethodNotDeclaredInChild(): void
     {
         $targetClass = new Fixtures\ChildClassOfTargetClass01();
         $greeting = $targetClass->greet('Flow');

--- a/Neos.Flow/Tests/Functional/Aop/Fixtures/AbstractClassTestingAspect.php
+++ b/Neos.Flow/Tests/Functional/Aop/Fixtures/AbstractClassTestingAspect.php
@@ -29,7 +29,7 @@ class AbstractClassTestingAspect
     public function abstractMethodInSubClassAdvice(JoinPointInterface $joinPoint)
     {
         $result = $joinPoint->getAdviceChain()->proceed($joinPoint);
-        return $result . ' adviced';
+        return $result . ' advised';
     }
 
     /**
@@ -40,6 +40,6 @@ class AbstractClassTestingAspect
     public function concreteMethodInAbstractClassAdvice(JoinPointInterface $joinPoint)
     {
         $result = $joinPoint->getAdviceChain()->proceed($joinPoint);
-        return $result . ' adviced';
+        return $result . ' advised';
     }
 }

--- a/Neos.Flow/Tests/Functional/Aop/Fixtures/BaseFunctionalityTestingAspect.php
+++ b/Neos.Flow/Tests/Functional/Aop/Fixtures/BaseFunctionalityTestingAspect.php
@@ -243,7 +243,7 @@ class BaseFunctionalityTestingAspect
      */
     public function methodWithStaticScalarReturnTypeDeclarationAdvice(\Neos\Flow\Aop\JoinPointInterface $joinPoint)
     {
-        return 'adviced: ' . $joinPoint->getAdviceChain()->proceed($joinPoint);
+        return 'advised: ' . $joinPoint->getAdviceChain()->proceed($joinPoint);
     }
 
     /**
@@ -264,7 +264,7 @@ class BaseFunctionalityTestingAspect
     public function methodWithNullableScalarReturnTypeDeclarationAdvice(\Neos\Flow\Aop\JoinPointInterface $joinPoint)
     {
         $originalResult = $joinPoint->getAdviceChain()->proceed($joinPoint);
-        return 'adviced: ' . ($originalResult === null ? 'NULL' : $originalResult);
+        return 'advised: ' . ($originalResult === null ? 'NULL' : $originalResult);
     }
 
 

--- a/Neos.Flow/Tests/Functional/Aop/FrameworkTest.php
+++ b/Neos.Flow/Tests/Functional/Aop/FrameworkTest.php
@@ -111,7 +111,7 @@ class FrameworkTest extends FunctionalTestCase
 
     /**
      * Due to the way the proxy classes are rendered, lifecycle methods such as
-     * initializeObject() were called twice if the constructor is adviced by some
+     * initializeObject() were called twice if the constructor is advised by some
      * aspect. This test makes sure that any code after the AOP advice code is only
      * executed once.
      *
@@ -133,7 +133,7 @@ class FrameworkTest extends FunctionalTestCase
      *
      * @test
      */
-    public function protectedMethodsCanAlsoBeAdviced(): void
+    public function protectedMethodsCanAlsoBeAdvised(): void
     {
         $targetClass = new Fixtures\TargetClass02();
         $result = $targetClass->publicTargetMethod('foo');
@@ -178,7 +178,7 @@ class FrameworkTest extends FunctionalTestCase
     }
 
     /**
-     * An interface with a method which is not adviced and thus not implemented can be introduced.
+     * An interface with a method which is not advised and thus not implemented can be introduced.
      * The proxy class contains a place holder implementation of that introduced method.
      *
      * @test
@@ -300,17 +300,17 @@ class FrameworkTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function methodWithStaticScalarReturnTypeDeclarationCanBeAdviced(): void
+    public function methodWithStaticScalarReturnTypeDeclarationCanBeAdvised(): void
     {
         $targetClass = new Fixtures\TargetClassWithPhp7Features();
 
-        self::assertSame('adviced: it works', $targetClass->methodWithStaticScalarReturnTypeDeclaration());
+        self::assertSame('advised: it works', $targetClass->methodWithStaticScalarReturnTypeDeclaration());
     }
 
     /**
      * @test
      */
-    public function methodWithStaticObjectReturnTypeDeclarationCanBeAdviced(): void
+    public function methodWithStaticObjectReturnTypeDeclarationCanBeAdvised(): void
     {
         $targetClass = new Fixtures\TargetClassWithPhp7Features();
 
@@ -320,17 +320,17 @@ class FrameworkTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function methodWithNullableScalarReturnTypeDeclarationCanBeAdviced(): void
+    public function methodWithNullableScalarReturnTypeDeclarationCanBeAdvised(): void
     {
         $targetClass = new TargetClassWithPhp7Features();
 
-        self::assertSame('adviced: NULL', $targetClass->methodWithNullableScalarReturnTypeDeclaration());
+        self::assertSame('advised: NULL', $targetClass->methodWithNullableScalarReturnTypeDeclaration());
     }
 
     /**
      * @test
      */
-    public function methodWithNullableObjectReturnTypeDeclarationCanBeAdviced(): void
+    public function methodWithNullableObjectReturnTypeDeclarationCanBeAdvised(): void
     {
         $targetClass = new TargetClassWithPhp7Features();
 

--- a/Neos.Flow/Tests/Unit/Aop/Builder/AbstractMethodInterceptorBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Builder/AbstractMethodInterceptorBuilderTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Aop\Builder;
  */
 
 use Neos\Flow\Aop\Builder\AbstractMethodInterceptorBuilder;
-use Neos\Flow\Aop\Builder\AdvicedConstructorInterceptorBuilder;
+use Neos\Flow\Aop\Builder\AdvisedConstructorInterceptorBuilder;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Tests\UnitTestCase;
 
@@ -162,7 +162,7 @@ class AbstractMethodInterceptorBuilderTest extends UnitTestCase
         $mockReflectionService = $this->getMockBuilder(ReflectionService::class)->disableOriginalConstructor()->getMock();
         $mockReflectionService->expects(self::any())->method('getMethodParameters')->with($className, '__construct')->will(self::returnValue($methodParameters));
 
-        $builder = $this->getAccessibleMock(AdvicedConstructorInterceptorBuilder::class, ['dummy'], [], '', false);
+        $builder = $this->getAccessibleMock(AdvisedConstructorInterceptorBuilder::class, ['dummy'], [], '', false);
         $builder->injectReflectionService($mockReflectionService);
 
         $expectedCode = '$this->Flow_Aop_Proxy_originalConstructorArguments[\'arg1\'], $this->Flow_Aop_Proxy_originalConstructorArguments[\'arg2\'], $this->Flow_Aop_Proxy_originalConstructorArguments[\'arg3\'], $this->Flow_Aop_Proxy_originalConstructorArguments[\'arg4\'], $this->Flow_Aop_Proxy_originalConstructorArguments[\'arg5\']';

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Fixture/BasicClass.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Fixture/BasicClass.php
@@ -184,7 +184,7 @@ class BasicClass
      *
      * @param  array $someArray Some array
      * @return void
-     * @see    \Neos\Flow\Aop\Builder\AdvicedMethodInterceptorBuilderTest
+     * @see    \Neos\Flow\Aop\Builder\AdvisedMethodInterceptorBuilderTest
      */
     public function methodWhichExpectsAnArrayArgument(array $someArray)
     {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -365,7 +365,7 @@
       <code>Flow_Aop_Proxy_invokeJoinpoint</code>
     </UndefinedInterfaceMethod>
   </file>
-  <file src="Packages/Framework/Neos.Flow/Classes/Aop/Builder/AdvicedConstructorInterceptorBuilder.php">
+  <file src="Packages/Framework/Neos.Flow/Classes/Aop/Builder/AdvisedConstructorInterceptorBuilder.php">
     <PossiblyInvalidMethodCall occurrences="1">
       <code>getConstructor</code>
     </PossiblyInvalidMethodCall>
@@ -373,7 +373,7 @@
       <code>buildMethodParametersCode</code>
     </UndefinedMethod>
   </file>
-  <file src="Packages/Framework/Neos.Flow/Classes/Aop/Builder/AdvicedMethodInterceptorBuilder.php">
+  <file src="Packages/Framework/Neos.Flow/Classes/Aop/Builder/AdvisedMethodInterceptorBuilder.php">
     <PossiblyInvalidMethodCall occurrences="1">
       <code>getMethod</code>
     </PossiblyInvalidMethodCall>


### PR DESCRIPTION
Fixed a good old typo everywhere in Flow by replacing all occurrences of "adviced" by "advised".