### PR TITLE
Experiment; WIP: BUGFIX: bugfix/use-md5paths-instead-classnames-to-flush-correctly

### DIFF
--- a/Neos.Flow/Classes/Command/CoreCommandController.php
+++ b/Neos.Flow/Classes/Command/CoreCommandController.php
@@ -197,9 +197,10 @@ class CoreCommandController extends CommandController
         $this->aopProxyClassBuilder->build();
         $this->dependencyInjectionProxyClassBuilder->build();
 
-        $classCount = $this->proxyClassCompiler->compile();
-
         $dataTemporaryPath = $this->environment->getPathToTemporaryDirectory();
+        $previousProxyClasses = @include($dataTemporaryPath . 'AvailableProxyClasses.php') ?: [];
+        $classCount = $this->proxyClassCompiler->compile($previousProxyClasses);
+
         Files::createDirectoryRecursively($dataTemporaryPath);
         file_put_contents($dataTemporaryPath . 'AvailableProxyClasses.php', $this->proxyClassCompiler->getStoredProxyClassMap());
 

--- a/Neos.Flow/Classes/Core/ProxyClassLoader.php
+++ b/Neos.Flow/Classes/Core/ProxyClassLoader.php
@@ -93,7 +93,7 @@ class ProxyClassLoader
         }
 
         // Loads any known proxied class:
-        if ($this->classesCache !== null && ($this->availableProxyClasses === null || isset($this->availableProxyClasses[implode('_', $namespaceParts)])) && $this->classesCache->requireOnce(implode('_', $namespaceParts)) !== false) {
+        if ($this->classesCache !== null && ($md5 = $this->availableProxyClasses[implode('_', $namespaceParts)] ?? null) && $this->classesCache->requireOnce($md5) !== false) {
             return true;
         }
 

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
@@ -186,7 +186,7 @@ class Compiler
      *
      * @return int Number of classes which have been compiled
      */
-    public function compile(): int
+    public function compile(array $previousProxyClasses): int
     {
         $compiledClasses = [];
         foreach ($this->objectManager->getRegisteredClassNames() as $fullOriginalClassNames) {
@@ -197,11 +197,12 @@ class Compiler
                         $class = new ReflectionClass($fullOriginalClassName);
                         $classPathAndFilename = $class->getFileName();
                         $this->cacheOriginalClassFileAndProxyCode($fullOriginalClassName, $classPathAndFilename, $proxyClassCode);
-                        $this->storedProxyClasses[str_replace('\\', '_', $fullOriginalClassName)] = true;
+                        $this->storedProxyClasses[str_replace('\\', '_', $fullOriginalClassName)] = md5($classPathAndFilename);
                         $compiledClasses[] = $fullOriginalClassName;
                     }
                 } elseif ($this->classesCache->has(str_replace('\\', '_', $fullOriginalClassName))) {
-                    $this->storedProxyClasses[str_replace('\\', '_', $fullOriginalClassName)] = true;
+                    assert($previousProxyClasses[str_replace('\\', '_', $fullOriginalClassName)]);
+                    $this->storedProxyClasses[str_replace('\\', '_', $fullOriginalClassName)] = $previousProxyClasses[str_replace('\\', '_', $fullOriginalClassName)];
                 }
             }
         }

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1141,7 +1141,7 @@ class ReflectionService
         // Development context.
         ksort($this->classReflectionData);
 
-        $this->updatedReflectionData[$className] = true;
+        $this->updatedReflectionData[$className] = md5($class->getFileName());
     }
 
     /**
@@ -1757,11 +1757,12 @@ class ReflectionService
             }
         }
 
-        foreach ($classNames as $className) {
-            if (!$this->statusCache->has($this->produceCacheIdentifierFromClassName($className))) {
-                $this->forgetClass($className);
-            }
-        }
+        // impossible without the path saved in classReflectionData
+        // foreach ($classNames as $className) {
+        //     if (!$this->statusCache->has($this->produceCacheIdentifierFromClassName($className))) {
+        //         $this->forgetClass($className);
+        //     }
+        // }
     }
 
     /**
@@ -2080,8 +2081,8 @@ class ReflectionService
     {
         $this->log(sprintf('Found %s classes whose reflection data was not cached previously.', count($this->updatedReflectionData)), LogLevel::DEBUG);
 
-        foreach (array_keys($this->updatedReflectionData) as $className) {
-            $this->statusCache->set($this->produceCacheIdentifierFromClassName($className), '');
+        foreach (array_keys($this->updatedReflectionData) as $md5FileName) {
+            $this->statusCache->set($md5FileName, '');
         }
 
         $data = [];


### PR DESCRIPTION
resolves #3303

but this is just an experiment. I was under the impression that we cannot find out the namespace of a removed php file, but we can do a reverse lookup by taking all possible psr-4 autoloading configs into account and then doing the flush. See https://github.com/neos/flow-development-collection/pull/3383

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
