### PR TITLE
BUGFIX: Allow passing paths as array for settings migrations

### DIFF
--- a/Neos.Flow/Scripts/Migrations/AbstractMigration.php
+++ b/Neos.Flow/Scripts/Migrations/AbstractMigration.php
@@ -340,8 +340,8 @@ abstract class AbstractMigration
     /**
      * Move a settings path from "source" to "destination"; best to be used when package names change.
      *
-     * @param string $sourcePath
-     * @param string $destinationPath
+     * @param array|string $sourcePath
+     * @param array|string $destinationPath
      */
     protected function moveSettingsPaths($sourcePath, $destinationPath)
     {
@@ -368,7 +368,7 @@ abstract class AbstractMigration
                     $configuration = Arrays::unsetValueByPath($configuration, $sourcePath);
 
                     // remove empty keys before our removed key (if it exists)
-                    $sourcePathExploded = explode('.', $sourcePath);
+                    $sourcePathExploded = !is_array($sourcePath) ? explode('.', $sourcePath) : $sourcePath;
                     for ($length = count($sourcePathExploded) - 1; $length > 0; $length--) {
                         $temporaryPath = array_slice($sourcePathExploded, 0, $length);
                         $valueAtPath = Arrays::getValueByPath($configuration, $temporaryPath);


### PR DESCRIPTION
This allows to write migrations also for paths with "." (dots) in the path key like:
```
Neos.Flow.mvc.routes.'Neos.Neos'.variables.defaultUriSuffix
```

```
        $this->moveSettingsPaths(['Neos', 'Flow', 'mvc', 'routes', 'Neos.Neos', 'variables', 'defaultUriSuffix'], ['Neos', 'Neos', 'sites', '*', 'uriPathSuffix']);
```

As the `Array::getValueByPath` and `Arrays::unsetValueByPath` already can handle string and array paths, this is a an easy fix. 