### PR TITLE
BUGFIX: Fix `ConfigurationManager::setTemporaryDirectoryBase()` for PHP 8+

### DIFF
--- a/Neos.Flow/Classes/Configuration/ConfigurationManager.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationManager.php
@@ -370,10 +370,8 @@ class ConfigurationManager
      */
     protected function replaceConfigurationForConfigurationType(string $configurationType, string $cachePathAndFilename): void
     {
-        /** @noinspection UsingInclusionReturnValueInspection */
-        $configurations = @include $cachePathAndFilename;
-        if ($configurations !== false) {
-            $this->configurations[$configurationType] = $configurations;
+        if (is_file($cachePathAndFilename)) {
+            $this->configurations[$configurationType] = include $cachePathAndFilename;
         }
     }
 
@@ -386,10 +384,8 @@ class ConfigurationManager
             return;
         }
         $cachePathAndFilename = $this->constructConfigurationCachePath();
-        /** @noinspection UsingInclusionReturnValueInspection */
-        $configurations = @include $cachePathAndFilename;
-        if ($configurations !== false) {
-            $this->configurations = $configurations;
+        if (is_file($cachePathAndFilename)) {
+            $this->configurations = include $cachePathAndFilename;
         }
     }
 

--- a/Neos.Flow/Tests/Functional/Configuration/ConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Functional/Configuration/ConfigurationManagerTest.php
@@ -20,7 +20,6 @@ use Neos\Flow\Utility\Environment;
 
 class ConfigurationManagerTest extends FunctionalTestCase
 {
-
     /**
      * @test
      */

--- a/Neos.Flow/Tests/Functional/Configuration/ConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Functional/Configuration/ConfigurationManagerTest.php
@@ -1,0 +1,37 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Configuration;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Configuration\ConfigurationManager;
+use Neos\Flow\Configuration\Loader\SettingsLoader;
+use Neos\Flow\Configuration\Source\YamlSource;
+use Neos\Flow\Core\ApplicationContext;
+use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Flow\Utility\Environment;
+
+class ConfigurationManagerTest extends FunctionalTestCase
+{
+
+    /**
+     * @test
+     */
+    public function customInstanceCanBeCreated(): void
+    {
+        $applicationContext = new ApplicationContext('Testing/SubContext');
+        $configurationManager = new ConfigurationManager($applicationContext);
+        $environment = new Environment($applicationContext);
+        $environment->setTemporaryDirectoryBase(FLOW_PATH_TEMPORARY_BASE);
+        $configurationManager->setTemporaryDirectoryPath($environment->getPathToTemporaryDirectory());
+        $configurationManager->registerConfigurationType(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, new SettingsLoader(new YamlSource()));
+        self::assertSame('Testing/SubContext', $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.Flow.core.context'));
+    }
+}


### PR DESCRIPTION
Fixes `ConfigurationManager::setTemporaryDirectoryBase()` by replacing the use of the [error control operator](https://www.php.net/manual/en/language.operators.errorcontrol.php) that leads to a Warning with PHP 8.0+

Fixes: #3182