### PR TITLE
BUGFIX: Fix return type in DocBlock

### DIFF
--- a/Neos.Flow/Classes/Session/SessionInterface.php
+++ b/Neos.Flow/Classes/Session/SessionInterface.php
@@ -63,7 +63,7 @@ interface SessionInterface
     public function renewId();
 
     /**
-     * Returns the contents (array) associated with the given key.
+     * Returns the content (mixed) associated with the given key.
      *
      * @param string $key An identifier for the content stored in the session.
      * @return mixed The contents associated with the given key

--- a/Neos.Flow/Classes/Session/SessionInterface.php
+++ b/Neos.Flow/Classes/Session/SessionInterface.php
@@ -66,7 +66,7 @@ interface SessionInterface
      * Returns the contents (array) associated with the given key.
      *
      * @param string $key An identifier for the content stored in the session.
-     * @return array The contents associated with the given key
+     * @return mixed The contents associated with the given key
      * @throws Exception\SessionNotStartedException
      */
     public function getData($key);


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

The return type of `SessionInterface::getData()` was noted as "array", but in fact is "mixed". 

The returned data is the same unchanged data as passed in `putData()` as second parameter, which already was "mixed". All implementations of the `SessionInterface` also use "mixed" as return type.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

Nothing to do

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

See current implementation of `TransientSession`: https://github.com/neos/flow-development-collection/blob/d14198d03d42a0f406565c50d85bcff6dad0f69e/Neos.Flow/Classes/Session/TransientSession.php#L132

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
