### PR TITLE
BUGFIX: Discover autoloader from FLOW_ROOTPATH rather than __DIR__

### DIFF
--- a/Neos.Flow/Scripts/flow.php
+++ b/Neos.Flow/Scripts/flow.php
@@ -39,18 +39,6 @@ if (isset($argv[1]) && ($argv[1] === 'neos.flow:core:setfilepermissions' || $arg
     array_shift($argv);
     require(__DIR__ . '/migrate.php');
 } else {
-    $autoloaderPath = dirname(__DIR__, 3) . '/Libraries/autoload.php';
-    if (!file_exists($autoloaderPath)) {
-        echo 'Composers "autoload.php" file was not found. The file is expected to be located in the path:' . PHP_EOL . PHP_EOL;
-        echo $autoloaderPath . PHP_EOL . PHP_EOL;
-        echo 'This could be due to a missing "config" => "vendor-dir" section of your root "composer.json" file.' . PHP_EOL . PHP_EOL;
-        echo 'The section key and value should look like the following:' . PHP_EOL;
-        echo '"vendor-dir": "Packages/Libraries"' . PHP_EOL;
-        echo 'Update your "composer.json" file accordingly and run the "composer update" command.' . PHP_EOL;
-        exit(1);
-    }
-    $composerAutoloader = require($autoloaderPath);
-
     if (DIRECTORY_SEPARATOR !== '/' && trim(getenv('FLOW_ROOTPATH'), '"\' ') === '') {
         $absoluteRootpath = dirname(realpath(__DIR__ . '/../../../'));
         if (realpath(getcwd()) === $absoluteRootpath) {
@@ -64,6 +52,18 @@ if (isset($argv[1]) && ($argv[1] === 'neos.flow:core:setfilepermissions' || $arg
     } else {
         $_SERVER['FLOW_ROOTPATH'] = trim(getenv('FLOW_ROOTPATH'), '"\' ') ?: dirname($_SERVER['PHP_SELF']);
     }
+
+    $autoloaderPath = $_SERVER['FLOW_ROOTPATH'] . '/Packages/Libraries/autoload.php';
+    if (!file_exists($autoloaderPath)) {
+        echo 'Composers "autoload.php" file was not found. The file is expected to be located in the path:' . PHP_EOL . PHP_EOL;
+        echo $autoloaderPath . PHP_EOL . PHP_EOL;
+        echo 'This could be due to a missing "config" => "vendor-dir" section of your root "composer.json" file.' . PHP_EOL . PHP_EOL;
+        echo 'The section key and value should look like the following:' . PHP_EOL;
+        echo '"vendor-dir": "Packages/Libraries"' . PHP_EOL;
+        echo 'Update your "composer.json" file accordingly and run the "composer update" command.' . PHP_EOL;
+        exit(1);
+    }
+    $composerAutoloader = require($autoloaderPath);
 
     $context = trim((string)\Neos\Flow\Core\Bootstrap::getEnvironmentConfigurationSetting('FLOW_CONTEXT'), '"\' ') ?: 'Development';
 


### PR DESCRIPTION
**The Problem**

In my development setups (for contribution), I prefer to have every repo that is under development installed via composer `path` repositories, like so:

```json
{
    "name": "vendor/dev-distribution",
    "require": {
        "neos/flow-development-collection": "9.0.x-dev",
        "neos/neos-development-collection": "9.0.x-dev",
        "neos/neos-ui": "9.0.x-dev",
        "vendor/site": "^1.0"
    },
    "repositories": {
        "local": {
            "type": "path",
            "url": "./DistributionPackages/*"
        },
       "dev": {
            "type": "path",
            "url": "./DevelopmentPackages/*"
        }
    }
}
```

Now if I clone, say, `neos/neos-development-collection` into `DevelopmentPackages/`, composer will install the local version rather than the one from packagist.

This works for `neos/neos-development-collection`, `neos/neos-ui` and pretty much any other package around, but not for `neos/flow-development-collection`.

The `flow` CLI script makes the assumption that it is always located under `Packages/*/` and uses this assumption to discover the `autoload.php` script. It does so starting at its own path using the `__DIR__` constant.

Unfortunately, PHP resolves symlinks before it sets the `__DIR__` constant. So when flow is installed via symlink, `__DIR__` does not contain its symlinked location, but its *real* location. This way it guesses the wrong path for `autoload.php`, rendering the `flow` CLI script unusable.

**The solution**

The `flow` CLI script also figures out the `FLOW_ROOTPATH`. It does so just after the autoload discovery.

I guessed that it would be a safe assumption that the `autoload.php` can always be found under `FLOW_ROOTPATH/Packages/Libraries/autoload.php`. *(though actually, this path may have been configured differently, but flow wouldn't be able to handle that as of right now)*

Therefore, I moved the composer autload discovery below the `FLOW_ROOTPATH` discovery, to then use `FLOW_ROOTPATH` as a starting point.

I'm pretty sure this is applicable to lower branches as well, but I didn't test this yet, so I'm targeting `9.0` for now.