### PR TITLE
!!! TASK: Deprecate and replace `ActionResponse` in dispatcher

### DIFF
--- a/Neos.Flow/Classes/Mvc/ActionResponse.php
+++ b/Neos.Flow/Classes/Mvc/ActionResponse.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Psr7\Response;
  * The minimal MVC response object.
  * It allows for simple interactions with the HTTP response from within MVC actions. More specific requirements can be implemented via HTTP middlewares.
  *
+ * @deprecated
  * @Flow\Proxy(false)
  * @api
  */

--- a/Neos.Flow/Classes/Mvc/ActionResponse.php
+++ b/Neos.Flow/Classes/Mvc/ActionResponse.php
@@ -233,7 +233,9 @@ final class ActionResponse
     }
 
     /**
-     * Use this if you want build your own HTTP Response inside your action
+     * Unsafe. Please avoid the use of this escape hatch as the behaviour is partly unspecified
+     * https://github.com/neos/flow-development-collection/issues/2492
+     *
      * @param ResponseInterface $response
      */
     public function replaceHttpResponse(ResponseInterface $response): void
@@ -275,10 +277,12 @@ final class ActionResponse
     }
 
     /**
-     * Note this is a special use case method that will apply the internal properties (Content-Type, StatusCode, Location, Set-Cookie and Content)
-     * to the given PSR-7 Response and return a modified response. This is used to merge the ActionResponse properties into a possible HttpResponse
-     * created in a View (see ActionController::renderView()) because those would be overwritten otherwise. Note that any component parameters will
-     * still run through the component chain and will not be propagated here.
+     * Note this is a special use case method that will apply the internal properties
+     * (Content-Type, StatusCode, Location, Set-Cookie and Content)
+     * to a new or replaced PSR-7 Response and return it.
+     *
+     * Possibly unsafe when used in combination with {@see self::replaceHttpResponse()}
+     * https://github.com/neos/flow-development-collection/issues/2492
      *
      * @return ResponseInterface
      * @internal

--- a/Neos.Flow/Classes/Mvc/ActionResponse.php
+++ b/Neos.Flow/Classes/Mvc/ActionResponse.php
@@ -3,6 +3,8 @@ namespace Neos\Flow\Mvc;
 
 use GuzzleHttp\Psr7\Utils;
 use Neos\Flow\Http\Cookie;
+use Neos\Flow\Mvc\Controller\AbstractController;
+use Neos\Flow\Mvc\Controller\ControllerContext;
 use Psr\Http\Message\ResponseInterface;
 use Neos\Flow\Annotations as Flow;
 use Psr\Http\Message\StreamInterface;
@@ -10,12 +12,34 @@ use Psr\Http\Message\UriInterface;
 use GuzzleHttp\Psr7\Response;
 
 /**
- * The minimal MVC response object.
- * It allows for simple interactions with the HTTP response from within MVC actions. More specific requirements can be implemented via HTTP middlewares.
+ * The legacy MVC response object.
  *
- * @deprecated
+ * Previously Flows MVC needed a single mutable response which was passed from dispatcher to controllers
+ * and even further to the view and other places via the controller context: {@see ControllerContext::getResponse()}.
+ * This allowed to manipulate the response at every place.
+ *
+ * With the dispatcher and controllers now directly returning a response, the mutability is no longer required.
+ * Additionally, the abstraction offers naturally nothing, that cant be archived by the psr response,
+ * as it directly translates to one: {@see ActionResponse::buildHttpResponse()}
+ *
+ * So you can and should use the immutable psr {@see ResponseInterface} instead where-ever possible.
+ *
+ * For backwards compatibility, each controller will might now manage an own instance of the action response
+ * via `$this->response` {@see AbstractController::$response} and pass it along to places.
+ * But this behaviour is deprecated!
+ *
+ * Instead, you can directly return a PSR repose {@see \GuzzleHttp\Psr7\Response} from a controller:
+ *
+ * ```php
+ * public function myAction()
+ * {
+ *     return (new Response(status: 200, body: $output))
+ *         ->withAddedHeader('X-My-Header', 'foo');
+ * }
+ * ```
+ *
+ * @deprecated with Flow 9
  * @Flow\Proxy(false)
- * @api
  */
 final class ActionResponse
 {
@@ -67,7 +91,7 @@ final class ActionResponse
     /**
      * @param string|StreamInterface $content
      * @return void
-     * @api
+     * @deprecated please use {@see ResponseInterface::withBody()} in combination with {@see \GuzzleHttp\Psr7\Utils::streamFor} instead
      */
     public function setContent($content): void
     {
@@ -83,7 +107,7 @@ final class ActionResponse
      *
      * @param string $contentType
      * @return void
-     * @api
+     * @deprecated please use {@see ResponseInterface::withHeader()} with "Content-Type" instead.
      */
     public function setContentType(string $contentType): void
     {
@@ -96,7 +120,7 @@ final class ActionResponse
      * @param UriInterface $uri
      * @param int $statusCode
      * @return void
-     * @api
+     * @deprecated please use {@see ResponseInterface::withStatus()} and {@see ResponseInterface::withHeader()} with "Header" instead.
      */
     public function setRedirectUri(UriInterface $uri, int $statusCode = 303): void
     {
@@ -110,7 +134,7 @@ final class ActionResponse
      *
      * @param int $statusCode
      * @return void
-     * @api
+     * @deprecated please use {@see ResponseInterface::withStatus()} instead.
      */
     public function setStatusCode(int $statusCode): void
     {
@@ -122,7 +146,7 @@ final class ActionResponse
      * This leads to a corresponding `Set-Cookie` header to be set in the HTTP response
      *
      * @param Cookie $cookie Cookie to be set in the HTTP response
-     * @api
+     * @deprecated please use {@see ResponseInterface::withHeader()} with "Set-Cookie" instead.
      */
     public function setCookie(Cookie $cookie): void
     {
@@ -134,7 +158,7 @@ final class ActionResponse
      * This leads to a corresponding `Set-Cookie` header with an expired Cookie to be set in the HTTP response
      *
      * @param string $cookieName Name of the cookie to delete
-     * @api
+     * @deprecated
      */
     public function deleteCookie(string $cookieName): void
     {
@@ -145,6 +169,8 @@ final class ActionResponse
 
     /**
      * Set the specified header in the response, overwriting any previous value set for this header.
+     *
+     * This behaviour is unsafe and partially unspecified: https://github.com/neos/flow-development-collection/issues/2492
      *
      * @param string $headerName The name of the header to set
      * @param array|string|\DateTime $headerValue An array of values or a single value for the specified header field
@@ -163,6 +189,8 @@ final class ActionResponse
 
     /**
      * Add the specified header to the response, without overwriting any previous value set for this header.
+     *
+     * This behaviour is unsafe and partially unspecified: https://github.com/neos/flow-development-collection/issues/2492
      *
      * @param string $headerName The name of the header to set
      * @param array|string|\DateTime $headerValue An array of values or a single value for the specified header field
@@ -277,6 +305,8 @@ final class ActionResponse
     }
 
     /**
+     * During the migration of {@see ActionResponse} to {@see HttpResponse} this might come in handy.
+     *
      * Note this is a special use case method that will apply the internal properties
      * (Content-Type, StatusCode, Location, Set-Cookie and Content)
      * to a new or replaced PSR-7 Response and return it.
@@ -285,7 +315,6 @@ final class ActionResponse
      * https://github.com/neos/flow-development-collection/issues/2492
      *
      * @return ResponseInterface
-     * @internal
      */
     public function buildHttpResponse(): ResponseInterface
     {

--- a/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
@@ -260,7 +260,7 @@ abstract class AbstractController implements ControllerInterface
      * @param string $actionName Name of the action to forward to
      * @param string|null $controllerName Unqualified object name of the controller to forward to. If not specified, the current controller is used.
      * @param string|null $packageKey Key of the package containing the controller to forward to. If not specified, the current package is assumed.
-     * @param array<string, string> $arguments Array of arguments for the target action
+     * @param array<string, mixed> $arguments Array of arguments for the target action
      * @param integer $delay (optional) The delay in seconds. Default is no delay.
      * @param integer $statusCode (optional) The HTTP status code for the redirect. Default is "303 See Other"
      * @param string|null $format The format to use for the redirect URI

--- a/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
@@ -333,7 +333,7 @@ abstract class AbstractController implements ControllerInterface
             $this->response->setStatusCode($statusCode);
             $this->response->setContent('<html><head><meta http-equiv="refresh" content="' . (int)$delay . ';url=' . $uri . '"/></head></html>');
         }
-        throw StopActionException::createForResponse($this->response, '');
+        throw StopActionException::createForResponse($this->response->buildHttpResponse(), '');
     }
 
     /**
@@ -358,7 +358,7 @@ abstract class AbstractController implements ControllerInterface
             );
         }
         $this->response->setContent($content);
-        throw StopActionException::createForResponse($this->response, $content);
+        throw StopActionException::createForResponse($this->response->buildHttpResponse(), $content);
     }
 
     /**

--- a/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
@@ -61,9 +61,9 @@ abstract class AbstractController implements ControllerInterface
     protected $request;
 
     /**
-     * The response which will be returned by this action controller
+     * The legacy response which will is provide by this action controller
      * @var ActionResponse
-     * @api
+     * @deprecated with Flow 9 {@see ActionResponse}
      */
     protected $response;
 

--- a/Neos.Flow/Classes/Mvc/Controller/ActionController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ActionController.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Mvc\Controller;
  * source code.
  */
 
+use GuzzleHttp\Psr7\Utils;
 use Neos\Error\Messages\Result;
 use Neos\Flow\Annotations as Flow;
 use Neos\Error\Messages as Error;
@@ -558,13 +559,16 @@ class ActionController extends AbstractController
             }
         }
 
-        if ($actionResult === null && $this->view instanceof ViewInterface) {
-            return $this->renderView($this->response);
-        } else {
-            $response->setContent($actionResult);
+        if ($actionResult instanceof ResponseInterface) {
+            return $actionResult;
         }
 
-        return $this->response->buildHttpResponse();
+        if ($actionResult === null && $this->view instanceof ViewInterface) {
+            return $this->renderView($this->response);
+        }
+
+        $httpResponse = $this->response->buildHttpResponse();
+        return $httpResponse->withBody(Utils::streamFor($actionResult));
     }
 
     /**

--- a/Neos.Flow/Classes/Mvc/Controller/ControllerContext.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ControllerContext.php
@@ -82,10 +82,10 @@ class ControllerContext
     }
 
     /**
-     * Get the response of the controller
+     * The legacy response of the controller.
      *
      * @return ActionResponse
-     * @api
+     * @deprecated with Flow 9 {@see ActionResponse}
      */
     public function getResponse()
     {

--- a/Neos.Flow/Classes/Mvc/Controller/ControllerInterface.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ControllerInterface.php
@@ -12,9 +12,9 @@ namespace Neos\Flow\Mvc\Controller;
  */
 
 use Neos\Flow\Mvc\ActionRequest;
-use Neos\Flow\Mvc\ActionResponse;
 use Neos\Flow\Mvc\Exception\ForwardException;
 use Neos\Flow\Mvc\Exception\StopActionException;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Generic interface for controllers
@@ -43,10 +43,10 @@ interface ControllerInterface
      * wich the Dispatcher will catch and handle its attached next-request.
      *
      * @param ActionRequest $request The dispatched action request
-     * @return ActionResponse The resulting created response
+     * @return ResponseInterface The resulting created response
      * @throws StopActionException
      * @throws ForwardException
      * @api
      */
-    public function processRequest(ActionRequest $request): ActionResponse;
+    public function processRequest(ActionRequest $request): ResponseInterface;
 }

--- a/Neos.Flow/Classes/Mvc/Controller/RestController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/RestController.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\Mvc\Controller;
  */
 
 use GuzzleHttp\Psr7\Uri;
+use GuzzleHttp\Psr7\Utils;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\ActionResponse;
@@ -134,7 +135,7 @@ class RestController extends ActionController
             parent::redirectToUri($uri, $delay, $statusCode);
         } catch (StopActionException $exception) {
             if ($this->request->getFormat() === 'json') {
-                $exception->response->setContent('');
+                throw StopActionException::createForResponse($exception->response->withBody(Utils::streamFor('')), '');
             }
             throw $exception;
         }

--- a/Neos.Flow/Classes/Mvc/DispatchMiddleware.php
+++ b/Neos.Flow/Classes/Mvc/DispatchMiddleware.php
@@ -41,6 +41,6 @@ class DispatchMiddleware implements MiddlewareInterface
             throw new Exception('No ActionRequest was created before the DispatchMiddleware. Make sure you have the SecurityEntryPointMiddleware configured before dispatch.', 1605091292);
         }
 
-        return $this->dispatcher->dispatch($actionRequest)->buildHttpResponse();
+        return $this->dispatcher->dispatch($actionRequest);
     }
 }

