### PR TITLE
BUGFIX: No useless read in `FileBackend` (improve performance)

### DIFF
--- a/Neos.Cache/Classes/Backend/FileBackend.php
+++ b/Neos.Cache/Classes/Backend/FileBackend.php
@@ -245,11 +245,15 @@ class FileBackend extends SimpleFileBackend implements PhpCapableBackendInterfac
      * specified tags.
      *
      * @param string[] $tags The tags to search for
-     * @return string[] An array with identifiers of all matching entries. An empty array if no entries matched
+     * @return string[] An array with identifiers of all matching entries. An empty array if no entries matched or no tags were provided
      * @api
      */
     public function findIdentifiersByTags(array $tags): array
     {
+        if (empty($tags)) {
+            return [];
+        }
+
         $entryIdentifiers = [];
         $now = $_SERVER['REQUEST_TIME'];
         $cacheEntryFileExtensionLength = strlen($this->cacheEntryFileExtension);


### PR DESCRIPTION
`FileBackend::findIdentifiersByTags` now early returns if `$tags` is empty. Otherwise it would read every cache entry completely unnecessarily from the filesystem. 

<details>
  <summary>Profile before</summary>

![Screenshot_1](https://github.com/neos/flow-development-collection/assets/54950395/ee332ce9-09c0-40c4-bbb6-688ccaf037de)

</details>

<details>
  <summary>Profile after</summary>

<img width="725" alt="Screenshot_2" src="https://github.com/neos/flow-development-collection/assets/54950395/2506d2c9-82e0-4678-9277-1025b011589c">

<img width="725" alt="Screenshot_3" src="https://github.com/neos/flow-development-collection/assets/54950395/d9469fb4-e5b9-41dc-928f-3aff68c4e756">

</details>

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html) |  7.3 does not have the method in `FileBackend` so using 8.0 instead
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
