### PR TITLE
TASK: Remove Neos.Media functionality in `resource:clean`

### DIFF
--- a/Neos.Flow/Classes/Command/ResourceCommandController.php
+++ b/Neos.Flow/Classes/Command/ResourceCommandController.php
@@ -221,6 +221,7 @@ class ResourceCommandController extends CommandController
         $resourcesCount = $this->resourceRepository->countAll();
         $this->output->progressStart($resourcesCount);
 
+        /** @var list<PersistentResource> $brokenResources */
         $brokenResources = [];
         $relatedAssets = new \SplObjectStorage();
         $relatedThumbnails = new \SplObjectStorage();
@@ -230,10 +231,9 @@ class ResourceCommandController extends CommandController
             $this->clearState($iteration);
             $iteration++;
             $this->output->progressAdvance(1);
-            /* @var PersistentResource $resource */
             $stream = $resource->getStream();
             if (!is_resource($stream)) {
-                $brokenResources[] = $this->persistenceManager->getIdentifierByObject($resource);
+                $brokenResources[] = $resource;
             }
         }
 
@@ -246,9 +246,7 @@ class ResourceCommandController extends CommandController
         $mediaPackagePresent = $this->packageManager->isPackageAvailable('Neos.Media');
 
         if (count($brokenResources) > 0) {
-            foreach ($brokenResources as $key => $resourceIdentifier) {
-                $resource = $this->resourceRepository->findByIdentifier($resourceIdentifier);
-                $brokenResources[$key] = $resource;
+            foreach ($brokenResources as $resource) {
                 if ($mediaPackagePresent) {
                     $assets = $assetRepository->findByResource($resource);
                     if ($assets !== null) {

--- a/bootstrap-phpstan.php
+++ b/bootstrap-phpstan.php
@@ -4,34 +4,6 @@
  * This bootstrap helps phpstan to detect all available constants
  */
 
-namespace {
-    $_SERVER['FLOW_ROOTPATH'] = dirname(__DIR__, 2);
+$_SERVER['FLOW_ROOTPATH'] = dirname(__DIR__, 2);
 
-    new \Neos\Flow\Core\Bootstrap('Testing');
-}
-
-// FIXME flow has no dependency on Neos.Media. This code should be extracted. https://github.com/neos/flow-development-collection/issues/3272
-// Theses stubs below allow phpstan to work correctly, if Neos is not installed while linting.
-namespace Neos\Media\Domain\Repository {
-    if (!class_exists(AssetRepository::class)) {
-        /**
-         * @method iterable<int, \Neos\Media\Domain\Model\AssetInterface> findByResource(\Neos\Flow\ResourceManagement\PersistentResource $resource)
-         * @method void removeWithoutUsageChecks(\Neos\Media\Domain\Model\AssetInterface $object)
-         */
-        class AssetRepository extends \Neos\Flow\Persistence\Repository
-        {
-        }
-    }
-}
-
-namespace Neos\Media\Domain\Repository {
-    if (!class_exists(ThumbnailRepository::class)) {
-        /**
-         * @method iterable<int,\Neos\Media\Domain\Model\Thumbnail> findByResource(\Neos\Flow\ResourceManagement\PersistentResource $resource)
-         * @method void remove(\Neos\Media\Domain\Model\Thumbnail $object)
-         */
-        class ThumbnailRepository extends \Neos\Flow\Persistence\Repository
-        {
-        }
-    }
-}
+new \Neos\Flow\Core\Bootstrap('Testing');


### PR DESCRIPTION
Depends on https://github.com/neos/flow-development-collection/pull/3275
Resolves #3272

There will be another PR towards Neos.Media to include this functionality in `./flow media:cleanresources`.

Additionally warn if this command is used in a Neos installation, and let the dev know that it's preferred to use Neos' command.