### PR TITLE
TASK: Extract test base classes into new `Neos.Flow.Testing` package

### DIFF
--- a/Neos.Eel/Tests/Functional/FlowQuery/OperationResolverTest.php
+++ b/Neos.Eel/Tests/Functional/FlowQuery/OperationResolverTest.php
@@ -3,7 +3,7 @@ namespace Neos\Eel\Tests\Functional\FlowQuery;
 
 use Neos\Eel\FlowQuery\OperationResolver;
 use Neos\Eel\FlowQuery\OperationResolverInterface;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Test cases for operation resolver

--- a/Neos.Eel/Tests/Unit/AbstractEvaluatorTest.php
+++ b/Neos.Eel/Tests/Unit/AbstractEvaluatorTest.php
@@ -15,7 +15,7 @@ use Neos\Eel\Context;
 use Neos\Eel\EelEvaluatorInterface;
 use Neos\Eel\EvaluationException;
 use Neos\Eel\ParserException;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Abstract evaluator test

--- a/Neos.Eel/Tests/Unit/CompilingEvaluatorBenchmarkTest.php
+++ b/Neos.Eel/Tests/Unit/CompilingEvaluatorBenchmarkTest.php
@@ -19,7 +19,7 @@ use Neos\Eel\CompilingEvaluator;
  *
  * @group benchmark
  */
-class CompilingEvaluatorBenchmarkTest extends \Neos\Flow\Tests\UnitTestCase
+class CompilingEvaluatorBenchmarkTest extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * @test

--- a/Neos.Eel/Tests/Unit/ContextTest.php
+++ b/Neos.Eel/Tests/Unit/ContextTest.php
@@ -16,7 +16,7 @@ use Neos\Eel\Context;
 /**
  * Eel context test
  */
-class ContextTest extends \Neos\Flow\Tests\UnitTestCase
+class ContextTest extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * Data provider with simple values

--- a/Neos.Eel/Tests/Unit/EelExpressionRecognizerTest.php
+++ b/Neos.Eel/Tests/Unit/EelExpressionRecognizerTest.php
@@ -15,7 +15,7 @@ namespace Neos\Eel\Tests\Unit;
 use Neos\Eel\Package;
 use Neos\Eel\Utility;
 
