### PR TITLE
!!! TASK: Make `QueryInterface::logicalAnd` variadic

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/Query.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Query.php
@@ -421,12 +421,12 @@ class Query implements QueryInterface
      * @return object
      * @api
      */
-    public function logicalAnd($constraint1)
+    public function logicalAnd(mixed $constraint1, mixed ...$constraints)
     {
         if (is_array($constraint1)) {
             $constraints = $constraint1;
         } else {
-            $constraints = func_get_args();
+            $constraints = [$constraint1, ...$constraints];
         }
         return $this->queryBuilder->expr()->andX(...$constraints);
     }
@@ -440,12 +440,12 @@ class Query implements QueryInterface
      * @return object
      * @api
      */
-    public function logicalOr($constraint1)
+    public function logicalOr(mixed $constraint1, mixed ...$constraints)
     {
         if (is_array($constraint1)) {
             $constraints = $constraint1;
         } else {
-            $constraints = func_get_args();
+            $constraints = [$constraint1, ...$constraints];
         }
         return $this->queryBuilder->expr()->orX(...$constraints);
     }

--- a/Neos.Flow/Classes/Persistence/QueryInterface.php
+++ b/Neos.Flow/Classes/Persistence/QueryInterface.php
@@ -223,22 +223,22 @@ interface QueryInterface
      * takes one or more constraints and concatenates them with a boolean AND.
      * It also accepts a single array of constraints to be concatenated.
      *
-     * @param mixed ...$constraint1 The first of multiple constraints or an array of constraints.
+     * @param mixed $constraint1 The first of multiple constraints or an array of constraints.
      * @return object
      * @api
      */
-    public function logicalAnd($constraint1);
+    public function logicalAnd(mixed $constraint1, mixed ...$constraints);
 
     /**
      * Performs a logical disjunction of the two given constraints. The method
      * takes one or more constraints and concatenates them with a boolean OR.
      * It also accepts a single array of constraints to be concatenated.
      *
-     * @param mixed ...$constraint1 The first of multiple constraints or an array of constraints.
+     * @param mixed $constraint1 The first of multiple constraints or an array of constraints.
      * @return object
      * @api
      */
-    public function logicalOr($constraint1);
+    public function logicalOr(mixed $constraint1, mixed ...$constraints);
 
     /**
      * Performs a logical negation of the given constraint

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,9 +1,5 @@
 parameters:
     level: 2
-    ignoreErrors:
-        # https://github.com/phpstan/phpstan/issues/9467 will be fixed with flow 9
-        - '#^Method Neos\\Flow\\Persistence\\QueryInterface\:\:logicalOr\(\) invoked with \d parameters, 1 required\.$#'
-        - '#^Method Neos\\Flow\\Persistence\\QueryInterface\:\:logicalAnd\(\) invoked with \d parameters, 1 required\.$#'
     paths:
         - Neos.Cache/Classes
         - Neos.Eel/Classes


### PR DESCRIPTION
_If_ someone implemented the `QueryInterface`, the implementation must now use conventional variadic parameters instead of legacy `func_get_args`

This allows phpstan to understand the code ;)