### PR TITLE
!!! FEATURE: Extract `LowLevelFrontendInterface` and implement PSR-6 and PSR-16 as cache frontends to be used via `Caches.yaml`

### DIFF
--- a/Neos.Cache/Classes/Backend/AbstractBackend.php
+++ b/Neos.Cache/Classes/Backend/AbstractBackend.php
@@ -14,7 +14,7 @@ namespace Neos\Cache\Backend;
  */
 
 use Neos\Cache\EnvironmentConfiguration;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 
 /**
  * An abstract caching backend
@@ -28,7 +28,7 @@ abstract class AbstractBackend implements BackendInterface
 
     /**
      * Reference to the cache frontend which uses this backend
-     * @var FrontendInterface
+     * @var LowLevelFrontendInterface
      */
     protected $cache;
 
@@ -109,11 +109,11 @@ abstract class AbstractBackend implements BackendInterface
     /**
      * Sets a reference to the cache frontend which uses this backend
      *
-     * @param FrontendInterface $cache The frontend for this backend
+     * @param LowLevelFrontendInterface $cache The frontend for this backend
      * @return void
      * @api
      */
-    public function setCache(FrontendInterface $cache): void
+    public function setCache(LowLevelFrontendInterface $cache): void
     {
         $this->cache = $cache;
         $this->cacheIdentifier = $this->cache->getIdentifier();

--- a/Neos.Cache/Classes/Backend/ApcuBackend.php
+++ b/Neos.Cache/Classes/Backend/ApcuBackend.php
@@ -16,7 +16,7 @@ namespace Neos\Cache\Backend;
 use Neos\Cache\Backend\AbstractBackend as IndependentAbstractBackend;
 use Neos\Cache\EnvironmentConfiguration;
 use Neos\Cache\Exception;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 
 /**
  * A caching backend which stores cache entries by using APCu.
@@ -76,10 +76,10 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
     /**
      * Initializes the identifier prefix when setting the cache.
      *
-     * @param FrontendInterface $cache
+     * @param LowLevelFrontendInterface $cache
      * @return void
      */
-    public function setCache(FrontendInterface $cache): void
+    public function setCache(LowLevelFrontendInterface $cache): void
     {
         parent::setCache($cache);
 
@@ -119,7 +119,7 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
      */
     public function set(string $entryIdentifier, string $data, array $tags = [], int $lifetime = null): void
     {
-        if (!$this->cache instanceof FrontendInterface) {
+        if (!$this->cache instanceof LowLevelFrontendInterface) {
             throw new Exception('No cache frontend has been set yet via setCache().', 1232986818);
         }
 
@@ -222,7 +222,7 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
      */
     public function flush(): void
     {
-        if (!$this->cache instanceof FrontendInterface) {
+        if (!$this->cache instanceof LowLevelFrontendInterface) {
             throw new Exception('Yet no cache frontend has been set via setCache().', 1232986971);
         }
         $this->flushByTag('%APCUBE%' . $this->cacheIdentifier);

--- a/Neos.Cache/Classes/Backend/BackendInterface.php
+++ b/Neos.Cache/Classes/Backend/BackendInterface.php
@@ -13,7 +13,7 @@ namespace Neos\Cache\Backend;
  * source code.
  */
 
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 
 /**
  * A contract for a Cache Backend
@@ -25,11 +25,11 @@ interface BackendInterface
     /**
      * Sets a reference to the cache frontend which uses this backend
      *
-     * @param FrontendInterface $cache The frontend for this backend
+     * @param LowLevelFrontendInterface $cache The frontend for this backend
      * @return void
      * @api
      */
-    public function setCache(FrontendInterface $cache): void;
+    public function setCache(LowLevelFrontendInterface $cache): void;
 
     /**
      * Returns the internally used, prefixed entry identifier for the given public

--- a/Neos.Cache/Classes/Backend/FileBackend.php
+++ b/Neos.Cache/Classes/Backend/FileBackend.php
@@ -14,7 +14,7 @@ namespace Neos\Cache\Backend;
  */
 
 use Neos\Cache\Exception;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 use Neos\Utility\Exception\FilesException;
 use Neos\Utility\Files;
 use Neos\Utility\OpcodeCacheHelper;
@@ -115,11 +115,11 @@ class FileBackend extends SimpleFileBackend implements PhpCapableBackendInterfac
      * This method also detects if this backend is frozen and sets the internal
      * flag accordingly.
      *
-     * @param FrontendInterface $cache The cache frontend
+     * @param LowLevelFrontendInterface $cache The cache frontend
      * @return void
      * @throws Exception
      */
-    public function setCache(FrontendInterface $cache): void
+    public function setCache(LowLevelFrontendInterface $cache): void
     {
         parent::setCache($cache);
 

--- a/Neos.Cache/Classes/Backend/MemcachedBackend.php
+++ b/Neos.Cache/Classes/Backend/MemcachedBackend.php
@@ -16,7 +16,7 @@ namespace Neos\Cache\Backend;
 use Neos\Cache\Backend\AbstractBackend as IndependentAbstractBackend;
 use Neos\Cache\EnvironmentConfiguration;
 use Neos\Cache\Exception;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 
 /**
  * A caching backend which stores cache entries by using Memcache/Memcached.
@@ -158,10 +158,10 @@ class MemcachedBackend extends IndependentAbstractBackend implements TaggableBac
     /**
      * Initializes the identifier prefix when setting the cache.
      *
-     * @param FrontendInterface $cache
+     * @param LowLevelFrontendInterface $cache
      * @return void
      */
-    public function setCache(FrontendInterface $cache): void
+    public function setCache(LowLevelFrontendInterface $cache): void
     {
         parent::setCache($cache);
 
@@ -204,7 +204,7 @@ class MemcachedBackend extends IndependentAbstractBackend implements TaggableBac
         if (strlen($this->getPrefixedIdentifier($entryIdentifier)) > 250) {
             throw new \InvalidArgumentException('Could not set value. Key more than 250 characters (' . $this->getPrefixedIdentifier($entryIdentifier) . ').', 1232969508);
         }
-        if (!$this->cache instanceof FrontendInterface) {
+        if (!$this->cache instanceof LowLevelFrontendInterface) {
             throw new Exception('No cache frontend has been set yet via setCache().', 1207149215);
         }
 
@@ -342,7 +342,7 @@ class MemcachedBackend extends IndependentAbstractBackend implements TaggableBac
      */
     public function flush(): void
     {
-        if (!$this->cache instanceof FrontendInterface) {
+        if (!$this->cache instanceof LowLevelFrontendInterface) {
             throw new Exception('Yet no cache frontend has been set via setCache().', 1204111376);
         }
 

--- a/Neos.Cache/Classes/Backend/PdoBackend.php
+++ b/Neos.Cache/Classes/Backend/PdoBackend.php
@@ -15,7 +15,7 @@ namespace Neos\Cache\Backend;
 
 use Neos\Cache\Backend\AbstractBackend as IndependentAbstractBackend;
 use Neos\Cache\Exception;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 use Neos\Error\Messages\Error;
 use Neos\Error\Messages\Notice;
 use Neos\Error\Messages\Result;
@@ -186,7 +186,7 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
     {
         $this->connect();
 
-        if (!$this->cache instanceof FrontendInterface) {
+        if (!$this->cache instanceof LowLevelFrontendInterface) {
             throw new Exception('No cache frontend has been set yet via setCache().', 1259515600);
         }
 

--- a/Neos.Cache/Classes/Backend/SimpleFileBackend.php
+++ b/Neos.Cache/Classes/Backend/SimpleFileBackend.php
@@ -21,7 +21,7 @@ use Neos\Error\Messages\Result;
 use Neos\Utility\Files;
 use Neos\Cache\Exception;
 use Neos\Cache\Frontend\PhpFrontend;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 use Neos\Utility\Exception\FilesException;
 use Neos\Utility\OpcodeCacheHelper;
 
@@ -99,11 +99,11 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
      * Sets a reference to the cache frontend which uses this backend and
      * initializes the default cache directory.
      *
-     * @param FrontendInterface $cache The cache frontend
+     * @param LowLevelFrontendInterface $cache The cache frontend
      * @return void
      * @throws Exception
      */
-    public function setCache(FrontendInterface $cache): void
+    public function setCache(LowLevelFrontendInterface $cache): void
     {
         parent::setCache($cache);
         $this->cacheEntryFileExtension = ($cache instanceof PhpFrontend) ? '.php' : '';

--- a/Neos.Cache/Classes/Backend/TransientMemoryBackend.php
+++ b/Neos.Cache/Classes/Backend/TransientMemoryBackend.php
@@ -15,7 +15,7 @@ namespace Neos\Cache\Backend;
 
 use Neos\Cache\Backend\AbstractBackend as IndependentAbstractBackend;
 use Neos\Cache\Exception;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 
 /**
  * A caching backend which stores cache entries during one script run.
@@ -47,7 +47,7 @@ class TransientMemoryBackend extends IndependentAbstractBackend implements Tagga
      */
     public function set(string $entryIdentifier, string $data, array $tags = [], int $lifetime = null): void
     {
-        if (!$this->cache instanceof FrontendInterface) {
+        if (!$this->cache instanceof LowLevelFrontendInterface) {
             throw new Exception('No cache frontend has been set yet via setCache().', 1238244992);
         }
 

--- a/Neos.Cache/Classes/CacheFactory.php
+++ b/Neos.Cache/Classes/CacheFactory.php
@@ -14,7 +14,7 @@ namespace Neos\Cache;
 use Neos\Cache\Backend\BackendInterface;
 use Neos\Cache\Exception\InvalidBackendException;
 use Neos\Cache\Exception\InvalidCacheException;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 
 /**
  * This cache factory takes care of instantiating a cache frontend and injecting
@@ -50,12 +50,12 @@ class CacheFactory implements CacheFactoryInterface
      * @param string $cacheObjectName Object name of the cache frontend
      * @param string $backendObjectName Object name of the cache backend
      * @param array $backendOptions (optional) Array of backend options
-     * @return FrontendInterface The created cache frontend
+     * @return LowLevelFrontendInterface The created cache frontend
      * @throws InvalidBackendException
      * @throws InvalidCacheException
      * @api
      */
-    public function create(string $cacheIdentifier, string $cacheObjectName, string $backendObjectName, array $backendOptions = []): FrontendInterface
+    public function create(string $cacheIdentifier, string $cacheObjectName, string $backendObjectName, array $backendOptions = []): LowLevelFrontendInterface
     {
         $backend = $this->instantiateBackend($backendObjectName, $backendOptions, $this->environmentConfiguration);
         $cache = $this->instantiateCache($cacheIdentifier, $cacheObjectName, $backend);
@@ -68,13 +68,13 @@ class CacheFactory implements CacheFactoryInterface
      * @param string $cacheIdentifier
      * @param string $cacheObjectName
      * @param BackendInterface $backend
-     * @return FrontendInterface
+     * @return LowLevelFrontendInterface
      * @throws InvalidCacheException
      */
-    protected function instantiateCache(string $cacheIdentifier, string $cacheObjectName, BackendInterface $backend): FrontendInterface
+    protected function instantiateCache(string $cacheIdentifier, string $cacheObjectName, BackendInterface $backend): LowLevelFrontendInterface
     {
         $cache = new $cacheObjectName($cacheIdentifier, $backend);
-        if (!$cache instanceof FrontendInterface) {
+        if (!$cache instanceof LowLevelFrontendInterface) {
             throw new InvalidCacheException('"' . $cacheObjectName . '" is not a valid cache frontend object.', 1216304300);
         }
 

--- a/Neos.Cache/Classes/CacheFactoryInterface.php
+++ b/Neos.Cache/Classes/CacheFactoryInterface.php
@@ -12,7 +12,7 @@ namespace Neos\Cache;
  */
 use Neos\Cache\Exception\InvalidCacheException;
 use Neos\Cache\Exception\InvalidBackendException;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 
 /**
  * This cache factory takes care of instantiating a cache frontend and injecting
@@ -31,10 +31,10 @@ interface CacheFactoryInterface
      * @param string $cacheObjectName Object name of the cache frontend
      * @param string $backendObjectName Object name of the cache backend
      * @param array $backendOptions (optional) Array of backend options
-     * @return \Neos\Cache\Frontend\FrontendInterface The created cache frontend
+     * @return \Neos\Cache\Frontend\LowLevelFrontendInterface The created cache frontend
      * @throws InvalidBackendException
      * @throws InvalidCacheException
      * @api
      */
-    public function create(string $cacheIdentifier, string $cacheObjectName, string $backendObjectName, array $backendOptions = []): FrontendInterface;
+    public function create(string $cacheIdentifier, string $cacheObjectName, string $backendObjectName, array $backendOptions = []): LowLevelFrontendInterface;
 }

--- a/Neos.Cache/Classes/Frontend/AbstractFrontend.php
+++ b/Neos.Cache/Classes/Frontend/AbstractFrontend.php
@@ -13,81 +13,14 @@ namespace Neos\Cache\Frontend;
  * source code.
  */
 
-use Neos\Cache\Backend\BackendInterface;
-use Neos\Cache\Backend\TaggableBackendInterface;
 
 /**
  * An abstract cache
  *
  * @api
  */
-abstract class AbstractFrontend implements FrontendInterface
+abstract class AbstractFrontend extends AbstractLowLevelFrontend implements FrontendInterface
 {
-    /**
-     * Identifies this cache
-     * @var string
-     */
-    protected $identifier;
-
-    /**
-     * @var BackendInterface
-     */
-    protected $backend;
-
-    /**
-     * Constructs the cache
-     *
-     * @param string $identifier A identifier which describes this cache
-     * @param BackendInterface $backend Backend to be used for this cache
-     * @throws \InvalidArgumentException if the identifier doesn't match PATTERN_ENTRYIDENTIFIER
-     */
-    public function __construct(string $identifier, BackendInterface $backend)
-    {
-        if (preg_match(self::PATTERN_ENTRYIDENTIFIER, $identifier) !== 1) {
-            throw new \InvalidArgumentException('"' . $identifier . '" is not a valid cache identifier.', 1203584729);
-        }
-        $this->identifier = $identifier;
-        $this->backend = $backend;
-    }
-
-    /**
-     * Initializes this frontend
-     *
-     * The backend is connected with this frontend in initializeObject(), not in __construct(), because the Cache Factory
-     * needs an opportunity to register the cache before the backend's setCache() method is called. See
-     * CacheFactory::create() for details. A backend (for example the SimpleFileBackend) may rely on the cache already
-     * being registered at the CacheManager when its setCache() method is called.
-     *
-     * @return void
-     */
-    public function initializeObject()
-    {
-        // FIXME: This can be removed in next major, since the Backend gets the Frontend set in the cache factory now.
-        $this->backend->setCache($this);
-    }
-
-    /**
-     * Returns this cache's identifier
-     *
-     * @return string The identifier for this cache
-     * @api
-     */
-    public function getIdentifier(): string
-    {
-        return $this->identifier;
-    }
-
-    /**
-     * Returns the backend used by this cache
-     *
-     * @return BackendInterface The backend used by this cache
-     * @api
-     */
-    public function getBackend(): BackendInterface
-    {
-        return $this->backend;
-    }
-
     /**
      * Checks if a cache entry with the specified identifier exists.
      *
@@ -120,91 +53,5 @@ abstract class AbstractFrontend implements FrontendInterface
         }
 
         return $this->backend->remove($entryIdentifier);
-    }
-
-    /**
-     * Removes all cache entries of this cache.
-     *
-     * @return void
-     * @api
-     */
-    public function flush()
-    {
-        $this->backend->flush();
-    }
-
-    /**
-     * Removes all cache entries of this cache which are tagged by the specified tag.
-     *
-     * @param string $tag The tag the entries must have
-     * @return integer The number of entries which have been affected by this flush
-     * @throws \InvalidArgumentException
-     * @api
-     */
-    public function flushByTag(string $tag): int
-    {
-        if (!$this->isValidTag($tag)) {
-            throw new \InvalidArgumentException('"' . $tag . '" is not a valid tag for a cache entry.', 1233057359);
-        }
-        if ($this->backend instanceof TaggableBackendInterface) {
-            return $this->backend->flushByTag($tag);
-        }
-        return 0;
-    }
-
-    /**
-     * Removes all cache entries of this cache which are tagged by any of the specified tags.
-     *
-     * @param array<string> $tags The tags the entries must have
-     * @return integer The number of entries which have been affected by this flush
-     * @throws \InvalidArgumentException
-     * @api
-     */
-    public function flushByTags(array $tags): int
-    {
-        foreach ($tags as $tag) {
-            if (!$this->isValidTag($tag)) {
-                throw new \InvalidArgumentException('"' . $tag . '" is not a valid tag for a cache entry.', 1646209443);
-            }
-        }
-        if ($this->backend instanceof TaggableBackendInterface) {
-            return $this->backend->flushByTags($tags);
-        }
-        return 0;
-    }
-
-    /**
-     * Does garbage collection
-     *
-     * @return void
-     * @api
-     */
-    public function collectGarbage()
-    {
-        $this->backend->collectGarbage();
-    }
-
-    /**
-     * Checks the validity of an entry identifier. Returns true if it's valid.
-     *
-     * @param string $identifier An identifier to be checked for validity
-     * @return boolean
-     * @api
-     */
-    public function isValidEntryIdentifier(string $identifier): bool
-    {
-        return preg_match(self::PATTERN_ENTRYIDENTIFIER, $identifier) === 1;
-    }
-
-    /**
-     * Checks the validity of a tag. Returns true if it's valid.
-     *
-     * @param string $tag An identifier to be checked for validity
-     * @return boolean
-     * @api
-     */
-    public function isValidTag(string $tag): bool
-    {
-        return preg_match(self::PATTERN_TAG, $tag) === 1;
     }
 }

--- a/Neos.Cache/Classes/Frontend/AbstractLowLevelFrontend.php
+++ b/Neos.Cache/Classes/Frontend/AbstractLowLevelFrontend.php
@@ -1,0 +1,160 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Cache\Frontend;
+
+/*
+ * This file is part of the Neos.Cache package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Cache\Backend\BackendInterface;
+use Neos\Cache\Backend\TaggableBackendInterface;
+
+/**
+ * An abstract cache
+ *
+ * @api
+ */
+abstract class AbstractLowLevelFrontend implements LowLevelFrontendInterface
+{
+    /**
+     * Identifies this cache
+     * @var string
+     */
+    protected $identifier;
+
+    /**
+     * @var BackendInterface
+     */
+    protected $backend;
+
+    /**
+     * Constructs the cache
+     *
+     * @param string $identifier A identifier which describes this cache
+     * @param BackendInterface $backend Backend to be used for this cache
+     * @throws \InvalidArgumentException if the identifier doesn't match PATTERN_ENTRYIDENTIFIER
+     */
+    public function __construct(string $identifier, BackendInterface $backend)
+    {
+        if (preg_match(self::PATTERN_ENTRYIDENTIFIER, $identifier) !== 1) {
+            throw new \InvalidArgumentException('"' . $identifier . '" is not a valid cache identifier.', 1203584729);
+        }
+        $this->identifier = $identifier;
+        $this->backend = $backend;
+    }
+
+    /**
+     * Returns this cache's identifier
+     *
+     * @return string The identifier for this cache
+     * @api
+     */
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    /**
+     * Returns the backend used by this cache
+     *
+     * @return BackendInterface The backend used by this cache
+     * @api
+     */
+    public function getBackend(): BackendInterface
+    {
+        return $this->backend;
+    }
+
+    /**
+     * Removes all cache entries of this cache.
+     *
+     * @return void
+     * @api
+     */
+    public function flush()
+    {
+        $this->backend->flush();
+    }
+
+    /**
+     * Removes all cache entries of this cache which are tagged by the specified tag.
+     *
+     * @param string $tag The tag the entries must have
+     * @return integer The number of entries which have been affected by this flush
+     * @throws \InvalidArgumentException
+     * @api
+     */
+    public function flushByTag(string $tag): int
+    {
+        if (!$this->isValidTag($tag)) {
+            throw new \InvalidArgumentException('"' . $tag . '" is not a valid tag for a cache entry.', 1233057359);
+        }
+        if ($this->backend instanceof TaggableBackendInterface) {
+            return $this->backend->flushByTag($tag);
+        }
+        return 0;
+    }
+
+    /**
+     * Removes all cache entries of this cache which are tagged by any of the specified tags.
+     *
+     * @param array<string> $tags The tags the entries must have
+     * @return integer The number of entries which have been affected by this flush
+     * @throws \InvalidArgumentException
+     * @api
+     */
+    public function flushByTags(array $tags): int
+    {
+        foreach ($tags as $tag) {
+            if (!$this->isValidTag($tag)) {
+                throw new \InvalidArgumentException('"' . $tag . '" is not a valid tag for a cache entry.', 1646209443);
+            }
+        }
+        if ($this->backend instanceof TaggableBackendInterface) {
+            return $this->backend->flushByTags($tags);
+        }
+        return 0;
+    }
+
+    /**
+     * Does garbage collection
+     *
+     * @return void
+     * @api
+     */
+    public function collectGarbage()
+    {
+        $this->backend->collectGarbage();
+    }
+
+    /**
+     * Checks the validity of an entry identifier. Returns true if it's valid.
+     *
+     * @param string $identifier An identifier to be checked for validity
+     * @return boolean
+     * @api
+     */
+    public function isValidEntryIdentifier(string $identifier): bool
+    {
+        return preg_match(self::PATTERN_ENTRYIDENTIFIER, $identifier) === 1;
+    }
+
+    /**
+     * Checks the validity of a tag. Returns true if it's valid.
+     *
+     * @param string $tag An identifier to be checked for validity
+     * @return boolean
+     * @api
+     */
+    public function isValidTag(string $tag): bool
+    {
+        return preg_match(self::PATTERN_TAG, $tag) === 1;
+    }
+}

--- a/Neos.Cache/Classes/Frontend/CacheEntryIterator.php
+++ b/Neos.Cache/Classes/Frontend/CacheEntryIterator.php
@@ -23,7 +23,7 @@ use Neos\Cache\Backend\IterableBackendInterface;
 class CacheEntryIterator implements \Iterator
 {
     /**
-     * @var FrontendInterface
+     * @var LowLevelFrontendInterface
      */
     protected $frontend;
 
@@ -35,10 +35,10 @@ class CacheEntryIterator implements \Iterator
     /**
      * Constructs this Iterator
      *
-     * @param FrontendInterface $frontend Frontend of the cache to iterate over
+     * @param LowLevelFrontendInterface $frontend Frontend of the cache to iterate over
      * @param IterableBackendInterface $backend Backend of the cache
      */
-    public function __construct(FrontendInterface $frontend, IterableBackendInterface $backend)
+    public function __construct(LowLevelFrontendInterface $frontend, IterableBackendInterface $backend)
     {
         $this->frontend = $frontend;
         $this->backend = $backend;

--- a/Neos.Cache/Classes/Frontend/FrontendInterface.php
+++ b/Neos.Cache/Classes/Frontend/FrontendInterface.php
@@ -18,34 +18,8 @@ namespace Neos\Cache\Frontend;
  *
  * @api
  */
-interface FrontendInterface
+interface FrontendInterface extends LowLevelFrontendInterface
 {
-    /**
-     * Pattern an entry identifier must match.
-     */
-    const PATTERN_ENTRYIDENTIFIER = '/^[a-zA-Z0-9_%\-&]{1,250}$/';
-
-    /**
-     * Pattern a tag must match.
-     */
-    const PATTERN_TAG = '/^[a-zA-Z0-9_%\-&]{1,250}$/';
-
-    /**
-     * Returns this cache's identifier
-     *
-     * @return string The identifier for this cache
-     * @api
-     */
-    public function getIdentifier();
-
-    /**
-     * Returns the backend used by this cache
-     *
-     * @return \Neos\Cache\Backend\BackendInterface The backend used by this cache
-     * @api
-     */
-    public function getBackend();
-
     /**
      * Saves data in the cache.
      *
@@ -92,55 +66,4 @@ interface FrontendInterface
      * @return boolean true if such an entry exists, false if not
      */
     public function remove(string $entryIdentifier): bool;
-
-    /**
-     * Removes all cache entries of this cache.
-     *
-     * @return void
-     */
-    public function flush();
-
-    /**
-     * Removes all cache entries of this cache which are tagged by the specified tag.
-     *
-     * @param string $tag The tag the entries must have
-     * @return integer The number of entries which have been affected by this flush
-     * @api
-     */
-    public function flushByTag(string $tag): int;
-
-    /**
-     * Removes all cache entries of this cache which are tagged by any of the specified tags.
-     *
-     * @param array<string> $tags The tags the entries must have
-     * @return integer The number of entries which have been affected by this flush
-     * @api
-     */
-    public function flushByTags(array $tags): int;
-
-    /**
-     * Does garbage collection
-     *
-     * @return void
-     * @api
-     */
-    public function collectGarbage();
-
-    /**
-     * Checks the validity of an entry identifier. Returns true if it's valid.
-     *
-     * @param string $identifier An identifier to be checked for validity
-     * @return boolean
-     * @api
-     */
-    public function isValidEntryIdentifier(string $identifier): bool;
-
-    /**
-     * Checks the validity of a tag. Returns true if it's valid.
-     *
-     * @param string $tag A tag to be checked for validity
-     * @return boolean
-     * @api
-     */
-    public function isValidTag(string $tag): bool;
 }

--- a/Neos.Cache/Classes/Frontend/LowLevelFrontendInterface.php
+++ b/Neos.Cache/Classes/Frontend/LowLevelFrontendInterface.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Cache\Frontend;
+
+/*
+ * This file is part of the Neos.Cache package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Contract for a Cache (frontend)
+ *
+ * @api
+ */
+interface LowLevelFrontendInterface
+{
+    /**
+     * Pattern an entry identifier must match.
+     */
+    const PATTERN_ENTRYIDENTIFIER = '/^[a-zA-Z0-9_%\-&]{1,250}$/';
+
+    /**
+     * Pattern a tag must match.
+     */
+    const PATTERN_TAG = '/^[a-zA-Z0-9_%\-&]{1,250}$/';
+
+    /**
+     * Returns this cache's identifier
+     *
+     * @return string The identifier for this cache
+     * @api
+     */
+    public function getIdentifier();
+
+    /**
+     * Returns the backend used by this cache
+     *
+     * @return \Neos\Cache\Backend\BackendInterface The backend used by this cache
+     * @api
+     */
+    public function getBackend();
+
+    /**
+     * Removes all cache entries of this cache.
+     *
+     * @return void
+     */
+    public function flush();
+
+    /**
+     * Removes all cache entries of this cache which are tagged by the specified tag.
+     *
+     * @param string $tag The tag the entries must have
+     * @return integer The number of entries which have been affected by this flush
+     * @api
+     */
+    public function flushByTag(string $tag): int;
+
+    /**
+     * Removes all cache entries of this cache which are tagged by any of the specified tags.
+     *
+     * @param array<string> $tags The tags the entries must have
+     * @return integer The number of entries which have been affected by this flush
+     * @api
+     */
+    public function flushByTags(array $tags): int;
+
+    /**
+     * Does garbage collection
+     *
+     * @return void
+     * @api
+     */
+    public function collectGarbage();
+
+    /**
+     * Checks the validity of an entry identifier. Returns true if it's valid.
+     *
+     * @param string $identifier An identifier to be checked for validity
+     * @return boolean
+     * @api
+     */
+    public function isValidEntryIdentifier(string $identifier): bool;
+
+    /**
+     * Checks the validity of a tag. Returns true if it's valid.
+     *
+     * @param string $tag A tag to be checked for validity
+     * @return boolean
+     * @api
+     */
+    public function isValidTag(string $tag): bool;
+}

--- a/Neos.Cache/Classes/Frontend/Psr/Cache/CacheItem.php
+++ b/Neos.Cache/Classes/Frontend/Psr/Cache/CacheItem.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Neos\Cache\Psr\Cache;
+namespace Neos\Cache\Frontend\Psr\Cache;
 
 /*
  * This file is part of the Neos.Cache package.
@@ -19,7 +19,6 @@ use Psr\Cache\CacheItemInterface;
  * A cache item (entry).
  * This is not to be created by user libraries. Instead request an item from the pool (frontend).
  * @see CachePool
- * @deprecated will be removed with Neos Flow 10. Use \Neos\Cache\Frontend\Psr\Cache\CacheItem instead.
  */
 class CacheItem implements CacheItemInterface
 {

--- a/Neos.Cache/Classes/Frontend/Psr/Cache/CacheItemPoolFrontend.php
+++ b/Neos.Cache/Classes/Frontend/Psr/Cache/CacheItemPoolFrontend.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Neos\Cache\Psr\Cache;
+namespace Neos\Cache\Frontend\Psr\Cache;
 
 /*
  * This file is part of the Neos.Cache package.
@@ -14,16 +14,14 @@ namespace Neos\Cache\Psr\Cache;
  */
 
 use Neos\Cache\Backend\BackendInterface;
-use Neos\Cache\Psr\InvalidArgumentException;
+use Neos\Cache\Frontend\AbstractLowLevelFrontend;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * An implementation of the CacheItemPoolInterface from the PSR-6 specification to be used with our provided backends.
- * @see CacheFactory
- * @deprecated will be removed with Neos Flow 10. Use \Neos\Cache\Frontend\Psr\Cache\CacheItemPoolFrontend instead.
  */
-class CachePool implements CacheItemPoolInterface
+class CacheItemPoolFrontend extends AbstractLowLevelFrontend implements CacheItemPoolInterface
 {
     /**
      * Pattern an entry identifier must match.
@@ -48,22 +46,6 @@ class CachePool implements CacheItemPoolInterface
      * @var array
      */
     protected $deferredItems = [];
-
-    /**
-     * Constructs the cache
-     *
-     * @param string $identifier A identifier which describes this cache
-     * @param BackendInterface $backend Backend to be used for this cache
-     * @throws \InvalidArgumentException if the identifier doesn't match PATTERN_ENTRYIDENTIFIER
-     */
-    public function __construct(string $identifier, BackendInterface $backend)
-    {
-        if (preg_match(self::PATTERN_ENTRYIDENTIFIER, $identifier) !== 1) {
-            throw new \InvalidArgumentException('"' . $identifier . '" is not a valid cache identifier.', 1203584729);
-        }
-        $this->identifier = $identifier;
-        $this->backend = $backend;
-    }
 
     /**
      * Returns a Cache Item representing the specified key.

--- a/Neos.Cache/Classes/Frontend/Psr/Cache/InvalidArgumentException.php
+++ b/Neos.Cache/Classes/Frontend/Psr/Cache/InvalidArgumentException.php
@@ -1,0 +1,21 @@
+<?php
+namespace Neos\Cache\Frontend\Psr\Cache;
+
+/*
+ * This file is part of the Neos.Cache package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Psr\Cache\InvalidArgumentException as Psr6InvalidArgumentException;
+
+/**
+ * An invalid argument (usually an inacceptable cache key) was given to a PSR cache.
+ */
+class InvalidArgumentException extends \InvalidArgumentException implements Psr6InvalidArgumentException
+{
+}

--- a/Neos.Cache/Classes/Frontend/Psr/SimpleCache/InvalidArgumentException.php
+++ b/Neos.Cache/Classes/Frontend/Psr/SimpleCache/InvalidArgumentException.php
@@ -1,0 +1,21 @@
+<?php
+namespace Neos\Cache\Frontend\Psr\SimpleCache;
+
+/*
+ * This file is part of the Neos.Cache package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Psr\SimpleCache\InvalidArgumentException as Psr16InvalidArgumentException;
+
+/**
+ * An invalid argument (usually an inacceptable cache key) was given to a PSR cache.
+ */
+class InvalidArgumentException extends \InvalidArgumentException implements Psr16InvalidArgumentException
+{
+}

--- a/Neos.Cache/Classes/Frontend/Psr/SimpleCache/SimpleCacheFrontend.php
+++ b/Neos.Cache/Classes/Frontend/Psr/SimpleCache/SimpleCacheFrontend.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Neos\Cache\Psr\SimpleCache;
+namespace Neos\Cache\Frontend\Psr\SimpleCache;
 
 /*
  * This file is part of the Neos.Cache package.
@@ -13,48 +13,19 @@ namespace Neos\Cache\Psr\SimpleCache;
  * source code.
  */
 
-use Neos\Cache\Backend\BackendInterface;
 use Neos\Cache\Exception;
-use Neos\Cache\Psr\InvalidArgumentException;
+use Neos\Cache\Frontend\AbstractLowLevelFrontend;
 use Psr\SimpleCache\CacheInterface;
 
 /**
  * A simple cache frontend
- * Note: This does not follow the \Neos\Cache\Frontend\FrontendInterface this package provides.
- * @deprecated will be removed with Neos Flow 10. Use \Neos\Cache\Frontend\Psr\SimpleCache\SimpleCacheFrontend instead.
  */
-class SimpleCache implements CacheInterface
+class SimpleCacheFrontend extends AbstractLowLevelFrontend implements CacheInterface
 {
     /**
      * Pattern an entry identifier must match.
      */
     const PATTERN_ENTRYIDENTIFIER = '/^[a-zA-Z0-9_\.]{1,64}$/';
-
-    /**
-     * @var string
-     */
-    protected $identifier;
-
-    /**
-     * @var BackendInterface
-     */
-    protected $backend;
-
-    /**
-     * Constructs the cache
-     *
-     * @param string $identifier A identifier which describes this cache
-     * @param BackendInterface $backend Backend to be used for this cache
-     * @throws InvalidArgumentException if the identifier doesn't match PATTERN_ENTRYIDENTIFIER
-     */
-    public function __construct(string $identifier, BackendInterface $backend)
-    {
-        if ($this->isValidEntryIdentifier($identifier) === false) {
-            throw new InvalidArgumentException('"' . $identifier . '" is not a valid cache identifier.', 1515192811703);
-        }
-        $this->identifier = $identifier;
-        $this->backend = $backend;
-    }
 
     /**
      * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
@@ -197,14 +168,6 @@ class SimpleCache implements CacheInterface
         return $this->backend->has($key);
     }
 
-    /**
-     * @param string $key
-     * @return bool
-     */
-    protected function isValidEntryIdentifier(string $key): bool
-    {
-        return (preg_match(self::PATTERN_ENTRYIDENTIFIER, $key) === 1);
-    }
 
     /**
      * @param string $key
@@ -213,7 +176,7 @@ class SimpleCache implements CacheInterface
      */
     protected function ensureValidEntryIdentifier($key): void
     {
-        if ($this->isValidEntryIdentifier($key) === false) {
+        if (preg_match(self::PATTERN_ENTRYIDENTIFIER, $key) !== 1) {
             throw new InvalidArgumentException('"' . $key . '" is not a valid cache key.', 1515192768083);
         }
     }

--- a/Neos.Cache/Classes/Frontend/VariableFrontend.php
+++ b/Neos.Cache/Classes/Frontend/VariableFrontend.php
@@ -40,7 +40,6 @@ class VariableFrontend extends AbstractFrontend
     public function initializeObject()
     {
         $this->useIgBinary = extension_loaded('igbinary');
-        parent::initializeObject();
     }
 
     /**

--- a/Neos.Cache/Classes/Psr/Cache/CacheFactory.php
+++ b/Neos.Cache/Classes/Psr/Cache/CacheFactory.php
@@ -22,6 +22,7 @@ use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * A factory for the PSR-6 compatible cache pool.
+ * @deprecated will be removed with Neos Flow 10. Use CacheManager and Caches.yaml instead.
  */
 class CacheFactory
 {

--- a/Neos.Cache/Classes/Psr/SimpleCache/SimpleCacheFactory.php
+++ b/Neos.Cache/Classes/Psr/SimpleCache/SimpleCacheFactory.php
@@ -22,6 +22,7 @@ use Psr\SimpleCache\CacheInterface;
 
 /**
  * A factory for PSR-16 simple caches.
+ * @deprecated will be removed with Neos Flow 10. Use CacheManager and Caches.yaml instead.
  */
 class SimpleCacheFactory
 {

--- a/Neos.Cache/Tests/Functional/Backend/PdoBackendTest.php
+++ b/Neos.Cache/Tests/Functional/Backend/PdoBackendTest.php
@@ -17,7 +17,7 @@ use Neos\Cache\Backend\BackendInterface;
 use Neos\Cache\Backend\PdoBackend;
 use Neos\Cache\EnvironmentConfiguration;
 use Neos\Cache\Tests\BaseTestCase;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 
 /**
  * Testcase for the PDO cache backend
@@ -36,7 +36,7 @@ class PdoBackendTest extends BaseTestCase
     private $backends = [];
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|FrontendInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|LowLevelFrontendInterface
      */
     private $cache;
 
@@ -49,7 +49,7 @@ class PdoBackendTest extends BaseTestCase
 
     public function backendsToTest(): array
     {
-        $this->cache = $this->createMock(FrontendInterface::class);
+        $this->cache = $this->createMock(LowLevelFrontendInterface::class);
         $this->cache->method('getIdentifier')->willReturn('TestCache');
         $this->setupBackends();
         return $this->backends;

--- a/Neos.Cache/Tests/Functional/Backend/RedisBackendTest.php
+++ b/Neos.Cache/Tests/Functional/Backend/RedisBackendTest.php
@@ -16,7 +16,7 @@ include_once(__DIR__ . '/../../BaseTestCase.php');
 use Neos\Cache\Backend\RedisBackend;
 use Neos\Cache\EnvironmentConfiguration;
 use Neos\Cache\Tests\BaseTestCase;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 
 /**
  * Testcase for the redis cache backend
@@ -37,7 +37,7 @@ class RedisBackendTest extends BaseTestCase
     private $backend;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|FrontendInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|LowLevelFrontendInterface
      */
     private $cache;
 
@@ -63,7 +63,7 @@ class RedisBackendTest extends BaseTestCase
             new EnvironmentConfiguration('Redis a wonderful color Testing', '/some/path', PHP_MAXPATHLEN),
             ['hostname' => '127.0.0.1', 'database' => 0]
         );
-        $this->cache = $this->createMock(FrontendInterface::class);
+        $this->cache = $this->createMock(LowLevelFrontendInterface::class);
         $this->cache->expects(self::any())->method('getIdentifier')->will(self::returnValue('TestCache'));
         $this->backend->setCache($this->cache);
         $this->backend->flush();

--- a/Neos.Cache/Tests/Unit/Backend/ApcuBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/ApcuBackendTest.php
@@ -17,7 +17,7 @@ use Neos\Cache\Backend\ApcuBackend;
 use Neos\Cache\EnvironmentConfiguration;
 use Neos\Cache\Exception;
 use Neos\Cache\Tests\BaseTestCase;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 use Neos\Cache\Frontend\VariableFrontend;
 
 /**
@@ -227,12 +227,12 @@ class ApcuBackendTest extends BaseTestCase
      */
     public function flushRemovesOnlyOwnEntries()
     {
-        $thisCache = $this->createMock(FrontendInterface::class);
+        $thisCache = $this->createMock(LowLevelFrontendInterface::class);
         $thisCache->expects(self::any())->method('getIdentifier')->will(self::returnValue('thisCache'));
         $thisBackend = new ApcuBackend($this->getEnvironmentConfiguration(), []);
         $thisBackend->setCache($thisCache);
 
-        $thatCache = $this->createMock(FrontendInterface::class);
+        $thatCache = $this->createMock(LowLevelFrontendInterface::class);
         $thatCache->expects(self::any())->method('getIdentifier')->will(self::returnValue('thatCache'));
         $thatBackend = new ApcuBackend($this->getEnvironmentConfiguration(), []);
         $thatBackend->setCache($thatCache);
@@ -422,7 +422,7 @@ class ApcuBackendTest extends BaseTestCase
      */
     protected function setUpBackend()
     {
-        $cache = $this->createMock(FrontendInterface::class);
+        $cache = $this->createMock(LowLevelFrontendInterface::class);
         $backend = new ApcuBackend($this->getEnvironmentConfiguration(), []);
         $backend->setCache($cache);
         $backend->flush(); // I'd rather start with a clean directory in the first place, but I can't get the "vfs" thing to work

--- a/Neos.Cache/Tests/Unit/Backend/FileBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/FileBackendTest.php
@@ -19,7 +19,7 @@ use Neos\Cache\EnvironmentConfiguration;
 use Neos\Cache\Exception;
 use Neos\Cache\Tests\BaseTestCase;
 use org\bovigo\vfs\vfsStream;
-use Neos\Cache\Frontend\AbstractFrontend;
+use Neos\Cache\Frontend\AbstractLowLevelFrontend;
 use Neos\Cache\Frontend\PhpFrontend;
 use Neos\Cache\Frontend\VariableFrontend;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -42,7 +42,7 @@ class FileBackendTest extends BaseTestCase
     public function setCacheThrowsExceptionOnNonWritableDirectory()
     {
         $this->expectException(Exception::class);
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
 
         $mockEnvironmentConfiguration = $this->createEnvironmentConfigurationMock([__DIR__ . '~Testing', 'http://localhost/', PHP_MAXPATHLEN]);
 
@@ -61,7 +61,7 @@ class FileBackendTest extends BaseTestCase
      */
     public function setCacheDirectoryAllowsToSetTheCurrentCacheDirectory()
     {
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::any())->method('getIdentifier')->will(self::returnValue('SomeCache'));
 
         $mockEnvironmentConfiguration = $this->createEnvironmentConfigurationMock([
@@ -86,7 +86,7 @@ class FileBackendTest extends BaseTestCase
      */
     public function getCacheDirectoryReturnsTheCurrentCacheDirectory()
     {
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::any())->method('getIdentifier')->will(self::returnValue('SomeCache'));
 
         // We need to create the directory here because vfs doesn't support touch() which is used by
@@ -120,7 +120,7 @@ class FileBackendTest extends BaseTestCase
      */
     public function setReallySavesToTheSpecifiedDirectory()
     {
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $data = 'some data' . microtime();
@@ -142,7 +142,7 @@ class FileBackendTest extends BaseTestCase
      */
     public function setOverwritesAnAlreadyExistingCacheEntryForTheSameIdentifier()
     {
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $data1 = 'some data' . microtime();
@@ -166,7 +166,7 @@ class FileBackendTest extends BaseTestCase
      */
     public function setAlsoSavesSpecifiedTags()
     {
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $data = 'some data' . microtime();
@@ -217,7 +217,7 @@ class FileBackendTest extends BaseTestCase
      */
     public function setCacheDetectsAndLoadsAFrozenCache()
     {
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $mockEnvironmentConfiguration = $this->createEnvironmentConfigurationMock([
@@ -256,7 +256,7 @@ class FileBackendTest extends BaseTestCase
      */
     public function getReturnsContentOfTheCorrectCacheFile()
     {
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $mockEnvironmentConfiguration = $this->createEnvironmentConfigurationMock([
@@ -290,7 +290,7 @@ class FileBackendTest extends BaseTestCase
      */
     public function getReturnsFalseForExpiredEntries()
     {
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $backend = $this->prepareDefaultBackend(['dummy'], [
@@ -313,7 +313,7 @@ class FileBackendTest extends BaseTestCase
      */
     public function getDoesUseInternalGetIfTheCacheIsFrozen()
     {
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
         /** @var MockObject $backend */
         $backend = $this->prepareDefaultBackend(['internalGet'], [
@@ -336,7 +336,7 @@ class FileBackendTest extends BaseTestCase
      */
     public function hasReturnsTrueIfAnEntryExists()
     {
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $backend = $this->prepareDefaultBackend();
@@ -368,7 +368,7 @@ class FileBackendTest extends BaseTestCase
      */
     public function hasDoesNotCheckIfAnEntryIsExpiredIfTheCacheIsFrozen()
     {
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $backend = $this->prepareDefaultBackend(['isCacheFileExpired'], [
@@ -392,7 +392,7 @@ class FileBackendTest extends BaseTestCase
      */
     public function removeReallyRemovesACacheEntry()
     {
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $data = 'some data' . microtime();
@@ -436,7 +436,7 @@ class FileBackendTest extends BaseTestCase
     public function setThrowsExceptionForInvalidIdentifier($identifier)
     {
         $this->expectException(\InvalidArgumentException::class);
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
         $backend = $this->prepareDefaultBackend();
         $backend->setCache($mockCache);
@@ -451,7 +451,7 @@ class FileBackendTest extends BaseTestCase
     public function getThrowsExceptionForInvalidIdentifier($identifier)
     {
         $this->expectException(\InvalidArgumentException::class);
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $backend = $this->prepareDefaultBackend(['isCacheFileExpired']);
@@ -479,7 +479,7 @@ class FileBackendTest extends BaseTestCase
     public function removeThrowsExceptionForInvalidIdentifier($identifier)
     {
         $this->expectException(\InvalidArgumentException::class);
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $backend = $this->prepareDefaultBackend();
@@ -495,7 +495,7 @@ class FileBackendTest extends BaseTestCase
     public function requireOnceThrowsExceptionForInvalidIdentifier($identifier)
     {
         $this->expectException(\InvalidArgumentException::class);
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $backend = $this->prepareDefaultBackend();
@@ -509,7 +509,7 @@ class FileBackendTest extends BaseTestCase
      */
     public function requireOnceIncludesAndReturnsResultOfIncludedPhpFile()
     {
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $backend = $this->prepareDefaultBackend();
@@ -529,7 +529,7 @@ class FileBackendTest extends BaseTestCase
      */
     public function requireOnceDoesNotCheckExpiryTimeIfBackendIsFrozen()
     {
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $backend = $this->prepareDefaultBackend(['isCacheFileExpired']);
@@ -552,7 +552,7 @@ class FileBackendTest extends BaseTestCase
     public function requireOnceDoesNotSwallowExceptionsOfTheIncludedFile()
     {
         $this->expectException(\Exception::class);
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $backend = $this->prepareDefaultBackend();
@@ -569,7 +569,7 @@ class FileBackendTest extends BaseTestCase
     public function requireOnceDoesNotSwallowPhpWarningsOfTheIncludedFile()
     {
         $this->expectWarning();
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $backend = $this->prepareDefaultBackend();
@@ -586,7 +586,7 @@ class FileBackendTest extends BaseTestCase
     public function requireOnceDoesNotSwallowPhpNoticesOfTheIncludedFile()
     {
         $this->expectNotice();
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $backend = $this->prepareDefaultBackend();
@@ -602,7 +602,7 @@ class FileBackendTest extends BaseTestCase
      */
     public function findIdentifiersByTagFindsCacheEntriesWithSpecifiedTag()
     {
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $backend = $this->prepareDefaultBackend();
@@ -626,7 +626,7 @@ class FileBackendTest extends BaseTestCase
      */
     public function findIdentifiersByTagReturnsEmptyArrayForExpiredEntries()
     {
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $backend = $this->prepareDefaultBackend();
@@ -646,7 +646,7 @@ class FileBackendTest extends BaseTestCase
      */
     public function flushRemovesAllCacheEntries()
     {
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $backend = $this->prepareDefaultBackend();
@@ -696,7 +696,7 @@ class FileBackendTest extends BaseTestCase
      */
     public function collectGarbageRemovesExpiredCacheEntries()
     {
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $backend = $this->prepareDefaultBackend(['isCacheFileExpired']);
@@ -720,7 +720,7 @@ class FileBackendTest extends BaseTestCase
      */
     public function flushUnfreezesTheCache()
     {
-        $mockCache = $this->createMock(AbstractFrontend::class);
+        $mockCache = $this->createMock(AbstractLowLevelFrontend::class);
         $mockCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('UnitTestCache'));
 
         $backend = $this->prepareDefaultBackend();

--- a/Neos.Cache/Tests/Unit/Backend/MemcachedBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/MemcachedBackendTest.php
@@ -17,8 +17,8 @@ use Neos\Cache\Backend\MemcachedBackend;
 use Neos\Cache\EnvironmentConfiguration;
 use Neos\Cache\Exception;
 use Neos\Cache\Tests\BaseTestCase;
-use Neos\Cache\Frontend\AbstractFrontend;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\AbstractLowLevelFrontend;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 
 /**
  * Testcase for the cache to memcached backend
@@ -233,12 +233,12 @@ class MemcachedBackendTest extends BaseTestCase
     {
         $backendOptions = ['servers' => ['localhost:11211']];
 
-        $thisCache = $this->getMockBuilder(AbstractFrontend::class)->disableOriginalConstructor()->getMock();
+        $thisCache = $this->getMockBuilder(AbstractLowLevelFrontend::class)->disableOriginalConstructor()->getMock();
         $thisCache->expects(self::any())->method('getIdentifier')->will(self::returnValue('thisCache'));
         $thisBackend = new MemcachedBackend($this->getEnvironmentConfiguration(), $backendOptions);
         $thisBackend->setCache($thisCache);
 
-        $thatCache = $this->getMockBuilder(AbstractFrontend::class)->disableOriginalConstructor()->getMock();
+        $thatCache = $this->getMockBuilder(AbstractLowLevelFrontend::class)->disableOriginalConstructor()->getMock();
         $thatCache->expects(self::any())->method('getIdentifier')->will(self::returnValue('thatCache'));
         $thatBackend = new MemcachedBackend($this->getEnvironmentConfiguration(), $backendOptions);
         $thatBackend->setCache($thatCache);
@@ -276,7 +276,7 @@ class MemcachedBackendTest extends BaseTestCase
      */
     protected function setUpBackend(array $backendOptions = [])
     {
-        $cache = $this->createMock(FrontendInterface::class, [], [], '', false);
+        $cache = $this->createMock(LowLevelFrontendInterface::class, [], [], '', false);
         if ($backendOptions == []) {
             $backendOptions = ['servers' => ['localhost:11211']];
         }

--- a/Neos.Cache/Tests/Unit/Backend/PdoBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/PdoBackendTest.php
@@ -16,7 +16,7 @@ include_once(__DIR__ . '/../../BaseTestCase.php');
 use Neos\Cache\Backend\PdoBackend;
 use Neos\Cache\EnvironmentConfiguration;
 use Neos\Cache\Exception;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 use Neos\Cache\Tests\BaseTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -218,12 +218,12 @@ class PdoBackendTest extends BaseTestCase
      */
     public function flushRemovesOnlyOwnEntries()
     {
-        $thisCache = $this->getMockBuilder(FrontendInterface::class)->disableOriginalConstructor()->getMock();
+        $thisCache = $this->getMockBuilder(LowLevelFrontendInterface::class)->disableOriginalConstructor()->getMock();
         $thisCache->expects(self::any())->method('getIdentifier')->will(self::returnValue('thisCache'));
         $thisBackend = $this->setUpBackend();
         $thisBackend->setCache($thisCache);
 
-        $thatCache = $this->getMockBuilder(FrontendInterface::class)->disableOriginalConstructor()->getMock();
+        $thatCache = $this->getMockBuilder(LowLevelFrontendInterface::class)->disableOriginalConstructor()->getMock();
         $thatCache->expects(self::any())->method('getIdentifier')->will(self::returnValue('thatCache'));
         $thatBackend = $this->setUpBackend();
         $thatBackend->setCache($thatCache);
@@ -338,8 +338,8 @@ class PdoBackendTest extends BaseTestCase
      */
     protected function setUpBackend()
     {
-        /** @var FrontendInterface|MockObject $mockCache */
-        $mockCache = $this->getMockBuilder(FrontendInterface::class)->disableOriginalConstructor()->getMock();
+        /** @var LowLevelFrontendInterface|MockObject $mockCache */
+        $mockCache = $this->getMockBuilder(LowLevelFrontendInterface::class)->disableOriginalConstructor()->getMock();
         $mockCache->expects(self::any())->method('getIdentifier')->will(self::returnValue('TestCache'));
 
         $mockEnvironmentConfiguration = $this->getMockBuilder(EnvironmentConfiguration::class)->setConstructorArgs([

--- a/Neos.Cache/Tests/Unit/Backend/RedisBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/RedisBackendTest.php
@@ -16,7 +16,7 @@ include_once(__DIR__ . '/../../BaseTestCase.php');
 
 use Neos\Cache\Backend\RedisBackend;
 use Neos\Cache\EnvironmentConfiguration;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 use Neos\Cache\Tests\BaseTestCase;
 
 /**
@@ -38,7 +38,7 @@ class RedisBackendTest extends BaseTestCase
     private $backend;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|FrontendInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|LowLevelFrontendInterface
      */
     private $cache;
 
@@ -54,7 +54,7 @@ class RedisBackendTest extends BaseTestCase
         }
 
         $this->redis = $this->getMockBuilder(\Redis::class)->disableOriginalConstructor()->getMock();
-        $this->cache = $this->createMock(FrontendInterface::class);
+        $this->cache = $this->createMock(LowLevelFrontendInterface::class);
         $this->cache->method('getIdentifier')
             ->willReturn('Foo_Cache');
 

--- a/Neos.Cache/Tests/Unit/Backend/SimpleFileBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/SimpleFileBackendTest.php
@@ -18,7 +18,7 @@ use Neos\Cache\EnvironmentConfiguration;
 use Neos\Cache\Exception;
 use Neos\Cache\Tests\BaseTestCase;
 use org\bovigo\vfs\vfsStream;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 use Neos\Cache\Frontend\PhpFrontend;
 
 /**
@@ -27,7 +27,7 @@ use Neos\Cache\Frontend\PhpFrontend;
 class SimpleFileBackendTest extends BaseTestCase
 {
     /**
-     * @var FrontendInterface|\PHPUnit\Framework\MockObject\MockObject
+     * @var LowLevelFrontendInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $mockCacheFrontend;
 
@@ -51,17 +51,17 @@ class SimpleFileBackendTest extends BaseTestCase
                 1024
             ])->getMock();
 
-        $this->mockCacheFrontend = $this->createMock(FrontendInterface::class);
+        $this->mockCacheFrontend = $this->createMock(LowLevelFrontendInterface::class);
     }
 
     /**
      * Convenience function to retrieve an instance of SimpleFileBackend with required dependencies
      *
      * @param array $options
-     * @param FrontendInterface $mockCacheFrontend
+     * @param LowLevelFrontendInterface $mockCacheFrontend
      * @return SimpleFileBackend
      */
-    protected function getSimpleFileBackend(array $options = [], FrontendInterface $mockCacheFrontend = null)
+    protected function getSimpleFileBackend(array $options = [], LowLevelFrontendInterface $mockCacheFrontend = null)
     {
         $simpleFileBackend = new SimpleFileBackend($this->mockEnvironmentConfiguration, $options);
 

--- a/Neos.Cache/Tests/Unit/Backend/TransientMemoryBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/TransientMemoryBackendTest.php
@@ -18,7 +18,7 @@ use Neos\Cache\EnvironmentConfiguration;
 use Neos\Cache\Exception;
 use Neos\Cache\Frontend\StringFrontend;
 use Neos\Cache\Tests\BaseTestCase;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 
 /**
  * Testcase for the Transient Memory Backend
@@ -44,7 +44,7 @@ class TransientMemoryBackendTest extends BaseTestCase
      */
     public function itIsPossibleToSetAndCheckExistenceInCache(): void
     {
-        $cache = $this->createMock(FrontendInterface::class);
+        $cache = $this->createMock(LowLevelFrontendInterface::class);
         $backend = new TransientMemoryBackend($this->getEnvironmentConfiguration());
         $backend->setCache($cache);
 
@@ -60,7 +60,7 @@ class TransientMemoryBackendTest extends BaseTestCase
      */
     public function itIsPossibleToSetAndGetEntry(): void
     {
-        $cache = $this->createMock(FrontendInterface::class);
+        $cache = $this->createMock(LowLevelFrontendInterface::class);
         $backend = new TransientMemoryBackend($this->getEnvironmentConfiguration());
         $backend->setCache($cache);
 
@@ -76,7 +76,7 @@ class TransientMemoryBackendTest extends BaseTestCase
      */
     public function itIsPossibleToRemoveEntryFromCache(): void
     {
-        $cache = $this->createMock(FrontendInterface::class);
+        $cache = $this->createMock(LowLevelFrontendInterface::class);
         $backend = new TransientMemoryBackend($this->getEnvironmentConfiguration());
         $backend->setCache($cache);
 
@@ -93,7 +93,7 @@ class TransientMemoryBackendTest extends BaseTestCase
      */
     public function itIsPossibleToOverwriteAnEntryInTheCache(): void
     {
-        $cache = $this->createMock(FrontendInterface::class);
+        $cache = $this->createMock(LowLevelFrontendInterface::class);
         $backend = new TransientMemoryBackend($this->getEnvironmentConfiguration());
         $backend->setCache($cache);
 
@@ -111,7 +111,7 @@ class TransientMemoryBackendTest extends BaseTestCase
      */
     public function findIdentifiersByTagFindsCacheEntriesWithSpecifiedTag(): void
     {
-        $cache = $this->createMock(FrontendInterface::class);
+        $cache = $this->createMock(LowLevelFrontendInterface::class);
         $backend = new TransientMemoryBackend($this->getEnvironmentConfiguration());
         $backend->setCache($cache);
 
@@ -168,7 +168,7 @@ class TransientMemoryBackendTest extends BaseTestCase
      */
     public function hasReturnsFalseIfTheEntryDoesntExist(): void
     {
-        $cache = $this->createMock(FrontendInterface::class);
+        $cache = $this->createMock(LowLevelFrontendInterface::class);
         $backend = new TransientMemoryBackend($this->getEnvironmentConfiguration());
         $backend->setCache($cache);
 
@@ -182,7 +182,7 @@ class TransientMemoryBackendTest extends BaseTestCase
      */
     public function removeReturnsFalseIfTheEntryDoesntExist(): void
     {
-        $cache = $this->createMock(FrontendInterface::class);
+        $cache = $this->createMock(LowLevelFrontendInterface::class);
         $backend = new TransientMemoryBackend($this->getEnvironmentConfiguration());
         $backend->setCache($cache);
 
@@ -196,7 +196,7 @@ class TransientMemoryBackendTest extends BaseTestCase
      */
     public function flushByTagRemovesCacheEntriesWithSpecifiedTag(): void
     {
-        $cache = $this->createMock(FrontendInterface::class);
+        $cache = $this->createMock(LowLevelFrontendInterface::class);
         $backend = new TransientMemoryBackend($this->getEnvironmentConfiguration());
         $backend->setCache($cache);
 
@@ -217,7 +217,7 @@ class TransientMemoryBackendTest extends BaseTestCase
      */
     public function flushByTagsRemovesCacheEntriesWithSpecifiedTags(): void
     {
-        $cache = $this->createMock(FrontendInterface::class);
+        $cache = $this->createMock(LowLevelFrontendInterface::class);
         $backend = new TransientMemoryBackend($this->getEnvironmentConfiguration());
         $backend->setCache($cache);
 
@@ -238,7 +238,7 @@ class TransientMemoryBackendTest extends BaseTestCase
      */
     public function flushRemovesAllCacheEntries(): void
     {
-        $cache = $this->createMock(FrontendInterface::class);
+        $cache = $this->createMock(LowLevelFrontendInterface::class);
         $backend = new TransientMemoryBackend($this->getEnvironmentConfiguration());
         $backend->setCache($cache);
 

--- a/Neos.Cache/Tests/Unit/Frontend/Psr/Cache/CachePoolTest.php
+++ b/Neos.Cache/Tests/Unit/Frontend/Psr/Cache/CachePoolTest.php
@@ -1,0 +1,210 @@
+<?php
+namespace Neos\Cache\Tests\Unit\Frontend\Psr\Cache;
+
+/*
+ * This file is part of the Neos.Cache package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Cache\Backend\AbstractBackend;
+use Neos\Cache\Backend\BackendInterface;
+use Neos\Cache\Frontend\Psr\Cache\CacheItem;
+use Neos\Cache\Frontend\Psr\Cache\CacheItemPoolFrontend;
+use Neos\Cache\Frontend\Psr\Cache\InvalidArgumentException;
+use Neos\Cache\Tests\BaseTestCase;
+
+/**
+ * Testcase for the PSR-6 cache frontend
+ *
+ */
+class CachePoolTest extends BaseTestCase
+{
+    public function validIdentifiersDataProvider(): array
+    {
+        return [
+            ['short'],
+            ['SomeValidIdentifier'],
+            ['withNumbers0123456789'],
+            ['withUnder_score'],
+            ['with.dot'],
+
+            // The following tests exceed the minimum requirements of the PSR-6 keys (@see https://www.php-fig.org/psr/psr-6/#definitions)
+            ['dashes-are-allowed'],
+            ['percent%sign'],
+            ['amper&sand'],
+            ['a-string-that-exceeds-the-psr-minimum-maxlength-of-sixtyfour-but-is-shorter-than-twohundredandfifty-characters'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider validIdentifiersDataProvider
+     */
+    public function validIdentifiers(string $identifier): void
+    {
+        $mockBackend = $this->getMockBuilder(BackendInterface::class)->getMock();
+        $cachePool = new CacheItemPoolFrontend('CacheItemPool', $mockBackend);
+        self::assertTrue($cachePool->isValidEntryIdentifier($identifier));
+    }
+
+    public function invalidIdentifiersDataProvider(): array
+    {
+        return [
+            [''],
+            ['späcialcharacters'],
+            ['a-string-that-exceeds-the-maximum-allowed-length-of-twohundredandfifty-characters-which-is-pretty-large-as-it-turns-out-so-i-repeat-a-string-that-exceeds-the-maximum-allowed-length-of-twohundredandfifty-characters-still-not-there-wow-crazy-flow-rocks-though'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidIdentifiersDataProvider
+     */
+    public function invalidIdentifiers(string $identifier): void
+    {
+        $mockBackend = $this->getMockBuilder(BackendInterface::class)->getMock();
+        $cachePool = new CacheItemPoolFrontend('CacheItemPool', $mockBackend);
+        $this->assertFalse($cachePool->isValidEntryIdentifier($identifier));
+    }
+
+
+
+    /**
+     * @test
+     */
+    public function getItemChecksIfTheIdentifierIsValid()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        /** @var PsrFrontend|\PHPUnit\Framework\MockObject\MockObject $cache */
+        $cache = $this->getMockBuilder(CacheItemPoolFrontend::class)
+            ->setMethods(['isValidEntryIdentifier'])
+            ->disableOriginalConstructor()
+            ->getMock();
+        $cache->expects(self::once())->method('isValidEntryIdentifier')->with('foo')->willReturn(false);
+        $cache->getItem('foo');
+    }
+
+    /**
+     * @test
+     */
+    public function savePassesSerializedStringToBackend()
+    {
+        $theString = 'Just some value';
+        $cacheItem = new CacheItem('PsrCacheTest', true, $theString);
+        $backend = $this->prepareDefaultBackend();
+        $backend->expects(self::once())->method('set')->with(self::equalTo('PsrCacheTest'), self::equalTo(serialize($theString)));
+
+        $cache = new CacheItemPoolFrontend('CachePool', $backend);
+        $cache->save($cacheItem);
+    }
+
+    /**
+     * @test
+     */
+    public function savePassesSerializedArrayToBackend()
+    {
+        $theArray = ['Just some value', 'and another one.'];
+        $cacheItem = new CacheItem('PsrCacheTest', true, $theArray);
+        $backend = $this->prepareDefaultBackend();
+        $backend->expects(self::once())->method('set')->with(self::equalTo('PsrCacheTest'), self::equalTo(serialize($theArray)));
+
+        $cache = new CacheItemPoolFrontend('CachePool', $backend);
+        $cache->save($cacheItem);
+    }
+
+    /**
+     * @test
+     */
+    public function savePassesLifetimeToBackend()
+    {
+        // Note that this test can fail due to fraction of second problems in the calculation of lifetime vs. expiration date.
+        $theString = 'Just some value';
+        $theLifetime = 1234;
+        $cacheItem = new CacheItem('PsrCacheTest', true, $theString);
+        $cacheItem->expiresAfter($theLifetime);
+        $backend = $this->prepareDefaultBackend();
+        $backend->expects(self::once())->method('set')->with(self::equalTo('PsrCacheTest'), self::equalTo(serialize($theString)), self::equalTo([]), self::equalTo($theLifetime, 1));
+
+        $cache = new CacheItemPoolFrontend('CachePool', $backend);
+        $cache->save($cacheItem);
+    }
+
+    /**
+     * @test
+     */
+    public function getItemFetchesValueFromBackend()
+    {
+        $theString = 'Just some value';
+        $backend = $this->prepareDefaultBackend();
+        $backend->expects(self::any())->method('get')->willReturn(serialize($theString));
+
+        $cache = new CacheItemPoolFrontend('CachePool', $backend);
+        self::assertEquals(true, $cache->getItem('PsrCacheTest')->isHit(), 'The item should have been a hit but is not');
+        self::assertEquals($theString, $cache->getItem('PsrCacheTest')->get(), 'The returned value was not the expected string.');
+    }
+
+    /**
+     * @test
+     */
+    public function getItemFetchesFalseBooleanValueFromBackend()
+    {
+        $backend = $this->prepareDefaultBackend();
+        $backend->expects(self::once())->method('get')->willReturn(serialize(false));
+
+        $cache = new CacheItemPoolFrontend('CachePool', $backend);
+        $retrievedItem = $cache->getItem('PsrCacheTest');
+        self::assertEquals(true, $retrievedItem->isHit(), 'The item should have been a hit but is not');
+        self::assertEquals(false, $retrievedItem->get(), 'The returned value was not the false.');
+    }
+
+    /**
+     * @test
+     */
+    public function hasItemReturnsResultFromBackend()
+    {
+        $backend = $this->prepareDefaultBackend();
+        $backend->expects(self::once())->method('has')->with(self::equalTo('PsrCacheTest'))->willReturn(true);
+
+        $cache = new CacheItemPoolFrontend('CachePool', $backend);
+        self::assertTrue($cache->hasItem('PsrCacheTest'), 'hasItem() did not return true.');
+    }
+
+    /**
+     * @test
+     */
+    public function deleteItemCallsBackend()
+    {
+        $cacheIdentifier = 'someCacheIdentifier';
+        $backend = $this->prepareDefaultBackend();
+
+        $backend->expects(self::once())->method('remove')->with(self::equalTo($cacheIdentifier))->willReturn(true);
+
+        $cache = new CacheItemPoolFrontend('CachePool', $backend);
+        self::assertTrue($cache->deleteItem($cacheIdentifier), 'deleteItem() did not return true');
+    }
+
+    /**
+     * @return AbstractBackend|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function prepareDefaultBackend()
+    {
+        return $this->getMockBuilder(AbstractBackend::class)
+            ->setMethods([
+                'get',
+                'set',
+                'has',
+                'remove',
+                'findIdentifiersByTag',
+                'flush',
+                'flushByTag',
+                'collectGarbage'
+            ])
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}

--- a/Neos.Cache/Tests/Unit/Frontend/Psr/SimpleCache/SimpleCacheTest.php
+++ b/Neos.Cache/Tests/Unit/Frontend/Psr/SimpleCache/SimpleCacheTest.php
@@ -1,10 +1,10 @@
 <?php
-namespace Neos\Cache\Tests\Unit\Psr\SimpleCache;
+namespace Neos\Cache\Tests\Unit\Frontend\Psr\SimpleCache;
 
 use Neos\Cache\Backend\BackendInterface;
 use Neos\Cache\Exception;
-use Neos\Cache\Psr\InvalidArgumentException;
-use Neos\Cache\Psr\SimpleCache\SimpleCache;
+use Neos\Cache\Frontend\Psr\SimpleCache\SimpleCacheFrontend;
+use Neos\Cache\Frontend\Psr\SimpleCache\InvalidArgumentException;
 use Neos\Cache\Tests\BaseTestCase;
 
 /**
@@ -27,11 +27,11 @@ class SimpleCacheTest extends BaseTestCase
 
     /**
      * @param string $identifier
-     * @return SimpleCache
+     * @return SimpleCacheFrontend
      */
     protected function createSimpleCache($identifier = 'SimpleCacheTest')
     {
-        return new SimpleCache($identifier, $this->mockBackend);
+        return new SimpleCacheFrontend($identifier, $this->mockBackend);
     }
 
     /**

--- a/Neos.Flow/Classes/Cache/CacheFactory.php
+++ b/Neos.Flow/Classes/Cache/CacheFactory.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Cache;
 use Neos\Cache\Backend\BackendInterface;
 use Neos\Cache\Backend\SimpleFileBackend;
 use Neos\Cache\EnvironmentConfiguration;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Cache\Exception\InvalidBackendException;
 use Neos\Flow\Core\ApplicationContext;
@@ -102,9 +102,9 @@ class CacheFactory extends \Neos\Cache\CacheFactory
      * @param string $backendObjectName
      * @param array $backendOptions
      * @param bool $persistent
-     * @return FrontendInterface
+     * @return LowLevelFrontendInterface
      */
-    public function create(string $cacheIdentifier, string $cacheObjectName, string $backendObjectName, array $backendOptions = [], bool $persistent = false): FrontendInterface
+    public function create(string $cacheIdentifier, string $cacheObjectName, string $backendObjectName, array $backendOptions = [], bool $persistent = false): LowLevelFrontendInterface
     {
         $backend = $this->instantiateBackend($backendObjectName, $backendOptions, $this->environmentConfiguration, $persistent);
         $cache = $this->instantiateCache($cacheIdentifier, $cacheObjectName, $backend);
@@ -116,7 +116,7 @@ class CacheFactory extends \Neos\Cache\CacheFactory
     /**
      * {@inheritdoc}
      */
-    protected function instantiateCache(string $cacheIdentifier, string $cacheObjectName, BackendInterface $backend): FrontendInterface
+    protected function instantiateCache(string $cacheIdentifier, string $cacheObjectName, BackendInterface $backend): LowLevelFrontendInterface
     {
         $cache = parent::instantiateCache($cacheIdentifier, $cacheObjectName, $backend);
 

--- a/Neos.Flow/Classes/Cache/CacheManager.php
+++ b/Neos.Flow/Classes/Cache/CacheManager.php
@@ -15,7 +15,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Cache\Backend\FileBackend;
 use Neos\Cache\Exception\DuplicateIdentifierException;
 use Neos\Cache\Exception\NoSuchCacheException;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Log\Utility\LogEnvironment;
@@ -57,7 +57,7 @@ class CacheManager
     protected $environment;
 
     /**
-     * @var FrontendInterface[]
+     * @var LowLevelFrontendInterface[]
      */
     protected $caches = [];
 
@@ -156,13 +156,13 @@ class CacheManager
     /**
      * Registers a cache so it can be retrieved at a later point.
      *
-     * @param FrontendInterface $cache The cache frontend to be registered
+     * @param LowLevelFrontendInterface $cache The cache frontend to be registered
      * @param bool $persistent
      * @return void
      * @throws DuplicateIdentifierException if a cache with the given identifier has already been registered.
      * @api
      */
-    public function registerCache(FrontendInterface $cache, bool $persistent = false): void
+    public function registerCache(LowLevelFrontendInterface $cache, bool $persistent = false): void
     {
         $identifier = $cache->getIdentifier();
         if (isset($this->caches[$identifier])) {
@@ -178,11 +178,12 @@ class CacheManager
      * Returns the cache specified by $identifier
      *
      * @param string $identifier Identifies which cache to return
-     * @return FrontendInterface The specified cache frontend
+     * @param class-string<T>|null $className The expected CacheManager for the cache frontend
+     * @return LowLevelFrontendInterface The specified cache frontend
      * @throws NoSuchCacheException
      * @api
      */
-    public function getCache(string $identifier): FrontendInterface
+    public function getCache(string $identifier): LowLevelFrontendInterface
     {
         if ($this->hasCache($identifier) === false) {
             throw new NoSuchCacheException('A cache with identifier "' . $identifier . '" does not exist.', 1203699034);
@@ -199,6 +200,7 @@ class CacheManager
      *
      * @param string $identifier
      * @return CacheInterface
+     * @deprecated will be removed with Neos Flow 10. Use Caches.yaml with \Neos\Cache\Frontend\Psr\SimpleCache\SimpleCacheFrontend.
      */
     public function getSimpleCache(string $identifier): CacheInterface
     {
@@ -217,6 +219,7 @@ class CacheManager
      *
      * @param string $identifier
      * @return CacheItemPoolInterface
+     * @deprecated will be removed with Neos Flow 10. Use Caches.yaml with \Neos\Cache\Frontend\Psr\CachePool\CachePoolFrontend.
      */
     public function getCacheItemPool(string $identifier): CacheItemPoolInterface
     {
@@ -263,7 +266,7 @@ class CacheManager
     public function flushCaches(bool $flushPersistentCaches = false): void
     {
         $this->createAllCaches();
-        /** @var FrontendInterface $cache */
+        /** @var LowLevelFrontendInterface $cache */
         foreach ($this->caches as $identifier => $cache) {
             if (!$flushPersistentCaches && $this->isCachePersistent($identifier)) {
                 continue;
@@ -287,7 +290,7 @@ class CacheManager
     public function flushCachesByTag(string $tag, bool $flushPersistentCaches = false): void
     {
         $this->createAllCaches();
-        /** @var FrontendInterface $cache */
+        /** @var LowLevelFrontendInterface $cache */
         foreach ($this->caches as $identifier => $cache) {
             if (!$flushPersistentCaches && $this->isCachePersistent($identifier)) {
                 continue;

--- a/Neos.Flow/Classes/Cache/NonMatchingCacheClassException.php
+++ b/Neos.Flow/Classes/Cache/NonMatchingCacheClassException.php
@@ -1,0 +1,11 @@
+<?php
+namespace Neos\Flow\Cache;
+
+/**
+ * An "Non Matching CacheClass" exception
+ *
+ * @api
+ */
+class NonMatchingCacheClassException extends \Exception
+{
+}

--- a/Neos.Flow/Classes/Mvc/Routing/Dto/RouteTags.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Dto/RouteTags.php
@@ -24,7 +24,7 @@ use Neos\Flow\Annotations as Flow;
 final class RouteTags
 {
     /**
-     * Pattern a tag must match. @see \Neos\Cache\Frontend\FrontendInterface::PATTERN_TAG
+     * Pattern a tag must match. @see \Neos\Cache\Frontend\LowLevelFrontendInterface::PATTERN_TAG
      */
     const PATTERN_TAG = '/^[a-zA-Z0-9_%\-&]{1,250}$/';
 

--- a/Neos.Flow/Classes/Persistence/Doctrine/CacheAdapter.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/CacheAdapter.php
@@ -13,7 +13,7 @@ namespace Neos\Flow\Persistence\Doctrine;
 
 use Doctrine\Common\Cache\Cache;
 use Neos\Flow\Annotations as Flow;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 use Neos\Flow\Security\Context;
 
 /**
@@ -22,7 +22,7 @@ use Neos\Flow\Security\Context;
 class CacheAdapter implements Cache
 {
     /**
-     * @var FrontendInterface
+     * @var LowLevelFrontendInterface
      */
     protected $cache;
 
@@ -35,10 +35,10 @@ class CacheAdapter implements Cache
     /**
      * Set the cache this adapter should use.
      *
-     * @param FrontendInterface $cache
+     * @param LowLevelFrontendInterface $cache
      * @return void
      */
-    public function setCache(FrontendInterface $cache)
+    public function setCache(LowLevelFrontendInterface $cache)
     {
         $this->cache = $cache;
     }

--- a/Neos.Flow/Classes/Session/Session.php
+++ b/Neos.Flow/Classes/Session/Session.php
@@ -24,7 +24,7 @@ use Neos\Flow\Security\Context;
 use Neos\Flow\Utility\Algorithms;
 use Neos\Flow\Http\Cookie;
 use Neos\Flow\Security\Authentication\TokenInterface;
-use Neos\Cache\Frontend\FrontendInterface;
+use Neos\Cache\Frontend\LowLevelFrontendInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -513,7 +513,7 @@ class Session implements CookieEnabledInterface
             throw new Exception\SessionNotStartedException('Tried to tag a session which has not been started yet.', 1355143533);
         }
         if (!$this->metaDataCache->isValidTag($tag)) {
-            throw new \InvalidArgumentException(sprintf('The tag used for tagging session %s contained invalid characters. Make sure it matches this regular expression: "%s"', $this->sessionIdentifier, FrontendInterface::PATTERN_TAG));
+            throw new \InvalidArgumentException(sprintf('The tag used for tagging session %s contained invalid characters. Make sure it matches this regular expression: "%s"', $this->sessionIdentifier, LowLevelFrontendInterface::PATTERN_TAG));
         }
         if (!in_array($tag, $this->tags)) {
             $this->tags[] = $tag;

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
@@ -293,22 +293,27 @@ which can be stored using a specific frontend.
 	The PHP frontend can only be used to cache PHP files, it does not work with strings,
 	arrays or objects.
 
-PSR Cache Interfaces
-====================
 
-The implementations of the PSR Cache Interfaces allow to provide caches for external
+PSR Cache Frontends
+===================
+
+The implementations of the PSR Cache Interfaces as cache frontends allows to provide caches for external
 libraries that do not know the flow cache interfaces.
 
-PSR-6 Caching Interface
------------------------
+PSR-6 Cache Interface
+---------------------
 
-The classes ``\Neos\Cache\Psr\Cache\CachePool`` and ``\Neos\Cache\Psr\Cache\CacheItem``
+``Neos\Cache\Frontend\Psr\Cache\CacheItemPoolFrontend``
+
+The classes ``\Neos\Cache\Frontend\Psr\Cache\CacheItemPoolFrontend`` and ``\Neos\Cache\Frontend\Psr\Cache\CacheItem``
 implement the Caching Interface as specified in https://www.php-fig.org/psr/psr-6/
 
 PSR-16 Simple Cache Interface
 -----------------------------
 
-The class ``\Neos\Cache\Psr\SimpleCache\SimpleCache`` implements the SimpleCacheInterface
+``Neos\Cache\Frontend\Psr\SimpleCache\SimpleCacheFrontend``
+
+The class ``\Neos\Cache\Frontend\Psr\SimpleCache\SimpleCacheFrontend`` implements the SimpleCacheInterface
 that is specified in https://www.php-fig.org/psr/psr-16/
 
 Cache Backends

--- a/Neos.Flow/Tests/Unit/Cache/CacheManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Cache/CacheManagerTest.php
@@ -83,10 +83,10 @@ class CacheManagerTest extends UnitTestCase
     public function managerThrowsExceptionOnCacheRegistrationWithAlreadyExistingIdentifier()
     {
         $this->expectException(Cache\Exception\DuplicateIdentifierException::class);
-        $cache1 = $this->getMockBuilder(Cache\Frontend\AbstractFrontend::class)->disableOriginalConstructor()->getMock();
+        $cache1 = $this->getMockBuilder(Cache\Frontend\AbstractLowLevelFrontend::class)->disableOriginalConstructor()->getMock();
         $cache1->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('test'));
 
-        $cache2 = $this->getMockBuilder(Cache\Frontend\AbstractFrontend::class)->disableOriginalConstructor()->getMock();
+        $cache2 = $this->getMockBuilder(Cache\Frontend\AbstractLowLevelFrontend::class)->disableOriginalConstructor()->getMock();
         $cache2->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('test'));
 
         $this->cacheManager->registerCache($cache1);
@@ -98,10 +98,10 @@ class CacheManagerTest extends UnitTestCase
      */
     public function managerReturnsThePreviouslyRegisteredCached()
     {
-        $cache1 = $this->getMockBuilder(Cache\Frontend\AbstractFrontend::class)->disableOriginalConstructor()->getMock();
+        $cache1 = $this->getMockBuilder(Cache\Frontend\AbstractLowLevelFrontend::class)->disableOriginalConstructor()->getMock();
         $cache1->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('cache1'));
 
-        $cache2 = $this->getMockBuilder(Cache\Frontend\AbstractFrontend::class)->disableOriginalConstructor()->getMock();
+        $cache2 = $this->getMockBuilder(Cache\Frontend\AbstractLowLevelFrontend::class)->disableOriginalConstructor()->getMock();
         $cache2->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('cache2'));
 
         $this->cacheManager->registerCache($cache1);
@@ -122,7 +122,7 @@ class CacheManagerTest extends UnitTestCase
     public function getCacheThrowsExceptionForNonExistingIdentifier()
     {
         $this->expectException(Cache\Exception\NoSuchCacheException::class);
-        $cache = $this->getMockBuilder(Cache\Frontend\AbstractFrontend::class)->disableOriginalConstructor()->getMock();
+        $cache = $this->getMockBuilder(Cache\Frontend\AbstractLowLevelFrontend::class)->disableOriginalConstructor()->getMock();
         $cache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('someidentifier'));
 
         $this->cacheManager->registerCache($cache);
@@ -137,7 +137,7 @@ class CacheManagerTest extends UnitTestCase
     public function getCacheItemPoolThrowsExceptionForNonExistingIdentifier()
     {
         $this->expectException(Cache\Exception\NoSuchCacheException::class);
-        $cache = $this->getMockBuilder(Cache\Frontend\AbstractFrontend::class)->disableOriginalConstructor()->getMock();
+        $cache = $this->getMockBuilder(Cache\Frontend\AbstractLowLevelFrontend::class)->disableOriginalConstructor()->getMock();
         $cache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('someidentifier'));
 
         $this->cacheManager->registerCache($cache);
@@ -152,7 +152,7 @@ class CacheManagerTest extends UnitTestCase
     public function getSimpleCacheThrowsExceptionForNonExistingIdentifier()
     {
         $this->expectException(Cache\Exception\NoSuchCacheException::class);
-        $cache = $this->getMockBuilder(Cache\Frontend\AbstractFrontend::class)->disableOriginalConstructor()->getMock();
+        $cache = $this->getMockBuilder(Cache\Frontend\AbstractLowLevelFrontend::class)->disableOriginalConstructor()->getMock();
         $cache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('someidentifier'));
 
         $this->cacheManager->registerCache($cache);
@@ -166,7 +166,7 @@ class CacheManagerTest extends UnitTestCase
      */
     public function hasCacheReturnsCorrectResult()
     {
-        $cache1 = $this->getMockBuilder(Cache\Frontend\AbstractFrontend::class)->disableOriginalConstructor()->getMock();
+        $cache1 = $this->getMockBuilder(Cache\Frontend\AbstractLowLevelFrontend::class)->disableOriginalConstructor()->getMock();
         $cache1->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('cache1'));
         $this->cacheManager->registerCache($cache1);
 
@@ -179,11 +179,11 @@ class CacheManagerTest extends UnitTestCase
      */
     public function isCachePersistentReturnsCorrectResult()
     {
-        $cache1 = $this->getMockBuilder(Cache\Frontend\AbstractFrontend::class)->disableOriginalConstructor()->getMock();
+        $cache1 = $this->getMockBuilder(Cache\Frontend\AbstractLowLevelFrontend::class)->disableOriginalConstructor()->getMock();
         $cache1->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('cache1'));
         $this->cacheManager->registerCache($cache1);
 
-        $cache2 = $this->getMockBuilder(Cache\Frontend\AbstractFrontend::class)->disableOriginalConstructor()->getMock();
+        $cache2 = $this->getMockBuilder(Cache\Frontend\AbstractLowLevelFrontend::class)->disableOriginalConstructor()->getMock();
         $cache2->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('cache2'));
         $this->cacheManager->registerCache($cache2, true);
 
@@ -196,17 +196,17 @@ class CacheManagerTest extends UnitTestCase
      */
     public function flushCachesByTagCallsTheFlushByTagMethodOfAllRegisteredCaches()
     {
-        $cache1 = $this->getMockBuilder(Cache\Frontend\AbstractFrontend::class)->disableOriginalConstructor()->getMock();
+        $cache1 = $this->getMockBuilder(Cache\Frontend\AbstractLowLevelFrontend::class)->disableOriginalConstructor()->getMock();
         $cache1->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('cache1'));
         $cache1->expects(self::once())->method('flushByTag')->with(self::equalTo('theTag'));
         $this->cacheManager->registerCache($cache1);
 
-        $cache2 = $this->getMockBuilder(Cache\Frontend\AbstractFrontend::class)->disableOriginalConstructor()->getMock();
+        $cache2 = $this->getMockBuilder(Cache\Frontend\AbstractLowLevelFrontend::class)->disableOriginalConstructor()->getMock();
         $cache2->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('cache2'));
         $cache2->expects(self::once())->method('flushByTag')->with(self::equalTo('theTag'));
         $this->cacheManager->registerCache($cache2);
 
-        $persistentCache = $this->getMockBuilder(Cache\Frontend\AbstractFrontend::class)->disableOriginalConstructor()->getMock();
+        $persistentCache = $this->getMockBuilder(Cache\Frontend\AbstractLowLevelFrontend::class)->disableOriginalConstructor()->getMock();
         $persistentCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('persistentCache'));
         $persistentCache->expects(self::never())->method('flushByTag')->with(self::equalTo('theTag'));
         $this->cacheManager->registerCache($persistentCache, true);
@@ -219,17 +219,17 @@ class CacheManagerTest extends UnitTestCase
      */
     public function flushCachesCallsTheFlushMethodOfAllRegisteredCaches()
     {
-        $cache1 = $this->getMockBuilder(Cache\Frontend\AbstractFrontend::class)->disableOriginalConstructor()->getMock();
+        $cache1 = $this->getMockBuilder(Cache\Frontend\AbstractLowLevelFrontend::class)->disableOriginalConstructor()->getMock();
         $cache1->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('cache1'));
         $cache1->expects(self::once())->method('flush');
         $this->cacheManager->registerCache($cache1);
 
-        $cache2 = $this->getMockBuilder(Cache\Frontend\AbstractFrontend::class)->disableOriginalConstructor()->getMock();
+        $cache2 = $this->getMockBuilder(Cache\Frontend\AbstractLowLevelFrontend::class)->disableOriginalConstructor()->getMock();
         $cache2->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('cache2'));
         $cache2->expects(self::once())->method('flush');
         $this->cacheManager->registerCache($cache2);
 
-        $persistentCache = $this->getMockBuilder(Cache\Frontend\AbstractFrontend::class)->disableOriginalConstructor()->getMock();
+        $persistentCache = $this->getMockBuilder(Cache\Frontend\AbstractLowLevelFrontend::class)->disableOriginalConstructor()->getMock();
         $persistentCache->expects(self::atLeastOnce())->method('getIdentifier')->will(self::returnValue('persistentCache'));
         $persistentCache->expects(self::never())->method('flush');
         $this->cacheManager->registerCache($persistentCache, true);

--- a/Neos.Flow/Tests/Unit/Security/Cryptography/HashServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Cryptography/HashServiceTest.php
@@ -64,8 +64,9 @@ class HashServiceTest extends UnitTestCase
      */
     protected function setUp(): void
     {
-        $this->cache = new StringFrontend('TestCache', new TransientMemoryBackend(new EnvironmentConfiguration('Hash Testing', '/some/path', PHP_MAXPATHLEN)));
-        $this->cache->initializeObject();
+        $cacheBackend = new TransientMemoryBackend(new EnvironmentConfiguration('Hash Testing', '/some/path', PHP_MAXPATHLEN));
+        $this->cache = new StringFrontend('TestCache', $cacheBackend);
+        $cacheBackend->setCache($this->cache);
 
         $this->mockObjectManager = $this->getMockBuilder(ObjectManagerInterface::class)->getMock();
 


### PR DESCRIPTION
While Neos had methods to create PSR caches those were seldomly used as they worked quite differently to other caches that were configured via `Caches.yaml`.

This change introduces implementations of PSR-6 Cache and PSR-16 SimpleCache that can be used as normal flow cache-frontends. To make this possible the low level functionality of object instantiation and garbage collection and flushing was extracted into a `LowLevelFrontendInterface` while the `FrontenInterface` on to defines the interaction with the caches.

```yaml
Vendor_Package_SimpleCache:
  frontend: Neos\Cache\Frontend\Psr\SimpleCache\SimpleCacheFrontend
  backend: Neos\Cache\Backend\FileBackend

Vendor_Package_Cache:
  frontend: Neos\Cache\Frontend\Psr\Cache\CacheItemPoolFrontend
  backend: Neos\Cache\Backend\FileBackend

```

Tho help to ensuring which cache interface you are working with the method `getCache` of the `CacheManager` now got an optional second argument that allows to specify the classname of the expected frontend implementation.

The old methods to create PSR caches are deprecated and marked for removal with Neos Flow 10.

**Upgrade instructions**

If Caches are configured via Caches.yaml and injected via Objects.yaml no changes are needed. 

If the CacheManager is used to obtain certain caches it is important to note that the the method `getCache` now returns `LowLevelFrontendInterface` instead of `FrontendInterface`. It will still return the configured cache implementation from `Caches.yaml` but you may have to add the expected className as second argument to convince your static analysis.

**Review instructions**

A secondary non-official goal of this pr is allowing to implement other cache interfaces like the following as flow cache and be managed by the cache manager.

```php
    public function resolve(string $identifier, \Closure $updateClosure, array $tags = [], ?int $lifeTime = null, ?int $gracePeriod = null, ?int $lockPeriod = null): mixed
```

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
