### PR TITLE
TASK: Fix settings for reference rendering

### DIFF
--- a/Neos.FluidAdaptor/Configuration/Settings.yaml
+++ b/Neos.FluidAdaptor/Configuration/Settings.yaml
@@ -26,8 +26,8 @@ Neos:
     collections:
       'Flow':
         references:
-          - 'TYPO3Fluid:ViewHelpers'
-          - 'Flow:FluidAdaptorViewHelpers'
+          'TYPO3Fluid:ViewHelpers': true
+          'Flow:FluidAdaptorViewHelpers': true
 
     commandReferences:
       'Flow:FlowCommands':


### PR DESCRIPTION
Since 4.0.0 the `neos/doctools` package expects the configuration in a different way. This lead to "hidden" errors during reference renedering on Jenkins.

**Review instructions**

This fixes errors like this:

```
15:37:24 Rendering Reference "0"
15:37:24 Neos\DocTools\Command\ReferenceCommandController_Original::renderReference(): Argument #1 ($reference) must be of type string, int given, called in /var/lib/jenkins/workspace/Flow - update references/Data/Temporary/Development/Cache/Code/Flow_Object_Classes/Neos_DocTools_Command_ReferenceCommandController.php on line 90
15:37:24 
15:37:24   Type: TypeError
15:37:24   File: Data/Temporary/Development/Cache/Code/Flow_Object_Classes/Neos_DocTools_Com
15:37:24         mand_ReferenceCommandController.php
15:37:24   Line: 98
```

Can be reproduced by doing this in a Flow development setup:

```
composer require --no-interaction --no-progress neos/doctools
./flow reference:rendercollection Flow
```

**Checklist**

- [ ] ~Code follows the PSR-2 coding style~
- [ ] ~Tests have been created, run and adjusted as needed~
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions~
