### PR TITLE
BUGFIX: Normalize windows package paths

### DIFF
--- a/Neos.Flow/Classes/Package/PackageManager.php
+++ b/Neos.Flow/Classes/Package/PackageManager.php
@@ -636,7 +636,7 @@ class PackageManager
                 yield from self::findComposerPackagesInPath($potentialPackageDirectory);
                 continue;
             }
-            yield $potentialPackageDirectory;
+            yield Files::getUnixStylePath($potentialPackageDirectory);
         }
     }
 


### PR DESCRIPTION
regression from: https://github.com/neos/flow-development-collection/pull/2736
solves: #3087

Thanks to @icpb and @eartahhj for reporting and helping me debug this ;)

The root of the problem that flow cant read the packages composer.jsons is because we want to cache the `packagePath`
 of each package as relative path. (see AvailablePackages.php in your cache folder)
On windows the cache would write include the absolute path.

This line:
https://github.com/neos/flow-development-collection/blob/2aefffd8fa3a579d9e1e7d0eed4dba047ba295c7/Neos.Flow/Classes/Package/PackageManager.php#L657

should make sure we trim it to an relative path, but because a mismatch of directory separators, the str_replace doesnt work. See example:
```php
# FLOW_PATH_PACKAGES = 'X:/project/packages' # always unix style format

$fullPackagePath = 'X:\Project\packages\Application\packageY'; # currently style depends on OS

str_replace(FLOW_PATH_PACKAGES, '', $fullPackagePath);
```

on linux the `fullPackagePath` would be `/project/packages/Application/packageY`, so we use Files::getUnixStylePath to normalize it.


It was reported that this problem also appeared in Neos 8.0, but this fix is now written for 8.3, as we refactored the code a little.

I cant actually believe that starting with Neos 8 it wouldnt work on windows anymore, as this would mean no one used Flow8 with windows.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
