### PR TITLE
DRAFT FEATURE: add 'validationErrorMessage' option

### DIFF
--- a/Neos.Flow/Classes/Validation/Validator/RegularExpressionValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/RegularExpressionValidator.php
@@ -24,7 +24,8 @@ class RegularExpressionValidator extends AbstractValidator
      * @var array
      */
     protected $supportedOptions = [
-        'regularExpression' => ['', 'The regular expression to use for validation, used as given', 'string', true]
+        'regularExpression' => ['', 'The regular expression to use for validation, used as given', 'string', true],
+        'validationErrorMessage' => ['', 'The error message to show for validation, if the regular expression validation fails', 'string', false]
     ];
 
     /**
@@ -39,7 +40,11 @@ class RegularExpressionValidator extends AbstractValidator
     {
         $result = preg_match($this->options['regularExpression'], $value);
         if ($result === 0) {
-            $this->addError('The given subject did not match the pattern. Got: %1$s', 1221565130, [$value]);
+            if ($this->options['validationErrorMessage']) {
+                $this->addError($this->options['validationErrorMessage'], 1692962252);
+            } else {
+                $this->addError('The given subject did not match the pattern. Got: %1$s', 1221565130, [$value]);
+            }
         }
         if ($result === false) {
             throw new InvalidValidationOptionsException('regularExpression "' . $this->options['regularExpression'] . '" in RegularExpressionValidator contained an error.', 1298273089);

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartV/ValidatorReference.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartV/ValidatorReference.rst
@@ -487,6 +487,7 @@ Arguments
 *********
 
 * ``regularExpression`` (string): The regular expression to use for validation, used as given
+* ``validationErrorMessage`` (string): The error message to show for validation, if the regular expression validation fails
 
 
 

--- a/Neos.Flow/Tests/Unit/Validation/Validator/RegularExpressionValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/RegularExpressionValidatorTest.php
@@ -80,4 +80,15 @@ class RegularExpressionValidatorTest extends AbstractValidatorTestcase
         $errors = $this->validator->validate($subject)->getErrors();
         self::assertEquals([new Validation\Error('The given subject did not match the pattern. Got: %1$s', 1221565130, [$subject])], $errors);
     }
+
+    /**
+     * @test
+     */
+    public function regularExpressionValidatorCreatesTheCorrectCustomErrorMessageIfTheExpressionDidNotMatch()
+    {
+        $this->validatorOptions(['regularExpression' => '/^simple[0-9]expression$/', 'validationErrorMessage' => 'Test Message']);
+        $subject = 'some subject that will not match';
+        $errors = $this->validator->validate($subject)->getErrors();
+        self::assertEquals([new Validation\Error('Test Message', 1692962252)], $errors);
+    }
 }


### PR DESCRIPTION
The 'validationErrorMessage' option for Validators was introduced here: https://github.com/neos/neos-ui/pull/2996.

But is currently unusable, see: https://github.com/neos/neos-ui/issues/3691

In a first DRAFT I added 'validationErrorMessage' as an supported option, for the RegularExpressionValidator.
If this looks good, I would add the option to the other validators (adopted in [Neos-UI](https://github.com/neos/neos-ui/pull/2996)) as well. 
So please give some Feedback : )

resolved: https://github.com/neos/neos-ui/issues/3691

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
