### PR TITLE
BUGFIX: improve performance of `Scripts::buildPhpCommand`

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -60,7 +60,7 @@ use Psr\Http\Message\RequestInterface;
  */
 class Scripts
 {
-    protected static ?string $buildPhpCommand = null;
+    protected static ?string $builtPhpCommand = null;
 
     /**
      * Initializes the Class Loader
@@ -777,8 +777,8 @@ class Scripts
      */
     public static function buildPhpCommand(array $settings): string
     {
-        if (isset(static::$buildPhpCommand)) {
-            return static::$buildPhpCommand;
+        if (isset(static::$builtPhpCommand)) {
+            return static::$builtPhpCommand;
         }
 
         $subRequestEnvironmentVariables = [
@@ -818,7 +818,7 @@ class Scripts
 
         static::ensureWebSubrequestsUseCurrentlyRunningPhpVersion($command);
 
-        return static::$buildPhpCommand = $command;
+        return static::$builtPhpCommand = $command;
     }
 
     /**

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -60,7 +60,8 @@ use Psr\Http\Message\RequestInterface;
  */
 class Scripts
 {
-    protected static ?string $builtPhpCommand = null;
+    /** @var string */
+    protected static $builtPhpCommand = null;
 
     /**
      * Initializes the Class Loader

--- a/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
+++ b/Neos.Flow/Tests/Unit/Core/Booting/ScriptsTest.php
@@ -37,6 +37,8 @@ class ScriptsMock extends Scripts
 
     public static function buildSubprocessCommand(string $commandIdentifier, array $settings, array $commandArguments = []): string
     {
+        // clear cache for testing
+        static::$builtPhpCommand = null;
         return parent::buildSubprocessCommand($commandIdentifier, $settings, $commandArguments);
     }
 }


### PR DESCRIPTION
https://github.com/neos/flow-development-collection/pull/2491 seems to cause a tiny minor performance regression. Booting minimal flow (only configuration manager), and running Scripts::buildPhpCommand went from `0.025s` to `0.044s` on my super fast machine ... it might be a more measurable difference on slower systems.


using `exec` and invoking another php process is just slower than not to.

Following changes were made:

A: runtime cache the buildPhpCommand
B: remove the overhead of a second `exec` by using first native realpath and only fallback in case of an open base dir restriction to `exec`

see https://github.com/neos/flow-development-collection/pull/2491#issuecomment-1639964461

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
