### PR TITLE
BUGFIX: Revert "TASK: Avoid potential deprecation warning in StringHelper"

### DIFF
--- a/Neos.Eel/Classes/Helper/StringHelper.php
+++ b/Neos.Eel/Classes/Helper/StringHelper.php
@@ -326,7 +326,7 @@ class StringHelper implements ProtectedContextAwareInterface
      */
     public function replace($string, $search, $replace)
     {
-        return str_replace((string)$search, (string)$replace, (string)$string);
+        return str_replace($search, $replace, (string)$string);
     }
 
     /**

--- a/Neos.Eel/Classes/Helper/StringHelper.php
+++ b/Neos.Eel/Classes/Helper/StringHelper.php
@@ -319,14 +319,24 @@ class StringHelper implements ProtectedContextAwareInterface
      *
      * Note: this method does not perform regular expression matching, @see pregReplace().
      *
-     * @param string|array $string The input string|array
+     * @param string|array $subject The input string|array
      * @param string|array $search A search string|array
-     * @param string $replace A replacement string
-     * @return string The string with all occurrences replaced
+     * @param string|array $replace A replacement string|array
+     * @return string|array The subject with all occurrences replaced
      */
-    public function replace($string, $search, $replace)
+    public function replace($subject, $search, $replace)
     {
-        return str_replace($search, $replace, (string)$string);
+        if (!is_array($subject) && !is_string($subject)) {
+            $subject = (string)$subject;
+        }
+        if (!is_array($search) && !is_string($search)) {
+            $search = (string)$search;
+        }
+        if (!is_array($replace) && !is_string($replace)) {
+            $replace = (string)$replace;
+        }
+
+        return str_replace($search, $replace, $subject);
     }
 
     /**

--- a/Neos.Eel/Classes/Helper/StringHelper.php
+++ b/Neos.Eel/Classes/Helper/StringHelper.php
@@ -319,8 +319,8 @@ class StringHelper implements ProtectedContextAwareInterface
      *
      * Note: this method does not perform regular expression matching, @see pregReplace().
      *
-     * @param string $string The input string
-     * @param string $search A search string
+     * @param string|array $string The input string|array
+     * @param string|array $search A search string|array
      * @param string $replace A replacement string
      * @return string The string with all occurrences replaced
      */


### PR DESCRIPTION
## Informations
**Based on #3166** 
Resolves #3166 

```php
str_replace()
```
`str_replace()` supports arrays as attributes.
We should allow users to use the function correctly.
https://www.php.net/manual/de/function.str-replace.php


This reverts commit 1390d88103a6be6ddfa827eb834b0f666f5ea67b. in 028e2e33570a20a835eff37021aa55b1b331a406
And updates the docs comment. 5ad36d9d925509697f33700dddf9c09d385b4aa7

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->


**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] ~~Tests have been created, run and adjusted as needed~~
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
