### PR TITLE
TASK: Use `getClassNameByObjectName` instead of manually traversing `…

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -356,16 +356,7 @@ class Scripts
         $configurationManager = $bootstrap->getEarlyInstance(ConfigurationManager::class);
         $environment = $bootstrap->getEarlyInstance(Environment::class);
 
-        // Workaround to find the correct CacheFactory implementation at compile time.
-        // We can rely on the $objectConfiguration being ordered by the package names after their loading order.
-        // Normally this wiring would be done for proxy building a similar way, see ConfigurationBuilder.
-        $cacheFactoryClass = CacheFactory::class;
-        $cacheFactoryObjectConfiguration = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_OBJECTS);
-        foreach ($cacheFactoryObjectConfiguration as $objectConfiguration) {
-            if (isset($objectConfiguration[CacheFactoryInterface::class]['className'])) {
-                $cacheFactoryClass = $objectConfiguration[CacheFactoryInterface::class]['className'];
-            }
-        }
+        $cacheFactoryClass = $bootstrap->getObjectManager()->getClassNameByObjectName(CacheFactoryInterface::class);
 
         /** @var CacheFactoryInterface $cacheFactory */
         $cacheFactory = new $cacheFactoryClass($bootstrap->getContext(), $environment, $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.Flow.cache.applicationIdentifier'));


### PR DESCRIPTION
…CONFIGURATION_TYPE_OBJECTS`

We were to blind to see it in https://github.com/neos/flow-development-collection/pull/3318 but thankfully christian noticed it the last second:

> For the respective use case we already HAVE a way better way to do this, namely:

> `\Neos\Flow\ObjectManagement\ObjectManagerInterface::getClassNameByObjectName()`, this should just return the _right_ implementation as in, the chosen one the objectmanager would inject if you asked it, and that's all we need and we have an object manager, at least compiletime which also can answer this question.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
