### PR TITLE
BUGFIX: Normalize source type for converting floats to ValueObjects

### DIFF
--- a/Neos.Flow/Classes/Property/TypeConverter/ScalarTypeToObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ScalarTypeToObjectConverter.php
@@ -71,7 +71,7 @@ class ScalarTypeToObjectConverter extends AbstractTypeConverter
             return false;
         }
         $methodParameter = array_shift($methodParameters);
-        return TypeHandling::normalizeType($methodParameter['type']) === gettype($source);
+        return TypeHandling::normalizeType($methodParameter['type']) === TypeHandling::normalizeType(gettype($source));
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Fixtures/ClassWithFloatConstructor.php
+++ b/Neos.Flow/Tests/Unit/Fixtures/ClassWithFloatConstructor.php
@@ -12,21 +12,21 @@ namespace Neos\Flow\Fixtures;
  */
 
 /**
- * A value object (POPO) with one constructor argument (integer)
+ * A value object (POPO) with one constructor argument (float)
  */
-class ClassWithIntegerConstructor
+class ClassWithFloatConstructor
 {
     /**
-     * @var int
+     * @var float
      */
     public $value;
 
     /**
-     * ClassWithIntegerConstructor constructor.
+     * ClassWithFloatConstructor constructor.
      *
-     * @param int $value
+     * @param float $value
      */
-    public function __construct(int $value)
+    public function __construct(float $value)
     {
         $this->value = $value;
     }

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/ScalarTypeToObjectConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/ScalarTypeToObjectConverterTest.php
@@ -16,6 +16,7 @@ require_once(__DIR__ . '/../../Fixtures/ClassWithIntegerConstructor.php');
 require_once(__DIR__ . '/../../Fixtures/ClassWithBoolConstructor.php');
 
 use Neos\Flow\Fixtures\ClassWithBoolConstructor;
+use Neos\Flow\Fixtures\ClassWithFloatConstructor;
 use Neos\Flow\Fixtures\ClassWithIntegerConstructor;
 use Neos\Flow\Fixtures\ClassWithStringConstructor;
 use Neos\Flow\Property\TypeConverter\ScalarTypeToObjectConverter;
@@ -106,6 +107,23 @@ class ScalarTypeToObjectConverterTest extends UnitTestCase
             ]]);
         $this->inject($converter, 'reflectionService', $this->reflectionMock);
         $canConvert = $converter->canConvertFrom(42, ClassWithIntegerConstructor::class);
+        self::assertTrue($canConvert);
+    }
+
+    /**
+     * @test
+     */
+    public function canConvertFromFloatToValueObject()
+    {
+        $converter = new ScalarTypeToObjectConverter();
+
+        $this->reflectionMock->expects(self::once())
+            ->method('getMethodParameters')
+            ->willReturn([[
+                'type' => 'float'
+            ]]);
+        $this->inject($converter, 'reflectionService', $this->reflectionMock);
+        $canConvert = $converter->canConvertFrom(4.2, ClassWithFloatConstructor::class);
         self::assertTrue($canConvert);
     }
 }


### PR DESCRIPTION
This change allows the ScalarTypeToObjectConverter to convert from floats to ValueObjects. The type converter uses `gettype()` which will return `double` for `floats`. As the constructor argument type of the ValueObject is passed through `TypeHandling::normalizeType()`, it will always be `float` and never `double` which will lead to floats not being converted by this type converter.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
