### PR TITLE
!!! WIP BUGFIX instantiation of singletons with new should fail?

### DIFF
--- a/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
@@ -160,6 +160,35 @@ class DependencyInjectionTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function singletonCannotBeInstantiatedViaNew(): void
+    {
+        $this->expectException(\Throwable::class);
+        new Fixtures\SingletonClassA();
+    }
+
+    /**
+     * TODO remove this test, only to proof our currently invalid? situation.
+     *
+     * @test
+     */
+    public function singletonCurrentlyCanBeInstantiatedViaNewAndReplacesInstanceInObjectManager(): void
+    {
+        $this->addWarning('This test should not succeed, but does.');
+
+        $singletonFromObjectManager = $this->objectManager->get(Fixtures\SingletonClassA::class);
+
+        $newSingleton = new Fixtures\SingletonClassA();
+
+        $this->assertNotSame($singletonFromObjectManager, $newSingleton);
+        $this->assertSame(
+            $this->objectManager->get(Fixtures\SingletonClassA::class),
+            $newSingleton
+        );
+    }
+
+    /**
+     * @test
+     */
     public function onCreationOfObjectInjectionInParentClassIsDoneOnlyOnce(): void
     {
         $prototypeDsub = $this->objectManager->get(Fixtures\PrototypeClassDsub::class);


### PR DESCRIPTION
see https://github.com/neos/flow-development-collection/issues/3078

@robertlemke i talked with you about this behaviour and i could reproduce it as described to you in this test.
What do you say, is this intended behaviour?


it does makes sense from a technical point of view, why it behaves like this, because the proxy contains this line in the constructor:

```php
if (get_class($this) === 'Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\SingletonClassA') \Neos\Flow\Core\Bootstrap::$staticObjectManager->setInstance('Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\SingletonClassA', $this);
```


<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
