### PR TITLE
TASK: Update "egulias/email-validator" version constraints 

### DIFF
--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -55,7 +55,7 @@
 
         "composer/composer": "~2.2.24 || ^2.7.7",
 
-        "egulias/email-validator": "^2.1.17 || ^3.0"
+        "egulias/email-validator": "^3.0||^4.0"
     },
     "require-dev": {
         "mikey179/vfsstream": "^1.6.10",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/dom-crawler": "^5.1||^6.0",
         "symfony/console": "^5.1||^6.0",
         "composer/composer": "~2.2.24 || ^2.7.7",
-        "egulias/email-validator": "^2.1.17 || ^3.0",
+        "egulias/email-validator": "^3.0||^4.0",
         "typo3fluid/fluid": "~2.7.0",
         "guzzlehttp/psr7": "^1.8.4 || ^2.1.1",
         "ext-mbstring": "*"


### PR DESCRIPTION
Updates the version constraints of "egulias/email-validator" and allows to use 4.x versions. 
Also removes the support of the 2.x versions