### PR TITLE
!!! TASK: Fix `TextIterator::following` and `preceding`

### DIFF
--- a/Neos.Utility.Unicode/Classes/TextIterator.php
+++ b/Neos.Utility.Unicode/Classes/TextIterator.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\Utility\Unicode;
 
 /*
@@ -195,13 +198,13 @@ class TextIterator implements \Iterator
     }
 
     /**
-     * Returns the next elment following the character of the original string
+     * Returns the offset of the next element following the character of the original string
      * given by its offset
      *
      * @param integer $offset The offset of the character
-     * @return string The element following this character
+     * @return int The offset of the element following this character
      */
-    public function following(int $offset): string
+    public function following(int $offset): int
     {
         $this->rewind();
         while ($this->valid()) {
@@ -215,14 +218,15 @@ class TextIterator implements \Iterator
     }
 
     /**
-     * Returns the element preceding the character of the original string given by its offset
+     * Returns the offset of the element preceding the character of the original string given by its offset
      *
      * @param integer $offset The offset of the character
-     * @return string The element preceding this character
+     * @return int The offset of the element preceding this character
      */
-    public function preceding(int $offset): string
+    public function preceding(int $offset): int
     {
         $this->rewind();
+        $currentElement = null;
         while ($this->valid()) {
             $previousElement = $this->getCurrentElement();
             $this->next();
@@ -231,8 +235,10 @@ class TextIterator implements \Iterator
                 return $previousElement->getOffset() + $previousElement->getLength();
             }
         }
-        /** @phpstan-ignore-next-line */
-        return $currentElement->getOffset() + $currentElement->getLength();
+        if ($currentElement) {
+            return $currentElement->getOffset() + $currentElement->getLength();
+        }
+        return -1;
     }
 
     /**


### PR DESCRIPTION
Accidentally they have been typed wrongly. First in phpdoc, which is harmless and later actual types introduced in https://github.com/neos/flow-development-collection/commit/70b671228ee4f66c54fb7fbfa390aac12b5a71c5#diff-947f5937b1e181a6e4ae7bb23349d22d839b073a07104b884c08583cc12f63df enforced that.

The tests didnt fail, because as strict types were not enabled php just cast the int's to string.

The tests, also casting when using assertEquals, didnt notice that.


This is required in preparation for https://github.com/neos/flow-development-collection/pull/3261