### PR TITLE
TASK: Deprecate Flow's RequestInterface

### DIFF
--- a/Neos.Flow/Classes/Mvc/RequestInterface.php
+++ b/Neos.Flow/Classes/Mvc/RequestInterface.php
@@ -14,7 +14,10 @@ namespace Neos\Flow\Mvc;
 /**
  * Contract for a dispatchable request.
  *
- * @api
+ * @deprecated Since the separation of http and cli requests
+ *             this is completely unused. And strict types against
+ *             its only implementation, the ActionRequest make it
+ *             impossible to implement a custom request.
  */
 interface RequestInterface
 {


### PR DESCRIPTION
Not to be confused with the psr requests interface.

TLTR:

Since the separation of http and cli requests the interface is completely unused. And strict types against its only implementation, the ActionRequest make it impossible to implement a custom request.

--------

_Initially_ the interface was introduced with https://github.com/neos/flow-development-collection/commit/2a269253c0345f6d2ec369d663214a6117df7a59 at beginning of time. At that time this was done probably to be able to type against the interface instead of the common `Request` class, that the Cli and Web Request both extended.

With the removal of many methods in its interface https://github.com/neos/flow-development-collection/commit/8c40ff2baf83158f6ce085e5b50c9b6400418fa6 and with the full separation of action and cli requests https://github.com/neos/flow-development-collection/pull/1552 the interface became useless.

The dispatcher and controller interface are both typed against the `ActionRequest` and so it's impossible to implement a custom request.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

Please reference the `ActionRequest` instead in typehints.

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
