### PR TITLE
BUGFIX: Stabilise file monitor

### DIFF
--- a/Neos.Flow/Classes/Monitor/ChangeDetectionStrategy/ModificationTimeStrategy.php
+++ b/Neos.Flow/Classes/Monitor/ChangeDetectionStrategy/ModificationTimeStrategy.php
@@ -65,6 +65,32 @@ class ModificationTimeStrategy implements ChangeDetectionStrategyInterface, Stra
     }
 
     /**
+     * @param string $onPath
+     * @param array<string,1> $filesIgnoreMask files to ignore as we are sure they exist
+     * @return array<string, ChangeDetectionStrategyInterface::STATUS_DELETED>
+     */
+    public function flushDeletedOnPath(string $onPath, array $filesIgnoreMask): array
+    {
+        $deletedFiles = [];
+        foreach ($this->filesAndModificationTimes as $pathAndFilename => $modificationTime) {
+            if (!str_starts_with($pathAndFilename, $onPath)) {
+                continue;
+            }
+            if (isset($filesIgnoreMask[$pathAndFilename])) {
+                continue;
+            }
+            if (file_exists($pathAndFilename)) {
+                // should not happen?
+                continue;
+            }
+            $this->modificationTimesChanged = true;
+            unset($this->filesAndModificationTimes[$pathAndFilename]);
+            $deletedFiles[$pathAndFilename] = ChangeDetectionStrategyInterface::STATUS_DELETED;
+        }
+        return $deletedFiles;
+    }
+
+    /**
      * Checks if the specified file has changed
      *
      * @param string $pathAndFilename

--- a/Neos.Flow/Classes/Monitor/ChangeDetectionStrategy/ModificationTimeStrategy.php
+++ b/Neos.Flow/Classes/Monitor/ChangeDetectionStrategy/ModificationTimeStrategy.php
@@ -18,7 +18,7 @@ use Neos\Flow\Annotations as Flow;
 /**
  * A change detection strategy based on modification times
  */
-class ModificationTimeStrategy implements ChangeDetectionStrategyInterface, StrategyWithMarkDeletedInterface
+class ModificationTimeStrategy implements ChangeDetectionStrategyInterface, StrategyWithMarkDeletedInterface, StrategyWithFlushDeletedOnPathInterface
 {
     /**
      * @var \Neos\Flow\Monitor\FileMonitor

--- a/Neos.Flow/Classes/Monitor/ChangeDetectionStrategy/StrategyWithFlushDeletedOnPathInterface.php
+++ b/Neos.Flow/Classes/Monitor/ChangeDetectionStrategy/StrategyWithFlushDeletedOnPathInterface.php
@@ -1,0 +1,27 @@
+<?php
+namespace Neos\Flow\Monitor\ChangeDetectionStrategy;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Contract for a change detection strategy that allows the FileMonitor to flush all removals directly.
+ *
+ * @api
+ */
+interface StrategyWithFlushDeletedOnPathInterface
+{
+    /**
+     * @param string $onPath
+     * @param array<string,1> $filesIgnoreMask files to ignore as we are sure they exist
+     * @return array<string, ChangeDetectionStrategyInterface::STATUS_DELETED>
+     */
+    public function flushDeletedOnPath(string $onPath, array $filesIgnoreMask): array;
+}

--- a/Neos.Flow/Classes/Monitor/ChangeDetectionStrategy/StrategyWithMarkDeletedInterface.php
+++ b/Neos.Flow/Classes/Monitor/ChangeDetectionStrategy/StrategyWithMarkDeletedInterface.php
@@ -14,6 +14,7 @@ namespace Neos\Flow\Monitor\ChangeDetectionStrategy;
 /**
  * Contract for a change detection strategy that allows the FileMonitor to mark a file deleted directly.
  *
+ * @deprecated in favour of more reliable {@see StrategyWithFlushDeletedOnPathInterface}
  * @api
  */
 interface StrategyWithMarkDeletedInterface

--- a/Neos.Flow/Classes/Monitor/FileMonitor.php
+++ b/Neos.Flow/Classes/Monitor/FileMonitor.php
@@ -303,7 +303,9 @@ class FileMonitor
             $this->changedPaths[$path] = ChangeDetectionStrategyInterface::STATUS_CREATED;
         }
 
+        $currentSubDirectoriesAndFilesMask = [];
         foreach ($currentSubDirectoriesAndFiles as $pathAndFilename) {
+            $currentSubDirectoriesAndFilesMask[$pathAndFilename] = 1;
             $status = $this->changeDetectionStrategy->getFileStatus($pathAndFilename);
             if ($status !== ChangeDetectionStrategyInterface::STATUS_UNCHANGED) {
                 $this->changedFiles[$pathAndFilename] = $status;
@@ -314,6 +316,12 @@ class FileMonitor
                 unset($this->directoriesAndFiles[$path][$pathAndFilename]);
             }
             $nowDetectedFilesAndDirectories[$pathAndFilename] = 1;
+        }
+
+        $deletedFiles = $this->changeDetectionStrategy->flushDeletedOnPath($path, $currentSubDirectoriesAndFilesMask);
+        if ($deletedFiles) {
+            $this->changedFiles = [...$this->changedFiles, ...$deletedFiles];
+            $currentDirectoryChanged = true;
         }
 
         if ($this->directoriesAndFiles[$path] !== []) {


### PR DESCRIPTION
While trying to fix https://github.com/neos/flow-development-collection/issues/3303 i noticed that my file monitor had stale caches.

I deleted a file long time, but it was still present in `Cache/Data/Flow_Monitor/Flow_ClassFiles_filesAndModificationTimes`.
That should not be the case as it should have been flushed. Maybe the file monitor even noticed the change and other parts of flow were aware of it but just the deletion in the file didnt work.

Either way it seems to be flaky and expensive to have two caches with similar data.
This change in theorie makes the `Flow_ClassFiles_directoriesAndFiles` cache obsolete by introducing a new method to that on the `ModificationTimeStrategy`.

The idea was, if i loop already through all the folders we can just diff it to the previously saved modification stamps and see whats left and check for file existence.

That seems to work well. And in one hickup in flow, that i could not further reproduce, even better than the current strategy which didnt detect a removal.

to test i just dumped a bit around ;D
```php
if ($this->identifier === 'Flow_ClassFiles' && str_ends_with($path, '/Packages/Neos/Neos.Neos/Classes/')) {
    // previously considered files for deletion
    var_dump($this->directoriesAndFiles[$path]);
    // more relivable?
    var_dump($deletedFiles);
}
```

TODOS;
- why is the filemonitor proxied???
- do people implement their own strategy? at least this commit suggests that: https://github.com/kitsunet/flow-development-collection/commit/b54f80393d15ac93086b15b9902b677dcd332b0f