### PR TITLE
BUGFIX: Sanitize uploaded svg files from suspicious content

### DIFF
--- a/Neos.Flow/Classes/ResourceManagement/ResourceManager.php
+++ b/Neos.Flow/Classes/ResourceManagement/ResourceManager.php
@@ -11,10 +11,12 @@ namespace Neos\Flow\ResourceManagement;
  * source code.
  */
 
+use enshrined\svgSanitize\Sanitizer;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Log\Utility\LogEnvironment;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Utility\MediaTypes;
 use Neos\Utility\ObjectAccess;
 use Neos\Flow\ResourceManagement\Storage\StorageInterface;
 use Neos\Flow\ResourceManagement\Storage\WritableStorageInterface;
@@ -160,13 +162,29 @@ class ResourceManager
         $collection = $this->collections[$collectionName];
 
         try {
-            $resource = $collection->importResource($source);
-            if ($forcedPersistenceObjectIdentifier !== null) {
-                ObjectAccess::setProperty($resource, 'Persistence_Object_Identifier', $forcedPersistenceObjectIdentifier, true);
-            }
-            if (!is_resource($source)) {
+            if (is_resource($source)) {
+                $mediaType = MediaTypes::getMediaTypeFromResource($source);
+                if ($this->isSanitizingRequired($mediaType)) {
+                    $content = stream_get_contents($source);
+                    $resource = $this->importResourceFromContent($content, '', $collectionName, $forcedPersistenceObjectIdentifier);
+                } else {
+                    $resource = $collection->importResource($source);
+                }
+            } else {
+                $resource = fopen($source, 'rb');
+                $mediaType = MediaTypes::getMediaTypeFromResource($resource);
+                fclose($resource);
+                if ($this->isSanitizingRequired($mediaType)) {
+                    $content = file_get_contents($source);
+                    $resource = $this->importResourceFromContent($content, '', $collectionName, $forcedPersistenceObjectIdentifier);
+                } else {
+                    $resource = $collection->importResource($source);
+                }
                 $pathInfo = UnicodeFunctions::pathinfo($source);
                 $resource->setFilename($pathInfo['basename']);
+            }
+            if ($forcedPersistenceObjectIdentifier !== null) {
+                ObjectAccess::setProperty($resource, 'Persistence_Object_Identifier', $forcedPersistenceObjectIdentifier, true);
             }
         } catch (Exception $exception) {
             throw new Exception(sprintf('Importing a file into the resource collection "%s" failed: %s', $collectionName, $exception->getMessage()), 1375197120, $exception);
@@ -204,6 +222,11 @@ class ResourceManager
 
         if (!isset($this->collections[$collectionName])) {
             throw new Exception(sprintf('Tried to import a file into the resource collection "%s" but no such collection exists. Please check your settings and the code which triggered the import.', $collectionName), 1380878131);
+        }
+
+        $mediaType = MediaTypes::getMediaTypeFromFileContent($content);
+        if ($this->isSanitizingRequired($mediaType)) {
+            $content = $this->sanitizeImportedFileContent($mediaType, $content, $filename);
         }
 
         /* @var CollectionInterface $collection */
@@ -606,6 +629,44 @@ class ResourceManager
 
             $this->collections[$collectionName] = new Collection($collectionName, $this->storages[$collectionDefinition['storage']], $this->targets[$collectionDefinition['target']], $pathPatterns, $filenames);
         }
+    }
+
+    /**
+     * Decide weather the given media-type has to be sanitized
+     * for now this only checks svg file to solve the issue here https://nvd.nist.gov/vuln/detail/CVE-2023-37611
+     *
+     * @todo create a feature from this and allow to register code for sanitizing file content before importing
+     */
+    protected function isSanitizingRequired(string $mediaType): bool
+    {
+        return $mediaType === 'image/svg+xml';
+    }
+
+    /**
+     * Sanitize file content and remove content that is suspicious
+     * for now this only checks svg file to solve the issue here https://nvd.nist.gov/vuln/detail/CVE-2023-37611
+     *
+     * @todo create a feature from this and allow to register code for sanitizing file content before importing
+     */
+    protected function sanitizeImportedFileContent(string $mediaType, string $content, $filename = ''): string
+    {
+        if ($mediaType === 'image/svg+xml') {
+            // @todo: Simplify again when https://github.com/darylldoyle/svg-sanitizer/pull/90 is merged and released.
+            $previousXmlErrorHandling = libxml_use_internal_errors(true);
+            $sanitizer = new Sanitizer();
+            $sanitizedContent = $sanitizer->sanitize($content);
+            libxml_clear_errors();
+            libxml_use_internal_errors($previousXmlErrorHandling);
+            $issues = $sanitizer->getXmlIssues();
+            if ($issues && count($issues) > 0) {
+                if ($sanitizedContent === false) {
+                    throw new Exception('Sanitizing of suspicious file "' . $filename . '" failed during import.', 1695395560);
+                }
+                $content = $sanitizedContent;
+                $this->logger->warning(sprintf('Imported file "%s" contained suspicious content and was sanitized.', $filename), $issues);
+            }
+        }
+        return $content;
     }
 
     /**

--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -51,7 +51,8 @@
 
         "composer/composer": "^2.2.8",
 
-        "egulias/email-validator": "^2.1.17 || ^3.0"
+        "egulias/email-validator": "^2.1.17 || ^3.0",
+        "enshrined/svg-sanitize": "^0.16.0"
     },
     "require-dev": {
         "vimeo/psalm": "~4.30.0",

--- a/Neos.Utility.MediaTypes/Classes/MediaTypes.php
+++ b/Neos.Utility.MediaTypes/Classes/MediaTypes.php
@@ -1831,6 +1831,21 @@ abstract class MediaTypes
     }
 
     /**
+     * Returns a Media Type based on the given resource
+     *
+     * @param resource $resource The resource to determine the media type from
+     * @return string The IANA Internet Media Type
+     */
+    public static function getMediaTypeFromResource($resource): string
+    {
+        if (!is_resource($resource)) {
+            throw new \TypeError('Argument "resource" has to be a resource');
+        }
+        $mediaType = self::trimMediaType(mime_content_type($resource));
+        return isset(self::$mediaTypeToFileExtension[$mediaType]) ? $mediaType : 'application/octet-stream';
+    }
+
+    /**
      * Returns the primary filename extension based on the given Media Type.
      *
      * @param string $mediaType The IANA Internet Media Type, for example "text/html"

--- a/Neos.Utility.MediaTypes/Tests/Unit/MediaTypesTest.php
+++ b/Neos.Utility.MediaTypes/Tests/Unit/MediaTypesTest.php
@@ -10,6 +10,7 @@ namespace Neos\Utility\MediaTypes\Tests\Unit;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
+
 use Neos\Utility\MediaTypes;
 
 /**

--- a/Neos.Utility.MediaTypes/Tests/Unit/MediaTypesTest.php
+++ b/Neos.Utility.MediaTypes/Tests/Unit/MediaTypesTest.php
@@ -10,7 +10,6 @@ namespace Neos\Utility\MediaTypes\Tests\Unit;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
 use Neos\Utility\MediaTypes;
 
 /**
@@ -66,6 +65,22 @@ class MediaTypesTest extends \PHPUnit\Framework\TestCase
         $filePath = __DIR__ . '/Fixtures/' . $filename;
         $fileContent = is_file($filePath) ? file_get_contents($filePath) : '';
         self::assertSame($expectedMediaType, MediaTypes::getMediaTypeFromFileContent($fileContent));
+    }
+
+    /**
+     * @test
+     * @dataProvider filesAndMediaTypes
+     */
+    public function getMediaTypeFromResource(string $filename, string $expectedMediaType)
+    {
+        $filePath = __DIR__ . '/Fixtures/' . $filename;
+        $resource = is_file($filePath) ? fopen($filePath, 'rb') : fopen('data://text/plain,', 'rb');
+        if ($resource !== false) {
+            self::assertSame($expectedMediaType, MediaTypes::getMediaTypeFromResource($resource));
+            fclose($resource);
+        } else {
+            $this->fail('fixture ' . $filePath . ' could not be read');
+        }
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "neos/composer-plugin": "^2.0",
         "composer/composer": "^2.2.8",
         "egulias/email-validator": "^2.1.17 || ^3.0",
+        "enshrined/svg-sanitize": "^0.16.0",
         "typo3fluid/fluid": "~2.7.0",
         "guzzlehttp/psr7": "^1.8.4",
         "ext-mbstring": "*"


### PR DESCRIPTION
Adding an internal methods `isSanitizingRequired` and `sanitizeImportedFileContent` to the resourceManager. The import is adjusted to first determine the mediaType of an imported resource to decide wether sanitizing is needed which for now happens only for SVG files. If no sanitizing is needed the code will perform as before by passing streams or filenames around.

If suspicious content was removed from a warning is logged that mentions the remove data and line. The sanitizing is done using "enshrined/svg-sanitize" that is used by other cms aswell.

The initial implementation will only sanitize SVG files as those can contain malicious scripts. In future this should be expanded to a feature that allows registering of custom sanitizing functions.

The sanitizing logic itself ist basically the same as what is done by typo3 here: https://github.com/TYPO3/typo3/blob/357b07064cf2c7f1735cfb8f73ac4a7248ab040e/typo3/sysext/core/Classes/Resource/Security/SvgSanitizer.php

This addresses the issue described here: https://nvd.nist.gov/vuln/detail/CVE-2023-37611

**Review Instructions**

The change adds quite a bit of complexity to the importResource method to avoid loading the file content into ram whenever possible. As this method accepts filenames and resources this leads to quite some nested checking. I consider this kindoff necessary as one does not want to read a full video file into php ram to check wether it may be an svg. 

Better suggestions are welcome.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
