### PR TITLE
Fix typo for the german Neos.Flow 1221565130 translation

### DIFF
--- a/Neos.Flow/Resources/Private/Translations/de/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/de/ValidationErrors.xlf
@@ -132,7 +132,7 @@
       <!-- RegularExpressionValidator -->
       <trans-unit id="1221565130" xml:space="preserve" approved="yes">
 				<source>The given subject did not match the pattern. Got: {0}</source>
-        <target state="final">Der Wert entspricht nicht den Muster. Erhalten: {0}</target>
+        <target state="final">Der Wert entspricht nicht dem Muster. Erhalten: {0}</target>
       </trans-unit>
       <!-- StringLengthValidator -->
       <trans-unit id="1238110957" xml:space="preserve" approved="yes">


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

Typo in the German Neos.Flow error (1221565130) translation for the Regular Expression Validator.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
