### PR TITLE
BUGFIX: Fix `redirectToRequest()` to use given request

### DIFF
--- a/Neos.Flow/Classes/Mvc/ActionRequest.php
+++ b/Neos.Flow/Classes/Mvc/ActionRequest.php
@@ -736,10 +736,19 @@ class ActionRequest implements RequestInterface
      */
     public function __sleep()
     {
-        $properties = ['controllerPackageKey', 'controllerSubpackageKey', 'controllerName', 'controllerActionName', 'arguments', 'internalArguments', 'pluginArguments', 'argumentNamespace', 'format', 'dispatched'];
-        if ($this->parentRequest instanceof ActionRequest) {
-            $properties[] = 'parentRequest';
-        }
-        return $properties;
+        return [
+            'controllerPackageKey',
+            'controllerSubpackageKey',
+            'controllerName',
+            'controllerActionName',
+            'arguments',
+            'internalArguments',
+            'pluginArguments',
+            'argumentNamespace',
+            'format',
+            'dispatched',
+            'parentRequest',
+            'rootRequest'
+        ];
     }
 }

--- a/Neos.Flow/Classes/Mvc/ActionRequest.php
+++ b/Neos.Flow/Classes/Mvc/ActionRequest.php
@@ -729,8 +729,7 @@ class ActionRequest implements RequestInterface
     }
 
     /**
-     * We provide our own __sleep method, where we serialize all properties *except* the parentRequest if it is
-     * a HTTP request -- as this one contains $_SERVER etc.
+     * We provide our own __sleep method to control serialization.
      *
      * @return array
      */

--- a/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
@@ -304,6 +304,7 @@ abstract class AbstractController implements ControllerInterface
         if ($subpackageKey !== null) {
             $packageKey .= '\\' . $subpackageKey;
         }
+        $this->uriBuilder->setRequest($request);
         $this->redirect($request->getControllerActionName(), $request->getControllerName(), $packageKey, $request->getArguments(), $delay, $statusCode, $request->getFormat());
     }
 


### PR DESCRIPTION
Makes it possible to really use `redirectToRequest()` with an "intercepted request" from authentication handling.

See #3137 and [this discuss.neos.io post](https://discuss.neos.io/t/redirect-to-intercepted-request-resulting-in-wrong-url/6383?u=kdambekalns) for details.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions~
