### PR TITLE
FEATURE: Consider PHP attributes in proxy method building

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Exception/UnsupportedAttributeException.php
+++ b/Neos.Flow/Classes/ObjectManagement/Exception/UnsupportedAttributeException.php
@@ -1,0 +1,16 @@
+<?php
+namespace Neos\Flow\ObjectManagement\Exception;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+class UnsupportedAttributeException extends \Neos\Flow\ObjectManagement\Exception
+{
+}

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
@@ -281,7 +281,11 @@ class ProxyMethodGenerator extends MethodGenerator
         $formattedArguments = [];
 
         foreach ($arguments as $key => $value) {
-            $formattedArguments[] = "{$key}: " . $this->formatAttributeValue($value, $methodName);
+            if (is_int($key)) {
+                $formattedArguments[] = $this->formatAttributeValue($value, $methodName);
+            } else {
+                $formattedArguments[] = "{$key}: " . $this->formatAttributeValue($value, $methodName);
+            }
         }
 
         return implode(', ', $formattedArguments);

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
@@ -125,7 +125,7 @@ class ProxyMethodGenerator extends MethodGenerator
             . $this->getName() . '(';
 
         $output .= implode(', ', array_map(
-            static fn(ParameterGenerator $parameter): string => $parameter->generate(),
+            static fn (ParameterGenerator $parameter): string => $parameter->generate(),
             $this->getParameters()
         ));
 
@@ -329,7 +329,8 @@ class ProxyMethodGenerator extends MethodGenerator
                 $this->getFullOriginalClassName(),
                 $methodName,
                 get_debug_type($value)
-            ), 1705501433
+            ),
+            1705501433
         );
     }
 }

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
@@ -13,14 +13,19 @@ namespace Neos\Flow\ObjectManagement\Proxy;
 
 use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\MethodGenerator;
+use Laminas\Code\Generator\ParameterGenerator;
 
 /**
- * Generator for proxy methods
+ * Class ProxyMethodGenerator
+ *
+ * This class is responsible for generating proxy methods that can be used as method interceptors.
+ * It extends the MethodGenerator class.
  */
 class ProxyMethodGenerator extends MethodGenerator
 {
     protected string $addedPreParentCallCode = '';
     protected string $addedPostParentCallCode = '';
+    protected string $attributesCode = '';
 
     /** @var class-string|null */
     protected ?string $fullOriginalClassName = null;
@@ -30,6 +35,7 @@ class ProxyMethodGenerator extends MethodGenerator
         $instance = parent::fromReflection($reflectionMethod);
         assert($instance instanceof static);
         $instance->fullOriginalClassName = $reflectionMethod->getDeclaringClass()->getName();
+        $instance->attributesCode = $instance->buildAttributesCode($reflectionMethod);
         return $instance;
     }
 
@@ -41,6 +47,7 @@ class ProxyMethodGenerator extends MethodGenerator
             $instance->setDocBlock(DocBlockGenerator::fromReflection($reflectionMethod->getDocBlock()));
         }
         $instance->fullOriginalClassName = $reflectionMethod->getDeclaringClass()->getName();
+        $instance->attributesCode = $instance->buildAttributesCode($reflectionMethod);
         return $instance;
     }
 
@@ -73,6 +80,15 @@ class ProxyMethodGenerator extends MethodGenerator
         $this->addedPostParentCallCode .= rtrim($code) . PHP_EOL;
     }
 
