### PR TITLE
!!! TASK: Deprecate concepts `addQueryString` and `argumentsToBeExcludedFromQueryString`

### DIFF
--- a/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
+++ b/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
@@ -73,11 +73,13 @@ class UriBuilder
 
     /**
      * @var boolean
+     * @deprecated with Flow 9.0
      */
     protected $addQueryString = false;
 
     /**
      * @var array
+     * @deprecated with Flow 9.0
      */
     protected $argumentsToBeExcludedFromQueryString = [];
 
@@ -205,7 +207,7 @@ class UriBuilder
      *
      * @param boolean $addQueryString
      * @return UriBuilder the current UriBuilder to allow method chaining
-     * @api
+     * @deprecated with Flow 9.0
      */
     public function setAddQueryString($addQueryString)
     {
@@ -215,7 +217,7 @@ class UriBuilder
 
     /**
      * @return boolean
-     * @api
+     * @deprecated with Flow 9.0
      */
     public function getAddQueryString()
     {
@@ -228,7 +230,7 @@ class UriBuilder
      *
      * @param array $argumentsToBeExcludedFromQueryString
      * @return UriBuilder the current UriBuilder to allow method chaining
-     * @api
+     * @deprecated with Flow 9.0
      */
     public function setArgumentsToBeExcludedFromQueryString(array $argumentsToBeExcludedFromQueryString)
     {
@@ -238,7 +240,7 @@ class UriBuilder
 
     /**
      * @return array
-     * @api
+     * @deprecated with Flow 9.0
      */
     public function getArgumentsToBeExcludedFromQueryString()
     {

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/FormViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/FormViewHelper.php
@@ -118,12 +118,13 @@ class FormViewHelper extends AbstractFormViewHelper
         $this->registerArgument('format', 'string', 'The requested format, e.g. ".html"', false, '');
         $this->registerArgument('additionalParams', 'array', 'additional query parameters that won\'t be prefixed like $arguments (overrule $arguments)', false, []);
         $this->registerArgument('absolute', 'boolean', 'If set, an absolute action URI is rendered (only active if $actionUri is not set)', false, false);
-        $this->registerArgument('addQueryString', 'boolean', 'If set, the current query parameters will be kept in the URI', false, false);
-        $this->registerArgument('argumentsToBeExcludedFromQueryString', 'array', 'arguments to be removed from the URI. Only active if $addQueryString = true', false, []);
         $this->registerArgument('fieldNamePrefix', 'string', 'Prefix that will be added to all field names within this form', false, null);
         $this->registerArgument('actionUri', 'string', 'can be used to overwrite the "action" attribute of the form tag', false, null);
         $this->registerArgument('objectName', 'string', 'name of the object that is bound to this form. If this argument is not specified, the name attribute of this form is used to determine the FormObjectName', false, null);
         $this->registerArgument('useParentRequest', 'boolean', 'If set, the parent Request will be used instead ob the current one', false, false);
+        // @deprecated with Flow 9:
+        $this->registerArgument('addQueryString', 'boolean', 'Deprecated with Flow 9. If set, the current query parameters will be kept in the URI', false, false);
+        $this->registerArgument('argumentsToBeExcludedFromQueryString', 'array', 'Deprecated with Flow 9. arguments to be removed from the URI. Only active if $addQueryString = true', false, []);
 
         $this->registerUniversalTagAttributes();
     }

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Link/ActionViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Link/ActionViewHelper.php
@@ -66,11 +66,12 @@ class ActionViewHelper extends AbstractTagBasedViewHelper
         $this->registerArgument('section', 'string', 'The anchor to be added to the URI', false, '');
         $this->registerArgument('format', 'string', 'The requested format, e.g. ".html"', false, '');
         $this->registerArgument('additionalParams', 'array', 'additional query parameters that won\'t be prefixed like $arguments (overrule $arguments)', false, []);
-        $this->registerArgument('addQueryString', 'boolean', 'If set, the current query parameters will be kept in the URI', false, false);
-        $this->registerArgument('argumentsToBeExcludedFromQueryString', 'array', 'arguments to be removed from the URI. Only active if $addQueryString = true', false, []);
         $this->registerArgument('useParentRequest', 'boolean', 'If set, the parent Request will be used instead of the current one. Note: using this argument can be a sign of undesired tight coupling, use with care', false, false);
         $this->registerArgument('absolute', 'boolean', 'By default this ViewHelper renders links with absolute URIs. If this is false, a relative URI is created instead', false, true);
         $this->registerArgument('useMainRequest', 'boolean', 'If set, the main Request will be used instead of the current one. Note: using this argument can be a sign of undesired tight coupling, use with care', false, false);
+        // @deprecated with Flow 9:
+        $this->registerArgument('addQueryString', 'boolean', 'Deprecated with Flow 9. If set, the current query parameters will be kept in the URI', false, false);
+        $this->registerArgument('argumentsToBeExcludedFromQueryString', 'array', 'Deprecated with Flow 9. arguments to be removed from the URI. Only active if $addQueryString = true', false, []);
     }
 
     /**

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Uri/ActionViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Uri/ActionViewHelper.php
@@ -57,10 +57,11 @@ class ActionViewHelper extends AbstractViewHelper
         $this->registerArgument('format', 'string', 'The requested format, e.g. ".html"', false, '');
         $this->registerArgument('additionalParams', 'array', 'additional query parameters that won\'t be prefixed like $arguments (overrule $arguments)', false, []);
         $this->registerArgument('absolute', 'boolean', 'By default this ViewHelper renders links with absolute URIs. If this is false, a relative URI is created instead', false, false);
-        $this->registerArgument('addQueryString', 'boolean', 'If set, the current query parameters will be kept in the URI', false, false);
-        $this->registerArgument('argumentsToBeExcludedFromQueryString', 'array', 'arguments to be removed from the URI. Only active if $addQueryString = true', false, []);
         $this->registerArgument('useParentRequest', 'boolean', 'If set, the parent Request will be used instead of the current one. Note: using this argument can be a sign of undesired tight coupling, use with care', false, false);
         $this->registerArgument('useMainRequest', 'boolean', 'If set, the main Request will be used instead of the current one. Note: using this argument can be a sign of undesired tight coupling, use with care', false, false);
+        // @deprecated with Flow 9:
+        $this->registerArgument('addQueryString', 'boolean', 'Deprecated with Flow 9. If set, the current query parameters will be kept in the URI', false, false);
+        $this->registerArgument('argumentsToBeExcludedFromQueryString', 'array', 'Deprecated with Flow 9. arguments to be removed from the URI. Only active if $addQueryString = true', false, []);
     }
 
     /**


### PR DESCRIPTION
in flows uri building APIs

See discussion at https://github.com/neos/neos-development-collection/issues/5076

Affected Fluid viewhelpers
- `<f:form />`
- `<f:link.action />`
- `<f:uri.action />`

Affected PHP APIs
- `UriBuilder::setAddQueryString`
- `UriBuilder::setArgumentsToBeExcludedFromQueryString`

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
