### PR TITLE
TASK: Ensure `IntegerConverter` converts DateTime to unix time stamp as int

### DIFF
--- a/Neos.Flow/Classes/Property/TypeConverter/IntegerConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/IntegerConverter.php
@@ -55,7 +55,7 @@ class IntegerConverter extends AbstractTypeConverter
     public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
     {
         if ($source instanceof \DateTimeInterface) {
-            return $source->format('U');
+            return (int)$source->format('U');
         }
 
         if ($source === null || $source === '') {

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/IntegerConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/IntegerConverterTest.php
@@ -57,7 +57,7 @@ class IntegerConverterTest extends UnitTestCase
     public function convertFromCastsDateTimeToInteger()
     {
         $dateTime = new \DateTime();
-        self::assertSame($dateTime->format('U'), $this->converter->convertFrom($dateTime, 'integer'));
+        self::assertSame((int)$dateTime->format('U'), $this->converter->convertFrom($dateTime, 'integer'));
     }
 
     /**


### PR DESCRIPTION
Previously the date was formatted to a unix time stamp, but in string format and not as desired as int.

This is required in preparation for https://github.com/neos/flow-development-collection/pull/3261