### PR TITLE
BUGFIX: Only set distinct on count clause if explicitely set to improve performance

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/CountWalker.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/CountWalker.php
@@ -49,7 +49,7 @@ class CountWalker extends TreeWalkerAdapter
 
         $AST->selectClause->selectExpressions = [
             new SelectExpression(
-                new AggregateExpression('count', $pathExpression, true),
+                new AggregateExpression('count', $pathExpression, $AST->selectClause->isDistinct),
                 null
             )
         ];


### PR DESCRIPTION
F.e. Postgres has performance issues with large datasets and the DISTINCT clause. In a test this change reduced the query time of a count query for ~900.000 entities by >80%.

In a custom project this affected their Neos Media.UI in which the following results were found:

* Count all assets |  580ms ->  260ms
* Query 20 assets  |  690ms ->  350ms
* Query 100 assets |  990ms -> 650ms
* Module load | 1900ms -> 1400ms

**Review instructions**

Everything should work the same, as https://github.com/neos/flow-development-collection/pull/415 already sets the distinct flag where (possibly) necessary.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
