### PR TITLE
BUGFIX: Prevent `getPublicStaticResourceUri` from crashing in cli con…

### DIFF
--- a/Neos.Flow/Classes/ResourceManagement/Target/FileSystemTarget.php
+++ b/Neos.Flow/Classes/ResourceManagement/Target/FileSystemTarget.php
@@ -392,7 +392,14 @@ class FileSystemTarget implements TargetInterface
             return $this->baseUri;
         }
 
-        $httpBaseUri = (string)$this->baseUriProvider->getConfiguredBaseUriOrFallbackToCurrentRequest();
+        try {
+            $httpBaseUri = (string)$this->baseUriProvider->getConfiguredBaseUriOrFallbackToCurrentRequest();
+        } catch (\Neos\Flow\Http\Exception) {
+            // the handstand to get the request via bootstrap failed. Most likely because we are in cli context.
+            // to avoid an error and still allow resolving a link we return a slash wich will result in building a relative uri.
+            // todo find a way to configure this fallback for this use case.
+            $httpBaseUri = '/';
+        }
         return $httpBaseUri . $this->baseUri;
     }
 


### PR DESCRIPTION
…text

Resolves: https://github.com/neos/neos-development-collection/issues/4888

Related: https://github.com/neos/flow-development-collection/issues/2157

Currently, if a no absolute baseUri is set the `BaseUriProvider::getConfiguredBaseUriOrFallbackToCurrentRequest` will throw an exception.

> No base URI could be provided. This probably means a call was made outside of an HTTP request and a base
  URI was neither configured nor specified as $fallbackRequest.

This makes it nearly* impossible to render resource paths in cli

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
