### PR TITLE
TASK: Add PHP 8.3 to build workflow matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.0', '8.1', '8.2']
+        php-versions: ['8.0', '8.1', '8.2', '8.3']
         # see https://mariadb.com/kb/en/mariadb-server-release-dates/
         # this should be a current release, e.g. the LTS version
         mariadb-versions: ['10.6']

--- a/Neos.Flow/Tests/Functional/Aop/FrameworkTest.php
+++ b/Neos.Flow/Tests/Functional/Aop/FrameworkTest.php
@@ -95,7 +95,7 @@ class FrameworkTest extends FunctionalTestCase
     public function adviceInformationIsAlsoBuiltWhenTheTargetClassIsUnserialized()
     {
         $className = Fixtures\TargetClass01::class;
-        $targetClass = unserialize('O:' . strlen($className) . ':"' . $className . '":0:{};');
+        $targetClass = unserialize('O:' . strlen($className) . ':"' . $className . '":0:{}');
         self::assertSame('Hello, me', $targetClass->greet('Flow'));
     }
 

--- a/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
@@ -93,7 +93,7 @@ class DependencyInjectionTest extends FunctionalTestCase
 
         $singletonA = $this->objectManager->get(Fixtures\SingletonClassA::class);
 
-        $prototypeA = unserialize('O:' . strlen($className) . ':"' . $className . '":0:{};');
+        $prototypeA = unserialize('O:' . strlen($className) . ':"' . $className . '":0:{}');
         self::assertSame($singletonA, $prototypeA->getSingletonA());
     }
 


### PR DESCRIPTION
This will test Flow against PHP 8.3

**Checklist**

- [ ] ~Code follows the PSR-2 coding style~
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the lowest branch supporting PHP > 8.1
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
