### PR TITLE
FEATURE: Exclude classes from constructor autowiring

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/CompileTimeObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/CompileTimeObjectManager.php
@@ -117,7 +117,7 @@ class CompileTimeObjectManager extends ObjectManager
     }
 
     /**
-     * Initializes the the object configurations and some other parts of this Object Manager.
+     * Initializes the object configurations and some other parts of this Object Manager.
      *
      * @param PackageInterface[] $packages An array of active packages to consider
      * @return void
@@ -132,6 +132,7 @@ class CompileTimeObjectManager extends ObjectManager
         $configurationBuilder = new ConfigurationBuilder();
         $configurationBuilder->injectReflectionService($this->reflectionService);
         $configurationBuilder->injectLogger($this->logger);
+        $configurationBuilder->injectExcludeClassesFromConstructorAutowiring($this->configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.Flow.object.dependencyInjection.excludeClassesFromConstructorAutowiring'));
 
         $this->objectConfigurations = $configurationBuilder->buildObjectConfigurations($this->registeredClassNames, $rawCustomObjectConfigurations);
 

--- a/Neos.Flow/Configuration/Settings.Object.yaml
+++ b/Neos.Flow/Configuration/Settings.Object.yaml
@@ -28,8 +28,8 @@ Neos:
 
         # Explicitly exclude classes from constructor autowiring.
         #
-        # This setting accepts an array of fully qualified class names, each class name
-        # being a regular expression.
+        # This setting accepts an array of regular expressions, each matching one or more fully
+        # qualified class names.
         #
         # Classes of scope prototype which expect objects to be passed to their constructor
         # are usually considered for autowiring which results in a proxy class being generated.
@@ -37,7 +37,7 @@ Neos:
         # like data transfer objects, read models, commands, events and value objects which
         # usually don't rely on dependency injection.
         #
-        # Flow cannot reliably detect weather a prototype class depends on autowiring for
+        # Flow cannot reliably detect wether a prototype class depends on autowiring for
         # constructor arguments or not. Use this option to optimize your application to avoid
         # the small but measurable overhead of proxy generation for those kinds of classes.
         #

--- a/Neos.Flow/Configuration/Settings.Object.yaml
+++ b/Neos.Flow/Configuration/Settings.Object.yaml
@@ -22,4 +22,32 @@ Neos:
       # reflected by default. You can however exclude specific (or all) classes from Flow packages
       # by specifying corresponding regular expressions that don't match classes to exclude.
       #
-      includeClasses: []
+      includeClasses: [ ]
+
+      dependencyInjection:
+
+        # Explicitly exclude classes from constructor autowiring.
+        #
+        # This setting accepts an array of fully qualified class names, each class name
+        # being a regular expression.
+        #
+        # Classes of scope prototype which expect objects to be passed to their constructor
+        # are usually considered for autowiring which results in a proxy class being generated.
+        # This option allows to exclude classes from this process. This is useful for classes
+        # like data transfer objects, read models, commands, events and value objects which
+        # usually don't rely on dependency injection.
+        #
+        # Flow cannot reliably detect weather a prototype class depends on autowiring for
+        # constructor arguments or not. Use this option to optimize your application to avoid
+        # the small but measurable overhead of proxy generation for those kinds of classes.
+        #
+        # Note that if there are other reasons than constructor injection which require a
+        # proxy class to be generated, the proxy class will be generated no matter what.
+        #
+        # Example:
+        #  excludeClassesFromConstructorAutowiring:
+        #  - '^Neos\\SomePackage\\Domain\\.*\\Command\\.*$'
+        #  - '^Neos\\SomePackage\\Domain\\.*\\Event\\.*$'
+        #  - '^Neos\\SomePackage\\ValueObjects\\SomeSpecificValueObject$'
+        #
+        excludeClassesFromConstructorAutowiring: []

--- a/Neos.Flow/Configuration/Testing/Settings.yaml
+++ b/Neos.Flow/Configuration/Testing/Settings.yaml
@@ -55,6 +55,10 @@ Neos:
     object:
       registerFunctionalTestClasses: true
 
+      dependencyInjection:
+        excludeClassesFromConstructorAutowiring:
+          - '^Neos\\Flow\\Tests\\Functional\\ObjectManagement\\Fixtures\\PrototypeClassH$'
+
     session:
       name: 'Flow_Testing_Session'
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ObjectManagement.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ObjectManagement.rst
@@ -6,11 +6,11 @@ Object Framework
 
 .. sectionauthor:: Robert Lemke <robert@neos.io>
 
-The lifecycle of objects are managed centrally by the object framework. It offers
+The lifecycle of objects is managed centrally by the object framework. It offers
 convenient support for Dependency Injection and provides some additional features such as
 a caching mechanism for objects. Because all packages are built on this foundation it is
 important to understand the general concept of objects in Flow.
-Note, the object management features of Flow are by default only enabled for classes in
+Note that the object management features of Flow are by default only enabled for classes in
 packages belonging to one of the `neos-*`` package types. All other classes are not
 considered by default. If you need that (see :ref:`sect-enabling-non-flow-packages`).
 
@@ -101,22 +101,23 @@ Objects live in a specific scope. The most commonly used are *prototype* and *si
 	The above examples are *not recommended* for the use within Flow applications.
 
 The scope of an object is determined from its configuration (see also :ref:`sect-configuring-objects`).
-The recommended way to specify the scope is the ``@scope`` annotation::
+The recommended way to specify the scope is the ``@scope`` attribute or annotation::
 
 	namespace MyCompany\MyPackage;
 
   use Neos\Flow\Annotations as Flow;
 
 	/**
-	 * A sample class
-	 *
 	 * @Flow\Scope("singleton")
 	 */
