### PR TITLE
FEATURE: InjectConfiguration for constructor arguments

### DIFF
--- a/Neos.Flow/Classes/Annotations/InjectConfiguration.php
+++ b/Neos.Flow/Classes/Annotations/InjectConfiguration.php
@@ -11,11 +11,11 @@ namespace Neos\Flow\Annotations;
  * source code.
  */
 
-use Neos\Flow\Configuration\ConfigurationManager;
 use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+use Neos\Flow\Configuration\ConfigurationManager;
 
 /**
- * Used to enable property injection for configuration including settings.
+ * Used to enable property and constructor argument injection for configuration including settings.
  *
  * Flow will build Dependency Injection code for the property and try
  * to inject the configured configuration.
@@ -24,46 +24,49 @@ use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
  * @NamedArgumentConstructor
  * @Target("PROPERTY")
  */
-#[\Attribute(\Attribute::TARGET_PROPERTY)]
-final class InjectConfiguration
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER)]
+final readonly class InjectConfiguration
 {
-    /**
-     * Path of a configuration which should be injected into the property.
-     * Can be specified as anonymous argument: InjectConfiguration("some.path")
-     *
-     * For type "Settings" this refers to the relative path (excluding the package key)
-     *
-     * Example: session.name
-     *
-     * @var string|null
-     */
-    public $path;
-
-    /**
-     * Defines the package key to be used for retrieving settings. If no package key is specified, we'll assume the
-     * package to be the same which contains the class where the InjectConfiguration annotation is used.
-     *
-     * Note: This property is only supported for type "Settings"
-     *
-     * Example: Neos.Flow
-     *
-     * @var string|null
-     */
-    public $package;
-
-    /**
-     * Type of Configuration (defaults to "Settings").
-     *
-     * @var string one of the ConfigurationManager::CONFIGURATION_TYPE_* constants
-     */
-    public $type = ConfigurationManager::CONFIGURATION_TYPE_SETTINGS;
-
-    public function __construct(?string $path = null, ?string $package = null, ?string $type = null)
-    {
-        $this->path = $path;
-        $this->package = $package;
-        if ($type !== null) {
-            $this->type = $type;
+    public function __construct(
+        /**
+         * Path of a configuration which should be injected into the property.
+         * Can be specified as anonymous argument: InjectConfiguration("some.path")
+         *
+         * For type "Settings" this refers to the relative path (excluding the package key)
+         *
+         * Example: session.name
+         */
+        public ?string $path = null,
+        /**
+         * Defines the package key to be used for retrieving settings. If no package key is specified, we'll assume the
+         * package to be the same which contains the class where the InjectConfiguration annotation is used.
+         *
+         * Note: This property is only supported for type "Settings"
+         *
+         * Example: Neos.Flow
+         */
+        public ?string $package = null,
+        /**
+         * Type of Configuration (defaults to "Settings").
+         *
+         * @param $type ?string one of the ConfigurationManager::CONFIGURATION_TYPE_* constants
+         */
+        public ?string $type = ConfigurationManager::CONFIGURATION_TYPE_SETTINGS
+    ) {
+        if ($this->type !== ConfigurationManager::CONFIGURATION_TYPE_SETTINGS && $this->package !== null) {
+            throw new \DomainException(sprintf('Invalid usage of "package" with configuration type "%s". Using "package" is only valid for "Settings".', $this->type), 1686910380912);
         }
+    }
+
+    /**
+     * @param string $fallbackPackageKey fallback, in case no package key is specified {@see self::$package}
+     */
+    public function getFullConfigurationPath(string $fallbackPackageKey): ?string
+    {
+        if ($this->type !== ConfigurationManager::CONFIGURATION_TYPE_SETTINGS) {
+            return $this->path;
+        }
+        $packageKey = $this->package ?? $fallbackPackageKey;
+        return rtrim($packageKey . '.' . $this->path, '.');
     }
 }

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
@@ -486,7 +486,17 @@ class ConfigurationBuilder
                 $debuggingHint = '';
                 $index = $parameterInformation['position'] + 1;
                 if (!isset($arguments[$index])) {
-                    if ($parameterInformation['optional'] === true) {
+                    $injectConfigurationAnnotation = $parameterInformation['annotations'][InjectConfiguration::class][0] ?? null;
+                    if ($injectConfigurationAnnotation instanceof InjectConfiguration) {
+                        if ($injectConfigurationAnnotation->type !== ConfigurationManager::CONFIGURATION_TYPE_SETTINGS) {
+                            throw new InvalidObjectConfigurationException(sprintf('InjectConfiguration for constructor arguments currently only supports settings. Got type "%s" in constructor argument %s of class %s.', $injectConfigurationAnnotation->type, $index, $className), 1710409120);
+                        }
+                        $arguments[$index] = new ConfigurationArgument(
+                            $index,
+                            $injectConfigurationAnnotation->getFullConfigurationPath($objectConfiguration->getPackageKey()),
+                            ConfigurationArgument::ARGUMENT_TYPES_SETTING
+                        );
+                    } elseif ($parameterInformation['optional'] === true) {
                         $defaultValue = (isset($parameterInformation['defaultValue'])) ? $parameterInformation['defaultValue'] : null;
                         $arguments[$index] = new ConfigurationArgument($index, $defaultValue, ConfigurationArgument::ARGUMENT_TYPES_STRAIGHTVALUE);
                         $arguments[$index]->setAutowiring(Configuration::AUTOWIRING_MODE_OFF);
@@ -602,21 +612,22 @@ class ConfigurationBuilder
                 if ($this->reflectionService->isPropertyPrivate($className, $propertyName)) {
                     throw new ObjectException(sprintf('The property "%s" in class "%s" must not be private when annotated for configuration injection.', $propertyName, $className), 1416765599);
                 }
+                if ($this->reflectionService->isPropertyPromoted($className, $propertyName)) {
+                    continue;
+                }
                 if (array_key_exists($propertyName, $properties)) {
                     continue;
                 }
                 /** @var InjectConfiguration $injectConfigurationAnnotation */
                 $injectConfigurationAnnotation = $this->reflectionService->getPropertyAnnotation($className, $propertyName, InjectConfiguration::class);
-                if ($injectConfigurationAnnotation->type === ConfigurationManager::CONFIGURATION_TYPE_SETTINGS) {
-                    $packageKey = $injectConfigurationAnnotation->package !== null ? $injectConfigurationAnnotation->package : $objectConfiguration->getPackageKey();
-                    $configurationPath = rtrim($packageKey . '.' . $injectConfigurationAnnotation->path, '.');
-                } else {
-                    if ($injectConfigurationAnnotation->package !== null) {
-                        throw new ObjectException(sprintf('The InjectConfiguration annotation for property "%s" in class "%s" specifies a "package" key for configuration type "%s", but this is only supported for injection of "Settings".', $propertyName, $className, $injectConfigurationAnnotation->type), 1420811958);
-                    }
-                    $configurationPath = $injectConfigurationAnnotation->path;
-                }
-                $properties[$propertyName] = new ConfigurationProperty($propertyName, ['type' => $injectConfigurationAnnotation->type, 'path' => $configurationPath], ConfigurationProperty::PROPERTY_TYPES_CONFIGURATION);
+                $properties[$propertyName] = new ConfigurationProperty(
+                    $propertyName,
+                    [
+                        'type' => $injectConfigurationAnnotation->type,
+                        'path' => $injectConfigurationAnnotation->getFullConfigurationPath($objectConfiguration->getPackageKey())
+                    ],
+                    ConfigurationProperty::PROPERTY_TYPES_CONFIGURATION
+                );
             }
 
             foreach ($this->reflectionService->getPropertyNamesByAnnotation($className, InjectCache::class) as $propertyName) {

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/CommandLine.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/CommandLine.rst
@@ -560,11 +560,8 @@ class and can be used as follows:
 	use Neos\Flow\Annotations as Flow;
 	use Neos\Flow\Core\Booting\Scripts;
 
-	/**
-	 * @Flow\InjectConfiguration(package="Neos.Flow")
-	 * @var array
-	 */
-	protected $flowSettings;
+	#[Flow\InjectConfiguration(package: "Neos.Flow")]
+	protected array $flowSettings;
 
 	public function runCommand() {
 		$success = Scripts::executeCommand('acme.foo:bar:baz', $this->flowSettings);

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Configuration.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Configuration.rst
@@ -313,12 +313,12 @@ of a classes' package and output some option value:
   a few settings you might want to inject those specifically with the Inject
   annotation described below.
 
-Injection of single settings into properties
---------------------------------------------
+Injection of single settings
+----------------------------
 
-Flow provides a way to inject specific settings through the ``InjectConfiguration`` annotation directly into your
-properties.
-The annotation provides three optional attributes related to configuration injection:
+Flow provides a way to inject specific settings through the ``InjectConfiguration`` PHP attribute directly into class
+properties and constructor arguments.
+The attribute is configured through three optional properties related to configuration injection:
 
 * ``package`` specifies the package to get the configuration from. Defaults to the package the current class belongs to.
 * ``path`` specifies the path to the setting that should be injected. If it's not set all settings of the current (or
@@ -326,11 +326,11 @@ The annotation provides three optional attributes related to configuration injec
   from, defaults to ConfigurationManager::CONFIGURATION_TYPE_SETTINGS.
 
 .. note::
-  As a best-practice for testing and extensibility you should also provide setters for
-  any setting you add to your class, although this is not required for the injection
-  to work.
+  As a best-practice for testing and extensibility you should prefer constructor arguments
+  over properties or provide setters for any setting you add to your class.
+  Annotations based on doc-comments supported but deprecated, therefore use PHP attributes instead.
 
-**Example: single setting injection**
+**Example: injecting settings**
 
 .. code-block:: yaml
 
@@ -351,32 +351,22 @@ The annotation provides three optional attributes related to configuration injec
 
     class SomeClass
     {
+      #[Flow\InjectConfiguration(path: "email", package: "SomeOther.Package")]
+      protected string $email;
 
       /**
-       * @Flow\InjectConfiguration(path="administrator.name")
-       * @var string
-       */
-      protected $name;
-
-      /**
-       * @Flow\InjectConfiguration(package="SomeOther.Package", path="email")
-       * @var string
-       */
-      protected $email;
-
-      /**
+       * Deprecated: doc-comment based annotation
+       *
        * @Flow\InjectConfiguration(package="SomeOther.Package")
        * @var array
        */
       protected $someOtherPackageSettings = array();
 
-      /**
-       * Overrides the name
-       */
-      public function setName($name): void
-      {
-        $this->name = $name;
-      }
+      public function __construct(
+        #[Flow\InjectConfiguration(path="administrator.name")]
+        readonly protected string $name
+      )
+      {}
 
       /**
        * Overrides the email

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ObjectManagement.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ObjectManagement.rst
@@ -735,7 +735,7 @@ the object belongs to and pass it to the ``injectSettings`` method.
 The ``doSomething`` method will output the settings of the ``MyPackage`` package.
 
 In case you only need a specific setting, there's an even more convenient way to inject a single
-setting value into a class property:
+setting value into a class property or constructor argument:
 
 .. code-block:: php
 
@@ -745,21 +745,17 @@ setting value into a class property:
 
 	class SomeClass {
 
-		/**
-		 * @var string
-		 * @Flow\InjectConfiguration("administrator.name")
-		 */
-		protected $name;
+		#[Flow\InjectConfiguration(path: "email", package: "SomeOther.Package")]
+		protected string $email;
 
-		/**
-		 * @var string
-		 * @Flow\InjectConfiguration(path="email", package="SomeOther.Package")
-		 */
-		protected $emailAddress;
-
+		public function __construct(
+		  #[Flow\InjectConfiguration(path: "administrator.name")]
+		  readonly protected string $name
+		  )
+		  {}
 	}
 
-The ``InjectConfiguration`` annotation also supports for injecting all settings of a package. And it can also be used
+The ``InjectConfiguration`` attribute also supports for injecting all settings of a package. And it can also be used
 to inject any other registered configuration type:
 
 .. code-block:: php
@@ -768,18 +764,11 @@ to inject any other registered configuration type:
 
 	class SomeClass {
 
-		/**
-		 * @var array
-		 * @Flow\InjectConfiguration(package="SomeOther.Package")
-		 */
-		protected $allSettingsOfSomeOtherPackage;
+		#[Flow\InjectConfiguration(package: "SomeOther.Package")]
+		protected array $allSettingsOfSomeOtherPackage;
 
-		/**
-		 * @var array
-		 * @Flow\InjectConfiguration(type="Views")
-		 */
-		protected $viewsConfiguration;
-
+		#[Flow\InjectConfiguration(type: "Views")]
+		protected array $viewsConfiguration;
 	}
 
 Required Dependencies

--- a/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
@@ -18,6 +18,7 @@ use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\FinalClassWithDependenc
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\Flow175\ClassWithTransitivePrototypeDependency;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassA;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassH;
+use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassL;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\SingletonClassA;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ValueObjectClassA;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ValueObjectClassB;
@@ -347,5 +348,18 @@ class DependencyInjectionTest extends FunctionalTestCase
 
         $object = new PrototypeClassA();
         self::assertInstanceOf(ProxyInterface::class, $object);
+    }
+
+    /**
+     * @test
+     */
+    public function constructorSettingsInjectionViaInjectAnnotation(): void
+    {
+        $object = $this->objectManager->get(PrototypeClassL::class);
+        self::assertInstanceOf(ProxyInterface::class, $object);
+        self::assertSame('injected setting', $object->value);
+
+        $object = new PrototypeClassL('override');
+        self::assertSame('override', $object->value);
     }
 }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassL.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassL.php
@@ -1,0 +1,27 @@
+<?php
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A readonly class of scope prototype with settings injected in the constructor
+ */
+readonly class PrototypeClassL
+{
+    public function __construct(
+        #[Flow\InjectConfiguration(path: 'tests.functional.settingInjection.someSetting')]
+        public string $value
+    ) {
+        assert($this->value !== '');
+    }
+}


### PR DESCRIPTION
Flow now supports InjectConfiguration attributes for constructor arguments which allows for injecting configuration, such as settings, via the constructor. Compared to property injection, constructor injection results in more portable and better testable code.

Resolves #3077