--- a/Neos.Flow/Classes/Mvc/Exception/StopActionException.php
+++ b/Neos.Flow/Classes/Mvc/Exception/StopActionException.php
@@ -11,7 +11,6 @@ namespace Neos\Flow\Mvc\Exception;
  * source code.
  */
 
-use Neos\Flow\Mvc\ActionResponse;
 use Psr\Http\Message\ResponseInterface;
 use Neos\Flow\Mvc\Controller\AbstractController;
 
@@ -41,11 +40,10 @@ final class StopActionException extends \Neos\Flow\Mvc\Exception
     }
 
     /**
-     * @deprecated
-     * @param ActionResponse $response The response to be received by the MVC Dispatcher.
+     * @param ResponseInterface $response The response to be received by the MVC Dispatcher.
      * @param string $details Additional details just for this exception, in case it is logged (the regular exception message).
      */
-    public static function createForResponse(ActionResponse $response, string $details): self
+    public static function createForResponse(ResponseInterface $response, string $details): self
     {
         if (empty($details)) {
             $details = sprintf(
@@ -53,6 +51,6 @@ final class StopActionException extends \Neos\Flow\Mvc\Exception
                 $response->getStatusCode()
             );
         }
-        return new self($details, 1558088618, null, $response->buildHttpResponse());
+        return new self($details, 1558088618, null, $response);
     }
 }