+	#[Flow\Scope("singleton")]
 	class SomeClass {
 	}
 
-Prototype is the default scope and is therefore assumed if no ``@scope`` annotation or
-other configuration was found.
+
+Note that only either the annotation or attribute is needed, not both. Prototype is the
+default scope and is therefore assumed if no ``Scope`` attribute or other configuration
+was found.
 
 Creating Prototypes
 -------------------
@@ -154,24 +155,20 @@ is dependency injection.
 
 	namespace MyCompany\MyPackage;
 
+	use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+
 	/**
 	 * A sample class
 	 */
 	class SampleClass {
 
-		/**
-		 * @var \Neos\Flow\ObjectManagement\ObjectManagerInterface
-		 */
-		protected $objectManager;
+		protected ObjectManagerInterface $objectManager;
 
 		/**
-		 * Constructor.
 		 * The Object Manager will automatically be passed (injected) by the object
 		 * framework on instantiating this class.
-		 *
-		 * @param \Neos\Flow\ObjectManagement\ObjectManagerInterface $objectManager
 		 */
-		public function __construct(\Neos\Flow\ObjectManagement\ObjectManagerInterface $objectManager) {
+		public function __construct(ObjectManagerInterface $objectManager) {
 			$this->objectManager = $objectManager;
 		}
 	}
@@ -188,7 +185,7 @@ to retrieve object instances directly. The ``ObjectManager`` provides methods fo
 retrieving object instances for these rare situations. First, you need an instance of the
 ``ObjectManager`` itself, again by taking advantage of constructor injection::
 
-	public function __construct(\Neos\Flow\ObjectManagement\ObjectManagerInterface $objectManager) {
+	public function __construct(ObjectManagerInterface $objectManager) {
 		$this->objectManager = $objectManager;
 	}
 
@@ -376,15 +373,16 @@ inject it to the authentication object.
 	demonstrates why ``new`` should be considered as a low-level tool and outlines issues
 	with polymorphism. He doesn't mention dependency injection though ...
 
-Dependencies on other objects can be declared in the object's configuration (see :ref:`sect-configuring-objects`) or they can be solved automatically (so called autowiring).
+Dependencies on other objects can be declared in the object's configuration
+(see :ref:`sect-configuring-objects`) or they can be solved automatically (so called autowiring).
 Generally there are two modes of dependency injection supported by Flow:
 *Constructor Injection* and *Setter Injection*.
 
 .. note::
 	Please note that Flow removes all injected properties before serializing an object.
-	Then after unserializing injections happen again. That means that injected properties are
-	fresh instances and do not keep any state from before the serialization. That hold true
-	also for Prototypes. If you want to keep a Prototype instance with its state throughout
+	Then after deserializing injections happen again. That means that injected properties are
+	fresh instances and do not keep any state from before the serialization. That holds true
+	also for prototypes. If you want to keep a prototype instance with its state throughout
 	a serialize/unserialize cycle you should not inject the Prototype but rather create it in
 	constructor of the object.
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ObjectManagement.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ObjectManagement.rst
@@ -1189,10 +1189,36 @@ the object configuration:
 	MyCompany\MyPackage\MyObject:
 	  autowiring: false
 
-Autowiring can also be switched off through the ``@Flow\Autowiring(false)`` annotation - either
-in the documentation block of a whole class or of a single method. For the latter the
-annotation only has an effect when used in comment blocks of a constructor or of a method
-whose name starts with ``inject``.
+Autowiring can also be switched off through the ``@Flow\Autowiring(false)`` annotation or
+the ``#[Flow\Autowiring(false)]`` attribute - either in the documentation block of a whole
+class or of a single method. For the latter the annotation or attribute only has an effect
+when used for a constructor or a method whose name starts with ``inject``.
+
+Finally, autowiring for constructors can also be disabled through a setting. The setting
+accepts an array of fully qualified class names, where each entry is a regular expression:
+
+.. code-block:: yaml
+
+	Neos:
+	  Flow:
+	    object:
+	      dependencyInjection:
+	        excludeClassesFromConstructorAutowiring:
+	          - '^Neos\\SomePackage\\Domain\\.*\\Command\\.*$'
+
+Classes of scope prototype which expect objects to be passed to their constructor
+are usually considered for autowiring which results in a proxy class being generated.
+This option allows to exclude classes from this process. This is useful for classes
+like data transfer objects, read models, commands, events and value objects which
+usually don't rely on dependency injection.
+
+.. note::
+
+	Flow cannot reliably detect weather a prototype class depends on autowiring for
+	constructor arguments or not. Use this option to optimize your application to avoid
+	the small but measurable overhead of proxy generation for those kinds of classes.
+	Note that if there are other reasons than constructor injection which require a
+	proxy class to be generated, the proxy class will be generated no matter what.
 
 Custom Factories
 ----------------

--- a/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.object.schema.yaml
+++ b/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.object.schema.yaml
@@ -7,3 +7,10 @@ properties:
     additionalProperties:
       type: array
       items: { type: string, required: true }
+  'dependencyInjection':
+    type: dictionary
+    additionalProperties: false
+    properties:
+      excludeClassesFromConstructorAutowiring:
+        type: array
+        items: { type: string, required: true }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
@@ -17,7 +17,6 @@ use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\FinalClassWithDependenc
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\Flow175\ClassWithTransitivePrototypeDependency;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassA;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassH;
-use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassI;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\SingletonClassA;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ValueObjectClassA;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ValueObjectClassB;
@@ -325,26 +324,10 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function noProxyClassIsGeneratedForPrototypeClassesWithOnlyPrototypeConstructorArguments(): void
+    public function noProxyClassIsGeneratedForClassesWhoseConstructorAutowiringIsDisabledViaSettings(): void
     {
         $object = new PrototypeClassH(
             new ValueObjectClassA('foo'),
-            new ValueObjectClassB('bar')
-        );
-        self::assertNotInstanceOf(ProxyInterface::class, $object);
-
-        $object = new PrototypeClassA();
-        self::assertInstanceOf(ProxyInterface::class, $object);
-    }
-
-    /**
-     * @test
-     */
-    public function noProxyClassIsGeneratedForPrototypeClassesWithOptionalStraightValues(): void
-    {
-        $object = new PrototypeClassI(
-            new ValueObjectClassA('foo'),
-            null,
             new ValueObjectClassB('bar')
         );
         self::assertNotInstanceOf(ProxyInterface::class, $object);

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassH.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassH.php
@@ -13,12 +13,14 @@ namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
 
 /**
  * A class of scope prototype in the style of a read model
+ *
+ * NOTE: Autowiring for the constructor is disabled via the setting "excludeClassesFromConstructorAutowiring".
  */
-class PrototypeClassH
+readonly class PrototypeClassH
 {
     public function __construct(
-        readonly public ValueObjectClassA $classA,
-        readonly public ValueObjectClassB $classB,
+        public ValueObjectClassA $classA,
+        public ValueObjectClassB $classB,
     ) {
     }
 }


### PR DESCRIPTION
Classes can now explicitly be excluded from constructor autowiring through a new setting.

The setting accepts an array of fully qualified class names, each class name being a regular expression. Classes of scope prototype which expect objects to be passed to their constructor are usually considered for autowiring which results in a proxy class being generated.

This option allows to exclude classes from this process. This is useful for classes like data transfer objects, read models, commands, events and value objects which usually don't rely on dependency injection.

Flow cannot reliably detect weather a prototype class depends on autowiring for constructor arguments or not. Use this option to optimize your application to avoid the small but measurable overhead of proxy generation for those kinds of classes.

Note that if there are other reasons than constructor injection which require a proxy class to be generated, the proxy class will be generated no matter what.

This change partly reverts #3050 because now proxy classes _are_ generated for prototype classes by default. Otherwise a lot of existing Flow applications would not work correctly anymore.

resolves: #3049