### PR TITLE
TASK: Remove persistence clone magic

### DIFF
--- a/Neos.Flow/Classes/Persistence/Aspect/PersistenceMagicAspect.php
+++ b/Neos.Flow/Classes/Persistence/Aspect/PersistenceMagicAspect.php
@@ -140,19 +140,4 @@ class PersistenceMagicAspect
         $proxy = $joinPoint->getProxy();
         ObjectAccess::setProperty($proxy, 'Persistence_Object_Identifier', sha1($serializedSource), true);
     }
-
-    /**
-     * Mark object as cloned after cloning.
-     *
-     * Note: this is not used by anything in the Flow base distribution,
-     * but might be needed by custom backends (like Neos.CouchDB).
-     *
-     * @param JoinPointInterface $joinPoint
-     * @return void
-     * @Flow\AfterReturning("Neos\Flow\Persistence\Aspect\PersistenceMagicAspect->isEntityOrValueObject && method(.*->__clone())")
-     */
-    public function cloneObject(JoinPointInterface $joinPoint)
-    {
-        $joinPoint->getProxy()->Flow_Persistence_clone = true;
-    }
 }

--- a/Neos.Flow/Tests/Functional/Persistence/Aspect/PersistenceMagicAspectTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Aspect/PersistenceMagicAspectTest.php
@@ -57,18 +57,6 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function aspectFlagsClonedEntities()
-    {
-        $entity = new Fixtures\AnnotatedIdEntity();
-        $clonedEntity = clone $entity;
-        self::assertObjectNotHasAttribute('Flow_Persistence_clone', $entity);
-        $this->assertObjectHasAttribute('Flow_Persistence_clone', $clonedEntity);
-        self::assertTrue($clonedEntity->Flow_Persistence_clone);
-    }
-
-    /**
-     * @test
-     */
     public function valueHashIsGeneratedForValueObjects()
     {
         $valueObject = new Fixtures\TestValueObject('value');

--- a/Neos.Flow/Tests/Unit/Persistence/Aspect/PersistenceMagicAspectTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Aspect/PersistenceMagicAspectTest.php
@@ -53,19 +53,6 @@ class PersistenceMagicAspectTest extends UnitTestCase
      * @test
      * @return void
      */
-    public function cloneObjectMarksTheObjectAsCloned()
-    {
-        $object = new \stdClass();
-        $this->mockJoinPoint->expects(self::any())->method('getProxy')->will(self::returnValue($object));
-
-        $this->persistenceMagicAspect->cloneObject($this->mockJoinPoint);
-        self::assertTrue($object->Flow_Persistence_clone);
-    }
-
-    /**
-     * @test
-     * @return void
-     */
     public function generateUuidGeneratesUuidAndRegistersProxyAsNewObject()
     {
         $className = 'Class' . md5(uniqid(mt_rand(), true));

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/PersistentObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/PersistentObjectConverterTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
  * source code.
  */
 
+use Doctrine\ORM\Query\Expr\Comparison;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Fixtures\ClassWithSetters;
 use Neos\Flow\Fixtures\ClassWithSettersAndConstructor;
@@ -27,6 +28,7 @@ use Neos\Flow\Property\TypeConverterInterface;
 use Neos\Flow\Reflection\ClassSchema;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Tests\UnitTestCase;
+use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
 
 require_once(__DIR__ . '/../../Fixtures/ClassWithSetters.php');
 require_once(__DIR__ . '/../../Fixtures/ClassWithSettersAndConstructor.php');
@@ -298,16 +300,16 @@ class PersistentObjectConverterTest extends UnitTestCase
 
     /**
      * @param integer $numberOfResults
-     * @param \PHPUnit_Framework_MockObject_Matcher_Invocation $howOftenIsGetFirstCalled
+     * @param InvocationOrder $howOftenIsGetFirstCalled
      * @return \stdClass
      */
     protected function setUpMockQuery($numberOfResults, $howOftenIsGetFirstCalled)
     {
-        $mockClassSchema = $this->createMock(ClassSchema::class, [], ['Dummy']);
+        $mockClassSchema = $this->createMock(ClassSchema::class);
         $mockClassSchema->expects(self::once())->method('getIdentityProperties')->will(self::returnValue(['key1' => 'someType']));
         $this->mockReflectionService->expects(self::once())->method('getClassSchema')->with('SomeType')->will(self::returnValue($mockClassSchema));
 
-        $mockConstraint = $this->getMockBuilder(Persistence\Generic\Qom\Comparison::class)->disableOriginalConstructor()->getMock();
+        $mockConstraint = $this->getMockBuilder(Comparison::class)->disableOriginalConstructor()->getMock();
 
         $mockObject = new \stdClass();
         $mockQuery = $this->createMock(Persistence\QueryInterface::class);


### PR DESCRIPTION
This removed the code that set `Flow_Persistence_clone` in entities or value objects when they were `clone`d.

As dynamic properties are deprecated with PHP 8.2, this caused warnings and will eventually break.

Since this was (re)-introduced in Flow 2 via 90cb65827c1550e9144e9f83b9231b430c106660 to support custom backends in the geenric persistence layer of Flow, like the (now outdated) `TYPO3.CouchDB`, we felt it is best to remove it.

**Upgrade instructions**

If you rely on this, you need to adjust your code. Chances are, if you still need this, you use the generic peristsnece layer, which is gone in Flow 7 aready (see https://github.com/neos/flow-development-collection/pull/1769 and https://github.com/neos/flow-development-collection/pull/2262). So, you have other problems to solve, anyway…

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [ ] ~The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)~
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
