### PR TITLE
FEATURE: Add `Flow\InjectCache` Attribute / Annotation for property injection

### DIFF
--- a/Neos.Flow/Classes/Annotations/InjectCache.php
+++ b/Neos.Flow/Classes/Annotations/InjectCache.php
@@ -1,0 +1,42 @@
+<?php
+namespace Neos\Flow\Annotations;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
+/**
+ * Used to enable property injection for cache frontends.
+ *
+ * Flow will build Dependency Injection code for the property and try
+ * to inject the specified cache.
+ *
+ * @Annotation
+ * @NamedArgumentConstructor
+ * @Target("PROPERTY")
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+final class InjectCache
+{
+    /**
+     * Identifier for the Cache that will be injected.
+     *
+     * Example: Neos_Fusion_Content
+     *
+     * @var string
+     */
+    public $identifier;
+
+    public function __construct(string $identifier)
+    {
+        $this->identifier = $identifier;
+    }
+}

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationProperty.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationProperty.php
@@ -23,6 +23,7 @@ class ConfigurationProperty
     const PROPERTY_TYPES_STRAIGHTVALUE = 0;
     const PROPERTY_TYPES_OBJECT = 1;
     const PROPERTY_TYPES_CONFIGURATION = 2;
+    const PROPERTY_TYPES_CACHE = 3;
 
     /**
      * @var string Name of the property

--- a/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
@@ -532,13 +532,13 @@ class ProxyClassBuilder
      *
      * @param Configuration $objectConfiguration Configuration of the object to inject into
      * @param string $propertyName Name of the property to inject
-     * @param string $cacheIdentiier the configuration type of the injected property (one of the ConfigurationManager::CONFIGURATION_TYPE_* constants)
+     * @param string $cacheIdentifier the identifier of the cache to inject
      * @return array PHP code
      */
-    public function buildPropertyInjectionCodeByCacheIdentifier(Configuration $objectConfiguration, string $propertyName, string $cacheIdentiier): array
+    public function buildPropertyInjectionCodeByCacheIdentifier(Configuration $objectConfiguration, string $propertyName, string $cacheIdentifier): array
     {
         $className = $objectConfiguration->getClassName();
-        $preparedSetterArgument = '\Neos\Flow\Core\Bootstrap::$staticObjectManager->get(\Neos\Flow\Cache\CacheManager::class)->getCache(\'' . $cacheIdentiier . '\')';
+        $preparedSetterArgument = '\Neos\Flow\Core\Bootstrap::$staticObjectManager->get(\Neos\Flow\Cache\CacheManager::class)->getCache(\'' . $cacheIdentifier . '\')';
         $result = $this->buildSetterInjectionCode($className, $propertyName, $preparedSetterArgument);
         if ($result !== null) {
             return $result;

--- a/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Tests\Functional\ObjectManagement;
  * source code.
  */
 
+use Neos\Flow\Cache\CacheManager;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\ObjectManagement\Proxy\ProxyInterface;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\FinalClassWithDependencies;
@@ -28,12 +29,14 @@ use Neos\Flow\Tests\FunctionalTestCase;
 class DependencyInjectionTest extends FunctionalTestCase
 {
     protected ConfigurationManager $configurationManager;
+    protected CacheManager $cacheManager;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->configurationManager = $this->objectManager->get(ConfigurationManager::class);
+        $this->cacheManager = $this->objectManager->get(CacheManager::class);
     }
 
     /**
@@ -293,6 +296,16 @@ class DependencyInjectionTest extends FunctionalTestCase
     {
         $classWithInjectedConfiguration = new Fixtures\ClassWithInjectedConfiguration();
         self::assertSame($this->configurationManager->getConfiguration('Views'), $classWithInjectedConfiguration->getInjectedViewsConfiguration());
+    }
+
+    /**
+     * @test
+     */
+    public function injectionOfCaches(): void
+    {
+        $classWithInjectedCache = new Fixtures\ClassWithInjectedCache();
+        self::assertSame($this->cacheManager->getCache('Flow_Monitor'), $classWithInjectedCache->getCacheInjectedViaAttribute());
+        self::assertSame($this->cacheManager->getCache('Flow_Monitor'), $classWithInjectedCache->getCacheInjectedViaAnnotation());
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassWithInjectedCache.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassWithInjectedCache.php
@@ -1,0 +1,40 @@
+<?php
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Cache\Frontend\StringFrontend;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A class for testing setting injection
+ */
+class ClassWithInjectedCache
+{
+    /**
+     * @Flow\InjectCache(identifier="Flow_Monitor")
+     * @var StringFrontend
+     */
+    protected $cacheByAnnotation;
+
+    #[Flow\InjectCache(identifier: 'Flow_Monitor')]
+    protected StringFrontend $cacheByAttribute;
+
+    public function getCacheInjectedViaAnnotation()
+    {
+        return $this->cacheByAnnotation;
+    }
+
+    public function getCacheInjectedViaAttribute()
+    {
+        return $this->cacheByAttribute;
+    }
+}


### PR DESCRIPTION
In many cases an `Objects.yaml` is created just to inject caches which can feel a bit cumbersome as one already had specified the cache in `Caches.yaml`.

To address this the new `@Flow\InjectCache` annotation allows to assign a cache frontend of a configured cache directly to a property without having to configure the `Objects.yaml` at all.

```php
    #[Flow\InjectCache(identifier: 'Flow_Mvc_Routing_Resolve')]
    protected VariableFrontend $cache;
```

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