+    /**
+     * Generates the code for the method.
+     *
+     * This method overrides the parent generate() method in order to insert attributes code. As soon
+     * as https://github.com/laminas/laminas-code/pull/145 is merged and released, this can be
+     * implemented properly.
+     *
+     * @return string The generated method code.
+     */
     public function generate(): string
     {
         if ($this->body === '') {
@@ -83,7 +99,59 @@ class ProxyMethodGenerator extends MethodGenerator
             return '';
         }
 
-        return parent::generate();
+        $output = '';
+
+        $indent = $this->getIndentation();
+
+        if (($docBlock = $this->getDocBlock()) !== null) {
+            $docBlock->setIndentation($indent);
+            $output .= $docBlock->generate();
+        }
+
+        $output .= $this->attributesCode;
+        $output .= $indent;
+
+        if ($this->isAbstract()) {
+            $output .= 'abstract ';
+        } else {
+            $output .= $this->isFinal() ? 'final ' : '';
+        }
+
+        $output .= $this->getVisibility()
+            . ($this->isStatic() ? ' static' : '')
+            . ' function '
+            . ($this->returnsReference() ? '& ' : '')
+            . $this->getName() . '(';
+
+        $output .= implode(', ', array_map(
+            static fn(ParameterGenerator $parameter): string => $parameter->generate(),
+            $this->getParameters()
+        ));
+
+        $output .= ')';
+
+        if ($this->getReturnType()) {
+            $output .= ' : ' . $this->getReturnType()->generate();
+        }
+
+        if ($this->isAbstract()) {
+            return $output . ';';
+        }
+
+        if ($this->isInterface()) {
+            return $output . ';';
+        }
+
+        $output .= self::LINE_FEED . $indent . '{' . self::LINE_FEED;
+
+        if ($this->body) {
+            $output .= preg_replace('#^((?![a-zA-Z0-9_-]+;).+?)$#m', $indent . $indent . '$1', trim($this->body))
+                . self::LINE_FEED;
+        }
+
+        $output .= $indent . '}' . self::LINE_FEED;
+
+        return $output;
     }
 
     public function renderBodyCode(): string
@@ -173,5 +241,79 @@ class ProxyMethodGenerator extends MethodGenerator
             return '';
         }
         return 'parent::' . $methodName . '(' . $this->buildMethodParametersCode($fullClassName, $methodName, false) . ");\n";
+    }
+
+    /**
+     * Build the code for the attributes of a given \ReflectionMethod object.
+     *
+     * Note: This is just a preliminary solution until https://github.com/laminas/laminas-code/pull/145
+     *       is implemented and released.
+     *
+     * @param \ReflectionMethod $reflectionMethod The \ReflectionMethod object to retrieve attributes from.
+     * @return string The code for the attributes of the given \ReflectionMethod object.
+     */
+    protected function buildAttributesCode(\ReflectionMethod $reflectionMethod): string
+    {
+        $indent = $this->getIndentation();
+        $attributesCode = "";
+
+        foreach ($reflectionMethod->getAttributes() as $attribute) {
+            $attributeName = "\\" . ltrim($attribute->getName(), '\\');
+            $argumentsString = $this->formatAttributesArguments($attribute->getArguments());
+            $attributesCode .= "{$indent}#[{$attributeName}({$argumentsString})]" . self::LINE_FEED;
+        }
+
+        return $attributesCode;
+    }
+
+    /**
+     * Formats the arguments of attributes into a string.
+     *
+     * @param array $arguments An array of arguments for attributes.
+     *
+     * @return string The formatted arguments as a string.
+     */
+    private function formatAttributesArguments(array $arguments): string
+    {
+        $formattedArguments = [];
+
+        foreach ($arguments as $key => $value) {
+            $formattedArguments[] = "{$key}: " . $this->formatAttributeValue($value);
+        }
+
+        return implode(', ', $formattedArguments);
+    }
+
+    /**
+     * Formats the given attribute value.
+     *
+     * @param mixed $value The value to be formatted.
+     * @return string The formatted attribute value.
+     */
+    private function formatAttributeValue(mixed $value): string
+    {
+        if (is_string($value)) {
+            return "\"$value\"";
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (is_int($value)) {
+            return (string)$value;
+        }
+
+        if (is_array($value)) {
+            $formattedArrayElements = implode(', ', array_map(function ($key, $value) {
+                return is_int($key)
+                    ? $this->formatAttributeValue($value)
+                    : "\"{$key}\" => " . $this->formatAttributeValue($value);
+            }, array_keys($value), $value));
+            return "[{$formattedArrayElements}]";
+        }
+
+        // Fallback for any other types (shouldn't happen with PHP attributes)
+        return '';
     }
 }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassWithPhpAttributes.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassWithPhpAttributes.php
