### PR TITLE
BUGFIX: harden `Scripts::buildPhpCommand`

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -835,7 +835,7 @@ class Scripts
         }
 
         // Try to resolve which binary file PHP is pointing to
-        exec($phpBinaryPathAndFilename . ' -r "echo realpath(PHP_BINARY);"', $output, $result);
+        exec($phpBinaryPathAndFilename . ' -r "echo realpath(PHP_BINARY);" 2>&1', $output, $result);
         if ($result === 0 && sizeof($output) === 1) {
             // Resolve any wrapper
             $configuredPhpBinaryPathAndFilename = $output[0];
@@ -879,7 +879,7 @@ class Scripts
             return;
         }
 
-        exec($phpCommand . ' -r "echo PHP_VERSION;"', $output, $result);
+        exec($phpCommand . ' -r "echo PHP_VERSION;" 2>&1', $output, $result);
 
         if ($result !== 0) {
             return;


### PR DESCRIPTION

The following changes are included to fix `Scripts::buildPhpCommand` 

- [BUGFIX: Catch stderr output, in case phpPathAndBinary is not found](https://github.com/neos/flow-development-collection/pull/3116/commits/9d106b16d25773980ac53e095f443bd415ede42e)
  - we dont want any unnecessary console output 
- [BUGFIX: Make Scripts::buildPhpCommand throw on invalid phpBinaryPathAndFilename](https://github.com/neos/flow-development-collection/pull/3116/commits/8edba3614f53def063383fa6f1622ccdae5c06af)
  - this is needed for our new setup see https://github.com/neos/setup/pull/59/commits/9098eb74a37ad250e78c63ad780454cc1dd1b14a where we `try catch` `buildPhpCommand` (so we can be sure `phpBinaryPathAndFilename` is correctly configured beforehand)
  - Also since `buildPhpCommand` is API anyone using it wants to be assured the php command will also work (point to an existing binary)
- [BUGFIX: Handle possible fast cgi in phpBinaryPathAndFilename: send empty stdin to close possible fast cgi server](https://github.com/neos/flow-development-collection/pull/3116/commits/ec0cc6961145b761d143132d64f3f5820efce0c8)
  - without this, the setup endpoint might never return on oddly configured webhosting
 
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
