### PR TITLE
BUGFIX: Revert changes to dependenies due to upmerge

### DIFF
--- a/Neos.Http.Factories/composer.json
+++ b/Neos.Http.Factories/composer.json
@@ -7,7 +7,7 @@
         "MIT"
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^7.1 || ^8.0",
         "psr/http-factory": "^1.0",
         "guzzlehttp/psr7": "^1.8.4 || ^2.1.1"
     },

--- a/Neos.Http.Factories/composer.json
+++ b/Neos.Http.Factories/composer.json
@@ -7,9 +7,9 @@
         "MIT"
     ],
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^8.0",
         "psr/http-factory": "^1.0",
-        "guzzlehttp/psr7": "^1.8.4"
+        "guzzlehttp/psr7": "^1.8.4 || ^2.1.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Due to an upmerge the dependencies where set to lower versions as before. This reverts this change to the old version values.

Fixes: #3079