### PR TITLE
TASK: Update default settings for stored throwable dumps

### DIFF
--- a/Neos.Flow/Configuration/Settings.Log.yaml
+++ b/Neos.Flow/Configuration/Settings.Log.yaml
@@ -58,3 +58,7 @@ Neos:
         optionsByImplementation:
           'Neos\Flow\Log\ThrowableStorage\FileStorage':
             storagePath: '%FLOW_PATH_DATA%Logs/Exceptions'
+            # The maximum age of throwable dump in seconds, 0 to disable cleaning based on age, default 30 days
+            maximumThrowableDumpAge: 2592000
+            # The maximum number of throwable dumps to store, 0 to disable cleaning based on count, default 10.000
+            maximumThrowableDumpCount: 10000


### PR DESCRIPTION
This updates the default settings in YAML to 30 days of dump retention and a maximum of 10.000 files.

The class properties keep their `0` default, so that in case the class has been extended no change is enforced.

**Review instructions**

Needs upmerge of https://github.com/neos/flow-development-collection/pull/3187

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
