### PR TITLE
FEATURE: Allow `PositionalArraySorter` to keep `null` values

### DIFF
--- a/Neos.Utility.Arrays/Classes/PositionalArraySorter.php
+++ b/Neos.Utility.Arrays/Classes/PositionalArraySorter.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Neos\Utility;
 
 /*
@@ -11,8 +14,10 @@ namespace Neos\Utility;
  * source code.
  */
 
+use Neos\Utility\Exception\InvalidPositionException;
+
 /**
- * Flexible array sorter that sorts an array according to a "position" meta data.
+ * Flexible array sorter that sorts an array according to a "position" metadata.
  * The expected format for the $subject is:
  *
  * array(
@@ -35,66 +40,43 @@ namespace Neos\Utility;
  *
  * where "weight" is the priority that defines which of two conflicting positions overrules the other,
  * "key" is a string that references another key in the $subject
- * and "numerical-order" is an integer that defines the order independently from the other keys.
+ * and "numerical-order" is an integer that defines the order independently of the other keys.
  *
  * With the $positionPropertyPath parameter the property path to the position string can be changed.
  */
-class PositionalArraySorter
+final class PositionalArraySorter
 {
-    /**
-     * @var array
-     */
-    protected $subject;
+    private array $startKeys;
 
-    /**
-     * @var string
-     */
-    protected $positionPropertyPath;
+    private array $middleKeys;
 
-    /**
-     * @var array
-     */
-    protected $startKeys;
+    private array $endKeys;
 
-    /**
-     * @var array
-     */
-    protected $middleKeys;
+    private array $beforeKeys;
 
-    /**
-     * @var array
-     */
-    protected $endKeys;
-
-    /**
-     * @var array
-     */
-    protected $beforeKeys;
-
-    /**
-     * @var array
-     */
-    protected $afterKeys;
+    private array $afterKeys;
 
     /**
      * @param array $subject The source array to sort
      * @param string $positionPropertyPath optional property path to the string that contains the position
+     * @param bool $removeNullValues if set to TRUE (default), null-values of the subject are removed
      */
-    public function __construct(array $subject, string $positionPropertyPath = 'position')
-    {
-        $this->subject = $subject;
-        $this->positionPropertyPath = $positionPropertyPath;
+    public function __construct(
+        private readonly array $subject,
+        private readonly string $positionPropertyPath = 'position',
+        private readonly bool $removeNullValues = true,
+    ) {
     }
 
     /**
      * Returns a sorted copy of the subject array
      *
      * @return array
+     * @throws InvalidPositionException
      */
     public function toArray(): array
     {
         $sortedArrayKeys = $this->getSortedKeys();
-
         $sortedArray = [];
         foreach ($sortedArrayKeys as $key) {
             $sortedArray[$key] = $this->subject[$key];
@@ -121,22 +103,19 @@ class PositionalArraySorter
         $this->extractBeforeKeys($arrayKeysWithPosition, $existingKeys);
         $this->extractAfterKeys($arrayKeysWithPosition, $existingKeys);
 
-        foreach ($arrayKeysWithPosition as $unresolvedKey => $unresolvedPosition) {
-            throw new Exception\InvalidPositionException(sprintf('The positional string "%s" (defined for key "%s") is not supported.', $unresolvedPosition, $unresolvedKey), 1379429920);
+        if ($arrayKeysWithPosition !== []) {
+            $unresolvedKey = array_key_first($arrayKeysWithPosition);
+            throw new Exception\InvalidPositionException(sprintf('The positional string "%s" (defined for key "%s") is not supported.', $arrayKeysWithPosition[$unresolvedKey], $unresolvedKey), 1379429920);
         }
-
         return $this->generateSortedKeysMap();
     }
 
     /**
      * Extracts all "middle" keys from $arrayKeysWithPosition. Those are all keys with a numeric position.
-     * The result is a multi-dimensional arrays where the KEY of each array is a PRIORITY and the VALUE is an array of matching KEYS
+     * The result is a multidimensional arrays where the KEY of each array is a PRIORITY and the VALUE is an array of matching KEYS
      * This also removes matching keys from the given $arrayKeysWithPosition
-     *
-     * @param array $arrayKeysWithPosition
-     * @return void
      */
-    protected function extractMiddleKeys(array &$arrayKeysWithPosition)
+    private function extractMiddleKeys(array &$arrayKeysWithPosition): void
     {
         $this->middleKeys = [];
         foreach ($arrayKeysWithPosition as $key => $position) {
@@ -151,13 +130,10 @@ class PositionalArraySorter
 
     /**
      * Extracts all "start" keys from $arrayKeysWithPosition. Those are all keys with a position starting with "start"
-     * The result is a multi-dimensional arrays where the KEY of each array is a PRIORITY and the VALUE is an array of matching KEYS
+     * The result is a multidimensional arrays where the KEY of each array is a PRIORITY and the VALUE is an array of matching KEYS
      * This also removes matching keys from the given $arrayKeysWithPosition
-     *
-     * @param array $arrayKeysWithPosition
-     * @return void
      */
-    protected function extractStartKeys(array &$arrayKeysWithPosition)
+    private function extractStartKeys(array &$arrayKeysWithPosition): void
     {
         $this->startKeys = [];
         foreach ($arrayKeysWithPosition as $key => $position) {
@@ -176,13 +152,10 @@ class PositionalArraySorter
 
     /**
      * Extracts all "end" keys from $arrayKeysWithPosition. Those are all keys with a position starting with "end"
-     * The result is a multi-dimensional arrays where the KEY of each array is a PRIORITY and the VALUE is an array of matching KEYS
+     * The result is a multidimensional arrays where the KEY of each array is a PRIORITY and the VALUE is an array of matching KEYS
      * This also removes matching keys from the given $arrayKeysWithPosition
-     *
-     * @param array $arrayKeysWithPosition
-     * @return void
      */
-    protected function extractEndKeys(array &$arrayKeysWithPosition)
+    private function extractEndKeys(array &$arrayKeysWithPosition): void
     {
         $this->endKeys = [];
         foreach ($arrayKeysWithPosition as $key => $position) {
@@ -201,14 +174,10 @@ class PositionalArraySorter
 
     /**
      * Extracts all "before" keys from $arrayKeysWithPosition. Those are all keys with a position starting with "before"
-     * The result is a multi-dimensional arrays where the KEY of each array is a PRIORITY and the VALUE is an array of matching KEYS
+     * The result is a multidimensional arrays where the KEY of each array is a PRIORITY and the VALUE is an array of matching KEYS
      * This also removes matching keys from the given $arrayKeysWithPosition
-     *
-     * @param array $arrayKeysWithPosition
-     * @param array $existingKeys
-     * @return void
      */
-    protected function extractBeforeKeys(array &$arrayKeysWithPosition, array $existingKeys)
+    private function extractBeforeKeys(array &$arrayKeysWithPosition, array $existingKeys): void
     {
         $this->beforeKeys = [];
         foreach ($arrayKeysWithPosition as $key => $position) {
@@ -232,14 +201,10 @@ class PositionalArraySorter
 
     /**
      * Extracts all "after" keys from $arrayKeysWithPosition. Those are all keys with a position starting with "after"
-     * The result is a multi-dimensional arrays where the KEY of each array is a PRIORITY and the VALUE is an array of matching KEYS
+     * The result is a multidimensional arrays where the KEY of each array is a PRIORITY and the VALUE is an array of matching KEYS
      * This also removes matching keys from the given $arrayKeysWithPosition
-     *
-     * @param array $arrayKeysWithPosition
-     * @param array $existingKeys
-     * @return void
      */
-    protected function extractAfterKeys(array &$arrayKeysWithPosition, array $existingKeys)
+    private function extractAfterKeys(array &$arrayKeysWithPosition, array $existingKeys): void
     {
         $this->afterKeys = [];
         foreach ($arrayKeysWithPosition as $key => $position) {
@@ -267,13 +232,12 @@ class PositionalArraySorter
      *
      * @return array an associative array where each key of $subject has a position string assigned
      */
-    protected function collectArrayKeysAndPositions(): array
+    private function collectArrayKeysAndPositions(): array
     {
         $arrayKeysWithPosition = [];
 
         foreach ($this->subject as $key => $value) {
-            // if the value was set to NULL it was unset and should not be used
-            if ($value === null) {
+            if ($value === null && $this->removeNullValues) {
                 continue;
             }
             $position = ObjectAccess::getPropertyPath($value, $this->positionPropertyPath);
@@ -291,10 +255,8 @@ class PositionalArraySorter
 
     /**
      * Flattens start-, middle-, end-, before- and afterKeys to a single dimension and merges them together to a single array
-     *
-     * @return array
      */
-    protected function generateSortedKeysMap(): array
+    private function generateSortedKeysMap(): array
     {
         $sortedKeysMap = [];
 

--- a/Neos.Utility.Arrays/Classes/PositionalArraySorter.php
+++ b/Neos.Utility.Arrays/Classes/PositionalArraySorter.php
@@ -14,8 +14,6 @@ namespace Neos\Utility;
  * source code.
  */
 
-use Neos\Utility\Exception\InvalidPositionException;
-
 /**
  * Flexible array sorter that sorts an array according to a "position" metadata.
  * The expected format for the $subject is:
@@ -72,7 +70,7 @@ final class PositionalArraySorter
      * Returns a sorted copy of the subject array
      *
      * @return array
-     * @throws InvalidPositionException
+     * @throws Exception\InvalidPositionException
      */
     public function toArray(): array
     {

--- a/Neos.Utility.Arrays/Tests/Unit/PositionalArraySorterTest.php
+++ b/Neos.Utility.Arrays/Tests/Unit/PositionalArraySorterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Neos\Utility\Arrays\Tests\Unit;
 
 /*
@@ -22,7 +23,7 @@ class PositionalArraySorterTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      */
-    public function toArraySortsNumericKeysIfNoPositionMetaDataIsSet()
+    public function toArraySortsNumericKeysIfNoPositionMetaDataIsSet(): void
     {
         $array = [2 => 'foo', 1 => 'bar', 'z' => 'baz', 'a' => 'quux'];
         $expectedResult = ['z' => 'baz', 'a' => 'quux', 1 => 'bar', 2 => 'foo'];
@@ -35,143 +36,139 @@ class PositionalArraySorterTest extends \PHPUnit\Framework\TestCase
     /**
      * @return array
      */
-    public function invalidPositions()
+    public function invalidPositions(): iterable
     {
         return [
-            ['subject' => ['foo' => ['position' => 'invalid'], 'first' => []]],
-            ['subject' => ['foo' => ['position' => 'start123'], 'first' => []]],
-            ['subject' => ['foo' => ['position' => 'start 12 34'], 'first' => []]],
-            ['subject' => ['foo' => ['position' => 'after 12 34 56'], 'first' => []]],
-            ['subject' => ['third' => ['position' => 'before nonexisting'], 'first' => []]],
-            ['subject' => ['third' => ['position' => 'after nonexisting'], 'first' => []]],
+            ['subject' => ['foo' => ['position' => 'invalid'], 'first' => []], 'expectedExceptionMessage' => 'The positional string "invalid" (defined for key "foo") is not supported.'],
+            ['subject' => ['foo' => ['position' => 'start123'], 'first' => []], 'expectedExceptionMessage' => 'The positional string "start123" (defined for key "foo") is not supported.'],
+            ['subject' => ['foo' => ['position' => 'start 12 34'], 'first' => []], 'expectedExceptionMessage' => 'The positional string "start 12 34" (defined for key "foo") is not supported.'],
+            ['subject' => ['foo' => ['position' => 'after 12 34 56'], 'first' => []], 'expectedExceptionMessage' => 'The positional string "after 12 34 56" (defined for key "foo") is not supported.'],
+            ['subject' => ['third' => ['position' => 'before nonexisting'], 'first' => []], 'expectedExceptionMessage' => 'The positional string "before nonexisting" (defined for key "third") references a non-existing key.'],
+            ['subject' => ['third' => ['position' => 'after nonexisting'], 'first' => []], 'expectedExceptionMessage' => 'The positional string "after nonexisting" (defined for key "third") references a non-existing key.'],
         ];
     }
 
     /**
      * @test
      * @dataProvider invalidPositions
-     *
-     * @param array $subject
      */
-    public function toArrayThrowsExceptionForInvalidPositions(array $subject)
+    public function toArrayThrowsExceptionForInvalidPositions(array $subject, string $expectedExceptionMessage): void
     {
         $this->expectException(InvalidPositionException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
         $positionalArraySorter = new PositionalArraySorter($subject);
         $positionalArraySorter->toArray();
     }
 
-    /**
-     * @return array
-     */
-    public function sampleArrays()
+    public function sampleArrays(): iterable
     {
-        return [
-            [
-                'message' => 'Position end should put element to end',
-                'subject' => ['second' => ['__meta' => ['position' => 'end']], 'first' => []],
-                'positionPropertyPath' => '__meta.position',
-                'expectedArrayKeys' => ['first', 'second']
-            ],
-            [
-                'message' => 'Position start should put element to start',
-                'subject' => ['second' => [], 'first' => ['__meta' => ['position' => 'start']]],
-                'positionPropertyPath' => '__meta.position',
-                'expectedArrayKeys' => ['first', 'second']
-            ],
-            [
-                'message' => 'Position start should respect priority',
-                'subject' => ['second' => ['__meta' => ['position' => 'start 50']], 'first' => ['__meta' => ['position' => 'start 52']]],
-                'positionPropertyPath' => '__meta.position',
-                'expectedArrayKeys' => ['first', 'second']
-            ],
-            [
-                'message' => 'Position end should respect priority',
-                'subject' => ['second' => ['__meta' => ['position' => 'end 17']], 'first' => ['__meta' => ['position' => 'end']]],
-                'positionPropertyPath' => '__meta.position',
-                'expectedArrayKeys' => ['first', 'second']
-            ],
-            [
-                'Positional numbers are in the middle',
-                'subject' => ['last' => ['__meta' => ['position' => 'end']], 'second' => ['__meta' => ['position' => '17']], 'first' => ['__meta' => ['position' => '5']], 'third' => ['__meta' => ['position' => '18']]],
-                'positionPropertyPath' => '__meta.position',
-                'expectedArrayKeys' => ['first', 'second', 'third', 'last']
-            ],
-            [
-                'message' => 'Position before adds before named element if present',
-                'subject' => ['second' => [], 'first' => ['__meta' => ['position' => 'before second']]],
-                'positionPropertyPath' => '__meta.position',
-                'expectedArrayKeys' => ['first', 'second']
-            ],
-            [
-                'message' => 'Position before uses priority when referencing the same element; The higher the priority the closer before the element gets added.',
-                'subject' => ['third' => [], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before third 12']]],
-                'positionPropertyPath' => '__meta.position',
-                'expectedArrayKeys' => ['second', 'first', 'third']
-            ],
-            [
-                'message' => 'Position before works recursively',
-                'subject' => ['third' => [], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before second']]],
-                'positionPropertyPath' => '__meta.position',
-                'expectedArrayKeys' => ['first', 'second', 'third']
-            ],
-            [
-                'Position after adds after named element if present',
-                'subject' => ['second' => ['__meta' => ['position' => 'after first']], 'first' => []],
-                'positionPropertyPath' => '__meta.position',
-                'expectedArrayKeys' => ['first', 'second']
-            ],
-            [
-                'message' => 'Position after uses priority when referencing the same element; The higher the priority the closer after the element gets added.',
-                'subject' => ['third' => ['__meta' => ['position' => 'after first']], 'second' => ['__meta' => ['position' => 'after first 12']], 'first' => []],
-                'positionPropertyPath' => '__meta.position',
-                'expectedArrayKeys' => ['first', 'second', 'third']
-            ],
-            [
-                'message' => 'Position after works recursively',
-                'subject' => ['third' => ['__meta' => ['position' => 'after second']], 'second' => ['__meta' => ['position' => 'after first']], 'first' => []],
-                'positionPropertyPath' => '__meta.position',
-                'expectedArrayKeys' => ['first', 'second', 'third']
-            ],
-            [
-                'message' => 'Array keys may contain special characters',
-                'subject' => ['thi:rd' => ['position' => 'end'], 'sec.ond' => ['position' => 'before thi:rd'], 'fir-st' => ['position' => 'before sec.ond']],
-                'positionPropertyPath' => 'position',
-                'expectedArrayKeys' => ['fir-st', 'sec.ond', 'thi:rd']
-            ],
+        yield 'Position end should put element to end' => [
+            'subject' => ['second' => ['__meta' => ['position' => 'end']], 'first' => []],
+            'positionPropertyPath' => '__meta.position',
+            'removeNullValues' => true,
+            'expectedArrayKeys' => ['first', 'second']
+        ];
+        yield 'Position start should put element to start' => [
+            'subject' => ['second' => [], 'first' => ['__meta' => ['position' => 'start']]],
+            'positionPropertyPath' => '__meta.position',
+            'removeNullValues' => true,
+            'expectedArrayKeys' => ['first', 'second']
+        ];
+        yield 'Position start should respect priority' => [
+            'subject' => ['second' => ['__meta' => ['position' => 'start 50']], 'first' => ['__meta' => ['position' => 'start 52']]],
+            'positionPropertyPath' => '__meta.position',
+            'removeNullValues' => true,
+            'expectedArrayKeys' => ['first', 'second']
+        ];
+        yield 'Position end should respect priority' => [
+            'subject' => ['second' => ['__meta' => ['position' => 'end 17']], 'first' => ['__meta' => ['position' => 'end']]],
+            'positionPropertyPath' => '__meta.position',
+            'removeNullValues' => true,
+            'expectedArrayKeys' => ['first', 'second']
+        ];
+        yield 'Positional numbers are in the middle' => [
+            'subject' => ['last' => ['__meta' => ['position' => 'end']], 'second' => ['__meta' => ['position' => '17']], 'first' => ['__meta' => ['position' => '5']], 'third' => ['__meta' => ['position' => '18']]],
+            'positionPropertyPath' => '__meta.position',
+            'removeNullValues' => true,
+            'expectedArrayKeys' => ['first', 'second', 'third', 'last']
+        ];
+        yield 'Position before adds before named element if present' => [
+            'subject' => ['second' => [], 'first' => ['__meta' => ['position' => 'before second']]],
+            'positionPropertyPath' => '__meta.position',
+            'removeNullValues' => true,
+            'expectedArrayKeys' => ['first', 'second']
+        ];
+        yield 'Position before uses priority when referencing the same element; The higher the priority the closer before the element gets added.' => [
+            'subject' => ['third' => [], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before third 12']]],
+            'positionPropertyPath' => '__meta.position',
+            'removeNullValues' => true,
+            'expectedArrayKeys' => ['second', 'first', 'third']
+        ];
+        yield 'Position before works recursively' => [
+            'subject' => ['third' => [], 'second' => ['__meta' => ['position' => 'before third']], 'first' => ['__meta' => ['position' => 'before second']]],
+            'positionPropertyPath' => '__meta.position',
+            'removeNullValues' => true,
+            'expectedArrayKeys' => ['first', 'second', 'third']
+        ];
+        yield 'Position after adds after named element if present' => [
+            'subject' => ['second' => ['__meta' => ['position' => 'after first']], 'first' => []],
+            'positionPropertyPath' => '__meta.position',
+            'removeNullValues' => true,
+            'expectedArrayKeys' => ['first', 'second']
+        ];
+        yield 'Position after uses priority when referencing the same element; The higher the priority the closer after the element gets added.' => [
+            'subject' => ['third' => ['__meta' => ['position' => 'after first']], 'second' => ['__meta' => ['position' => 'after first 12']], 'first' => []],
+            'positionPropertyPath' => '__meta.position',
+            'removeNullValues' => true,
+            'expectedArrayKeys' => ['first', 'second', 'third']
+        ];
+        yield 'Position after works recursively' => [
+            'subject' => ['third' => ['__meta' => ['position' => 'after second']], 'second' => ['__meta' => ['position' => 'after first']], 'first' => []],
+            'positionPropertyPath' => '__meta.position',
+            'removeNullValues' => true,
+            'expectedArrayKeys' => ['first', 'second', 'third']
+        ];
+        yield 'Array keys may contain special characters' => [
+            'subject' => ['thi:rd' => ['position' => 'end'], 'sec.ond' => ['position' => 'before thi:rd'], 'fir-st' => ['position' => 'before sec.ond']],
+            'positionPropertyPath' => 'position',
+            'removeNullValues' => true,
+            'expectedArrayKeys' => ['fir-st', 'sec.ond', 'thi:rd']
+        ];
+        yield 'Null values are skipped by default' => [
+            'subject' => ['foo' => ['p' => 'end'], 'bar' => ['p' => 'start'], 'baz' => null],
+            'positionPropertyPath' => 'p',
+            'removeNullValues' => true,
+            'expectedArrayKeys' => ['bar', 'foo']
+        ];
+        yield 'Null values are kept if removeNullValues is set to false' => [
+            'subject' => ['foo' => ['p' => 'end'], 'bar' => ['p' => 'start'], 'baz' => null],
+            'positionPropertyPath' => 'p',
+            'removeNullValues' => false,
+            'expectedArrayKeys' => ['bar', 'baz', 'foo']
         ];
     }
 
     /**
      * @test
      * @dataProvider sampleArrays
-     *
-     * @param string $message
-     * @param array $subject
-     * @param string $positionPropertyPath
-     * @param array $expectedKeyOrder
      */
-    public function toArrayTests($message, array $subject, $positionPropertyPath, array $expectedKeyOrder)
+    public function toArrayTests(array $subject, $positionPropertyPath, ?bool $removeNullValues, array $expectedKeyOrder): void
     {
-        $positionalArraySorter = new PositionalArraySorter($subject, $positionPropertyPath);
+        $positionalArraySorter = new PositionalArraySorter($subject, $positionPropertyPath, $removeNullValues);
         $result = $positionalArraySorter->toArray();
 
-        self::assertSame($expectedKeyOrder, array_keys($result), $message);
+        self::assertSame($expectedKeyOrder, array_keys($result));
     }
 
     /**
      * @test
      * @dataProvider sampleArrays
-     *
-     * @param string $message
-     * @param array $subject
-     * @param string $positionPropertyPath
-     * @param array $expectedKeyOrder
      */
-    public function getSortedKeysTests($message, array $subject, $positionPropertyPath, array $expectedKeyOrder)
+    public function getSortedKeysTests(array $subject, $positionPropertyPath, ?bool $removeNullValues, array $expectedKeyOrder): void
     {
-        $positionalArraySorter = new PositionalArraySorter($subject, $positionPropertyPath);
+        $positionalArraySorter = new PositionalArraySorter($subject, $positionPropertyPath, $removeNullValues);
         $result = $positionalArraySorter->getSortedKeys();
 
-        self::assertSame($expectedKeyOrder, $result, $message);
+        self::assertSame($expectedKeyOrder, $result);
     }
 }


### PR DESCRIPTION
By default, the `PositionalArraySorter` removes all `null` values. This change makes this behavior an _option_ that can be passed to the constructor:

```php
(new PositionalArraySorter(['foo' => null]))->toArray(); // []
(new PositionalArraySorter(['foo' => null], removeNullValues: false))->toArray(); // ['foo']
```

Besides, this cleans up the code and tests