### PR TITLE
TASK: Clean up stored throwable dumps

### DIFF
--- a/Neos.Flow/Configuration/Settings.Log.yaml
+++ b/Neos.Flow/Configuration/Settings.Log.yaml
@@ -58,3 +58,7 @@ Neos:
         optionsByImplementation:
           'Neos\Flow\Log\ThrowableStorage\FileStorage':
             storagePath: '%FLOW_PATH_DATA%Logs/Exceptions'
+            # The maximum age of throwable dump in seconds, 0 to disable cleaning based on age
+            maximumThrowableDumpAge: 0
+            # The maximum number of throwable dumps to store, 0 to disable cleaning based on count
+            maximumThrowableDumpCount: 0

--- a/Neos.Flow/Configuration/Settings.Log.yaml
+++ b/Neos.Flow/Configuration/Settings.Log.yaml
@@ -59,6 +59,6 @@ Neos:
           'Neos\Flow\Log\ThrowableStorage\FileStorage':
             storagePath: '%FLOW_PATH_DATA%Logs/Exceptions'
             # The maximum age of throwable dump in seconds, 0 to disable cleaning based on age, default 30 days
-            maximumThrowableDumpAge: 2592000
+            maximumThrowableDumpAge: 0
             # The maximum number of throwable dumps to store, 0 to disable cleaning based on count, default 10.000
-            maximumThrowableDumpCount: 10000
+            maximumThrowableDumpCount: 0

--- a/Neos.Flow/Configuration/Settings.Log.yaml
+++ b/Neos.Flow/Configuration/Settings.Log.yaml
@@ -58,7 +58,7 @@ Neos:
         optionsByImplementation:
           'Neos\Flow\Log\ThrowableStorage\FileStorage':
             storagePath: '%FLOW_PATH_DATA%Logs/Exceptions'
-            # The maximum age of throwable dump in seconds, 0 to disable cleaning based on age
-            maximumThrowableDumpAge: 0
-            # The maximum number of throwable dumps to store, 0 to disable cleaning based on count
-            maximumThrowableDumpCount: 0
+            # The maximum age of throwable dump in seconds, 0 to disable cleaning based on age, default 30 days
+            maximumThrowableDumpAge: 2592000
+            # The maximum number of throwable dumps to store, 0 to disable cleaning based on count, default 10.000
+            maximumThrowableDumpCount: 10000


### PR DESCRIPTION
Whenever a new dump is written, check the existing dumps and remove those that are older than allowed or exceed the maximum count.

By default nothing is cleaned up.

Resolves #3158

**Review instructions**

Should remove old dump files as configured…

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions~
