### PR TITLE
BUGFIX: Document `Scripts::executeCommand` properly

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -675,16 +675,16 @@ class Scripts
      * @param array $settings The Neos.Flow settings
      * @param boolean $outputResults Echo the commands output on success
      * @param array $commandArguments Command arguments
-     * @param array|null &$output If the output argument is present, then the specified array will be filled with every line of output from the command. {@see exec()}
      * @return true Legacy return value. Will always be true. A failure is expressed as a thrown exception
      * @throws Exception\SubProcessException The execution of the sub process failed
      * @api
      */
-    public static function executeCommand(string $commandIdentifier, array $settings, bool $outputResults = true, array $commandArguments = [], ?array &$output = []): bool
+    public static function executeCommand(string $commandIdentifier, array $settings, bool $outputResults = true, array $commandArguments = []): bool
     {
         $command = self::buildSubprocessCommand($commandIdentifier, $settings, $commandArguments);
         // Output errors in response
         $command .= ' 2>&1';
+        $output = [];
         exec($command, $output, $result);
         if ($result !== 0) {
             if (count($output) > 0) {

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -673,16 +673,16 @@ class Scripts
      *
      * @param string $commandIdentifier E.g. neos.flow:cache:flush
      * @param array $settings The Neos.Flow settings
-     * @param boolean $outputResults if false the output of this command is only echoed if the execution was not successful
+     * @param boolean $outputResults Echo the commands output on success
      * @param array $commandArguments Command arguments
-     * @return boolean true if the command execution was successful (exit code = 0)
+     * @param array|null &$output If the output argument is present, then the specified array will be filled with every line of output from the command. {@see exec()}
+     * @return true Legacy return value. Will always be true. A failure is expressed as a thrown exception
+     * @throws Exception\SubProcessException The execution of the sub process failed
      * @api
-     * @throws Exception\SubProcessException if execution of the sub process failed
      */
-    public static function executeCommand(string $commandIdentifier, array $settings, bool $outputResults = true, array $commandArguments = []): bool
+    public static function executeCommand(string $commandIdentifier, array $settings, bool $outputResults = true, array $commandArguments = [], ?array &$output = []): bool
     {
         $command = self::buildSubprocessCommand($commandIdentifier, $settings, $commandArguments);
-        $output = [];
         // Output errors in response
         $command .= ' 2>&1';
         exec($command, $output, $result);
@@ -696,11 +696,11 @@ class Scripts
                 // If anything else goes wrong, it may as well not produce any $output, but might do so when run on an interactive
                 // shell. Thus we dump the command next to the exception dumps.
                 $exceptionMessage .= ' Try to run the command manually, to hopefully get some hint on the actual error.';
-
                 if (!file_exists(FLOW_PATH_DATA . 'Logs/Exceptions')) {
                     Files::createDirectoryRecursively(FLOW_PATH_DATA . 'Logs/Exceptions');
                 }
                 if (file_exists(FLOW_PATH_DATA . 'Logs/Exceptions') && is_dir(FLOW_PATH_DATA . 'Logs/Exceptions') && is_writable(FLOW_PATH_DATA . 'Logs/Exceptions')) {
+                    // Logs the command string `php ./flow foo:bar` inside `Logs/Exceptions/123-command.txt`
                     $referenceCode = date('YmdHis', $_SERVER['REQUEST_TIME']) . substr(md5(rand()), 0, 6);
                     $errorDumpPathAndFilename = FLOW_PATH_DATA . 'Logs/Exceptions/' . $referenceCode . '-command.txt';
                     file_put_contents($errorDumpPathAndFilename, $command);
@@ -714,7 +714,8 @@ class Scripts
         if ($outputResults) {
             echo implode(PHP_EOL, $output);
         }
-        return $result === 0;
+        // Legacy return value
+        return true;
     }
 
     /**


### PR DESCRIPTION
Related: #3112

`Scripts::executeCommand` has currently an odd, i suppose historically evolved api https://github.com/neos/flow-development-collection/blob/1531a8125ad41e62324c7a85e440c14c1cb768ac/Neos.Flow/Classes/Core/Booting/Scripts.php#L682

1. its not obvious at first what the behavior on error is. The returned status code is actually irrelevant - it will always be true because otherwise we throw an exceptions.
2. the doc commend `$outputResults if false the output of this command is only echoed if the execution was not successful` is lying. In case of an error the output is converted into an exception

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
