### PR TITLE
BUGFIX: Add PDO driverOptions

### DIFF
--- a/Neos.Cache/Classes/Backend/PdoBackend.php
+++ b/Neos.Cache/Classes/Backend/PdoBackend.php
@@ -48,6 +48,11 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
     protected $password;
 
     /**
+     * @var array
+     */
+    protected $driverOptions = [];
+
+    /**
      * @var \PDO
      */
     protected $databaseHandle;
@@ -111,6 +116,18 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
     protected function setPassword(string $password): void
     {
         $this->password = $password;
+    }
+
+    /**
+     * Sets the driverOptions to use
+     *
+     * @param array $driverOptions The options to use for connecting to the DB
+     * @return void
+     * @api
+     */
+    protected function setDriverOptions(array $driverOptions): void
+    {
+        $this->driverOptions = $driverOptions;
     }
 
     /**
@@ -428,10 +445,10 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
                         throw new Exception(sprintf('Could not create directory for sqlite file "%s"', $splitdsn[1]), 1565359792, $exception);
                     }
                 }
-                $this->databaseHandle = new \PDO($this->dataSourceName, $this->username, $this->password);
+                $this->databaseHandle = new \PDO($this->dataSourceName, $this->username, $this->password, $this->driverOptions);
                 $this->createCacheTables();
             } else {
-                $this->databaseHandle = new \PDO($this->dataSourceName, $this->username, $this->password);
+                $this->databaseHandle = new \PDO($this->dataSourceName, $this->username, $this->password, $this->driverOptions);
             }
             $this->databaseHandle->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
 


### PR DESCRIPTION
This allows to pass driver options for the PDO cache backend, e.g. to make use of SSL, like so:

```yaml
Flow_Session_Storage:
  backend: Neos\Cache\Backend\PdoBackend
  backendOptions:
    dataSourceName: 'mysql:host=%env:DB_HOST%;dbname=%env:DB_NAME%;charset=utf8mb4'
    username: '%env:DB_USER%'
    password: '%env:DB_PASSWORD%'
    cacheTableName: 'cache_session_storage'
    tagsTableName: 'cache_session_storage_tags'
    driverOptions:
      '%PDO::MYSQL_ATTR_SSL_CA%': 'https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem'
      '%PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT%': false
```

Fixes #3157

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions~
