### PR TITLE
BUGFIX: Assume content exists, if stream size is unknown

### DIFF
--- a/Neos.Flow/Classes/Http/Helper/ResponseInformationHelper.php
+++ b/Neos.Flow/Classes/Http/Helper/ResponseInformationHelper.php
@@ -228,7 +228,7 @@ abstract class ResponseInformationHelper
             }
         }
 
-        if (!$response->hasHeader('Content-Length')) {
+        if (!$response->hasHeader('Content-Length') && $response->getBody()->getSize() !== null) {
             $response = $response->withHeader('Content-Length', $response->getBody()->getSize());
         }
 

--- a/Neos.Flow/Classes/Mvc/ActionResponse.php
+++ b/Neos.Flow/Classes/Mvc/ActionResponse.php
@@ -345,6 +345,7 @@ final class ActionResponse
      */
     private function hasContent(): bool
     {
-        return $this->content->getSize() > 0;
+        $contentSize = $this->content->getSize();
+        return $contentSize === null || $contentSize > 0;
     }
 }


### PR DESCRIPTION
If a PSR7 stream is returned from an `ActionController` action, no content arrives at the client, if the stream has an unknown size.

Why is that? Because the check in our `ActionResponse` in `hasContent()` is implemented like this: 

    $this->content->getSize() > 0

If a stream returns `null` here, because the size is unknown, we should assume content exists...

There should be no change in behavior, even if the stream is in fact empty. Because that would lead to `hasContent()` returning `true`, and the HTTP response being built in `ActionResponse` would get the stream as content. When being delivered that would evaluate to "a stream from an empty string", so there will be (again) no difference, if you look at what the `MessageTrait`does if the internal stream is `null`:

```php
    public function getBody(): StreamInterface
    {
        if (!$this->stream) {
            $this->stream = Utils::streamFor('');
        }

        return $this->stream;
    }
```

**Upgrade instructions**

**Review instructions**

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
