### PR TITLE
TASK: Deprecate `ControllerContext::getFlashMessageContainer`

### DIFF
--- a/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
@@ -153,15 +153,11 @@ abstract class AbstractController implements ControllerInterface
      * @param array $messageArguments arguments to be passed to the FlashMessage
      * @param integer $messageCode
      * @return void
-     * @throws \InvalidArgumentException if the message body is no string
      * @see Error\Message
      * @api
      */
-    public function addFlashMessage($messageBody, $messageTitle = '', $severity = Error\Message::SEVERITY_OK, array $messageArguments = [], $messageCode = null)
+    public function addFlashMessage(string $messageBody, string $messageTitle = '', string $severity = Error\Message::SEVERITY_OK, array $messageArguments = [], int $messageCode = null)
     {
-        if (!is_string($messageBody)) {
-            throw new \InvalidArgumentException('The message body must be of type string, "' . gettype($messageBody) . '" given.', 1243258395);
-        }
         switch ($severity) {
             case Error\Message::SEVERITY_NOTICE:
                 $message = new Error\Notice($messageBody, $messageCode, $messageArguments, $messageTitle);

--- a/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
@@ -19,6 +19,7 @@ use Neos\Flow\Mvc\Exception\InvalidArgumentNameException;
 use Neos\Flow\Mvc\Exception\InvalidArgumentTypeException;
 use Neos\Flow\Mvc\Exception\InvalidControllerNameException;
 use Neos\Flow\Mvc\Exception\NoSuchArgumentException;
+use Neos\Flow\Mvc\FlashMessage\FlashMessageService;
 use Neos\Flow\Mvc\Routing\Exception\MissingActionNameException;
 use Neos\Flow\Persistence\Exception\UnknownObjectException;
 use Neos\Flow\Property\Exception;
@@ -84,6 +85,9 @@ abstract class AbstractController implements ControllerInterface
      * @var PersistenceManagerInterface
      */
     protected $persistenceManager;
+
+    #[Flow\Inject]
+    protected FlashMessageService $flashMessageService;
 
     /**
      * A list of IANA media types which are supported by this controller
@@ -172,7 +176,7 @@ abstract class AbstractController implements ControllerInterface
                 $message = new Error\Message($messageBody, $messageCode, $messageArguments, $messageTitle);
                 break;
         }
-        $this->controllerContext->getFlashMessageContainer()->addMessage($message);
+        $this->flashMessageService->getFlashMessageContainerForRequest($this->request)->addMessage($message);
     }
 
     /**

--- a/Neos.Flow/Classes/Mvc/Controller/ActionController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ActionController.php
@@ -765,7 +765,8 @@ class ActionController extends AbstractController
     {
         $errorFlashMessage = $this->getErrorFlashMessage();
         if ($errorFlashMessage !== false) {
-            $this->controllerContext->getFlashMessageContainer()->addMessage($errorFlashMessage);
+            $this->flashMessageService->getFlashMessageContainerForRequest($this->request)
+                ->addMessage($errorFlashMessage);
         }
     }
 

--- a/Neos.Flow/Classes/Mvc/Controller/ControllerContext.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ControllerContext.php
@@ -118,7 +118,7 @@ class ControllerContext
      * Get the flash message container
      *
      * @return FlashMessageContainer A container for flash messages
-     * @api
+     * @deprecated please use {@see FlashMessageService::getFlashMessageContainerForRequest()} instead.
      */
     public function getFlashMessageContainer()
     {

--- a/Neos.Flow/Classes/Security/Authentication/Controller/AbstractAuthenticationController.php
+++ b/Neos.Flow/Classes/Security/Authentication/Controller/AbstractAuthenticationController.php
@@ -120,7 +120,8 @@ abstract class AbstractAuthenticationController extends ActionController
      */
     protected function onAuthenticationFailure(AuthenticationRequiredException $exception = null)
     {
-        $this->controllerContext->getFlashMessageContainer()->addMessage(new Error('Authentication failed!', ($exception === null ? 1347016771 : $exception->getCode())));
+        $this->flashMessageService->getFlashMessageContainerForRequest($this->request)
+            ->addMessage(new Error('Authentication failed!', ($exception === null ? 1347016771 : $exception->getCode())));
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/StandardController.php
+++ b/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/StandardController.php
@@ -35,7 +35,7 @@ class StandardController extends ActionController
      */
     public function targetAction()
     {
-        $flashMessages = $this->controllerContext->getFlashMessageContainer()->getMessagesAndFlush();
+        $flashMessages = $this->flashMessageService->getFlashMessageContainerForRequest($this->request)->getMessagesAndFlush();
         return json_encode(array_map(static function (Message $message) {
             return $message->getMessage();
         }, $flashMessages));

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
@@ -144,22 +144,6 @@ class AbstractControllerTest extends UnitTestCase
     /**
      * @test
      */
-    public function addFlashMessageThrowsExceptionOnInvalidMessageBody()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $flashMessageContainer = new FlashMessageContainer();
-        $controller = $this->getAccessibleMock(AbstractController::class, ['processRequest']);
-
-        $controllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
-        $controllerContext->method('getFlashMessageContainer')->willReturn($flashMessageContainer);
-        $this->inject($controller, 'controllerContext', $controllerContext);
-
-        $controller->addFlashMessage(new \stdClass());
-    }
-
-    /**
-     * @test
-     */
     public function forwardSetsControllerAndArgumentsAtTheRequestObjectIfTheyAreSpecified()
     {
         $mockPersistenceManager = $this->createMock(PersistenceManagerInterface::class);

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
@@ -13,13 +13,13 @@ namespace Neos\Flow\Tests\Unit\Mvc\Controller;
 
 use GuzzleHttp\Psr7\ServerRequest;
 use GuzzleHttp\Psr7\Uri;
+use Neos\Flow\Mvc\FlashMessage\FlashMessageService;
 use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ServerRequestInterface;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\ActionResponse;
 use Neos\Flow\Mvc\Controller\AbstractController;
 use Neos\Flow\Mvc\Controller\Arguments;
-use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Flow\Mvc\Exception\ForwardException;
 use Neos\Flow\Mvc\Exception\RequiredArgumentMissingException;
 use Neos\Flow\Mvc\Exception\StopActionException;
@@ -131,13 +131,27 @@ class AbstractControllerTest extends UnitTestCase
     public function addFlashMessageTests($expectedMessage, $messageBody, $messageTitle = '', $severity = FlowError\Message::SEVERITY_OK, array $messageArguments = [], $messageCode = null)
     {
         $flashMessageContainer = new FlashMessageContainer();
-        $controller = $this->getAccessibleMock(AbstractController::class, ['processRequest']);
 
-        $controllerContext = $this->getMockBuilder(ControllerContext::class)->disableOriginalConstructor()->getMock();
-        $controllerContext->method('getFlashMessageContainer')->willReturn($flashMessageContainer);
-        $this->inject($controller, 'controllerContext', $controllerContext);
+        $flashMessageService = $this->getMockBuilder(FlashMessageService::class)->disableOriginalConstructor()->getMock();
+        $flashMessageService->method('getFlashMessageContainerForRequest')->willReturn($flashMessageContainer);
 
-        $controller->addFlashMessage($messageBody, $messageTitle, $severity, $messageArguments, $messageCode);
+        $mockController = new class($messageBody, $messageTitle, $severity, $messageArguments, $messageCode) extends AbstractController {
+            public function __construct(private mixed $messageBody, private mixed $messageTitle, private mixed $severity, private mixed $messageArguments, private mixed $messageCode)
+            {
+            }
+
+            public function processRequest(ActionRequest $request): ActionResponse
+            {
+                $this->initializeController($request, new ActionResponse());
+                $this->addFlashMessage($this->messageBody, $this->messageTitle, $this->severity, $this->messageArguments, $this->messageCode);
+                return new ActionResponse();
+            }
+        };
+
+        $this->inject($mockController, 'flashMessageService', $flashMessageService);
+
+        $mockController->processRequest($this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->getMock());
+
         self::assertEquals([$expectedMessage], $flashMessageContainer->getMessages());
     }
 

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/ActionControllerTest.php
@@ -49,11 +49,6 @@ class ActionControllerTest extends UnitTestCase
      */
     protected $mockViewConfigurationManager;
 
-    /**
-     * @var Mvc\Controller\ControllerContext
-     */
-    protected $mockControllerContext;
-
     protected function setUp(): void
     {
         $this->actionController = $this->getAccessibleMock(ActionController::class, ['dummy']);
@@ -143,7 +138,6 @@ class ActionControllerTest extends UnitTestCase
         $this->actionController = new ActionController();
 
         $this->inject($this->actionController, 'objectManager', $this->mockObjectManager);
-        $this->inject($this->actionController, 'controllerContext', $this->mockControllerContext);
 
         $mockRequest = $this->getMockBuilder(Mvc\ActionRequest::class)->disableOriginalConstructor()->getMock();
         $mockRequest->expects(self::any())->method('getControllerActionName')->will(self::returnValue('nonExisting'));
@@ -167,7 +161,6 @@ class ActionControllerTest extends UnitTestCase
         $this->actionController = new ActionController();
 
         $this->inject($this->actionController, 'objectManager', $this->mockObjectManager);
-        $this->inject($this->actionController, 'controllerContext', $this->mockControllerContext);
         $this->inject($this->actionController, 'arguments', new Arguments([]));
 
         $mockRequest = $this->getMockBuilder(Mvc\ActionRequest::class)->disableOriginalConstructor()->getMock();
@@ -240,7 +233,6 @@ class ActionControllerTest extends UnitTestCase
         $this->actionController->method('resolveActionMethodName')->willReturn('indexAction');
 
         $this->inject($this->actionController, 'objectManager', $this->mockObjectManager);
-        $this->inject($this->actionController, 'controllerContext', $this->mockControllerContext);
 
         $mockSettings = ['foo', 'bar'];
         $this->inject($this->actionController, 'settings', $mockSettings);


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

As `AbstractController::addFlashMessage` should be used to add FlashMessages rather than interacting with the container directly this deprecation should go unnoticed.
If its required, one should use the `FlashMessageService` to get the container:
```php
$this->flashMessageService->getFlashMessageContainerForRequest($this->request)
    ->addMessage($errorFlashMessage);
```

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

This pr should not be merged before targeting 9.0.
See https://github.com/neos/flow-development-collection/pull/3232#issuecomment-1915676748 for explanation.

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
