### PR TITLE
BUGFIX: ReflectionService must always initialize

### DIFF
--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1153,6 +1153,10 @@ class ReflectionService
      */
     public function getClassSchema($classNameOrObject)
     {
+        if (!$this->initialized) {
+            $this->initialize();
+        }
+
         $className = $classNameOrObject;
         if (is_object($classNameOrObject)) {
             $className = TypeHandling::getTypeForValue($classNameOrObject);
@@ -1331,6 +1335,10 @@ class ReflectionService
      */
     public function reflectClassProperty($className, PropertyReflection $property)
     {
+        if (!$this->initialized) {
+            $this->initialize();
+        }
+
         $propertyName = $property->getName();
         $this->classReflectionData[$className][self::DATA_CLASS_PROPERTIES][$propertyName] = [];
         if ($property->hasType()) {


### PR DESCRIPTION
The ReflectionService lazy loads reflection data from cache, but every method making use of the data needs to call initialize.
This change adds missing calls that seem to never happen first in regular flow applications. Still better to prevent broken reflection in case we optimize other uses in the future.
