### PR TITLE
!!! TASK: `Mvc\Dispatcher::afterControllerInvocation` will not be called for CLI requests anymore.

### DIFF
--- a/Neos.Flow/Classes/Cli/Dispatcher.php
+++ b/Neos.Flow/Classes/Cli/Dispatcher.php
@@ -77,6 +77,7 @@ class Dispatcher
      * @param Response $response
      * @param CommandControllerInterface $controller
      * @return void
+     * @Flow\Signal
      */
     protected function emitBeforeControllerInvocation(Request $request, Response $response, CommandControllerInterface $controller)
     {
@@ -90,6 +91,7 @@ class Dispatcher
      * @param Response $response
      * @param CommandControllerInterface $controller
      * @return void
+     * @Flow\Signal
      */
     protected function emitAfterControllerInvocation(Request $request, Response $response, CommandControllerInterface $controller)
     {

--- a/Neos.Flow/Classes/Cli/Dispatcher.php
+++ b/Neos.Flow/Classes/Cli/Dispatcher.php
@@ -5,7 +5,6 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\Exception\InfiniteLoopException;
 use Neos\Flow\Cli\Exception\InvalidCommandControllerException;
 use Neos\Flow\Cli\Exception\StopCommandException;
-use Neos\Flow\ObjectManagement\CompileTimeObjectManager;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 
 /**
@@ -81,16 +80,6 @@ class Dispatcher
      */
     protected function emitBeforeControllerInvocation(Request $request, Response $response, CommandControllerInterface $controller)
     {
-        // Before Flow 5.3 you could rely on this slot only being called during runtime
-        // There will be new slots in 7.x, which will run in compile time, too
-        if ($this->objectManager instanceof CompileTimeObjectManager) {
-            return;
-        }
-        $this->signalDispatcher->dispatch(\Neos\Flow\Mvc\Dispatcher::class, 'beforeControllerInvocation', [
-            'request' => $request,
-            'response' => $response,
-            'controller' => $controller
-        ]);
     }
 
     /**
@@ -104,16 +93,6 @@ class Dispatcher
      */
     protected function emitAfterControllerInvocation(Request $request, Response $response, CommandControllerInterface $controller)
     {
-        // Before Flow 5.3 you could rely on this slot only being called during runtime
-        // There will be new slots in 7.x, which will run in compile time, too
-        if ($this->objectManager instanceof CompileTimeObjectManager) {
-            return;
-        }
-        $this->signalDispatcher->dispatch(\Neos\Flow\Mvc\Dispatcher::class, 'afterControllerInvocation', [
-            'request' => $request,
-            'response' => $response,
-            'controller' => $controller
-        ]);
     }
 
     /**

--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -16,6 +16,7 @@ use Neos\Flow\Configuration\Loader\AppendLoader;
 use Neos\Flow\Configuration\Source\YamlSource;
 use Neos\Flow\Core\Booting\Step;
 use Neos\Flow\Http\Helper\SecurityHelper;
+use Neos\Flow\ObjectManagement\CompileTimeObjectManager;
 use Neos\Flow\ObjectManagement\Proxy;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\Flow\Package\PackageManager;
@@ -67,10 +68,11 @@ class Package extends BasePackage
 
         $dispatcher->connect(Mvc\Dispatcher::class, 'afterControllerInvocation', function ($request) use ($bootstrap) {
             // No auto-persistence if there is no PersistenceManager registered
+            // This signal will not be fired at compile time, as it's only emitted for web requests which happen at runtime.
             if (
                 $bootstrap->getObjectManager()->has(Persistence\PersistenceManagerInterface::class)
             ) {
-                if (!$request instanceof Mvc\ActionRequest || SecurityHelper::hasSafeMethod($request->getHttpRequest()) !== true) {
+                if (SecurityHelper::hasSafeMethod($request->getHttpRequest()) !== true) {
                     $bootstrap->getObjectManager()->get(Persistence\PersistenceManagerInterface::class)->persistAll();
                 } elseif (SecurityHelper::hasSafeMethod($request->getHttpRequest())) {
                     /** @phpstan-ignore-next-line the persistence manager interface doesn't specify this method */
@@ -78,6 +80,17 @@ class Package extends BasePackage
                 }
             }
         });
+
+        $dispatcher->connect(Cli\Dispatcher::class, 'afterControllerInvocation', function () use ($bootstrap) {
+            // No auto-persistence if there is no PersistenceManager registered or during compile time
+            if (
+                $bootstrap->getObjectManager()->has(Persistence\PersistenceManagerInterface::class)
+                && !($bootstrap->getObjectManager() instanceof CompileTimeObjectManager)
+            ) {
+                $bootstrap->getObjectManager()->get(Persistence\PersistenceManagerInterface::class)->persistAll();
+            }
+        });
+
         $dispatcher->connect(Cli\SlaveRequestHandler::class, 'dispatchedCommandLineSlaveRequest', Persistence\PersistenceManagerInterface::class, 'persistAll', false);
 
         $dispatcher->connect(Command\CacheCommandController::class, 'warmupCaches', PrecomposedHashProvider::class, 'precomposeHash');


### PR DESCRIPTION
Reverts that the cli dispatcher invokes the mvc slots dispatcher slots with cli requests.

When there was one dispatcher the slot `afterControllerInvocation` was fired for both cli and web request. (Seemingly only ever at Runtime?)

Then with the split of web and cli dispatchers this legacy layer was introduced:

https://github.com/neos/flow-development-collection/commit/cf55b180c953de8d02adb680216f5c24a3524237#diff-2c9408e74a8ac737f84468e74c23956d2057e64196e66b97281905d8697226ca

Now during a short time the `Mvc\Dispatcher::afterControllerInvocation` signal was now also called for cli request during compile time.

With this bugfix https://github.com/neos/flow-development-collection/pull/2529 the initial behaviour was restored again. For cli request it will only fire at runtime, and web request are either way always runtime.

This breaking change cleans up the legacy layer.

- The original signals `Mvc\Dispatcher` `'afterControllerInvocation'` and `'beforeControllerInvocation'`
  Will be only invoked for action requests.
They still only fire at runtime, as web requests happen at runtime.

- The with Flow 6.0 introduced signals `Cli\Dispatcher` `'afterControllerInvocation'` and `'beforeControllerInvocation'`
  Will still be only invoked for cli requests.
Will still fired either at compile or runtime, as cli requests can happen always.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

In case you used the MVC signals and relied on it to also be invoked for CliRequest, you need to connect as well to the respective Cli\Dispatcher signal. But keep in mind that you might need to check if flow is in runtime as this signal will be also fired for compile time unlike the mvc signal before.

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
