### PR TITLE
BUGFIX: Return the expected result for `is_dir('resource://sha1')`

### DIFF
--- a/Neos.Flow/Classes/ResourceManagement/Streams/ResourceStreamWrapper.php
+++ b/Neos.Flow/Classes/ResourceManagement/Streams/ResourceStreamWrapper.php
@@ -475,7 +475,11 @@ class ResourceStreamWrapper implements StreamWrapperInterface
      */
     public function pathStat($path, $flags)
     {
-        return @stat($this->evaluateResourcePath($path));
+        $evaluatedResourcePath = $this->evaluateResourcePath($path);
+        if (is_resource($evaluatedResourcePath)) {
+            return @fstat($evaluatedResourcePath);
+        }
+        return @stat($evaluatedResourcePath);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/ResourceManagement/Streams/ResourceStreamWrapperTest.php
+++ b/Neos.Flow/Tests/Unit/ResourceManagement/Streams/ResourceStreamWrapperTest.php
@@ -103,6 +103,22 @@ class ResourceStreamWrapperTest extends UnitTestCase
     /**
      * @test
      */
+    public function resourceStreamWrapperAllowsStatOfValidResourceLinks()
+    {
+        $sha1Hash = '68ac906495480a3404beee4874ed853a037a7a8f';
+
+        $tempFile = tmpfile();
+
+        $mockResource = $this->getMockBuilder(PersistentResource::class)->disableOriginalConstructor()->getMock();
+        $this->mockResourceManager->expects(self::once())->method('getResourceBySha1')->with($sha1Hash)->will(self::returnValue($mockResource));
+        $this->mockResourceManager->expects(self::once())->method('getStreamByResource')->with($mockResource)->will(self::returnValue($tempFile));
+
+        self::assertIsArray($this->resourceStreamWrapper->pathStat('resource://' . $sha1Hash, 0));
+    }
+
+    /**
+     * @test
+     */
     public function openThrowsExceptionForNonExistingPackages()
     {
         $this->expectException(Exception::class);


### PR DESCRIPTION
Fixes #3225

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
