### PR TITLE
BUGFIX: add 'validationErrorMessage' as a supported option

### DIFF
--- a/Neos.Flow/Classes/Validation/Validator/RegularExpressionValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/RegularExpressionValidator.php
@@ -24,7 +24,8 @@ class RegularExpressionValidator extends AbstractValidator
      * @var array
      */
     protected $supportedOptions = [
-        'regularExpression' => ['', 'The regular expression to use for validation, used as given', 'string', true]
+        'regularExpression' => ['', 'The regular expression to use for validation, used as given', 'string', true],
+        'validationErrorMessage' => ['', 'The error message to show for validation, if the regular expression validation fails', 'string', false]
     ];
 
     /**


### PR DESCRIPTION
Add 'validationErrorMessage' as an supported option, for the RegularExpressionValidator.

resolved: https://github.com/neos/neos-ui/issues/3691

**Checklist**
- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
