### PR TITLE
TASK: Remove code related to PHP < 8.2

### DIFF
--- a/Neos.Flow/Classes/Error/Debugger.php
+++ b/Neos.Flow/Classes/Error/Debugger.php
@@ -292,7 +292,7 @@ class Debugger
                     $dump .= chr(10);
                     $dump .= str_repeat(' ', $level) . ($plaintext ? '' : '<span class="debug-property">') . self::ansiEscapeWrap($property->getName(), '36', $ansiColors) . ($plaintext ? '' : '</span>') . ' => ';
                     $property->setAccessible(true);
-                    if (PHP_VERSION_ID >= 70400 && $property->isInitialized($object) === false) {
+                    if ($property->isInitialized($object) === false) {
                         $value = null;
                     } else {
                         $value = $property->getValue($object);

--- a/Neos.Flow/Classes/ObjectManagement/CompileTimeObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/CompileTimeObjectManager.php
@@ -237,12 +237,6 @@ class CompileTimeObjectManager extends ObjectManager
                 }
                 if ($package instanceof FlowPackageInterface && $shouldRegisterFunctionalTestClasses) {
                     foreach ($package->getFunctionalTestsClassFiles() as $fullClassName => $path) {
-                        if (PHP_VERSION_ID <= 80000 && str_contains($fullClassName, '\\PHP8\\')) {
-                            continue;
-                        }
-                        if (PHP_VERSION_ID <= 80100 && str_contains($fullClassName, '\\PHP81\\')) {
-                            continue;
-                        }
                         if (!str_ends_with($fullClassName, 'Exception')) {
                             $availableClassNames[$packageKey][] = $fullClassName;
                         }

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyClass.php
@@ -275,10 +275,8 @@ class ProxyClass
         $classReflection = new ClassReflection($this->fullOriginalClassName);
 
         $classDocumentation = str_replace("*/", "* @codeCoverageIgnore\n */", $classReflection->getDocComment()) . "\n";
-        if (PHP_MAJOR_VERSION >= 8) {
-            foreach ($classReflection->getAttributes() as $attribute) {
-                $classDocumentation .= Compiler::renderAttribute($attribute) . "\n";
-            }
+        foreach ($classReflection->getAttributes() as $attribute) {
+            $classDocumentation .= Compiler::renderAttribute($attribute) . "\n";
         }
 
         return $classDocumentation;

--- a/Neos.Flow/Classes/Property/TypeConverter/MediaTypeConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/MediaTypeConverter.php
@@ -92,19 +92,9 @@ class MediaTypeConverter extends AbstractTypeConverter implements MediaTypeConve
                 }
                 break;
             case 'xml':
-                // TODO: Remove those lines once the minimum PHP version is 8.0
-                if (PHP_MAJOR_VERSION < 8) {
-                    $entityLoaderValue = libxml_disable_entity_loader(true);
-                }
                 try {
                     $xmlElement = new \SimpleXMLElement(urldecode($requestBody), LIBXML_NOERROR);
-                    if (PHP_MAJOR_VERSION < 8) {
-                        libxml_disable_entity_loader($entityLoaderValue);
-                    }
                 } catch (\Exception $exception) {
-                    if (PHP_MAJOR_VERSION < 8) {
-                        libxml_disable_entity_loader($entityLoaderValue);
-                    }
                     return [];
                 }
                 $result = Arrays::convertObjectToArray($xmlElement);

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -698,13 +698,11 @@ class ReflectionService
 
             $method = new MethodReflection($className, $methodName);
             $methodAnnotations = $this->annotationReader->getMethodAnnotations($method);
-            if (PHP_MAJOR_VERSION >= 8) {
-                foreach ($method->getAttributes() as $attribute) {
-                    if ($this->isAttributeIgnored($attribute->getName())) {
-                        continue;
-                    }
-                    $methodAnnotations[] = $attribute->newInstance();
+            foreach ($method->getAttributes() as $attribute) {
+                if ($this->isAttributeIgnored($attribute->getName())) {
+                    continue;
                 }
+                $methodAnnotations[] = $attribute->newInstance();
             }
             $this->methodAnnotationsRuntimeCache[$className][$methodName] = $methodAnnotations;
         }

--- a/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
@@ -470,11 +470,7 @@ class ActionControllerTest extends FunctionalTestCase
 
         $uri = str_replace('{@action}', 'requireddate', 'http://localhost/test/mvc/actioncontrollertestb/{@action}');
         $response = $this->browser->request($uri, 'POST', $arguments);
-        if (PHP_MAJOR_VERSION < 8) {
-            $expectedResult = 'Uncaught Exception in Flow Argument 1 passed to Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController_Original::requiredDateAction() must be an instance of DateTime, null given';
-        } else {
-            $expectedResult = 'Uncaught Exception in Flow Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController_Original::requiredDateAction(): Argument #1 ($argument) must be of type DateTime, null given';
-        }
+        $expectedResult = 'Uncaught Exception in Flow Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestBController_Original::requiredDateAction(): Argument #1 ($argument) must be of type DateTime, null given';
         self::assertTrue(strpos(trim($response->getBody()->getContents()), (string)$expectedResult) === 0, sprintf('The resulting string did not start with the expected string. Expected: "%s", Actual: "%s"', $expectedResult, $response->getBody()->getContents()));
     }
 

--- a/Neos.Flow/Tests/Unit/Error/DebuggerTest.php
+++ b/Neos.Flow/Tests/Unit/Error/DebuggerTest.php
@@ -68,9 +68,6 @@ class DebuggerTest extends UnitTestCase
      */
     public function uninitializedTypedPropertiesAreNotAccessed()
     {
-        if (PHP_VERSION_ID < 70400) {
-            self::markTestSkipped('Test only works on PHP 7.4 and above');
-        }
         // if the test fails, an exception raises an error, no assertion needed
         $this->expectNotToPerformAssertions();
 


### PR DESCRIPTION
Code supporting backwards-compatibility with PHP versions earlier than 8.2 were removed, since the minimum required version for Flow is 8.2.

Resolves #3085