### PR TITLE
TASK: Declare state properties in controller to be readonly

### DIFF
--- a/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
@@ -56,28 +56,32 @@ abstract class AbstractController implements ControllerInterface
     /**
      * The current action request directed to this controller
      * @var ActionRequest
+     * @readonly it should not be necessary to modify the request in any way.
      * @api
      */
-    protected $request;
+    protected ActionRequest $request;
 
     /**
      * The response which will be returned by this action controller
      * @var ActionResponse
+     * @readonly you should prefer to return a new response, but it is possible to mutate this instance.
      * @api
      */
-    protected $response;
+    protected ActionResponse $response;
 
     /**
      * Arguments passed to the controller
      * @var Arguments
+     * @readonly
      * @api
      */
-    protected $arguments;
+    protected Arguments $arguments;
 
     /**
      * @var ControllerContext
+     * @readonly
      */
-    protected $controllerContext;
+    protected ControllerContext $controllerContext;
 
     /**
      * @Flow\Inject

--- a/Neos.Flow/Classes/Mvc/Controller/ActionController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ActionController.php
@@ -560,7 +560,7 @@ class ActionController extends AbstractController
         }
 
         if ($actionResult === null && $this->view instanceof ViewInterface) {
-            $this->response = $this->renderView($this->response);
+            return $this->renderView($this->response);
         } else {
             $this->response->setContent($actionResult);
         }

--- a/Neos.Flow/Classes/Mvc/Controller/RestController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/RestController.php
@@ -14,7 +14,6 @@ namespace Neos\Flow\Mvc\Controller;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\ActionRequest;
-use Neos\Flow\Mvc\ActionResponse;
 use Neos\Flow\Mvc\Exception\InvalidActionNameException;
 use Neos\Flow\Mvc\Exception\InvalidActionVisibilityException;
 use Neos\Flow\Mvc\Exception\NoSuchActionException;
@@ -27,18 +26,6 @@ use Psr\Http\Message\UriInterface;
  */
 class RestController extends ActionController
 {
-    /**
-     * The current request
-     * @var ActionRequest
-     */
-    protected $request;
-
-    /**
-     * The response which will be returned by this action controller
-     * @var ActionResponse
-     */
-    protected $response;
-
     /**
      * Name of the action method argument which acts as the resource for the
      * RESTful controller. If an argument with the specified name is passed

--- a/Neos.Flow/Configuration/Settings.Reflection.yaml
+++ b/Neos.Flow/Configuration/Settings.Reflection.yaml
@@ -34,7 +34,7 @@ Neos:
         'covers': true
         'doesNotPerformAssertions': true
         'template': true
-
+        'readonly': true
 
       # If enabled, the Reflection Service notes all incorrect or inconsistent usage
       # of @param annotations in the default log.


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

In https://github.com/neos/flow-development-collection/pull/3232#discussion_r1467443443 i mentioned that "replacing" the `$this->response` is probably not a good idea and we should disallow this via readonly. Mutating by object reference is the only way allowed.

I tried to actually enforce this via real `readonly` in https://github.com/neos/flow-development-collection/pull/3283, but it has some severe flaws:

- There was only one place where we ourselves replace the variable for real, but i solved it with a `mergeIntoParent` or return.
- that means that controllers cant be singletons anymore (why are they declared as such even in general sometimes???)
   - the only usecase of a controller being a singleton would be for forwarded requests, but that is hacky as hell to then rely on internal state :D
- In widgets we rely on that the controller's process to be called multiple times: https://github.com/neos/flow-development-collection/blob/465c80be0b6753356fe6e2c71178405970bf1fea/Neos.FluidAdaptor/Classes/Core/Widget/AbstractWidgetViewHelper.php#L241 which is also not forbidden per se.

As compromise i suggest to use the read only annotation to make people aware. 

**Upgrade instructions**

You should never replace any of the stateful properties of the action controller.

**Review instructions**

This pr should not be merged before targeting 9.0.
See https://github.com/neos/flow-development-collection/pull/3232#issuecomment-1915676748 for explanation.

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**TODO**

- [ ] Can the ignore `readonly` be by any chance breaking??
like `use Neos/Flow/Annotations/Inject as readonly`