### PR TITLE
BUGFIX: Replacement proxy methods rendered again

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
@@ -154,7 +154,7 @@ class ProxyClassBuilder
             $constructor->addPostParentCallCode($this->buildLifecycleInitializationCode($objectConfiguration, ObjectManagerInterface::INITIALIZATIONCAUSE_CREATED));
             $constructor->addPostParentCallCode($this->buildLifecycleShutdownCode($objectConfiguration, ObjectManagerInterface::INITIALIZATIONCAUSE_CREATED));
 
-            if ($this->objectManager->getContext()->isProduction()) {
+            if ($this->objectManager->getContext()->isProduction() || $this->objectManager->getContext()->isTesting()) {
                 $this->compileStaticMethods($className, $proxyClass);
             }
         }

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php
@@ -249,9 +249,7 @@ class ProxyClass
 
         foreach ($this->methods as $proxyMethod) {
             assert($proxyMethod instanceof ProxyMethodGenerator);
-            $methodBodyCode = $proxyMethod->renderBodyCode();
-            if ($methodBodyCode !== '') {
-                $proxyMethod->setBody($methodBodyCode);
+            if ($proxyMethod->willBeRendered()) {
                 $methodsCode .= PHP_EOL . $proxyMethod->generate();
             }
         }

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php
@@ -142,7 +142,7 @@ class ProxyClass
         }
         if (!isset($this->methods[$methodName])) {
             if (method_exists($this->fullOriginalClassName, $methodName)) {
-                $this->methods[$methodName] = ProxyMethodGenerator::copyMethodSignature(new MethodReflection($this->fullOriginalClassName, $methodName));
+                $this->methods[$methodName] = ProxyMethodGenerator::copyMethodSignatureAndDocblock(new MethodReflection($this->fullOriginalClassName, $methodName));
             } else {
                 $this->methods[$methodName] = new ProxyMethodGenerator($methodName);
             }

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php
@@ -142,7 +142,7 @@ class ProxyClass
         }
         if (!isset($this->methods[$methodName])) {
             if (method_exists($this->fullOriginalClassName, $methodName)) {
-                $this->methods[$methodName] = ProxyMethodGenerator::fromReflection(new MethodReflection($this->fullOriginalClassName, $methodName));
+                $this->methods[$methodName] = ProxyMethodGenerator::copyMethodSignature(new MethodReflection($this->fullOriginalClassName, $methodName));
             } else {
                 $this->methods[$methodName] = new ProxyMethodGenerator($methodName);
             }

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
@@ -108,7 +108,7 @@ class ProxyMethodGenerator extends MethodGenerator
      */
     public function willBeRendered(): bool
     {
-        return ($this->addedPreParentCallCode !== '' || $this->addedPostParentCallCode !== '');
+        return ($this->addedPreParentCallCode !== '' || $this->addedPostParentCallCode !== '' || $this->body !== '');
     }
 
     /**

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
@@ -23,11 +23,14 @@ class ProxyMethodGenerator extends MethodGenerator
 
     protected string $fullOriginalClassName = '';
 
+    protected bool $bodyWasOverridden = false;
+
     public static function fromReflection(\Laminas\Code\Reflection\MethodReflection $reflectionMethod): static
     {
         $instance = parent::fromReflection($reflectionMethod);
         assert($instance instanceof static);
         $instance->fullOriginalClassName = $reflectionMethod->getDeclaringClass()->getName();
+        $instance->bodyWasOverridden = false;
         return $instance;
     }
 
@@ -108,7 +111,7 @@ class ProxyMethodGenerator extends MethodGenerator
      */
     public function willBeRendered(): bool
     {
-        return ($this->addedPreParentCallCode !== '' || $this->addedPostParentCallCode !== '' || $this->body !== '');
+        return ($this->addedPreParentCallCode !== '' || $this->addedPostParentCallCode !== '' || $this->bodyWasOverridden);
     }
 
     /**
@@ -160,5 +163,11 @@ class ProxyMethodGenerator extends MethodGenerator
             return '';
         }
         return 'parent::' . $methodName . '(' . $this->buildMethodParametersCode($fullClassName, $methodName, false) . ");\n";
+    }
+
+    public function setBody($body): static
+    {
+        $this->bodyWasOverridden = true;
+        return parent::setBody($body);
     }
 }

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\ObjectManagement\Proxy;
  * source code.
  */
 
+use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\MethodGenerator;
 
 /**
@@ -31,10 +32,13 @@ class ProxyMethodGenerator extends MethodGenerator
         return $instance;
     }
 
-    public static function copyMethodSignature(\Laminas\Code\Reflection\MethodReflection $reflectionMethod): static
+    public static function copyMethodSignatureAndDocblock(\Laminas\Code\Reflection\MethodReflection $reflectionMethod): static
     {
         $instance = parent::copyMethodSignature($reflectionMethod);
         assert($instance instanceof static);
+        if ($reflectionMethod->getDocComment() !== false) {
+            $instance->setDocBlock(DocBlockGenerator::fromReflection($reflectionMethod->getDocBlock()));
+        }
         $instance->fullOriginalClassName = $reflectionMethod->getDeclaringClass()->getName();
         return $instance;
     }

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
@@ -23,14 +23,11 @@ class ProxyMethodGenerator extends MethodGenerator
 
     protected string $fullOriginalClassName = '';
 
-    protected bool $bodyWasOverridden = false;
-
     public static function fromReflection(\Laminas\Code\Reflection\MethodReflection $reflectionMethod): static
     {
         $instance = parent::fromReflection($reflectionMethod);
         assert($instance instanceof static);
         $instance->fullOriginalClassName = $reflectionMethod->getDeclaringClass()->getName();
-        $instance->bodyWasOverridden = false;
         return $instance;
     }
 
@@ -73,6 +70,11 @@ class ProxyMethodGenerator extends MethodGenerator
         if ($this->body === '') {
             $this->body = $this->renderBodyCode();
         }
+
+        if ($this->body === '') {
+            return '';
+        }
+
         return parent::generate();
     }
 
@@ -111,7 +113,7 @@ class ProxyMethodGenerator extends MethodGenerator
      */
     public function willBeRendered(): bool
     {
-        return ($this->addedPreParentCallCode !== '' || $this->addedPostParentCallCode !== '' || $this->bodyWasOverridden);
+        return ($this->addedPreParentCallCode !== '' || $this->addedPostParentCallCode !== '' || $this->body !== '');
     }
 
     /**
@@ -163,11 +165,5 @@ class ProxyMethodGenerator extends MethodGenerator
             return '';
         }
         return 'parent::' . $methodName . '(' . $this->buildMethodParametersCode($fullClassName, $methodName, false) . ");\n";
-    }
-
-    public function setBody($body): static
-    {
-        $this->bodyWasOverridden = true;
-        return parent::setBody($body);
     }
 }

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
@@ -89,7 +89,7 @@ class ProxyMethodGenerator extends MethodGenerator
         }
 
         $callParentMethodCode = $this->buildCallParentMethodCode($this->fullOriginalClassName, $this->name);
-        $returnTypeIsVoidOrNever = ((string)$this->getReturnType() === 'void' || (string)$this->getReturnType() === 'never' );
+        $returnTypeIsVoidOrNever = ((string)$this->getReturnType() === 'void' || (string)$this->getReturnType() === 'never');
         $code = $this->addedPreParentCallCode;
         if ($this->addedPostParentCallCode !== '') {
             if ($returnTypeIsVoidOrNever) {

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassK.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassK.php
@@ -22,6 +22,6 @@ class PrototypeClassK
      */
     public static function compiledStaticallyMethod(): float
     {
-        return microtime(true);
+        return bin2hex(random_bytes(10));
     }
 }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassK.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassK.php
