### PR TITLE
Bugfix: 3076 named constructor argument with objects should work

### DIFF
--- a/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
@@ -17,6 +17,8 @@ use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\FinalClassWithDependenc
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\Flow175\ClassWithTransitivePrototypeDependency;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassA;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassH;
+use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassJ;
+use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassK;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\SingletonClassA;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ValueObjectClassA;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ValueObjectClassB;
@@ -334,5 +336,28 @@ class DependencyInjectionTest extends FunctionalTestCase
 
         $object = new PrototypeClassA();
         self::assertInstanceOf(ProxyInterface::class, $object);
+    }
+
+    /**
+     * @test
+     */
+    public function namedConstructorArgumentWithObjectForSimplePrototype(): void
+    {
+        $classA = new ValueObjectClassA(value: 'foo');
+        $object = new PrototypeClassJ(classA: $classA);
+        self::assertInstanceOf(ProxyInterface::class, $object);
+        self::assertSame($classA, $object->classA);
+    }
+
+    /**
+     * @test
+     */
+    public function namedConstructorArgumentWithObjectForProxyPrototypeWithInjectedDependencies(): void
+    {
+        $classA = new ValueObjectClassA(value: 'foo');
+        $object = new PrototypeClassK(classA: $classA);
+        self::assertInstanceOf(ProxyInterface::class, $object);
+        self::assertSame($classA, $object->classA);
+        self::assertSame($this->objectManager->get(SingletonClassA::class), $object->singletonClassA);
     }
 }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassJ.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassJ.php
@@ -1,0 +1,23 @@
+<?php
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A class of scope prototype with a value object as constructor argument
+ */
+class PrototypeClassJ
+{
+    public function __construct(
+        public ValueObjectClassA $classA
+    ) {
+    }
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassK.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassK.php
@@ -1,0 +1,30 @@
+<?php
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A class of scope prototype with a value object as constructor argument and additional injected properties
+ */
+class PrototypeClassK
+{
+    /**
+     * @Flow\Inject(lazy=false)
+     */
+    public readonly SingletonClassA $singletonClassA;
+
+    public function __construct(
+        public ValueObjectClassA $classA
+    ) {
+    }
+}


### PR DESCRIPTION
but they fail

> Error: Unknown named parameter $classA

see this issue for a detailed description whats going wrong #3076

@robertlemke here is my failing test ^^

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
