### PR TITLE
TASK: Fix some nullable php doc types

### DIFF
--- a/Neos.Eel/Classes/FlowQuery/FlowQuery.php
+++ b/Neos.Eel/Classes/FlowQuery/FlowQuery.php
@@ -257,7 +257,7 @@ class FlowQuery implements ProtectedContextAwareInterface, \IteratorAggregate, \
      *
      * Should only be called inside an operation.
      *
-     * @return string the next operation name or NULL if no next operation found.
+     * @return string|null the next operation name or NULL if no next operation found.
      */
     public function peekOperationName()
     {

--- a/Neos.Eel/Classes/Helper/StringHelper.php
+++ b/Neos.Eel/Classes/Helper/StringHelper.php
@@ -230,7 +230,7 @@ class StringHelper implements ProtectedContextAwareInterface
      *
      * @param string $string The input string
      * @param string $pattern A PREG pattern
-     * @return array The matches as array or NULL if not matched
+     * @return array|null The matches as array or NULL if not matched
      * @throws EvaluationException
      */
     public function pregMatch($string, $pattern)
@@ -255,7 +255,7 @@ class StringHelper implements ProtectedContextAwareInterface
      *
      * @param string $string The input string
      * @param string $pattern A PREG pattern
-     * @return array The matches as array or NULL if not matched
+     * @return array|null The matches as array or NULL if not matched
      * @throws EvaluationException
      */
     public function pregMatchAll($string, $pattern)

--- a/Neos.Flow/Classes/Aop/JoinPointInterface.php
+++ b/Neos.Flow/Classes/Aop/JoinPointInterface.php
@@ -91,7 +91,7 @@ interface JoinPointInterface
      * If no exception has been thrown, NULL is returned.
      * Only makes sense for After Throwing advices.
      *
-     * @return \Exception The exception thrown or NULL
+     * @return \Exception|null The exception thrown or NULL
      */
     public function getException();
 

--- a/Neos.Flow/Classes/Cli/Response.php
+++ b/Neos.Flow/Classes/Cli/Response.php
@@ -118,7 +118,7 @@ class Response
     /**
      * Sets color support / styled output to yes, no or auto detection
      *
-     * @param boolean $colorSupport true, false or NULL (= autodetection)
+     * @param boolean|null $colorSupport true, false or NULL (= autodetection)
      * @return void
      */
     public function setColorSupport(bool $colorSupport): void

--- a/Neos.Flow/Classes/Cli/Response.php
+++ b/Neos.Flow/Classes/Cli/Response.php
@@ -47,12 +47,12 @@ class Response
     private $content = '';
 
     /**
-     * @var
+     * @var bool|null
      */
     private $colorSupport;
 
     /**
-     * @var
+     * @var int
      */
     private $outputFormat = self::OUTPUTFORMAT_STYLED;
 
@@ -121,7 +121,7 @@ class Response
      * @param boolean|null $colorSupport true, false or NULL (= autodetection)
      * @return void
      */
-    public function setColorSupport(bool $colorSupport): void
+    public function setColorSupport(bool|null $colorSupport): void
     {
         $this->colorSupport = $colorSupport;
     }

--- a/Neos.Flow/Classes/Configuration/ConfigurationSchemaValidator.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationSchemaValidator.php
@@ -90,7 +90,7 @@ class ConfigurationSchemaValidator
      * Validate a single configuration type
      *
      * @param string $configurationType the configuration typr to validate
-     * @param string $path configuration path to validate, or NULL.
+     * @param string|null $path configuration path to validate, or NULL.
      * @param array $loadedSchemaFiles will be filled with a list of loaded schema files
      * @return \Neos\Error\Messages\Result
      * @throws Exception\SchemaValidationException

--- a/Neos.Flow/Classes/Configuration/ConfigurationSchemaValidator.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationSchemaValidator.php
@@ -95,7 +95,7 @@ class ConfigurationSchemaValidator
      * @return \Neos\Error\Messages\Result
      * @throws Exception\SchemaValidationException
      */
-    protected function validateSingleType(string $configurationType, string $path = null, array&$loadedSchemaFiles = []): Result
+    protected function validateSingleType(string $configurationType, ?string $path = null, array&$loadedSchemaFiles = []): Result
     {
         $availableConfigurationTypes = $this->configurationManager->getAvailableConfigurationTypes();
         if (in_array($configurationType, $availableConfigurationTypes) === false) {

--- a/Neos.Flow/Classes/Core/ApplicationContext.php
+++ b/Neos.Flow/Classes/Core/ApplicationContext.php
@@ -135,7 +135,7 @@ class ApplicationContext
     /**
      * Returns the parent context object, if any
      *
-     * @return ApplicationContext the parent context or NULL, if there is none
+     * @return ApplicationContext|null the parent context or NULL, if there is none
      * @api
      */
     public function getParent()

--- a/Neos.Flow/Classes/Error/AbstractExceptionHandler.php
+++ b/Neos.Flow/Classes/Error/AbstractExceptionHandler.php
@@ -188,7 +188,7 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
      * Checks if custom rendering rules apply to the given $exception and returns those.
      *
      * @param \Throwable $exception
-     * @return array|null the custom rendering options, or NULL if no custom rendering is defined for this exception
+     * @return array the custom rendering options, or the default
      */
     protected function resolveCustomRenderingOptions(\Throwable $exception): array
     {

--- a/Neos.Flow/Classes/Error/AbstractExceptionHandler.php
+++ b/Neos.Flow/Classes/Error/AbstractExceptionHandler.php
@@ -188,7 +188,7 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
      * Checks if custom rendering rules apply to the given $exception and returns those.
      *
      * @param \Throwable $exception
-     * @return array the custom rendering options, or NULL if no custom rendering is defined for this exception
+     * @return array|null the custom rendering options, or NULL if no custom rendering is defined for this exception
      */
     protected function resolveCustomRenderingOptions(\Throwable $exception): array
     {
@@ -206,7 +206,7 @@ abstract class AbstractExceptionHandler implements ExceptionHandlerInterface
 
     /**
      * @param \Throwable $exception
-     * @return string name of the resolved renderingGroup or NULL if no group could be resolved
+     * @return string|null name of the resolved renderingGroup or NULL if no group could be resolved
      */
     protected function resolveRenderingGroup(\Throwable $exception)
     {

--- a/Neos.Flow/Classes/Http/Client/Browser.php
+++ b/Neos.Flow/Classes/Http/Client/Browser.php
@@ -223,7 +223,7 @@ class Browser implements ClientInterface
     /**
      * Returns the response received after the last request.
      *
-     * @return ResponseInterface The HTTP response or NULL if there wasn't a response yet
+     * @return ResponseInterface|null The HTTP response or NULL if there wasn't a response yet
      * @api
      */
     public function getLastResponse()
@@ -234,7 +234,7 @@ class Browser implements ClientInterface
     /**
      * Returns the last request executed.
      *
-     * @return RequestInterface The HTTP request or NULL if there wasn't a request yet
+     * @return RequestInterface|null The HTTP request or NULL if there wasn't a request yet
      * @api
      */
     public function getLastRequest()

--- a/Neos.Flow/Classes/Http/Cookie.php
+++ b/Neos.Flow/Classes/Http/Cookie.php
@@ -318,7 +318,7 @@ class Cookie
      * This information is rendered as the Max-Age attribute (RFC 6265, 4.1.2.2).
      * Note that not all browsers support this attribute.
      *
-     * @return integer The maximum age in seconds, or NULL if none has been defined.
+     * @return integer|null The maximum age in seconds, or NULL if none has been defined.
      * @api
      */
     public function getMaximumAge()

--- a/Neos.Flow/Classes/Http/Headers.php
+++ b/Neos.Flow/Classes/Http/Headers.php
@@ -257,7 +257,7 @@ class Headers implements \Iterator
      * Returns a cookie specified by the given name
      *
      * @param string $name Name of the cookie
-     * @return Cookie The cookie or NULL if no such cookie exists
+     * @return Cookie|null The cookie or NULL if no such cookie exists
      * @api
      */
     public function getCookie($name)

--- a/Neos.Flow/Classes/Http/Middleware/TrustedProxiesMiddleware.php
+++ b/Neos.Flow/Classes/Http/Middleware/TrustedProxiesMiddleware.php
@@ -152,7 +152,7 @@ class TrustedProxiesMiddleware implements MiddlewareInterface
      *
      * @param string $type One of the HEADER_* constants
      * @param ServerRequestInterface $request The request to get the trusted proxy header from
-     * @return \Iterator|null An array of the values for this header type or NULL if this header type should not be trusted
+     * @return \Generator<array|null> Yields the array of the values for this header type or yields NULL if this header type should not be trusted
      */
     protected function getTrustedProxyHeaderValues($type, ServerRequestInterface $request)
     {

--- a/Neos.Flow/Classes/Http/Middleware/TrustedProxiesMiddleware.php
+++ b/Neos.Flow/Classes/Http/Middleware/TrustedProxiesMiddleware.php
@@ -152,7 +152,7 @@ class TrustedProxiesMiddleware implements MiddlewareInterface
      *
      * @param string $type One of the HEADER_* constants
      * @param ServerRequestInterface $request The request to get the trusted proxy header from
-     * @return \Iterator An array of the values for this header type or NULL if this header type should not be trusted
+     * @return \Iterator|null An array of the values for this header type or NULL if this header type should not be trusted
      */
     protected function getTrustedProxyHeaderValues($type, ServerRequestInterface $request)
     {

--- a/Neos.Flow/Classes/I18n/Cldr/CldrRepository.php
+++ b/Neos.Flow/Classes/I18n/Cldr/CldrRepository.php
@@ -104,7 +104,7 @@ class CldrRepository
      *
      * @param I18n\Locale $locale A locale
      * @param string $directoryPath Relative path to existing CLDR directory which contains one file per locale (see 'main' directory in CLDR for example)
-     * @return CldrModel A CldrModel instance or NULL on failure
+     * @return CldrModel|null A CldrModel instance or NULL on failure
      */
     public function getModelForLocale(I18n\Locale $locale, $directoryPath = 'main')
     {

--- a/Neos.Flow/Classes/I18n/LocaleCollection.php
+++ b/Neos.Flow/Classes/I18n/LocaleCollection.php
@@ -78,7 +78,7 @@ class LocaleCollection
      * system, please use findBestMatchingLocale() method of this class.
      *
      * @param Locale $locale The Locale to search parent for
-     * @return mixed Existing Locale instance or NULL on failure
+     * @return Locale|null Existing Locale instance or NULL on failure
      */
     public function getParentLocaleOf(Locale $locale)
     {
@@ -110,7 +110,7 @@ class LocaleCollection
      * is most similar to the "template" Locale object given as parameter.
      *
      * @param Locale $locale The "template" locale to be matched
-     * @return mixed Existing Locale instance on success, NULL on failure
+     * @return Locale|null Existing Locale instance on success, NULL on failure
      */
     public function findBestMatchingLocale(Locale $locale)
     {

--- a/Neos.Flow/Classes/I18n/Service.php
+++ b/Neos.Flow/Classes/I18n/Service.php
@@ -232,7 +232,7 @@ class Service
      * Returns a parent Locale object of the locale provided.
      *
      * @param Locale $locale The Locale to search parent for
-     * @return Locale Existing Locale instance or NULL on failure
+     * @return Locale|null Existing Locale instance or NULL on failure
      * @api
      */
     public function getParentLocaleOf(Locale $locale)

--- a/Neos.Flow/Classes/Mvc/ActionRequest.php
+++ b/Neos.Flow/Classes/Mvc/ActionRequest.php
@@ -613,7 +613,7 @@ class ActionRequest implements RequestInterface
      * internal argument, its name must start with two underscores.
      *
      * @param string $argumentName Name of the argument, for example "__fooBar"
-     * @return string|object Value of the argument, or NULL if not set.
+     * @return string|object|null Value of the argument, or NULL if not set.
      */
     public function getInternalArgument(string $argumentName)
     {

--- a/Neos.Flow/Classes/Mvc/Routing/Router.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Router.php
@@ -112,7 +112,7 @@ class Router implements RouterInterface
      * route could be found.
      *
      * @param RouteContext $routeContext The Route Context containing the current HTTP Request and, optional, Routing RouteParameters
-     * @return array|null The results of the matching route or NULL if no route matched
+     * @return array The results of the matching route
      * @throws InvalidRouteSetupException
      * @throws NoMatchingRouteException if no route matched the given $routeContext
      * @throws InvalidRoutePartValueException

--- a/Neos.Flow/Classes/Mvc/Routing/Router.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Router.php
@@ -97,7 +97,7 @@ class Router implements RouterInterface
     /**
      * Sets the routes configuration.
      *
-     * @param array $routesConfiguration The routes configuration or NULL if it should be fetched from configuration
+     * @param array|null $routesConfiguration The routes configuration or NULL if it should be fetched from configuration
      * @return void
      */
     public function setRoutesConfiguration(array $routesConfiguration = null)
@@ -112,7 +112,7 @@ class Router implements RouterInterface
      * route could be found.
      *
      * @param RouteContext $routeContext The Route Context containing the current HTTP Request and, optional, Routing RouteParameters
-     * @return array The results of the matching route or NULL if no route matched
+     * @return array|null The results of the matching route or NULL if no route matched
      * @throws InvalidRouteSetupException
      * @throws NoMatchingRouteException if no route matched the given $routeContext
      * @throws InvalidRoutePartValueException

--- a/Neos.Flow/Classes/Mvc/Routing/RouterCachingService.php
+++ b/Neos.Flow/Classes/Mvc/Routing/RouterCachingService.php
@@ -260,7 +260,7 @@ class RouterCachingService
      * Recursively converts objects in an array to their identifiers
      *
      * @param array $routeValues the array to be processed
-     * @return array the modified array or NULL if $routeValues contain an object and its identifier could not be determined
+     * @return array|null the modified array or NULL if $routeValues contain an object and its identifier could not be determined
      */
     protected function convertObjectsToHashes(array $routeValues)
     {

--- a/Neos.Flow/Classes/Mvc/View/JsonView.php
+++ b/Neos.Flow/Classes/Mvc/View/JsonView.php
@@ -269,7 +269,7 @@ class JsonView extends AbstractView
      * array structure.
      *
      * @param object $object Object to traverse
-     * @param array|null $configuration Configuration for transforming the given object or NULL
+     * @param array $configuration Configuration for transforming the given object
      * @return array|string Object structure as an array
      */
     protected function transformObject($object, array $configuration)

--- a/Neos.Flow/Classes/Mvc/View/JsonView.php
+++ b/Neos.Flow/Classes/Mvc/View/JsonView.php
@@ -269,7 +269,7 @@ class JsonView extends AbstractView
      * array structure.
      *
      * @param object $object Object to traverse
-     * @param array $configuration Configuration for transforming the given object or NULL
+     * @param array|null $configuration Configuration for transforming the given object or NULL
      * @return array|string Object structure as an array
      */
     protected function transformObject($object, array $configuration)

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationProperty.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationProperty.php
@@ -124,7 +124,7 @@ class ConfigurationProperty
     /**
      * Returns the (optional) object configuration which may be defined for properties of type OBJECT
      *
-     * @return Configuration The object configuration or NULL
+     * @return Configuration|null The object configuration or NULL
      */
     public function getObjectConfiguration()
     {

--- a/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
@@ -508,7 +508,7 @@ class ProxyClassBuilder
      * @param Configuration $objectConfiguration Configuration of the object to inject into
      * @param string $propertyName Name of the property to inject
      * @param string $configurationType the configuration type of the injected property (one of the ConfigurationManager::CONFIGURATION_TYPE_* constants)
-     * @param string $configurationPath Path with "." as separator specifying the setting value to inject or NULL if the complete configuration array should be injected
+     * @param string|null $configurationPath Path with "." as separator specifying the setting value to inject or NULL if the complete configuration array should be injected
      * @return array PHP code
      */
     public function buildPropertyInjectionCodeByConfigurationTypeAndPath(Configuration $objectConfiguration, $propertyName, $configurationType, $configurationPath = null): array

--- a/Neos.Flow/Classes/Property/PropertyMappingConfiguration.php
+++ b/Neos.Flow/Classes/Property/PropertyMappingConfiguration.php
@@ -374,7 +374,7 @@ class PropertyMappingConfiguration implements PropertyMappingConfigurationInterf
     /**
      * Return the type converter set for this configuration.
      *
-     * @return TypeConverterInterface
+     * @return TypeConverterInterface|null
      * @api
      */
     public function getTypeConverter()

--- a/Neos.Flow/Classes/Property/PropertyMappingConfigurationInterface.php
+++ b/Neos.Flow/Classes/Property/PropertyMappingConfigurationInterface.php
@@ -79,7 +79,7 @@ interface PropertyMappingConfigurationInterface
     /**
      * This method can be used to explicitely force a TypeConverter to be used for this Configuration.
      *
-     * @return TypeConverterInterface The type converter to be used for this particular PropertyMappingConfiguration, or NULL if the system-wide configured type converter should be used.
+     * @return TypeConverterInterface|null The type converter to be used for this particular PropertyMappingConfiguration, or NULL if the system-wide configured type converter should be used.
      * @api
      */
     public function getTypeConverter();

--- a/Neos.Flow/Classes/ResourceManagement/ResourceManager.php
+++ b/Neos.Flow/Classes/ResourceManagement/ResourceManager.php
@@ -468,7 +468,7 @@ class ResourceManager
      * Returns a Storage instance by the given name
      *
      * @param string $storageName Name of the storage as defined in the settings
-     * @return StorageInterface or NULL
+     * @return StorageInterface|null or NULL
      */
     public function getStorage($storageName)
     {
@@ -481,7 +481,7 @@ class ResourceManager
      * Returns a Collection instance by the given name
      *
      * @param string $collectionName Name of the collection as defined in the settings
-     * @return CollectionInterface or NULL
+     * @return CollectionInterface|null or NULL
      * @api
      */
     public function getCollection($collectionName)

--- a/Neos.Flow/Classes/ResourceManagement/ResourceManager.php
+++ b/Neos.Flow/Classes/ResourceManagement/ResourceManager.php
@@ -468,7 +468,7 @@ class ResourceManager
      * Returns a Storage instance by the given name
      *
      * @param string $storageName Name of the storage as defined in the settings
-     * @return StorageInterface|null or NULL
+     * @return StorageInterface|null
      */
     public function getStorage($storageName)
     {
@@ -481,7 +481,7 @@ class ResourceManager
      * Returns a Collection instance by the given name
      *
      * @param string $collectionName Name of the collection as defined in the settings
-     * @return CollectionInterface|null or NULL
+     * @return CollectionInterface|null
      * @api
      */
     public function getCollection($collectionName)

--- a/Neos.Flow/Classes/Security/Policy/Role.php
+++ b/Neos.Flow/Classes/Security/Policy/Role.php
@@ -247,7 +247,7 @@ class Role
     /**
      * @param string $privilegeTargetIdentifier
      * @param array $privilegeParameters
-     * @return PrivilegeInterface the matching privilege or NULL if no privilege exists for the given constraints
+     * @return PrivilegeInterface|null the matching privilege or NULL if no privilege exists for the given constraints
      */
     public function getPrivilegeForTarget(string $privilegeTargetIdentifier, array $privilegeParameters = []): ?PrivilegeInterface
     {

--- a/Neos.Flow/Classes/Session/Session.php
+++ b/Neos.Flow/Classes/Session/Session.php
@@ -616,7 +616,7 @@ class Session implements CookieEnabledInterface
      * Iterates over all existing sessions and removes their data if the inactivity
      * timeout was reached.
      *
-     * @return integer The number of outdated entries removed or NULL if no such information could be determined
+     * @return integer|null The number of outdated entries removed or NULL if no such information could be determined
      * @deprecated will be removed with Flow 9, use SessionManager->collectGarbage
      * @throws \Neos\Cache\Exception
      * @throws NotSupportedByBackendException

--- a/Neos.Flow/Classes/Session/SessionInterface.php
+++ b/Neos.Flow/Classes/Session/SessionInterface.php
@@ -162,7 +162,7 @@ interface SessionInterface
     /**
      * Remove data of all sessions which are considered to be expired.
      *
-     * @return integer The number of outdated entries removed or NULL if no such information could be determined
+     * @return integer|null The number of outdated entries removed or NULL if no such information could be determined
      * @deprecated will be removed with Flow 9, use SessionManager->collectGarbage
      */
     public function collectGarbage();

--- a/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractLocaleAwareViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/Core/ViewHelper/AbstractLocaleAwareViewHelper.php
@@ -48,7 +48,7 @@ abstract class AbstractLocaleAwareViewHelper extends AbstractViewHelper
      * Get the locale to use for all locale specific functionality.
      *
      * @throws InvalidVariableException
-     * @return I18n\Locale The locale to use or NULL if locale should not be used
+     * @return I18n\Locale|null The locale to use or NULL if locale should not be used
      */
     protected function getLocale()
     {

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Form/AbstractFormViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Form/AbstractFormViewHelper.php
@@ -69,7 +69,7 @@ abstract class AbstractFormViewHelper extends AbstractTagBasedViewHelper
      *
      * @param object $object Object to create the identity field for
      * @param string $name Name
-     * @return string|null A hidden field containing the Identity (UUID in Flow) of the given object or NULL if the object is unknown to the persistence framework
+     * @return string A hidden field containing the Identity (UUID in Flow) of the given object or empty string if the object is unknown to the persistence framework
      * @see \Neos\Flow\Mvc\Controller\Argument::setValue()
      */
     protected function renderHiddenIdentityField($object, $name)

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Form/AbstractFormViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Form/AbstractFormViewHelper.php
@@ -69,7 +69,7 @@ abstract class AbstractFormViewHelper extends AbstractTagBasedViewHelper
      *
      * @param object $object Object to create the identity field for
      * @param string $name Name
-     * @return string A hidden field containing the Identity (UUID in Flow) of the given object or NULL if the object is unknown to the persistence framework
+     * @return string|null A hidden field containing the Identity (UUID in Flow) of the given object or NULL if the object is unknown to the persistence framework
      * @see \Neos\Flow\Mvc\Controller\Argument::setValue()
      */
     protected function renderHiddenIdentityField($object, $name)

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Form/UploadViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Form/UploadViewHelper.php
@@ -128,7 +128,7 @@ class UploadViewHelper extends AbstractFormFieldViewHelper
      * Returns a previously uploaded resource, or the resource specified via "value" argument if no resource has been uploaded before
      * If errors occurred during property mapping for this property, NULL is returned
      *
-     * @return PersistentResource or NULL if no resource was uploaded and the "value" argument is not set
+     * @return PersistentResource|null or NULL if no resource was uploaded and the "value" argument is not set
      * @throws \Neos\Flow\Property\Exception
      * @throws \Neos\Flow\Security\Exception
      */

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/FormViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/FormViewHelper.php
@@ -371,7 +371,7 @@ class FormViewHelper extends AbstractFormViewHelper
      * If the "objectName" argument has been specified, this is returned. Otherwise the name attribute of this form.
      * If neither objectName nor name arguments have been set, NULL is returned.
      *
-     * @return string specified Form name or NULL if neither $objectName nor $name arguments have been specified
+     * @return string|null specified Form name or NULL if neither $objectName nor $name arguments have been specified
      */
     protected function getFormObjectName()
     {


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

I ran phpstan level 3 once on flow. And it seems we dont specifiy the nullable types correctly, but we document them in the doc string.
So i wrote a little helping script that would add the `|null` php doc annotation to all `@param` and `@return` types if we specify `or NULL` in the message. I carefully reviewed every change and made additionally some manual changes and corrected things. This is completely non breaking as only doc comments are being touched.

This will help for migrating to phpstan level 3.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
