### PR TITLE
FEATURE: Add `getAccessorByPath` to `Neos\Utility\Arrays` for type safe accessing of array values

### DIFF
--- a/Neos.Utility.Arrays/Classes/Arrays.php
+++ b/Neos.Utility.Arrays/Classes/Arrays.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Utility;
 
 /*
@@ -194,28 +195,38 @@ abstract class Arrays
     /**
      * Returns the value of a nested array by following the specifed path.
      *
-     * @param array &$array The array to traverse as a reference
+     * @param array $array The array to traverse
      * @param array|string $path The path to follow. Either a simple array of keys or a string in the format 'foo.bar.baz'
      * @return mixed The value found, NULL if the path didn't exist (note there is no way to distinguish between a found NULL value and "path not found")
-     * @throws \InvalidArgumentException
      */
-    public static function getValueByPath(array &$array, $path)
+    public static function getValueByPath(array $array, array|string $path): mixed
     {
-        if (is_string($path)) {
-            $path = explode('.', $path);
-        } elseif (!is_array($path)) {
-            throw new \InvalidArgumentException('getValueByPath() expects $path to be string or array, "' . gettype($path) . '" given.', 1304950007);
-        }
-        $key = array_shift($path);
-        if (isset($array[$key])) {
-            if (count($path) > 0) {
-                return (is_array($array[$key])) ? self::getValueByPath($array[$key], $path) : null;
-            } else {
-                return $array[$key];
-            }
-        } else {
+        $pathSegments = is_string($path) ? explode('.', $path) : $path;
+        $pathSegment = array_shift($pathSegments);
+
+        if (!isset($array[$pathSegment])) {
             return null;
         }
+        if ($pathSegments === []) {
+            return $array[$pathSegment];
+        }
+        return is_array($array[$pathSegment])
+            ? self::getValueByPath($array[$pathSegment], $pathSegments)
+            : null;
+    }
+
+    /**
+     * Returns a type safe accessor for a value in a nested array by following the specifed path.
+     *
+     * @param array $array The array to traverse
+     * @param array|string $path The path to follow. Either a simple array of keys or a string in the format 'foo.bar.baz'
+     * @return ValueAccessor
+     */
+    public static function getAccessorByPath(array $array, array|string $path): ValueAccessor
+    {
+        $pathinfo = is_array($path) ? implode('.', $path) : $path;
+        $value = self::getValueByPath($array, $path);
+        return new ValueAccessor($value, $pathinfo);
     }
 
     /**

--- a/Neos.Utility.Arrays/Classes/ValueAccessor.php
+++ b/Neos.Utility.Arrays/Classes/ValueAccessor.php
@@ -23,9 +23,9 @@ class ValueAccessor
     ) {
     }
 
-    private function createTypeError($message): \TypeError
+    private function createTypeError($message): \UnexpectedValueException
     {
-        return new \TypeError(get_debug_type($this->value) . ' ' . $message . ($this->pathinfo ? ' in path ' . $this->pathinfo : ''));
+        return new \UnexpectedValueException(get_debug_type($this->value) . ' ' . $message . ($this->pathinfo ? ' in path ' . $this->pathinfo : ''));
     }
 
     public function int(): int
@@ -86,10 +86,10 @@ class ValueAccessor
      */
     public function instanceOf(string $className): object
     {
-        if (is_a($this->value, $type, false)) {
+        if ($this->value instanceof $className) {
             return $this->value;
         }
-        throw $this->createTypeError(sprintf('is not of type class %s', $type));
+        throw $this->createTypeError(sprintf('is not an instance of %s', $className));
     }
 
     public function intOrNull(): ?int
@@ -150,9 +150,9 @@ class ValueAccessor
      */
     public function instanceOfOrNull(string $className): ?object
     {
-        if (is_a($this->value, $type, false) || is_null($this->value)) {
+        if ($this->value instanceof $className || is_null($this->value)) {
             return $this->value;
         }
-        throw $this->createTypeError(sprintf('is not of type class %s or null', $type));
+        throw $this->createTypeError(sprintf('is not an instance of %s or null', $className));
     }
 }

--- a/Neos.Utility.Arrays/Classes/ValueAccessor.php
+++ b/Neos.Utility.Arrays/Classes/ValueAccessor.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Neos\Utility;
+
+/*
+ * This file is part of the Neos.Utility.Arrays package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Type safe accessing of values from nested arrays
+ */
+class ValueAccessor
+{
+    public function __construct(
+        public readonly mixed   $value,
+        public readonly ?string $pathinfo = null
+    ) {
+    }
+
+    private function createTypeError($message): \TypeError
+    {
+        return new \TypeError(get_debug_type($this->value) . ' ' . $message . ($this->pathinfo ? ' in path ' . $this->pathinfo : ''));
+    }
+
+    public function int(): int
+    {
+        if (is_int($this->value)) {
+            return $this->value;
+        }
+        throw $this->createTypeError("is not an integer");
+    }
+
+    public function float(): float
+    {
+        if (is_float($this->value)) {
+            return $this->value;
+        }
+        throw $this->createTypeError("is not a float");
+    }
+
+    public function number(): int|float
+    {
+        if (is_int($this->value) || is_float($this->value)) {
+            return $this->value;
+        }
+        throw $this->createTypeError("is not a number");
+    }
+
+    public function string(): string
+    {
+        if (is_string($this->value)) {
+            return $this->value;
+        }
+        throw $this->createTypeError("is not a string");
+    }
+
+    /**
+     * @return class-string
+     */
+    public function classString(): string
+    {
+        if (is_string($this->value) && class_exists($this->value)) {
+            return $this->value;
+        }
+        throw $this->createTypeError("is not a class-string");
+    }
+
+    public function array(): array
+    {
+        if (is_array($this->value)) {
+            return $this->value;
+        }
+        throw $this->createTypeError("is not an array");
+    }
+
+    /**
+     * @template T
+     * @param class-string<T> $type
+     * @return object&T
+     */
+    public function object(string $type): object
+    {
+        if (is_a($this->value, $type, false)) {
+            return $this->value;
+        }
+        throw $this->createTypeError(sprintf('is not of type class %s', $type));
+    }
+
+    public function intOrNull(): ?int
+    {
+        if (is_int($this->value) || is_null($this->value)) {
+            return $this->value;
+        }
+        throw $this->createTypeError("is not an integer or null");
+    }
+
+    public function floatOrNull(): ?float
+    {
+        if (is_float($this->value) || is_null($this->value)) {
+            return $this->value;
+        }
+        throw $this->createTypeError("is not a float or null");
+    }
+
+    public function numberOrNull(): null|int|float
+    {
+        if (is_int($this->value) || is_float($this->value) || is_null($this->value)) {
+            return $this->value;
+        }
+        throw $this->createTypeError("is not a number or null");
+    }
+
+    public function stringOrNull(): ?string
+    {
+        if (is_string($this->value) || is_null($this->value)) {
+            return $this->value;
+        }
+        throw $this->createTypeError("is not a string or null");
+    }
+
+    /**
+     * @return class-string|null
+     */
+    public function classStringOrNull(): ?string
+    {
+        if ((is_string($this->value) && class_exists($this->value)) || is_null($this->value)) {
+            return $this->value;
+        }
+        throw $this->createTypeError("is not a class-string");
+    }
+
+    public function arrayOrNull(): ?array
+    {
+        if (is_array($this->value) || is_null($this->value)) {
+            return $this->value;
+        }
+        throw $this->createTypeError("is not an array or null");
+    }
+
+    /**
+     * @template T
+     * @param class-string<T> $type
+     * @return (object&T)|null
+     */
+    public function objectOrNull(string $type): ?object
+    {
+        if (is_a($this->value, $type, false) || is_null($this->value)) {
+            return $this->value;
+        }
+        throw $this->createTypeError(sprintf('is not of type class %s or null', $type));
+    }
+}

--- a/Neos.Utility.Arrays/Classes/ValueAccessor.php
+++ b/Neos.Utility.Arrays/Classes/ValueAccessor.php
@@ -81,10 +81,10 @@ class ValueAccessor
 
     /**
      * @template T
-     * @param class-string<T> $type
+     * @param class-string<T> $className
      * @return object&T
      */
-    public function object(string $type): object
+    public function instanceOf(string $className): object
     {
         if (is_a($this->value, $type, false)) {
             return $this->value;
@@ -145,10 +145,10 @@ class ValueAccessor
 
     /**
      * @template T
-     * @param class-string<T> $type
+     * @param class-string<T> $className
      * @return (object&T)|null
      */
-    public function objectOrNull(string $type): ?object
+    public function instanceOfOrNull(string $className): ?object
     {
         if (is_a($this->value, $type, false) || is_null($this->value)) {
             return $this->value;

--- a/Neos.Utility.Arrays/Tests/Unit/ArraysTest.php
+++ b/Neos.Utility.Arrays/Tests/Unit/ArraysTest.php
@@ -85,7 +85,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
      */
     public function getValueByPathThrowsExceptionIfPathIsNoArrayOrString()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(\TypeError::class);
         $array = ['Foo' => ['Bar' => ['Baz' => [2 => 'the value']]]];
         Arrays::getValueByPath($array, null);
     }
@@ -106,6 +106,94 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
     {
         $array = ['Foo' => ['Bar' => ['Baz' => 'the value']]];
         self::assertNull(Arrays::getValueByPath($array, ['Foo', 'Bar', 'Baz', 'Bux']));
+    }
+
+    /**
+     * @test
+     */
+    public function getAccessorByPathReturnsTheValueOfANestedArrayByFollowingTheGivenSimplePath()
+    {
+        $array = ['Foo' => 'the value'];
+        self::assertSame('the value', Arrays::getAccessorByPath($array, ['Foo'])->string());
+    }
+
+    /**
+     * @test
+     */
+    public function getAccessorByPathReturnsTheValueOfANestedArrayByFollowingTheGivenPath()
+    {
+        $array = ['Foo' => ['Bar' => ['Baz' => [2 => 'the value']]]];
+        self::assertSame('the value', Arrays::getAccessorByPath($array, ['Foo', 'Bar', 'Baz', 2])->string());
+    }
+
+    /**
+     * @test
+     */
+    public function getAccessorByPathReturnsTheValueOfANestedArrayByFollowingTheGivenPathIfPathIsString()
+    {
+        $array = ['Foo' => ['Bar' => ['Baz' => [2 => 'the value']]]];
+        self::assertSame('the value', Arrays::getAccessorByPath($array, 'Foo.Bar.Baz.2')->string());
+    }
+
+    /**
+     * @test
+     */
+    public function getAccessorByPathThrowsTypeErrorIfPathIsNoArrayOrString()
+    {
+        $this->expectException(\TypeError::class);
+        $array = ['Foo' => ['Bar' => ['Baz' => [2 => 'the value']]]];
+        Arrays::getAccessorByPath($array, null);
+    }
+
+    /**
+     * @test
+     */
+    public function getAccessorByPathReturnsNullIfTheSegementsOfThePathDontExist()
+    {
+        $array = ['Foo' => ['Bar' => ['Baz' => [2 => 'the value']]]];
+        self::assertNull(Arrays::getAccessorByPath($array, ['Foo', 'Bar', 'Bax', 2])->intOrNull());
+    }
+
+    /**
+     * @test
+     */
+    public function getAccessorByPathReturnsNullIfThePathHasMoreSegmentsThanTheGivenArray()
+    {
+        $array = ['Foo' => ['Bar' => ['Baz' => 'the value']]];
+        self::assertNull(Arrays::getAccessorByPath($array, ['Foo', 'Bar', 'Baz', 'Bux'])->intOrNull());
+    }
+
+    /**
+     * @test
+     */
+    public function getAccessorByPathTypeErrorContainsPathForNonMatchingTypes()
+    {
+        $array = ['Foo' => ['Bar' => ['Baz' => 'the value']]];
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('in path Foo.Bar.Baz');
+        Arrays::getAccessorByPath($array, ['Foo', 'Bar', 'Baz'])->int();
+    }
+
+    /**
+     * @test
+     */
+    public function getAccessorByPathTypeErrorContainsPathForNonMatchingTypesOnRoot()
+    {
+        $array = ['Foo' => 'string'];
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('in path Foo');
+        Arrays::getAccessorByPath($array, ['Foo'])->int();
+    }
+
+    /**
+     * @test
+     */
+    public function getAccessorByPathTypeErrorContainsPathForNonExistingPathes()
+    {
+        $array = ['Foo' => ['Bar' => ['Baz' => 'the value']]];
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('in path Foo.Bar.Bax');
+        Arrays::getAccessorByPath($array, ['Foo', 'Bar', 'Bax'])->int();
     }
 
     /**

--- a/Neos.Utility.Arrays/Tests/Unit/ArraysTest.php
+++ b/Neos.Utility.Arrays/Tests/Unit/ArraysTest.php
@@ -138,7 +138,7 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function getAccessorByPathThrowsTypeErrorIfPathIsNoArrayOrString()
+    public function getAccessorByPathThrowsExceptionIfPathIsNoArrayOrString()
     {
         $this->expectException(\TypeError::class);
         $array = ['Foo' => ['Bar' => ['Baz' => [2 => 'the value']]]];
@@ -166,10 +166,10 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function getAccessorByPathTypeErrorContainsPathForNonMatchingTypes()
+    public function getAccessorByPathUnexpectedValueExceptionContainsPathForNonMatchingTypes()
     {
         $array = ['Foo' => ['Bar' => ['Baz' => 'the value']]];
-        $this->expectException(\TypeError::class);
+        $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('in path Foo.Bar.Baz');
         Arrays::getAccessorByPath($array, ['Foo', 'Bar', 'Baz'])->int();
     }
@@ -177,10 +177,10 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function getAccessorByPathTypeErrorContainsPathForNonMatchingTypesOnRoot()
+    public function getAccessorByPathUnexpectedValueExceptionContainsPathForNonMatchingTypesOnRoot()
     {
         $array = ['Foo' => 'string'];
-        $this->expectException(\TypeError::class);
+        $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('in path Foo');
         Arrays::getAccessorByPath($array, ['Foo'])->int();
     }
@@ -188,10 +188,10 @@ class ArraysTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function getAccessorByPathTypeErrorContainsPathForNonExistingPathes()
+    public function getAccessorByPathUnexpectedValueExceptionContainsPathForNonExistingPathes()
     {
         $array = ['Foo' => ['Bar' => ['Baz' => 'the value']]];
-        $this->expectException(\TypeError::class);
+        $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('in path Foo.Bar.Bax');
         Arrays::getAccessorByPath($array, ['Foo', 'Bar', 'Bax'])->int();
     }

--- a/Neos.Utility.Arrays/Tests/Unit/ValueAccessorTest.php
+++ b/Neos.Utility.Arrays/Tests/Unit/ValueAccessorTest.php
@@ -100,8 +100,8 @@ class ValueAccessorTest extends \PHPUnit\Framework\TestCase
         $acceptableAsDateTimeInterface = [new \DateTime(), new \DateTimeImmutable()];
         $notAcceptableAsDateTimeInterface = [new \stdClass(), 1, -1, true, false, 'string'];
 
-        $this->testAccessor($acceptableAsDateTimeInterface, [...$notAcceptableAsDateTimeInterface, null], 'object', [\DateTimeInterface::class]);
-        $this->testAccessor([...$acceptableAsDateTimeInterface, null], $notAcceptableAsDateTimeInterface, 'objectOrNull', [\DateTimeInterface::class]);
+        $this->testAccessor($acceptableAsDateTimeInterface, [...$notAcceptableAsDateTimeInterface, null], 'instanceOf', [\DateTimeInterface::class]);
+        $this->testAccessor([...$acceptableAsDateTimeInterface, null], $notAcceptableAsDateTimeInterface, 'instanceOfOrNull', [\DateTimeInterface::class]);
 
         $acceptableAsDateTime = [new \DateTime()];
         $notAcceptableAsDateTime = [new \stdClass(), new \DateTimeImmutable(), 1, -1, true, false, 'string'];
@@ -122,13 +122,9 @@ class ValueAccessorTest extends \PHPUnit\Framework\TestCase
             $this->assertEquals($value, $result);
         }
         foreach ($inacceptibleValues as $value) {
+            $this->expectException(\UnexpectedValueException::class);
             $accessor = new ValueAccessor($value, (is_scalar($value) || $value instanceof \Stringable) ? (string)$value : get_debug_type($value) . 'was given');
-            try {
-                $accessor->$methodName(...$methodArguments);
-                $this->fail('this should lead to an error');
-            } catch (\Error $error) {
-                $this->assertInstanceOf(\TypeError::class, $error);
-            }
+            $accessor->$methodName(...$methodArguments);
         }
     }
 }

--- a/Neos.Utility.Arrays/Tests/Unit/ValueAccessorTest.php
+++ b/Neos.Utility.Arrays/Tests/Unit/ValueAccessorTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Neos\Utility\Arrays\Tests\Unit;
+
+/*
+ * This file is part of the Neos.Utility.Arrays package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Utility\Arrays;
+use Neos\Utility\ValueAccessor;
+
+/**
+ * Testcase for the Utility Array class
+ */
+class ValueAccessorTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @test
+     */
+    public function intAccessorWorks()
+    {
+        $acceptableValues = [0, 1, -1, 99999, -99999];
+        $inacceptableValues = [0.000001, 1.000001, true, false, 'string', new \DateTimeImmutable()];
+
+        $this->testAccessor($acceptableValues, [...$inacceptableValues, null], 'int');
+        $this->testAccessor([...$acceptableValues, null], $inacceptableValues, 'intOrNull');
+    }
+
+    /**
+     * @test
+     */
+    public function floatAccessorWorks()
+    {
+        $acceptableValues = [0.000001, 1.000001];
+        $inacceptableValues = [0, 1, 99999, -1, -99999, true, false, 'string', new \DateTimeImmutable()];
+
+        $this->testAccessor($acceptableValues, [...$inacceptableValues, null], 'float');
+        $this->testAccessor([...$acceptableValues, null], $inacceptableValues, 'floatOrNull');
+    }
+
+    /**
+     * @test
+     */
+    public function numberAccessorWorks()
+    {
+        $acceptableValues = [0.000001, 1.000001, 0, 1, 99999, -1, -99999];
+        $inacceptableValues = [true, false, 'string', new \DateTimeImmutable()];
+
+        $this->testAccessor($acceptableValues, [...$inacceptableValues, null], 'number');
+        $this->testAccessor([...$acceptableValues, null], $inacceptableValues, 'numberOrNull');
+    }
+
+    /**
+     * @test
+     */
+    public function stringAccessorWorks()
+    {
+        $acceptableValues = ['string', ''];
+        $inacceptableValues = [1, 0, -1, 9999, 0.000001, 1.000001, true, false, new \DateTimeImmutable()];
+
+        $this->testAccessor($acceptableValues, [...$inacceptableValues, null], 'string');
+        $this->testAccessor([...$acceptableValues, null], $inacceptableValues, 'stringOrNull');
+    }
+
+    /**
+     * @test
+     */
+    public function arrayAccessorWorks()
+    {
+        $acceptableValues = [[], [1,2,3], ['foo'=>'bar']];
+        $inacceptableValues = [0, 1, 99999, -1, -99999, true, false, 'string', new \DateTimeImmutable()];
+
+        $this->testAccessor($acceptableValues, [...$inacceptableValues, null], 'array');
+        $this->testAccessor([...$acceptableValues, null], $inacceptableValues, 'arrayOrNull');
+    }
+
+    /**
+     * @test
+     */
+    public function classstringAccessorWorks()
+    {
+        $acceptableValues = [\DateTime::class, \DateTimeImmutable::class];
+        $inacceptableValues = [\DateTimeInterface::class, 0, 1, false, true, 'string', '\This\Class\DoesNotExist'];
+
+        $this->testAccessor($acceptableValues, [...$inacceptableValues, null], 'classString');
+        $this->testAccessor([...$acceptableValues, null], $inacceptableValues, 'classStringOrNull');
+    }
+
+    /**
+     * @test
+     */
+    public function objectAccessorWorks()
+    {
+        $acceptableAsDateTimeInterface = [new \DateTime(), new \DateTimeImmutable()];
+        $notAcceptableAsDateTimeInterface = [new \stdClass(), 1, -1, true, false, 'string'];
+
+        $this->testAccessor($acceptableAsDateTimeInterface, [...$notAcceptableAsDateTimeInterface, null], 'object', [\DateTimeInterface::class]);
+        $this->testAccessor([...$acceptableAsDateTimeInterface, null], $notAcceptableAsDateTimeInterface, 'objectOrNull', [\DateTimeInterface::class]);
+
+        $acceptableAsDateTime = [new \DateTime()];
+        $notAcceptableAsDateTime = [new \stdClass(), new \DateTimeImmutable(), 1, -1, true, false, 'string'];
+
+        $this->testAccessor($acceptableAsDateTime, [...$notAcceptableAsDateTime, null], 'object', [\DateTime::class]);
+        $this->testAccessor([...$acceptableAsDateTime, null], $notAcceptableAsDateTime, 'objectOrNull', [\DateTime::class]);
+    }
+
+    protected function testAccessor(
+        array  $acceptibleValues,
+        array  $inacceptibleValues,
+        string $methodName,
+        array  $methodArguments = [],
+    ): void {
+        foreach ($acceptibleValues as $value) {
+            $accessor = new ValueAccessor($value, (is_scalar($value) || $value instanceof \Stringable) ? (string)$value : get_debug_type($value) . 'was given');
+            $result = $accessor->$methodName(...$methodArguments);
+            $this->assertEquals($value, $result);
+        }
+        foreach ($inacceptibleValues as $value) {
+            $accessor = new ValueAccessor($value, (is_scalar($value) || $value instanceof \Stringable) ? (string)$value : get_debug_type($value) . 'was given');
+            try {
+                $accessor->$methodName(...$methodArguments);
+                $this->fail('this should lead to an error');
+            } catch (\Error $error) {
+                $this->assertInstanceOf(\TypeError::class, $error);
+            }
+        }
+    }
+}

--- a/Neos.Utility.Arrays/Tests/Unit/ValueAccessorTest.php
+++ b/Neos.Utility.Arrays/Tests/Unit/ValueAccessorTest.php
@@ -95,7 +95,7 @@ class ValueAccessorTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function objectAccessorWorks()
+    public function instanceOfAccessorWorks()
     {
         $acceptableAsDateTimeInterface = [new \DateTime(), new \DateTimeImmutable()];
         $notAcceptableAsDateTimeInterface = [new \stdClass(), 1, -1, true, false, 'string'];
@@ -106,8 +106,8 @@ class ValueAccessorTest extends \PHPUnit\Framework\TestCase
         $acceptableAsDateTime = [new \DateTime()];
         $notAcceptableAsDateTime = [new \stdClass(), new \DateTimeImmutable(), 1, -1, true, false, 'string'];
 
-        $this->testAccessor($acceptableAsDateTime, [...$notAcceptableAsDateTime, null], 'object', [\DateTime::class]);
-        $this->testAccessor([...$acceptableAsDateTime, null], $notAcceptableAsDateTime, 'objectOrNull', [\DateTime::class]);
+        $this->testAccessor($acceptableAsDateTime, [...$notAcceptableAsDateTime, null], 'instanceOf', [\DateTime::class]);
+        $this->testAccessor([...$acceptableAsDateTime, null], $notAcceptableAsDateTime, 'instanceOfOrNull', [\DateTime::class]);
     }
 
     protected function testAccessor(


### PR DESCRIPTION
_**Please note that this is an experimental feature and the API is not stable yet.**_

The array utility allows to create a type safe accessor via `Arrays::getAccessorByPath($arrayValue, 'your.path')`. The accessor provides the following methods that will either return the requested type or throw a `\UnexpectedValueException`.  

* `int(): int`
* `float(): float`
* `number(): int|float`
* `string(): string`
* `classString(): string` - with annotation for class-string
* `array(): array`
* `instanceOf(string $className): object` - with annotation for dynamic type
* `intOrNull(): ?int`
* `floatOrNull(): ?float`
* `numberOrNull(): null|int|float`
* `stringOrNull(): ?string`
* `classStringOrNull(): ?string` - with annotation for class-string | null
* `arrayOrNull(): ?array`
* `instanceOfOrNull(string $className): ?object` - with annotation for dynamic type | null

This will allow to write code that accesses settings via pathes without checking every level for existence still beeing type safe and accessible for static analysis.

This can be used together with settingInjection.

```php
public function injectSettings(array $settings): void
{
   $this->limit = Arrays::getAccessorByPath($settings, 'limit')->intOrNull();
}
```

Resolves: #3164

**Review instructions**

It may look inefficient to manually throw TypeErrors that in many cases would be thrown automatically because of the declared return types. However this is not a performance issue as those are never on the happy-path and the created TypeError provides additional informations to help understand and fix problems faster.

Inspired by https://github.com/PackageFactory/extractor

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
