### PR TITLE
BUGFIX: Deduplication on prePersist

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/ObjectValidationAndDeDuplicationListener.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/ObjectValidationAndDeDuplicationListener.php
@@ -75,7 +75,7 @@ class ObjectValidationAndDeDuplicationListener
 
         if ($classSchema !== null && $classSchema->getModelType() === ClassSchema::MODELTYPE_VALUEOBJECT) {
             foreach ($identityMap[$className] ?? [] as $objectInIdentityMap) {
-                if ($objectInIdentityMap == $object) {
+                if ($this->persistenceManager->getIdentifierByObject($objectInIdentityMap) === $this->persistenceManager->getIdentifierByObject($object)) {
                     $unitOfWork->removeFromIdentityMap($objectInIdentityMap);
                 }
             }

--- a/Neos.Flow/Classes/Persistence/Doctrine/ObjectValidationAndDeDuplicationListener.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/ObjectValidationAndDeDuplicationListener.php
@@ -20,7 +20,7 @@ use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Validation\ValidatorResolver;
 use Neos\Utility\ObjectAccess;
 use Neos\Utility\TypeHandling;
-use Doctrine\ORM\Event\PrePersistEventArgs;
+use Doctrine\ORM\Event\LifecycleEventArgs;
 
 /**
  * An onFlush listener for Flow's Doctrine PersistenceManager.
@@ -58,10 +58,10 @@ class ObjectValidationAndDeDuplicationListener
     /**
      * An prePersist event listener
      *
-     * @param PrePersistEventArgs $eventArgs
+     * @param LifecycleEventArgs $eventArgs
      * @return void
      */
-    public function prePersist(PrePersistEventArgs $eventArgs)
+    public function prePersist(LifecycleEventArgs $eventArgs)
     {
         $this->entityManager = $eventArgs->getObjectManager();
         $unitOfWork = $this->entityManager->getUnitOfWork();

--- a/Neos.Flow/Configuration/Settings.Persistence.yaml
+++ b/Neos.Flow/Configuration/Settings.Persistence.yaml
@@ -44,7 +44,7 @@ Neos:
             events: ['onFlush']
             listener: 'Neos\Flow\Persistence\Doctrine\AllowedObjectsListener'
           'Neos\Flow\Persistence\Doctrine\ObjectValidationAndDeDuplicationListener':
-            events: ['onFlush']
+            events: ['onFlush', 'prePersist']
             listener: 'Neos\Flow\Persistence\Doctrine\ObjectValidationAndDeDuplicationListener'
 
         # Doctrine ORM Second Level Cache configuration.

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "psr/http-server-middleware": "^1.0",
         "psr/http-server-handler": "^1.0",
         "ramsey/uuid": "^3.0 || ^4.0",
-        "doctrine/orm": "^2.9.3 <2.16.0",
+        "doctrine/orm": "^2.9.3",
         "doctrine/migrations": "^3.0",
         "doctrine/dbal": "^2.13",
         "doctrine/common": "^3.0.3",


### PR DESCRIPTION
Doctrine refactored their IdentityMap, so it checks for duplicated objects already on persist instead of on flush before.

The way Flow works with ValueObjects allows creating multiple object instances, but they are equal on there persistance identifier. To prevent doctrine from throwing exceptions, because the objects are equal on their persistance identifier we remove one value objects from the IdentityMap if there is an equal one to persist.

```
        $post1 = new Fixtures\Post();
        $post1->setAuthor(new Fixtures\TestValueObject('Some Name'));

        $post2 = new Fixtures\Post();
        $post2->setAuthor(new Fixtures\TestValueObject('Some Name'));

        $this->postRepository->add($post1);
        $this->postRepository->add($post2); // <-- doctrine would throw an exception here
        $this->persistenceManager->persistAll();
```

Until now, flow removes the duplicated value objects on before flush from the list of scheduled insertions, but this is to late now.