### PR TITLE
TASK: PHP 8.1 deprecations compatibility

### DIFF
--- a/Neos.Cache/Classes/Backend/ApcuBackend.php
+++ b/Neos.Cache/Classes/Backend/ApcuBackend.php
@@ -319,6 +319,7 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
      * @return mixed
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         if ($this->cacheEntriesIterator === null) {
@@ -333,6 +334,7 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
      * @return void
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         if ($this->cacheEntriesIterator === null) {
@@ -348,6 +350,7 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
      * @return string
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function key(): string
     {
         if ($this->cacheEntriesIterator === null) {
@@ -362,6 +365,7 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
      * @return boolean true if the current position is valid, otherwise false
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function valid(): bool
     {
         if ($this->cacheEntriesIterator === null) {
@@ -376,6 +380,7 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
      * @return void
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         if ($this->cacheEntriesIterator === null) {

--- a/Neos.Cache/Classes/Backend/PdoBackend.php
+++ b/Neos.Cache/Classes/Backend/PdoBackend.php
@@ -466,6 +466,7 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
      * @return mixed
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         if ($this->cacheEntriesIterator === null) {
@@ -480,6 +481,7 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
      * @return void
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         if ($this->cacheEntriesIterator === null) {
@@ -495,6 +497,7 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
      * @return string
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function key(): string
     {
         if ($this->cacheEntriesIterator === null) {
@@ -509,6 +512,7 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
      * @return boolean true if the current position is valid, otherwise false
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function valid(): bool
     {
         if ($this->cacheEntriesIterator === null) {
@@ -524,6 +528,7 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
      * @return void
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         try {

--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -296,6 +296,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->get($this->key());
@@ -304,6 +305,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->entryCursor++;
@@ -312,6 +314,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         $entryIdentifier = $this->redis->lIndex($this->getPrefixedIdentifier('entries'), $this->entryCursor);
@@ -324,6 +327,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function valid(): bool
     {
         return $this->key() !== false;
@@ -332,6 +336,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->entryCursor = 0;

--- a/Neos.Cache/Classes/Backend/SimpleFileBackend.php
+++ b/Neos.Cache/Classes/Backend/SimpleFileBackend.php
@@ -347,6 +347,7 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
      * @return mixed
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         if ($this->cacheFilesIterator === null) {
@@ -363,6 +364,7 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
      * @return void
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         if ($this->cacheFilesIterator === null) {
@@ -381,6 +383,7 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
      * @return string
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function key(): string
     {
         if ($this->cacheFilesIterator === null) {
@@ -395,6 +398,7 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
      * @return boolean true if the current position is valid, otherwise false
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function valid(): bool
     {
         if ($this->cacheFilesIterator === null) {
@@ -409,6 +413,7 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
      * @return void
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         if ($this->cacheFilesIterator === null) {

--- a/Neos.Cache/Classes/Frontend/CacheEntryIterator.php
+++ b/Neos.Cache/Classes/Frontend/CacheEntryIterator.php
@@ -52,6 +52,7 @@ class CacheEntryIterator implements \Iterator
      * @return mixed
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->frontend->get((string) $this->backend->key());
@@ -63,6 +64,7 @@ class CacheEntryIterator implements \Iterator
      * @return void
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->backend->next();
@@ -75,6 +77,7 @@ class CacheEntryIterator implements \Iterator
      * @return string
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function key(): string
     {
         return (string) $this->backend->key();
@@ -86,6 +89,7 @@ class CacheEntryIterator implements \Iterator
      * @return boolean true if the current element of the iterator is valid, otherwise false
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function valid(): bool
     {
         return $this->backend->valid();
@@ -97,6 +101,7 @@ class CacheEntryIterator implements \Iterator
      * @return void
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->backend->rewind();

--- a/Neos.Cache/Tests/Unit/Backend/FileBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/FileBackendTest.php
@@ -131,7 +131,7 @@ class FileBackendTest extends BaseTestCase
         $backend->set($entryIdentifier, $data);
 
         self::assertFileExists($pathAndFilename);
-        $retrievedData = file_get_contents($pathAndFilename, null, null, 0, strlen($data));
+        $retrievedData = file_get_contents($pathAndFilename, false, null, 0, strlen($data));
         self::assertEquals($data, $retrievedData);
     }
 
@@ -155,7 +155,7 @@ class FileBackendTest extends BaseTestCase
 
         $pathAndFilename = 'vfs://Foo/Cache/Data/UnitTestCache/' . $entryIdentifier;
         self::assertFileExists($pathAndFilename);
-        $retrievedData = file_get_contents($pathAndFilename, null, null, 0, strlen($data2));
+        $retrievedData = file_get_contents($pathAndFilename, false, null, 0, strlen($data2));
         self::assertEquals($data2, $retrievedData);
     }
 
@@ -177,7 +177,7 @@ class FileBackendTest extends BaseTestCase
 
         $pathAndFilename = 'vfs://Foo/Cache/Data/UnitTestCache/' . $entryIdentifier;
         self::assertFileExists($pathAndFilename);
-        $retrievedData = file_get_contents($pathAndFilename, null, null, strlen($data), 9);
+        $retrievedData = file_get_contents($pathAndFilename, false, null, strlen($data), 9);
         self::assertEquals('Tag1 Tag2', $retrievedData);
     }
 

--- a/Neos.Eel/Classes/FlowQuery/FlowQuery.php
+++ b/Neos.Eel/Classes/FlowQuery/FlowQuery.php
@@ -182,6 +182,7 @@ class FlowQuery implements ProtectedContextAwareInterface, \IteratorAggregate, \
      *
      * @return integer
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return $this->__call('count', []);
@@ -194,6 +195,7 @@ class FlowQuery implements ProtectedContextAwareInterface, \IteratorAggregate, \
      *
      * @return \ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         if (count($this->operations) > 0) {

--- a/Neos.Eel/Classes/FlowQuery/Operations/Object/FilterOperation.php
+++ b/Neos.Eel/Classes/FlowQuery/Operations/Object/FilterOperation.php
@@ -254,7 +254,7 @@ class FilterOperation extends AbstractOperation
                     }
                     return false;
                 } else {
-                    return strrpos($value, (string)$operand) === strlen($value) - strlen($operand);
+                    return strrpos((string)$value, (string)$operand) === strlen((string)$value) - strlen($operand);
                 }
                 // no break
             case '$=~':
@@ -264,7 +264,7 @@ class FilterOperation extends AbstractOperation
                     }
                     return false;
                 } else {
-                    return strripos($value, (string)$operand) === strlen($value) - strlen($operand);
+                    return strripos((string)$value, (string)$operand) === strlen((string)$value) - strlen($operand);
                 }
                 // no break
             case '^=':
@@ -274,7 +274,7 @@ class FilterOperation extends AbstractOperation
                     }
                     return false;
                 } else {
-                    return strpos($value, (string)$operand) === 0;
+                    return strpos((string)$value, (string)$operand) === 0;
                 }
                 // no break
             case '^=~':
@@ -284,7 +284,7 @@ class FilterOperation extends AbstractOperation
                     }
                     return false;
                 } else {
-                    return stripos($value, (string)$operand) === 0;
+                    return stripos((string)$value, (string)$operand) === 0;
                 }
                 // no break
             case '*=':
@@ -296,7 +296,7 @@ class FilterOperation extends AbstractOperation
                     }
                     return false;
                 } else {
-                    return strpos($value, (string)$operand) !== false;
+                    return strpos((string)$value, (string)$operand) !== false;
                 }
                 // no break
             case '*=~':
@@ -308,7 +308,7 @@ class FilterOperation extends AbstractOperation
                     }
                     return false;
                 } else {
-                    return stripos($value, (string)$operand) !== false;
+                    return stripos((string)$value, (string)$operand) !== false;
                 }
                 // no break
             case 'instanceof':

--- a/Neos.Eel/Classes/Helper/MathHelper.php
+++ b/Neos.Eel/Classes/Helper/MathHelper.php
@@ -99,6 +99,9 @@ class MathHelper implements ProtectedContextAwareInterface
         if (!is_numeric($x) && $x !== null) {
             return NAN;
         }
+        if ($x === null) {
+            return 0.0;
+        }
         return abs($x);
     }
 
@@ -411,7 +414,7 @@ class MathHelper implements ProtectedContextAwareInterface
         if ($precision != null && !is_int($precision)) {
             return NAN;
         }
-        return round($subject, $precision);
+        return round($subject, (int)$precision);
     }
 
     /**

--- a/Neos.Eel/Classes/Helper/StringHelper.php
+++ b/Neos.Eel/Classes/Helper/StringHelper.php
@@ -121,7 +121,7 @@ class StringHelper implements ProtectedContextAwareInterface
 
         $position = $position !== null ? $position : mb_strlen($string, 'UTF-8');
         $position = $position - mb_strlen($search, 'UTF-8');
-        return mb_strrpos($string, $search, null, 'UTF-8') === $position;
+        return mb_strrpos($string, $search, 0, 'UTF-8') === $position;
     }
 
     /**
@@ -305,9 +305,9 @@ class StringHelper implements ProtectedContextAwareInterface
      * @param integer $limit The maximum amount of items to return, in contrast to split() this will return all remaining characters in the last item (see example)
      * @return array An array of the splitted parts, excluding the matched pattern
      */
-    public function pregSplit($string, $pattern, $limit = null)
+    public function pregSplit($string, $pattern, $limit = -1)
     {
-        return preg_split($pattern, (string)$string, $limit);
+        return preg_split($pattern, (string)$string, (int)$limit);
     }
 
     /**
@@ -383,7 +383,7 @@ class StringHelper implements ProtectedContextAwareInterface
     public function startsWith($string, $search, $position = null)
     {
         $position = $position !== null ? $position : 0;
-        return mb_strpos((string)$string, $search, null, 'UTF-8') === $position;
+        return mb_strpos((string)$string, $search, 0, 'UTF-8') === $position;
     }
 
     /**

--- a/Neos.Eel/Tests/Unit/Fixtures/TestArrayIterator.php
+++ b/Neos.Eel/Tests/Unit/Fixtures/TestArrayIterator.php
@@ -29,26 +29,31 @@ class TestArrayIterator implements \Iterator
         return new self($array);
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return current($this->array);
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         next($this->array);
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->array);
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return current($this->array) !== false;
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->array);

--- a/Neos.Flow.Log/Classes/Backend/FileBackend.php
+++ b/Neos.Flow.Log/Classes/Backend/FileBackend.php
@@ -241,7 +241,7 @@ class FileBackend extends AbstractBackend
         }
         $ipAddress = ($this->logIpAddress === true) ? str_pad(($_SERVER['REMOTE_ADDR'] ?? ''), 15) : '';
         $severityLabel = $this->severityLabels[$severity] ?? 'UNKNOWN  ';
-        $output = strftime('%y-%m-%d %H:%M:%S', time()) . $processId . ' ' . $ipAddress . $severityLabel . ' ' . str_pad((string)$packageKey, 20) . ' ' . $message;
+        $output = (new \DateTime())->format('y-m-d H:m:i') . $processId . ' ' . $ipAddress . $severityLabel . ' ' . str_pad((string)$packageKey, 20) . ' ' . $message;
 
         if ($this->logMessageOrigin === true && ($className !== null || $methodName !== null)) {
             $output .= ' [logged in ' . $className . '::' . $methodName . '()]';

--- a/Neos.Flow/Classes/Http/Cookie.php
+++ b/Neos.Flow/Classes/Http/Cookie.php
@@ -421,7 +421,7 @@ class Cookie
             $value = $this->value;
         }
 
-        $cookiePair = sprintf('%s=%s', $this->name, urlencode($value));
+        $cookiePair = sprintf('%s=%s', $this->name, urlencode((string)$value));
         $attributes = '';
 
         if ($this->expiresTimestamp !== 0) {

--- a/Neos.Flow/Classes/Http/Headers.php
+++ b/Neos.Flow/Classes/Http/Headers.php
@@ -440,6 +440,7 @@ class Headers implements \Iterator
     /**
      * @return string[]|mixed
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->getRaw($this->key());
@@ -448,6 +449,7 @@ class Headers implements \Iterator
     /**
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         next($this->fields);
@@ -456,6 +458,7 @@ class Headers implements \Iterator
     /**
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->fields);
@@ -464,6 +467,7 @@ class Headers implements \Iterator
     /**
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return !(key($this->fields) === null && current($this->fields) === false);
@@ -472,6 +476,7 @@ class Headers implements \Iterator
     /**
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->fields);

--- a/Neos.Flow/Classes/Http/RequestHandler.php
+++ b/Neos.Flow/Classes/Http/RequestHandler.php
@@ -161,7 +161,7 @@ class RequestHandler implements HttpRequestHandlerInterface
      */
     protected function sendResponse(ResponseInterface $response)
     {
-        ob_implicit_flush(1);
+        ob_implicit_flush();
         foreach (ResponseInformationHelper::prepareHeaders($response) as $prepareHeader) {
             header($prepareHeader, false);
         }

--- a/Neos.Flow/Classes/Mvc/Controller/Arguments.php
+++ b/Neos.Flow/Classes/Mvc/Controller/Arguments.php
@@ -38,6 +38,7 @@ class Arguments extends \ArrayObject
      * @throws \InvalidArgumentException if the argument is not a valid Controller Argument object
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (!$value instanceof Argument) {
@@ -57,6 +58,7 @@ class Arguments extends \ArrayObject
      * @throws \InvalidArgumentException if the argument is not a valid Controller Argument object
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function append($value)
     {
         if (!$value instanceof Argument) {
@@ -72,6 +74,7 @@ class Arguments extends \ArrayObject
      * @return void
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $translatedOffset = $this->validateArgumentExistence($offset);
@@ -90,6 +93,7 @@ class Arguments extends \ArrayObject
      * @return boolean
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         $translatedOffset = $this->validateArgumentExistence($offset);
@@ -104,6 +108,7 @@ class Arguments extends \ArrayObject
      * @throws NoSuchArgumentException if the argument does not exist
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $translatedOffset = $this->validateArgumentExistence($offset);

--- a/Neos.Flow/Classes/Mvc/Routing/IdentityRoutePart.php
+++ b/Neos.Flow/Classes/Mvc/Routing/IdentityRoutePart.php
@@ -283,7 +283,7 @@ class IdentityRoutePart extends DynamicRoutePart
                         throw new InvalidUriPatternException(sprintf('Invalid uriPattern "%s" for route part "%s". Property "%s" must be of type string or \DateTime. "%s" given.', $this->getUriPattern(), $this->getName(), $propertyPath, is_object($dynamicPathSegment) ? get_class($dynamicPathSegment) : gettype($dynamicPathSegment)), 1316442409);
                     }
                 } else {
-                    $pathSegment .= $this->rewriteForUri($dynamicPathSegment);
+                    $pathSegment .= $this->rewriteForUri((string)$dynamicPathSegment);
                 }
             }
         }

--- a/Neos.Flow/Classes/Mvc/Routing/StaticRoutePart.php
+++ b/Neos.Flow/Classes/Mvc/Routing/StaticRoutePart.php
@@ -37,6 +37,7 @@ class StaticRoutePart extends \Neos\Flow\Mvc\Routing\AbstractRoutePart
      */
     public function match(&$routePath)
     {
+        $routePath = (string)$routePath;
         $this->value = null;
         if ($this->name === null || $this->name === '') {
             return false;

--- a/Neos.Flow/Classes/Persistence/Doctrine/QueryResult.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/QueryResult.php
@@ -95,6 +95,7 @@ class QueryResult implements QueryResultInterface
      * @return integer The number of matching objects
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         if ($this->numberOfRows === null) {
@@ -126,6 +127,7 @@ class QueryResult implements QueryResultInterface
      * @param mixed $offset
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         $this->initialize();
@@ -136,6 +138,7 @@ class QueryResult implements QueryResultInterface
      * @param mixed $offset
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $this->initialize();
@@ -149,6 +152,7 @@ class QueryResult implements QueryResultInterface
      * @param mixed $value
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->initialize();
@@ -161,6 +165,7 @@ class QueryResult implements QueryResultInterface
      * @param mixed $offset
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->initialize();
@@ -170,6 +175,7 @@ class QueryResult implements QueryResultInterface
     /**
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $this->initialize();
@@ -179,6 +185,7 @@ class QueryResult implements QueryResultInterface
     /**
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         $this->initialize();
@@ -188,6 +195,7 @@ class QueryResult implements QueryResultInterface
     /**
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->initialize();
@@ -197,6 +205,7 @@ class QueryResult implements QueryResultInterface
     /**
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->initialize();
@@ -206,6 +215,7 @@ class QueryResult implements QueryResultInterface
     /**
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         $this->initialize();

--- a/Neos.Flow/Classes/Persistence/EmptyQueryResult.php
+++ b/Neos.Flow/Classes/Persistence/EmptyQueryResult.php
@@ -69,6 +69,7 @@ class EmptyQueryResult implements QueryResultInterface
     /**
      * @return object Returns NULL in this case
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return null;
@@ -77,6 +78,7 @@ class EmptyQueryResult implements QueryResultInterface
     /**
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
     }
@@ -84,6 +86,7 @@ class EmptyQueryResult implements QueryResultInterface
     /**
      * @return integer Returns 0 in this case
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return 0;
@@ -100,6 +103,7 @@ class EmptyQueryResult implements QueryResultInterface
     /**
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
     }
@@ -108,6 +112,7 @@ class EmptyQueryResult implements QueryResultInterface
      * @param mixed $offset
      * @return boolean Returns false in this case
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return false;
@@ -117,6 +122,7 @@ class EmptyQueryResult implements QueryResultInterface
      * @param mixed $offset
      * @return mixed Returns NULL in this case
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return null;
@@ -127,6 +133,7 @@ class EmptyQueryResult implements QueryResultInterface
      * @param mixed $value The value is ignored in this case
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
     }
@@ -135,6 +142,7 @@ class EmptyQueryResult implements QueryResultInterface
      * @param mixed $offset The offset is ignored in this case
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
     }
@@ -142,6 +150,7 @@ class EmptyQueryResult implements QueryResultInterface
     /**
      * @return integer Returns 0 in this case
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return 0;

--- a/Neos.Flow/Classes/Reflection/ClassReflection.php
+++ b/Neos.Flow/Classes/Reflection/ClassReflection.php
@@ -50,6 +50,7 @@ class ClassReflection extends \ReflectionClass
      *
      * @return MethodReflection Method reflection object of the constructor method
      */
+    #[\ReturnTypeWillChange]
     public function getConstructor()
     {
         $parentConstructor = parent::getConstructor();
@@ -63,6 +64,7 @@ class ClassReflection extends \ReflectionClass
      *
      * @return array<ClassReflection> Class reflection objects of the properties in this class
      */
+    #[\ReturnTypeWillChange]
     public function getInterfaces()
     {
         $extendedInterfaces = [];
@@ -81,6 +83,7 @@ class ClassReflection extends \ReflectionClass
      * @param string $name
      * @return MethodReflection Method reflection object of the named method
      */
+    #[\ReturnTypeWillChange]
     public function getMethod($name)
     {
         return new MethodReflection($this->getName(), $name);
@@ -94,6 +97,7 @@ class ClassReflection extends \ReflectionClass
      * @param integer|null $filter A filter mask
      * @return array<MethodReflection> Method reflection objects of the methods in this class
      */
+    #[\ReturnTypeWillChange]
     public function getMethods($filter = null)
     {
         $extendedMethods = [];
@@ -112,6 +116,7 @@ class ClassReflection extends \ReflectionClass
      *
      * @return ClassReflection|false Reflection of the parent class - if any
      */
+    #[\ReturnTypeWillChange]
     public function getParentClass()
     {
         $parentClass = parent::getParentClass();
@@ -126,6 +131,7 @@ class ClassReflection extends \ReflectionClass
      * @param integer $filter A filter mask
      * @return array<PropertyReflection> Property reflection objects of the properties in this class
      */
+    #[\ReturnTypeWillChange]
     public function getProperties($filter = null)
     {
         $extendedProperties = [];
@@ -144,6 +150,7 @@ class ClassReflection extends \ReflectionClass
      * @param string $name Name of the property
      * @return PropertyReflection Property reflection object of the specified property in this class
      */
+    #[\ReturnTypeWillChange]
     public function getProperty($name)
     {
         return new PropertyReflection($this->getName(), $name);
@@ -200,6 +207,7 @@ class ClassReflection extends \ReflectionClass
      * @see https://github.com/doctrine/doctrine2/commit/530c01b5e3ed7345cde564bd511794ac72f49b65
      * @return object
      */
+    #[\ReturnTypeWillChange]
     public function newInstanceWithoutConstructor()
     {
         $instance = parent::newInstanceWithoutConstructor();

--- a/Neos.Flow/Classes/Reflection/MethodReflection.php
+++ b/Neos.Flow/Classes/Reflection/MethodReflection.php
@@ -30,6 +30,7 @@ class MethodReflection extends \ReflectionMethod
      *
      * @return ClassReflection The declaring class
      */
+    #[\ReturnTypeWillChange]
     public function getDeclaringClass()
     {
         return new ClassReflection(parent::getDeclaringClass()->getName());
@@ -42,6 +43,7 @@ class MethodReflection extends \ReflectionMethod
      *
      * @return array<ParameterReflection> objects of the parameters of this method
      */
+    #[\ReturnTypeWillChange]
     public function getParameters()
     {
         $extendedParameters = [];

--- a/Neos.Flow/Classes/Reflection/ParameterReflection.php
+++ b/Neos.Flow/Classes/Reflection/ParameterReflection.php
@@ -30,6 +30,7 @@ class ParameterReflection extends \ReflectionParameter
      *
      * @return ClassReflection The declaring class
      */
+    #[\ReturnTypeWillChange]
     public function getDeclaringClass()
     {
         return new ClassReflection(parent::getDeclaringClass()->getName());
@@ -40,6 +41,7 @@ class ParameterReflection extends \ReflectionParameter
      *
      * @return ClassReflection|null The parameter class
      */
+    #[\ReturnTypeWillChange]
     public function getClass()
     {
         try {

--- a/Neos.Flow/Classes/Reflection/PropertyReflection.php
+++ b/Neos.Flow/Classes/Reflection/PropertyReflection.php
@@ -50,6 +50,7 @@ class PropertyReflection extends \ReflectionProperty
      *
      * @return ClassReflection The declaring class
      */
+    #[\ReturnTypeWillChange]
     public function getDeclaringClass()
     {
         return new ClassReflection(parent::getDeclaringClass()->getName());
@@ -93,6 +94,7 @@ class PropertyReflection extends \ReflectionProperty
      * @return mixed Value of the property
      * @throws Exception
      */
+    #[\ReturnTypeWillChange]
     public function getValue($object = null)
     {
         if (!is_object($object)) {
@@ -114,6 +116,7 @@ class PropertyReflection extends \ReflectionProperty
      * @return void
      * @throws Exception
      */
+    #[\ReturnTypeWillChange]
     public function setValue($object = null, $value = null)
     {
         if (!is_object($object)) {

--- a/Neos.Flow/Classes/Security/Cryptography/Algorithms.php
+++ b/Neos.Flow/Classes/Security/Cryptography/Algorithms.php
@@ -37,7 +37,7 @@ class Algorithms
      */
     public static function pbkdf2($password, $salt, $iterationCount, $derivedKeyLength, $algorithm = 'sha256')
     {
-        $hashLength = strlen(hash($algorithm, null, true));
+        $hashLength = strlen(hash($algorithm, '', true));
         $keyBlocksToCompute = ceil($derivedKeyLength / $hashLength);
         $derivedKey = '';
 

--- a/Neos.Flow/Classes/Validation/Validator/AbstractCompositeValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/AbstractCompositeValidator.php
@@ -129,6 +129,7 @@ abstract class AbstractCompositeValidator implements ObjectValidatorInterface, \
      * @return integer The number of validators
      * @api
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->validators);

--- a/Neos.Flow/Classes/Validation/Validator/TextValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/TextValidator.php
@@ -36,7 +36,7 @@ class TextValidator extends AbstractValidator
      */
     protected function isValid($value)
     {
-        if ($value !== filter_var($value, FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES)) {
+        if ($value !== strip_tags((string)$value)) {
             $this->addError('Valid text without any XML tags is expected.', 1221565786);
         }
     }

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/ActionControllerTest.php
@@ -224,6 +224,7 @@ class ActionControllerTest extends UnitTestCase
         $mockView = $this->createMock(Mvc\View\ViewInterface::class);
         $mockView->expects(self::once())->method('setControllerContext')->with($this->mockControllerContext);
         $this->actionController->expects(self::once())->method('resolveView')->will(self::returnValue($mockView));
+        $this->actionController->expects(self::once())->method('resolveActionMethodName')->will(self::returnValue('someAction'));
 
         $this->actionController->processRequest($this->mockRequest, $mockResponse);
     }
@@ -252,6 +253,7 @@ class ActionControllerTest extends UnitTestCase
         $mockView = $this->createMock(Mvc\View\ViewInterface::class);
         $mockView->expects(self::once())->method('assign')->with('settings', $mockSettings);
         $this->actionController->expects(self::once())->method('resolveView')->will(self::returnValue($mockView));
+        $this->actionController->expects(self::once())->method('resolveActionMethodName')->will(self::returnValue('someAction'));
 
         $this->actionController->processRequest($this->mockRequest, $mockResponse);
     }
@@ -274,6 +276,7 @@ class ActionControllerTest extends UnitTestCase
     public function processRequestSetsNegotiatedContentTypeOnResponse($supportedMediaTypes, $acceptHeader, $expected)
     {
         $this->actionController = $this->getAccessibleMock(ActionController::class, ['resolveActionMethodName', 'initializeActionMethodArguments', 'initializeActionMethodValidators', 'resolveView', 'callActionMethod']);
+        $this->actionController->expects(self::once())->method('resolveActionMethodName')->will(self::returnValue('someAction'));
 
         $this->inject($this->actionController, 'objectManager', $this->mockObjectManager);
 
@@ -298,6 +301,7 @@ class ActionControllerTest extends UnitTestCase
     public function processRequestUsesContentTypeFromActionResponse($supportedMediaTypes, $acceptHeader, $expected)
     {
         $this->actionController = $this->getAccessibleMock(ActionController::class, ['resolveActionMethodName', 'initializeActionMethodArguments', 'initializeActionMethodValidators', 'resolveView', 'callActionMethod']);
+        $this->actionController->expects(self::once())->method('resolveActionMethodName')->will(self::returnValue('someAction'));
 
         $this->inject($this->actionController, 'objectManager', $this->mockObjectManager);
 

--- a/Neos.Flow/Tests/Unit/Property/PropertyMappingConfigurationTest.php
+++ b/Neos.Flow/Tests/Unit/Property/PropertyMappingConfigurationTest.php
@@ -118,7 +118,7 @@ class PropertyMappingConfigurationTest extends UnitTestCase
      */
     public function setTypeConverterOptionsCanBeRetrievedAgain()
     {
-        $mockTypeConverterClass = $this->getMockClass(TypeConverterInterface::class);
+        $mockTypeConverterClass = get_class($this->createMock(TypeConverterInterface::class));
 
         $this->propertyMappingConfiguration->setTypeConverterOptions($mockTypeConverterClass, ['k1' => 'v1', 'k2' => 'v2']);
         self::assertEquals('v1', $this->propertyMappingConfiguration->getConfigurationValue($mockTypeConverterClass, 'k1'));
@@ -138,7 +138,7 @@ class PropertyMappingConfigurationTest extends UnitTestCase
      */
     public function setTypeConverterOptionsShouldOverrideAlreadySetOptions()
     {
-        $mockTypeConverterClass = $this->getMockClass(TypeConverterInterface::class);
+        $mockTypeConverterClass = get_class($this->createMock(TypeConverterInterface::class));
         $this->propertyMappingConfiguration->setTypeConverterOptions($mockTypeConverterClass, ['k1' => 'v1', 'k2' => 'v2']);
         $this->propertyMappingConfiguration->setTypeConverterOptions($mockTypeConverterClass, ['k3' => 'v3']);
 
@@ -151,7 +151,7 @@ class PropertyMappingConfigurationTest extends UnitTestCase
      */
     public function setTypeConverterOptionShouldOverrideAlreadySetOptions()
     {
-        $mockTypeConverterClass = $this->getMockClass(TypeConverterInterface::class);
+        $mockTypeConverterClass = get_class($this->createMock(TypeConverterInterface::class));
         $this->propertyMappingConfiguration->setTypeConverterOptions($mockTypeConverterClass, ['k1' => 'v1', 'k2' => 'v2']);
         $this->propertyMappingConfiguration->setTypeConverterOption($mockTypeConverterClass, 'k1', 'v3');
 

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/DateTimeConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/DateTimeConverterTest.php
@@ -508,25 +508,15 @@ class DateTimeConverterTest extends UnitTestCase
     public function convertFromSupportsDateTimeSubClasses()
     {
         $className = 'DateTimeSubClass' . md5(uniqid(mt_rand(), true));
-        if (version_compare(PHP_VERSION, '7.0.0-dev')) {
-            eval('
-			class ' . $className . ' extends \\DateTime {
-				public static function createFromFormat($format, $time, $timezone = NULL) {
-					return new ' . $className . '();
-				}
-				public function foo() { return "Bar"; }
-			}
-		');
-        } else {
-            eval('
-				class ' . $className . ' extends \\DateTime {
-					public static function createFromFormat($format, $time, \\DateTimeZone $timezone = NULL) {
-						return new ' . $className . '();
-					}
-					public function foo() { return "Bar"; }
-				}
-			');
+        eval('
+        class ' . $className . ' extends \\DateTime {
+            #[\ReturnTypeWillChange]
+            public static function createFromFormat($format, $time, $timezone = NULL) {
+                return new ' . $className . '();
+            }
+            public function foo() { return "Bar"; }
         }
+    ');
         $date = $this->converter->convertFrom('2005-08-15T15:52:01+00:00', $className);
 
         self::assertInstanceOf($className, $date);

--- a/Neos.Flow/Tests/Unit/Reflection/Fixture/ArrayAccessClass.php
+++ b/Neos.Flow/Tests/Unit/Reflection/Fixture/ArrayAccessClass.php
@@ -26,21 +26,25 @@ class ArrayAccessClass implements \ArrayAccess
         $this->array = $array;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return array_key_exists($offset, $this->array);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->array[$offset];
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->array[$offset] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->array[$offset]);

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Form/SelectViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Form/SelectViewHelper.php
@@ -370,12 +370,12 @@ class SelectViewHelper extends AbstractFormFieldViewHelper
      */
     protected function renderOptionTag($value, $label)
     {
-        $output = '<option value="' . htmlspecialchars($value) . '"';
+        $output = '<option value="' . htmlspecialchars((string)$value) . '"';
         if ($this->isSelected($value)) {
             $output .= ' selected="selected"';
         }
 
-        $output .= '>' . htmlspecialchars($label) . '</option>';
+        $output .= '>' . htmlspecialchars((string)$label) . '</option>';
 
         return $output;
     }

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Form/TextareaViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Form/TextareaViewHelper.php
@@ -67,7 +67,7 @@ class TextareaViewHelper extends AbstractFormFieldViewHelper
 
         $this->tag->forceClosingTag(true);
         $this->tag->addAttribute('name', $name);
-        $this->tag->setContent(htmlspecialchars($this->getValueAttribute()));
+        $this->tag->setContent(htmlspecialchars((string)$this->getValueAttribute()));
 
         $this->addAdditionalIdentityPropertiesIfNeeded();
         $this->setErrorClassAttribute();

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetControllerTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetControllerTest.php
@@ -59,6 +59,7 @@ class AbstractWidgetControllerTest extends UnitTestCase
         $mockActionRequest->expects(self::atLeastOnce())->method('getInternalArgument')->with('__widgetContext')->will(self::returnValue($widgetContext));
 
         $abstractWidgetController = $this->getAccessibleMock(\Neos\FluidAdaptor\Core\Widget\AbstractWidgetController::class, ['resolveActionMethodName', 'initializeActionMethodArguments', 'initializeActionMethodValidators', 'mapRequestArgumentsToControllerArguments', 'detectFormat', 'resolveView', 'callActionMethod']);
+        $abstractWidgetController->method('resolveActionMethodName')->will(self::returnValue('someAction'));
         $abstractWidgetController->_set('mvcPropertyMappingConfigurationService', $this->createMock(\Neos\Flow\Mvc\Controller\MvcPropertyMappingConfigurationService::class));
 
         $abstractWidgetController->processRequest($mockActionRequest, $mockResponse);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/FormViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/FormViewHelperTest.php
@@ -74,6 +74,7 @@ class FormViewHelperTest extends ViewHelperBaseTestcase
         $this->hashService = $this->createMock(\Neos\Flow\Security\Cryptography\HashService::class);
         $this->inject($viewHelper, 'hashService', $this->hashService);
         $this->mvcPropertyMappingConfigurationService = $this->createMock(\Neos\Flow\Mvc\Controller\MvcPropertyMappingConfigurationService::class);
+        $this->mvcPropertyMappingConfigurationService->method('generateTrustedPropertiesToken')->willReturn('someToken');
         $this->inject($viewHelper, 'mvcPropertyMappingConfigurationService', $this->mvcPropertyMappingConfigurationService);
         $this->securityContext = $this->createMock(\Neos\Flow\Security\Context::class);
         $this->inject($viewHelper, 'securityContext', $this->securityContext);
@@ -206,7 +207,7 @@ class FormViewHelperTest extends ViewHelperBaseTestcase
             '<input type="hidden" name="__referrer[@controller]" value="" />' . chr(10) .
             '<input type="hidden" name="__referrer[@action]" value="" />' . chr(10) .
             '<input type="hidden" name="__referrer[arguments]" value="" />' . chr(10) .
-            '<input type="hidden" name="__trustedProperties" value="" />' . chr(10) .
+            '<input type="hidden" name="__trustedProperties" value="someToken" />' . chr(10) .
             '</div>' . chr(10) .
             'formContent';
         $this->tagBuilder->expects(self::once())->method('setContent')->with($expectedResult);
@@ -265,7 +266,7 @@ class FormViewHelperTest extends ViewHelperBaseTestcase
             '<input type="hidden" name="__referrer[@controller]" value="" />' . chr(10) .
             '<input type="hidden" name="__referrer[@action]" value="" />' . chr(10) .
             '<input type="hidden" name="__referrer[arguments]" value="" />' . chr(10) .
-            '<input type="hidden" name="__trustedProperties" value="" />' . chr(10) .
+            '<input type="hidden" name="__trustedProperties" value="someToken" />' . chr(10) .
             '</div>' . chr(10) .
             'formContent';
         $this->tagBuilder->expects(self::once())->method('setContent')->with($expectedResult);

--- a/Neos.Utility.Arrays/Classes/Arrays.php
+++ b/Neos.Utility.Arrays/Classes/Arrays.php
@@ -284,7 +284,7 @@ abstract class Arrays
      * @return boolean true on success, false on failure
      * @see asort()
      */
-    public static function sortKeysRecursively(array &$array, int $sortFlags = null): bool
+    public static function sortKeysRecursively(array &$array, int $sortFlags = \SORT_REGULAR): bool
     {
         foreach ($array as &$value) {
             if (is_array($value)) {

--- a/Neos.Utility.Files/Classes/Files.php
+++ b/Neos.Utility.Files/Classes/Files.php
@@ -320,7 +320,7 @@ abstract class Files
      * @return mixed The file content as a string or false if the file could not be opened.
      * @api
      */
-    public static function getFileContents(string $pathAndFilename, int $flags = 0, $context = null, int $offset = null, int $maximumLength = -1)
+    public static function getFileContents(string $pathAndFilename, int $flags = 0, $context = null, int $offset = 0, int $maximumLength = -1)
     {
         if ($flags === true) {
             $flags = FILE_USE_INCLUDE_PATH;

--- a/Neos.Utility.ObjectHandling/Tests/Unit/Fixture/ArrayAccessClass.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/Fixture/ArrayAccessClass.php
@@ -26,21 +26,25 @@ class ArrayAccessClass implements \ArrayAccess
         $this->array = $array;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return array_key_exists($offset, $this->array);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->array[$offset];
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->array[$offset] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->array[$offset]);

--- a/Neos.Utility.Unicode/Classes/TextIterator.php
+++ b/Neos.Utility.Unicode/Classes/TextIterator.php
@@ -108,6 +108,7 @@ class TextIterator implements \Iterator
      *
      * @return string The value of the current element
      */
+    #[\ReturnTypeWillChange]
     public function current(): string
     {
         return $this->getCurrentElement()->getValue();
@@ -118,6 +119,7 @@ class TextIterator implements \Iterator
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->previousElement = $this->getCurrentElement();
@@ -130,6 +132,7 @@ class TextIterator implements \Iterator
      *
      * @return mixed Key (number) of the current element
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->iteratorCacheIterator->key();
@@ -140,6 +143,7 @@ class TextIterator implements \Iterator
      *
      * @return boolean True if the iterator has not reached it's end
      */
+    #[\ReturnTypeWillChange]
     public function valid(): bool
     {
         if ($this->getCurrentElement() !== null && $this->getCurrentElement()->getValue() !== self::DONE && $this->getCurrentElement()->getOffset() !== -1) {
@@ -153,6 +157,7 @@ class TextIterator implements \Iterator
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->iteratorCacheIterator->rewind();

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -66,17 +66,12 @@
     </PossiblyNullReference>
   </file>
   <file src="Packages/Framework/Neos.Cache/Classes/Backend/RedisBackend.php">
-    <InvalidArgument occurrences="2">
-      <code>$entryIdentifier</code>
+    <InvalidArgument occurrences="1">
       <code>1</code>
     </InvalidArgument>
     <PossiblyInvalidArgument occurrences="1">
       <code>$this-&gt;redis-&gt;get($this-&gt;getPrefixedIdentifier('entry:' . $entryIdentifier))</code>
     </PossiblyInvalidArgument>
-    <ReservedWord occurrences="2">
-      <code>$entries</code>
-      <code>$tags</code>
-    </ReservedWord>
   </file>
   <file src="Packages/Framework/Neos.Cache/Classes/Backend/SimpleFileBackend.php">
     <PossiblyNullReference occurrences="4">
@@ -169,9 +164,9 @@
     </MissingDocblockType>
   </file>
   <file src="Packages/Framework/Neos.Eel/Classes/FlowQuery/Operations/CountOperation.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <PossiblyInvalidArgument occurrences="1">
       <code>$flowQuery-&gt;getContext()</code>
-    </ArgumentTypeCoercion>
+    </PossiblyInvalidArgument>
   </file>
   <file src="Packages/Framework/Neos.Eel/Classes/FlowQuery/Operations/FirstOperation.php">
     <UndefinedInterfaceMethod occurrences="1">
@@ -184,22 +179,20 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="Packages/Framework/Neos.Eel/Classes/FlowQuery/Operations/IsOperation.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <PossiblyInvalidArgument occurrences="1">
       <code>$flowQuery-&gt;getContext()</code>
-    </ArgumentTypeCoercion>
+    </PossiblyInvalidArgument>
   </file>
   <file src="Packages/Framework/Neos.Eel/Classes/FlowQuery/Operations/LastOperation.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <PossiblyInvalidArgument occurrences="2">
       <code>$context</code>
-    </ArgumentTypeCoercion>
-    <PossiblyInvalidArgument occurrences="1">
       <code>$context</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="Packages/Framework/Neos.Eel/Classes/FlowQuery/Operations/Object/ChildrenOperation.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <PossiblyInvalidArgument occurrences="1">
       <code>$flowQuery-&gt;getContext()</code>
-    </ArgumentTypeCoercion>
+    </PossiblyInvalidArgument>
   </file>
   <file src="Packages/Framework/Neos.Eel/Classes/FlowQuery/Operations/Object/FilterOperation.php">
     <InvalidArrayOffset occurrences="3">
@@ -258,12 +251,10 @@
       <code>$x</code>
       <code>$x</code>
     </InvalidScalarArgument>
-    <PossiblyNullArgument occurrences="1">
-      <code>$x</code>
-    </PossiblyNullArgument>
-    <RedundantCastGivenDocblockType occurrences="2">
+    <RedundantCastGivenDocblockType occurrences="3">
       <code>(float)$x</code>
       <code>(float)$x</code>
+      <code>(int)$precision</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="Packages/Framework/Neos.Eel/Classes/Helper/StringHelper.php">
@@ -276,24 +267,20 @@
       <code>$iterator-&gt;preceding($maximumCharacters)</code>
       <code>$iterator-&gt;preceding($maximumCharacters)</code>
     </InvalidScalarArgument>
-    <NullArgument occurrences="2">
-      <code>null</code>
-      <code>null</code>
-    </NullArgument>
     <NullableReturnStatement occurrences="3">
       <code>min(mb_strlen($string, 'UTF-8'), $fromIndex)</code>
       <code>null</code>
       <code>null</code>
     </NullableReturnStatement>
-    <PossiblyNullArgument occurrences="2">
+    <PossiblyNullArgument occurrences="1">
       <code>$fromIndex</code>
-      <code>$limit</code>
     </PossiblyNullArgument>
     <RedundantCast occurrences="2">
       <code>(integer)$index</code>
       <code>(integer)$index</code>
     </RedundantCast>
-    <RedundantCastGivenDocblockType occurrences="36">
+    <RedundantCastGivenDocblockType occurrences="37">
+      <code>(int)$limit</code>
       <code>(int)$value</code>
       <code>(string)$string</code>
       <code>(string)$string</code>
@@ -409,7 +396,8 @@
     </TypeDoesNotContainType>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Aop/Builder/ProxyClassBuilder.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$aspectClassName</code>
       <code>$targetClassName</code>
     </ArgumentTypeCoercion>
     <MissingDocblockType occurrences="1">
@@ -655,9 +643,6 @@
     </UndefinedConstant>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Command/SecurityCommandController.php">
-    <PossiblyNullIterator occurrences="1">
-      <code>$methodNames</code>
-    </PossiblyNullIterator>
     <PossiblyNullReference occurrences="1">
       <code>createPrivilege</code>
     </PossiblyNullReference>
@@ -858,9 +843,6 @@
     <UndefinedConstant occurrences="1">
       <code>FLOW_SAPITYPE</code>
     </UndefinedConstant>
-    <UndefinedMethod occurrences="1">
-      <code>isInitialized</code>
-    </UndefinedMethod>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Error/ErrorHandler.php">
     <InvalidArgument occurrences="1">
@@ -922,9 +904,6 @@
     <InvalidNullableReturnType occurrences="1">
       <code>Cookie</code>
     </InvalidNullableReturnType>
-    <InvalidScalarArgument occurrences="1">
-      <code>$value</code>
-    </InvalidScalarArgument>
     <NullableReturnStatement occurrences="2">
       <code>null</code>
       <code>null</code>
@@ -1223,6 +1202,9 @@
     </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Mvc/ActionRequest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$controllerClassName</code>
+    </ArgumentTypeCoercion>
     <NullableReturnStatement occurrences="1">
       <code>$this-&gt;internalArguments[$argumentName] ?? null</code>
     </NullableReturnStatement>
@@ -1441,6 +1423,11 @@
       <code>null</code>
     </NullableReturnStatement>
   </file>
+  <file src="Packages/Framework/Neos.Flow/Classes/Mvc/Routing/StaticRoutePart.php">
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(string)$routePath</code>
+    </RedundantCastGivenDocblockType>
+  </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php">
     <PossiblyNullPropertyAssignmentValue occurrences="2">
       <code>null</code>
@@ -1478,6 +1465,9 @@
     </InvalidScalarArgument>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$className</code>
+    </ArgumentTypeCoercion>
     <InvalidScalarArgument occurrences="1">
       <code>$objectConfigurations[$implementationClassName]-&gt;getScope()</code>
     </InvalidScalarArgument>
@@ -1562,9 +1552,6 @@
     <UndefinedClass occurrences="1">
       <code>BaseTestCase</code>
     </UndefinedClass>
-    <UndefinedDocblockClass occurrences="1">
-      <code>\ReflectionAttribute</code>
-    </UndefinedDocblockClass>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php">
     <PossiblyFalseArgument occurrences="1">
@@ -1575,14 +1562,6 @@
       <code>isset($this-&gt;constructor)</code>
       <code>isset($this-&gt;constructor)</code>
     </RedundantPropertyInitializationCheck>
-    <UndefinedMethod occurrences="1">
-      <code>getAttributes</code>
-    </UndefinedMethod>
-  </file>
-  <file src="Packages/Framework/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethod.php">
-    <UndefinedMethod occurrences="1">
-      <code>getAttributes</code>
-    </UndefinedMethod>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Package.php">
     <UndefinedClass occurrences="2">
@@ -1662,9 +1641,6 @@
       <code>$parent['metadata']</code>
       <code>$qComp['parent']</code>
     </PossiblyUndefinedArrayOffset>
-    <UndefinedDocblockClass occurrences="1">
-      <code>$this-&gt;_getQueryComponents()</code>
-    </UndefinedDocblockClass>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Persistence/Doctrine/DataTypes/JsonArrayType.php">
     <LessSpecificImplementedReturnType occurrences="1">
@@ -1715,7 +1691,8 @@
     </ArgumentTypeCoercion>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php">
-    <ArgumentTypeCoercion occurrences="5">
+    <ArgumentTypeCoercion occurrences="6">
+      <code>$className</code>
       <code>$className</code>
       <code>$className</code>
       <code>$classSchema-&gt;getRepositoryClassName()</code>
@@ -1967,7 +1944,7 @@
       <code>array&lt;PropertyReflection&gt;</code>
     </LessSpecificImplementedReturnType>
     <MethodSignatureMismatch occurrences="1">
-      <code>public function newInstanceWithoutConstructor()</code>
+      <code>#[\ReturnTypeWillChange]</code>
     </MethodSignatureMismatch>
     <NullableReturnStatement occurrences="1">
       <code>(!is_object($parentConstructor)) ? $parentConstructor : new MethodReflection($this-&gt;getName(), $parentConstructor-&gt;getName())</code>
@@ -1995,19 +1972,21 @@
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Reflection/ParameterReflection.php">
     <MissingImmutableAnnotation occurrences="3">
+      <code>#[\ReturnTypeWillChange]</code>
+      <code>#[\ReturnTypeWillChange]</code>
       <code>\ReflectionParameter</code>
-      <code>public function getClass()</code>
-      <code>public function getDeclaringClass()</code>
     </MissingImmutableAnnotation>
     <PossiblyNullReference occurrences="1">
       <code>getName</code>
     </PossiblyNullReference>
-    <UndefinedMethod occurrences="1">
+    <UndefinedMethod occurrences="2">
       <code>getName</code>
+      <code>isBuiltin</code>
     </UndefinedMethod>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Reflection/ReflectionService.php">
-    <ArgumentTypeCoercion occurrences="3">
+    <ArgumentTypeCoercion occurrences="5">
+      <code>$className</code>
       <code>$className</code>
       <code>$className</code>
       <code>$this-&gt;cleanClassName($className)</code>
@@ -2037,18 +2016,13 @@
     <TooManyArguments occurrences="1">
       <code>getPropertyAnnotations</code>
     </TooManyArguments>
-    <UndefinedClass occurrences="1">
-      <code>\ReflectionUnionType</code>
-    </UndefinedClass>
     <UndefinedInterfaceMethod occurrences="3">
       <code>freeze</code>
       <code>freeze</code>
       <code>isFrozen</code>
     </UndefinedInterfaceMethod>
-    <UndefinedMethod occurrences="3">
-      <code>getAttributes</code>
-      <code>getAttributes</code>
-      <code>getAttributes</code>
+    <UndefinedMethod occurrences="1">
+      <code>getName</code>
     </UndefinedMethod>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Reflection/ReflectionServiceFactory.php">
@@ -2534,11 +2508,6 @@
       <code>null</code>
     </PossiblyNullPropertyAssignmentValue>
   </file>
-  <file src="Packages/Framework/Neos.Flow/Classes/Security/Cryptography/Algorithms.php">
-    <NullArgument occurrences="1">
-      <code>null</code>
-    </NullArgument>
-  </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Security/Cryptography/BCryptHashingStrategy.php">
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>sprintf('%02d', $cost)</code>
@@ -2573,6 +2542,17 @@
     </UndefinedConstant>
   </file>
   <file src="Packages/Framework/Neos.Flow/Classes/Security/Cryptography/RsaWalletServicePhp.php">
+    <InvalidArgument occurrences="9">
+      <code>$keyResource</code>
+      <code>$keyResource</code>
+      <code>$keyResource</code>
+      <code>$keyResource</code>
+      <code>$keyResource</code>
+      <code>$keyResource</code>
+      <code>$keyResource</code>
+      <code>$keyResource</code>
+      <code>$keyResource</code>
+    </InvalidArgument>
     <NullArgument occurrences="1">
       <code>null</code>
     </NullArgument>
@@ -2849,11 +2829,7 @@
     </PropertyTypeCoercion>
   </file>
   <file src="Packages/Framework/Neos.FluidAdaptor/Classes/Service/AbstractGenerator.php">
-    <PossiblyNullPropertyFetch occurrences="1">
-      <code>$parentDomNode-&gt;ownerDocument</code>
-    </PossiblyNullPropertyFetch>
-    <PossiblyNullReference occurrences="2">
-      <code>appendChild</code>
+    <PossiblyNullReference occurrences="1">
       <code>importNode</code>
     </PossiblyNullReference>
   </file>
@@ -2932,6 +2908,10 @@
     <InvalidCast occurrences="1">
       <code>$valueElement</code>
     </InvalidCast>
+    <RedundantCastGivenDocblockType occurrences="2">
+      <code>(string)$label</code>
+      <code>(string)$value</code>
+    </RedundantCastGivenDocblockType>
     <TypeDoesNotContainType occurrences="1">
       <code>is_array($value)</code>
     </TypeDoesNotContainType>
@@ -3164,9 +3144,6 @@
     </PossiblyFalseOperand>
   </file>
   <file src="Packages/Framework/Neos.Utility.Arrays/Classes/Arrays.php">
-    <PossiblyNullArgument occurrences="1">
-      <code>$sortFlags</code>
-    </PossiblyNullArgument>
     <PossiblyUndefinedVariable occurrences="3">
       <code>$chunks</code>
       <code>$chunks</code>
@@ -3210,6 +3187,11 @@
     </NullableReturnStatement>
   </file>
   <file src="Packages/Framework/Neos.Utility.ObjectHandling/Classes/ObjectAccess.php">
+    <ArgumentTypeCoercion occurrences="3">
+      <code>$className</code>
+      <code>$className</code>
+      <code>$className</code>
+    </ArgumentTypeCoercion>
     <InvalidScalarArgument occurrences="1">
       <code>$propertyName</code>
     </InvalidScalarArgument>


### PR DESCRIPTION
This tweaks the code so that it runs without deprecations on PHP 8.1.

**Upgrade instructions**

None.

**Review instructions**

None.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions~
