### PR TITLE
TASK: Remove dead condition in `FlowAnnotationDriver`

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -249,14 +249,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
             if ($tableAnnotation->uniqueConstraints !== null) {
                 foreach ($tableAnnotation->uniqueConstraints as $uniqueConstraint) {
                     $uniqueConstraint = ['columns' => $uniqueConstraint->columns];
-                    if (!empty($uniqueConstraint->options)) {
-                        $uniqueConstraint['options'] = $uniqueConstraint->options;
-                    }
-                    if (!empty($uniqueConstraint->name)) {
-                        $primaryTable['uniqueConstraints'][$uniqueConstraint->name] = $uniqueConstraint;
-                    } else {
-                        $primaryTable['uniqueConstraints'][] = $uniqueConstraint;
-                    }
+                    $primaryTable['uniqueConstraints'][] = $uniqueConstraint;
                 }
             }
 


### PR DESCRIPTION
phpStan rightfully complains in the `FlowAnnotationDriver` about this dead code.

We foreach over the `$tableAnnotation->uniqueConstraints` as `$uniqueConstraint`. But in Line 251 we reassign the variable `$uniqueConstraint` to `['columns' => $uniqueConstraint->columns];` and thus the check `if (!empty($uniqueConstraint->options))` will always fail.

The code was introduced as fix via https://github.com/neos/flow-development-collection/commit/012f0e76a3169ed9b30b2dd23698718c4d550782, but it could never have worked as intended.

One can only guess but this might be the actual intention of the code.

```php
foreach ($tableAnnotation->uniqueConstraints as $uniqueConstraint) {
    $someOtherVariableName = ['columns' => $uniqueConstraint->columns];
    if (!empty($uniqueConstraint->options)) {
        $someOtherVariableName['options'] = $uniqueConstraint->options;
    }
    if (!empty($uniqueConstraint->name)) {
        $primaryTable['uniqueConstraints'][$uniqueConstraint->name] = $someOtherVariableName;
    } else {
        $primaryTable['uniqueConstraints'][] = $someOtherVariableName;
    }
}
```

But as this behaviour is now untouched since Flow 2, it might be already functioning correctly - and thus the dead conditions were removed.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
