### PR TITLE
FEATURE: Add more information for object arguments in debugging

### DIFF
--- a/Neos.Flow/Classes/Error/Debugger.php
+++ b/Neos.Flow/Classes/Error/Debugger.php
@@ -466,8 +466,6 @@ class Debugger
 
     protected static function getObjectSnippetPlaintext(object $object): string
     {
-
-
         if (is_callable([$object, '__toString'])) {
             return self::getObjectShortName($object) . '|' . self::truncateObjectOutput((string)$object) . '|';
         }


### PR DESCRIPTION
For stacktraces in exceptions and logs we now render some representation of content for objects to ease debugging with DTOs.

Specifically we will try to obtain a string representation for such an object by using either in this order:

- a string cast if __toString() is available
- json_encode if it is JsonSerializable
- json_encode on the array of public properties

For readability json_encode will be limited to the first level, also all of those string representations will be cut off after 100 characters.

If any of those options works we will also shorten the className to avoid this output becoming overly long.

Note that we use JSON_PARTIAL_OUTPUT_ON_ERROR to make sure some output is provided. This might lead to partial or weird outputs depending on the object structure, but might still provide pointers for debugging.

Fixes: #3165