--- a/Neos.Flow/Classes/Mvc/Exception/StopActionException.php
+++ b/Neos.Flow/Classes/Mvc/Exception/StopActionException.php
@@ -12,6 +12,7 @@ namespace Neos\Flow\Mvc\Exception;
  */
 
 use Neos\Flow\Mvc\ActionResponse;
+use Psr\Http\Message\ResponseInterface;
 use Neos\Flow\Mvc\Controller\AbstractController;
 
 /**
@@ -31,15 +32,16 @@ final class StopActionException extends \Neos\Flow\Mvc\Exception
     /**
      * The response to be received by the MVC Dispatcher.
      */
-    public readonly ActionResponse $response;
+    public readonly ResponseInterface $response;
 
-    private function __construct(string $message, int $code, ?\Throwable $previous, ActionResponse $response)
+    private function __construct(string $message, int $code, ?\Throwable $previous, ResponseInterface $response)
     {
         parent::__construct($message, $code, $previous);
         $this->response = $response;
     }
 
     /**
+     * @deprecated
      * @param ActionResponse $response The response to be received by the MVC Dispatcher.
      * @param string $details Additional details just for this exception, in case it is logged (the regular exception message).
      */
@@ -51,6 +53,6 @@ final class StopActionException extends \Neos\Flow\Mvc\Exception
                 $response->getStatusCode()
             );
         }
