### PR TITLE
FEATURE: Replace self with static in proxy classes

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Exception/ProxyCompilerException.php
+++ b/Neos.Flow/Classes/ObjectManagement/Exception/ProxyCompilerException.php
@@ -1,0 +1,18 @@
+<?php
+namespace Neos\Flow\ObjectManagement\Exception;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\ObjectManagement\Exception;
+
+class ProxyCompilerException extends Exception
+{
+}

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyConstructorGenerator.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyConstructorGenerator.php
@@ -16,6 +16,8 @@ use Neos\Flow\ObjectManagement\DependencyInjection\ProxyClassBuilder;
 
 final class ProxyConstructorGenerator extends ProxyMethodGenerator
 {
+    private ?string $originalVisibility = null;
+
     public function __construct($name = null, array $parameters = [], $flags = self::FLAG_PUBLIC, $body = null, $docBlock = null)
     {
         if ($docBlock === null) {
@@ -35,13 +37,13 @@ final class ProxyConstructorGenerator extends ProxyMethodGenerator
         $method->fullOriginalClassName = $declaringClass->name;
         $method->setFinal($reflectionMethod->isFinal());
 
+        # Safe the original visibility of the constructor for later use in the proxy constructor
         if ($reflectionMethod->isPrivate()) {
-            $method->setVisibility(self::VISIBILITY_PRIVATE);
+            $method->originalVisibility = self::VISIBILITY_PRIVATE;
         } elseif ($reflectionMethod->isProtected()) {
-            $method->setVisibility(self::VISIBILITY_PROTECTED);
-        } else {
-            $method->setVisibility(self::VISIBILITY_PUBLIC);
+            $method->originalVisibility = self::VISIBILITY_PROTECTED;
         }
+        $method->setVisibility(self::VISIBILITY_PUBLIC);
 
         if (!empty($reflectionMethod->getDocComment())) {
             $docBlock = DocBlockGenerator::fromReflection($reflectionMethod->getDocBlock());
@@ -64,6 +66,11 @@ final class ProxyConstructorGenerator extends ProxyMethodGenerator
         throw new \BadMethodCallException('copyMethodSignature() is not supported, nor needed for constructor proxies.', 1685078402);
     }
 
+    public function getOriginalVisibility(): ?string
+    {
+        return $this->originalVisibility;
+    }
+
     public function renderBodyCode(): string
     {
         if ((trim($this->addedPreParentCallCode) === '' && trim($this->addedPostParentCallCode) === '')) {
@@ -75,6 +82,7 @@ final class ProxyConstructorGenerator extends ProxyMethodGenerator
         $this->addedPostParentCallCode = rtrim($this->addedPostParentCallCode);
 
         return
+            ($callParentMethodCode !== '' && $this->originalVisibility !== null ? $this->buildEnforceVisibilityCode($this->originalVisibility) : '') .
             ($callParentMethodCode !== '' ? $this->buildAssignMethodArgumentsCode() : '') .
             ($this->addedPreParentCallCode !== '' ? $this->addedPreParentCallCode . PHP_EOL : '') .
             $callParentMethodCode .
@@ -87,14 +95,66 @@ final class ProxyConstructorGenerator extends ProxyMethodGenerator
     }
 
     /**
+     * Build code which calls the parent method, if any.
+     *
+     * Note that $fullClassName is the original, non-proxied class and $parentClassName is the
+     * name of a potential non-proxied parent class of the original class.
+     *
+     * The context where the parent:: call is made is a proxy class. Therefore, the call will
+     *
+     *  - either call the method in the original class of the current proxy, if it exists, or
+     *  - call the original method in the parent class or
+     *  - call the proxied method in the parent class or
+     *  - call the original method in a subclass or
+     *  - call the proxied method in a subclass
+     *
+     * See the ProxyCompilerTest functional tests for examples of these cases.
+     *
      * @psalm-param class-string $fullClassName
      */
     protected function buildCallParentMethodCode(string $fullClassName, string $methodName): string
     {
-        # Note that the parent class "parent::" calls here is actually the original class, which is $fullClassName
-        if (!method_exists($fullClassName, $methodName)) {
+        $parentClassName = get_parent_class($fullClassName);
+        if (
+            !method_exists($fullClassName, $methodName) &&
+            ($parentClassName === false || !method_exists($parentClassName, $methodName))
+        ) {
             return '';
         }
         return "parent::{$methodName}(...\$arguments);" . PHP_EOL;
+    }
+
+    /**
+     * Build code which enforces the original visibility of the constructor.
+     *
+     * This code is added to the beginning of the constructor body of a proxy class if
+     * the original visibility was not "public".
+     *
+     * For private or protected constructors there are two cases which are allowed:
+     *
+     * 1) The constructor is called from within the original class itself
+     * 2) The constructor is called from within a subclass of the original class
+     *
+     * In all other cases, an exception is thrown which is similar to the fatal error
+     * PHP would throw in that case.
+     */
+    private function buildEnforceVisibilityCode(string $originalVisibility): string
+    {
+        if ($originalVisibility === self::VISIBILITY_PUBLIC) {
+            return '';
+        }
+        $originalVisibilityString = $originalVisibility === self::VISIBILITY_PROTECTED ? 'protected' : 'private';
+        $fullOriginalClassNameWithSuffix = $this->fullOriginalClassName . Compiler::ORIGINAL_CLASSNAME_SUFFIX;
+        return <<<PHP
+        \$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+        if (isset(\$backtrace[1]) &&
+            !is_subclass_of(\$backtrace[1]['class'], \\{$this->fullOriginalClassName}::class) &&
+            !is_subclass_of(\\{$this->fullOriginalClassName}::class, \$backtrace[1]['class']) &&
+            \$backtrace[1]['class'] !== '{$this->fullOriginalClassName}' &&
+            \$backtrace[1]['class'] !== '{$fullOriginalClassNameWithSuffix}'
+        ) {
+            throw new \\Error('Call to {$originalVisibilityString} {$this->fullOriginalClassName}::__construct() from invalid context', 1686153840);
+        }
+        PHP . PHP_EOL;
     }
 }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/AbstractClassWithFactoryMethod.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/AbstractClassWithFactoryMethod.php
@@ -1,0 +1,24 @@
+<?php
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+abstract class AbstractClassWithFactoryMethod
+{
+    /**
+     * This is a weird example: how can this abstract class assume that there are two arguments to the constructor of the concrete class?
+     * However, this exists in Flow, see for example Neos\Flow\Security\Authentication\Provider\AbstractProvider.
+     */
+    public static function createInAbstractClass(string $constructorArgument, PrototypeClassA $anotherDependency): static
+    {
+        return new static($constructorArgument, $anotherDependency);
+    }
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassExtendingClassWithPrivateConstructor.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassExtendingClassWithPrivateConstructor.php
@@ -1,0 +1,20 @@
+<?php
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+class ClassExtendingClassWithPrivateConstructor extends ClassWithPrivateConstructor
+{
+    public static function createInSubClass(string $constructorArgument, PrototypeClassA $anotherDependency): static
+    {
+        return new static($constructorArgument, $anotherDependency);
+    }
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassWithPrivateConstructor.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassWithPrivateConstructor.php
@@ -26,4 +26,21 @@ class ClassWithPrivateConstructor extends AbstractClassWithFactoryMethod
     {
         return new static($constructorArgument, $anotherDependency);
     }
+
+    public static function createUsingSelf(string $constructorArgument, PrototypeClassA $anotherDependency): self
+    {
+        return new self($constructorArgument, $anotherDependency);
+    }
+
+    public function getStringContainingALotOfSelves(): string
+    {
+        return <<<PHP
+            new self();
+            self::class;
+            self::create();
+            function foo(self \$self): self {
+                return \$self;
+            }
+        PHP;
+    }
 }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassWithPrivateConstructor.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassWithPrivateConstructor.php
@@ -1,0 +1,29 @@
+<?php
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+class ClassWithPrivateConstructor extends AbstractClassWithFactoryMethod
+{
+    #[Flow\Inject(lazy: false)]
+    public SingletonClassA $dependency;
+
+    private function __construct(public string $constructorArgument, readonly public PrototypeClassA $anotherDependency)
+    {
+    }
+
+    public static function createInParentClass(string $constructorArgument, PrototypeClassA $anotherDependency): static
+    {
+        return new static($constructorArgument, $anotherDependency);
+    }
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
@@ -321,4 +321,28 @@ class ProxyCompilerTest extends FunctionalTestCase
         self::assertNotInstanceOf(ClassExtendingClassWithPrivateConstructor::class, $object);
         self::assertSame($anotherDependency, $object->anotherDependency);
     }
+
+    /**
+     * @test
+     */
+    public function factoryMethodUsingSelfWorksEvenIfClassIsProxied(): void
+    {
+        $anotherDependency = new PrototypeClassA();
+        $object = ClassWithPrivateConstructor::createUsingSelf('the argument', $anotherDependency);
+
+        self::assertInstanceOf(ProxyInterface::class, $object);
+        self::assertInstanceOf(ClassWithPrivateConstructor::class, $object);
+        self::assertNotInstanceOf(ClassExtendingClassWithPrivateConstructor::class, $object);
+        self::assertSame($anotherDependency, $object->anotherDependency);
+
+        $expectedSelves = <<<PHP
+            new self();
+            self::class;
+            self::create();
+            function foo(self \$self): self {
+                return \$self;
+            }
+        PHP;
+        self::assertSame($expectedSelves, $object->getStringContainingALotOfSelves());
+    }
 }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
@@ -15,11 +15,13 @@ use Neos\Flow\ObjectManagement\Exception\CannotBuildObjectException;
 use Neos\Flow\ObjectManagement\Proxy\ProxyClass;
 use Neos\Flow\ObjectManagement\Proxy\ProxyInterface;
 use Neos\Flow\Reflection\ClassReflection;
-use Neos\Flow\Reflection\MethodReflection;
 use Neos\Flow\Reflection\PropertyReflection;
 use Neos\Flow\Reflection\ReflectionService;
+use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ClassExtendingClassWithPrivateConstructor;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ClassImplementingInterfaceWithConstructor;
+use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ClassWithPrivateConstructor;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PHP81\BackedEnumWithMethod;
+use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassA;
 use Neos\Flow\Tests\FunctionalTestCase;
 
 /**
@@ -30,7 +32,7 @@ class ProxyCompilerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function proxyClassesStillContainAnnotationsFromItsOriginalClass()
+    public function proxyClassesStillContainAnnotationsFromItsOriginalClass(): void
     {
         $class = new ClassReflection(Fixtures\PrototypeClassA::class);
         $method = $class->getMethod('setSomeProperty');
@@ -43,7 +45,7 @@ class ProxyCompilerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function proxyClassesStillContainDocCommentsFromItsOriginalClass()
+    public function proxyClassesStillContainDocCommentsFromItsOriginalClass(): void
     {
         $class = new ClassReflection(Fixtures\ClassWithDocComments::class);
         $expectedResult = 'This is a example doc comment which should be copied' . chr(10) . 'to the proxy class.';
@@ -55,7 +57,7 @@ class ProxyCompilerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function proxiedMethodsStillContainReturnAnnotationFromOriginalClass()
+    public function proxiedMethodsStillContainReturnAnnotationFromOriginalClass(): void
     {
         $class = new ClassReflection(Fixtures\PrototypeClassA::class);
         $method = $class->getMethod('getSingletonA');
@@ -66,7 +68,7 @@ class ProxyCompilerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function proxiedMethodsStillContainParamDocumentationFromOriginalClass()
+    public function proxiedMethodsStillContainParamDocumentationFromOriginalClass(): void
     {
         $class = new ClassReflection(Fixtures\PrototypeClassA::class);
         $method = $class->getMethod('setSomeProperty');
@@ -77,7 +79,7 @@ class ProxyCompilerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function proxiedMethodsDoContainAnnotationsOnlyOnce()
+    public function proxiedMethodsDoContainAnnotationsOnlyOnce(): void
     {
         $class = new ClassReflection(Fixtures\PrototypeClassA::class);
         $method = $class->getMethod('setSomeProperty');
@@ -88,7 +90,7 @@ class ProxyCompilerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function classesAnnotatedWithProxyDisableAreNotProxied()
+    public function classesAnnotatedWithProxyDisableAreNotProxied(): void
     {
         $singletonB = $this->objectManager->get(Fixtures\SingletonClassB::class);
         $this->assertNotInstanceOf(ProxyInterface::class, $singletonB);
@@ -102,9 +104,9 @@ class ProxyCompilerTest extends FunctionalTestCase
      *
      * @test
      */
-    public function enumsAreNotProxied()
+    public function enumsAreNotProxied(): void
     {
-        if (version_compare(PHP_VERSION, '8.1', '<=')) {
+        if (PHP_VERSION_ID <= 80100) {
             $this->markTestSkipped('Only for PHP.1 8 with Enums');
         }
 
@@ -115,7 +117,7 @@ class ProxyCompilerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function setInstanceOfSubClassDoesNotOverrideParentClass()
+    public function setInstanceOfSubClassDoesNotOverrideParentClass(): void
     {
         $singletonE = $this->objectManager->get(Fixtures\SingletonClassE::class);
         self::assertEquals(Fixtures\SingletonClassE::class, get_class($singletonE));
@@ -132,7 +134,7 @@ class ProxyCompilerTest extends FunctionalTestCase
      * @test
      * @noinspection SuspiciousAssignmentsInspection
      */
-    public function transientPropertiesAreNotSerializedOnSleep()
+    public function transientPropertiesAreNotSerializedOnSleep(): void
     {
         $prototypeF = $this->objectManager->get(Fixtures\PrototypeClassF::class);
         $prototypeF->setTransientProperty('foo');
@@ -149,7 +151,7 @@ class ProxyCompilerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function proxiedFinalClassesAreStillFinal()
+    public function proxiedFinalClassesAreStillFinal(): void
     {
         $reflectionClass = new ClassReflection(Fixtures\FinalClassWithDependencies::class);
         self::assertTrue($reflectionClass->isFinal());
@@ -168,7 +170,7 @@ class ProxyCompilerTest extends FunctionalTestCase
      * @see https://github.com/neos/flow-development-collection/issues/1835
      * @test
      */
-    public function classKeywordIsIgnoredInsideClassBody()
+    public function classKeywordIsIgnoredInsideClassBody(): void
     {
         $reflectionClass = new ClassReflection(Fixtures\ClassWithKeywordsInClassBody::class);
         self::assertEquals(Fixtures\ClassWithKeywordsInClassBody::class, $reflectionClass->getNamespaceName() . '\ClassWithKeywordsInClassBody');
@@ -177,7 +179,7 @@ class ProxyCompilerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function attributesArePreserved()
+    public function attributesArePreserved(): void
     {
         if (PHP_MAJOR_VERSION < 8) {
             $this->markTestSkipped('Only for PHP 8 with Attributes');
@@ -192,8 +194,9 @@ class ProxyCompilerTest extends FunctionalTestCase
     /**
      * @test
      * @see https://github.com/neos/flow-development-collection/issues/2554
+     * @throws
      */
-    public function proxyingClassImplementingInterfacesWithParametrizedConstructorsLeadsToException()
+    public function proxyingClassImplementingInterfacesWithParametrizedConstructorsLeadsToException(): void
     {
         $this->expectException(CannotBuildObjectException::class);
         $proxyClass = new ProxyClass(ClassImplementingInterfaceWithConstructor::class);
@@ -228,13 +231,12 @@ class ProxyCompilerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function complexMethodReturnTypesArePreserved()
+    public function complexMethodReturnTypesArePreserved(): void
     {
         if (PHP_MAJOR_VERSION < 8) {
             $this->markTestSkipped('Only for PHP 8 with UnionTypes');
         }
         $reflectionClass = new ClassReflection(Fixtures\PHP8\ClassWithUnionTypes::class);
-        /** @var MethodReflection $method */
         foreach ($reflectionClass->getMethods() as $method) {
             if (str_starts_with($method->getName(), 'get') &&
                 !str_ends_with($method->getName(), 'PropertyA') &&
@@ -252,7 +254,7 @@ class ProxyCompilerTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function constructorPropertiesArePreserved()
+    public function constructorPropertiesArePreserved(): void
     {
         if (PHP_MAJOR_VERSION < 8) {
             $this->markTestSkipped('Only for PHP 8 with Constructor properties');
@@ -266,5 +268,57 @@ class ProxyCompilerTest extends FunctionalTestCase
         self::assertEquals('?string', (string)$reflectionClass->getProperty('propertyA')->getType());
         self::assertEquals('?int', (string)$reflectionClass->getProperty('propertyB')->getType());
         self::assertEquals('?DateTime', (string)$reflectionClass->getProperty('propertyC')->getType());
+    }
+
+    /**
+     * @test
+     */
+    public function classWithPrivateConstructorCanBeProxied(): void
+    {
+        $anotherDependency = new PrototypeClassA();
+        $object = ClassWithPrivateConstructor::createInParentClass('the argument', $anotherDependency);
+
+        self::assertInstanceOf(ProxyInterface::class, $object);
+        self::assertSame($anotherDependency, $object->anotherDependency);
+    }
+
+    /**
+     * @test
+     * @noinspection PhpExpressionResultUnusedInspection
+     */
+    public function privateConstructorOfProxiedClassCannotBeCalledFromOtherContexts(): void
+    {
+        $this->expectExceptionCode(1686153840);
+        new ClassWithPrivateConstructor('the argument', new PrototypeClassA());
+    }
+
+    /**
+     * @test
+     * @noinspection UnnecessaryAssertionInspection
+     */
+    public function privateConstructorOfProxiedClassCanBeCalledFromProxiedSubClass(): void
+    {
+        $anotherDependency = new PrototypeClassA();
+        $object = ClassExtendingClassWithPrivateConstructor::createInSubClass('the argument', $anotherDependency);
+
+        self::assertInstanceOf(ProxyInterface::class, $object);
+        self::assertInstanceOf(ClassWithPrivateConstructor::class, $object);
+        self::assertInstanceOf(ClassExtendingClassWithPrivateConstructor::class, $object);
+        self::assertSame($anotherDependency, $object->anotherDependency);
+    }
+
+    /**
+     * @test
+     * @noinspection UnnecessaryAssertionInspection
+     */
+    public function privateConstructorOfProxiedClassCanBeCalledFromAbstractParentClass(): void
+    {
+        $anotherDependency = new PrototypeClassA();
+        $object = ClassWithPrivateConstructor::createInAbstractClass('the argument', $anotherDependency);
+
+        self::assertInstanceOf(ProxyInterface::class, $object);
+        self::assertInstanceOf(ClassWithPrivateConstructor::class, $object);
+        self::assertNotInstanceOf(ClassExtendingClassWithPrivateConstructor::class, $object);
+        self::assertSame($anotherDependency, $object->anotherDependency);
     }
 }


### PR DESCRIPTION
Factory methods which use code like new self() for creating a new instance are now handled correctly in proxy classes. The compiler automatically replaces "self" keywords with "static" in the rendered proxy class file to make this possible.

This implementation has not been optimized for performance.

Resolves: #3059