### PR TITLE
BUGFIX: __wakeup must not return

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethod.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethod.php
@@ -165,7 +165,7 @@ class ProxyMethod
         $staticKeyword = $this->reflectionService->isMethodStatic($this->fullOriginalClassName, $this->methodName) ? 'static ' : '';
 
         $returnType = $this->reflectionService->getMethodDeclaredReturnType($this->fullOriginalClassName, $this->methodName);
-        $returnTypeIsVoid = $returnType === 'void';
+        $returnTypeIsVoidOrNull = $returnType === 'void' || $returnType === null;
         $returnTypeDeclaration = ($returnType !== null ? ' : ' . $returnType : '');
 
 
@@ -179,7 +179,7 @@ class ProxyMethod
             } else {
                 $code .= $this->addedPreParentCallCode;
                 if ($this->addedPostParentCallCode !== '') {
-                    if ($returnTypeIsVoid) {
+                    if ($returnTypeIsVoidOrNull) {
                         if ($callParentMethodCode !== '') {
                             $code .= '            ' . $callParentMethodCode;
                         }
@@ -187,11 +187,11 @@ class ProxyMethod
                         $code .= '            $result = ' . ($callParentMethodCode === '' ? "NULL;\n" : $callParentMethodCode);
                     }
                     $code .= $this->addedPostParentCallCode;
-                    if (!$returnTypeIsVoid) {
+                    if (!$returnTypeIsVoidOrNull) {
                         $code .= "        return \$result;\n";
                     }
                 } else {
-                    if (!$returnTypeIsVoid && $callParentMethodCode !== '') {
+                    if (!$returnTypeIsVoidOrNull && $callParentMethodCode !== '') {
                         $code .= '        return ' . $callParentMethodCode . ";\n";
                     }
                 }


### PR DESCRIPTION
Generated proxy classes return something in `__wakeup`, but that is not allowed since PHP 8.0. Root cause for this is the fact, that we check for `void` but take an "undefined return type" as "something".

This fixes the issue by checking for `'void' || null`…

**Review instructions**

The `__wakeup()` method in the generated proxy class must not contain `return $result` anymore.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions~