-        return new self($details, 1558088618, null, $response);
+        return new self($details, 1558088618, null, $response->buildHttpResponse());
     }
 }

--- a/Neos.Flow/Classes/Mvc/View/ViewInterface.php
+++ b/Neos.Flow/Classes/Mvc/View/ViewInterface.php
@@ -63,7 +63,9 @@ interface ViewInterface
     /**
      * Renders the view
      *
-     * @return string|ActionResponse|ResponseInterface|StreamInterface|object The rendered result; object is only handled if __toString() exists!
+     * Returning an {@see ActionResponse} is deprecated.
+     *
+     * @return string|ActionResponse|ResponseInterface|StreamInterface|\Stringable The rendered result
      * @api
      */
     public function render();

--- a/Neos.Flow/Tests/Functional/Http/Fixtures/Controller/FooController.php
+++ b/Neos.Flow/Tests/Functional/Http/Fixtures/Controller/FooController.php
@@ -13,18 +13,19 @@ namespace Neos\Flow\Tests\Functional\Http\Fixtures\Controller;
 
 use Neos\Flow\Mvc\ActionResponse;
 use Neos\Flow\Mvc\Controller\AbstractController;
+use Psr\Http\Message\ResponseInterface;
 
 class FooController extends AbstractController
 {
     /**
      * @inheritDoc
      */
-    public function processRequest($request): ActionResponse
+    public function processRequest($request): ResponseInterface
     {
         $response = new ActionResponse();
         // test's AbstractController::initializeController
         $this->initializeController($request, $response);
         $response->setContent('FooController responded');
-        return $response;
+        return $response->buildHttpResponse();
     }
 }

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
@@ -14,6 +14,7 @@ namespace Neos\Flow\Tests\Unit\Mvc\Controller;
 use GuzzleHttp\Psr7\ServerRequest;
 use GuzzleHttp\Psr7\Uri;
 use PHPUnit\Framework\Assert;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\ActionResponse;
