### PR TITLE
9.0 FEATURE: Add `unique` flowQuery operation

### DIFF
--- a/Neos.Eel/Classes/FlowQuery/Operations/UniqueOperation.php
+++ b/Neos.Eel/Classes/FlowQuery/Operations/UniqueOperation.php
@@ -1,0 +1,43 @@
+<?php
+namespace Neos\Eel\FlowQuery\Operations;
+
+/*
+ * This file is part of the Neos.Eel package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Eel\FlowQuery\FlowQuery;
+
+/**
+ * Removes duplicate items from the current context.
+ */
+class UniqueOperation extends AbstractOperation
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @var string
+     */
+    protected static $shortName = 'unique';
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param FlowQuery $flowQuery the FlowQuery object
+     * @param array $arguments the elements to remove (as array in index 0)
+     * @return void
+     */
+    public function evaluate(FlowQuery $flowQuery, array $arguments)
+    {
+        $context = $flowQuery->getContext();
+        if ($context instanceof \Traversable) {
+            $context = iterator_to_array($context);
+        }
+        $flowQuery->setContext(array_unique($context));
+    }
+}

--- a/Neos.Eel/Tests/Unit/FlowQuery/Operations/UniqueOperationTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/Operations/UniqueOperationTest.php
@@ -1,0 +1,56 @@
+<?php
+namespace Neos\Eel\Tests\Unit\FlowQuery\Operations;
+
+/*
+ * This file is part of the Neos.Eel package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Eel\FlowQuery\FlowQuery;
+use Neos\Eel\FlowQuery\Operations\UniqueOperation;
+use Neos\Eel\Tests\Unit\Fixtures\TestArrayIterator;
+use Neos\Flow\Tests\UnitTestCase;
+
+/**
+ * UniqueOperation test
+ */
+class UniqueOperationTest extends UnitTestCase
+{
+    public function uniqueExamples(): \Generator
+    {
+        yield 'numeric indices' => [
+            ['bar', 12, 'two', 'bar', 13, 12, false, 0, null],
+            [0 => 'bar', 1 => 12, 2 => 'two', 4 => 13, 6 => false, 7 => 0]
+        ];
+        yield 'string keys' => [
+            ['foo' => 'bar', 'baz' => 'foo', 'foo' => 'bar2', 'bar' => false, 'foonull' => null],
+            ['foo' => 'bar2', 'baz' => 'foo', 'bar' => false]
+        ];
+        yield 'mixed keys' => [
+            ['bar', '24' => 'bar', 'i' => 181.84, 'foo' => 'abc', 'foo2' => 'abc', 76],
+            [0 => 'bar', 'i' => 181.84, 'foo' => 'abc', 25 => 76]
+        ];
+        yield 'traversable' => [
+            TestArrayIterator::fromArray(['a', 'a', 'b']),
+            [0 => 'a', 2 => 'b']
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider uniqueExamples
+     */
+    public function uniqueRemovesDuplicateItemsWorks($array, $expected): void
+    {
+        $flowQuery = new FlowQuery($array);
+        $operation = new UniqueOperation();
+        $operation->evaluate($flowQuery, []);
+
+        self::assertEquals($expected, $flowQuery->getContext());
+    }
+}


### PR DESCRIPTION
This operation applies `array_unique` to the current flowQuery context.

While the same could previously achieved via `Array.unique()` the flow query operation can be placed in an operation chain without extra wrapping.

**Review instructions**

There is also a node specific implementation of the `unique` operation in https://github.com/neos/neos-development-collection/pull/4355

I know the php code looks oldish but the style is in line with the other flowQuery operations around. 

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
