### PR TITLE
TASK: Support PHP never, null, false, and true as stand-alone types

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
@@ -80,21 +80,21 @@ class ProxyMethodGenerator extends MethodGenerator
         }
 
         $callParentMethodCode = $this->buildCallParentMethodCode($this->fullOriginalClassName, $this->name);
-        $returnTypeIsVoid = ((string)$this->getReturnType() === 'void');
+        $returnTypeIsVoidOrNever = ((string)$this->getReturnType() === 'void' || (string)$this->getReturnType() === 'never' );
         $code = $this->addedPreParentCallCode;
         if ($this->addedPostParentCallCode !== '') {
-            if ($returnTypeIsVoid) {
+            if ($returnTypeIsVoidOrNever) {
                 if ($callParentMethodCode !== '') {
                     $code .= '    ' . $callParentMethodCode;
                 }
             } else {
-                $code .= '$result = ' . ($callParentMethodCode === '' ? "NULL;\n" : $callParentMethodCode);
+                $code .= '$result = ' . ($callParentMethodCode === '' ? "null;\n" : $callParentMethodCode);
             }
             $code .= $this->addedPostParentCallCode;
-            if (!$returnTypeIsVoid) {
+            if (!$returnTypeIsVoidOrNever) {
                 $code .= "return \$result;\n";
             }
-        } elseif (!$returnTypeIsVoid && $callParentMethodCode !== '') {
+        } elseif (!$returnTypeIsVoidOrNever && $callParentMethodCode !== '') {
             $code .= 'return ' . $callParentMethodCode . ";\n";
         }
         return $code;

--- a/Neos.Flow/Tests/Functional/Aop/Fixtures/BaseFunctionalityTestingAspect.php
+++ b/Neos.Flow/Tests/Functional/Aop/Fixtures/BaseFunctionalityTestingAspect.php
@@ -298,4 +298,11 @@ class BaseFunctionalityTestingAspect
         $joinPoint->setMethodArgument('aFlag', true);
         return $joinPoint->getAdviceChain()->proceed($joinPoint);
     }
+
+    #[Flow\Around("method(Neos\Flow\Tests\Functional\Aop\Fixtures\TargetClassWithPhp8Features->always.*())")]
+    public function methodsWithPhp8SimpleReturnTypesAdvice(JoinPointInterface $joinPoint): mixed
+    {
+        $joinPoint->setMethodArgument('throwException', false);
+        return $joinPoint->getAdviceChain()->proceed($joinPoint);
+    }
 }

--- a/Neos.Flow/Tests/Functional/Aop/Fixtures/TargetClassWithPhp8Features.php
+++ b/Neos.Flow/Tests/Functional/Aop/Fixtures/TargetClassWithPhp8Features.php
@@ -11,6 +11,8 @@ namespace Neos\Flow\Tests\Functional\Aop\Fixtures;
  * source code.
  */
 
+use RuntimeException;
+
 class TargetClassWithPhp8Features
 {
     public function methodWithUnionTypes(string|int $aStringOrInteger, int $aNumber, TargetClassWithPhp8Features $anObject): string
@@ -21,6 +23,51 @@ class TargetClassWithPhp8Features
     public function __invoke(string $aString, mixed $something, bool $aFlag): mixed
     {
         return $aFlag ? $aString : $something;
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    public function alwaysTrue(bool $throwException = true): true
+    {
+        if ($throwException) {
+            throw new RuntimeException('The $throwException flag in ' . __METHOD__ . ' was not set to false.');
+        }
+        return true;
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    public function alwaysFalse(bool $throwException = true): false
+    {
+        if ($throwException) {
+            throw new RuntimeException('The $throwException flag in ' . __METHOD__ . ' was not set to false.');
+        }
+        return false;
+    }
+
+// This needs https://github.com/laminas/laminas-code/pull/186 to be merged in order to work:
+//    /**
+//     * @throws RuntimeException
+//     */
+//    public function alwaysNull(bool $throwException = true): null
+//    {
+//        if ($throwException) {
+//            throw new RuntimeException('The $throwException flag in ' . __METHOD__ . ' was not set to false.');
+//        }
+//        return null;
+//    }
+
+    /**
+     * @throws RuntimeException
+     */
+    public function alwaysNever(bool $throwException = true): never
+    {
+        if ($throwException) {
+            throw new RuntimeException('The $throwException flag in ' . __METHOD__ . ' was not set to false.');
+        }
+        throw new RuntimeException('Here is the expected exception.', 1686132896);
     }
 
     public function __toString(): string

--- a/Neos.Flow/Tests/Functional/Aop/FrameworkTest.php
+++ b/Neos.Flow/Tests/Functional/Aop/FrameworkTest.php
@@ -370,4 +370,25 @@ class FrameworkTest extends FunctionalTestCase
         #       modifies the flag and sets it to true
         self::assertSame('Flag is set', $targetClass->__invoke('Flag is set', 42, false));
     }
+
+    /**
+     * @test
+     * @see https://github.com/neos/flow-development-collection/issues/3027
+     * @throws
+     */
+    public function methodsWithReturnPhp8SimpleReturnTypesAreGeneratedCorrectly(): void
+    {
+        $targetClass = new TargetClassWithPhp8Features();
+
+        # Note: In order to prove that the advice is actually executed, the advice BaseFunctionalityTestingAspect::methodsWithPhp8SimpleReturnTypesAdvice()
+        #       modifies the flag and sets it to true
+        self::assertTrue($targetClass->alwaysTrue());
+        self::assertFalse($targetClass->alwaysFalse());
+
+        # This needs https://github.com/laminas/laminas-code/pull/186 to be merged in order to work:
+        # self::assertNull($targetClass->alwaysNull());
+
+        $this->expectExceptionCode(1686132896);
+        $targetClass->alwaysNever();
+    }
 }


### PR DESCRIPTION
This change adds functional tests to prove that Flow can handle PHP 8 stand-alone return types in AOP proxy class building.

Note that "null" is not supported yet by laminas-code, therefore the corresponding test is not active yet.

Resolves: #3027
