### PR TITLE
FEATURE: Add depth option to `configuration:show`

### DIFF
--- a/Neos.Flow/Classes/Command/ConfigurationCommandController.php
+++ b/Neos.Flow/Classes/Command/ConfigurationCommandController.php
@@ -62,18 +62,18 @@ class ConfigurationCommandController extends CommandController
      *
      * @param string $type Configuration type to show, defaults to Settings
      * @param string $path path to subconfiguration separated by "." like "Neos.Flow"
-     * @param int $level Truncate the configuration at this depth and show '...'
+     * @param int $depth Truncate the configuration at this depth and show '...'
      * @return void
      */
-    public function showCommand(string $type = 'Settings', ?string $path = null, int $level = 0)
+    public function showCommand(string $type = 'Settings', string $path = '', int $depth = 0)
     {
         $availableConfigurationTypes = $this->configurationManager->getAvailableConfigurationTypes();
         if (in_array($type, $availableConfigurationTypes)) {
             $configuration = $this->configurationManager->getConfiguration($type);
-            if ($path !== null) {
+            if ($path !== '') {
                 $configuration = Arrays::getValueByPath($configuration, $path);
             }
-            $configuration = self::truncateArrayAtLevel($configuration, $level);
+            $configuration = self::truncateArrayAtDepth($configuration, $depth);
             $typeAndPath = $type . ($path ? ': ' . $path : '');
             if ($configuration === null) {
                 $this->outputLine('<b>Configuration "%s" was empty!</b>', [$typeAndPath]);
@@ -96,17 +96,17 @@ class ConfigurationCommandController extends CommandController
     }
 
     /**
-     * @param int $truncateLevel 0 for no truncation and 1 to only show the first keys of the array
+     * @param int $maximumDepth 0 for no truncation and 1 to only show the first keys of the array
      * @param int $currentLevel 1 for the start and will be incremented recursively
      */
-    private static function truncateArrayAtLevel(array $array, int $truncateLevel, int $currentLevel = 1): array
+    private static function truncateArrayAtDepth(array $array, int $maximumDepth, int $currentLevel = 1): array
     {
-        if ($truncateLevel <= 0) {
+        if ($maximumDepth <= 0) {
             return $array;
         }
         $truncatedArray = [];
         foreach ($array as $key => $value) {
-            if ($currentLevel >= $truncateLevel) {
+            if ($currentLevel >= $maximumDepth) {
                 $truncatedArray[$key] = '...'; // truncated
                 continue;
             }
@@ -114,7 +114,7 @@ class ConfigurationCommandController extends CommandController
                 $truncatedArray[$key] = $value;
                 continue;
             }
-            $truncatedArray[$key] = self::truncateArrayAtLevel($value, $truncateLevel, $currentLevel + 1);
+            $truncatedArray[$key] = self::truncateArrayAtDepth($value, $maximumDepth, $currentLevel + 1);
         }
         return $truncatedArray;
     }

--- a/Neos.Flow/Classes/Command/ConfigurationCommandController.php
+++ b/Neos.Flow/Classes/Command/ConfigurationCommandController.php
@@ -62,9 +62,10 @@ class ConfigurationCommandController extends CommandController
      *
      * @param string $type Configuration type to show, defaults to Settings
      * @param string $path path to subconfiguration separated by "." like "Neos.Flow"
+     * @param int $level Truncate the configuration at this depth and show '...'
      * @return void
      */
-    public function showCommand(string $type = 'Settings', ?string $path = null)
+    public function showCommand(string $type = 'Settings', ?string $path = null, int $level = 0)
     {
         $availableConfigurationTypes = $this->configurationManager->getAvailableConfigurationTypes();
         if (in_array($type, $availableConfigurationTypes)) {
@@ -72,6 +73,7 @@ class ConfigurationCommandController extends CommandController
             if ($path !== null) {
                 $configuration = Arrays::getValueByPath($configuration, $path);
             }
+            $configuration = self::truncateArrayAtLevel($configuration, $level);
             $typeAndPath = $type . ($path ? ': ' . $path : '');
             if ($configuration === null) {
                 $this->outputLine('<b>Configuration "%s" was empty!</b>', [$typeAndPath]);
@@ -91,6 +93,30 @@ class ConfigurationCommandController extends CommandController
             $this->outputLine('Hint: <b>%s configuration:show --type <configurationType></b>', [$this->getFlowInvocationString()]);
             $this->outputLine('      shows the configuration of the specified type.');
         }
+    }
+
+    /**
+     * @param int $truncateLevel 0 for no truncation and 1 to only show the first keys of the array
+     * @param int $currentLevel 1 for the start and will be incremented recursively
+     */
+    private static function truncateArrayAtLevel(array $array, int $truncateLevel, int $currentLevel = 1): array
+    {
+        if ($truncateLevel <= 0) {
+            return $array;
+        }
+        $truncatedArray = [];
+        foreach ($array as $key => $value) {
+            if ($currentLevel >= $truncateLevel) {
+                $truncatedArray[$key] = '...'; // truncated
+                continue;
+            }
+            if (!is_array($value)) {
+                $truncatedArray[$key] = $value;
+                continue;
+            }
+            $truncatedArray[$key] = self::truncateArrayAtLevel($value, $truncateLevel, $currentLevel + 1);
+        }
+        return $truncatedArray;
     }
 
     /**


### PR DESCRIPTION
This introduces similar to https://github.com/neos/neos-development-collection/pull/4619 a `--depth` option to `flow configuration:show`. It helps when inspecting large nested configuration parts and for scouting out only the first few keys:

```
./flow configuration:show --path Neos.Neos.userInterface.inspector --depth 2
Configuration "Settings: Neos.Neos.userInterface.inspector":

dataTypes:
    string: ...
    integer: ...
    boolean: ...
    array: ...
    Neos\Media\Domain\Model\ImageInterface: ...
    Neos\Media\Domain\Model\Asset: ...
    array<Neos\Media\Domain\Model\Asset>: ...
    DateTime: ...
    reference: ...
    references: ...
editors:
    Neos.Neos/Inspector/Editors/CodeEditor: ...
    Neos.Neos/Inspector/Editors/DateTimeEditor: ...
    Neos.Neos/Inspector/Editors/AssetEditor: ...
    Neos.Neos/Inspector/Editors/ImageEditor: ...
    Neos.Neos/Inspector/Editors/LinkEditor: ...
    Neos.Neos/Inspector/Editors/ReferencesEditor: ...
    Neos.Neos/Inspector/Editors/ReferenceEditor: ...
    Neos.Neos/Inspector/Editors/SelectBoxEditor: ...
```

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
