### PR TITLE
TASK: `resource:clean` followup #1678

### DIFF
--- a/Neos.Flow/Classes/Command/ResourceCommandController.php
+++ b/Neos.Flow/Classes/Command/ResourceCommandController.php
@@ -273,8 +273,8 @@ class ResourceCommandController extends CommandController
                 }
             }
             $response = null;
-            while (!in_array($response, ['y', 'n', 'c'])) {
-                $response = $this->output->ask('<comment>Do you want to remove all broken resource objects and related assets from the database? (y/n/c) </comment>');
+            while (!in_array($response, ['y', 'n'])) {
+                $response = $this->output->ask('<comment>Do you want to remove all broken resource objects and related assets from the database? (y/n) </comment>');
             }
 
             switch ($response) {
@@ -318,9 +318,6 @@ class ResourceCommandController extends CommandController
                     break;
                 case 'n':
                     $this->outputLine('Did not delete any resource objects.');
-                    break;
-                case 'c':
-                    $this->outputLine('Stopping. Did not delete any resource objects.');
                     $this->quit(0);
                     break;
             }

--- a/Neos.Flow/Classes/Command/ResourceCommandController.php
+++ b/Neos.Flow/Classes/Command/ResourceCommandController.php
@@ -221,6 +221,7 @@ class ResourceCommandController extends CommandController
         $resourcesCount = $this->resourceRepository->countAll();
         $this->output->progressStart($resourcesCount);
 
+        /** @var list<PersistentResource> $brokenResources */
         $brokenResources = [];
         $relatedAssets = new \SplObjectStorage();
         $relatedThumbnails = new \SplObjectStorage();
@@ -230,10 +231,9 @@ class ResourceCommandController extends CommandController
             $this->clearState($iteration);
             $iteration++;
             $this->output->progressAdvance(1);
-            /* @var PersistentResource $resource */
             $stream = $resource->getStream();
             if (!is_resource($stream)) {
-                $brokenResources[] = $this->persistenceManager->getIdentifierByObject($resource);
+                $brokenResources[] = $resource;
             }
         }
 
@@ -246,9 +246,7 @@ class ResourceCommandController extends CommandController
         $mediaPackagePresent = $this->packageManager->isPackageAvailable('Neos.Media');
 
         if (count($brokenResources) > 0) {
-            foreach ($brokenResources as $key => $resourceIdentifier) {
-                $resource = $this->resourceRepository->findByIdentifier($resourceIdentifier);
-                $brokenResources[$key] = $resource;
+            foreach ($brokenResources as $resource) {
                 if ($mediaPackagePresent) {
                     $assets = $assetRepository->findByResource($resource);
                     if ($assets !== null) {


### PR DESCRIPTION
While reading the code, looking for improvement, it seems tedious that we `getIdentifierByObject` just to `findByIdentifier` a few lines later.

This happened due to a funny history of back and forth.

At first - 2014 - `resource:clean` was introduced looping over the PersistentResource: https://github.com/neos/flow-development-collection/commit/8a1ce0fba6cb0bf301f971a6d7d5675e0c038d75

Then - 2016 - it was decided to save the sha1 and loop over them and retrieve the asset via `findOneBySha1`: https://github.com/neos/flow-development-collection/commit/879fba19f93d0a8628682698e57da9f1b58ad7d4

But that did not improve the situation as described in https://github.com/neos/flow-development-collection/pull/1678 and was removed again - 2019.

So in functionality we made a full round, im just here to followup on the last fix to restore the full state syntactically as it was once though of.
