### PR TITLE
BUGFIX: Dont log stack trace for `InvalidHashException` in Production

### DIFF
--- a/Neos.Flow/Classes/Mvc/Controller/ActionController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ActionController.php
@@ -31,8 +31,6 @@ use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Property\Exception\TargetNotFoundException;
 use Neos\Flow\Property\TypeConverter\Error\TargetNotFoundError;
 use Neos\Flow\Reflection\ReflectionService;
-use Neos\Flow\Security\Exception\InvalidArgumentForHashGenerationException;
-use Neos\Flow\Security\Exception\InvalidHashException;
 use Neos\Utility\TypeHandling;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -227,13 +225,8 @@ class ActionController extends AbstractController
         if (method_exists($this, $actionInitializationMethodName)) {
             call_user_func([$this, $actionInitializationMethodName]);
         }
-        try {
-            $this->mvcPropertyMappingConfigurationService->initializePropertyMappingConfigurationFromRequest($this->request, $this->arguments);
-        } catch (InvalidArgumentForHashGenerationException|InvalidHashException $e) {
-            $message = $this->throwableStorage->logThrowable($e);
-            $this->logger->notice('Property mapping configuration failed due to HMAC errors. ' . $message, LogEnvironment::fromMethodName(__METHOD__));
-            $this->throwStatus(400, null, 'Invalid HMAC submitted');
-        }
+
+        $this->mvcPropertyMappingConfigurationService->initializePropertyMappingConfigurationFromRequest($this->request, $this->arguments);
 
         try {
             $this->mapRequestArgumentsToControllerArguments();

--- a/Neos.Flow/Configuration/Development/Settings.yaml
+++ b/Neos.Flow/Configuration/Development/Settings.yaml
@@ -23,6 +23,11 @@ Neos:
         defaultRenderingOptions:
           renderTechnicalDetails: true
 
+        renderingGroups:
+          noStacktraceExceptionGroup:
+            options:
+              logException: true
+
       errorHandler:
         exceptionalErrors: ['%E_USER_ERROR%', '%E_RECOVERABLE_ERROR%', '%E_WARNING%', '%E_NOTICE%', '%E_USER_WARNING%', '%E_USER_NOTICE%', '%E_STRICT%']
 

--- a/Neos.Flow/Configuration/Settings.Error.yaml
+++ b/Neos.Flow/Configuration/Settings.Error.yaml
@@ -37,6 +37,14 @@ Neos:
               variables:
                 errorDescription: 'Sorry, the database connection couldn''t be established.'
 
+          noStacktraceExceptionGroup:
+            matchingExceptionClassNames: ['Neos\Flow\Security\Exception\InvalidHashException']
+            options:
+              logException: false
+              templatePathAndFilename: 'resource://Neos.Flow/Private/Templates/Error/Default.html'
+              variables:
+                errorDescription: 'Sorry, something went wrong.'
+
       errorHandler:
 
         # Defines which errors should result in an exception thrown - all other error
@@ -71,4 +79,3 @@ Neos:
 
         # Maximal recursion for the debugger
         recursionLimit: 5
-


### PR DESCRIPTION
This configures an `invalidHashExceptions` exception handler rendering group and configures it to not dump stack traces in `Production` context. For `Development` context stack traces are still written to ease debugging.

See #3159

**Upgrade instructions**

In case you need trace dumps for `InvalidHashException` in production context, override the settings as needed.

**Review instructions**

See #3159 for ways to trigger those exceptions. Then check if a trace is dumped.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
