### PR TITLE
BUGFIX: Only publish static collection, if collection is present

### DIFF
--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -107,7 +107,9 @@ class Package extends BasePackage
                 }
                 $objectManager = $bootstrap->getObjectManager();
                 $resourceManager = $objectManager->get(ResourceManager::class);
-                $resourceManager->getCollection(ResourceManager::DEFAULT_STATIC_COLLECTION_NAME)->publish();
+                if ($staticCollection = $resourceManager->getCollection(ResourceManager::DEFAULT_STATIC_COLLECTION_NAME)) {
+                    $staticCollection->publish();
+                }
             };
 
             $dispatcher->connect(Monitor\FileMonitor::class, 'filesHaveChanged', $publishResources);


### PR DESCRIPTION
Fixes #3097 

**Upgrade instructions**

No changes needed

**Review instructions**

Reset the collections configuration like this

```
Neos:
  Flow:
    resource:
      collections: []
      storages: []
      targets: []
```

and find the booting throw a exception as "can not call publish() on null"

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
