### PR TITLE
TASK: Migrate to PHPStan (adjustments in Flow 9)

### DIFF
--- a/.composer.json
+++ b/.composer.json
@@ -7,17 +7,15 @@
     "test:behavioral": [
       "../../flow doctrine:migrate --quiet",
       "../../bin/behat -f progress -c Neos.Flow/Tests/Behavior/behat.yml"
+    ],
+    "lint": [
+      "../../bin/phpstan analyse"
     ]
   },
   "require": {
     "behat/behat": "^3.10"
   },
   "replace": {
-  },
-  "scripts": {
-    "lint": [
-      "../../bin/phpstan analyse"
-    ]
   },
   "suggest": {
   },

--- a/Neos.Cache/Classes/Backend/TaggableMultiBackend.php
+++ b/Neos.Cache/Classes/Backend/TaggableMultiBackend.php
@@ -60,7 +60,6 @@ class TaggableMultiBackend extends MultiBackend implements TaggableBackendInterf
      * @param array<string> $tags The tags the entries must have
      * @return integer The number of entries which have been affected by this flush
      * @throws Throwable
-     * @psalm-suppress MethodSignatureMismatch
      */
     public function flushByTags(array $tags): int
     {

--- a/Neos.Eel/Classes/FlowQuery/Operations/Object/FilterOperation.php
+++ b/Neos.Eel/Classes/FlowQuery/Operations/Object/FilterOperation.php
@@ -341,7 +341,7 @@ class FilterOperation extends AbstractOperation
 
     /**
      * @param string $operand
-     * @param string $value
+     * @param mixed $value
      * @return boolean true if $value is of type $operand; false otherwise
      */
     protected function handleSimpleTypeOperand($operand, $value)

--- a/Neos.Eel/Classes/Helper/MathHelper.php
+++ b/Neos.Eel/Classes/Helper/MathHelper.php
@@ -493,9 +493,6 @@ class MathHelper implements ProtectedContextAwareInterface
     public function trunc($x)
     {
         $sign = $this->sign($x);
-        /**
-         * @psalm-suppress RedundantCastGivenDocblockType
-         */
         return match ($sign) {
             -1 => (int)ceil((float)$x),
             1 => (int)floor((float)$x),

--- a/Neos.Eel/Classes/Helper/StringHelper.php
+++ b/Neos.Eel/Classes/Helper/StringHelper.php
@@ -308,7 +308,6 @@ class StringHelper implements ProtectedContextAwareInterface
      */
     public function pregSplit($string, $pattern, $limit = -1)
     {
-        /** @psalm-suppress RedundantCastGivenDocblockType */
         return preg_split($pattern, (string)$string, (int)$limit);
     }
 

--- a/Neos.Flow/Classes/Aop/Builder/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/Aop/Builder/ProxyClassBuilder.php
@@ -18,7 +18,6 @@ use Neos\Flow\Aop\AdvicesTrait;
 use Neos\Flow\Aop\AspectContainer;
 use Neos\Flow\Aop\Exception;
 use Neos\Flow\Aop\Exception\InvalidPointcutExpressionException;
-use Neos\Flow\Aop\Exception\InvalidTargetClassException;
 use Neos\Flow\Aop\Exception\VoidImplementationException;
 use Neos\Flow\Aop\Pointcut\Pointcut;
 use Neos\Flow\Aop\Pointcut\PointcutExpressionParser;

--- a/Neos.Flow/Classes/Cli/CommandController.php
+++ b/Neos.Flow/Classes/Cli/CommandController.php
@@ -331,10 +331,9 @@ class CommandController implements CommandControllerInterface
      * shutdown (such as the persistence framework), you must use quit() instead of exit().
      *
      * @param integer $exitCode Exit code to return on exit (see http://www.php.net/exit)
-     * @psalm-return never-returns
      * @throws StopCommandException
      */
-    protected function quit(int $exitCode = 0)
+    protected function quit(int $exitCode = 0): never
     {
         $this->response->setExitCode($exitCode);
         throw new StopCommandException(sprintf('Quitting with exit code %s', $exitCode));
@@ -345,9 +344,8 @@ class CommandController implements CommandControllerInterface
      * Should be used for commands that flush code caches.
      *
      * @param integer $exitCode Exit code to return on exit
-     * @psalm-return never-returns
      */
-    protected function sendAndExit(int $exitCode = 0)
+    protected function sendAndExit(int $exitCode = 0): never
     {
         $this->response->send();
         exit($exitCode);

--- a/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
@@ -183,12 +183,11 @@ abstract class AbstractController implements ControllerInterface
      * @param string $controllerName Unqualified object name of the controller to forward to. If not specified, the current controller is used.
      * @param string $packageKey Key of the package containing the controller to forward to. May also contain the sub package, concatenated with backslash (Vendor.Foo\Bar\Baz). If not specified, the current package is assumed.
      * @param array $arguments Arguments to pass to the target action
-     * @psalm-return never-returns
      * @throws ForwardException
      * @see redirect()
      * @api
      */
-    protected function forward($actionName, $controllerName = null, $packageKey = null, array $arguments = [])
+    protected function forward($actionName, $controllerName = null, $packageKey = null, array $arguments = []): never
     {
         $nextRequest = clone $this->request;
         $nextRequest->setControllerActionName($actionName);
@@ -258,12 +257,11 @@ abstract class AbstractController implements ControllerInterface
      * @param integer $delay (optional) The delay in seconds. Default is no delay.
      * @param integer $statusCode (optional) The HTTP status code for the redirect. Default is "303 See Other"
      * @param string $format The format to use for the redirect URI
-     * @return void
      * @throws StopActionException
      * @see forward()
      * @api
      */
-    protected function redirect($actionName, $controllerName = null, $packageKey = null, array $arguments = [], $delay = 0, $statusCode = 303, $format = null)
+    protected function redirect($actionName, $controllerName = null, $packageKey = null, array $arguments = [], $delay = 0, $statusCode = 303, $format = null): never
     {
         if ($packageKey !== null && strpos($packageKey, '\\') !== false) {
             list($packageKey, $subpackageKey) = explode('\\', $packageKey, 2);
@@ -313,12 +311,11 @@ abstract class AbstractController implements ControllerInterface
      * @param mixed $uri Either a string representation of a URI or a \Neos\Flow\Http\Uri object
      * @param integer $delay (optional) The delay in seconds. Default is no delay.
      * @param integer $statusCode (optional) The HTTP status code for the redirect. Default is "303 See Other"
-     * @psalm-return never-returns
      * @throws UnsupportedRequestTypeException If the request is not a web request
      * @throws StopActionException
      * @api
      */
-    protected function redirectToUri($uri, $delay = 0, $statusCode = 303)
+    protected function redirectToUri($uri, $delay = 0, $statusCode = 303): never
     {
         if ($delay === 0) {
             if (!$uri instanceof UriInterface) {
@@ -340,11 +337,10 @@ abstract class AbstractController implements ControllerInterface
      * @param integer $statusCode The HTTP status code
      * @param string $statusMessage A custom HTTP status message
      * @param string $content Body content which further explains the status
-     * @psalm-return never-returns
      * @throws StopActionException
      * @api
      */
-    protected function throwStatus(int $statusCode, $statusMessage = null, $content = null)
+    protected function throwStatus(int $statusCode, $statusMessage = null, $content = null): never
     {
         $this->response->setStatusCode($statusCode);
         if ($content === null) {

--- a/Neos.Flow/Classes/Mvc/Controller/ActionController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ActionController.php
@@ -23,6 +23,7 @@ use Neos\Flow\Mvc\Exception\InvalidActionVisibilityException;
 use Neos\Flow\Mvc\Exception\InvalidArgumentTypeException;
 use Neos\Flow\Mvc\Exception\NoSuchActionException;
 use Neos\Flow\Mvc\Exception\RequiredArgumentMissingException;
+use Neos\Flow\Mvc\Exception\StopActionException;
 use Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException;
 use Neos\Flow\Mvc\Exception\ViewNotFoundException;
 use Neos\Flow\Mvc\View\ViewInterface;
@@ -209,6 +210,7 @@ class ActionController extends AbstractController
      * @throws UnsupportedRequestTypeException
      * @throws ViewNotFoundException
      * @throws \Neos\Flow\Mvc\Exception\RequiredArgumentMissingException
+     * @throws StopActionException
      * @api
      */
     public function processRequest(ActionRequest $request, ActionResponse $response)
@@ -810,7 +812,7 @@ class ActionController extends AbstractController
      * display no flash message at all on errors. Override this to customize
      * the flash message in your action controller.
      *
-     * @return \Neos\Error\Messages\Message The flash message or false if no flash message should be set
+     * @return Error\Error|false The flash message or false if no flash message should be set
      * @api
      */
     protected function getErrorFlashMessage()

--- a/Neos.Flow/Classes/Mvc/Controller/RestController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/RestController.php
@@ -118,11 +118,10 @@ class RestController extends ActionController
      * @param mixed $uri Either a string representation of a URI or a \Neos\Flow\Http\Uri object
      * @param integer $delay (optional) The delay in seconds. Default is no delay.
      * @param integer $statusCode (optional) The HTTP status code for the redirect. Default is "303 See Other"
-     * @psalm-return never-returns
      * @throws StopActionException
      * @api
      */
-    protected function redirectToUri($uri, $delay = 0, $statusCode = 303)
+    protected function redirectToUri($uri, $delay = 0, $statusCode = 303): never
     {
         // the parent method throws the exception, but we need to act afterwards
         // thus the code in catch - it's the expected state

--- a/Neos.Flow/Classes/Mvc/Routing/Dto/MatchResult.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Dto/MatchResult.php
@@ -80,7 +80,7 @@ final class MatchResult
      * Whether this has a lifetime
      *
      * @return bool
-     * @psalm-assert-if-true RouteLifetime $this->getLifetime()
+     * @phpstan-assert-if-true RouteLifetime $this->getLifetime()
      */
     public function hasLifetime(): bool
     {

--- a/Neos.Flow/Classes/Mvc/Routing/Dto/ResolveResult.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Dto/ResolveResult.php
@@ -105,7 +105,7 @@ final class ResolveResult
      * Whether this result has a lifetime
      *
      * @return bool
-     * @psalm-assert-if-true RouteLifetime $this->getLifetime()
+     * @phpstan-assert-if-true RouteLifetime $this->getLifetime()
      */
     public function hasLifetime(): bool
     {

--- a/Neos.Flow/Classes/Mvc/Routing/ObjectPathMapping.php
+++ b/Neos.Flow/Classes/Mvc/Routing/ObjectPathMapping.php
@@ -31,7 +31,7 @@ class ObjectPathMapping
      * Class name of the object this mapping belongs to
      *
      * @var string
-     * @psalm-var class-string
+     * @phpstan-var class-string
      * @ORM\Id
      * @Flow\Validate(type="NotEmpty")
      */
@@ -111,9 +111,7 @@ class ObjectPathMapping
     }
 
     /**
-     * @param string $objectType
-     *
-     * @psalm-param class-string $objectType
+     * @param class-string $objectType
      */
     public function setObjectType($objectType): void
     {
@@ -121,8 +119,7 @@ class ObjectPathMapping
     }
 
     /**
-     * @return string
-     * @psalm-return class-string
+     * @return class-string
      */
     public function getObjectType()
     {

--- a/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
@@ -543,7 +543,7 @@ class ProxyClassBuilder
      *
      * @return null|string[] PHP code
      *
-     * @psalm-return array{0?: string}|null
+     * @phpstan-return array{0?: string}|null
      */
     protected function buildSetterInjectionCode(string $className, string $propertyName, string $preparedSetterArgument): array|null
     {

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
@@ -125,11 +125,10 @@ class Compiler
      * false will be returned
      *
      * @param string $fullClassName Name of the original class
-     * @return ProxyClass|bool
      */
-    public function getProxyClass(string $fullClassName): bool|ProxyClass
+    public function getProxyClass(string $fullClassName): ProxyClass|false
     {
-        if (interface_exists($fullClassName) || in_array(BaseTestCase::class, class_parents($fullClassName), true)) {
+        if (interface_exists($fullClassName) || (class_exists(BaseTestCase::class) && in_array(BaseTestCase::class, class_parents($fullClassName), true))) {
             return false;
         }
 
@@ -403,6 +402,8 @@ return ' . var_export($this->storedProxyClasses, true) . ';';
 
     private function getClassNameTokenIndex(array $tokens): ?int
     {
+        $classToken = null;
+        $previousToken = null;
         foreach ($tokens as $i => $token) {
             # $token is an array: [0] => token id, [1] => token text, [2] => line number
             if (isset($classToken) && is_array($token) && $token[0] === T_STRING) {

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php
@@ -40,8 +40,7 @@ class ProxyClass
     /**
      * Fully qualified class name of the original class
      *
-     * @var string
-     * @psalm-var class-string
+     * @var class-string
      */
     protected $fullOriginalClassName;
 
@@ -85,8 +84,7 @@ class ProxyClass
     /**
      * Creates a new ProxyClass instance.
      *
-     * @param string $fullOriginalClassName The fully qualified class name of the original class
-     * @psalm-param class-string $fullOriginalClassName
+     * @param class-string $fullOriginalClassName The fully qualified class name of the original class
      */
     public function __construct(string $fullOriginalClassName)
     {
@@ -241,7 +239,6 @@ class ProxyClass
             $methodsCode .= PHP_EOL . $this->constructor->generate();
 
             foreach (class_implements($this->fullOriginalClassName) as $interface) {
-                /** @psalm-suppress ArgumentTypeCoercion */
                 if (method_exists($interface, '__construct')) {
                     throw new CannotBuildObjectException(sprintf('The class "%s" implements the interface "%s" which has a constructor. Proxy classes implementing an interface containing a constructor is not supported and constructors interfaces are generally strongly discouraged.', $this->fullOriginalClassName, $interface), 1685433328);
                 }

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyConstructorGenerator.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyConstructorGenerator.php
@@ -18,6 +18,7 @@ final class ProxyConstructorGenerator extends ProxyMethodGenerator
 {
     private ?string $originalVisibility = null;
 
+    /** @phpstan-ignore-next-line */
     public function __construct($name = null, array $parameters = [], $flags = self::FLAG_PUBLIC, $body = null, $docBlock = null)
     {
         if ($docBlock === null) {

--- a/Neos.Flow/Classes/Persistence/EmptyQueryResult.php
+++ b/Neos.Flow/Classes/Persistence/EmptyQueryResult.php
@@ -66,65 +66,35 @@ class EmptyQueryResult implements QueryResultInterface
         return [];
     }
 
-    /**
-     * @return object Returns NULL in this case
-     */
-    #[\ReturnTypeWillChange]
-    public function current()
+    public function current(): mixed
     {
         return null;
     }
 
-    /**
-     * @return void
-     */
-    #[\ReturnTypeWillChange]
-    public function next()
+    public function next(): void
     {
     }
 
-    /**
-     * @return integer Returns 0 in this case
-     */
-    #[\ReturnTypeWillChange]
-    public function key()
+    public function key(): int
     {
         return 0;
     }
 
-    /**
-     * @return boolean Returns false in this case
-     */
-    #[\ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         return false;
     }
 
-    /**
-     * @return void
-     */
-    #[\ReturnTypeWillChange]
-    public function rewind()
+    public function rewind(): void
     {
     }
 
-    /**
-     * @param mixed $offset
-     * @return boolean Returns false in this case
-     */
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return false;
     }
 
-    /**
-     * @param mixed $offset
-     * @return mixed Returns NULL in this case
-     */
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return null;
     }
@@ -132,27 +102,19 @@ class EmptyQueryResult implements QueryResultInterface
     /**
      * @param mixed $offset The offset is ignored in this case
      * @param mixed $value The value is ignored in this case
-     * @return void
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
     }
 
     /**
      * @param mixed $offset The offset is ignored in this case
-     * @return void
      */
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
     }
 
-    /**
-     * @return integer Returns 0 in this case
-     */
-    #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return 0;
     }

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -385,8 +385,8 @@ class ReflectionService
      * Searches for and returns all names of classes inheriting the specified class.
      * If no class inheriting the given class was found, an empty array is returned.
      *
-     * @psalm-param class-string $className
-     * @psalm-return array<class-string>
+     * @param class-string $className
+     * @return array<class-string>
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
      * @api

--- a/Neos.Flow/Classes/Security/Authentication/Controller/AbstractAuthenticationController.php
+++ b/Neos.Flow/Classes/Security/Authentication/Controller/AbstractAuthenticationController.php
@@ -71,7 +71,7 @@ abstract class AbstractAuthenticationController extends ActionController
      * the according callback methods instead (onAuthenticationSuccess() and
      * onAuthenticationFailure()).
      *
-     * @return string
+     * @return string|null
      * @Flow\SkipCsrfProtection
      */
     public function authenticateAction()
@@ -135,7 +135,7 @@ abstract class AbstractAuthenticationController extends ActionController
      * $this->redirect('someDefaultActionAfterLogin');
      *
      * @param ActionRequest $originalRequest The request that was intercepted by the security framework, NULL if there was none
-     * @return string
+     * @return string|null
      */
     abstract protected function onAuthenticationSuccess(ActionRequest $originalRequest = null);
 
@@ -148,7 +148,7 @@ abstract class AbstractAuthenticationController extends ActionController
      * Note: If you implement a nice redirect in the onAuthenticationFailure()
      * method of you login controller, this message should never be displayed.
      *
-     * @return Error The flash message
+     * @return Error|false The flash message
      * @api
      */
     protected function getErrorFlashMessage()

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
         "test:behavioral": [
             "../../flow doctrine:migrate --quiet",
             "../../bin/behat -f progress -c Neos.Flow/Tests/Behavior/behat.yml"
+        ],
+        "lint": [
+            "../../bin/phpstan analyse"
         ]
     },
     "require": {
@@ -70,11 +73,6 @@
         "neos/utility-pdo": "self.version",
         "neos/utility-schema": "self.version",
         "neos/utility-unicode": "self.version"
-    },
-    "scripts": {
-        "lint": [
-            "../../bin/phpstan analyse"
-        ]
     },
     "suggest": {
         "ext-memcache": "If you have a memcache server and want to use it for caching.",


### PR DESCRIPTION
With https://github.com/neos/flow-development-collection/pull/3218 PHPStan level 1 was added to the whole Flow code base and CI for Flow 8. This upmerged change needs some adjustments to pass the CI in Flow 9

- fix types in code that was introduced with Flow 9
- fix types where neos depends on it (by correcting types and adding `never`)
- adjust unit test as `never` cannot be doubled (eventually this will be fixed via: https://github.com/sebastianbergmann/phpunit/issues/5048)
- fix ci and style as neos 9 followup for https://github.com/neos/flow-development-collection/pull/3218

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] ~The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)~
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