-class EelExpressionRecognizerTest extends \Neos\Flow\Tests\UnitTestCase
+class EelExpressionRecognizerTest extends \Neos\Flow\Testing\UnitTestCase
 {
     public function wrappedEelExpressionProvider()
     {

--- a/Neos.Eel/Tests/Unit/FlowQuery/FizzleParserTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/FizzleParserTest.php
@@ -19,7 +19,7 @@ require_once(__DIR__ . '/../../../Resources/Private/PHP/php-peg/tests/ParserTest
 /**
  * Fizzle parser test
  */
-class FizzleParserTest extends \Neos\Flow\Tests\UnitTestCase
+class FizzleParserTest extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * @test

--- a/Neos.Eel/Tests/Unit/FlowQuery/FlowQueryTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/FlowQueryTest.php
@@ -17,7 +17,7 @@ use Neos\Eel\FlowQuery\OperationResolver;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Utility\ObjectAccess;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Eel\FlowQuery\Operations;
 
 /**

--- a/Neos.Eel/Tests/Unit/FlowQuery/Operations/AddOperationTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/Operations/AddOperationTest.php
@@ -17,7 +17,7 @@ use Neos\Eel\FlowQuery\Operations\AddOperation;
 /**
  * AddOperation test
  */
-class AddOperationTest extends \Neos\Flow\Tests\UnitTestCase
+class AddOperationTest extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * This corresponds to ${q(node).add(q(someOtherNode))}

--- a/Neos.Eel/Tests/Unit/FlowQuery/Operations/ChildrenOperationTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/Operations/ChildrenOperationTest.php
@@ -16,7 +16,7 @@ use Neos\Eel\FlowQuery\Operations\Object\ChildrenOperation;
 /**
  * ChildrenOperation test
  */
-class ChildrenOperationTest extends \Neos\Flow\Tests\UnitTestCase
+class ChildrenOperationTest extends \Neos\Flow\Testing\UnitTestCase
 {
     public function childrenExamples()
     {

--- a/Neos.Eel/Tests/Unit/FlowQuery/Operations/RemoveOperationTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/Operations/RemoveOperationTest.php
@@ -17,7 +17,7 @@ use Neos\Eel\FlowQuery\Operations\RemoveOperation;
 /**
  * RemoveOperation test
  */
-class RemoveOperationTest extends \Neos\Flow\Tests\UnitTestCase
+class RemoveOperationTest extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * This corresponds to ${q(node).remove(q(someOtherNode))}

--- a/Neos.Eel/Tests/Unit/FlowQuery/Operations/SliceOperationTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/Operations/SliceOperationTest.php
@@ -16,7 +16,7 @@ use Neos\Eel\FlowQuery\Operations\SliceOperation;
 /**
  * SliceOperation test
  */
-class SliceOperationTest extends \Neos\Flow\Tests\UnitTestCase
+class SliceOperationTest extends \Neos\Flow\Testing\UnitTestCase
 {
     public function sliceExamples()
     {

--- a/Neos.Eel/Tests/Unit/Helper/ArrayHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/ArrayHelperTest.php
@@ -17,7 +17,7 @@ use Neos\Eel\Tests\Unit\Fixtures\TestArrayIterator;
 /**
  * Tests for ArrayHelper
  */
-class ArrayHelperTest extends \Neos\Flow\Tests\UnitTestCase
+class ArrayHelperTest extends \Neos\Flow\Testing\UnitTestCase
 {
     public function concatExamples()
     {

--- a/Neos.Eel/Tests/Unit/Helper/DateHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/DateHelperTest.php
@@ -17,7 +17,7 @@ use Neos\Flow\I18n\Locale;
 /**
  * Tests for DateHelper
  */
-class DateHelperTest extends \Neos\Flow\Tests\UnitTestCase
+class DateHelperTest extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * @return array

--- a/Neos.Eel/Tests/Unit/Helper/FileHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/FileHelperTest.php
@@ -12,7 +12,7 @@ namespace Neos\Eel\Tests\Unit;
  */
 
 use Neos\Eel\Helper\FileHelper;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use org\bovigo\vfs\vfsStream;
 
 /**

--- a/Neos.Eel/Tests/Unit/Helper/JsonHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/JsonHelperTest.php
@@ -16,7 +16,7 @@ use Neos\Eel\Helper\JsonHelper;
 /**
  * Tests for JsonHelper
  */
-class JsonHelperTest extends \Neos\Flow\Tests\UnitTestCase
+class JsonHelperTest extends \Neos\Flow\Testing\UnitTestCase
 {
     public function stringifyExamples()
     {

--- a/Neos.Eel/Tests/Unit/Helper/MathHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/MathHelperTest.php
@@ -16,7 +16,7 @@ use Neos\Eel\Helper\MathHelper;
 /**
  * Tests for MathHelper
  */
-class MathHelperTest extends \Neos\Flow\Tests\UnitTestCase
+class MathHelperTest extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * Define a "not a number" constant for comparison (because NAN !== NAN)

--- a/Neos.Eel/Tests/Unit/Helper/SecurityHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/SecurityHelperTest.php
@@ -10,7 +10,7 @@ use Neos\Eel\Helper\SecurityHelper;
 /**
  * Eel SecurityHelper test
  */
-class SecurityHelperTest extends \Neos\Flow\Tests\UnitTestCase
+class SecurityHelperTest extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * @test

--- a/Neos.Eel/Tests/Unit/Helper/StringHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/StringHelperTest.php
@@ -13,7 +13,7 @@ namespace Neos\Eel\Tests\Unit;
 
 use Neos\Eel\Helper\StringHelper;
 use Neos\Eel\Tests\Unit\Fixtures\TestObject;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Tests for StringHelper

--- a/Neos.Eel/Tests/Unit/InterpretedEvaluatorBenchmarkTest.php
+++ b/Neos.Eel/Tests/Unit/InterpretedEvaluatorBenchmarkTest.php
@@ -19,7 +19,7 @@ use Neos\Eel\InterpretedEvaluator;
  *
  * @group benchmark
  */
-class InterpretedEvaluatorBenchmarkTest extends \Neos\Flow\Tests\UnitTestCase
+class InterpretedEvaluatorBenchmarkTest extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * @test

--- a/Neos.Eel/Tests/Unit/ProtectedContextTest.php
+++ b/Neos.Eel/Tests/Unit/ProtectedContextTest.php
@@ -16,7 +16,7 @@ use Neos\Eel\CompilingEvaluator;
 use Neos\Eel\NotAllowedException;
 use Neos\Eel\ProtectedContext;
 use Neos\Eel\Tests\Unit\Fixtures\TestObject;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Untrusted context test

--- a/Neos.Flow.Log/Tests/Unit/Backend/AbstractBackendTest.php
+++ b/Neos.Flow.Log/Tests/Unit/Backend/AbstractBackendTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Log\Tests\Unit\Backend;
  */
 
 use Neos\Flow\Log\Backend\AbstractBackend;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the abstract log backend

--- a/Neos.Flow.Log/Tests/Unit/Backend/FileBackendTest.php
+++ b/Neos.Flow.Log/Tests/Unit/Backend/FileBackendTest.php
@@ -15,7 +15,7 @@ use Neos\Flow\Log\Exception\CouldNotOpenResourceException;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamWrapper;
 use Neos\Flow\Log\Backend\FileBackend;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the File Backend

--- a/Neos.Flow.Log/Tests/Unit/Backend/JsonFileBackendTest.php
+++ b/Neos.Flow.Log/Tests/Unit/Backend/JsonFileBackendTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Log\Tests\Unit\Backend;
 use Neos\Flow\Log\Backend\JsonFileBackend;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamWrapper;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Test case for the Json File Backend

--- a/Neos.Flow.Log/Tests/Unit/Psr/LoggerTest.php
+++ b/Neos.Flow.Log/Tests/Unit/Psr/LoggerTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Log\Tests\Unit\Psr;
 
 use Neos\Flow\Log\Backend\BackendInterface;
 use Neos\Flow\Log\Psr\Logger;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Log\LogLevel;
 
 /**

--- a/Neos.Flow.Testing/Classes/BaseTestCase.php
+++ b/Neos.Flow.Testing/Classes/BaseTestCase.php
@@ -1,5 +1,5 @@
 <?php
-namespace Neos\Flow\Tests;
+namespace Neos\Flow\Testing;
 
 /*
  * This file is part of the Neos.Flow package.

--- a/Neos.Flow.Testing/Classes/FunctionalTestCase.php
+++ b/Neos.Flow.Testing/Classes/FunctionalTestCase.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Testing;
  * source code.
  */
 
+use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Mvc\ActionRequest;

--- a/Neos.Flow.Testing/Classes/FunctionalTestCase.php
+++ b/Neos.Flow.Testing/Classes/FunctionalTestCase.php
@@ -1,5 +1,5 @@
 <?php
-namespace Neos\Flow\Tests;
+namespace Neos\Flow\Testing;
 
 /*
  * This file is part of the Neos.Flow package.
@@ -13,17 +13,16 @@ namespace Neos\Flow\Tests;
 
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Core\Bootstrap;
-use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Mvc\Routing\Dto\RouteContext;
+use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
+use Neos\Flow\Mvc\Routing\Route;
 use Neos\Flow\Security\Authentication\TokenAndProviderFactory;
 use Neos\Http\Factories\ServerRequestFactory;
 use Neos\Http\Factories\UriFactory;
-use Psr\Http\Message\ServerRequestInterface as HttpRequest;
-use Neos\Flow\Mvc\ActionRequest;
-use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
-use Neos\Flow\Mvc\Routing\Dto\RouteContext;
-use Neos\Flow\Mvc\Routing\Route;
 use Neos\Utility\Arrays;
 use Neos\Utility\Files;
+use Psr\Http\Message\ServerRequestInterface as HttpRequest;
 
 /**
  * A base test case for functional tests
@@ -33,7 +32,7 @@ use Neos\Utility\Files;
  *
  * @api
  */
-abstract class FunctionalTestCase extends \Neos\Flow\Tests\BaseTestCase
+abstract class FunctionalTestCase extends \Neos\Flow\Testing\BaseTestCase
 {
     /**
      * A functional instance of the Object Manager, for use in concrete test cases.

--- a/Neos.Flow.Testing/Classes/FunctionalTestRequestHandler.php
+++ b/Neos.Flow.Testing/Classes/FunctionalTestRequestHandler.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\Testing;
  */
 
 use GuzzleHttp\Psr7\ServerRequest;
+use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Core\Bootstrap;
 use Psr\Http\Message\ServerRequestInterface;
 

--- a/Neos.Flow.Testing/Classes/FunctionalTestRequestHandler.php
+++ b/Neos.Flow.Testing/Classes/FunctionalTestRequestHandler.php
@@ -1,5 +1,5 @@
 <?php
-namespace Neos\Flow\Tests;
+namespace Neos\Flow\Testing;
 
 /*
  * This file is part of the Neos.Flow package.
@@ -12,7 +12,6 @@ namespace Neos\Flow\Tests;
  */
 
 use GuzzleHttp\Psr7\ServerRequest;
-use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Core\Bootstrap;
 use Psr\Http\Message\ServerRequestInterface;
 

--- a/Neos.Flow.Testing/Classes/UnitTestCase.php
+++ b/Neos.Flow.Testing/Classes/UnitTestCase.php
@@ -1,5 +1,5 @@
 <?php
-namespace Neos\Flow\Tests;
+namespace Neos\Flow\Testing;
 
 /*
  * This file is part of the Neos.Flow package.
@@ -21,6 +21,6 @@ namespace Neos\Flow\Tests;
  *
  * @api
  */
-abstract class UnitTestCase extends \Neos\Flow\Tests\BaseTestCase
+abstract class UnitTestCase extends \Neos\Flow\Testing\BaseTestCase
 {
 }

--- a/Neos.Flow.Testing/composer.json
+++ b/Neos.Flow.Testing/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "neos/flow-testing",
+    "type": "neos-framework",
+    "description": "Flow Framework Testing classes",
+    "homepage": "http://flow.neos.io",
+    "license": [
+        "MIT"
+    ],
+    "require": {
+        "php": "^8.2",
+        "phpunit/phpunit": "~9.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "Neos\\Flow\\Testing\\": "Classes"
+        }
+    },
+    "extra": {
+        "neos": {
+            "package-key": "Neos.Flow.Testing"
+        }
+    }
+}

--- a/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
+++ b/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
@@ -25,7 +25,7 @@ use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Session\SessionInterface;
 use Neos\Flow\Session\SessionManager;
-use Neos\Flow\Tests\FunctionalTestRequestHandler;
+use Neos\Flow\Testing\FunctionalTestRequestHandler;
 use Neos\Flow\Validation\ValidatorResolver;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
@@ -18,7 +18,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\CompileTimeObjectManager;
 use Neos\Flow\ObjectManagement\Exception\ProxyCompilerException;
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\BaseTestCase;
+use Neos\Flow\Testing\BaseTestCase;
 use ReflectionAttribute;
 use ReflectionClass;
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
@@ -673,7 +673,7 @@ other application parts which are accessible via HTTP. This browser has the ``In
 	/**
 	 * Some functional tests
 	 */
-	class SomeTest extends \Neos\Flow\Tests\FunctionalTestCase
+	class SomeTest extends \Neos\Flow\Testing\FunctionalTestCase
 	{
 
 		/**

--- a/Neos.Flow/Tests/BaseTestCase.php
+++ b/Neos.Flow/Tests/BaseTestCase.php
@@ -1,0 +1,25 @@
+<?php
+namespace Neos\Flow\Tests;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * The mother of all test cases.
+ *
+ * Don't sub class this test case but rather choose a more specialized base test case,
+ * such as UnitTestCase or FunctionalTestCase
+ *
+ * @api
+ * @deprecated will be removed with Flow 10 use \Neos\Flow\Testing\BaseTestCase
+ */
+abstract class BaseTestCase extends \Neos\Flow\Testing\BaseTestCase
+{
+}

--- a/Neos.Flow/Tests/Functional/Aop/AopProxyTest.php
+++ b/Neos.Flow/Tests/Functional/Aop/AopProxyTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Functional\Aop;
  * source code.
  */
 
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Test suite for aop proxy classes

--- a/Neos.Flow/Tests/Functional/Aop/FrameworkTest.php
+++ b/Neos.Flow/Tests/Functional/Aop/FrameworkTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Functional\Aop;
 
 use Neos\Flow\Tests\Functional\Aop\Fixtures\TargetClassWithPhp7Features;
 use Neos\Flow\Tests\Functional\Aop\Fixtures\TargetClassWithPhp8Features;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Testcase for the AOP Framework class

--- a/Neos.Flow/Tests/Functional/Aop/PointcutExpressionTest.php
+++ b/Neos.Flow/Tests/Functional/Aop/PointcutExpressionTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Functional\Aop;
  * source code.
  */
 
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Test suite for poincut expression related features

--- a/Neos.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
+++ b/Neos.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
@@ -20,7 +20,7 @@ use Neos\Flow\Configuration\Loader\SettingsLoader;
 use Neos\Flow\Core\ApplicationContext;
 use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Tests\Functional\Configuration\Fixtures\RootDirectoryIgnoringYamlSource;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Neos\Utility\ObjectAccess;
 
 /**

--- a/Neos.Flow/Tests/Functional/Configuration/SchemaValidationTest.php
+++ b/Neos.Flow/Tests/Functional/Configuration/SchemaValidationTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Functional\Configuration;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Core\Bootstrap;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Neos\Flow\Package\PackageManager;
 use Neos\Utility\SchemaValidator;
 use Neos\Utility\Files;

--- a/Neos.Flow/Tests/Functional/Error/DebuggerTest.php
+++ b/Neos.Flow/Tests/Functional/Error/DebuggerTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Functional\Error;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Core\ApplicationContext;
 use Neos\Utility\ObjectAccess;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Neos\Flow\Error\Debugger;
 use Neos\Utility\Arrays;
 

--- a/Neos.Flow/Tests/Functional/Http/CacheHeadersTest.php
+++ b/Neos.Flow/Tests/Functional/Http/CacheHeadersTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Functional\Http;
  * source code.
  */
 
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Functional tests for the HTTP cache header support

--- a/Neos.Flow/Tests/Functional/Http/Client/BrowserTest.php
+++ b/Neos.Flow/Tests/Functional/Http/Client/BrowserTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Functional\Http\Client;
  * source code.
  */
 
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Functional tests for the HTTP browser

--- a/Neos.Flow/Tests/Functional/Http/Client/CurlEngineTest.php
+++ b/Neos.Flow/Tests/Functional/Http/Client/CurlEngineTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Functional\Http\Client;
 
 use Neos\Flow\Http\Client\CurlEngine;
 use Neos\Flow\Http\InvalidArgumentException;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Functional tests for the HTTP client internal request engine

--- a/Neos.Flow/Tests/Functional/Http/Client/InternalRequestEngineTest.php
+++ b/Neos.Flow/Tests/Functional/Http/Client/InternalRequestEngineTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Functional\Http\Client;
  */
 
 use Neos\Flow\Mvc\Routing\Route;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Functional tests for the HTTP client internal request engine

--- a/Neos.Flow/Tests/Functional/Http/RequestHandlerTest.php
+++ b/Neos.Flow/Tests/Functional/Http/RequestHandlerTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Functional\Http;
  */
 
 use Neos\Flow\Http\RequestHandler;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ResponseInterface;
 

--- a/Neos.Flow/Tests/Functional/I18n/Cldr/CldrRepositoryTest.php
+++ b/Neos.Flow/Tests/Functional/I18n/Cldr/CldrRepositoryTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Functional\I18n\Cldr;
 
 use Neos\Flow\I18n;
 use Neos\Flow\I18n\Cldr\CldrRepository;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Neos\Utility\Files;
 use Neos\Utility\ObjectAccess;
 

--- a/Neos.Flow/Tests/Functional/I18n/Cldr/Reader/DatesReaderTest.php
+++ b/Neos.Flow/Tests/Functional/I18n/Cldr/Reader/DatesReaderTest.php
@@ -15,7 +15,7 @@ namespace Neos\Flow\Tests\Functional\I18n\Cldr\Reader;
 
 use Neos\Flow\I18n\Cldr\Reader\DatesReader;
 use Neos\Flow\I18n\Locale;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 class DatesReaderTest extends FunctionalTestCase
 {

--- a/Neos.Flow/Tests/Functional/I18n/Cldr/Reader/NumbersReaderTest.php
+++ b/Neos.Flow/Tests/Functional/I18n/Cldr/Reader/NumbersReaderTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Functional\I18n\Cldr\Reader;
  */
 
 use Neos\Flow\I18n\Cldr\Reader\NumbersReader;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Neos\Flow\I18n;
 
 class NumbersReaderTest extends FunctionalTestCase

--- a/Neos.Flow/Tests/Functional/I18n/Cldr/Reader/PluralsReaderTest.php
+++ b/Neos.Flow/Tests/Functional/I18n/Cldr/Reader/PluralsReaderTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Functional\I18n\Cldr\Reader;
  */
 
 use Neos\Flow\I18n\Cldr\Reader\PluralsReader;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Neos\Flow\I18n;
 
 class PluralsReaderTest extends FunctionalTestCase

--- a/Neos.Flow/Tests/Functional/I18n/FormatResolverTest.php
+++ b/Neos.Flow/Tests/Functional/I18n/FormatResolverTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Functional\I18n;
  */
 
 use Neos\Flow\I18n\FormatResolver;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Neos\Flow\I18n;
 
 /**

--- a/Neos.Flow/Tests/Functional/I18n/TranslatorTest.php
+++ b/Neos.Flow/Tests/Functional/I18n/TranslatorTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Functional\I18n;
  */
 
 use Neos\Flow\I18n;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Testcase for the I18N translations

--- a/Neos.Flow/Tests/Functional/I18n/Xliff/Service/XliffFileProviderTest.php
+++ b/Neos.Flow/Tests/Functional/I18n/Xliff/Service/XliffFileProviderTest.php
@@ -18,7 +18,7 @@ use Neos\Flow\I18n\Locale;
 use Neos\Flow\I18n\Xliff\Service\XliffFileProvider;
 use Neos\Flow\Package\Package;
 use Neos\Flow\Package\PackageManager;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Testcases for the XLIFF file provider

--- a/Neos.Flow/Tests/Functional/Log/Utility/LogEnvironmentTest.php
+++ b/Neos.Flow/Tests/Functional/Log/Utility/LogEnvironmentTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Functional\Log\Utility;
  */
 
 use Neos\Flow\Log\Utility\LogEnvironment;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 class LogEnvironmentTest extends FunctionalTestCase
 {

--- a/Neos.Flow/Tests/Functional/Mvc/AbstractControllerTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/AbstractControllerTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Functional\Mvc;
  */
 
 use Neos\Flow\Mvc\Routing\Route;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 class AbstractControllerTest extends FunctionalTestCase
 {

--- a/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
@@ -19,7 +19,7 @@ use Neos\Flow\Mvc\Controller\MvcPropertyMappingConfigurationService;
 use Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\StandardController;
 use Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\TestObjectArgument;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures\TestEntity;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 
 class ActionControllerTest extends FunctionalTestCase

--- a/Neos.Flow/Tests/Functional/Mvc/ActionRequestTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/ActionRequestTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Functional\Mvc;
 use GuzzleHttp\Psr7\ServerRequest;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Mvc\ActionRequest;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Functional tests for the ActionRequest

--- a/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
@@ -20,7 +20,7 @@ use Neos\Flow\Mvc\Routing\Dto\RouteContext;
 use Neos\Flow\Mvc\Routing\Route;
 use Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestAController;
 use Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\RoutingTestAController;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Neos\Utility\Arrays;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/Neos.Flow/Tests/Functional/Mvc/UriBuilderTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/UriBuilderTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Functional\Mvc;
 
 use Neos\Flow\Tests\Functional\Mvc\Fixtures\RoutePartHandler\UriBuilderSetDomainAndPathPrefixRoutePartHandler;
 use Neos\Flow\Tests\Functional\Mvc\Fixtures\RoutePartHandler\UriBuilderSetDomainRoutePartHandler;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 
 /**

--- a/Neos.Flow/Tests/Functional/Mvc/ViewsConfiguration/ViewsConfigurationTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/ViewsConfiguration/ViewsConfigurationTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Functional\Mvc\ViewsConfiguration;
  */
 
 use Neos\Flow\Package\PackageManager;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Functional tests for the ActionController

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ConfigurationTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ConfigurationTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Functional\ObjectManagement;
  */
 
 use Neos\Utility\ObjectAccess;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Functional tests for the Object configuration via Objects.yaml

--- a/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
@@ -20,7 +20,7 @@ use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassH;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\SingletonClassA;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ValueObjectClassA;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ValueObjectClassB;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Functional tests for the Dependency Injection features

--- a/Neos.Flow/Tests/Functional/ObjectManagement/LazyDependencyInjectionTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/LazyDependencyInjectionTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Functional\ObjectManagement;
  */
 
 use Neos\Flow\ObjectManagement\DependencyInjection\DependencyProxy;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Functional tests for the Lazy Dependency Injection features

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ObjectManagerTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ObjectManagerTest.php
@@ -15,7 +15,7 @@ use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\SignalSlot\Dispatcher;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Functional tests for the Object Manager features
@@ -101,7 +101,7 @@ class ObjectManagerTest extends FunctionalTestCase
         self::assertSame(ObjectManagerInterface::class, $first);
         self::assertSame(ConfigurationManager::class, $last);
     }
-    
+
     /**
      * @test
      */

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ObjectSerializationTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ObjectSerializationTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Functional\ObjectManagement;
  * source code.
  */
 
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Functional tests for Object serialization.

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
@@ -22,7 +22,7 @@ use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ClassImplementingInterf
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ClassWithPrivateConstructor;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PHP81\BackedEnumWithMethod;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassA;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Functional tests for the Proxy Compiler and related features

--- a/Neos.Flow/Tests/Functional/Persistence/Aspect/PersistenceMagicAspectTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Aspect/PersistenceMagicAspectTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Functional\Persistence\Aspect;
 
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Testcase for PersistenceMagicAspect

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/AggregateTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/AggregateTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Functional\Persistence\Doctrine;
 
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Testcase for aggregate-related behavior

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/IndexedCollectionTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/IndexedCollectionTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Functional\Persistence\Doctrine;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Test for Doctrine indexed Collections

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/LazyLoadingTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/LazyLoadingTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Functional\Persistence\Doctrine;
 
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Testcase for proxy initialization within doctrine lazy loading

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriverTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriverTest.php
@@ -18,7 +18,7 @@ use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Tests\Functional\Aop\Fixtures\TargetClass04;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures;
 use Neos\Flow\Persistence\Doctrine\Mapping\ClassMetadata;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Testcase for ORM annotation driver

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/PersistClonedRelatedEntitiesTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/PersistClonedRelatedEntitiesTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Functional\Persistence\Doctrine;
 
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Testcase for persisting cloned related entities

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/QueryTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/QueryTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Functional\Persistence\Doctrine;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Persistence\Doctrine\Query;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Testcase for query

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/RepositoryTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/RepositoryTest.php
@@ -16,7 +16,7 @@ use Neos\Flow\Persistence\Doctrine\Repository;
 use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Flow\Persistence\QueryResultInterface;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Testcase for basic repository operations

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/ValueObjectTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/ValueObjectTest.php
@@ -5,7 +5,7 @@ use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Persistence\Doctrine\Query;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures\TestEntity;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures\TestValueObject;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 class ValueObjectTest extends FunctionalTestCase
 {

--- a/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
@@ -18,7 +18,7 @@ use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Persistence\Doctrine\QueryResult;
 use Neos\Flow\Persistence\Exception;
 use Neos\Flow\Persistence\Exception\ObjectValidationFailedException;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Neos\Utility\ObjectAccess;
 
 /**

--- a/Neos.Flow/Tests/Functional/Property/PropertyMapperTest.php
+++ b/Neos.Flow/Tests/Functional/Property/PropertyMapperTest.php
@@ -19,7 +19,7 @@ use Neos\Flow\Property\TypeConverter\ObjectConverter;
 use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
 use Neos\Flow\Security\Account;
 use Neos\Flow\Tests\Functional\Property\Fixtures\TestClassWithMissingCollectionElementType;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Test case for Property Mapper

--- a/Neos.Flow/Tests/Functional/Property/TypeConverter/FloatConverterTest.php
+++ b/Neos.Flow/Tests/Functional/Property/TypeConverter/FloatConverterTest.php
@@ -15,7 +15,7 @@ use Neos\Flow\I18n\Exception\InvalidLocaleIdentifierException;
 use Neos\Flow\I18n\Locale;
 use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\Property\TypeConverter\FloatConverter;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Neos\Error\Messages\Error as FlowError;
 
 /**

--- a/Neos.Flow/Tests/Functional/Property/TypeConverter/ObjectConverterTest.php
+++ b/Neos.Flow/Tests/Functional/Property/TypeConverter/ObjectConverterTest.php
@@ -15,7 +15,7 @@ use Neos\Flow\Property\Exception\InvalidTargetException;
 use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\Property\TypeConverter\ObjectConverter;
 use Neos\Utility\ObjectAccess;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Neos\Flow\Tests\Functional\Property\Fixtures;
 
 /**

--- a/Neos.Flow/Tests/Functional/Property/TypeConverter/PersistentObjectConverterTest.php
+++ b/Neos.Flow/Tests/Functional/Property/TypeConverter/PersistentObjectConverterTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Functional\Property\TypeConverter;
 
 use Neos\Flow\Property\Exception;
 use Neos\Flow\Property\PropertyMapper;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Neos\Flow\Tests\Functional\Property\Fixtures;
 
 class PersistentObjectConverterTest extends FunctionalTestCase

--- a/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Functional\Reflection;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Tests\Functional\Persistence;
 use Neos\Flow\Tests\Functional\Reflection;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Functional tests for the Reflection Service features

--- a/Neos.Flow/Tests/Functional/ResourceManagement/PersistentResourceTest.php
+++ b/Neos.Flow/Tests/Functional/ResourceManagement/PersistentResourceTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Functional\ResourceManagement;
 
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\ResourceManagement\ResourceManager;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Functional tests for resources

--- a/Neos.Flow/Tests/Functional/ResourceManagement/ResourceManagerTest.php
+++ b/Neos.Flow/Tests/Functional/ResourceManagement/ResourceManagerTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Functional\ResourceManagement;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Flow\ResourceManagement\ResourceRepository;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Functional tests for the ResourceManager

--- a/Neos.Flow/Tests/Functional/Security/AccountFactoryTest.php
+++ b/Neos.Flow/Tests/Functional/Security/AccountFactoryTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Functional\Security;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Security\AccountFactory;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Testcase for the account factory

--- a/Neos.Flow/Tests/Functional/Security/AccountTest.php
+++ b/Neos.Flow/Tests/Functional/Security/AccountTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Functional\Security;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Security\Account;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Testcase for the account factory

--- a/Neos.Flow/Tests/Functional/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
+++ b/Neos.Flow/Tests/Functional/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Functional\Security\Authentication\Provider;
  */
 
 use Neos\Flow\Security\Authentication\Provider\PersistedUsernamePasswordProvider;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Neos\Flow\Security;
 
 /**

--- a/Neos.Flow/Tests/Functional/Security/AuthenticationTest.php
+++ b/Neos.Flow/Tests/Functional/Security/AuthenticationTest.php
@@ -15,7 +15,7 @@ use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Mvc\Routing\Route;
 use Neos\Flow\Security\AccountFactory;
 use Neos\Flow\Security\AccountRepository;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 
 /**

--- a/Neos.Flow/Tests/Functional/Security/Authorization/Privilege/Entity/Doctrine/ContentSecurityTest.php
+++ b/Neos.Flow/Tests/Functional/Security/Authorization/Privilege/Entity/Doctrine/ContentSecurityTest.php
@@ -15,7 +15,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Neos\Flow\Cache\CacheManager;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Tests\Functional\Security\Fixtures;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Neos\Flow\Tests\Functional\Aop;
 use Neos\Flow\Security;
 

--- a/Neos.Flow/Tests/Functional/Security/Authorization/Privilege/Entity/Doctrine/EntityPrivilegeExpressionEvaluatorTest.php
+++ b/Neos.Flow/Tests/Functional/Security/Authorization/Privilege/Entity/Doctrine/EntityPrivilegeExpressionEvaluatorTest.php
@@ -17,7 +17,7 @@ use Neos\Flow\Security\Authorization\Privilege\Entity\Doctrine\ConditionGenerato
 use Neos\Flow\Security\Authorization\Privilege\Entity\Doctrine\EntityPrivilegeExpressionEvaluator;
 use Neos\Flow\Security\Authorization\Privilege\Entity\Doctrine\SqlFilter;
 use Neos\Flow\Tests\Functional\Security\Fixtures\TestEntityC;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Neos\Eel;
 use Neos\Flow\Tests\Functional\Security\Fixtures;
 

--- a/Neos.Flow/Tests/Functional/Security/CsrfProtectionTest.php
+++ b/Neos.Flow/Tests/Functional/Security/CsrfProtectionTest.php
@@ -15,7 +15,7 @@ use Neos\Flow\Http\Cookie;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Security\AccountFactory;
 use Neos\Flow\Security\AccountRepository;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 
 /**

--- a/Neos.Flow/Tests/Functional/Security/Policy/PolicyTest.php
+++ b/Neos.Flow/Tests/Functional/Security/Policy/PolicyTest.php
@@ -10,7 +10,7 @@ namespace Neos\Flow\Tests\Functional\Security\Policy;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Testcase for the security policy behavior

--- a/Neos.Flow/Tests/Functional/Session/SessionManagementTest.php
+++ b/Neos.Flow/Tests/Functional/Session/SessionManagementTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Functional\Session;
  */
 
 use Neos\Flow\Mvc\Routing\Route;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Neos\Flow\Session;
 
 class SessionManagementTest extends FunctionalTestCase

--- a/Neos.Flow/Tests/Functional/SignalSlot/SignalSlotTest.php
+++ b/Neos.Flow/Tests/Functional/SignalSlot/SignalSlotTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Functional\SignalSlot;
  * source code.
  */
 use Neos\Flow\SignalSlot\Dispatcher;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Test suite for Signal Slot

--- a/Neos.Flow/Tests/Functional/Utility/NowTest.php
+++ b/Neos.Flow/Tests/Functional/Utility/NowTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Functional\Utility;
  * source code.
  */
 
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Neos\Flow\Utility;
 
 /**

--- a/Neos.Flow/Tests/Functional/Validation/ValidationTest.php
+++ b/Neos.Flow/Tests/Functional/Validation/ValidationTest.php
@@ -14,7 +14,7 @@ use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Utility\ObjectAccess;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures\SubEntity;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures\TestEntity;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /**

--- a/Neos.Flow/Tests/Functional/Validation/Validator/UniqueEntityValidatorTest.php
+++ b/Neos.Flow/Tests/Functional/Validation/Validator/UniqueEntityValidatorTest.php
@@ -18,7 +18,7 @@ use Neos\Flow\Tests\Functional\Persistence\Fixtures\AnnotatedIdentitiesEntity;
  * Testcase for the UniqueEntity Validator
  *
  */
-class UniqueEntityValidatorTest extends \Neos\Flow\Tests\FunctionalTestCase
+class UniqueEntityValidatorTest extends \Neos\Flow\Testing\FunctionalTestCase
 {
     /**
      * @var boolean

--- a/Neos.Flow/Tests/FunctionalTestCase.php
+++ b/Neos.Flow/Tests/FunctionalTestCase.php
@@ -1,0 +1,25 @@
+<?php
+namespace Neos\Flow\Tests;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A base test case for functional tests
+ *
+ * Subclass this base class if you want to take advantage of the framework
+ * capabilities, for example are in need of the object manager.
+ *
+ * @api
+ * @deprecated will be removed with Flow 10 use \Neos\Flow\Testing\FunctionalTestCase
+ */
+abstract class FunctionalTestCase extends \Neos\Flow\Testing\FunctionalTestCase
+{
+}

--- a/Neos.Flow/Tests/FunctionalTestRequestHandler.php
+++ b/Neos.Flow/Tests/FunctionalTestRequestHandler.php
@@ -1,0 +1,34 @@
+<?php
+namespace Neos\Flow\Tests;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A request handler which boots up Flow into a basic runtime level and then returns
+ * without actually further handling command line commands.
+ *
+ * As this request handler will be the "active" request handler returned by
+ * the bootstrap's getActiveRequestHandler() method, it also needs some support
+ * for HTTP request testing scenarios. For that reason it features a setRequest()
+ * method which is used by the FunctionalTestCase for setting the current HTTP
+ * request. That way, the request handler acts pretty much like the Http\RequestHandler
+ * from a client code perspective.
+ *
+ * The virtual browser's InternalRequestEngine will also set the current request
+ * via the setRequest() method.
+ *
+ * @Flow\Proxy(false)
+ * @Flow\Scope("singleton")
+ * @deprecated will be removed with Flow 10 use \Neos\Flow\Testing\FunctionalTestRequestHandler
+ */
+class FunctionalTestRequestHandler extends \Neos\Flow\Testing\FunctionalTestRequestHandler
+{
+}

--- a/Neos.Flow/Tests/FunctionalTestRequestHandler.php
+++ b/Neos.Flow/Tests/FunctionalTestRequestHandler.php
@@ -11,6 +11,8 @@ namespace Neos\Flow\Tests;
  * source code.
  */
 
+use Neos\Flow\Annotations as Flow;
+
 /**
  * A request handler which boots up Flow into a basic runtime level and then returns
  * without actually further handling command line commands.

--- a/Neos.Flow/Tests/Unit/Aop/Advice/AbstractAdviceTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Advice/AbstractAdviceTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Aop\Advice;
  */
 
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\SignalSlot;
 use Neos\Flow\Aop;
 

--- a/Neos.Flow/Tests/Unit/Aop/Advice/AroundAdviceTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Advice/AroundAdviceTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Aop\Advice;
  */
 
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\SignalSlot;
 use Neos\Flow\Aop;
 

--- a/Neos.Flow/Tests/Unit/Aop/Builder/AbstractMethodInterceptorBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Builder/AbstractMethodInterceptorBuilderTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Aop\Builder;
 use Neos\Flow\Aop\Builder\AbstractMethodInterceptorBuilder;
 use Neos\Flow\Aop\Builder\AdvisedConstructorInterceptorBuilder;
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the Abstract Method Interceptor Builder

--- a/Neos.Flow/Tests/Unit/Aop/Builder/ClassNameIndexTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Builder/ClassNameIndexTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\Aop\Builder;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Aop;
 
 /**

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutClassAnnotatedWithFilterTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutClassAnnotatedWithFilterTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Aop\Pointcut;
  */
 
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Aop;
 
 /**

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutClassNameFilterTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutClassNameFilterTest.php
@@ -15,7 +15,7 @@ require_once(FLOW_PATH_FLOW . 'Tests/Unit/Fixtures/DummyClass.php');
 require_once(FLOW_PATH_FLOW . 'Tests/Unit/Fixtures/SecondDummyClass.php');
 
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Aop;
 
 /**

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutClassTypeFilterTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutClassTypeFilterTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Aop\Pointcut;
  */
 
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Aop;
 
 /**

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutExpressionParserTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutExpressionParserTest.php
@@ -17,7 +17,7 @@ use Neos\Flow\Log\PsrLoggerFactoryInterface;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Utility\ObjectAccess;
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Aop;
 use Neos\Flow\Annotations as Flow;
 use Psr\Log\LoggerInterface;

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutFilterCompositeTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutFilterCompositeTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\Aop\Pointcut;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Aop\Pointcut;
 use Neos\Flow\Aop;
 

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutFilterTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutFilterTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\Aop\Pointcut;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Aop;
 
 /**

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutMethodAnnotatedWithFilterTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutMethodAnnotatedWithFilterTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Aop\Pointcut;
  */
 
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Aop;
 
 /**

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutMethodNameFilterTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutMethodNameFilterTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Aop\Pointcut;
 
 use Neos\Flow\Aop;
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutSettingFilterTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutSettingFilterTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Aop\Pointcut;
  */
 
 use Neos\Flow\Configuration\ConfigurationManager;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Aop;
 
 /**

--- a/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Pointcut/PointcutTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\Aop\Pointcut;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Aop\Pointcut;
 use Neos\Flow\Aop;
 

--- a/Neos.Flow/Tests/Unit/Cache/CacheFactoryTest.php
+++ b/Neos.Flow/Tests/Unit/Cache/CacheFactoryTest.php
@@ -19,7 +19,7 @@ use Neos\Flow\Cache\CacheFactory;
 use Neos\Flow\Cache\CacheManager;
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Core\ApplicationContext;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Utility;
 
 /**

--- a/Neos.Flow/Tests/Unit/Cache/CacheManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Cache/CacheManagerTest.php
@@ -16,7 +16,7 @@ use Neos\Cache;
 use Neos\Flow\Cache\CacheManager;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Monitor\ChangeDetectionStrategy\ChangeDetectionStrategyInterface;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Utility\Environment;
 use Psr\Log\LoggerInterface;
 use Psr\Cache\CacheItemPoolInterface;

--- a/Neos.Flow/Tests/Unit/Cli/CommandManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/CommandManagerTest.php
@@ -18,7 +18,7 @@ use Neos\Flow\Mvc\Exception\AmbiguousCommandIdentifierException;
 use Neos\Flow\Mvc\Exception\NoSuchCommandException;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 require_once('Fixtures/Command/MockCommandController.php');
 

--- a/Neos.Flow/Tests/Unit/Cli/CommandTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/CommandTest.php
@@ -17,7 +17,7 @@ use Neos\Flow\Reflection\MethodReflection;
 use Neos\Flow\Reflection\ParameterReflection;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Tests\Unit\Cli\Fixtures\Command\MockACommandController;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the CLI Command class

--- a/Neos.Flow/Tests/Unit/Cli/ConsoleOutputTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/ConsoleOutputTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Cli;
  */
 
 use Neos\Flow\Cli\ConsoleOutput;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Exception\RuntimeException;

--- a/Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php
@@ -16,7 +16,7 @@ use Neos\Flow\Mvc\Exception\InvalidArgumentMixingException;
 use Neos\Flow\Mvc\Exception\NoSuchCommandException;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Cli;
 
 /**

--- a/Neos.Flow/Tests/Unit/Cli/RequestTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/RequestTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Cli;
 
 use Neos\Flow\Cli\Request;
 use Neos\Flow\Command\CacheCommandController;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the CLI Request class

--- a/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -26,7 +26,7 @@ use Neos\Flow\Core\ApplicationContext;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Package\FlowPackageInterface;
 use Neos\Flow\Package\Package;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\MockObject\MockObject;
 

--- a/Neos.Flow/Tests/Unit/Configuration/Source/YamlSourceTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/Source/YamlSourceTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Configuration\Source;
 use Neos\Flow\Configuration\Exception;
 use org\bovigo\vfs\vfsStream;
 use Neos\Flow\Configuration\Source\YamlSource;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the YAML configuration source

--- a/Neos.Flow/Tests/Unit/Core/ApplicationContextTest.php
+++ b/Neos.Flow/Tests/Unit/Core/ApplicationContextTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Core;
 
 use Neos\Flow\Core\ApplicationContext;
 use Neos\Flow\Exception;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the ApplicationContext class

--- a/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
+++ b/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
@@ -15,7 +15,7 @@ use Neos\Flow\Core\Booting\Scripts;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Package\PackageManager;
 use Neos\Flow\SignalSlot\Dispatcher;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * This is something that PHPUnit would have to do in order to support stubbing static methods. And

--- a/Neos.Flow/Tests/Unit/Core/BootstrapTest.php
+++ b/Neos.Flow/Tests/Unit/Core/BootstrapTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Core;
 
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Exception;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the Bootstrap class

--- a/Neos.Flow/Tests/Unit/Core/ClassLoaderTest.php
+++ b/Neos.Flow/Tests/Unit/Core/ClassLoaderTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Core;
 use org\bovigo\vfs\vfsStream;
 use Neos\Flow\Core\ClassLoader;
 use Neos\Flow\Package\Package;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the object class loader

--- a/Neos.Flow/Tests/Unit/Core/LockManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Core/LockManagerTest.php
@@ -15,7 +15,7 @@ use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use org\bovigo\vfs\vfsStreamFile;
 use Neos\Flow\Core\LockManager;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the LockManager

--- a/Neos.Flow/Tests/Unit/Error/AbstractExceptionHandlerTest.php
+++ b/Neos.Flow/Tests/Unit/Error/AbstractExceptionHandlerTest.php
@@ -14,7 +14,7 @@ use Neos\Flow\Error\AbstractExceptionHandler;
 use Neos\Flow\Exception;
 use Neos\Flow\Log\ThrowableStorageInterface;
 use Neos\Flow\Mvc\Exception\NoMatchingRouteException;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/Neos.Flow/Tests/Unit/Error/DebugExceptionHandlerTest.php
+++ b/Neos.Flow/Tests/Unit/Error/DebugExceptionHandlerTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Error;
  */
 
 use Neos\Flow\Error\DebugExceptionHandler;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the Debug Exception Handler

--- a/Neos.Flow/Tests/Unit/Error/DebuggerTest.php
+++ b/Neos.Flow/Tests/Unit/Error/DebuggerTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Error;
 
 use Neos\Flow\Core\ApplicationContext;
 use Neos\Flow\Error\Debugger;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the Debugger

--- a/Neos.Flow/Tests/Unit/Error/ErrorTest.php
+++ b/Neos.Flow/Tests/Unit/Error/ErrorTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\Error;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Error\Messages\Error as FlowError;
 
 /**

--- a/Neos.Flow/Tests/Unit/Http/BaseUriProviderTest.php
+++ b/Neos.Flow/Tests/Unit/Http/BaseUriProviderTest.php
@@ -17,7 +17,7 @@ use Neos\Flow\Core\RequestHandlerInterface;
 use Neos\Flow\Http\BaseUriProvider;
 use Neos\Flow\Http\Exception as HttpException;
 use Neos\Flow\Http\HttpRequestHandlerInterface;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**

--- a/Neos.Flow/Tests/Unit/Http/BrowserTest.php
+++ b/Neos.Flow/Tests/Unit/Http/BrowserTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Http;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Http\Client;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Http\Factories\ServerRequestFactory;
 use Neos\Http\Factories\UriFactory;
 use Psr\Http\Message\RequestInterface;

--- a/Neos.Flow/Tests/Unit/Http/ContentStreamTest.php
+++ b/Neos.Flow/Tests/Unit/Http/ContentStreamTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Http;
  */
 
 use Neos\Flow\Http\ContentStream;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Test case for the Http ContentStream class

--- a/Neos.Flow/Tests/Unit/Http/CookieTest.php
+++ b/Neos.Flow/Tests/Unit/Http/CookieTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Http;
 
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Http\Cookie;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Test case for the Http Cookie class

--- a/Neos.Flow/Tests/Unit/Http/HeadersTest.php
+++ b/Neos.Flow/Tests/Unit/Http/HeadersTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Http;
 
 use Neos\Flow\Http\Headers;
 use Neos\Flow\Http\Cookie;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Test case for the Http Headers class

--- a/Neos.Flow/Tests/Unit/Http/Helper/RequestInformationHelperTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Helper/RequestInformationHelperTest.php
@@ -3,7 +3,7 @@ namespace Neos\Flow\Tests\Unit\Http\Helper;
 
 use GuzzleHttp\Psr7\ServerRequest;
 use Neos\Flow\Http\Helper\RequestInformationHelper;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Tests for the RequestInformationHelper

--- a/Neos.Flow/Tests/Unit/Http/Helper/ResponseInformationHelperTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Helper/ResponseInformationHelperTest.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\ServerRequest;
 use GuzzleHttp\Psr7\Utils;
 use Neos\Flow\Http\Helper\ResponseInformationHelper;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Tests for the ResponseInformationHelper

--- a/Neos.Flow/Tests/Unit/Http/Middleware/MethodOverrideMiddlewareTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Middleware/MethodOverrideMiddlewareTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Http\Component;
  */
 
 use Neos\Flow\Http\Middleware\MethodOverrideMiddleware;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/Neos.Flow/Tests/Unit/Http/Middleware/SecurityEntryPointMiddlewareTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Middleware/SecurityEntryPointMiddlewareTest.php
@@ -22,7 +22,7 @@ use Neos\Flow\Security\Authentication\Token\TestingToken;
 use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Security\Exception\AuthenticationRequiredException;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/Neos.Flow/Tests/Unit/Http/Middleware/SessionMiddlewareTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Middleware/SessionMiddlewareTest.php
@@ -16,7 +16,7 @@ use Neos\Flow\Http\Cookie;
 use Neos\Flow\Http\Middleware\SessionMiddleware;
 use Neos\Flow\Session\SessionInterface;
 use Neos\Flow\Session\SessionManager;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ServerRequestInterface;
 

--- a/Neos.Flow/Tests/Unit/Http/Middleware/TrustedProxiesMiddlewareTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Middleware/TrustedProxiesMiddlewareTest.php
@@ -16,7 +16,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Neos\Flow\Http\Middleware\TrustedProxiesMiddleware;
 use Neos\Flow\Http\ServerRequestAttributes;
 use GuzzleHttp\Psr7\Uri;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Http\Factories\ServerRequestFactory;
 use Neos\Http\Factories\UriFactory;
 use Psr\Http\Message\ResponseInterface;

--- a/Neos.Flow/Tests/Unit/Http/UriTemplateTest.php
+++ b/Neos.Flow/Tests/Unit/Http/UriTemplateTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Http;
  */
 
 use Neos\Flow\Http\UriTemplate;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the UriTemplate class

--- a/Neos.Flow/Tests/Unit/Http/UriTest.php
+++ b/Neos.Flow/Tests/Unit/Http/UriTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Http;
  */
 
 use GuzzleHttp\Psr7\Uri;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the URI class

--- a/Neos.Flow/Tests/Unit/I18n/AbstractXmlParserTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/AbstractXmlParserTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\I18n;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\I18n;
 
 /**

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/CldrModelTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/CldrModelTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\I18n\Cldr;
  */
 
 use Neos\Cache\Frontend\VariableFrontend;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\I18n;
 
 /**

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/CldrParserTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/CldrParserTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\I18n\Cldr;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\I18n;
 
 /**

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/CldrRepositoryTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/CldrRepositoryTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\I18n\Cldr;
 
 use Neos\Utility\ObjectAccess;
 use org\bovigo\vfs\vfsStream;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\I18n;
 
 /**

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/CurrencyReaderTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/CurrencyReaderTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\I18n\Cldr\Reader;
 
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\I18n\Cldr\Reader\CurrencyReader;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\I18n;
 
 /**

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/DatesReaderTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/DatesReaderTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\I18n\Cldr\Reader;
 
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\I18n;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/NumbersReaderTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/NumbersReaderTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\I18n\Cldr\Reader;
  */
 
 use Neos\Cache\Frontend\VariableFrontend;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\I18n;
 
 /**

--- a/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/PluralsReaderTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Cldr/Reader/PluralsReaderTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\I18n\Cldr\Reader;
 
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\I18n\Cldr\Reader\PluralsReader;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\I18n;
 
 /**

--- a/Neos.Flow/Tests/Unit/I18n/DetectorTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/DetectorTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\I18n;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\I18n;
 
 /**

--- a/Neos.Flow/Tests/Unit/I18n/EelHelper/TranslationHelperTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/EelHelper/TranslationHelperTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\I18n\EelHelper;
 
 use Neos\Flow\I18n\EelHelper\TranslationHelper;
 use Neos\Flow\I18n\EelHelper\TranslationParameterToken;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Tests for TranslateHelper

--- a/Neos.Flow/Tests/Unit/I18n/FormatResolverTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/FormatResolverTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\I18n;
 
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\I18n;
 
 /**

--- a/Neos.Flow/Tests/Unit/I18n/Formatter/DatetimeFormatterTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Formatter/DatetimeFormatterTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\I18n\Formatter;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\I18n;
 
 /**

--- a/Neos.Flow/Tests/Unit/I18n/Formatter/NumberFormatterTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Formatter/NumberFormatterTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\I18n\Formatter;
 
 use Neos\Flow\I18n\Cldr\Reader\CurrencyReader;
 use Neos\Flow\I18n\Cldr\Reader\NumbersReader;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\I18n;
 
 /**

--- a/Neos.Flow/Tests/Unit/I18n/LocaleCollectionTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/LocaleCollectionTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\I18n;
  */
 
 use Neos\Flow\I18n;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the LocaleCollection class

--- a/Neos.Flow/Tests/Unit/I18n/LocaleTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/LocaleTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\I18n;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\I18n;
 
 /**

--- a/Neos.Flow/Tests/Unit/I18n/LocaleTypeConverterTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/LocaleTypeConverterTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\I18n;
 use Neos\Flow\I18n;
 use Neos\Flow\I18n\LocaleTypeConverter;
 use Neos\Flow\Property\TypeConverterInterface;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the Locale type converter

--- a/Neos.Flow/Tests/Unit/I18n/Parser/DatetimeParserTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Parser/DatetimeParserTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\I18n\Parser;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\I18n;
 
 /**

--- a/Neos.Flow/Tests/Unit/I18n/Parser/NumberParserTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Parser/NumberParserTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\I18n\Parser;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\I18n;
 
 /**

--- a/Neos.Flow/Tests/Unit/I18n/ServiceTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/ServiceTest.php
@@ -15,7 +15,7 @@ use Neos\Flow\Package\FlowPackageInterface;
 use Neos\Flow\Package\PackageManager;
 use org\bovigo\vfs\vfsStream;
 use Neos\Cache\Frontend\VariableFrontend;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\I18n;
 
 /**

--- a/Neos.Flow/Tests/Unit/I18n/TranslationProvider/XliffTranslationProviderTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/TranslationProvider/XliffTranslationProviderTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\I18n\TranslationProvider;
  */
 
 use Neos\Flow\I18n;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the XliffTranslationProvider

--- a/Neos.Flow/Tests/Unit/I18n/TranslatorTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/TranslatorTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\I18n;
 use Neos\Flow\I18n;
 use Neos\Flow\I18n\Cldr\Reader\PluralsReader;
 use Neos\Flow\I18n\TranslationProvider\XliffTranslationProvider;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the Translator

--- a/Neos.Flow/Tests/Unit/I18n/UtilityTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/UtilityTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\I18n;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\I18n;
 
 /**

--- a/Neos.Flow/Tests/Unit/I18n/Xliff/Model/FileAdapterTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Xliff/Model/FileAdapterTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\I18n\Xliff;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\I18n;
 use Psr\Log\LoggerInterface;
 

--- a/Neos.Flow/Tests/Unit/I18n/Xliff/V12/XliffParserTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/Xliff/V12/XliffParserTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\I18n\Xliff\V12;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\I18n;
 
 /**

--- a/Neos.Flow/Tests/Unit/Monitor/ChangeDetectionStrategy/ModificationTimeStrategyTest.php
+++ b/Neos.Flow/Tests/Unit/Monitor/ChangeDetectionStrategy/ModificationTimeStrategyTest.php
@@ -18,7 +18,7 @@ use org\bovigo\vfs\vfsStreamWrapper;
  * Testcase for the Modification Time Change Detection Strategy
  *
  */
-class ModificationTimeStrategyTest extends \Neos\Flow\Tests\UnitTestCase
+class ModificationTimeStrategyTest extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * @var \Neos\Flow\Monitor\ChangeDetectionStrategy\ModificationTimeStrategy

--- a/Neos.Flow/Tests/Unit/Monitor/FileMonitorTest.php
+++ b/Neos.Flow/Tests/Unit/Monitor/FileMonitorTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Monitor;
 use Neos\Flow\Monitor\ChangeDetectionStrategy\ChangeDetectionStrategyInterface;
 use org\bovigo\vfs\vfsStream;
 use Neos\Flow\Monitor\FileMonitor;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Utility\Files;
 use Neos\Cache;
 use Psr\Log\LoggerInterface;

--- a/Neos.Flow/Tests/Unit/Mvc/ActionRequestTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/ActionRequestTest.php
@@ -22,7 +22,7 @@ use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Security\Cryptography\HashService;
 use Neos\Flow\Security\Exception\InvalidHashException;
 use Neos\Flow\SignalSlot\Dispatcher;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
@@ -26,7 +26,7 @@ use Neos\Flow\Mvc\FlashMessage\FlashMessageContainer;
 use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Property\PropertyMapper;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Cli;
 use Neos\Error\Messages as FlowError;
 

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/ActionControllerTest.php
@@ -18,7 +18,7 @@ use Neos\Flow\Mvc\View\SimpleTemplateView;
 use Neos\Flow\Mvc;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Validation\Validator\ConjunctionValidator;
 use Neos\Flow\Validation\Validator\ValidatorInterface;
 use Neos\Flow\Validation\ValidatorResolver;

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/ArgumentTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/ArgumentTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Mvc\Controller;
 
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Mvc;
 use Neos\Flow\Validation\Validator\ValidatorInterface;
 use Neos\Error\Messages as FlowError;
@@ -164,7 +164,7 @@ class ArgumentTest extends UnitTestCase
     {
         self::assertSame($this->simpleValueArgument, $this->setupPropertyMapperAndSetValue());
     }
-    
+
     /**
      * @test
      */

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/ArgumentsTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/ArgumentsTest.php
@@ -15,7 +15,7 @@ use Neos\Flow\Mvc\Controller\Arguments;
 use Neos\Flow\Mvc\Controller\Argument;
 use Neos\Flow\Mvc\Exception\NoSuchArgumentException;
 use Neos\Error\Messages as FlowError;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the MVC Controller Arguments

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/CommandControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/CommandControllerTest.php
@@ -18,7 +18,7 @@ use Neos\Flow\Cli\Request;
 use Neos\Flow\Cli\Response;
 use Neos\Flow\Mvc\Controller\Arguments;
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Mvc;
 
 /**

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/FlashMessageContainerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/FlashMessageContainerTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Mvc\Controller;
  */
 
 use Neos\Error\Messages as FlowError;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Mvc\FlashMessage\FlashMessageContainer;
 
 /**

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/MvcPropertyMappingConfigurationServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/MvcPropertyMappingConfigurationServiceTest.php
@@ -15,7 +15,7 @@ use Neos\Flow\Mvc\Controller\MvcPropertyMappingConfiguration;
 use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
 use Neos\Flow\Security\Cryptography\HashService;
 use Neos\Flow\Security\Exception\InvalidArgumentForHashGenerationException;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Mvc;
 
 /**

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/MvcPropertyMappingConfigurationTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/MvcPropertyMappingConfigurationTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Mvc\Controller;
  */
 
 use Neos\Flow\Mvc\Controller\MvcPropertyMappingConfiguration;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the MVC Controller Argument

--- a/Neos.Flow/Tests/Unit/Mvc/DispatchMiddlewareTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/DispatchMiddlewareTest.php
@@ -16,7 +16,7 @@ use Neos\Flow\Http\ServerRequestAttributes;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\DispatchMiddleware;
 use Neos\Flow\Mvc\Dispatcher;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;

--- a/Neos.Flow/Tests/Unit/Mvc/DispatcherTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/DispatcherTest.php
@@ -25,7 +25,7 @@ use Neos\Flow\Security\Authorization\FirewallInterface;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Security\Exception\AccessDeniedException;
 use Neos\Flow\Security\Exception\AuthenticationRequiredException;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;

--- a/Neos.Flow/Tests/Unit/Mvc/ResponseTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/ResponseTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Mvc;
  */
 
 use Neos\Flow\Mvc\ActionResponse;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the MVC Generic ActionResponse

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/MatchResultTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/MatchResultTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Mvc\Routing\Dto;
 
 use Neos\Flow\Mvc\Routing\Dto\MatchResult;
 use Neos\Flow\Mvc\Routing\Dto\RouteTags;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the MatchResult DTO

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/RouteContextTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/RouteContextTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Mvc\Routing\Dto;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
 use Neos\Flow\Mvc\Routing\Dto\RouteContext;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/RouteLifetimeTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/RouteLifetimeTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Mvc\Routing\Dto;
  */
 
 use Neos\Flow\Mvc\Routing\Dto\RouteLifetime;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the RouteLifetime DTO

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/RouteParametersTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/RouteParametersTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Mvc\Routing\Dto;
 use Neos\Cache\CacheAwareInterface;
 use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
 use Neos\Flow\Mvc\Routing\RouterInterface;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the RouteParameters DTO

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/RouteTagsTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/RouteTagsTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Mvc\Routing\Dto;
  */
 
 use Neos\Flow\Mvc\Routing\Dto\RouteTags;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the RouteTags DTO

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/UriConstraintsTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/UriConstraintsTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Mvc\Routing\Dto;
 
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Mvc\Routing\Dto\UriConstraints;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Utility\ObjectAccess;
 
 /**

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/DynamicRoutePartTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/DynamicRoutePartTest.php
@@ -15,7 +15,7 @@ use Neos\Flow\Mvc\Routing\Dto\ResolveResult;
 use Neos\Flow\Mvc\Routing\DynamicRoutePart;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Tests\Unit\Mvc\Routing\Fixtures\UriArgumentObjectWithToString;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the MVC Web Routing DynamicRoutePart Class

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/IdentityRoutePartTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/IdentityRoutePartTest.php
@@ -19,7 +19,7 @@ use Neos\Flow\Mvc\Routing\ObjectPathMappingRepository;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Reflection\ClassSchema;
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the MVC Web Routing IdentityRoutePart Class

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/RouteTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/RouteTest.php
@@ -25,7 +25,7 @@ use Neos\Flow\Mvc\Routing\Dto\UriConstraints;
 use Neos\Flow\Mvc\Routing\Fixtures\MockRoutePartHandler;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/RouterCachingServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/RouterCachingServiceTest.php
@@ -23,7 +23,7 @@ use Neos\Flow\Mvc\Routing\Dto\UriConstraints;
 use Neos\Flow\Mvc\Routing\RouterCachingService;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerInterface;

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/RouterTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/RouterTest.php
@@ -25,7 +25,7 @@ use Neos\Flow\Mvc\Routing\Route;
 use Neos\Flow\Mvc\Routing\Router;
 use Neos\Flow\Mvc\Routing\RouterCachingService;
 use Neos\Flow\Mvc\ActionRequest;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerInterface;

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/RoutingMiddlewareTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/RoutingMiddlewareTest.php
@@ -18,7 +18,7 @@ use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
 use Neos\Flow\Mvc\Routing\Dto\RouteContext;
 use Neos\Flow\Mvc\Routing\Router;
 use Neos\Flow\Mvc\Routing\RoutingMiddleware;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Http\Server\RequestHandlerInterface;

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/StaticRoutePartTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/StaticRoutePartTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\Mvc\Routing;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Mvc;
 
 /**

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/UriBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/UriBuilderTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Mvc\Routing;
 use Neos\Flow\Http;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\Routing\Dto\ResolveContext;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Mvc;
 use Neos\Flow\Utility;
 use Psr\Http\Message\ServerRequestInterface;

--- a/Neos.Flow/Tests/Unit/Mvc/View/AbstractViewTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/View/AbstractViewTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Mvc\View;
  */
 
 use Neos\Flow\Mvc;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the MVC AbstractView

--- a/Neos.Flow/Tests/Unit/Mvc/View/JsonViewTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/View/JsonViewTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Mvc\View;
 
 use Neos\Flow\Mvc;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the JSON view

--- a/Neos.Flow/Tests/Unit/Mvc/ViewConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/ViewConfigurationManagerTest.php
@@ -22,7 +22,7 @@ use Neos\Eel\CompilingEvaluator;
  * Testcase for the MVC ViewConfigurationManager
  *
  */
-class ViewConfigurationManagerTest extends \Neos\Flow\Tests\UnitTestCase
+class ViewConfigurationManagerTest extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * @var ViewConfigurationManager

--- a/Neos.Flow/Tests/Unit/ObjectManagement/CompileTimeObjectManagerTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/CompileTimeObjectManagerTest.php
@@ -15,7 +15,7 @@ use org\bovigo\vfs\vfsStream;
 use Neos\Flow\ObjectManagement\CompileTimeObjectManager;
 use Neos\Flow\Package\Package;
 use Neos\Flow\Package\PackageManager;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Log\LoggerInterface;
 
 class CompileTimeObjectManagerTest extends UnitTestCase

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationBuilderTest.php
@@ -20,7 +20,7 @@ use Neos\Flow\ObjectManagement\Exception;
 use Neos\Flow\ObjectManagement\Exception\InvalidObjectConfigurationException;
 use Neos\Flow\ObjectManagement\Exception\UnresolvedDependenciesException;
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Annotations as Flow;
 
 /**

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\ObjectManagement\Configuration;
  */
 
 use Neos\Flow\Configuration\Exception\InvalidConfigurationException;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\ObjectManagement\Configuration;
 
 /**

--- a/Neos.Flow/Tests/Unit/ObjectManagement/DependencyInjection/DependencyProxyTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/DependencyInjection/DependencyProxyTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\ObjectManagement\DependencyInjection;
  */
 
 use Neos\Flow\ObjectManagement\DependencyInjection\DependencyProxy;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 class DependencyProxyTest extends UnitTestCase
 {

--- a/Neos.Flow/Tests/Unit/ObjectManagement/ObjectManagerTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/ObjectManagerTest.php
@@ -17,7 +17,7 @@ use Neos\Flow\Core\ApplicationContext;
 use Neos\Flow\ObjectManagement\Configuration\ConfigurationArgument;
 use Neos\Flow\ObjectManagement\ObjectManager;
 use Neos\Flow\Tests\Unit\ObjectManagement\Fixture\BasicClass;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\ObjectManagement\Configuration\Configuration as ObjectConfiguration;
 
 class ObjectManagerTest extends UnitTestCase

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/CompilerTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/CompilerTest.php
@@ -20,7 +20,7 @@ use Neos\Flow\Annotations\Signal;
 use Neos\Flow\Annotations\Validate;
 use Neos\Flow\ObjectManagement\Proxy\Compiler;
 use Neos\Flow\Tests\Unit\ObjectManagement\Fixture\FooBarAnnotation;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyClassTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyClassTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\ObjectManagement\Proxy;
 use Neos\Flow\ObjectManagement\Proxy\Compiler;
 use Neos\Flow\ObjectManagement\Proxy\ProxyClass;
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class ProxyClassTest extends UnitTestCase

--- a/Neos.Flow/Tests/Unit/Package/PackageFactoryTest.php
+++ b/Neos.Flow/Tests/Unit/Package/PackageFactoryTest.php
@@ -19,7 +19,7 @@ use Neos\Flow\Package\Package;
 use Neos\Flow\Package\PackageFactory;
 use Neos\Flow\Package\PackageManager;
 use Neos\Utility\ObjectAccess;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the package factory

--- a/Neos.Flow/Tests/Unit/Package/PackageManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Package/PackageManagerTest.php
@@ -25,7 +25,7 @@ use org\bovigo\vfs\vfsStream;
 use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\SignalSlot\Dispatcher;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Utility\Files;
 
 /**

--- a/Neos.Flow/Tests/Unit/Package/PackageOrderResolverTest.php
+++ b/Neos.Flow/Tests/Unit/Package/PackageOrderResolverTest.php
@@ -15,7 +15,7 @@ use Neos\Flow\Package\PackageOrderResolver;
 /**
  * Test the PackageOrderResolver
  */
-class PackageOrderResolverTest extends \Neos\Flow\Tests\UnitTestCase
+class PackageOrderResolverTest extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * Data provider for testing if a list of unordered packages gets ordered correctly.

--- a/Neos.Flow/Tests/Unit/Package/PackageTest.php
+++ b/Neos.Flow/Tests/Unit/Package/PackageTest.php
@@ -17,7 +17,7 @@ use Neos\Flow\Package\Package;
 use org\bovigo\vfs\vfsStream;
 use Neos\Flow\Package\PackageManager;
 use Neos\Utility\ObjectAccess;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the package class

--- a/Neos.Flow/Tests/Unit/Persistence/AbstractPersistenceManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/AbstractPersistenceManagerTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Persistence;
 
 use Neos\Flow\Persistence\AbstractPersistenceManager;
 use Neos\Flow\Persistence\Exception\UnknownObjectException;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the Abstract Persistence Manager

--- a/Neos.Flow/Tests/Unit/Persistence/Aspect/PersistenceMagicAspectTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Aspect/PersistenceMagicAspectTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Persistence\Aspect;
 use Neos\Flow\Aop\JoinPointInterface;
 use Neos\Flow\Persistence\Aspect\PersistenceMagicAspect;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the PersistenceMagicAspect

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/DataTypes/JsonArrayTypeTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/DataTypes/JsonArrayTypeTest.php
@@ -18,7 +18,7 @@ use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\BooleanBasedValueObject;
 use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\FloatBasedValueObject;
 use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\IntegerBasedValueObject;
 use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\StringBasedValueObject;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 class JsonArrayTypeTest extends UnitTestCase
 {

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/EntityManagerConfigurationTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/EntityManagerConfigurationTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Persistence\Doctrine;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Neos\Flow\Persistence\Doctrine\EntityManagerConfiguration;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 class EntityManagerConfigurationTest extends UnitTestCase
 {

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriverTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriverTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Persistence\Doctrine\Mapping\Driver;
  */
 
 use Neos\Flow\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriver;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Security;
 
 /**

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/PersistenceManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/PersistenceManagerTest.php
@@ -22,7 +22,7 @@ use Neos\Flow\Persistence\AllowedObjectsContainer;
 use Neos\Flow\Persistence\Doctrine\AllowedObjectsListener;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Persistence\Exception;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/QueryResultTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/QueryResultTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Persistence\Doctrine;
 use Neos\Flow\Persistence\Doctrine\QueryResult;
 use Neos\Flow\Persistence\Doctrine\Query;
 use Neos\Flow\Persistence\QueryInterface;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for \Neos\Flow\Persistence\QueryResult

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/RepositoryTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/RepositoryTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Persistence\Doctrine;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Neos\Flow\Persistence\Doctrine\Repository;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the doctrine Repository

--- a/Neos.Flow/Tests/Unit/Persistence/RepositoryTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/RepositoryTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\Persistence;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Persistence;
 
 require_once('Fixture/Repository/NonstandardEntityRepository.php');

--- a/Neos.Flow/Tests/Unit/Property/PropertyMapperTest.php
+++ b/Neos.Flow/Tests/Unit/Property/PropertyMapperTest.php
@@ -21,7 +21,7 @@ use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
 use Neos\Flow\Property\TypeConverterInterface;
 use Neos\Flow\Security\Exception;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Utility\TypeHandling;
 
 require_once(__DIR__ . '/../Fixtures/ClassWithSetters.php');

--- a/Neos.Flow/Tests/Unit/Property/PropertyMappingConfigurationTest.php
+++ b/Neos.Flow/Tests/Unit/Property/PropertyMappingConfigurationTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Property;
 
 use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\Property\TypeConverterInterface;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 require_once(__DIR__ . '/../Fixtures/ClassWithSetters.php');
 

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/ArrayConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/ArrayConverterTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
 
 use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\Property\TypeConverter\ArrayConverter;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\ResourceManagement\PersistentResource;
 
 /**

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/ArrayFromObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/ArrayFromObjectConverterTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
  */
 
 use Neos\Flow\Property\TypeConverter\ArrayFromObjectConverter;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the ArrayFromObject converter

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/ArrayObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/ArrayObjectConverterTest.php
@@ -16,7 +16,7 @@ namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
 use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\Property\TypeConverter\ArrayConverter;
 use Neos\Flow\Property\TypeConverter\ArrayObjectConverter;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the ArrayObject converter

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/BooleanConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/BooleanConverterTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
  */
 
 use Neos\Flow\Property\TypeConverter\BooleanConverter;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the Boolean converter

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/CollectionConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/CollectionConverterTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
 use Neos\Flow\Property\Exception\InvalidDataTypeException;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
 use Neos\Flow\Property\TypeConverter\CollectionConverter;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the Collection converter

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/DateTimeConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/DateTimeConverterTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
 
 use Neos\Flow\Property\Exception\TypeConverterException;
 use Neos\Flow\Property\TypeConverter\DateTimeConverter;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
 use Neos\Error\Messages\Error as FlowError;

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/DenormalizingObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/DenormalizingObjectConverterTest.php
@@ -19,7 +19,7 @@ use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\FloatBasedValueObject;
 use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\IntegerBasedValueObject;
 use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\IntegerBasedValueObjectWithLongName;
 use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\StringBasedValueObject;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 final class DenormalizingObjectConverterTest extends UnitTestCase
 {

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/FloatConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/FloatConverterTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
 
 use Neos\Flow\Property\TypeConverter\FloatConverter;
 use Neos\Flow\Property\TypeConverterInterface;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Error\Messages as Error;
 
 /**

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/IntegerConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/IntegerConverterTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
 
 use Neos\Flow\Property\TypeConverter\IntegerConverter;
 use Neos\Flow\Property\TypeConverterInterface;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Error\Messages as FlowError;
 
 /**

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/MediaTypeConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/MediaTypeConverterTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
 use Neos\Flow\Property\TypeConverter\MediaTypeConverter;
 use Neos\Flow\Property\TypeConverter\MediaTypeConverterInterface;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the MediaTypeConverter

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/ObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/ObjectConverterTest.php
@@ -16,7 +16,7 @@ use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\Property\TypeConverter\ObjectConverter;
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the ObjectConverter

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/PersistentObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/PersistentObjectConverterTest.php
@@ -26,7 +26,7 @@ use Neos\Flow\Property\TypeConverter\PersistentObjectConverter;
 use Neos\Flow\Property\TypeConverterInterface;
 use Neos\Flow\Reflection\ClassSchema;
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 require_once(__DIR__ . '/../../Fixtures/ClassWithSetters.php');
 require_once(__DIR__ . '/../../Fixtures/ClassWithSettersAndConstructor.php');

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/ScalarTypeToObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/ScalarTypeToObjectConverterTest.php
@@ -20,7 +20,7 @@ use Neos\Flow\Fixtures\ClassWithIntegerConstructor;
 use Neos\Flow\Fixtures\ClassWithStringConstructor;
 use Neos\Flow\Property\TypeConverter\ScalarTypeToObjectConverter;
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Annotations as Flow;
 
 /**

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/StringConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/StringConverterTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
 
 use Neos\Flow\Property\PropertyMappingConfiguration;
 use Neos\Flow\Property\TypeConverter\StringConverter;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the String converter

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/TypedArrayConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/TypedArrayConverterTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
  */
 
 use Neos\Flow\Property\TypeConverter\TypedArrayConverter;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the TypedArrayConverter

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/UriTypeConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/UriTypeConverterTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
 
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Property\TypeConverter\UriTypeConverter;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Error\Messages as FlowError;
 use Psr\Http\Message\UriInterface;
 

--- a/Neos.Flow/Tests/Unit/Reflection/ClassReflectionTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/ClassReflectionTest.php
@@ -17,7 +17,7 @@ require_once('Fixture/DummyInterface2.php');
 use Neos\Flow\Reflection\ClassReflection;
 use Neos\Flow\Reflection\MethodReflection;
 use Neos\Flow\Reflection\PropertyReflection;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Tests\Reflection\Fixture;
 
 /**

--- a/Neos.Flow/Tests/Unit/Reflection/ClassSchemaTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/ClassSchemaTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Reflection;
 
 use Neos\Flow\Reflection\ClassSchema;
 use Neos\Flow\Reflection\Exception\ClassSchemaConstraintViolationException;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the Class Schema.

--- a/Neos.Flow/Tests/Unit/Reflection/DocCommentParserTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/DocCommentParserTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Reflection;
  */
 
 use Neos\Flow\Reflection\DocCommentParser;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for DocCommentParser

--- a/Neos.Flow/Tests/Unit/Reflection/MethodReflectionTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/MethodReflectionTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Reflection;
  */
 
 use Neos\Flow\Reflection;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for MethodReflection

--- a/Neos.Flow/Tests/Unit/Reflection/ParameterReflectionTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/ParameterReflectionTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Reflection;
 
 use Neos\Flow\Reflection\ClassReflection;
 use Neos\Flow\Reflection\ParameterReflection;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the ParameterReflection

--- a/Neos.Flow/Tests/Unit/Reflection/PropertyReflectionTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/PropertyReflectionTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\Reflection;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Reflection;
 
 /**

--- a/Neos.Flow/Tests/Unit/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Reflection/ReflectionServiceTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Reflection;
 use Doctrine\Common\Annotations\Reader;
 use Neos\Flow\Reflection\Exception\ClassLoadingForReflectionFailedException;
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the ReflectionService

--- a/Neos.Flow/Tests/Unit/ResourceManagement/PersistentResourceTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/PersistentResourceTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\ResourceManagement;
  */
 
 use Neos\Flow\ResourceManagement\PersistentResource;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Test case for the PersistentResource class

--- a/Neos.Flow/Tests/Unit/ResourceManagement/ResourceTypeConverterTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/ResourceTypeConverterTest.php
@@ -16,7 +16,7 @@ use Neos\Flow\ResourceManagement\Exception;
 use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Flow\ResourceManagement\ResourceTypeConverter;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Error\Messages as FlowError;
 use Psr\Http\Message\UploadedFileInterface;
 use Psr\Log\LoggerInterface;
@@ -94,7 +94,7 @@ class ResourceTypeConverterTest extends UnitTestCase
         $source = ['error' => \UPLOAD_ERR_NO_FILE];
         self::assertNull($this->resourceTypeConverter->convertFrom($source, PersistentResource::class));
     }
-    
+
     /**
      * @test
      */

--- a/Neos.Flow/Tests/Unit/ResourceManagement/Storage/WritableFileSystemStorageTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/Storage/WritableFileSystemStorageTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\ResourceManagement\Storage;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use Neos\Flow\ResourceManagement\Storage\WritableFileSystemStorage;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Utility\Environment;
 use Neos\Utility\Files;
 

--- a/Neos.Flow/Tests/Unit/ResourceManagement/Streams/ResourceStreamWrapperTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/Streams/ResourceStreamWrapperTest.php
@@ -19,7 +19,7 @@ use Neos\Flow\Package\PackageManager;
 use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Flow\ResourceManagement\Streams\ResourceStreamWrapper;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Tests for the ResourceStreamWrapper class

--- a/Neos.Flow/Tests/Unit/ResourceManagement/Streams/StreamWrapperAdapterTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/Streams/StreamWrapperAdapterTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\ResourceManagement\Streams;
 
 use Neos\Flow\ResourceManagement\Streams\StreamWrapperAdapter;
 use Neos\Flow\ResourceManagement\Streams\StreamWrapperInterface;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the StreamWrapperAdapter class

--- a/Neos.Flow/Tests/Unit/ResourceManagement/Target/FileSystemTargetTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/Target/FileSystemTargetTest.php
@@ -19,7 +19,7 @@ use Neos\Flow\ResourceManagement\Collection;
 use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\Flow\ResourceManagement\Storage\PackageStorage;
 use Neos\Flow\ResourceManagement\Target\FileSystemTarget;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use org\bovigo\vfs\vfsStream;
 use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerInterface;

--- a/Neos.Flow/Tests/Unit/Security/AccountTest.php
+++ b/Neos.Flow/Tests/Unit/Security/AccountTest.php
@@ -15,7 +15,7 @@ use Neos\Flow\Security\Account;
 use Neos\Flow\Security\Exception\NoSuchRoleException;
 use Neos\Flow\Security\Policy\PolicyService;
 use Neos\Flow\Security\Policy\Role;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Test case for the account

--- a/Neos.Flow/Tests/Unit/Security/Aspect/PolicyEnforcementAspectTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Aspect/PolicyEnforcementAspectTest.php
@@ -15,7 +15,7 @@ use Neos\Flow\Aop\Advice\AdviceChain;
 use Neos\Flow\Aop\JoinPointInterface;
 use Neos\Flow\Security;
 use Neos\Flow\Security\Aspect\PolicyEnforcementAspect;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the security policy enforcement aspect

--- a/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderManagerTest.php
@@ -15,7 +15,7 @@ use Neos\Flow\Security\Authentication\AuthenticationProviderInterface;
 use Neos\Flow\Security\Authentication\TokenAndProviderFactoryInterface;
 use Neos\Flow\Security\Exception\AuthenticationRequiredException;
 use Neos\Flow\Session\SessionManager;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Security\Account;
 use Neos\Flow\Security\Authentication\AuthenticationProviderManager;
 use Neos\Flow\Security\Authentication\TokenInterface;

--- a/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderResolverTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderResolverTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Security\Authentication;
 use Neos\Flow\ObjectManagement\ObjectManager;
 use Neos\Flow\Security\Authentication\AuthenticationProviderResolver;
 use Neos\Flow\Security\Exception\NoAuthenticationProviderFoundException;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the security interceptor resolver

--- a/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationTokenResolverTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationTokenResolverTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Security\Authentication;
 use Neos\Flow\ObjectManagement\ObjectManager;
 use Neos\Flow\Security\Authentication\AuthenticationTokenResolver;
 use Neos\Flow\Security\Exception\NoAuthenticationTokenFoundException;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the security token resolver

--- a/Neos.Flow/Tests/Unit/Security/Authentication/EntryPoint/HttpBasicTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/EntryPoint/HttpBasicTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Security\Authentication\EntryPoint;
 
 use GuzzleHttp\Psr7\Response;
 use Neos\Flow\Security\Authentication\EntryPoint\HttpBasic;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**

--- a/Neos.Flow/Tests/Unit/Security/Authentication/EntryPoint/WebRedirectTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/EntryPoint/WebRedirectTest.php
@@ -18,7 +18,7 @@ use Neos\Flow\Http\BaseUriProvider;
 use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\Flow\Security\Authentication\EntryPoint\WebRedirect;
 use Neos\Flow\Security\Exception\MissingConfigurationException;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for web redirect authentication entry point

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Provider/FileBasedSimpleKeyProviderTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Provider/FileBasedSimpleKeyProviderTest.php
@@ -20,7 +20,7 @@ use Neos\Flow\Security\Cryptography\HashService;
 use Neos\Flow\Security\Exception\UnsupportedAuthenticationTokenException;
 use Neos\Flow\Security\Policy\PolicyService;
 use Neos\Flow\Security\Policy\Role;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for file based simple key authentication provider.

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Provider/PersistedUsernamePasswordProviderTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Security\Authentication\Provider;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Security;
 use Neos\Flow\Security\Authentication\Provider\PersistedUsernamePasswordProvider;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for username/password authentication provider. The account are stored in the CR.

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Token/AbstractTokenTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Token/AbstractTokenTest.php
@@ -16,7 +16,7 @@ use Neos\Flow\Security\Authentication\Token\AbstractToken;
 use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\Exception\InvalidAuthenticationStatusException;
 use Neos\Flow\Security\RequestPattern\Uri as UriRequestPattern;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for abstract authentication token

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Token/PasswordTokenTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Token/PasswordTokenTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Security\Authentication\Token;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\Authentication\Token\PasswordToken;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Token/UsernamePasswordHttpBasicTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Token/UsernamePasswordHttpBasicTest.php
@@ -16,7 +16,7 @@ use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Security\Authentication\Token\UsernamePasswordHttpBasic;
 use Neos\Flow\Security\Authentication\TokenInterface;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Http\Factories\ServerRequestFactory;
 use Neos\Http\Factories\UriFactory;
 

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Token/UsernamePasswordTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Token/UsernamePasswordTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Security\Authentication\Token;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\Authentication\Token\UsernamePassword;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**

--- a/Neos.Flow/Tests/Unit/Security/Authentication/TokenAndProviderFactoryTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/TokenAndProviderFactoryTest.php
@@ -16,7 +16,7 @@ use Neos\Flow\Security\Authentication\AuthenticationTokenResolver;
 use Neos\Flow\Security\Authentication\TokenAndProviderFactory;
 use Neos\Flow\Security\Exception\InvalidAuthenticationProviderException;
 use Neos\Flow\Security\RequestPatternResolver;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Test for the default token and provider factory

--- a/Neos.Flow/Tests/Unit/Security/Authorization/FilterFirewallTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authorization/FilterFirewallTest.php
@@ -21,7 +21,7 @@ use Neos\Flow\Security\Authorization\RequestFilter;
 use Neos\Flow\Security\Exception\AccessDeniedException;
 use Neos\Flow\Security\RequestPattern\Uri;
 use Neos\Flow\Security\RequestPatternResolver;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the filter firewall

--- a/Neos.Flow/Tests/Unit/Security/Authorization/Interceptor/AfterInvocationTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authorization/Interceptor/AfterInvocationTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\Security\Authorization\Interceptor;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Security;
 
 /**

--- a/Neos.Flow/Tests/Unit/Security/Authorization/Interceptor/PolicyEnforcementTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authorization/Interceptor/PolicyEnforcementTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Security\Authorization\Interceptor;
  */
 
 use Neos\Flow\Aop\JoinPointInterface;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Security;
 
 /**

--- a/Neos.Flow/Tests/Unit/Security/Authorization/Interceptor/RequireAuthenticationTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authorization/Interceptor/RequireAuthenticationTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Security\Authorization\Interceptor;
 
 use Neos\Flow\Security\Authentication\AuthenticationManagerInterface;
 use Neos\Flow\Security\Authorization\Interceptor\RequireAuthentication;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the authentication required security interceptor

--- a/Neos.Flow/Tests/Unit/Security/Authorization/InterceptorResolverTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authorization/InterceptorResolverTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Security\Authorization;
  */
 
 use Neos\Flow\ObjectManagement\ObjectManager;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Security;
 
 /**

--- a/Neos.Flow/Tests/Unit/Security/Authorization/PrivilegeManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authorization/PrivilegeManagerTest.php
@@ -21,7 +21,7 @@ use Neos\Flow\Security\Authorization\Privilege\PrivilegeInterface;
 use Neos\Flow\Security\Authorization\PrivilegeManager;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Security;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the privilege manager

--- a/Neos.Flow/Tests/Unit/Security/Authorization/RequestFilterTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authorization/RequestFilterTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Security\Authorization;
  */
 
 use Neos\Flow\Mvc\ActionRequest;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Security;
 
 /**

--- a/Neos.Flow/Tests/Unit/Security/ContextTest.php
+++ b/Neos.Flow/Tests/Unit/Security/ContextTest.php
@@ -25,7 +25,7 @@ use Neos\Flow\Security\RequestPatternInterface;
 use Neos\Flow\Security\SessionDataContainer;
 use Neos\Flow\Session\SessionInterface;
 use Neos\Flow\Session\SessionManagerInterface;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Security\Policy\Role;
 use Psr\Log\LoggerInterface;
 

--- a/Neos.Flow/Tests/Unit/Security/Cryptography/AlgorithmsTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Cryptography/AlgorithmsTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Security\Cryptography;
  */
 
 use Neos\Flow\Security\Cryptography\Algorithms;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the cryptographic algorithms

--- a/Neos.Flow/Tests/Unit/Security/Cryptography/BCryptHashingStrategyTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Cryptography/BCryptHashingStrategyTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Security\Cryptography;
  */
 
 use Neos\Flow\Security\Cryptography\BCryptHashingStrategy;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the BCryptHashingStrategy

--- a/Neos.Flow/Tests/Unit/Security/Cryptography/HashServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Cryptography/HashServiceTest.php
@@ -21,7 +21,7 @@ use Neos\Flow\Security\Exception\InvalidArgumentForHashGenerationException;
 use Neos\Flow\Security\Exception\InvalidHashException;
 use Neos\Flow\Security\Exception\MissingConfigurationException;
 use Neos\Flow\Tests\Unit\Cryptography\Fixture\TestHashingStrategy;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Test case for the Hash Service

--- a/Neos.Flow/Tests/Unit/Security/Cryptography/Pbkdf2HashingStrategyTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Cryptography/Pbkdf2HashingStrategyTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Security\Cryptography;
  */
 
 use Neos\Flow\Security\Cryptography\Pbkdf2HashingStrategy;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the Pbkdf2HashingStrategy

--- a/Neos.Flow/Tests/Unit/Security/Cryptography/RsaWalletServicePhpTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Cryptography/RsaWalletServicePhpTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Security\Cryptography;
 use Neos\Flow\Security\Exception\DecryptionNotAllowedException;
 use org\bovigo\vfs\vfsStream;
 use Neos\Flow\Security\Cryptography\RsaWalletServicePhp;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for for the PHP (OpenSSL) based RSAWalletService

--- a/Neos.Flow/Tests/Unit/Security/Policy/PolicyExpressionParserTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Policy/PolicyExpressionParserTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Security\Policy;
 
 use Neos\Flow\Aop\Exception\InvalidPointcutExpressionException;
 use Neos\Flow\Security\Authorization\Privilege\Method\MethodTargetExpressionParser;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the policy expression parser

--- a/Neos.Flow/Tests/Unit/Security/Policy/PolicyServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Policy/PolicyServiceTest.php
@@ -18,7 +18,7 @@ use Neos\Flow\Security\Authorization\Privilege\PrivilegeTarget;
 use Neos\Flow\Security\Exception\NoSuchRoleException;
 use Neos\Flow\Security\Policy\PolicyService;
 use Neos\Flow\Security\Policy\Role;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for for the PolicyService

--- a/Neos.Flow/Tests/Unit/Security/Policy/RoleTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Policy/RoleTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Security\Policy;
  */
 
 use Neos\Flow\Security\Policy\Role;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for for Neos\Flow\Security\Policy\Role

--- a/Neos.Flow/Tests/Unit/Security/RequestPattern/ControllerObjectNameTest.php
+++ b/Neos.Flow/Tests/Unit/Security/RequestPattern/ControllerObjectNameTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Security\RequestPattern;
 
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Security\RequestPattern\ControllerObjectName;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the controller object name request pattern

--- a/Neos.Flow/Tests/Unit/Security/RequestPattern/CsrfProtectionTest.php
+++ b/Neos.Flow/Tests/Unit/Security/RequestPattern/CsrfProtectionTest.php
@@ -19,7 +19,7 @@ use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Security\Authentication\AuthenticationManagerInterface;
 use Neos\Flow\Security\Authorization\Privilege\Method\MethodPrivilegeInterface;
 use Neos\Flow\Security;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/Neos.Flow/Tests/Unit/Security/RequestPattern/HostTest.php
+++ b/Neos.Flow/Tests/Unit/Security/RequestPattern/HostTest.php
@@ -15,7 +15,7 @@ use GuzzleHttp\Psr7\ServerRequest;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Security\RequestPattern\Host;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the URI request pattern

--- a/Neos.Flow/Tests/Unit/Security/RequestPattern/IpTest.php
+++ b/Neos.Flow/Tests/Unit/Security/RequestPattern/IpTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Security\RequestPattern;
 use Neos\Flow\Http\ServerRequestAttributes;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Security\RequestPattern\Ip;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**

--- a/Neos.Flow/Tests/Unit/Security/RequestPattern/UriTest.php
+++ b/Neos.Flow/Tests/Unit/Security/RequestPattern/UriTest.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Tests\Unit\Security\RequestPattern;
 
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Security\RequestPattern\Uri as UriPattern;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 

--- a/Neos.Flow/Tests/Unit/Security/RequestPatternResolverTest.php
+++ b/Neos.Flow/Tests/Unit/Security/RequestPatternResolverTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Security;
 use Neos\Flow\ObjectManagement\ObjectManager;
 use Neos\Flow\Security\Exception\NoRequestPatternFoundException;
 use Neos\Flow\Security\RequestPatternResolver;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the request pattern resolver

--- a/Neos.Flow/Tests/Unit/Security/SessionDataContainerTest.php
+++ b/Neos.Flow/Tests/Unit/Security/SessionDataContainerTest.php
@@ -15,7 +15,7 @@ use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Security\Authentication\Token\TestingToken;
 use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\SessionDataContainer;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the SessionDataContainer

--- a/Neos.Flow/Tests/Unit/Session/Aspect/LoggingAspectTest.php
+++ b/Neos.Flow/Tests/Unit/Session/Aspect/LoggingAspectTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\Session\Aspect;
 use Neos\Flow\Aop\JoinPoint;
 use Neos\Flow\Session\TransientSession;
 use Neos\Flow\Session\Aspect\LoggingAspect;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/Neos.Flow/Tests/Unit/Session/Aspect/SessionObjectMethodsPointcutFilterTest.php
+++ b/Neos.Flow/Tests/Unit/Session/Aspect/SessionObjectMethodsPointcutFilterTest.php
@@ -15,7 +15,7 @@ use Neos\Flow\Aop\Builder\ClassNameIndex;
 use Neos\Flow\ObjectManagement\CompileTimeObjectManager;
 use Neos\Flow\ObjectManagement\Configuration\Configuration;
 use Neos\Flow\Session\Aspect\SessionObjectMethodsPointcutFilter;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the SessionObjectMethodsPointcutFilter

--- a/Neos.Flow/Tests/Unit/Session/SessionManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Session/SessionManagerTest.php
@@ -26,7 +26,7 @@ use Neos\Flow\Session\Session;
 use Neos\Flow\Session\SessionManager;
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Http\Cookie;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;

--- a/Neos.Flow/Tests/Unit/Session/SessionTest.php
+++ b/Neos.Flow/Tests/Unit/Session/SessionTest.php
@@ -32,7 +32,7 @@ use Neos\Flow\Http\Cookie;
 use Neos\Flow\Security\Authentication\Token\UsernamePassword;
 use Neos\Flow\Security\Authentication\TokenInterface;
 use Neos\Flow\Security\Account;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 

--- a/Neos.Flow/Tests/Unit/Session/TransientSessionTest.php
+++ b/Neos.Flow/Tests/Unit/Session/TransientSessionTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\Session;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Session;
 
 /**

--- a/Neos.Flow/Tests/Unit/SignalSlot/DispatcherTest.php
+++ b/Neos.Flow/Tests/Unit/SignalSlot/DispatcherTest.php
@@ -17,7 +17,7 @@ use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\SignalSlot\Dispatcher;
 use Neos\Flow\SignalSlot\Exception\InvalidSlotException;
 use Neos\Flow\SignalSlot\SignalInformation;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the Signal Dispatcher Class

--- a/Neos.Flow/Tests/Unit/SignalSlot/SignalAspectTest.php
+++ b/Neos.Flow/Tests/Unit/SignalSlot/SignalAspectTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Unit\SignalSlot;
 use Neos\Flow\Aop\JoinPoint;
 use Neos\Flow\SignalSlot\Dispatcher;
 use Neos\Flow\SignalSlot\SignalAspect;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 
 /**
  * Testcase for the Signal Aspect

--- a/Neos.Flow/Tests/Unit/Utility/AlgorithmsTest.php
+++ b/Neos.Flow/Tests/Unit/Utility/AlgorithmsTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\Utility;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Utility\Algorithms;
 
 /**

--- a/Neos.Flow/Tests/Unit/Utility/EnvironmentTest.php
+++ b/Neos.Flow/Tests/Unit/Utility/EnvironmentTest.php
@@ -12,7 +12,7 @@ namespace Neos\Flow\Tests\Unit\Utility;
  */
 
 use Neos\Flow\Core\ApplicationContext;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Utility\Environment;
 use Neos\Utility\Files;
 

--- a/Neos.Flow/Tests/Unit/Utility/IpTest.php
+++ b/Neos.Flow/Tests/Unit/Utility/IpTest.php
@@ -17,7 +17,7 @@ use Neos\Flow\Utility\Ip;
  * Testcase for the Utility Ip class
  *
  */
-class IpTest extends \Neos\Flow\Tests\UnitTestCase
+class IpTest extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * Data provider with valid and invalid IP ranges

--- a/Neos.Flow/Tests/Unit/Utility/PhpAnalyzerTest.php
+++ b/Neos.Flow/Tests/Unit/Utility/PhpAnalyzerTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\Utility;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Utility\PhpAnalyzer;
 
 /**

--- a/Neos.Flow/Tests/Unit/Validation/Validator/AbstractValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/AbstractValidatorTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\Validation\Validator;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Validation\Exception\InvalidValidationOptionsException;
 use Neos\Flow\Validation\Validator\AbstractValidator;
 

--- a/Neos.Flow/Tests/Unit/Validation/Validator/AbstractValidatorTestcase.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/AbstractValidatorTestcase.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\Validation\Validator;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Validation\Validator\ValidatorInterface;
 
 /**

--- a/Neos.Flow/Tests/Unit/Validation/Validator/ConjunctionValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/ConjunctionValidatorTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\Validation\Validator;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Validation\Exception\NoSuchValidatorException;
 use Neos\Flow\Validation\Validator\ConjunctionValidator;
 use Neos\Flow\Validation\Validator\ValidatorInterface;

--- a/Neos.Flow/Tests/Unit/Validation/Validator/DisjunctionValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/DisjunctionValidatorTest.php
@@ -11,7 +11,7 @@ namespace Neos\Flow\Tests\Unit\Validation\Validator;
  * source code.
  */
 
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Validation\Validator\DisjunctionValidator;
 use Neos\Flow\Validation\Validator\ValidatorInterface;
 use Neos\Error\Messages as Error;

--- a/Neos.Flow/Tests/Unit/Validation/ValidatorResolverTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/ValidatorResolverTest.php
@@ -16,7 +16,7 @@ use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\ObjectManagement\Configuration\Configuration;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\Flow\Validation\Exception\InvalidValidationConfigurationException;
 use Neos\Flow\Validation\Validator\CollectionValidator;
 use Neos\Flow\Validation\Validator\ConjunctionValidator;

--- a/Neos.Flow/Tests/UnitTestCase.php
+++ b/Neos.Flow/Tests/UnitTestCase.php
@@ -1,0 +1,27 @@
+<?php
+namespace Neos\Flow\Tests;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Base test case for unit tests.
+ *
+ * This class currently only inherits the base test case. However, it is recommended
+ * to extend this class for unit test cases instead of the base test case because if,
+ * at some point, specific behavior needs to be implemented for unit tests, your test cases
+ * will profit from it automatically.
+ *
+ * @api
+ * @deprecated will be removed with Flow 10 use \Neos\Flow\Testing\UnitTestCase
+ */
+abstract class UnitTestCase extends \Neos\Flow\Testing\UnitTestCase
+{
+}

--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -58,6 +58,7 @@
         "egulias/email-validator": "^2.1.17 || ^3.0"
     },
     "require-dev": {
+        "neos/flow-testing": "self.version",
         "vimeo/psalm": "~4.30.0",
         "mikey179/vfsstream": "^1.6.10",
         "phpunit/phpunit": "~9.1"

--- a/Neos.FluidAdaptor/Tests/Functional/Core/WidgetTest.php
+++ b/Neos.FluidAdaptor/Tests/Functional/Core/WidgetTest.php
@@ -12,7 +12,7 @@ namespace Neos\FluidAdaptor\Tests\Functional\Core;
  */
 
 use Neos\Flow\Mvc\Routing\Route;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 
 /**
  * Testcase for the widget mechanism

--- a/Neos.FluidAdaptor/Tests/Functional/Form/FormObjectsTest.php
+++ b/Neos.FluidAdaptor/Tests/Functional/Form/FormObjectsTest.php
@@ -18,7 +18,7 @@ use Neos\Flow\Mvc\Routing\Route;
  *
  * @group large
  */
-class FormObjectsTest extends \Neos\Flow\Tests\FunctionalTestCase
+class FormObjectsTest extends \Neos\Flow\Testing\FunctionalTestCase
 {
     /**
      * @var boolean

--- a/Neos.FluidAdaptor/Tests/Functional/View/StandaloneViewTest.php
+++ b/Neos.FluidAdaptor/Tests/Functional/View/StandaloneViewTest.php
@@ -13,7 +13,7 @@ namespace Neos\FluidAdaptor\Tests\Functional\View;
 
 use Neos\Flow\Cache\CacheManager;
 use Neos\Flow\Mvc\ActionRequest;
-use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Testing\FunctionalTestCase;
 use Neos\FluidAdaptor\Core\ViewHelper\Exception\WrongEnctypeException;
 use Neos\FluidAdaptor\Tests\Functional\View\Fixtures\View\StandaloneView;
 use Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException;

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Parser/Interceptor/ResourceInterceptorTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Parser/Interceptor/ResourceInterceptorTest.php
@@ -13,7 +13,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\Core\Parser\Interceptor;
 
 use Neos\FluidAdaptor\Core\Parser\Interceptor\ResourceInterceptor;
 use Neos\FluidAdaptor\Core\Parser\SyntaxTree\ResourceUriNode;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use TYPO3Fluid\Fluid\Core\Parser\InterceptorInterface;
 use TYPO3Fluid\Fluid\Core\Parser\ParsingState;
 use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\RootNode;

--- a/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractTagBasedViewHelperTest.php
@@ -17,7 +17,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 /**
  * Testcase for TagBasedViewHelper
  */
-class AbstractTagBasedViewHelperTest extends \Neos\Flow\Tests\UnitTestCase
+class AbstractTagBasedViewHelperTest extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|AbstractTagBasedViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/ViewHelper/AbstractViewHelperTest.php
@@ -14,7 +14,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\Core\ViewHelper;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 use Neos\FluidAdaptor\Core\ViewHelper\TemplateVariableContainer;
 use Neos\FluidAdaptor\View\TemplateView;

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetControllerTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetControllerTest.php
@@ -14,7 +14,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\Core\Widget;
 use GuzzleHttp\Psr7\ServerRequest;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Mvc\ActionResponse;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\FluidAdaptor\Core\Widget\Exception\WidgetContextNotFoundException;
 use Neos\FluidAdaptor\Core\Widget\WidgetContext;
 

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetViewHelperTest.php
@@ -20,7 +20,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 /**
  * Testcase for AbstractWidgetViewHelper
  */
-class AbstractWidgetViewHelperTest extends \Neos\Flow\Tests\UnitTestCase
+class AbstractWidgetViewHelperTest extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * @var \Neos\FluidAdaptor\Core\Widget\AbstractWidgetViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AjaxWidgetContextHolderTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AjaxWidgetContextHolderTest.php
@@ -17,7 +17,7 @@ use Neos\FluidAdaptor\Core\Widget\Exception\WidgetContextNotFoundException;
  * Testcase for AjaxWidgetContextHolder
  *
  */
-class AjaxWidgetContextHolderTest extends \Neos\Flow\Tests\UnitTestCase
+class AjaxWidgetContextHolderTest extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * @test

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AjaxWidgetMiddlewareTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AjaxWidgetMiddlewareTest.php
@@ -18,7 +18,7 @@ use Neos\Flow\Mvc\Dispatcher;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Security\Cryptography\HashService;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\FluidAdaptor\Core\Widget\AjaxWidgetMiddleware;
 use Neos\FluidAdaptor\Core\Widget\AjaxWidgetContextHolder;
 use Neos\FluidAdaptor\Core\Widget\WidgetContext;

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/WidgetContextTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/WidgetContextTest.php
@@ -17,7 +17,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
  * Testcase for WidgetContext
  *
  */
-class WidgetContextTest extends \Neos\Flow\Tests\UnitTestCase
+class WidgetContextTest extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * @var \Neos\FluidAdaptor\Core\Widget\WidgetContext

--- a/Neos.FluidAdaptor/Tests/Unit/View/AbstractTemplateViewTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/View/AbstractTemplateViewTest.php
@@ -18,7 +18,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 /**
  * Testcase for the TemplateView
  */
-class AbstractTemplateViewTest extends \Neos\Flow\Tests\UnitTestCase
+class AbstractTemplateViewTest extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * @var AbstractTemplateView

--- a/Neos.FluidAdaptor/Tests/Unit/View/StandaloneViewTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/View/StandaloneViewTest.php
@@ -16,7 +16,7 @@ use Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException;
 use org\bovigo\vfs\vfsStreamWrapper;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\Controller\ControllerContext;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\FluidAdaptor\View\StandaloneView;
 
 /**

--- a/Neos.FluidAdaptor/Tests/Unit/View/TemplatePathsTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/View/TemplatePathsTest.php
@@ -7,7 +7,7 @@ use Neos\FluidAdaptor\View\Exception\InvalidTemplateResourceException;
 use org\bovigo\vfs\vfsStreamWrapper;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\Controller\ControllerContext;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\FluidAdaptor\View\TemplatePaths;
 
 /**

--- a/Neos.FluidAdaptor/Tests/Unit/View/TemplateViewTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/View/TemplateViewTest.php
@@ -16,7 +16,7 @@ include_once(__DIR__ . '/Fixtures/TemplateViewFixture.php');
 use GuzzleHttp\Psr7\ServerRequest;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Mvc\Controller\ControllerContext;
-use Neos\Flow\Tests\UnitTestCase;
+use Neos\Flow\Testing\UnitTestCase;
 use Neos\FluidAdaptor\View\TemplateView;
 
 /**

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php
@@ -22,7 +22,7 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 /**
  * Base test class for testing view helpers
  */
-abstract class ViewHelperBaseTestcase extends \Neos\Flow\Tests\UnitTestCase
+abstract class ViewHelperBaseTestcase extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * @var \TYPO3Fluid\Fluid\Core\ViewHelper\ViewHelperVariableContainer|\PHPUnit\Framework\MockObject\MockObject

--- a/Neos.Kickstarter/Resources/Private/Generator/Tests/Unit/Model/EntityTestTemplate.php.tmpl
+++ b/Neos.Kickstarter/Resources/Private/Generator/Tests/Unit/Model/EntityTestTemplate.php.tmpl
@@ -8,7 +8,7 @@ namespace {namespace};
 /**
  * Testcase for {modelName -> k:inflect.humanizeCamelCase()}
  */
-class {testName} extends \Neos\Flow\Tests\UnitTestCase
+class {testName} extends \Neos\Flow\Testing\UnitTestCase
 {
 
     /**

--- a/Neos.Kickstarter/Tests/Unit/Service/GeneratorServiceTest.php
+++ b/Neos.Kickstarter/Tests/Unit/Service/GeneratorServiceTest.php
@@ -15,7 +15,7 @@ namespace Neos\Kickstarter\Tests\Unit\Service;
  * Testcase for the generator service
  *
  */
-class GeneratorServiceTest extends \Neos\Flow\Tests\UnitTestCase
+class GeneratorServiceTest extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * @test

--- a/Neos.Kickstarter/Tests/Unit/Utility/InflectorTest.php
+++ b/Neos.Kickstarter/Tests/Unit/Utility/InflectorTest.php
@@ -17,7 +17,7 @@ require_once(__DIR__ . '/../../../Resources/Private/PHP/Sho_Inflect.php');
  * Testcase for the Inflector
  *
  */
-class InflectorTest extends \Neos\Flow\Tests\UnitTestCase
+class InflectorTest extends \Neos\Flow\Testing\UnitTestCase
 {
     /**
      * @test

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
         "neos/eel": "self.version",
         "neos/error-messages": "self.version",
         "neos/flow-log": "self.version",
+        "neos/flow-testing": "self.version",
         "neos/flow": "self.version",
         "neos/fluid-adaptor": "self.version",
         "neos/http-factories": "self.version",
@@ -86,6 +87,9 @@
             ],
             "Neos\\Flow\\Log\\": [
                 "Neos.Flow.Log/Classes"
+            ],
+            "Neos\\Flow\\Testing\\": [
+                "Neos.Flow.Testing/Classes"
             ],
             "Neos\\Flow\\": [
                 "Neos.Flow/Classes"


### PR DESCRIPTION
The test base classes are moved into a separate package that can be required as dev-dependency.

Background: The `autoload-dev` directive of composer is only included for the currently tested package (`root-only`). That is why in pure PHPunit one cannot create a test that is based on a test package from another package. See  https://getcomposer.org/doc/04-schema.md#autoload-dev

Eventually, this should allow getting rid of the custom autoloader in testing here: https://github.com/neos/BuildEssentials/blob/master/PhpUnit/UnitTestBootstrap.php#L41-L65 and that would allow us to run phpunit in many cases without special bootstrap.

**Upgrade instructions**

For now no changes are needed as the old class names are still in place. If you extend the base test cases from Neos.Flow.Test you can prepare your code for future changes by adding a dev-dependency to "Neos.Flow.Testing" and the base-classes from there directly.

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