@@ -9,7 +9,7 @@ use Neos\Flow\Utility\Algorithms;
  */
 class PrototypeClassK
 {
-    public function getMicrotime(): float
+    public function getToken(): string
     {
         return static::compiledStaticallyMethod();
     }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassK.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassK.php
@@ -1,0 +1,27 @@
+<?php
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A class to test static compile functionality
+ */
+class PrototypeClassK
+{
+    public function getMicrotime(): float
+    {
+        return static::compiledStaticallyMethod();
+    }
+
+    /**
+     * Method that should get static compiled into the proxy, saving some processing power in production,
+     * but also providing the exact same result on every call.
+     *
+     * @return float
+     * @Flow\CompileStatic
+     */
+    public static function compiledStaticallyMethod(): float
+    {
+        return microtime(true);
+    }
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassK.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PrototypeClassK.php
@@ -2,6 +2,7 @@
 namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Utility\Algorithms;
 
 /**
  * A class to test static compile functionality
@@ -17,11 +18,11 @@ class PrototypeClassK
      * Method that should get static compiled into the proxy, saving some processing power in production,
      * but also providing the exact same result on every call.
      *
-     * @return float
+     * @return string
      * @Flow\CompileStatic
      */
-    public static function compiledStaticallyMethod(): float
+    public static function compiledStaticallyMethod(): string
     {
-        return bin2hex(random_bytes(10));
+        return Algorithms::generateRandomToken(10);
     }
 }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
@@ -22,6 +22,7 @@ use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ClassImplementingInterf
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ClassWithPrivateConstructor;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PHP81\BackedEnumWithMethod;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassA;
+use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassK;
 use Neos\Flow\Tests\FunctionalTestCase;
 
 /**
@@ -344,5 +345,14 @@ class ProxyCompilerTest extends FunctionalTestCase
             }
         PHP;
         self::assertSame($expectedSelves, $object->getStringContainingALotOfSelves());
+    }
+
+    /**
+     * @test
+     */
+    public function staticCompileWillResultInAFrozenReturnValue(): void
+    {
+        $object = new PrototypeClassK();
+        self::assertSame($object->getMicrotime(), $object->getMicrotime());
     }
 }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
