### PR TITLE
TASK: Update .phpstorm.meta.php to work with psr `ContainerInterface`

### DIFF
--- a/Neos.Flow/.phpstorm.meta.php
+++ b/Neos.Flow/.phpstorm.meta.php
@@ -5,6 +5,11 @@
  */
 
 namespace PHPSTORM_META {
+    override(
+        \Psr\Container\ContainerInterface::get(),
+        map(['' => '@'])
+    );
+
     expectedArguments(\Neos\Flow\Annotations\Validate::__construct(), 1, 'AggregateBoundary', 'Alphanumeric', 'Boolean', 'Collection', 'Conjunction', 'Count', 'DateTimeRange', 'DateTime', 'Disjunction', 'EmailAddress', 'Float', 'GenericObject', 'Integer', 'Label', 'LocaleIdentifier', 'NotEmpty', 'NumberRange', 'Number', 'Raw', 'RegularExpresion', 'StringLength', 'Text', 'UniqueEntity', 'Uuid');
 
     expectedArguments(\Neos\Flow\Annotations\Scope::__construct(), 0, 'prototype', 'session', 'singleton');


### PR DESCRIPTION
Currently only php storm autocompletion is supported for the `\Neos\Flow\ObjectManagement\ObjectManagerInterface::get`, but sometimes you dont want to pass the whole object manager around but only a psr `\Psr\Container\ContainerInterface` (which our `ObjectManagerInterface` extends, as we are psr compatible.

This fix allows the same autocompletion for simple psr container.

Test it like:

```php
/** @var $objectMngr \Neos\Flow\ObjectManagement\ObjectManagerInterface */
$objectMngr->

// and

/** @var $container \Psr\Container\ContainerInterface */
$container->
```

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
