### PR TITLE
TASK: Declare `ValueAccessor` as experimental for now

### DIFF
--- a/Neos.Utility.Arrays/Classes/Arrays.php
+++ b/Neos.Utility.Arrays/Classes/Arrays.php
@@ -221,6 +221,7 @@ abstract class Arrays
      *
      * See {@see ValueAccessor}
      *
+     * @internal experimental feature, not stable API
      * @param array $array The array to traverse
      * @param array|string $path The path to follow. Either a simple array of keys or a string in the format 'foo.bar.baz'
      * @return ValueAccessor

--- a/Neos.Utility.Arrays/Classes/ValueAccessor.php
+++ b/Neos.Utility.Arrays/Classes/ValueAccessor.php
@@ -27,7 +27,7 @@ namespace Neos\Utility;
  * $intValue = Arrays::getAccessorByPath($mixedArray, 'foo.myIntOption')->int();
  * ```
  *
- * @api
+ * @internal experimental feature, not stable API
  */
 final readonly class ValueAccessor
 {
@@ -37,6 +37,9 @@ final readonly class ValueAccessor
     ) {
     }
 
+    /**
+     * @internal experimental feature, not stable API
+     */
     public static function forValue(mixed $value): self
     {
         return new self($value, null);


### PR DESCRIPTION
The feature introduce with https://github.com/neos/flow-development-collection/pull/3149 will be marked internal and experimental for now before the stable release of Flow 9.0

my reasons for this are
- the feature is not necessary scoped to arrays so `Neos\Utility\Arrays` might not be the best location
- copy further features from https://github.com/PackageFactory/extractor especially accessing deep array structures with good exceptions: https://github.com/PackageFactory/extractor/blob/b8a135dbd95c3a51a26787063981ce2454b81dd6/src/Extractor.php#L335
    - or just take the code 1 to 1
- the naming `ValueAccessor` vs `Extractor`
- `Arrays::getAccessorByPath($array, 'path.bar')->int()` vs `ValueAccessor::for($array)['path']['bar']->int()`
    - im not sure about if we want to propagate the dot access pattern forever ;)
- we currently dont use the `ValueAccessor` ourselves in the code base and thus don't know yet if the api really makes things easier
- it doesn't support forgiving casting / access like `stringOrIgnore`
- how to integrate this for validating configuration? https://github.com/neos/flow-development-collection/issues/3043


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