@@ -353,6 +353,6 @@ class ProxyCompilerTest extends FunctionalTestCase
     public function staticCompileWillResultInAFrozenReturnValue(): void
     {
         $object = new PrototypeClassK();
-        self::assertSame($object->getMicrotime(), $object->getMicrotime());
+        self::assertSame($object->getToken(), $object->getToken());
     }
 }

--- a/Neos.Flow/Tests/Functional/Persistence/Aspect/PersistenceMagicAspectTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Aspect/PersistenceMagicAspectTest.php
@@ -81,17 +81,19 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
      * @test
      * @dataProvider sameValueObjectDataProvider
      */
-    public function valueObjectsWithTheSamePropertyValuesAreEqual($valueObject1, $valueObject2)
+    public function valueObjectsWithTheSamePropertyValuesAreEqual($closure)
     {
+        [$valueObject1, $valueObject2] = $closure();
         self::assertEquals($this->persistenceManager->getIdentifierByObject($valueObject1), $this->persistenceManager->getIdentifierByObject($valueObject2));
     }
 
     public function sameValueObjectDataProvider()
     {
+        // These need to be provided as closures so that the construction happens inside the test and not outside of the test environment.
         return [
-            [new Fixtures\TestValueObject('value'), new Fixtures\TestValueObject('value')],
-            [new Fixtures\TestValueObjectWithConstructorLogic('val', 'val'), new Fixtures\TestValueObjectWithConstructorLogic(' val', 'val ')],
-            [new Fixtures\TestValueObjectWithConstructorLogic('moreThan5Chars', 'alsoMoreButDoesntMatter'), new Fixtures\TestValueObjectWithConstructorLogic('  moreThan5Chars  ', '        alsoMoreButDoesntMatter ')]
+            [static fn () => [new Fixtures\TestValueObject('value'), new Fixtures\TestValueObject('value')]],
+            [static fn () => [new Fixtures\TestValueObjectWithConstructorLogic('val', 'val'), new Fixtures\TestValueObjectWithConstructorLogic(' val', 'val ')]],
+            [static fn () => [new Fixtures\TestValueObjectWithConstructorLogic('moreThan5Chars', 'alsoMoreButDoesntMatter'), new Fixtures\TestValueObjectWithConstructorLogic('  moreThan5Chars  ', '        alsoMoreButDoesntMatter ')]]
         ];
     }
 
@@ -99,17 +101,19 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
      * @test
      * @dataProvider differentValueObjectDataProvider
      */
-    public function valueObjectWithDifferentPropertyValuesAreNotEqual($valueObject1, $valueObject2)
+    public function valueObjectWithDifferentPropertyValuesAreNotEqual($closure)
     {
+        [$valueObject1, $valueObject2] = $closure();
         self::assertNotEquals($this->persistenceManager->getIdentifierByObject($valueObject1), $this->persistenceManager->getIdentifierByObject($valueObject2));
     }
 
     public function differentValueObjectDataProvider()
     {
+        // These need to be provided as closures so that the construction happens inside the test and not outside of the test environment.
         return [
-            [new Fixtures\TestValueObject('value1'), new Fixtures\TestValueObject('value2')],
-            [new Fixtures\TestValueObject(''), new Fixtures\TestValueObject(null)],
-            [new Fixtures\TestValueObjectWithConstructorLogic('chars', ' value2IsJustTrimmed        '), new Fixtures\TestValueObjectWithConstructorLogic('chars ', '        value2IsJustTrimmed ')]
+            [static fn () => [new Fixtures\TestValueObject('value1'), new Fixtures\TestValueObject('value2')]],
+            [static fn () => [new Fixtures\TestValueObject(''), new Fixtures\TestValueObject(null)]],
+            [static fn () => [new Fixtures\TestValueObjectWithConstructorLogic('chars', ' value2IsJustTrimmed        '), new Fixtures\TestValueObjectWithConstructorLogic('chars ', '        value2IsJustTrimmed ')]]
         ];
     }
 


### PR DESCRIPTION
This fixes a bug introduced in d939e6b8 switching to laminuas-code. A proxy method can replace the full body of an existing method or even be a fully new method, in which case only `body` will be set in the proxy method. We still want those to be generated. This for example currently breaks the CompileStatic feature, as those methods do not get rendered anymore resulting in worse performance in Production context compared to before.

This fix renders a proxy method also when a body was set for it, but still skips it if neither pre/post nor body is set.

It also enabled CompileStatic in Testing Context so that it is testable and adds a test to make sure it works as intended.

Fixes: #3099