### PR TITLE
BUGFIX: Prevent deprecation warning in `RouteTags::createFromArray()`

### DIFF
--- a/Neos.Flow/Classes/Mvc/Routing/Dto/RouteTags.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Dto/RouteTags.php
@@ -71,7 +71,9 @@ final class RouteTags
      */
     public static function createFromArray(array $tags): self
     {
-        array_walk($tags, 'static::validateTag');
+        foreach ($tags as $tag) {
+            self::validateTag($tag);
+        }
         return new static($tags);
     }
 


### PR DESCRIPTION
Fixes: #3120