### PR TITLE
BUGFIX: Pin doctrine/orm to <2.16.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "psr/http-server-middleware": "^1.0",
         "psr/http-server-handler": "^1.0",
         "ramsey/uuid": "^3.0 || ^4.0",
-        "doctrine/orm": "^2.9.3",
+        "doctrine/orm": "^2.9.3 <2.16.0",
         "doctrine/migrations": "^3.0",
         "doctrine/dbal": "^2.13",
         "doctrine/common": "^3.0.3",


### PR DESCRIPTION
After release of 2.16.0 of doctrine/orm the order of created objects has changed. 
See: https://github.com/doctrine/orm/issues/10864

From Slack: https://neos-project.slack.com/archives/C050KKBEB/p1690915423960539

Until this got fixed or we could fix this on our end we need to pin to a version below 2.16.0.