### PR TITLE
BUGFIX: Fix race-condition when initializing I18n Service

### DIFF
--- a/Neos.Flow/Classes/I18n/Service.php
+++ b/Neos.Flow/Classes/I18n/Service.php
@@ -83,8 +83,10 @@ class Service
         $this->configuration = new Configuration($this->settings['defaultLocale']);
         $this->configuration->setFallbackRule($this->settings['fallbackRule']);
 
-        if ($this->cache->has('availableLocales')) {
-            $this->localeCollection = $this->cache->get('availableLocales');
+        $cachedCollection = $this->cache->get('availableLocales');
+
+        if ($cachedCollection !== false) {
+            $this->localeCollection = $cachedCollection;
         } elseif (isset($this->settings['availableLocales']) && !empty($this->settings['availableLocales'])) {
             $this->generateAvailableLocalesCollectionFromSettings();
             $this->cache->set('availableLocales', $this->localeCollection);


### PR DESCRIPTION
We noticed in our error logs that we had quite a few errors being thrown from [here](https://github.com/neos/flow-development-collection/blob/b82054f980913d63aecd917692b4213bf034854a/Neos.Flow/Classes/I18n/Service.php#L256-L257):
```
Call to a member function findBestMatchingLocale() on bool
```

My best guess is that this is due to a race-condition when the service is called for the first time on a host by multiple requests simultaneously.

In general, the pattern of first checking if some value is in the cache, and then reading the value out afterwards without checking it is never safe, as a different process/thread could have removed it.

The safe way is to read the value out once, and verify that it is set correctly (e.g. it should not `=== false`).

I think there's [a few other places](https://github.com/search?q=repo%3Aneos%2Fflow-development-collection+%22-%3Ecache-%3Ehas%22&type=code) that follow the same unsafe pattern, but I suggest that they are addresses separately from this PR.

I haven't added any tests for this case, but please let me know if you have any ideas of how to test this.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
