### PR TITLE
BUGFIX: Use configured cache factory

### DIFF
--- a/Neos.Flow/Classes/Cache/CacheFactory.php
+++ b/Neos.Flow/Classes/Cache/CacheFactory.php
@@ -39,13 +39,6 @@ class CacheFactory extends \Neos\Cache\CacheFactory
     protected $context;
 
     /**
-     * A reference to the cache manager
-     *
-     * @var CacheManager
-     */
-    protected $cacheManager;
-
-    /**
      * @var Environment
      */
     protected $environment;
@@ -54,15 +47,6 @@ class CacheFactory extends \Neos\Cache\CacheFactory
      * @var EnvironmentConfiguration
      */
     protected $environmentConfiguration;
-
-    /**
-     * @param CacheManager $cacheManager
-     * @Flow\Autowiring(enabled=false)
-     */
-    public function injectCacheManager(CacheManager $cacheManager)
-    {
-        $this->cacheManager = $cacheManager;
-    }
 
     /**
      * @param EnvironmentConfiguration $environmentConfiguration

--- a/Neos.Flow/Classes/Cache/CacheManager.php
+++ b/Neos.Flow/Classes/Cache/CacheManager.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Cache;
  * source code.
  */
 
+use Neos\Cache\CacheFactoryInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Cache\Backend\FileBackend;
 use Neos\Cache\Exception\DuplicateIdentifierException;
@@ -37,7 +38,7 @@ use Psr\Cache\CacheItemPoolInterface;
 class CacheManager
 {
     /**
-     * @var CacheFactory
+     * @var CacheFactoryInterface
      */
     protected $cacheFactory;
 
@@ -100,10 +101,10 @@ class CacheManager
     }
 
     /**
-     * @param CacheFactory $cacheFactory
+     * @param CacheFactoryInterface $cacheFactory
      * @return void
      */
-    public function injectCacheFactory(CacheFactory $cacheFactory): void
+    public function injectCacheFactory(CacheFactoryInterface $cacheFactory): void
     {
         $this->cacheFactory = $cacheFactory;
     }

--- a/Neos.Flow/Classes/Cache/CacheManager.php
+++ b/Neos.Flow/Classes/Cache/CacheManager.php
@@ -497,6 +497,7 @@ class CacheManager
         $backend = isset($this->cacheConfigurations[$identifier]['backend']) ? $this->cacheConfigurations[$identifier]['backend'] : $this->cacheConfigurations['Default']['backend'];
         $backendOptions = isset($this->cacheConfigurations[$identifier]['backendOptions']) ? $this->cacheConfigurations[$identifier]['backendOptions'] : $this->cacheConfigurations['Default']['backendOptions'];
         $persistent = isset($this->cacheConfigurations[$identifier]['persistent']) ? $this->cacheConfigurations[$identifier]['persistent'] : $this->cacheConfigurations['Default']['persistent'];
+        // @phpstan-ignore-next-line - $persistent is not yet part of the CacheFactoryInterface
         $cache = $this->cacheFactory->create($identifier, $frontend, $backend, $backendOptions, $persistent);
         $this->registerCache($cache, $persistent);
     }

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -377,8 +377,6 @@ class Scripts
         $cacheManager->injectEnvironment($environment);
         $cacheManager->injectCacheFactory($cacheFactory);
 
-        $cacheFactory->injectCacheManager($cacheManager);
-
         $bootstrap->setEarlyInstance(CacheManager::class, $cacheManager);
         $bootstrap->setEarlyInstance(CacheFactory::class, $cacheFactory);
     }

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -356,10 +356,15 @@ class Scripts
         $configurationManager = $bootstrap->getEarlyInstance(ConfigurationManager::class);
         $environment = $bootstrap->getEarlyInstance(Environment::class);
 
-        $cacheFactoryObjectConfiguration = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_OBJECTS, CacheFactoryInterface::class);
-        $cacheFactoryClass = isset($cacheFactoryObjectConfiguration['className']) ? $cacheFactoryObjectConfiguration['className'] : CacheFactory::class;
+        $cacheFactoryClass = null;
+        $cacheFactoryObjectConfiguration = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_OBJECTS);
+        foreach ($cacheFactoryObjectConfiguration as $objectConfiguration) {
+            if (isset($objectConfiguration[CacheFactoryInterface::class])) {
+                $cacheFactoryClass = $objectConfiguration[CacheFactoryInterface::class]['className'] ?? CacheFactory::class;
+            }
+        }
 
-        /** @var CacheFactory $cacheFactory */
+        /** @var CacheFactoryInterface $cacheFactory */
         $cacheFactory = new $cacheFactoryClass($bootstrap->getContext(), $environment, $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.Flow.cache.applicationIdentifier'));
 
         $cacheManager = new CacheManager();

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -356,11 +356,14 @@ class Scripts
         $configurationManager = $bootstrap->getEarlyInstance(ConfigurationManager::class);
         $environment = $bootstrap->getEarlyInstance(Environment::class);
 
-        $cacheFactoryClass = null;
+        // Workaround to find the correct CacheFactory implementation at compile time.
+        // We can rely on the $objectConfiguration being ordered by the package names after their loading order.
+        // Normally this wiring would be done for proxy building a similar way, see ConfigurationBuilder.
+        $cacheFactoryClass = CacheFactory::class;
         $cacheFactoryObjectConfiguration = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_OBJECTS);
         foreach ($cacheFactoryObjectConfiguration as $objectConfiguration) {
-            if (isset($objectConfiguration[CacheFactoryInterface::class])) {
-                $cacheFactoryClass = $objectConfiguration[CacheFactoryInterface::class]['className'] ?? CacheFactory::class;
+            if (isset($objectConfiguration[CacheFactoryInterface::class]['className'])) {
+                $cacheFactoryClass = $objectConfiguration[CacheFactoryInterface::class]['className'];
             }
         }
 

--- a/Neos.Flow/Tests/Unit/Cache/CacheFactoryTest.php
+++ b/Neos.Flow/Tests/Unit/Cache/CacheFactoryTest.php
@@ -99,9 +99,7 @@ class CacheFactoryTest extends UnitTestCase
      */
     public function aDifferentDefaultCacheDirectoryIsUsedForPersistentFileCaches()
     {
-        $cacheManager = new CacheManager();
         $factory = new CacheFactory(new ApplicationContext('Testing'), $this->mockEnvironment, 'UnitTesting');
-        $factory->injectCacheManager($cacheManager);
         $factory->injectEnvironmentConfiguration($this->mockEnvironmentConfiguration);
 
         $cache = $factory->create('Persistent_Cache', VariableFrontend::class, FileBackend::class, [], true);


### PR DESCRIPTION
The previously used method to select the configured CacheFactory class from the Objects.yaml never returned a result as the raw configuration split by package name was accessed, therefore the fallback was used and it was not possible to provide a custom CacheFactory.

Resolves: #3317
