### PR TITLE
TASK: Use generics via @template instead of PHPSTORM_META

### DIFF
--- a/Neos.Eel/Classes/FlowQuery/OperationResolver.php
+++ b/Neos.Eel/Classes/FlowQuery/OperationResolver.php
@@ -73,7 +73,6 @@ class OperationResolver implements OperationResolverInterface
 
         $reflectionService = $objectManager->get(ReflectionService::class);
         $operationClassNames = $reflectionService->getAllImplementationClassNamesForInterface(OperationInterface::class);
-        /** @var $operationClassName OperationInterface */
         foreach ($operationClassNames as $operationClassName) {
             $shortOperationName = $operationClassName::getShortName();
             $operationPriority = $operationClassName::getPriority();

--- a/Neos.Flow/.phpstorm.meta.php
+++ b/Neos.Flow/.phpstorm.meta.php
@@ -5,17 +5,6 @@
  */
 
 namespace PHPSTORM_META {
-
-    override(
-        \Neos\Flow\ObjectManagement\ObjectManagerInterface::get(),
-        map(['' => '@'])
-    );
-
-    override(
-        \Neos\Flow\Core\Bootstrap::getEarlyInstance(),
-        map(['' => '@'])
-    );
-
     expectedArguments(\Neos\Flow\Annotations\Validate::__construct(), 1, 'AggregateBoundary', 'Alphanumeric', 'Boolean', 'Collection', 'Conjunction', 'Count', 'DateTimeRange', 'DateTime', 'Disjunction', 'EmailAddress', 'Float', 'GenericObject', 'Integer', 'Label', 'LocaleIdentifier', 'NotEmpty', 'NumberRange', 'Number', 'Raw', 'RegularExpresion', 'StringLength', 'Text', 'UniqueEntity', 'Uuid');
 
     expectedArguments(\Neos\Flow\Annotations\Scope::__construct(), 0, 'prototype', 'session', 'singleton');

--- a/Neos.Flow/Classes/Core/Bootstrap.php
+++ b/Neos.Flow/Classes/Core/Bootstrap.php
@@ -362,8 +362,9 @@ class Bootstrap
     /**
      * Returns an instance which was registered earlier through setEarlyInstance()
      *
-     * @param string $objectName Object name of the registered instance
-     * @return object
+     * @template T of object
+     * @param class-string<T> $objectName Object name of the registered instance
+     * @return T
      * @throws FlowException
      * @api
      */

--- a/Neos.Flow/Classes/Core/Bootstrap.php
+++ b/Neos.Flow/Classes/Core/Bootstrap.php
@@ -45,12 +45,12 @@ class Bootstrap
     protected $context;
 
     /**
-     * @var array
+     * @var array<class-string<RequestHandlerInterface>, RequestHandlerInterface>
      */
     protected $requestHandlers = [];
 
     /**
-     * @var string
+     * @var class-string<RequestHandlerInterface>
      */
     protected $preselectedRequestHandlerClassName;
 
@@ -67,12 +67,12 @@ class Bootstrap
     public static $staticObjectManager;
 
     /**
-     * @var array
+     * @var array<string, true>
      */
     protected $compiletimeCommands = [];
 
     /**
-     * @var array
+     * @var array<string|class-string, object>
      */
     protected $earlyInstances = [];
 
@@ -167,7 +167,7 @@ class Bootstrap
      * it will be used if it can handle the request – regardless of the priority
      * of this or other request handlers.
      *
-     * @param string $className
+     * @param class-string<RequestHandlerInterface> $className
      */
     public function setPreselectedRequestHandlerClassName(string $className)
     {
@@ -338,12 +338,11 @@ class Bootstrap
      * On finalizing the Object Manager initialization, all those instances will
      * be transferred to the Object Manager's registry.
      *
-     * @param string $objectName Object name, as later used by the Object Manager
+     * @param string|class-string $objectName Object name, as later used by the Object Manager
      * @param object $instance The instance to register
-     * @return void
      * @api
      */
-    public function setEarlyInstance(string $objectName, $instance)
+    public function setEarlyInstance(string $objectName, object $instance): void
     {
         $this->earlyInstances[$objectName] = $instance;
     }
@@ -356,14 +355,15 @@ class Bootstrap
      */
     public function getSignalSlotDispatcher(): Dispatcher
     {
-        return $this->earlyInstances[Dispatcher::class];
+        return $this->getEarlyInstance(Dispatcher::class);
     }
 
     /**
      * Returns an instance which was registered earlier through setEarlyInstance()
      *
      * @template T of object
-     * @param class-string<T> $objectName Object name of the registered instance
+     * @param class-string<T>|string $objectName Object name of the registered instance
+     * @phpstan-return ($objectName is class-string<T> ? T : object)
      * @return T
      * @throws FlowException
      * @api
@@ -379,7 +379,7 @@ class Bootstrap
     /**
      * Returns all registered early instances indexed by object name
      *
-     * @return array
+     * @return array<string|class-string, object>
      */
     public function getEarlyInstances(): array
     {
@@ -394,11 +394,11 @@ class Bootstrap
      */
     public function getObjectManager(): ObjectManagerInterface
     {
-        if (!isset($this->earlyInstances[ObjectManagerInterface::class])) {
-            debug_print_backtrace();
+        try {
+            return $this->getEarlyInstance(ObjectManagerInterface::class);
+        } catch (FlowException) {
             throw new FlowException('The Object Manager is not available at this stage of the bootstrap run.', 1301120788);
         }
-        return $this->earlyInstances[ObjectManagerInterface::class];
     }
 
     /**
@@ -410,14 +410,12 @@ class Bootstrap
     protected function resolveRequestHandler(): RequestHandlerInterface
     {
         if ($this->preselectedRequestHandlerClassName !== null && isset($this->requestHandlers[$this->preselectedRequestHandlerClassName])) {
-            /** @var RequestHandlerInterface $requestHandler */
             $requestHandler = $this->requestHandlers[$this->preselectedRequestHandlerClassName];
             if ($requestHandler->canHandleRequest()) {
                 return $requestHandler;
             }
         }
 
-        /** @var RequestHandlerInterface $requestHandler */
         foreach ($this->requestHandlers as $requestHandler) {
             if ($requestHandler->canHandleRequest() > 0) {
                 $priority = $requestHandler->getPriority();
@@ -442,7 +440,7 @@ class Bootstrap
      */
     protected function emitFinishedCompiletimeRun()
     {
-        $this->earlyInstances[Dispatcher::class]->dispatch(__CLASS__, 'finishedCompiletimeRun', []);
+        $this->getSignalSlotDispatcher()->dispatch(__CLASS__, 'finishedCompiletimeRun', []);
     }
 
     /**
@@ -453,7 +451,7 @@ class Bootstrap
      */
     protected function emitFinishedRuntimeRun()
     {
-        $this->earlyInstances[Dispatcher::class]->dispatch(__CLASS__, 'finishedRuntimeRun', []);
+        $this->getSignalSlotDispatcher()->dispatch(__CLASS__, 'finishedRuntimeRun', []);
     }
 
     /**
@@ -465,7 +463,7 @@ class Bootstrap
      */
     protected function emitBootstrapShuttingDown(string $runLevel)
     {
-        $this->earlyInstances[Dispatcher::class]->dispatch(__CLASS__, 'bootstrapShuttingDown', [$runLevel]);
+        $this->getSignalSlotDispatcher()->dispatch(__CLASS__, 'bootstrapShuttingDown', [$runLevel]);
     }
 
     /**

--- a/Neos.Flow/Classes/ObjectManagement/CompileTimeObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/CompileTimeObjectManager.php
@@ -364,9 +364,10 @@ class CompileTimeObjectManager extends ObjectManager
      * This specialized get() method is able to do setter injection for properties
      * defined in the object configuration of the specified object.
      *
-     * @param string $objectName The name of the object to return an instance of
+     * @template T of object
+     * @param class-string<T> $objectName The name of the object to return an instance of
      * @param mixed ...$constructorArguments Any number of arguments that should be passed to the constructor of the object
-     * @return object The object instance
+     * @return T The object instance
      * @throws \Neos\Flow\ObjectManagement\Exception\CannotBuildObjectException
      * @throws \Neos\Flow\ObjectManagement\Exception\UnresolvedDependenciesException
      * @throws \Neos\Flow\ObjectManagement\Exception\UnknownObjectException

--- a/Neos.Flow/Classes/ObjectManagement/CompileTimeObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/CompileTimeObjectManager.php
@@ -365,8 +365,9 @@ class CompileTimeObjectManager extends ObjectManager
      * defined in the object configuration of the specified object.
      *
      * @template T of object
-     * @param class-string<T> $objectName The name of the object to return an instance of
+     * @param class-string<T>|string $objectName The name of the object to return an instance of
      * @param mixed ...$constructorArguments Any number of arguments that should be passed to the constructor of the object
+     * @phpstan-return ($objectName is class-string<T> ? T : object) The object instance
      * @return T The object instance
      * @throws \Neos\Flow\ObjectManagement\Exception\CannotBuildObjectException
      * @throws \Neos\Flow\ObjectManagement\Exception\UnresolvedDependenciesException

--- a/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
@@ -180,8 +180,9 @@ class ObjectManager implements ObjectManagerInterface
      * Returns a fresh or existing instance of the object specified by $objectName.
      *
      * @template T of object
-     * @param class-string<T> $objectName The name of the object to return an instance of
+     * @param class-string<T>|string $objectName The name of the object to return an instance of
      * @param mixed ...$constructorArguments Any number of arguments that should be passed to the constructor of the object
+     * @phpstan-return ($objectName is class-string<T> ? T : object) The object instance
      * @return T The object instance
      * @throws Exception\CannotBuildObjectException
      * @throws Exception\UnknownObjectException if an object with the given name does not exist
@@ -370,7 +371,8 @@ class ObjectManager implements ObjectManagerInterface
      * registered yet.
      *
      * @template T of object
-     * @param class-string<T> $objectName The object name
+     * @param class-string<T>|string $objectName The object name
+     * @phpstan-return ($objectName is class-string<T> ? T|null : object|null) The object instance or null
      * @return T|null The object instance or null
      */
     public function getInstance($objectName)

--- a/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
@@ -179,9 +179,10 @@ class ObjectManager implements ObjectManagerInterface
     /**
      * Returns a fresh or existing instance of the object specified by $objectName.
      *
-     * @param string $objectName The name of the object to return an instance of
+     * @template T of object
+     * @param class-string<T> $objectName The name of the object to return an instance of
      * @param mixed ...$constructorArguments Any number of arguments that should be passed to the constructor of the object
-     * @return object The object instance
+     * @return T The object instance
      * @throws Exception\CannotBuildObjectException
      * @throws Exception\UnknownObjectException if an object with the given name does not exist
      * @throws \InvalidArgumentException
@@ -368,8 +369,9 @@ class ObjectManager implements ObjectManagerInterface
      * Returns the instance of the specified object or NULL if no instance has been
      * registered yet.
      *
-     * @param string $objectName The object name
-     * @return object The object or NULL
+     * @template T of object
+     * @param class-string<T> $objectName The object name
+     * @return T|null The object instance or null
      */
     public function getInstance($objectName)
     {

--- a/Neos.Flow/Classes/ObjectManagement/ObjectManagerInterface.php
+++ b/Neos.Flow/Classes/ObjectManagement/ObjectManagerInterface.php
@@ -43,9 +43,10 @@ interface ObjectManagerInterface extends ContainerInterface
      * new keyword and Singleton objects should rather be injected by some type of
      * Dependency Injection.
      *
-     * @param string $objectName The name of the object to return an instance of
-     * @param mixed[] ...$constructorArguments Any number of arguments that should be passed to the constructor of the object
-     * @return object The object instance
+     * @template T of object
+     * @param class-string<T> $objectName The name of the object to return an instance of
+     * @param mixed ...$constructorArguments Any number of arguments that should be passed to the constructor of the object
+     * @return T The object instance
      * @api
      */
     public function get($objectName, ...$constructorArguments);

--- a/Neos.Flow/Classes/ObjectManagement/ObjectManagerInterface.php
+++ b/Neos.Flow/Classes/ObjectManagement/ObjectManagerInterface.php
@@ -44,8 +44,9 @@ interface ObjectManagerInterface extends ContainerInterface
      * Dependency Injection.
      *
      * @template T of object
-     * @param class-string<T> $objectName The name of the object to return an instance of
+     * @param class-string<T>|string $objectName The name of the object to return an instance of
      * @param mixed ...$constructorArguments Any number of arguments that should be passed to the constructor of the object
+     * @phpstan-return ($objectName is class-string<T> ? T : object) The object instance
      * @return T The object instance
      * @api
      */

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -362,6 +362,9 @@ class ReflectionService
      * Searches for and returns all class names of implementations of the given object type
      * (interface name). If no class implementing the interface was found, an empty array is returned.
      *
+     * @template T of object
+     * @param class-string<T> $interfaceName
+     * @return list<class-string<T>>
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
      * @api

--- a/Neos.Utility.Arrays/Classes/ValueAccessor.php
+++ b/Neos.Utility.Arrays/Classes/ValueAccessor.php
@@ -80,9 +80,9 @@ class ValueAccessor
     }
 
     /**
-     * @template T
+     * @template T of object
      * @param class-string<T> $className
-     * @return object&T
+     * @return T
      */
     public function instanceOf(string $className): object
     {
@@ -144,9 +144,9 @@ class ValueAccessor
     }
 
     /**
-     * @template T
+     * @template T of object
      * @param class-string<T> $className
-     * @return (object&T)|null
+     * @return T|null
      */
     public function instanceOfOrNull(string $className): ?object
     {


### PR DESCRIPTION
Since the php universe evolved im gonna try https://github.com/neos/flow-development-collection/pull/2753 again ;)

Adds typings to:

\Neos\Flow\ObjectManagement\ObjectManagerInterface::get()

and

\Neos\Flow\Core\Bootstrap::getEarlyInstance()

by usage of the @template tag: https://phpstan.org/writing-php-code/phpdocs-basics#generics

This feature is supported by phpstorm, psalm and phpstan and also used widely in Neos 9

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
