### PR TITLE
BUGFIX: If bytes to read is not > 0, return empty string

### DIFF
--- a/Neos.Cache/Classes/Backend/SimpleFileBackend.php
+++ b/Neos.Cache/Classes/Backend/SimpleFileBackend.php
@@ -510,7 +510,7 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
                     $length = $maxlen !== null ? $maxlen : filesize($cacheEntryPathAndFilename) - (int)$offset;
 
                     // fread requires a positive length. If the file is empty, we just return an empty string.
-                    if ($length === 0) {
+                    if ($length <= 0) {
                         $data = '';
                     } else {
                         $data = fread($file, $length);


### PR DESCRIPTION
Fixes #2929

**Upgrade instructions**

**Review instructions**

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions~
