### PR TITLE
BUGFIX: Make new object debug output more robust

### DIFF
--- a/Neos.Eel/Classes/Context.php
+++ b/Neos.Eel/Classes/Context.php
@@ -200,17 +200,4 @@ class Context
         }
         return $this;
     }
-
-    /**
-     * @return string
-     */
-    public function __toString()
-    {
-        return sprintf('[%s%s]', gettype($this->value), match (true) {
-            is_object($this->value) => ' ' . get_class($this->value),
-            is_array($this->value) => ' length=' . count($this->value),
-            is_string($this->value)  => ' length=' . strlen($this->value),
-            default => ''
-        });
-    }
 }

--- a/Neos.Eel/Classes/Context.php
+++ b/Neos.Eel/Classes/Context.php
@@ -206,9 +206,11 @@ class Context
      */
     public function __toString()
     {
-        if (is_object($this->value) && !method_exists($this->value, '__toString')) {
-            return '[object ' . get_class($this->value) . ']';
-        }
-        return (string)$this->value;
+        return sprintf('[%s%s]', gettype($this->value), match (true) {
+            is_object($this->value) => ' ' . get_class($this->value),
+            is_array($this->value) => ' length=' . count($this->value),
+            is_string($this->value)  => ' length=' . strlen($this->value),
+            default => ''
+        });
     }
 }

--- a/Neos.Eel/Classes/InterpretedEelParser.php
+++ b/Neos.Eel/Classes/InterpretedEelParser.php
@@ -226,20 +226,19 @@ class InterpretedEelParser extends EelParser
 
     public function SumCalculation_rgt(&$result, $sub)
     {
-        $lval = $result['val'];
-        $rval = $sub['val'];
+        $lval = $this->unwrap($result['val']);
+        $rval = $this->unwrap($sub['val']);
 
         switch ($result['op']) {
             case '+':
                 if (is_string($lval) || is_string($rval)) {
-                    // Do not unwrap here and use better __toString handling of Context
                     $result['val'] = $lval . $rval;
                 } else {
-                    $result['val'] = $this->unwrap($lval) + $this->unwrap($rval);
+                    $result['val'] = $lval + $rval;
                 }
                 break;
             case '-':
-                $result['val'] = $this->unwrap($lval) - $this->unwrap($rval);
+                $result['val'] = $lval - $rval;
                 break;
         }
     }

--- a/Neos.Flow/Classes/Error/Debugger.php
+++ b/Neos.Flow/Classes/Error/Debugger.php
@@ -467,7 +467,10 @@ class Debugger
     protected static function getObjectSnippetPlaintext(object $object): string
     {
         if (is_callable([$object, '__toString'])) {
-            return self::getObjectShortName($object) . '|' . self::truncateObjectOutput((string)$object) . '|';
+            try {
+                $string = (string)$object;
+                return self::getObjectShortName($object) . '|' . self::truncateObjectOutput($string) . '|';
+            } catch (\Throwable $_) {/* This can happen if what was callable was not actually __toString (a magic __call() will do that) we can try other ways to get information. */}
         }
 
         if ($object instanceof \JsonSerializable) {

--- a/Neos.Flow/Classes/Error/Debugger.php
+++ b/Neos.Flow/Classes/Error/Debugger.php
@@ -466,7 +466,7 @@ class Debugger
 
     protected static function getObjectSnippetPlaintext(object $object): string
     {
-        if (method_exists([$object, '__toString'])) {
+        if (method_exists($object, '__toString')) {
             try {
                 $string = (string)$object;
                 return self::getObjectShortName($object) . '|' . self::truncateObjectOutput($string) . '|';

--- a/Neos.Flow/Classes/Error/Debugger.php
+++ b/Neos.Flow/Classes/Error/Debugger.php
@@ -466,7 +466,7 @@ class Debugger
 
     protected static function getObjectSnippetPlaintext(object $object): string
     {
-        if (is_callable([$object, '__toString'])) {
+        if (method_exists([$object, '__toString'])) {
             try {
                 $string = (string)$object;
                 return self::getObjectShortName($object) . '|' . self::truncateObjectOutput($string) . '|';

--- a/Neos.Flow/Classes/Error/Debugger.php
+++ b/Neos.Flow/Classes/Error/Debugger.php
@@ -470,7 +470,8 @@ class Debugger
             try {
                 $string = (string)$object;
                 return self::getObjectShortName($object) . '|' . self::truncateObjectOutput($string) . '|';
-            } catch (\Throwable $_) {/* This can happen if what was callable was not actually __toString (a magic __call() will do that) we can try other ways to get information. */}
+            } catch (\Throwable $_) {/* This can happen if what was callable was not actually __toString (a magic __call() will do that) we can try other ways to get information. */
+            }
         }
 
         if ($object instanceof \JsonSerializable) {


### PR DESCRIPTION
Unfortunately magic methods are tricky and __toString is no exception, a check if it's callable can result in true if the magic __call method is implemented but then the results of this call are completely undefined and therefore catching errors and continuing with other options is a good safeguard here.

Noticed this when I had an error in the `Mvc\Arguments` implementation which declares __call.

Followup to https://github.com/neos/flow-development-collection/pull/3211