@@ -291,7 +292,7 @@ class AbstractControllerTest extends UnitTestCase
         $mockUriBuilder->expects(self::once())->method('uriFor')->with('show', ['foo' => 'bar'], 'Stuff', 'Super', 'Duper\Package')->willReturn('the_uri');
 
         $controller = new class extends AbstractController {
-            public function processRequest(ActionRequest $request): ActionResponse
+            public function processRequest(ActionRequest $request): ResponseInterface
             {
                 $response = new ActionResponse();
                 $mockUriBuilder = $this->uriBuilder;
@@ -300,7 +301,7 @@ class AbstractControllerTest extends UnitTestCase
 
                 $this->myIndexAction();
 
-                return $this->response;
+                return $this->response->buildHttpResponse();
             }
 
             public function myIndexAction(): void
@@ -336,7 +337,7 @@ class AbstractControllerTest extends UnitTestCase
         $mockUriBuilder->expects(self::once())->method('uriFor')->with('show', ['foo' => 'bar'], 'Stuff', 'Super', null)->willReturn('the_uri');
 
         $controller = new class extends AbstractController {
-            public function processRequest(ActionRequest $request): ActionResponse
+            public function processRequest(ActionRequest $request): ResponseInterface
             {
                 $response = new ActionResponse();
                 $mockUriBuilder = $this->uriBuilder;
@@ -345,7 +346,7 @@ class AbstractControllerTest extends UnitTestCase
 
                 $this->myIndexAction();
 
-                return $this->response;
+                return $this->response->buildHttpResponse();
             }
 
             public function myIndexAction(): void

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
@@ -466,10 +466,12 @@ class AbstractControllerTest extends UnitTestCase
         try {
             $controller->_call('throwStatus', 404, 'File Really Not Found', $message);
         } catch (StopActionException $e) {
+            self::assertSame(404, $e->response->getStatusCode());
+            self::assertSame($message, $e->response->getBody()->getContents());
+            return;
         }
 
-        self::assertSame(404, $this->actionResponse->getStatusCode());
-        self::assertSame($message, $this->actionResponse->getContent());
+        self::fail('Expected throwStatus to throw.');
     }
 
     /**
@@ -483,10 +485,12 @@ class AbstractControllerTest extends UnitTestCase
         try {
             $controller->_call('throwStatus', 404);
         } catch (StopActionException $e) {
+            self::assertSame(404, $e->response->getStatusCode());
+            self::assertSame('404 Not Found', $e->response->getBody()->getContents());
+            return;
         }
 
-        self::assertSame(404, $this->actionResponse->getStatusCode());
-        self::assertSame('404 Not Found', $this->actionResponse->getContent());
+        self::fail('Expected throwStatus to throw.');
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
@@ -316,7 +316,7 @@ class AbstractControllerTest extends UnitTestCase
             $controller->processRequest($this->mockActionRequest);
         } catch (StopActionException $exception) {
             $actionResponse = $exception->response;
-            Assert::assertSame('the_uri', $actionResponse->getRedirectUri()?->__toString());
+            Assert::assertSame('the_uri', $actionResponse->getHeaderLine('Location'));
             Assert::assertSame(303, $actionResponse->getStatusCode());
             return;
         }
@@ -361,7 +361,7 @@ class AbstractControllerTest extends UnitTestCase
             $controller->processRequest($this->mockActionRequest);
         } catch (StopActionException $exception) {
             $actionResponse = $exception->response;
-            Assert::assertSame('the_uri', $actionResponse->getRedirectUri()?->__toString());
+            Assert::assertSame('the_uri', $actionResponse->getHeaderLine('Location'));
             Assert::assertSame(303, $actionResponse->getStatusCode());
             return;
         }
@@ -420,7 +420,7 @@ class AbstractControllerTest extends UnitTestCase
         }
 
         self::assertNotNull($response);
-        self::assertSame($uri, (string)$response->getRedirectUri());
+        self::assertSame($uri, $response->getHeaderLine('Location'));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/ActionControllerTest.php
@@ -219,13 +219,12 @@ class ActionControllerTest extends UnitTestCase
         $this->mockRequest->expects(self::any())->method('getHttpRequest')->will(self::returnValue($mockHttpRequest));
 
         $mockResponse = new Mvc\ActionResponse;
-        $mockResponse->setContentType('text/plain');
         $this->inject($this->actionController, 'response', $mockResponse);
 
         $mockView = $this->createMock(Mvc\View\ViewInterface::class);
         $mockView->expects(self::once())->method('setControllerContext')->with($this->mockControllerContext);
         $this->actionController->expects(self::once())->method('resolveView')->with($this->mockRequest)->will(self::returnValue($mockView));
-        $this->actionController->expects(self::once())->method('callActionMethod')->willReturn($mockResponse);
+        $this->actionController->expects(self::once())->method('callActionMethod')->willReturn(new Response());
         $this->actionController->expects(self::once())->method('resolveActionMethodName')->with($this->mockRequest)->will(self::returnValue('someAction'));
 
         $this->actionController->processRequest($this->mockRequest);
@@ -251,11 +250,10 @@ class ActionControllerTest extends UnitTestCase
         $mockHttpRequest = $this->getMockBuilder(ServerRequestInterface::class)->disableOriginalConstructor()->getMock();
         $this->mockRequest->expects(self::any())->method('getHttpRequest')->will(self::returnValue($mockHttpRequest));
 
-        $mockResponse = new Mvc\ActionResponse();
         $mockView = $this->createMock(Mvc\View\ViewInterface::class);
         $mockView->expects(self::once())->method('assign')->with('settings', $mockSettings);
         $this->actionController->expects(self::once())->method('resolveView')->with($this->mockRequest)->will(self::returnValue($mockView));
-        $this->actionController->expects(self::once())->method('callActionMethod')->willReturn($mockResponse);
+        $this->actionController->expects(self::once())->method('callActionMethod')->willReturn(new Response());
         $this->actionController->expects(self::once())->method('resolveActionMethodName')->with($this->mockRequest)->will(self::returnValue('someAction'));
         $this->actionController->processRequest($this->mockRequest);
     }
@@ -289,12 +287,11 @@ class ActionControllerTest extends UnitTestCase
         $mockHttpRequest->method('getHeaderLine')->with('Accept')->willReturn($acceptHeader);
         $this->mockRequest->method('getHttpRequest')->willReturn($mockHttpRequest);
 
-        $mockResponse = new Mvc\ActionResponse;
-        $this->actionController->expects(self::once())->method('callActionMethod')->willReturn($mockResponse);
+        $this->actionController->expects(self::once())->method('callActionMethod')->willReturn(new Response());
         $this->inject($this->actionController, 'supportedMediaTypes', $supportedMediaTypes);
 
         $response = $this->actionController->processRequest($this->mockRequest);
-        self::assertSame($expected, $response->getContentType());
+        self::assertSame($expected, $response->getHeaderLine('Content-Type'));
     }
 
     /**
@@ -307,8 +304,8 @@ class ActionControllerTest extends UnitTestCase
         $this->actionController->method('resolveActionMethodName')->willReturn('indexAction');
         $this->inject($this->actionController, 'objectManager', $this->mockObjectManager);
 
-        $mockResponse = new Mvc\ActionResponse;
-        $mockResponse->setContentType('application/json');
+        $mockResponse = new Response();
+        $mockResponse = $mockResponse->withHeader('Content-Type', 'application/json');
         $this->inject($this->actionController, 'supportedMediaTypes', ['application/xml']);
 
         $this->actionController->expects(self::once())->method('callActionMethod')->willReturn($mockResponse);
@@ -321,10 +318,8 @@ class ActionControllerTest extends UnitTestCase
         $mockHttpRequest->method('getHeaderLine')->with('Accept')->willReturn('application/xml');
         $this->mockRequest->method('getHttpRequest')->willReturn($mockHttpRequest);
 
-
-
         $response = $this->actionController->processRequest($this->mockRequest);
-        self::assertSame('application/json', $response->getContentType());
+        self::assertSame('application/json', $response->getHeaderLine('Content-Type'));
     }
 
     /**
@@ -347,8 +342,6 @@ class ActionControllerTest extends UnitTestCase
         $mockHttpRequest->method('getHeaderLine')->with('Accept')->willReturn('application/xml');
         $this->mockRequest->method('getHttpRequest')->willReturn($mockHttpRequest);
 
-        $mockResponse = new Mvc\ActionResponse;
-
         $this->inject($this->actionController, 'supportedMediaTypes', ['application/xml']);
 
         $mockView = $this->createMock(Mvc\View\ViewInterface::class);
@@ -356,7 +349,7 @@ class ActionControllerTest extends UnitTestCase
         $this->actionController->expects(self::once())->method('resolveView')->with($this->mockRequest)->willReturn($mockView);
 
         $mockResponse = $this->actionController->processRequest($this->mockRequest);
-        self::assertSame('application/json', $mockResponse->getContentType());
+        self::assertSame('application/json', $mockResponse->getHeaderLine('Content-Type'));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Mvc/DispatchMiddlewareTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/DispatchMiddlewareTest.php
@@ -14,7 +14,6 @@ namespace Neos\Flow\Tests\Unit\Mvc;
 use GuzzleHttp\Psr7\Response;
 use Neos\Flow\Http\ServerRequestAttributes;
 use Neos\Flow\Mvc\ActionRequest;
-use Neos\Flow\Mvc\ActionResponse;
 use Neos\Flow\Mvc\DispatchMiddleware;
 use Neos\Flow\Mvc\Dispatcher;
 use Neos\Flow\Tests\UnitTestCase;
@@ -81,8 +80,8 @@ class DispatchMiddlewareTest extends UnitTestCase
     {
         $testContentType = 'audio/ogg';
         $this->mockHttpRequest->method('getQueryParams')->willReturn([]);
-        $testResponse = new ActionResponse();
-        $testResponse->setContentType($testContentType);
+        $testResponse = new Response();
+        $testResponse = $testResponse->withHeader('Content-Type', $testContentType);
         $this->mockDispatcher->expects(self::once())->method('dispatch')->with($this->mockActionRequest)->willReturn($testResponse);
 
         $response = $this->dispatchMiddleware->process($this->mockHttpRequest, $this->mockRequestHandler);

--- a/Neos.Flow/Tests/Unit/Mvc/DispatcherTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/DispatcherTest.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Tests\Unit\Mvc;
  * source code.
  */
 
+use GuzzleHttp\Psr7\Response;
 use Neos\Flow\Log\PsrLoggerFactoryInterface;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\ActionResponse;
@@ -142,7 +143,7 @@ class DispatcherTest extends UnitTestCase
     {
         $this->mockActionRequest->expects(self::exactly(3))->method('isDispatched')->willReturnOnConsecutiveCalls(false, false, true);
 
-        $this->mockController->expects(self::exactly(2))->method('processRequest')->with($this->mockActionRequest)->willReturn($this->actionResponse);
+        $this->mockController->expects(self::exactly(2))->method('processRequest')->with($this->mockActionRequest)->willReturn(new Response());
 
         $this->dispatcher->dispatch($this->mockActionRequest);
     }
@@ -197,8 +198,7 @@ class DispatcherTest extends UnitTestCase
      */
     public function dispatchThrowsAnInfiniteLoopExceptionIfTheRequestCouldNotBeDispachedAfter99Iterations()
     {
-        $response = new ActionResponse();
-        $this->mockController->expects(self::any())->method('processRequest')->with($this->mockActionRequest)->willReturn($response);
+        $this->mockController->expects(self::any())->method('processRequest')->with($this->mockActionRequest)->willReturn(new Response());
 
         $this->expectException(InfiniteLoopException::class);
         $requestCallCounter = 0;

--- a/Neos.Flow/Tests/Unit/Mvc/DispatcherTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/DispatcherTest.php
@@ -156,7 +156,7 @@ class DispatcherTest extends UnitTestCase
         $this->mockParentRequest->expects(self::exactly(2))->method('isDispatched')->willReturnOnConsecutiveCalls(false, true);
         $this->mockParentRequest->expects(self::once())->method('isMainRequest')->willReturn(true);
 
-        $this->mockController->expects(self::atLeastOnce())->method('processRequest')->will(self::throwException(StopActionException::createForResponse(new ActionResponse(), '')));
+        $this->mockController->expects(self::atLeastOnce())->method('processRequest')->will(self::throwException(StopActionException::createForResponse(new Response(), '')));
 
         $this->dispatcher->dispatch($this->mockParentRequest);
     }
@@ -169,7 +169,7 @@ class DispatcherTest extends UnitTestCase
         $this->mockActionRequest->expects(self::atLeastOnce())->method('isDispatched')->willReturn(false);
         $this->mockParentRequest->expects(self::atLeastOnce())->method('isDispatched')->willReturn(true);
 
-        $this->mockController->expects(self::atLeastOnce())->method('processRequest')->will(self::throwException(StopActionException::createForResponse(new ActionResponse(), '')));
+        $this->mockController->expects(self::atLeastOnce())->method('processRequest')->will(self::throwException(StopActionException::createForResponse(new Response(), '')));
 
         $this->dispatcher->dispatch($this->mockActionRequest, $this->actionResponse);
     }
