### PR TITLE
BUGFIX: Fix `RedisBackend` to allow scheme in hostname

### DIFF
--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -490,7 +490,8 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
         try {
             $connected = false;
             // keep the assignment above! the connect calls below leaves the variable undefined, if an error occurs.
-            if (strpos($this->hostname, '/') !== false) {
+            if (strncmp($this->hostname, '/', 1) === 0) {
+                // if the "hostname" starts with a slash, assume it's a socket and omit port.
                 $connected = $redis->connect($this->hostname);
             } else {
                 $connected = $redis->connect($this->hostname, $this->port);


### PR DESCRIPTION
The hostname can hold a scheme, that is needed to enable TLS for the connection:

    tls://127.0.0.1

or

    tlsv1.2://127.0.0.1

This change fixes the overly naive check for a unix socket to allow using a scheme in the hostname together with a custom port.

**Review instructions**

Have an TLS enabled Redis (e.g. free tier on upstash.com) and try to connect to it…

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions~
