### PR TITLE
TASK: Avoid potential deprecation warning in StringHelper

### DIFF
--- a/Neos.Eel/Classes/Helper/StringHelper.php
+++ b/Neos.Eel/Classes/Helper/StringHelper.php
@@ -326,7 +326,7 @@ class StringHelper implements ProtectedContextAwareInterface
      */
     public function replace($string, $search, $replace)
     {
-        return str_replace($search, $replace, (string)$string);
+        return str_replace((string)$search, (string)$replace, (string)$string);
     }
 
     /**


### PR DESCRIPTION
`str_replace()` expects strings, but Eel with it's loose typing might pass in different types.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] ~Tests have been created, run and adjusted as needed~
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions~