@@ -26,6 +26,7 @@ class ClassWithPhpAttributes
      */
     #[Flow\Around(pointcutExpression: "method(somethingImpossible())")]
     #[Flow\Session(autoStart: false)]
+    #[SampleMethodAttribute('value without name')]
     public function methodWithAttributes(): void
     {
     }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassWithPhpAttributes.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/ClassWithPhpAttributes.php
@@ -21,4 +21,12 @@ use Neos\Flow\Annotations as Flow;
 #[SampleAttribute(ClassWithPhpAttributes::class, ['foo' => 'bar'])]
 class ClassWithPhpAttributes
 {
+    /**
+     * @return void
+     */
+    #[Flow\Around(pointcutExpression: "method(somethingImpossible())")]
+    #[Flow\Session(autoStart: false)]
+    public function methodWithAttributes(): void
+    {
+    }
 }

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/SampleMethodAttribute.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/SampleMethodAttribute.php
@@ -1,0 +1,13 @@
+<?php
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class SampleMethodAttribute
+{
+    public function __construct(
+        readonly public string $method,
+        readonly public array $options = [],
+        readonly public string $argWithDefault = 'default'
+    ) {
+    }
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
@@ -25,7 +25,6 @@ use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ClassWithPrivateConstru
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PHP81\BackedEnumWithMethod;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassA;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassK;
-use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\SampleAttribute;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\SampleMethodAttribute;
 use Neos\Flow\Tests\FunctionalTestCase;
 

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
@@ -11,6 +11,8 @@ namespace Neos\Flow\Tests\Functional\ObjectManagement;
  * source code.
  */
 
+use Neos\Flow\Annotations\Around;
+use Neos\Flow\Annotations\Session;
 use Neos\Flow\ObjectManagement\Exception\CannotBuildObjectException;
 use Neos\Flow\ObjectManagement\Proxy\ProxyClass;
 use Neos\Flow\ObjectManagement\Proxy\ProxyInterface;
@@ -23,6 +25,7 @@ use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ClassWithPrivateConstru
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PHP81\BackedEnumWithMethod;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassA;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassK;
+use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\SampleAttribute;
 use Neos\Flow\Tests\FunctionalTestCase;
 
 /**
@@ -86,6 +89,32 @@ class ProxyCompilerTest extends FunctionalTestCase
         $method = $class->getMethod('setSomeProperty');
 
         self::assertEquals(['autoStart=true'], $method->getTagValues('session'));
+    }
+
+    /**
+     * @test
+     */
+    public function proxiedMethodsStillContainMethodAttributesFromOriginalClass(): void
+    {
+        $class = new ClassReflection(Fixtures\ClassWithPhpAttributes::class);
+        $actualAttributes = [];
+        foreach ($class->getMethod('methodWithAttributes')->getAttributes() as $attribute) {
+            $actualAttributes[] = [
+                'name' => $attribute->getName(),
+                'arguments' => $attribute->getArguments(),
+            ];
+        }
+        $expectedAttributes = [
+            [
+                'name' => Around::class,
+                'arguments' => ['pointcutExpression' => 'method(somethingImpossible())']
+            ],
+            [
+                'name' => Session::class,
+                'arguments' => ['autoStart' => false]
+            ]
+        ];
+        self::assertEquals($expectedAttributes, $actualAttributes);
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/ProxyCompilerTest.php
@@ -26,6 +26,7 @@ use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PHP81\BackedEnumWithMet
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassA;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassK;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\SampleAttribute;
+use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\SampleMethodAttribute;
 use Neos\Flow\Tests\FunctionalTestCase;
 
 /**
@@ -112,7 +113,11 @@ class ProxyCompilerTest extends FunctionalTestCase
             [
                 'name' => Session::class,
                 'arguments' => ['autoStart' => false]
-            ]
+            ],
+            [
+                'name' => SampleMethodAttribute::class,
+                'arguments' => ['value without name']
+            ],
         ];
         self::assertEquals($expectedAttributes, $actualAttributes);
     }


### PR DESCRIPTION
Added support for preserving PHP 8 attributes in generated proxy class methods. This feature enables correct argument passing from attributes to proxied methods which allows developers to use attributes instead of annotations in most cases.

Resolves #3075