### PR TITLE
BUGFIX: Respect psr buffer streams and use them for string streams

### DIFF
--- a/Neos.Flow/Classes/Mvc/ActionResponse.php
+++ b/Neos.Flow/Classes/Mvc/ActionResponse.php
@@ -198,7 +198,9 @@ final class ActionResponse
     public function getContent(): string
     {
         $content = $this->content->getContents();
-        $this->content->rewind();
+        if ($this->content->isSeekable()) {
+            $this->content->rewind();
+        }
         return $content;
     }
 

--- a/Neos.Http.Factories/Classes/StreamFactoryTrait.php
+++ b/Neos.Http.Factories/Classes/StreamFactoryTrait.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Neos\Http\Factories;
 
+use GuzzleHttp\Psr7\BufferStream;
 use GuzzleHttp\Psr7\Stream;
-use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -17,11 +17,9 @@ trait StreamFactoryTrait
      */
     public function createStream(string $content = ''): StreamInterface
     {
-        $fileHandle = fopen('php://temp', 'r+');
-        fwrite($fileHandle, $content);
-        rewind($fileHandle);
-
-        return $this->createStreamFromResource($fileHandle);
+        $stream = new BufferStream();
+        $stream->write($content);
+        return $stream;
     }
 
     /**


### PR DESCRIPTION
the idea is that this is more light weight instead of creating a memory resource.

see https://neos-project.slack.com/archives/C050KKBEB/p1710320388608069

Originally meant as part of https://github.com/neos/flow-development-collection/pull/3286, but we dont support buffer streams yet fully in all places.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
