### PR TITLE
TASK: Deprecate BaseTestCase functionalities

### DIFF
--- a/Neos.Flow/Tests/AccessibleProxyInterface.php
+++ b/Neos.Flow/Tests/AccessibleProxyInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Neos\Flow\Tests;
+
+use Neos\Utility\ObjectAccess;
+
+/**
+ * This interface defines the methods provided by {@see BaseTestCase::getAccessibleMock()}
+ * Do not implement this interface in own classes.
+ *
+ * It allows for calling even protected methods and access of protected properties.
+ *
+ * Note that this interface is not actually implemented by the accessible proxy, but only provides IDE support.
+ *
+ * @deprecated you should not use this for unit testing
+ */
+interface AccessibleProxyInterface
+{
+    /** @deprecated */
+    public function _call(string $methodName, mixed ...$arguments): mixed;
+    /** @deprecated */
+    public function _callRef(string $methodName, mixed ...$argumentsPassedByReference): mixed;
+    /** @deprecated please use {@see BaseTestCase::inject()} instead */
+    public function _set(string $propertyName, mixed $value): void;
+    /** @deprecated */
+    public function _setRef(string $propertyName, mixed &$value): void;
+    /** @deprecated please use {@see ObjectAccess::getProperty()} instead */
+    public function _get(string $propertyName): mixed;
+}

--- a/Neos.Flow/Tests/AccessibleProxyInterface.php
+++ b/Neos.Flow/Tests/AccessibleProxyInterface.php
@@ -12,7 +12,8 @@ use Neos\Utility\ObjectAccess;
  *
  * Note that this interface is not actually implemented by the accessible proxy, but only provides IDE support.
  *
- * @deprecated you should not use this for unit testing
+ * @deprecated you should not use this for testing. As it will couple the tests to highly to the internal implementation
+ * and makes refactorings without rewriting major tests impossible.
  */
 interface AccessibleProxyInterface
 {
@@ -20,10 +21,10 @@ interface AccessibleProxyInterface
     public function _call(string $methodName, mixed ...$arguments): mixed;
     /** @deprecated */
     public function _callRef(string $methodName, mixed ...$argumentsPassedByReference): mixed;
-    /** @deprecated please use {@see BaseTestCase::inject()} instead */
+    /** @deprecated please specify properties via constructor call the injector manually or use - if you must - {@see ObjectAccess::setProperty()} instead. */
     public function _set(string $propertyName, mixed $value): void;
     /** @deprecated */
     public function _setRef(string $propertyName, mixed &$value): void;
-    /** @deprecated please use {@see ObjectAccess::getProperty()} instead */
+    /** @deprecated please use - if you must - {@see ObjectAccess::setProperty()} instead. */
     public function _get(string $propertyName): mixed;
 }

--- a/Neos.Flow/Tests/BaseTestCase.php
+++ b/Neos.Flow/Tests/BaseTestCase.php
@@ -37,7 +37,8 @@ abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
      * Returns a mock object which allows for calling protected methods and access
      * of protected properties.
      *
-     * @param string $originalClassName Full qualified name of the original class
+     * @template T of object
+     * @param class-string<T> $originalClassName Full qualified name of the original class
      * @param array $methods
      * @param array $arguments
      * @param string $mockClassName
@@ -47,8 +48,8 @@ abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
      * @param boolean $cloneArguments
      * @param boolean $callOriginalMethods
      * @param object $proxyTarget
-     * @return \PHPUnit\Framework\MockObject\MockObject
-     * @api
+     * @return T&\PHPUnit\Framework\MockObject\MockObject&AccessibleProxyInterface
+     * @deprecated please don't use this {@see AccessibleProxyInterface}
      */
     protected function getAccessibleMock($originalClassName, $methods = [], array $arguments = [], $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $cloneArguments = false, $callOriginalMethods = false, $proxyTarget = null)
     {
@@ -87,7 +88,8 @@ abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
      * Returns a mock object which allows for calling protected methods and access
      * of protected properties.
      *
-     * @param string $originalClassName Full qualified name of the original class
+     * @template T of object
+     * @param class-string<T> $originalClassName Full qualified name of the original class
      * @param array $arguments
      * @param string $mockClassName
      * @param boolean $callOriginalConstructor
@@ -95,8 +97,8 @@ abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
      * @param boolean $callAutoload
      * @param array $mockedMethods
      * @param boolean $cloneArguments
-     * @return \PHPUnit\Framework\MockObject\MockObject
-     * @api
+     * @return T&\PHPUnit\Framework\MockObject\MockObject&AccessibleProxyInterface
+     * @deprecated please don't use this {@see AccessibleProxyInterface}
      */
     protected function getAccessibleMockForAbstractClass($originalClassName, array $arguments = [], $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $mockedMethods = [], $cloneArguments = false)
     {
@@ -109,7 +111,7 @@ abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
      *
      * @param string $className Full qualified name of the original class
      * @return string Full qualified name of the built class
-     * @api
+     * @deprecated please don't use this {@see AccessibleProxyInterface}
      */
     protected function buildAccessibleProxy($className)
     {

--- a/Neos.Flow/Tests/BaseTestCase.php
+++ b/Neos.Flow/Tests/BaseTestCase.php
@@ -17,18 +17,16 @@ namespace Neos\Flow\Tests;
  * Don't sub class this test case but rather choose a more specialized base test case,
  * such as UnitTestCase or FunctionalTestCase
  *
- * @api
+ * @deprecated its utilities are deprecated.
  */
 abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var array
      */
-    protected $backupGlobalsBlacklist = ['GLOBALS', 'bootstrap', '__PHPUNIT_BOOTSTRAP'];
+    protected $backupGlobalsExcludeList = ['GLOBALS', 'bootstrap', '__PHPUNIT_BOOTSTRAP'];
 
     /**
-     * Enable or disable the backup and restoration of static attributes.
-     *
      * @var boolean
      */
     protected $backupStaticAttributes = false;
@@ -164,13 +162,11 @@ abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
      * @return void
      * @throws \RuntimeException
      * @throws \InvalidArgumentException
+     * @deprecated please specify properties via constructor, call the injector manually or use - if you must - ObjectAccess::setProperty instead.
      */
-    protected function inject($target, $name, $dependency)
+    protected function inject(object $target, string $name, mixed $dependency)
     {
-        if (!is_object($target)) {
-            throw new \InvalidArgumentException('Wrong type for argument $target, must be object.');
-        }
-
+        // we don't use ObjectAccess::setProperty as it doesn't support `inject*`
         $objectReflection = new \ReflectionObject($target);
         $methodNamePart = strtoupper($name[0]) . substr($name, 1);
         if ($objectReflection->hasMethod('set' . $methodNamePart)) {


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

Flow has a custom extension of php unit mocks, that comes from times of typo3.
Via the accessibly proxy it allows for calling even protected methods and access of protected properties.

The usage and retrieval `BaseTestCase::getAccessibleMock()` has been deprecated as one should not use this for testing. It will lead to a super high coupling of the tests to the super internal implementation which makes refactoring basically impossible (without rewriting major parts of the tests).
In Neos.Neos we see this very well because we are just removing these tests and rewriting them in behat for Neos 9 :D. 

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