@@ -188,7 +188,7 @@ class DispatcherTest extends UnitTestCase
 
         $this->mockController->expects(self::exactly(2))->method('processRequest')
             ->withConsecutive([$this->mockActionRequest], [$this->mockParentRequest])
-            ->willReturnOnConsecutiveCalls(self::throwException(StopActionException::createForResponse(new ActionResponse(), '')), self::throwException($forwardException));
+            ->willReturnOnConsecutiveCalls(self::throwException(StopActionException::createForResponse(new Response(), '')), self::throwException($forwardException));
 
         $this->dispatcher->dispatch($this->mockActionRequest);
     }

--- a/Neos.FluidAdaptor/Classes/Core/Widget/AbstractWidgetController.php
+++ b/Neos.FluidAdaptor/Classes/Core/Widget/AbstractWidgetController.php
@@ -12,7 +12,6 @@ namespace Neos\FluidAdaptor\Core\Widget;
  */
 
 use Neos\Flow\Mvc\ActionRequest;
-use Neos\Flow\Mvc\ActionResponse;
 use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Mvc\Exception\ForwardException;
 use Neos\Flow\Mvc\Exception\InvalidActionVisibilityException;

--- a/Neos.FluidAdaptor/Classes/Core/Widget/AbstractWidgetController.php
+++ b/Neos.FluidAdaptor/Classes/Core/Widget/AbstractWidgetController.php
@@ -24,6 +24,7 @@ use Neos\Flow\Mvc\Exception\ViewNotFoundException;
 use Neos\Flow\Property\Exception;
 use Neos\Flow\Persistence\QueryResultInterface;
 use Neos\FluidAdaptor\Core\Widget\Exception\WidgetContextNotFoundException;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * This is the base class for all widget controllers.
