### PR TITLE
BUGFIX: Fix count for query across OneToMany joins

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/CountWalker.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/CountWalker.php
@@ -63,7 +63,8 @@ class CountWalker extends TreeWalkerAdapter
         $AST->orderByClause = null;
     }
 
-    private function isDistinctRequired(): bool {
+    private function isDistinctRequired(): bool
+    {
         foreach ($this->getQueryComponents() as $queryComponent) {
             if (isset($queryComponent['relation']['type']) && $queryComponent['relation']['type'] === ClassMetadataInfo::ONE_TO_MANY) {
                 return true;

--- a/Neos.Flow/Classes/Persistence/Doctrine/CountWalker.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/CountWalker.php
@@ -8,6 +8,7 @@ namespace Neos\Flow\Persistence\Doctrine;
  * with this package in the file License-BSD.txt.                         *
  *                                                                        */
 
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Query\AST\AggregateExpression;
 use Doctrine\ORM\Query\AST\PathExpression;
 use Doctrine\ORM\Query\AST\SelectExpression;
@@ -40,6 +41,10 @@ class CountWalker extends TreeWalkerAdapter
             }
         }
 
+        if ($this->isDistinctRequired()) {
+            $AST->selectClause->isDistinct = true;
+        }
+
         $pathExpression = new PathExpression(
             PathExpression::TYPE_STATE_FIELD | PathExpression::TYPE_SINGLE_VALUED_ASSOCIATION,
             $parentName,
@@ -49,12 +54,21 @@ class CountWalker extends TreeWalkerAdapter
 
         $AST->selectClause->selectExpressions = [
             new SelectExpression(
-                new AggregateExpression('count', $pathExpression, true),
+                new AggregateExpression('count', $pathExpression, $AST->selectClause->isDistinct),
                 null
             )
         ];
 
         // ORDER BY is not needed, only increases query execution through unnecessary sorting.
         $AST->orderByClause = null;
+    }
+
+    private function isDistinctRequired(): bool {
+        foreach ($this->getQueryComponents() as $queryComponent) {
+            if (isset($queryComponent['relation']['type']) && $queryComponent['relation']['type'] === ClassMetadataInfo::ONE_TO_MANY) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/Neos.Flow/Classes/Persistence/Doctrine/CountWalker.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/CountWalker.php
@@ -49,7 +49,7 @@ class CountWalker extends TreeWalkerAdapter
 
         $AST->selectClause->selectExpressions = [
             new SelectExpression(
-                new AggregateExpression('count', $pathExpression, $AST->selectClause->isDistinct),
+                new AggregateExpression('count', $pathExpression, true),
                 null
             )
         ];


### PR DESCRIPTION
The `Query->count` now returns the correct count when a criterion is added on a OneToMany relation.

**Review instructions**

The problem is described in details in #3331.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
