### PR TITLE
BUGFIX: Change type hint of returned security logger

### DIFF
--- a/Neos.Flow/Classes/Mvc/Dispatcher.php
+++ b/Neos.Flow/Classes/Mvc/Dispatcher.php
@@ -27,6 +27,7 @@ use Neos\Flow\Security\Context;
 use Neos\Flow\Security\Exception\AccessDeniedException;
 use Neos\Flow\Security\Exception\AuthenticationRequiredException;
 use Neos\Flow\Security\Exception\MissingConfigurationException;
+use Psr\Log\LoggerInterface;
 
 /**
  * Dispatches requests to the controller which was specified by the request and
@@ -105,7 +106,7 @@ class Dispatcher
             // Rethrow as the SecurityEntryPoint middleware will take care of the rest
             throw $exception->attachInterceptedRequest($request);
         } catch (AccessDeniedException $exception) {
-            /** @var PsrLoggerFactoryInterface $securityLogger */
+            /** @var LoggerInterface $securityLogger */
             $securityLogger = $this->objectManager->get(PsrLoggerFactoryInterface::class)->get('securityLogger');
             $securityLogger->warning('Access denied', LogEnvironment::fromMethodName(__METHOD__));
             throw $exception;


### PR DESCRIPTION
The type hint for the `$securityLogger` was referring to the `PsrLoggerFactoryInterface` instead of the correct `LoggerInterface`

Replaces PR #2998

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
