### PR TITLE
FEATURE: Introduce PHP 8.2 DNF type support

### DIFF
--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -443,9 +443,9 @@ class ReflectionService
     /**
      * Returns the specified class annotations or an empty array
      *
+     * @param null|string $annotationClassName
      * @return array<object>
      *
-     * @param null|string $annotationClassName
      */
     public function getClassAnnotations(string $className, string|null $annotationClassName = null): array
     {
@@ -797,9 +797,9 @@ class ReflectionService
     /**
      * Returns the declared return type of a method (for PHP < 7.0 this will always return null)
      *
+     * @param class-string $className
      * @return ?string The declared return type of the method or null if none was declared
      *
-     * @param class-string $className
      */
     public function getMethodDeclaredReturnType(string $className, string $methodName): ?string
     {
@@ -1118,15 +1118,14 @@ class ReflectionService
             $this->annotatedClasses[$annotationClassName][$className] = true;
             $this->classReflectionData[$className][self::DATA_CLASS_ANNOTATIONS][] = $annotation;
         }
-        if (PHP_MAJOR_VERSION >= 8) {
-            foreach ($class->getAttributes() as $attribute) {
-                $annotationClassName = $attribute->getName();
-                if ($this->isAttributeIgnored($annotationClassName)) {
-                    continue;
-                }
-                $this->annotatedClasses[$annotationClassName][$className] = true;
-                $this->classReflectionData[$className][self::DATA_CLASS_ANNOTATIONS][] = $attribute->newInstance();
+
+        foreach ($class->getAttributes() as $attribute) {
+            $annotationClassName = $attribute->getName();
+            if ($this->isAttributeIgnored($annotationClassName)) {
+                continue;
             }
+            $this->annotatedClasses[$annotationClassName][$className] = true;
+            $this->classReflectionData[$className][self::DATA_CLASS_ANNOTATIONS][] = $attribute->newInstance();
         }
 
         foreach ($class->getProperties() as $property) {
@@ -1169,18 +1168,17 @@ class ReflectionService
         foreach ($this->annotationReader->getPropertyAnnotations($property) as $annotation) {
             $this->classReflectionData[$className][self::DATA_CLASS_PROPERTIES][$propertyName][self::DATA_PROPERTY_ANNOTATIONS][get_class($annotation)][] = $annotation;
         }
-        if (PHP_MAJOR_VERSION >= 8) {
-            foreach ($property->getAttributes() as $attribute) {
-                if ($this->isAttributeIgnored($attribute->getName())) {
-                    continue;
-                }
-                try {
-                    $attributeInstance = $attribute->newInstance();
-                } catch (\Error $error) {
-                    throw new \RuntimeException(sprintf('Attribute "%s" used in class "%s" was not found.', $attribute->getName(), $className), 1695635128, $error);
-                }
-                $this->classReflectionData[$className][self::DATA_CLASS_PROPERTIES][$propertyName][self::DATA_PROPERTY_ANNOTATIONS][$attribute->getName()][] = $attributeInstance;
+
+        foreach ($property->getAttributes() as $attribute) {
+            if ($this->isAttributeIgnored($attribute->getName())) {
+                continue;
             }
+            try {
+                $attributeInstance = $attribute->newInstance();
+            } catch (\Error $error) {
+                throw new \RuntimeException(sprintf('Attribute "%s" used in class "%s" was not found.', $attribute->getName(), $className), 1695635128, $error);
+            }
+            $this->classReflectionData[$className][self::DATA_CLASS_PROPERTIES][$propertyName][self::DATA_PROPERTY_ANNOTATIONS][$attribute->getName()][] = $attributeInstance;
         }
 
         return $visibility;
@@ -1239,7 +1237,9 @@ class ReflectionService
     }
 
     /**
+     * @throws FilesException
      * @throws ReflectionException
+     * @throws \Neos\Flow\Utility\Exception
      */
     protected function reflectClassMethod(string $className, MethodReflection $method): void
     {
@@ -1261,8 +1261,8 @@ class ReflectionService
             $this->classesByMethodAnnotations[$annotationClassName][$className][] = $methodName;
         }
 
-        $returnType= $method->getDeclaredReturnType();
-        $applyLeadingSlashIfNeeded = function (string $type): string {
+        $returnType = $method->getDeclaredReturnType();
+        $applyLeadingSlashIfNeeded = static function (string $type): string {
             if (!in_array($type, ['self', 'parent', 'static', 'null', 'callable', 'void', 'never', 'iterable', 'object', 'resource', 'mixed'])
                 && !TypeHandling::isSimpleType($type)
             ) {
@@ -1295,7 +1295,7 @@ class ReflectionService
      * @param ParameterReflection $parameter
      * @return void
      */
-    protected function reflectClassMethodParameter($className, MethodReflection $method, ParameterReflection $parameter): void
+    protected function reflectClassMethodParameter(string $className, MethodReflection $method, ParameterReflection $parameter): void
     {
         $methodName = $method->getName();
         $paramAnnotations = $method->isTaggedWith('param') ? $method->getTagValues('param') : [];
@@ -1370,9 +1370,9 @@ class ReflectionService
 
         // ... and try to expand them
         $typeParts = explode('\\', $typeWithoutNull, 2);
-        $lowercasedFirstTypePart = strtolower($typeParts[0]);
-        if (isset($useStatementsForClass[$lowercasedFirstTypePart])) {
-            $typeParts[0] = $useStatementsForClass[$lowercasedFirstTypePart];
+        $lowerCasedFirstTypePart = strtolower($typeParts[0]);
+        if (isset($useStatementsForClass[$lowerCasedFirstTypePart])) {
+            $typeParts[0] = $useStatementsForClass[$lowerCasedFirstTypePart];
 
             return implode('\\', $typeParts) . ($isNullable ? '|null' : '');
         }
@@ -1399,9 +1399,10 @@ class ReflectionService
     /**
      * Builds class schemata from classes annotated as entities or value objects
      *
+     * @throws ClassLoadingForReflectionFailedException
      * @throws ClassSchemaConstraintViolationException
      * @throws Exception
-     * @throws InvalidPropertyTypeException
+     * @throws InvalidClassException
      * @throws InvalidValueObjectException
      */
     protected function buildClassSchemata(array $classNames): void
@@ -1416,8 +1417,10 @@ class ReflectionService
 
     /**
      * @param class-string $className
-     * @throws InvalidValueObjectException
+     * @return ClassSchema
      * @throws ClassSchemaConstraintViolationException
+     * @throws InvalidPropertyTypeException
+     * @throws InvalidValueObjectException
      */
     protected function buildClassSchema(string $className): ClassSchema
     {

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PHP8/ClassWithUnionTypes.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/PHP8/ClassWithUnionTypes.php
@@ -13,13 +13,20 @@ namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PHP8;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\ClassToBeSerialized;
+use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassA;
+use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassB;
+use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\PrototypeClassC;
+use Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\SingletonClassA;
 
 /**
  * A class with PHP 8 type hints with union types
- * @Flow\Scope("prototype")
  */
 class ClassWithUnionTypes
 {
+    /* Make sure that this class is proxied, so we can test the proxy compiler */
+    #[Flow\Inject]
+    protected SingletonClassA $classA;
+
     protected ?string $propertyA;
 
     /* This should be fully equal to $propertyA */
@@ -31,6 +38,8 @@ class ClassWithUnionTypes
     protected ClassToBeSerialized|string|null $propertyD;
 
     protected int|float|string|null $propertyE;
+
+    protected PrototypeClassA|(PrototypeClassB&PrototypeClassC)|null $propertyF;
 
     public function getPropertyA(): ?string
     {
@@ -80,5 +89,15 @@ class ClassWithUnionTypes
     public function setPropertyE(float|int|string|null $propertyE): void
     {
         $this->propertyE = $propertyE;
+    }
+
+    public function setPropertyF(PrototypeClassA | (PrototypeClassB & PrototypeClassC) | null  $propertyF): void
+    {
+        $this->propertyF = $propertyF;
+    }
+
+    public function classA(): SingletonClassA
+    {
+        return $this->classA;
     }
 }

--- a/Neos.Flow/Tests/Functional/Reflection/Fixtures/PHP8/DummyClassWithDisjunctiveNormalFormTypes.php
+++ b/Neos.Flow/Tests/Functional/Reflection/Fixtures/PHP8/DummyClassWithDisjunctiveNormalFormTypes.php
@@ -1,0 +1,32 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Reflection\Fixtures\PHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyClassWithProperties;
+use Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyClassWithTypeHints;
+use Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyReadonlyClass;
+
+/**
+ * A class with PHP 8.2 disjunctive normal form types
+ *
+ * @see https://wiki.php.net/rfc/dnf_types
+ */
+class DummyClassWithDisjunctiveNormalFormTypes
+{
+    public function dnfTypesA(DummyReadonlyClass | (DummyClassWithTypeHints & DummyClassWithUnionTypeHints) | null $theParameter): void
+    {
+    }
+
+    public function dnfTypesB(DummyReadonlyClass | (DummyClassWithTypeHints & DummyClassWithUnionTypeHints) | (DummyClassWithTypeHints & DummyClassWithProperties) | null $theParameter): void
+    {
+    }
+}

--- a/Neos.Flow/Tests/Functional/Reflection/Fixtures/PHP8/DummyClassWithUnionTypeHints.php
+++ b/Neos.Flow/Tests/Functional/Reflection/Fixtures/PHP8/DummyClassWithUnionTypeHints.php
@@ -13,19 +13,21 @@ namespace Neos\Flow\Tests\Functional\Reflection\Fixtures\PHP8;
 
 /**
  * Dummy class for the Reflection tests
- *
  */
 class DummyClassWithUnionTypeHints
 {
     public function methodWithUnionReturnTypeA(): string|false
     {
+        return '';
     }
 
     public function methodWithUnionReturnTypesB(): false|DummyClassWithUnionTypeHints
     {
+        return false;
     }
 
     public function methodWithUnionReturnTypesC(): null|DummyClassWithUnionTypeHints
     {
+        return null;
     }
 }

--- a/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
@@ -306,9 +306,6 @@ class ReflectionServiceTest extends FunctionalTestCase
      */
     public function unionReturnTypesWorkCorrectly(): void
     {
-        if (PHP_MAJOR_VERSION < 8) {
-            $this->markTestSkipped('Only for PHP 8 with UnionTypes');
-        }
         $returnTypeA = $this->reflectionService->getMethodDeclaredReturnType(Reflection\Fixtures\PHP8\DummyClassWithUnionTypeHints::class, 'methodWithUnionReturnTypeA');
         $returnTypeB = $this->reflectionService->getMethodDeclaredReturnType(Reflection\Fixtures\PHP8\DummyClassWithUnionTypeHints::class, 'methodWithUnionReturnTypesB');
         $returnTypeC = $this->reflectionService->getMethodDeclaredReturnType(Reflection\Fixtures\PHP8\DummyClassWithUnionTypeHints::class, 'methodWithUnionReturnTypesC');

--- a/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
@@ -318,6 +318,38 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function disjunctiveNormalFormTypesWorkCorrectly(): void
+    {
+        $parameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\PHP8\DummyClassWithDisjunctiveNormalFormTypes::class, 'dnfTypesA');
+        self::assertEquals(
+            Reflection\Fixtures\DummyReadonlyClass::class .
+            '|(' .
+            Reflection\Fixtures\DummyClassWithTypeHints::class .
+            '&' .
+            Reflection\Fixtures\PHP8\DummyClassWithUnionTypeHints::class .
+            ')|null',
+            $parameters['theParameter']['type']
+        );
+
+        $parameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\PHP8\DummyClassWithDisjunctiveNormalFormTypes::class, 'dnfTypesB');
+        self::assertEquals(
+            Reflection\Fixtures\DummyReadonlyClass::class .
+            '|(' .
+            Reflection\Fixtures\DummyClassWithTypeHints::class .
+            '&' .
+            Reflection\Fixtures\PHP8\DummyClassWithUnionTypeHints::class .
+            ')|(' .
+            Reflection\Fixtures\DummyClassWithTypeHints::class .
+            '&' .
+            Reflection\Fixtures\DummyClassWithProperties::class .
+            ')|null',
+            $parameters['theParameter']['type']
+        );
+    }
+
+    /**
+     * @test
+     */
     public function readonlyClassIsDetectedCorrectly(): void
     {
         $isReadonly = $this->reflectionService->isClassReadOnly(Reflection\Fixtures\DummyReadonlyClass::class);

--- a/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
@@ -21,10 +21,7 @@ use Neos\Flow\Tests\FunctionalTestCase;
  */
 class ReflectionServiceTest extends FunctionalTestCase
 {
-    /**
-     * @var ReflectionService
-     */
-    protected $reflectionService;
+    protected ReflectionService $reflectionService;
 
     protected function setUp(): void
     {
@@ -35,7 +32,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function theReflectionServiceBuildsClassSchemataForEntities()
+    public function theReflectionServiceBuildsClassSchemataForEntities(): void
     {
         $classSchema = $this->reflectionService->getClassSchema(Reflection\Fixtures\ClassSchemaFixture::class);
 
@@ -49,15 +46,16 @@ class ReflectionServiceTest extends FunctionalTestCase
      * @test
      * @doesNotPerformAssertions
      */
-    public function classSchemaCanBeBuiltForAggregateRootsWithPlainOldPhpBaseClasses()
+    public function classSchemaCanBeBuiltForAggregateRootsWithPlainOldPhpBaseClasses(): void
     {
         $this->reflectionService->getClassSchema(Reflection\Fixtures\Model\EntityExtendingPlainObject::class);
     }
 
     /**
      * @test
+     * @throws
      */
-    public function theReflectionServiceCorrectlyBuildsMethodTagsValues()
+    public function theReflectionServiceCorrectlyBuildsMethodTagsValues(): void
     {
         $actual = $this->reflectionService->getMethodTagsValues(Reflection\Fixtures\ClassSchemaFixture::class, 'setName');
 
@@ -80,7 +78,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function aggregateRootAssignmentsInHierarchiesAreCorrect()
+    public function aggregateRootAssignmentsInHierarchiesAreCorrect(): void
     {
         self::assertEquals(Reflection\Fixtures\Repository\SuperEntityRepository::class, $this->reflectionService->getClassSchema(Reflection\Fixtures\Model\SuperEntity::class)->getRepositoryClassName());
         self::assertEquals(Reflection\Fixtures\Repository\SuperEntityRepository::class, $this->reflectionService->getClassSchema(Reflection\Fixtures\Model\SubEntity::class)->getRepositoryClassName());
@@ -91,7 +89,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function propertyTypesAreExpandedWithUseStatements()
+    public function propertyTypesAreExpandedWithUseStatements(): void
     {
         $varTagValues = $this->reflectionService->getPropertyTagValues(Reflection\Fixtures\AnnotatedClassWithUseStatements::class, 'reflectionService', 'var');
         $expected = [ReflectionService::class];
@@ -101,7 +99,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function propertyTypesFromAbstractBaseClassAreExpandedWithRelativeNamespaces()
+    public function propertyTypesFromAbstractBaseClassAreExpandedWithRelativeNamespaces(): void
     {
         $varTagValues = $this->reflectionService->getPropertyTagValues(Reflection\Fixtures\AnnotatedClassWithUseStatements::class, 'subSubEntity', 'var');
         $expected = [Reflection\Fixtures\Model\SubSubEntity::class];
@@ -111,7 +109,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function propertyTypesFromAbstractBaseClassAreExpandedWithUseStatements()
+    public function propertyTypesFromAbstractBaseClassAreExpandedWithUseStatements(): void
     {
         $varTagValues = $this->reflectionService->getPropertyTagValues(Reflection\Fixtures\AnnotatedClassWithUseStatements::class, 'superEntity', 'var');
         $expected = [Reflection\Fixtures\Model\SuperEntity::class];
@@ -121,7 +119,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function propertyTypesFromSameSubpackageAreRetrievedCorrectly()
+    public function propertyTypesFromSameSubpackageAreRetrievedCorrectly(): void
     {
         $varTagValues = $this->reflectionService->getPropertyTagValues(Reflection\Fixtures\AnnotatedClassWithUseStatements::class, 'annotatedClass', 'var');
         $expected = [Reflection\Fixtures\AnnotatedClass::class];
@@ -131,7 +129,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function propertyTypesFromNestedSubpackageAreRetrievedCorrectly()
+    public function propertyTypesFromNestedSubpackageAreRetrievedCorrectly(): void
     {
         $varTagValues = $this->reflectionService->getPropertyTagValues(Reflection\Fixtures\AnnotatedClassWithUseStatements::class, 'subEntity', 'var');
         $expected = [Reflection\Fixtures\Model\SubEntity::class];
@@ -141,7 +139,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function domainModelPropertyTypesAreExpandedWithUseStatementsInClassSchema()
+    public function domainModelPropertyTypesAreExpandedWithUseStatementsInClassSchema(): void
     {
         $classSchema = $this->reflectionService->getClassSchema(Reflection\Fixtures\Model\EntityWithUseStatements::class);
         self::assertEquals(Reflection\Fixtures\Model\SubSubEntity::class, $classSchema->getProperty('subSubEntity')['type']);
@@ -152,7 +150,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function methodParameterTypeExpansionWorksWithFullyQualifiedClassName()
+    public function methodParameterTypeExpansionWorksWithFullyQualifiedClassName(): void
     {
         $methodParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\Model\EntityWithUseStatements::class, 'fullyQualifiedClassName');
 
@@ -164,7 +162,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function methodParameterTypeExpansionWorksWithAliasedClassName()
+    public function methodParameterTypeExpansionWorksWithAliasedClassName(): void
     {
         $methodParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\Model\EntityWithUseStatements::class, 'aliasedClassName');
 
@@ -176,7 +174,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function methodParameterTypeExpansionWorksWithRelativeClassName()
+    public function methodParameterTypeExpansionWorksWithRelativeClassName(): void
     {
         $methodParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\Model\EntityWithUseStatements::class, 'relativeClassName');
 
@@ -188,7 +186,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function methodParameterTypeExpansionWorksWithNullable()
+    public function methodParameterTypeExpansionWorksWithNullable(): void
     {
         $methodParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\Model\EntityWithUseStatements::class, 'nullableClassName');
 
@@ -200,7 +198,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function methodParameterTypeExpansionDoesNotModifySimpleTypes()
+    public function methodParameterTypeExpansionDoesNotModifySimpleTypes(): void
     {
         $methodParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\Model\EntityWithUseStatements::class, 'simpleType');
 
@@ -228,7 +226,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function booleanPropertiesGetANormlizedType()
+    public function booleanPropertiesGetANormlizedType(): void
     {
         $className = Reflection\Fixtures\DummyClassWithProperties::class;
 
@@ -244,7 +242,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function methodParametersGetNormalizedType()
+    public function methodParametersGetNormalizedType(): void
     {
         $methodParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\AnnotatedClass::class, 'intAndIntegerParameters');
 
@@ -256,7 +254,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function nullableMethodParametersWorkCorrectly()
+    public function nullableMethodParametersWorkCorrectly(): void
     {
         $nativeNullableMethodParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\AnnotatedClass::class, 'nativeNullableParameter');
         $annotatedNullableMethodParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\AnnotatedClass::class, 'annotatedNullableParameter');
@@ -277,7 +275,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function scalarTypeHintsWorkCorrectly()
+    public function scalarTypeHintsWorkCorrectly(): void
     {
         $methodWithTypeHintsParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\DummyClassWithTypeHints::class, 'methodWithScalarTypeHints');
 
@@ -288,7 +286,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function arrayTypeHintsWorkCorrectly()
+    public function arrayTypeHintsWorkCorrectly(): void
     {
         $methodWithTypeHintsParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\DummyClassWithTypeHints::class, 'methodWithArrayTypeHint');
         self::assertEquals('array', $methodWithTypeHintsParameters['array']['type']);
@@ -297,7 +295,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function annotatedArrayTypeHintsWorkCorrectly()
+    public function annotatedArrayTypeHintsWorkCorrectly(): void
     {
         $methodWithTypeHintsParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\DummyClassWithTypeHints::class, 'methodWithArrayTypeHintAndAnnotation');
         self::assertEquals('array<string>', $methodWithTypeHintsParameters['array']['type']);
@@ -306,7 +304,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function unionReturnTypesWorkCorrectly()
+    public function unionReturnTypesWorkCorrectly(): void
     {
         if (PHP_MAJOR_VERSION < 8) {
             $this->markTestSkipped('Only for PHP 8 with UnionTypes');


### PR DESCRIPTION
The Reflection Service now supports Disjunctive Normal Form (DNF) types for method arguments.

See: https://www.php.net/releases/8.2/en.php#dnf_types

Resolves #3026