### PR TITLE
BUGFIX: Add exponential backoff when reading from Redis

### DIFF
--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -170,7 +170,18 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      */
     public function get(string $entryIdentifier): string|bool
     {
-        return $this->uncompress($this->redis->get($this->getPrefixedIdentifier('entry:' . $entryIdentifier)));
+        $tries = 1;
+        do {
+            try {
+                return $this->uncompress($this->redis->get($this->getPrefixedIdentifier('entry:' . $entryIdentifier)));
+            } catch (\RedisException  $exception) {
+                if ($tries > 8) {
+                    throw $exception;
+                }
+                usleep($tries^2 * 100000);
+                $tries++;
+            }
+        } while (true);
     }
 
     /**

--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -178,7 +178,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
                 if ($tries > 8) {
                     throw $exception;
                 }
-                usleep($tries^2 * 100000);
+                usleep($tries**2 * 100000);
                 $tries++;
             }
         } while (true);


### PR DESCRIPTION
When Redis is not ready (yet) when trying to read from the cache, this makes Flow wait and retry up to 8 times with an exponentially growing back-off time.

Fixes #3284

**Review instructions**

This might be hard to check in real life, sorry…

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
