### PR TITLE
BUGFIX: Allow arrays in `replace`-String-Helper

### DIFF
--- a/Neos.Eel/Classes/Helper/StringHelper.php
+++ b/Neos.Eel/Classes/Helper/StringHelper.php
@@ -316,17 +316,23 @@ class StringHelper implements ProtectedContextAwareInterface
      * Example::
      *
      *     String.replace("canal", "ana", "oo") == "cool"
+     *     String.replace("cool gridge", ["oo", "gri"], ["ana", "bri"]) == "canal bridge"
      *
      * Note: this method does not perform regular expression matching, @see pregReplace().
      *
-     * @param string $string The input string
-     * @param string $search A search string
-     * @param string $replace A replacement string
-     * @return string The string with all occurrences replaced
+     * @param array|string|null $string The input string
+     * @param array|string|null $search A search string
+     * @param array|string|null $replace A replacement string
+     * @return array|string|string[] The string with all occurrences replaced
      */
     public function replace($string, $search, $replace)
     {
-        return str_replace((string)$search, (string)$replace, (string)$string);
+        // Replace null values with empty strings
+        $string = is_array($string) ? $string : (string) $string;
+        $search = is_array($search) ? $search : (string) $search;
+        $replace = is_array($replace) ? $replace : (string) $replace;
+
+        return str_replace($search, $replace, $string);
     }
 
     /**

--- a/Neos.Eel/Tests/Unit/Helper/StringHelperTest.php
+++ b/Neos.Eel/Tests/Unit/Helper/StringHelperTest.php
@@ -284,6 +284,7 @@ class StringHelperTest extends UnitTestCase
     {
         return [
             'replace' => ['canal', 'ana', 'oo', 'cool'],
+            'replace-array' => ['cool gridge', ['oo', 'gri'], ['ana', 'bri'], 'canal bridge'],
             'no match' => ['canal', 'x', 'y', 'canal'],
             'unicode replacement' => ['Öaßaü', 'aßa', 'g', 'Ögü']
         ];


### PR DESCRIPTION
The `str_replace` function allows arrays as arguments to replace multiple words with other words

### Here is a simple example:
If you have an array to replace i. e. BB-Codes:

```yaml
Foo:
  Bar:
    bbCodes:
      '[h2]': '<h2>'
      '[/h2]': '</h2>'
      '[h3]': '<h3>'
      '[/h3]': '</h3>'
```

You can usethe helper (with my changes) like this:

```neosfusion
prototype(Foo.Bar:String) < prototype(Neos.Fusion:Value) {
    string = '[h2]Hello[/h2][h3]something[/h3]';

    search = ${Array.keys(Configuration.setting('Foo.Bar.bbCodes'))}
    replace = ${Configuration.setting('Foo.Bar.bbCodes')}

    value = ${String.replace(this.string, this.search, this.replace)}
}
```

Resolves #3166

**Review instructions**

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions~
