### PR TITLE
TASK: Update default .htaccess for _Resources

### DIFF
--- a/Neos.Flow/Resources/Private/Installer/Distribution/Defaults/Web/_Resources/.htaccess
+++ b/Neos.Flow/Resources/Private/Installer/Distribution/Defaults/Web/_Resources/.htaccess
@@ -8,9 +8,9 @@ SetHandler default-handler
   SetHandler default-handler
 </Files>
 
-<IfModule mod_php5.c>
+<IfModule mod_php7.c>
   php_flag engine off
 </IfModule>
-<IfModule mod_php7.c>
+<IfModule mod_php.c>
   php_flag engine off
 </IfModule>


### PR DESCRIPTION
PHP 5 is a thing of the past, but for PHP 8 the module is name just `mod_php.c`, so that needs to be added.

**Upgrade instructions**

Depending in the way you deploy and whether you have that file even in version control, the change might need to be applied manually to your setup.

**Review instructions**

**Checklist**

- [ ] ~Code follows the PSR-2 coding style~
- [ ] ~Tests have been created, run and adjusted as needed~
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
