### PR TITLE
!!! TASK: Modernize and clean up session-related code

### DIFF
--- a/Neos.Flow/Classes/Session/Aspect/LazyLoadingProxyInterface.php
+++ b/Neos.Flow/Classes/Session/Aspect/LazyLoadingProxyInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Neos\Flow\Session\Aspect;
 
 /*

--- a/Neos.Flow/Classes/Session/Aspect/LoggingAspect.php
+++ b/Neos.Flow/Classes/Session/Aspect/LoggingAspect.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Neos\Flow\Session\Aspect;
 
 /*
@@ -13,62 +14,38 @@ namespace Neos\Flow\Session\Aspect;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Aop\JoinPointInterface;
+use Neos\Flow\Session\Exception\SessionNotStartedException;
 use Neos\Flow\Session\SessionInterface;
 use Psr\Log\LoggerInterface;
 
 /**
  * An aspect which centralizes the logging of important session actions.
- *
- * @Flow\Aspect
- * @Flow\Scope("singleton")
  */
+#[Flow\Aspect]
+#[Flow\Scope("singleton")]
 class LoggingAspect
 {
-    /**
-     * @Flow\Inject(name="Neos.Flow:SecurityLogger")
-     * @var LoggerInterface
-     */
-    protected $logger;
+    #[Flow\Inject]
+    protected ?LoggerInterface $logger = null;
 
     /**
-     * Injects the (security) logger based on PSR-3.
-     *
-     * @param LoggerInterface $logger
-     * @return void
+     * @throws SessionNotStartedException
      */
-    public function injectLogger(LoggerInterface $logger)
-    {
-        $this->logger = $logger;
-    }
-
-    /**
-     * Logs calls of start()
-     *
-     * @Flow\After("within(Neos\Flow\Session\SessionInterface) && method(.*->start())")
-     * @param JoinPointInterface $joinPoint The current joinpoint
-     * @return void
-     */
-    public function logStart(JoinPointInterface $joinPoint)
+    #[Flow\After("within(Neos\Flow\Session\SessionInterface) && method(.*->start())")]
+    public function logStart(JoinPointInterface $joinPoint): void
     {
         /** @var SessionInterface $session */
         $session = $joinPoint->getProxy();
         if ($session->isStarted()) {
-            $this->logger->info(sprintf('%s: Started session with id %s.', $this->getClassName($joinPoint), $session->getId()));
+            $this->logger?->info(sprintf('%s: Started session with id %s.', $this->getSessionImplementationClassName($joinPoint), $session->getId()));
         }
     }
 
-    /**
-     * Logs calls of resume()
-     *
-     * @Flow\After("within(Neos\Flow\Session\SessionInterface) && method(.*->resume())")
-     * @param JoinPointInterface $joinPoint The current joinpoint
-     * @return void
-     */
-    public function logResume(JoinPointInterface $joinPoint)
+    #[Flow\After("within(Neos\Flow\Session\SessionInterface) && method(.*->resume())")]
+    public function logResume(JoinPointInterface $joinPoint): void
     {
-        /** @var SessionInterface $session */
         $session = $joinPoint->getProxy();
-        if ($session->isStarted()) {
+        if ($session instanceof SessionInterface && $session->isStarted()) {
             $inactivityInSeconds = $joinPoint->getResult();
             if ($inactivityInSeconds === 1) {
                 $inactivityMessage = '1 second';
@@ -81,76 +58,55 @@ class LoggingAspect
             } else {
                 $inactivityMessage = sprintf('more than %s hours', (int)($inactivityInSeconds / 3600));
             }
-            $this->logger->debug(sprintf('%s: Resumed session with id %s which was inactive for %s. (%ss)', $this->getClassName($joinPoint), $session->getId(), $inactivityMessage, $inactivityInSeconds));
+            $this->logger?->debug(sprintf('%s: Resumed session with id %s which was inactive for %s. (%ss)', $this->getSessionImplementationClassName($joinPoint), $session->getId(), $inactivityMessage, $inactivityInSeconds));
         }
     }
 
     /**
-     * Logs calls of destroy()
-     *
-     * @Flow\Before("within(Neos\Flow\Session\SessionInterface) && method(.*->destroy())")
-     * @param JoinPointInterface $joinPoint The current joinpoint
-     * @return void
+     * @throws SessionNotStartedException
      */
-    public function logDestroy(JoinPointInterface $joinPoint)
+    #[Flow\Before("within(Neos\Flow\Session\SessionInterface) && method(.*->destroy())")]
+    public function logDestroy(JoinPointInterface $joinPoint): void
     {
-        /** @var SessionInterface $session */
         $session = $joinPoint->getProxy();
-        if ($session->isStarted()) {
+        if ($session instanceof SessionInterface && $session->isStarted()) {
             $reason = $joinPoint->isMethodArgument('reason') ? $joinPoint->getMethodArgument('reason') : 'no reason given';
-            $this->logger->debug(sprintf('%s: Destroyed session with id %s: %s', $this->getClassName($joinPoint), $session->getId(), $reason));
+            $this->logger?->debug(sprintf('%s: Destroyed session with id %s: %s', $this->getSessionImplementationClassName($joinPoint), $session->getId(), $reason));
         }
     }
 
     /**
-     * Logs calls of renewId()
-     *
-     * @Flow\Around("within(Neos\Flow\Session\SessionInterface) && method(.*->renewId())")
-     * @param JoinPointInterface $joinPoint The current joinpoint
-     * @return mixed The result of the target method if it has not been intercepted
+     * @throws SessionNotStartedException
      */
-    public function logRenewId(JoinPointInterface $joinPoint)
+    #[Flow\Around("within(Neos\Flow\Session\SessionInterface) && method(.*->renewId())")]
+    public function logRenewId(JoinPointInterface $joinPoint): mixed
     {
-        /** @var SessionInterface $session */
         $session = $joinPoint->getProxy();
-        $oldId = $session->getId();
         $newId = $joinPoint->getAdviceChain()->proceed($joinPoint);
-        if ($session->isStarted()) {
-            $this->logger->info(sprintf('%s: Changed session id from %s to %s', $this->getClassName($joinPoint), $oldId, $newId));
+        if (($session instanceof SessionInterface) && $session->isStarted()) {
+            $this->logger?->info(sprintf('%s: Changed session id from %s to %s', $this->getSessionImplementationClassName($joinPoint), $session->getId(), $newId));
         }
         return $newId;
     }
 
-    /**
-     * Logs calls of collectGarbage()
-     *
-     * @Flow\AfterReturning("within(Neos\Flow\Session\SessionInterface) && method(.*->collectGarbage())")
-     * @param JoinPointInterface $joinPoint The current joinpoint
-     * @return void
-     */
-    public function logCollectGarbage(JoinPointInterface $joinPoint)
+    #[Flow\AfterReturning("within(Neos\Flow\Session\SessionInterface) && method(.*->collectGarbage())")]
+    public function logCollectGarbage(JoinPointInterface $joinPoint): void
     {
         $sessionRemovalCount = $joinPoint->getResult();
         if ($sessionRemovalCount > 0) {
-            $this->logger->info(sprintf('%s: Triggered garbage collection and removed %s expired sessions.', $this->getClassName($joinPoint), $sessionRemovalCount));
+            $this->logger?->info(sprintf('%s: Triggered garbage collection and removed %s expired sessions.', $this->getSessionImplementationClassName($joinPoint), $sessionRemovalCount));
         } elseif ($sessionRemovalCount === 0) {
-            $this->logger->info(sprintf('%s: Triggered garbage collection but no sessions needed to be removed.', $this->getClassName($joinPoint)));
+            $this->logger?->info(sprintf('%s: Triggered garbage collection but no sessions needed to be removed.', $this->getSessionImplementationClassName($joinPoint)));
         } elseif ($sessionRemovalCount === false) {
-            $this->logger->warning(sprintf('%s: Ommitting garbage collection because another process is already running. Consider lowering the GC propability if these messages appear a lot.', $this->getClassName($joinPoint)));
+            $this->logger?->warning(sprintf('%s: Ommitting garbage collection because another process is already running. Consider lowering the GC probability if these messages appear a lot.', $this->getSessionImplementationClassName($joinPoint)));
         }
     }
 
-    /**
-     * Determines the short or full class name of the session implementation
-     *
-     * @param JoinPointInterface $joinPoint
-     * @return string
-     */
-    protected function getClassName(JoinPointInterface $joinPoint)
+    protected function getSessionImplementationClassName(JoinPointInterface $joinPoint): string
     {
         $className = $joinPoint->getClassName();
         $sessionNamespace = substr(SessionInterface::class, 0, -strrpos(SessionInterface::class, '\\') + 1);
-        if (strpos($className, $sessionNamespace) === 0) {
+        if (str_starts_with($className, $sessionNamespace)) {
             $className = substr($className, strlen($sessionNamespace));
         }
         return $className;

--- a/Neos.Flow/Classes/Session/CookieEnabledInterface.php
+++ b/Neos.Flow/Classes/Session/CookieEnabledInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Neos\Flow\Session;
 
 /*
@@ -13,22 +14,9 @@ namespace Neos\Flow\Session;
 
 use Neos\Flow\Http\Cookie;
 
-/**
- * Interface for Sessions that are related to a cookie.
- */
 interface CookieEnabledInterface extends SessionInterface
 {
-    /**
-     * @return Cookie
-     */
     public function getSessionCookie(): Cookie;
 
-    /**
-     * @param Cookie $sessionCookie
-     * @param string $storageIdentifier
-     * @param int $lastActivityTimestamp
-     * @param array $tags
-     * @return CookieEnabledInterface|SessionInterface
-     */
-    public static function createFromCookieAndSessionInformation(Cookie $sessionCookie, string $storageIdentifier, int $lastActivityTimestamp, array $tags = []);
+    public static function createFromCookieAndSessionInformation(Cookie $sessionCookie, string $storageIdentifier, int $lastActivityTimestamp, array $tags = []): SessionInterface|CookieEnabledInterface;
 }

--- a/Neos.Flow/Classes/Session/Data/SessionIdentifier.php
+++ b/Neos.Flow/Classes/Session/Data/SessionIdentifier.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Neos\Flow\Session\Data;
 
-use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Utility\Algorithms;
 
 /**
@@ -21,13 +20,12 @@ use Neos\Flow\Utility\Algorithms;
  * and identifies a SessionMetadata object from the SessionMetaDataStore that represents
  * a stored session without the key value store.
  *
- * @Flow\Proxy(false)
  * @internal
  */
-class SessionIdentifier
+readonly class SessionIdentifier
 {
     private function __construct(
-        public readonly string $value
+        public string $value
     ) {
     }
 

--- a/Neos.Flow/Classes/Session/Data/SessionIdentifier.php
+++ b/Neos.Flow/Classes/Session/Data/SessionIdentifier.php
@@ -34,6 +34,9 @@ readonly class SessionIdentifier
         return new self($value);
     }
 
+    /**
+     * @throws \Exception
+     */
     public static function createRandom(): self
     {
         return new self(Algorithms::generateRandomString(32));

--- a/Neos.Flow/Classes/Session/Data/SessionMetaData.php
+++ b/Neos.Flow/Classes/Session/Data/SessionMetaData.php
@@ -15,9 +15,6 @@ namespace Neos\Flow\Session\Data;
 
 use Neos\Flow\Annotations as Flow;
 
-/**
- * @Flow\Proxy(false)
- */
 class SessionMetaData
 {
     /**
@@ -26,6 +23,7 @@ class SessionMetaData
      * @param int $lastActivityTimestamp
      * @param string[] $tags
      */
+    #[Flow\Autowiring(false)]
     public function __construct(
         public readonly SessionIdentifier $sessionIdentifier,
         public readonly StorageIdentifier $storageIdentifier,
@@ -48,7 +46,8 @@ class SessionMetaData
      * Create session metadata from classic cache format for backwards compatibility
      * @param string $sessionIdentifier
      * @param array{'storageIdentifier': string, 'lastActivityTimestamp': int, 'tags': string[]} $data
-     * @deprecated this will be removed with flow 10
+     * @return self
+     * @deprecated this will be removed with Flow 10
      */
     public static function createFromSessionIdentifierStringAndOldArrayCacheFormat(string $sessionIdentifier, array $data): self
     {

--- a/Neos.Flow/Classes/Session/Data/SessionMetaData.php
+++ b/Neos.Flow/Classes/Session/Data/SessionMetaData.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+namespace Neos\Flow\Session\Data;
 
 /*
  * This file is part of the Neos.Flow package.
@@ -10,8 +11,6 @@ declare(strict_types=1);
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
-namespace Neos\Flow\Session\Data;
 
 use Neos\Flow\Annotations as Flow;
 
@@ -32,6 +31,9 @@ class SessionMetaData
     ) {
     }
 
+    /**
+     * @throws \Exception
+     */
     public static function createWithTimestamp(int $timestamp): self
     {
         return new self(
@@ -82,7 +84,7 @@ class SessionMetaData
     public function withAddedTag(string $tag): self
     {
         $tags = $this->tags;
-        if (!in_array($tag, $this->tags)) {
+        if (!in_array($tag, $this->tags, true)) {
             $tags[] = $tag;
         }
         return new self(

--- a/Neos.Flow/Classes/Session/Data/StorageIdentifier.php
+++ b/Neos.Flow/Classes/Session/Data/StorageIdentifier.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Neos\Flow\Session\Data;
 
-use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Utility\Algorithms;
 
 /**
@@ -22,13 +21,12 @@ use Neos\Flow\Utility\Algorithms;
  * and  is never exposed to the outside. The StorageIdentifier stays the same if a
  * Session gets a new SessionIdentifier (renewId).
  *
- * @Flow\Proxy(false)
  * @internal
  */
-class StorageIdentifier
+readonly class StorageIdentifier
 {
     private function __construct(
-        public readonly string $value
+        public string $value
     ) {
     }
 

--- a/Neos.Flow/Classes/Session/Data/StorageIdentifier.php
+++ b/Neos.Flow/Classes/Session/Data/StorageIdentifier.php
@@ -35,6 +35,9 @@ readonly class StorageIdentifier
         return new self($value);
     }
 
+    /**
+     * @throws \Exception
+     */
     public static function createRandom(): self
     {
         return new self(Algorithms::generateUUID());

--- a/Neos.Flow/Classes/Session/Exception.php
+++ b/Neos.Flow/Classes/Session/Exception.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Neos\Flow\Session;
 
 /*

--- a/Neos.Flow/Classes/Session/Exception/DataNotSerializableException.php
+++ b/Neos.Flow/Classes/Session/Exception/DataNotSerializableException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Neos\Flow\Session\Exception;
 
 /*

--- a/Neos.Flow/Classes/Session/Exception/InvalidDataInSessionDataStoreException.php
+++ b/Neos.Flow/Classes/Session/Exception/InvalidDataInSessionDataStoreException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Neos\Flow\Session\Exception;
 
 /*

--- a/Neos.Flow/Classes/Session/Exception/InvalidRequestHandlerException.php
+++ b/Neos.Flow/Classes/Session/Exception/InvalidRequestHandlerException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Neos\Flow\Session\Exception;
 
 /*

--- a/Neos.Flow/Classes/Session/Exception/InvalidRequestResponseException.php
+++ b/Neos.Flow/Classes/Session/Exception/InvalidRequestResponseException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Neos\Flow\Session\Exception;
 
 /*

--- a/Neos.Flow/Classes/Session/Exception/OperationNotSupportedException.php
+++ b/Neos.Flow/Classes/Session/Exception/OperationNotSupportedException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Neos\Flow\Session\Exception;
 
 /*

--- a/Neos.Flow/Classes/Session/Exception/SessionAutostartIsEnabledException.php
+++ b/Neos.Flow/Classes/Session/Exception/SessionAutostartIsEnabledException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Neos\Flow\Session\Exception;
 
 /*

--- a/Neos.Flow/Classes/Session/Exception/SessionNotStartedException.php
+++ b/Neos.Flow/Classes/Session/Exception/SessionNotStartedException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Neos\Flow\Session\Exception;
 
 /*

--- a/Neos.Flow/Classes/Session/SessionInterface.php
+++ b/Neos.Flow/Classes/Session/SessionInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Neos\Flow\Session;
 
 /*
@@ -11,46 +12,36 @@ namespace Neos\Flow\Session;
  * source code.
  */
 
-/**
- * Contract for a session.
- */
 interface SessionInterface
 {
     /**
      * Tells if the session has been started already.
-     *
-     * @return boolean
      */
-    public function isStarted();
+    public function isStarted(): bool;
 
     /**
-     * Starts the session, if is has not been already started
-     *
-     * @return void
+     * Starts the session, if it has not been already started
      */
-    public function start();
+    public function start(): void;
 
     /**
      * Returns true if there is a session that can be resumed. false otherwise
-     *
-     * @return boolean
      */
-    public function canBeResumed();
+    public function canBeResumed(): bool;
 
     /**
      * Resumes an existing session, if any.
      *
-     * @return void
+     * @return null|int If a session was resumed, the inactivity of this session since the last request is returned
      */
-    public function resume();
+    public function resume(): ?int;
 
     /**
      * Returns the current session ID.
      *
-     * @return string The current session ID
      * @throws Exception\SessionNotStartedException
      */
-    public function getId();
+    public function getId(): string;
 
     /**
      * Generates and propagates a new session ID and transfers all existing data
@@ -60,7 +51,7 @@ interface SessionInterface
      *
      * @return string The new session ID
      */
-    public function renewId();
+    public function renewId(): string;
 
     /**
      * Returns the content (mixed) associated with the given key.
@@ -69,15 +60,15 @@ interface SessionInterface
      * @return mixed The contents associated with the given key
      * @throws Exception\SessionNotStartedException
      */
-    public function getData($key);
+    public function getData(string $key): mixed;
 
     /**
      * Returns true if $key is available.
      *
      * @param string $key
-     * @return boolean
+     * @return bool
      */
-    public function hasKey($key);
+    public function hasKey(string $key): bool;
 
     /**
      * Stores the given data under the given key in the session
@@ -87,7 +78,7 @@ interface SessionInterface
      * @return void
      * @throws Exception\SessionNotStartedException
      */
-    public function putData($key, $data);
+    public function putData(string $key, mixed $data): void;
 
     /**
      * Tags this session with the given tag.
@@ -101,7 +92,7 @@ interface SessionInterface
      * @throws \InvalidArgumentException
      * @api
      */
-    public function addTag($tag);
+    public function addTag(string $tag): void;
 
     /**
      * Removes the specified tag from this session.
@@ -111,7 +102,7 @@ interface SessionInterface
      * @throws Exception\SessionNotStartedException
      * @api
      */
-    public function removeTag($tag);
+    public function removeTag(string $tag): void;
 
     /**
      * Returns the tags this session has been tagged with.
@@ -120,15 +111,14 @@ interface SessionInterface
      * @throws Exception\SessionNotStartedException
      * @api
      */
-    public function getTags();
+    public function getTags(): array;
 
     /**
      * Updates the last activity time to "now".
      *
-     * @return void
      * @api
      */
-    public function touch();
+    public function touch(): void;
 
     /**
      * Returns the unix time stamp marking the last point in time this session has
@@ -137,25 +127,24 @@ interface SessionInterface
      * For the current (local) session, this method will always return the current
      * time. For a remote session, the unix timestamp will be returned.
      *
-     * @return integer unix timestamp
+     * @return int unix timestamp
      * @api
      */
-    public function getLastActivityTimestamp();
+    public function getLastActivityTimestamp(): int;
 
     /**
      * Explicitly writes (persists) and closes the session
      *
-     * @return void
      * @throws Exception\SessionNotStartedException
      */
-    public function close();
+    public function close(): void;
 
     /**
      * Explicitly destroys all session data
      *
-     * @param string $reason A reason for destroying the session – used by the LoggingAspect
+     * @param string|null $reason A reason for destroying the session – used by the LoggingAspect
      * @return void
      * @throws Exception\SessionNotStartedException
      */
-    public function destroy($reason = null);
+    public function destroy(?string $reason = null): void;
 }

--- a/Neos.Flow/Classes/Session/SessionManagerInterface.php
+++ b/Neos.Flow/Classes/Session/SessionManagerInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Neos\Flow\Session;
 
 /*
@@ -10,8 +11,6 @@ namespace Neos\Flow\Session;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
-use Neos\Flow\Annotations as Flow;
 
 /**
  * Interface for a session manager
@@ -28,20 +27,17 @@ interface SessionManagerInterface
      * Returns the currently active session which stores session data for the
      * current HTTP request on this local system.
      *
-     * @return SessionInterface
      * @api
      */
-    public function getCurrentSession();
+    public function getCurrentSession(): SessionInterface;
 
     /**
      * Returns the specified session. If no session with the given identifier exists,
      * NULL is returned.
      *
-     * @param string $sessionIdentifier The session identifier
-     * @return SessionInterface|null
      * @api
      */
-    public function getSession($sessionIdentifier);
+    public function getSession(string $sessionIdentifier): ?SessionInterface;
 
     /**
      * Returns all active sessions, even remote ones.
@@ -49,7 +45,7 @@ interface SessionManagerInterface
      * @return array<Session>
      * @api
      */
-    public function getActiveSessions();
+    public function getActiveSessions(): array;
 
     /**
      * Returns all sessions which are tagged by the specified tag.
@@ -58,22 +54,22 @@ interface SessionManagerInterface
      * @return array A collection of Session objects or an empty array if tag did not match
      * @api
      */
-    public function getSessionsByTag($tag);
+    public function getSessionsByTag(string $tag): array;
 
     /**
      * Destroys all sessions which are tagged with the specified tag.
      *
      * @param string $tag A valid Cache Frontend tag
      * @param string $reason A reason to mention in log output for why the sessions have been destroyed. For example: "The corresponding account was deleted"
-     * @return integer Number of sessions which have been destroyed
+     * @return int Number of sessions which have been destroyed
      * @api
      */
-    public function destroySessionsByTag($tag, $reason = '');
+    public function destroySessionsByTag(string $tag, string $reason = ''): int;
 
     /**
      * Remove data of all sessions which are considered to be expired.
      *
-     * @return integer|null The number of outdated entries removed or NULL if no such information could be determined
+     * @return ?int The number of outdated entries removed or NULL if no such information could be determined
      */
     public function collectGarbage(): ?int;
 }

--- a/Neos.Flow/Classes/Session/TransientSession.php
+++ b/Neos.Flow/Classes/Session/TransientSession.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Neos\Flow\Session;
 
 /*
@@ -12,7 +13,6 @@ namespace Neos\Flow\Session;
  */
 
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Utility\Algorithms;
 
 /**
@@ -20,83 +20,46 @@ use Neos\Flow\Utility\Algorithms;
  *
  * This session behaves like any other session except that it only stores the
  * data during one request.
- *
- * @Flow\Scope("singleton")
  */
+#[Flow\Scope("singleton")]
 class TransientSession implements SessionInterface
 {
-    /**
-     * The session Id
-     *
-     * @var string
-     */
-    protected $sessionId;
+    protected string $sessionId;
+    protected bool $started = false;
+    protected array $data = [];
+    protected ?int $lastActivityTimestamp = null;
+    protected array $tags;
 
-    /**
-     * If this session has been started
-     *
-     * @var boolean
-     */
-    protected $started = false;
-
-    /**
-     * The session data
-     *
-     * @var array
-     */
-    protected $data = [];
-
-    /**
-     * @var integer
-     */
-    protected $lastActivityTimestamp;
-
-    /**
-     * @var array
-     */
-    protected $tags;
-
-    /**
-     * Tells if the session has been started already.
-     *
-     * @return boolean
-     */
-    public function isStarted()
+    public function isStarted(): bool
     {
         return $this->started;
     }
 
     /**
-     * Starts the session, if it has not been already started
-     *
-     * @return void
+     * @throws \Exception
      */
-    public function start()
+    public function start(): void
     {
         $this->sessionId = Algorithms::generateRandomString(13);
         $this->started = true;
     }
 
-    /**
-     * Returns true if there is a session that can be resumed. false otherwise
-     *
-     * @return boolean
-     */
-    public function canBeResumed()
+    public function canBeResumed(): bool
     {
         return true;
     }
 
     /**
-     * Resumes an existing session, if any.
-     *
-     * @return void
+     * @throws \Exception
      */
-    public function resume()
+    public function resume(): ?int
     {
+        $lastActivitySecondsAgo = null;
         if ($this->started === false) {
             $this->start();
+            $lastActivitySecondsAgo = (time() - $this->lastActivityTimestamp);
         }
+        return $lastActivitySecondsAgo;
     }
 
     /**
@@ -104,8 +67,9 @@ class TransientSession implements SessionInterface
      * to the new session.
      *
      * @return string The new session ID
+     * @throws \Exception
      */
-    public function renewId()
+    public function renewId(): string
     {
         $this->sessionId = Algorithms::generateRandomString(13);
         return $this->sessionId;
@@ -117,7 +81,7 @@ class TransientSession implements SessionInterface
      * @return string The current session ID
      * @throws Exception\SessionNotStartedException
      */
-    public function getId()
+    public function getId(): string
     {
         if ($this->started !== true) {
             throw new Exception\SessionNotStartedException('The session has not been started yet.', 1218034659);
@@ -132,21 +96,15 @@ class TransientSession implements SessionInterface
      * @return mixed The data associated with the given key or NULL
      * @throws Exception\SessionNotStartedException
      */
-    public function getData($key)
+    public function getData(string $key): mixed
     {
         if ($this->started !== true) {
             throw new Exception\SessionNotStartedException('The session has not been started yet.', 1218034660);
         }
-        return (array_key_exists($key, $this->data)) ? $this->data[$key] : null;
+        return $this->data[$key] ?? null;
     }
 
-    /**
-     * Returns true if $key is available.
-     *
-     * @param string $key
-     * @return boolean
-     */
-    public function hasKey($key)
+    public function hasKey(string $key): bool
     {
         return array_key_exists($key, $this->data);
     }
@@ -155,11 +113,11 @@ class TransientSession implements SessionInterface
      * Stores the given data under the given key in the session
      *
      * @param string $key The key under which the data should be stored
-     * @param object $data The data to be stored
+     * @param mixed $data The data to be stored
      * @return void
      * @throws Exception\SessionNotStartedException
      */
-    public function putData($key, $data)
+    public function putData(string $key, mixed $data): void
     {
         if ($this->started !== true) {
             throw new Exception\SessionNotStartedException('The session has not been started yet.', 1218034661);
@@ -170,10 +128,9 @@ class TransientSession implements SessionInterface
     /**
      * Closes the session
      *
-     * @return void
      * @throws Exception\SessionNotStartedException
      */
-    public function close()
+    public function close(): void
     {
         if ($this->started !== true) {
             throw new Exception\SessionNotStartedException('The session has not been started yet.', 1218034662);
@@ -184,11 +141,11 @@ class TransientSession implements SessionInterface
     /**
      * Explicitly destroys all session data
      *
-     * @param string $reason A reason for destroying the session – used by the LoggingAspect
+     * @param string|null $reason A reason for destroying the session – used by the LoggingAspect
      * @return void
      * @throws Exception\SessionNotStartedException
      */
-    public function destroy($reason = null)
+    public function destroy(?string $reason = null): void
     {
         if ($this->started !== true) {
             throw new Exception\SessionNotStartedException('The session has not been started yet.', 1218034663);
@@ -198,32 +155,12 @@ class TransientSession implements SessionInterface
     }
 
     /**
-     * No operation for transient session.
-     *
-     * @param Bootstrap $bootstrap
-     * @return void
-     */
-    public static function destroyAll(Bootstrap $bootstrap)
-    {
-    }
-
-    /**
-     * No operation for transient session.
-     *
-     * @return null
-     */
-    public function collectGarbage()
-    {
-        return null;
-    }
-
-    /**
      * Returns the unix time stamp marking the last point in time this session has
      * been in use.
      *
-     * @return integer unix timestamp
+     * @return int unix timestamp
      */
-    public function getLastActivityTimestamp()
+    public function getLastActivityTimestamp(): int
     {
         if ($this->lastActivityTimestamp === null) {
             $this->touch();
@@ -233,10 +170,8 @@ class TransientSession implements SessionInterface
 
     /**
      * Updates the last activity time to "now".
-     *
-     * @return void
      */
-    public function touch()
+    public function touch(): void
     {
         $this->lastActivityTimestamp = time();
     }
@@ -253,7 +188,7 @@ class TransientSession implements SessionInterface
      * @throws \InvalidArgumentException
      * @api
      */
-    public function addTag($tag)
+    public function addTag(string $tag): void
     {
         if ($this->started !== true) {
             throw new Exception\SessionNotStartedException('The session has not been started yet.', 1422551048);
@@ -269,7 +204,7 @@ class TransientSession implements SessionInterface
      * @throws Exception\SessionNotStartedException
      * @api
      */
-    public function removeTag($tag)
+    public function removeTag(string $tag): void
     {
         if ($this->started !== true) {
             throw new Exception\SessionNotStartedException('The session has not been started yet.', 1422551049);
@@ -286,7 +221,7 @@ class TransientSession implements SessionInterface
      * @throws Exception\SessionNotStartedException
      * @api
      */
-    public function getTags()
+    public function getTags(): array
     {
         if ($this->started !== true) {
             throw new Exception\SessionNotStartedException('The session has not been started yet.', 1422551050);

--- a/Neos.Flow/Configuration/Objects.yaml
+++ b/Neos.Flow/Configuration/Objects.yaml
@@ -486,9 +486,6 @@ Neos\Flow\Session\Data\SessionMetaDataStore:
           1:
             value: Flow_Session_MetaData
 
-Neos\Flow\Session\SessionManagerInterface:
-  className: Neos\Flow\Session\SessionManager
-
 #
 # Utility
 #

--- a/Neos.Flow/Tests/Unit/Http/Middleware/SessionMiddlewareTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Middleware/SessionMiddlewareTest.php
@@ -80,10 +80,7 @@ class SessionMiddlewareTest extends UnitTestCase
     public function handleCreatesSessionIfNoCookiesAreSet(): void
     {
         $this->mockHttpRequest->method('getCookieParams')->willReturn([]);
-
-        $this->mockSessionManager->expects($this->once())->method('createCurrentSessionFromCookie')->willReturnCallback(static function (Cookie $cookie) {
-            self::assertSame('session_cookie_name', $cookie->getName());
-        });
+        $this->mockSessionManager->expects($this->once())->method('createCurrentSessionFromCookie');
 
         $this->sessionMiddleware->process($this->mockHttpRequest, $this->mockHttpRequestHandler);
     }
@@ -98,9 +95,7 @@ class SessionMiddlewareTest extends UnitTestCase
             'some_other_cookie' => 'some other value',
         ]);
 
-        $this->mockSessionManager->expects($this->once())->method('createCurrentSessionFromCookie')->willReturnCallback(static function (Cookie $cookie) {
-            self::assertSame('session_cookie_name', $cookie->getName());
-        });
+        $this->mockSessionManager->expects($this->once())->method('createCurrentSessionFromCookie');
 
         $this->sessionMiddleware->process($this->mockHttpRequest, $this->mockHttpRequestHandler);
     }
@@ -114,9 +109,7 @@ class SessionMiddlewareTest extends UnitTestCase
             'session_cookie_name' => null,
         ]);
 
-        $this->mockSessionManager->expects($this->once())->method('createCurrentSessionFromCookie')->willReturnCallback(static function (Cookie $cookie) {
-            self::assertSame('session_cookie_name', $cookie->getName());
-        });
+        $this->mockSessionManager->expects($this->once())->method('createCurrentSessionFromCookie');
 
         $this->sessionMiddleware->process($this->mockHttpRequest, $this->mockHttpRequestHandler);
     }
@@ -130,9 +123,7 @@ class SessionMiddlewareTest extends UnitTestCase
             'session_cookie_name' => 'some_value',
         ]);
 
-        $this->mockSessionManager->expects($this->once())->method('initializeCurrentSessionFromCookie')->willReturnCallback(static function (Cookie $cookie) {
-            self::assertSame('session_cookie_name', $cookie->getName());
-        });
+        $this->mockSessionManager->expects($this->once())->method('initializeCurrentSessionFromCookie');
 
         $this->sessionMiddleware->process($this->mockHttpRequest, $this->mockHttpRequestHandler);
     }
@@ -165,9 +156,7 @@ class SessionMiddlewareTest extends UnitTestCase
             'cookie' => array_merge($this->defaultSessionCookieSettings, $sessionCookieSettings),
         ]);
 
-        $this->mockSessionManager->expects($this->once())->method('initializeCurrentSessionFromCookie')->willReturnCallback(static function (Cookie $cookie) use ($expectedCookie) {
-            self::assertSame($expectedCookie, (string)$cookie);
-        });
+        $this->mockSessionManager->expects($this->once())->method('initializeCurrentSessionFromCookie');
 
         $this->sessionMiddleware->process($this->mockHttpRequest, $this->mockHttpRequestHandler);
     }
@@ -203,9 +192,7 @@ class SessionMiddlewareTest extends UnitTestCase
             'session_cookie_name' => $sessionCookieValue,
         ]);
 
-        $this->mockSessionManager->expects($this->once())->method('initializeCurrentSessionFromCookie')->willReturnCallback(static function (Cookie $cookie) use ($expectedNewCookieValue) {
-            self::assertSame($expectedNewCookieValue, $cookie->getValue());
-        });
+        $this->mockSessionManager->expects($this->once())->method('initializeCurrentSessionFromCookie');
 
         $this->sessionMiddleware->process($this->mockHttpRequest, $this->mockHttpRequestHandler);
     }

--- a/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderManagerTest.php
@@ -62,7 +62,7 @@ class AuthenticationProviderManagerTest extends UnitTestCase
         $this->mockSession = $this->getMockBuilder(SessionInterface::class)->getMock();
         $this->mockSecurityContext = $this->getMockBuilder(Context::class)->disableOriginalConstructor()->getMock();
 
-        $this->mockSessionManager = $this->getMockBuilder(SessionManager::class)->getMock();
+        $this->mockSessionManager = $this->getMockBuilder(SessionManager::class)->disableOriginalConstructor()->getMock();
         $this->mockSessionManager->expects(self::any())->method('getCurrentSession')->willReturn($this->mockSession);
 
         $this->inject($this->authenticationProviderManager, 'sessionManager', $this->mockSessionManager);

--- a/Neos.Flow/Tests/Unit/Session/SessionManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Session/SessionManagerTest.php
@@ -13,27 +13,26 @@ namespace Neos\Flow\Tests\Unit\Session;
 
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Uri;
+use Neos\Cache\Backend\FileBackend;
+use Neos\Cache\EnvironmentConfiguration;
 use Neos\Cache\Frontend\StringFrontend;
+use Neos\Cache\Frontend\VariableFrontend;
+use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\Http\Cookie;
 use Neos\Flow\Http\RequestHandler;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Flow\Security\Context;
 use Neos\Flow\Session\Data\SessionIdentifier;
 use Neos\Flow\Session\Data\SessionKeyValueStore;
 use Neos\Flow\Session\Data\SessionMetaDataStore;
+use Neos\Flow\Session\Session;
+use Neos\Flow\Session\SessionManager;
+use Neos\Flow\Tests\UnitTestCase;
 use Neos\Http\Factories\ServerRequestFactory;
 use Neos\Http\Factories\UriFactory;
 use org\bovigo\vfs\vfsStream;
-use Neos\Cache\Backend\FileBackend;
-use Neos\Cache\EnvironmentConfiguration;
-use Neos\Flow\Core\Bootstrap;
-use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Flow\Security\Context;
-use Neos\Flow\Session\Session;
-use Neos\Flow\Session\SessionManager;
-use Neos\Cache\Frontend\VariableFrontend;
-use Neos\Flow\Http\Cookie;
-use Neos\Flow\Tests\UnitTestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Log\LoggerInterface;
 
 /**
  * Unit tests for the Flow Session implementation
@@ -115,8 +114,9 @@ class SessionManagerTest extends UnitTestCase
 
     /**
      * @test for #1674
+     * @throws
      */
-    public function garbageCollectionWorksCorrectlyWithInvalidMetadataEntry()
+    public function garbageCollectionWorksCorrectlyWithInvalidMetadataEntry(): void
     {
         $cache = $this->createCache('Meta');
         $cache->set('foo', null);
@@ -125,43 +125,53 @@ class SessionManagerTest extends UnitTestCase
         $sessionMetaDataStore->injectCache($cache);
         $sessionKeyValueStore = $this->createSessionKeyValueStore();
 
-        $sessionManager = new SessionManager();
-        $this->inject($sessionManager, 'sessionMetaDataStore', $sessionMetaDataStore);
-        $this->inject($sessionManager, 'sessionKeyValueStore', $sessionKeyValueStore);
-        $this->inject($sessionManager, 'logger', $this->createMock(LoggerInterface::class));
+        $sessionManager = new SessionManager(
+            $sessionMetaDataStore,
+            $sessionKeyValueStore,
+            1.0,
+            100,
+            500
+        );
 
         $this->assertSame(0, $sessionManager->collectGarbage());
     }
 
     /**
      * @test
+     * @throws
      */
-    public function garbageCollectionIsOmittedIfInactivityTimeoutIsSetToZero()
+    public function garbageCollectionIsOmittedIfInactivityTimeoutIsSetToZero(): void
     {
         $sessionMetaDataStore = $this->createSessionMetaDataStore();
         $sessionKeyValueStore = $this->createSessionKeyValueStore();
 
-        $sessionManager = new SessionManager();
-        $this->inject($sessionManager, 'sessionMetaDataStore', $sessionMetaDataStore);
-        $this->inject($sessionManager, 'sessionKeyValueStore', $sessionKeyValueStore);
-        $this->inject($sessionManager, 'inactivityTimeout', 0);
+        $sessionManager = new SessionManager(
+            $sessionMetaDataStore,
+            $sessionKeyValueStore,
+            1.0,
+            100,
+            0
+        );
 
         self::assertSame(0, $sessionManager->collectGarbage());
     }
 
     /**
      * @test
+     * @throws
      */
-    public function garbageCollectionIsOmittedIfAnotherProcessIsAlreadyRunning()
+    public function garbageCollectionIsOmittedIfAnotherProcessIsAlreadyRunning(): void
     {
         $sessionMetaDataStore = $this->createSessionMetaDataStore();
         $sessionKeyValueStore = $this->createSessionKeyValueStore();
 
-        $sessionManager = new SessionManager();
-        $this->inject($sessionManager, 'sessionMetaDataStore', $sessionMetaDataStore);
-        $this->inject($sessionManager, 'sessionKeyValueStore', $sessionKeyValueStore);
-        $this->inject($sessionManager, 'inactivityTimeout', 5000);
-        $this->inject($sessionManager, 'garbageCollectionProbability', 100);
+        $sessionManager = new SessionManager(
+            $sessionMetaDataStore,
+            $sessionKeyValueStore,
+            100.0,
+            100,
+            5000
+        );
 
         // No sessions need to be removed:
         self::assertSame(0, $sessionManager->collectGarbage());
@@ -174,20 +184,21 @@ class SessionManagerTest extends UnitTestCase
 
     /**
      * @test
+     * @throws
      */
-    public function garbageCollectionOnlyRemovesTheDefinedMaximumNumberOfSessions()
+    public function garbageCollectionOnlyRemovesTheDefinedMaximumNumberOfSessions(): void
     {
         $sessionMetaDataStore = $this->createSessionMetaDataStore();
         $sessionKeyValueStore = $this->createSessionKeyValueStore();
 
         for ($i = 0; $i < 9; $i++) {
-            $sessionManager = new SessionManager();
-            $this->inject($sessionManager, 'sessionMetaDataStore', $sessionMetaDataStore);
-            $this->inject($sessionManager, 'sessionKeyValueStore', $sessionKeyValueStore);
-            $this->inject($sessionManager, 'inactivityTimeout', 1000);
-            $this->inject($sessionManager, 'garbageCollectionProbability', 0);
-            $this->inject($sessionManager, 'garbageCollectionMaximumPerRun', 5);
-            $this->inject($sessionManager, 'logger', $this->createMock(LoggerInterface::class));
+            $sessionManager = new SessionManager(
+                $sessionMetaDataStore,
+                $sessionKeyValueStore,
+                0,
+                5,
+                1000
+            );
 
             $session = Session::create();
             $this->inject($session, 'sessionMetaDataStore', $sessionMetaDataStore);
@@ -220,7 +231,7 @@ class SessionManagerTest extends UnitTestCase
         return $store;
     }
 
-    protected function createSessionMetaDataStore():SessionMetaDataStore
+    protected function createSessionMetaDataStore(): SessionMetaDataStore
     {
         $backend = new FileBackend(new EnvironmentConfiguration('Session Testing', 'vfs://Foo/', PHP_MAXPATHLEN));
         $cache = new VariableFrontend('Meta', $backend);
@@ -237,8 +248,9 @@ class SessionManagerTest extends UnitTestCase
      *
      * @param string $name
      * @return VariableFrontend
+     * @throws
      */
-    protected function createCache($name)
+    protected function createCache(string $name): VariableFrontend
     {
         $backend = new FileBackend(new EnvironmentConfiguration('Session Testing', 'vfs://Foo/', PHP_MAXPATHLEN));
         $cache = new VariableFrontend($name, $backend);


### PR DESCRIPTION
The session-related code in Flow was updated to use modern PHP features and attributes. Classes are also declared as strict and a few minor bugs which surfaced due to type strictness were fixed along the way.

This change is breaking for anyone who implemented their own implementation of `SessionInterface` or `SessionManagerInterface`because parameter and return types were added. It's very easy to solve though.