### PR TITLE
BUGFIX: Set InvalidHashException status code to 400

### DIFF
--- a/Neos.Flow/Classes/Security/Exception/InvalidHashException.php
+++ b/Neos.Flow/Classes/Security/Exception/InvalidHashException.php
@@ -18,4 +18,5 @@ namespace Neos\Flow\Security\Exception;
  */
 class InvalidHashException extends \Neos\Flow\Security\Exception
 {
+    protected $statusCode = 400;
 }


### PR DESCRIPTION
`InvalidHashException` now declares `400` as it's status code (not the inherited `500` it has now), as that is clearly a case of a "bad request".

See #3159

**Upgrade instructions**

This might need adjustment, if you rely on the `InvalidHashException` throwing a status code of `500` somewhere.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
