### PR TITLE
TASK: Scripts.php avoid use of same references for exec

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -861,6 +861,7 @@ class Scripts
         $command[] = '2>&1'; // Output errors in response
 
         // Try to resolve which binary file PHP is pointing to
+        $output = [];
         exec(join(' ', $command), $output, $result);
 
         if ($result === 0 && count($output) === 1) {
@@ -883,6 +884,7 @@ class Scripts
         $realPhpBinary = @realpath(PHP_BINARY);
         if ($realPhpBinary === false) {
             // bypass with exec open_basedir restriction
+            $output = [];
             exec(PHP_BINARY . ' -r "echo realpath(PHP_BINARY);"', $output);
             $realPhpBinary = $output[0];
         }


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

Followup to https://github.com/neos/flow-development-collection/pull/3116

I debugged with @dlubitz a problem and we found that in theory?  $output _might_ be possibly already filled?
I dont know if that can happen but just to be sure we set it to empty as its also a bad practice.


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