@@ -46,7 +47,7 @@ abstract class AbstractWidgetController extends ActionController
      * Handles a request. The result output is returned by altering the given response.
      *
      * @param ActionRequest $request The request object
-     * @return ActionResponse $response The response, modified by this handler
+     * @return ResponseInterface The response, created by this handler
      * @throws WidgetContextNotFoundException
      * @throws InvalidActionVisibilityException
      * @throws InvalidArgumentTypeException
@@ -59,7 +60,7 @@ abstract class AbstractWidgetController extends ActionController
      * @throws \Neos\Flow\Security\Exception
      * @api
      */
-    public function processRequest(ActionRequest $request): ActionResponse
+    public function processRequest(ActionRequest $request): ResponseInterface
     {
         /** @var WidgetContext $widgetContext */
         $widgetContext = $request->getInternalArgument('__widgetContext');

--- a/Neos.FluidAdaptor/Classes/Core/Widget/AbstractWidgetViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/Core/Widget/AbstractWidgetViewHelper.php
@@ -241,6 +241,7 @@ abstract class AbstractWidgetViewHelper extends AbstractViewHelper implements Ch
                 $subResponse = $exception->response;
                 $parentResponse = $this->controllerContext->getResponse()->buildHttpResponse();
 
+                // legacy behaviour of "mergeIntoParentResponse":
                 // transfer possible headers that have been set dynamically
                 foreach ($subResponse->getHeaders() as $name => $values) {
                     $parentResponse = $parentResponse->withHeader($name, $values);
@@ -249,7 +250,7 @@ abstract class AbstractWidgetViewHelper extends AbstractViewHelper implements Ch
                 if ($subResponse->getStatusCode() !== 200) {
                     $parentResponse = $parentResponse->withStatus($subResponse->getStatusCode());
                 }
-
+                // if the known body size is not empty replace the body
                 if ($subResponse->getBody()->getSize() !== 0) {
                     $parentResponse = $parentResponse->withBody($subResponse->getBody());
                 }
@@ -263,7 +264,8 @@ abstract class AbstractWidgetViewHelper extends AbstractViewHelper implements Ch
             // We need to make sure to not merge content up into the parent ActionResponse because that _could_ break the parent response.
             $content = $subResponse->getBody()->getContents();
 
-            // hacky, but part of the deal. We have to manipulate the global response to redirect for example.
+            // hacky, but part of the deal. Legacy behaviour of "mergeIntoParentResponse":
+            // we have to manipulate the global response to redirect for example.
             // transfer possible headers that have been set dynamically
             foreach ($subResponse->getHeaders() as $name => $values) {
                 $this->controllerContext->getResponse()->setHttpHeader($name, $values);

--- a/Neos.FluidAdaptor/Classes/Core/Widget/AjaxWidgetMiddleware.php
+++ b/Neos.FluidAdaptor/Classes/Core/Widget/AjaxWidgetMiddleware.php
@@ -79,7 +79,7 @@ class AjaxWidgetMiddleware implements MiddlewareInterface
         $actionRequest = $this->actionRequestFactory->createActionRequest($httpRequest, ['__widgetContext' => $widgetContext]);
         $actionRequest->setControllerObjectName($widgetContext->getControllerObjectName());
         $this->securityContext->setRequest($actionRequest);
-        return $this->dispatcher->dispatch($actionRequest)->buildHttpResponse();
+        return $this->dispatcher->dispatch($actionRequest);
     }
 
     /**

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetControllerTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetControllerTest.php
@@ -11,6 +11,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\Core\Widget;
  * source code.
  */
 
+use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\ServerRequest;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Mvc\ActionResponse;
@@ -48,7 +49,6 @@ class AbstractWidgetControllerTest extends UnitTestCase
     {
         /** @var \Neos\Flow\Mvc\ActionRequest $mockActionRequest */
         $mockActionRequest = $this->createMock(\Neos\Flow\Mvc\ActionRequest::class);
-        $mockResponse = new ActionResponse();
 
         $httpRequest = new ServerRequest('GET', new Uri('http://localhost'));
         $mockActionRequest->expects(self::any())->method('getHttpRequest')->will(self::returnValue($httpRequest));
@@ -64,7 +64,7 @@ class AbstractWidgetControllerTest extends UnitTestCase
         $abstractWidgetController = $this->getAccessibleMock(\Neos\FluidAdaptor\Core\Widget\AbstractWidgetController::class, ['resolveActionMethodName', 'initializeActionMethodArguments', 'initializeActionMethodValidators', 'mapRequestArgumentsToControllerArguments', 'detectFormat', 'resolveView', 'callActionMethod']);
         $abstractWidgetController->method('resolveActionMethodName')->willReturn('indexAction');
         $abstractWidgetController->_set('mvcPropertyMappingConfigurationService', $this->createMock(\Neos\Flow\Mvc\Controller\MvcPropertyMappingConfigurationService::class));
-        $abstractWidgetController->expects(self::once())->method('callActionMethod')->willReturn($mockResponse);
+        $abstractWidgetController->expects(self::once())->method('callActionMethod')->willReturn(new Response());
         $abstractWidgetController->processRequest($mockActionRequest);
 
         $actualWidgetConfiguration = $abstractWidgetController->_get('widgetConfiguration');

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AjaxWidgetMiddlewareTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AjaxWidgetMiddlewareTest.php
@@ -14,7 +14,6 @@ namespace Neos\FluidAdaptor\Tests\Unit\Core\Widget;
 use GuzzleHttp\Psr7\Response;
 use Neos\Flow\Mvc\ActionRequest;
 use Neos\Flow\Mvc\ActionRequestFactory;
-use Neos\Flow\Mvc\ActionResponse;
 use Neos\Flow\Mvc\Dispatcher;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Security\Context;
@@ -120,8 +119,7 @@ class AjaxWidgetMiddlewareTest extends UnitTestCase
         $this->inject($this->ajaxWidgetMiddleware, 'hashService', $this->mockHashService);
 
         $this->mockDispatcher = $this->getMockBuilder(Dispatcher::class)->getMock();
-        $actionResponse = new ActionResponse();
-        $this->mockDispatcher->expects(self::any())->method('dispatch')->willReturn($actionResponse);
+        $this->mockDispatcher->expects(self::any())->method('dispatch')->willReturn(new Response());
         $this->inject($this->ajaxWidgetMiddleware, 'dispatcher', $this->mockDispatcher);
 
         $this->mockSecurityContext = $this->getMockBuilder(Context::class)->getMock();
@@ -180,8 +178,7 @@ class AjaxWidgetMiddlewareTest extends UnitTestCase
         $mockActionRequest = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->getMock();
         $this->mockActionRequestFactory->method('prepareActionRequest')->willReturn($mockActionRequest);
 
-        $actionResponse = new ActionResponse();
-        $this->mockDispatcher->expects(self::once())->method('dispatch')->willReturn($actionResponse);
+        $this->mockDispatcher->expects(self::once())->method('dispatch')->willReturn(new Response());
 
         $this->ajaxWidgetMiddleware->process($this->mockHttpRequest, $this->mockRequestHandler);
     }


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

Resolves: #3289 (Contains discussion about the reasoning).

will not be merged directly into 9.0 but included in this mvc overhaul pr: https://github.com/neos/flow-development-collection/pull/3311

_(original pr in christians fork https://github.com/kitsunet/flow-development-collection/pull/5)_


```php
class Dispatcher
{
    public function dispatch(ActionRequest $request): ResponseInterface;
}
```