### PR TITLE
TASK: Correct symfony dependencies in Flow composer.json

### DIFF
--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -48,9 +48,9 @@
         "doctrine/common": "^3.0.3",
         "doctrine/annotations": "^1.12",
 
-        "symfony/yaml": "^5.1",
-        "symfony/dom-crawler": "^5.1",
-        "symfony/console": "^5.1",
+        "symfony/yaml": "^5.1||^6.0",
+        "symfony/dom-crawler": "^5.1||^6.0",
+        "symfony/console": "^5.1||^6.0",
 
         "composer/composer": "^2.2.8",
 


### PR DESCRIPTION
The upmerge commit `e2b895120eb00a6c2a352ce22d84f0302b6c3c71` wrongly removed symfony 6.0 in the version constraints of `neos/flow`.

Relates: #2999
