### PR TITLE
TASK: Benchmark basics

### DIFF
--- a/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
+++ b/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
@@ -25,7 +25,6 @@ use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Security\Context;
 use Neos\Flow\Session\SessionInterface;
 use Neos\Flow\Session\SessionManager;
-use Neos\Flow\Tests\FunctionalTestRequestHandler;
 use Neos\Flow\Validation\ValidatorResolver;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -126,8 +125,7 @@ class InternalRequestEngine implements RequestEngineInterface
         }
 
         $requestHandler = $this->bootstrap->getActiveRequestHandler();
-        /** @phpstan-ignore-next-line composer doesnt autoload this class */
-        if (!$requestHandler instanceof FunctionalTestRequestHandler) {
+        if (!$this->bootstrap->getContext()->isTesting()) {
             throw new Http\Exception('The browser\'s internal request engine has only been designed for use within functional tests.', 1335523749);
         }
 

--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -56,6 +56,8 @@ class Package extends BasePackage
         }
 
         if ($context->isTesting()) {
+            // TODO: This is technically not necessary as we can register the request handler in the functional bootstrap
+            // A future commit will remove this aftter BuildEssentials is adapted
             /** @phpstan-ignore-next-line composer doesnt autoload this class */
             $bootstrap->registerRequestHandler(new Tests\FunctionalTestRequestHandler($bootstrap));
         }

--- a/Neos.Flow/Classes/Testing/RequestHandler/EmptyRequestHandler.php
+++ b/Neos.Flow/Classes/Testing/RequestHandler/EmptyRequestHandler.php
@@ -17,7 +17,7 @@ use Neos\Flow\Core\RequestHandlerInterface;
  *
  * @Flow\Proxy(false)
  */
-class EmptyRequestHandler implements RequestHandlerInterface
+final class EmptyRequestHandler implements RequestHandlerInterface
 {
     public function handleRequest(): void
     {

--- a/Neos.Flow/Classes/Testing/RequestHandler/EmptyRequestHandler.php
+++ b/Neos.Flow/Classes/Testing/RequestHandler/EmptyRequestHandler.php
@@ -11,9 +11,14 @@ namespace Neos\Flow\Testing\RequestHandler;
 
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Core\RequestHandlerInterface;
+use Neos\Flow\Tests\PhpBench\Core\BootstrapBench;
 
 /**
- * A test request handler that does absolutely nothing
+ * A test request handler that does absolutely nothing.
+ *
+ * Useful for testing a Flow Bootstrap without having run a full boot sequence. E.g. performance of
+ * Bootstrap->run() without boot sequence (to compare against with boot sequence).
+ * @see BootstrapBench
  *
  * @Flow\Proxy(false)
  */

--- a/Neos.Flow/Classes/Testing/RequestHandler/EmptyRequestHandler.php
+++ b/Neos.Flow/Classes/Testing/RequestHandler/EmptyRequestHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * (c) Contributors of the Neos Project - www.neos.io
+ * Please see the LICENSE file which was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Testing\RequestHandler;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Core\RequestHandlerInterface;
+
+/**
+ * A test request handler that does absolutely nothing
+ *
+ * @Flow\Proxy(false)
+ */
+class EmptyRequestHandler implements RequestHandlerInterface
+{
+    public function handleRequest(): void
+    {
+    }
+
+    public function canHandleRequest(): bool
+    {
+        return true;
+    }
+
+    public function getPriority(): int
+    {
+        return 0;
+    }
+}

--- a/Neos.Flow/Classes/Testing/RequestHandler/RuntimeSequenceHttpRequestHandler.php
+++ b/Neos.Flow/Classes/Testing/RequestHandler/RuntimeSequenceHttpRequestHandler.php
@@ -15,7 +15,7 @@ use Neos\Flow\Http\HttpRequestHandlerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
- * Everything from `RuntimeSequenceInvokingRequestHandler` applies to this.
+ * Everything from {@see RuntimeSequenceInvokingRequestHandler} applies to this.
  *
  * Additionally, it also provides some support for HTTP request testing scenarios.
  * For that reason it features a setRequest() method which is used by the FunctionalTestCase

--- a/Neos.Flow/Classes/Testing/RequestHandler/RuntimeSequenceHttpRequestHandler.php
+++ b/Neos.Flow/Classes/Testing/RequestHandler/RuntimeSequenceHttpRequestHandler.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * (c) Contributors of the Neos Project - www.neos.io
+ * Please see the LICENSE file which was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Testing\RequestHandler;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Http\HttpRequestHandlerInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Everything from `RuntimeSequenceInvokingRequestHandler` applies to this.
+ *
+ * Additionally, it also provides some support for HTTP request testing scenarios.
+ * For that reason it features a setRequest() method which is used by the FunctionalTestCase
+ * for setting the current HTTP request. That way, the request handler acts pretty much
+ * like the Http\RequestHandler from a client code perspective.
+ *
+ * @Flow\Scope("singleton")
+ * @Flow\Proxy(false)
+ */
+class RuntimeSequenceHttpRequestHandler extends RuntimeSequenceInvokingRequestHandler implements HttpRequestHandlerInterface
+{
+    private ServerRequestInterface|null $httpRequest;
+
+    /**
+     * @param ServerRequestInterface $request
+     */
+    public function setHttpRequest(ServerRequestInterface $request): void
+    {
+        $this->httpRequest = $request;
+    }
+
+    /**
+     * Returns the currently processed HTTP request
+     *
+     * @return ServerRequestInterface
+     */
+    public function getHttpRequest(): ServerRequestInterface
+    {
+        if ($this->httpRequest === null) {
+            $this->httpRequest = ServerRequest::fromGlobals();
+        }
+
+        return $this->httpRequest;
+    }
+}

--- a/Neos.Flow/Classes/Testing/RequestHandler/RuntimeSequenceInvokingRequestHandler.php
+++ b/Neos.Flow/Classes/Testing/RequestHandler/RuntimeSequenceInvokingRequestHandler.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * (c) Contributors of the Neos Project - www.neos.io
+ * Please see the LICENSE file which was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Testing\RequestHandler;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\Core\RequestHandlerInterface;
+
+/**
+ * A request handler which boots up Flow into a basic runtime level and then returns
+ * without actually further handling anything.
+ *
+ * As this request handler will be the "active" request handler returned by
+ * the bootstrap's getActiveRequestHandler() method.
+ *
+ * @Flow\Scope("singleton")
+ * @Flow\Proxy(false)
+ */
+class RuntimeSequenceInvokingRequestHandler implements RequestHandlerInterface
+{
+    /**
+     * @var \Neos\Flow\Core\Bootstrap
+     */
+    protected $bootstrap;
+
+    /**
+     * Constructor
+     *
+     * @param \Neos\Flow\Core\Bootstrap $bootstrap
+     */
+    public function __construct(Bootstrap $bootstrap)
+    {
+        $this->bootstrap = $bootstrap;
+    }
+
+    /**
+     * This request handler can handle requests in Testing Context.
+     *
+     * @return boolean If the context is Testing, true otherwise false
+     */
+    public function canHandleRequest()
+    {
+        return true;
+    }
+
+    /**
+     * Returns the priority - how eager the handler is to actually handle the
+     * request.
+     *
+     * As this request handler can only be used as a preselected request handler,
+     * the priority for all other cases is 0.
+     *
+     * @return integer The priority of the request handler.
+     */
+    public function getPriority()
+    {
+        return 0;
+    }
+
+    /**
+     * Handles a command line request
+     *
+     * @return void
+     */
+    public function handleRequest()
+    {
+        $sequence = $this->bootstrap->buildRuntimeSequence();
+        $sequence->invoke($this->bootstrap);
+    }
+}

--- a/Neos.Flow/Classes/Testing/RequestHandler/RuntimeSequenceInvokingRequestHandler.php
+++ b/Neos.Flow/Classes/Testing/RequestHandler/RuntimeSequenceInvokingRequestHandler.php
@@ -25,10 +25,7 @@ use Neos\Flow\Core\RequestHandlerInterface;
  */
 class RuntimeSequenceInvokingRequestHandler implements RequestHandlerInterface
 {
-    /**
-     * @var \Neos\Flow\Core\Bootstrap
-     */
-    protected $bootstrap;
+    protected Bootstrap $bootstrap;
 
     /**
      * Constructor
@@ -45,7 +42,7 @@ class RuntimeSequenceInvokingRequestHandler implements RequestHandlerInterface
      *
      * @return boolean If the context is Testing, true otherwise false
      */
-    public function canHandleRequest()
+    public function canHandleRequest(): bool
     {
         return true;
     }
@@ -59,7 +56,7 @@ class RuntimeSequenceInvokingRequestHandler implements RequestHandlerInterface
      *
      * @return integer The priority of the request handler.
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 0;
     }
@@ -69,7 +66,7 @@ class RuntimeSequenceInvokingRequestHandler implements RequestHandlerInterface
      *
      * @return void
      */
-    public function handleRequest()
+    public function handleRequest(): void
     {
         $sequence = $this->bootstrap->buildRuntimeSequence();
         $sequence->invoke($this->bootstrap);

--- a/Neos.Flow/Tests/PhpBench/Configuration/ConfigurationManagerBench.php
+++ b/Neos.Flow/Tests/PhpBench/Configuration/ConfigurationManagerBench.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * (c) Contributors of the Neos Project - www.neos.io
+ * Please see the LICENSE file which was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Tests\PhpBench\Configuration;
+
+use Neos\BuildEssentials\PhpBench\FrameworkEnabledBenchmark;
+use Neos\Flow\Configuration\ConfigurationManager;
+
+/**
+ *
+ */
+class ConfigurationManagerBench extends FrameworkEnabledBenchmark
+{
+    /**
+     * @BeforeMethods("bootstrapWithTestRequestHandler")
+     * @Revs(5)
+     */
+    public function benchGetSettings(): void
+    {
+        /** @var ConfigurationManager $configurationManager */
+        $configurationManager = $this->flowBootstrap->getObjectManager()->get(ConfigurationManager::class);
+        $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS);
+    }
+
+    /**
+     * @BeforeMethods("bootstrapWithTestRequestHandler")
+     * @Revs(5)
+     */
+    public function benchGetRoutes(): void
+    {
+        /** @var ConfigurationManager $configurationManager */
+        $configurationManager = $this->flowBootstrap->getObjectManager()->get(ConfigurationManager::class);
+        $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_ROUTES);
+    }
+
+    /**
+     * @BeforeMethods("bootstrapWithTestRequestHandler")
+     * @Revs(5)
+     */
+    public function benchRefreshConfiguration(): void
+    {
+        /** @var ConfigurationManager $configurationManager */
+        $configurationManager = $this->flowBootstrap->getObjectManager()->get(ConfigurationManager::class);
+        $configurationManager->refreshConfiguration();
+    }
+}

--- a/Neos.Flow/Tests/PhpBench/Configuration/ConfigurationManagerBench.php
+++ b/Neos.Flow/Tests/PhpBench/Configuration/ConfigurationManagerBench.php
@@ -13,7 +13,8 @@ use Neos\BuildEssentials\PhpBench\FrameworkEnabledBenchmark;
 use Neos\Flow\Configuration\ConfigurationManager;
 
 /**
- *
+ * Benchmark cases for the ConfigurationManager
+ * Check performance of getting different types of configuration and handling the low level configuration caches.
  */
 class ConfigurationManagerBench extends FrameworkEnabledBenchmark
 {

--- a/Neos.Flow/Tests/PhpBench/Core/BootstrapBench.php
+++ b/Neos.Flow/Tests/PhpBench/Core/BootstrapBench.php
@@ -16,7 +16,8 @@ use Neos\Flow\Testing\RequestHandler\EmptyRequestHandler;
 use Neos\Flow\Testing\RequestHandler\RuntimeSequenceInvokingRequestHandler;
 
 /**
- *
+ * Benchmark cases for the Flow bootstrap
+ * Shows performance of constructing and running a bootstrap and also a full runtime boot sequence
  */
 class BootstrapBench extends FrameworkEnabledBenchmark
 {

--- a/Neos.Flow/Tests/PhpBench/Core/BootstrapBench.php
+++ b/Neos.Flow/Tests/PhpBench/Core/BootstrapBench.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * (c) Contributors of the Neos Project - www.neos.io
+ * Please see the LICENSE file which was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Tests\PhpBench\Core;
+
+use Neos\BuildEssentials\PhpBench\FrameworkEnabledBenchmark;
+use Neos\BuildEssentials\TestableFramework;
+use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\Testing\RequestHandler\EmptyRequestHandler;
+use Neos\Flow\Testing\RequestHandler\RuntimeSequenceInvokingRequestHandler;
+
+/**
+ *
+ */
+class BootstrapBench extends FrameworkEnabledBenchmark
+{
+    /**
+     * How long does constructing the bootstrap take
+     *
+     * @BeforeMethods("withRootPath")
+     * @Revs(5)
+     */
+    public function benchBootstrapConstruct(): void
+    {
+        $flowBootstrap = new Bootstrap(TestableFramework::getApplicationContext());
+    }
+
+    /**
+     * How long does creating a bootstrap and running an (empty) request handler take
+     *
+     * @BeforeMethods("withRootPath")
+     * @Revs(5)
+     */
+    public function benchBootstrapRunWithoutBootSequence(): void
+    {
+        $flowBootstrap = new Bootstrap(TestableFramework::getApplicationContext());
+        $flowBootstrap->registerRequestHandler(new EmptyRequestHandler());
+        $flowBootstrap->setPreselectedRequestHandlerClassName(EmptyRequestHandler::class);
+        $flowBootstrap->run();
+    }
+
+    /**
+     * How long does the runtime boot sequence take
+     * Warmup of 1 cycle to trigger compile outside of the measurement
+     *
+     * @BeforeMethods("withRootPath")
+     * @Revs(3)
+     * @Warmup(1)
+     */
+    public function benchBootstrapRunWithRuntimeBootSequence(): void
+    {
+        $flowBootstrap = new Bootstrap(TestableFramework::getApplicationContext());
+        $flowBootstrap->registerRequestHandler(new RuntimeSequenceInvokingRequestHandler($flowBootstrap));
+        $flowBootstrap->setPreselectedRequestHandlerClassName(RuntimeSequenceInvokingRequestHandler::class);
+        $flowBootstrap->run();
+    }
+}

--- a/Neos.Flow/Tests/PhpBench/Package/PackageManagerBench.php
+++ b/Neos.Flow/Tests/PhpBench/Package/PackageManagerBench.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * (c) Contributors of the Neos Project - www.neos.io
+ * Please see the LICENSE file which was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Tests\PhpBench\Package;
+
+use Neos\BuildEssentials\PhpBench\FrameworkEnabledBenchmark;
+use Neos\Flow\Package\PackageManager;
+
+/**
+ *
+ */
+class PackageManagerBench extends FrameworkEnabledBenchmark
+{
+    /**
+     * @BeforeMethods("bootstrapWithTestRequestHandler")
+     * @Revs(5)
+     */
+    public function benchGetPackageManager()
+    {
+        $this->flowBootstrap->getObjectManager()->get(PackageManager::class);
+    }
+
+    /**
+     * @BeforeMethods("bootstrapWithTestRequestHandler")
+     * @Revs(5)
+     */
+    public function benchIsPackageAvailable(): void
+    {
+        $packageManager = $this->flowBootstrap->getObjectManager()->get(PackageManager::class);
+        $packageManager->isPackageAvailable('Neos.Flow');
+    }
+
+    /**
+     * @BeforeMethods("bootstrapWithTestRequestHandler")
+     * @Revs(5)
+     */
+    public function benchGetPackageKeyFromComposerName(): void
+    {
+        $packageManager = $this->flowBootstrap->getObjectManager()->get(PackageManager::class);
+        $packageManager->getPackageKeyFromComposerName('neos/flow');
+    }
+}

--- a/Neos.Flow/Tests/PhpBench/Package/PackageManagerBench.php
+++ b/Neos.Flow/Tests/PhpBench/Package/PackageManagerBench.php
@@ -13,7 +13,8 @@ use Neos\BuildEssentials\PhpBench\FrameworkEnabledBenchmark;
 use Neos\Flow\Package\PackageManager;
 
 /**
- *
+ * PackageManager benchmark cases
+ * Checks performance for various basic operations used in the codebase.
  */
 class PackageManagerBench extends FrameworkEnabledBenchmark
 {

--- a/Neos.Flow/Tests/PhpBench/ResourceManagement/PersistentResourceBench.php
+++ b/Neos.Flow/Tests/PhpBench/ResourceManagement/PersistentResourceBench.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * (c) Contributors of the Neos Project - www.neos.io
+ * Please see the LICENSE file which was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Tests\PhpBench\ResourceManagement;
+
+use Neos\BuildEssentials\PhpBench\FrameworkEnabledBenchmark;
+use Neos\Flow\Persistence\PersistenceManagerInterface;
+use Neos\Flow\Reflection\ReflectionService;
+use Neos\Flow\ResourceManagement\PersistentResource;
+use Neos\Flow\ResourceManagement\ResourceRepository;
+
+/**
+ * @BeforeClassMethods("enablePersistence")
+ * @AfterClassMethods("cleanUpPersistence")
+ */
+class PersistentResourceBench extends FrameworkEnabledBenchmark
+{
+    public static function enablePersistence(): void
+    {
+        parent::enablePersistence();
+    }
+
+    /**
+     * This should be a good measure of our UUID persistence magic aspect
+     *
+     * @BeforeMethods("bootstrapWithTestRequestHandler")
+     * @Revs(10)
+     */
+    public function benchCreatePersistentResourceObjectWithoutPersist(): void
+    {
+        $persistentResource = new PersistentResource();
+    }
+
+    /**
+     * We should actually benchmark things like this in a benchmark for the ReflectionService
+     *
+     * @BeforeMethods("bootstrapWithTestRequestHandler")
+     * @Revs(10)
+     */
+    public function benchRequestPersistentResourceSchema(): void
+    {
+        /** @var ReflectionService $reflectionService */
+        $reflectionService = $this->flowBootstrap->getObjectManager()->get(ReflectionService::class);
+        $reflectionService->getClassSchema(PersistentResource::class);
+    }
+
+    /**
+     * Create and persist a resource object, mostly a test for ORM enetity persistence speed
+     *
+     * @BeforeMethods("bootstrapWithTestRequestHandler")
+     * @Revs(3)
+     */
+    public function benchCreatePersistentResourceObjectAndPersist(): void
+    {
+        $resourceRepository = $this->flowBootstrap->getObjectManager()->get(ResourceRepository::class);
+        $persistentResource = new PersistentResource();
+        $persistentResource->disableLifecycleEvents();
+        $persistentResource->setFilename('benchCreatePersistentResourceObjectAndPersist.empty');
+        $persistentResource->setFileSize(0);
+        $persistentResource->setCollectionName('default');
+        $persistentResource->setMediaType('text/plain');
+        $persistentResource->setSha1('da39a3ee5e6b4b0d3255bfef95601890afd80709');
+        $resourceRepository->add($persistentResource);
+        $persistenceManager = $this->flowBootstrap->getObjectManager()->get(PersistenceManagerInterface::class);
+        $persistenceManager->persistAll();
+    }
+}

--- a/Neos.Flow/Tests/PhpBench/ResourceManagement/PersistentResourceBench.php
+++ b/Neos.Flow/Tests/PhpBench/ResourceManagement/PersistentResourceBench.php
@@ -16,6 +16,10 @@ use Neos\Flow\ResourceManagement\PersistentResource;
 use Neos\Flow\ResourceManagement\ResourceRepository;
 
 /**
+ * Benchmark cases for PersistentResources
+ * Checks performance of creating a PersistentResource (object) as
+ * well as persisting it via ORM
+ *
  * @BeforeClassMethods("enablePersistence")
  * @AfterClassMethods("cleanUpPersistence")
  */

--- a/Neos.Utility.Arrays/Tests/PhpBench/PositionalArraySorterBench.php
+++ b/Neos.Utility.Arrays/Tests/PhpBench/PositionalArraySorterBench.php
@@ -5,7 +5,9 @@ namespace Neos\Utility\Arrays\Tests\PhpBench;
 use Neos\Utility\PositionalArraySorter;
 
 /**
- *
+ * PositionalArraySorter benchmark cases
+ * Provides values for basic cases of using it, given that we make heavy use of this throughout the codebase it is
+ * important this doesn't slow down and is as optimized as possible.
  */
 class PositionalArraySorterBench
 {

--- a/Neos.Utility.Arrays/Tests/PhpBench/PositionalArraySorterBench.php
+++ b/Neos.Utility.Arrays/Tests/PhpBench/PositionalArraySorterBench.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Neos\Utility\Arrays\Tests\PhpBench;
+
+use Neos\Utility\PositionalArraySorter;
+
+/**
+ *
+ */
+class PositionalArraySorterBench
+{
+    /**
+     * Ideally this should be a noop as there is nothing to sort
+     * @Revs(20)
+     */
+    public function benchEmptyArray(): void
+    {
+        $positionalArraySorter = new PositionalArraySorter([]);
+        $positionalArraySorter->toArray();
+    }
+
+    /**
+     * Ideally a noop as well because a single entry will always be firstt and last regardless of position
+     * @Revs(20)
+     */
+    public function benchSingleEntry(): void
+    {
+        $positionalArraySorter = new PositionalArraySorter([
+            'ten' => [
+                'position' => 10,
+                'value' => 10
+            ]
+        ]);
+        $positionalArraySorter->toArray();
+    }
+
+    /**
+     * Few entrires with sorting props
+     * @Revs(20)
+     */
+    public function benchWithSortingProperties(): void
+    {
+        $positionalArraySorter = new PositionalArraySorter([
+            'ten' => [
+                'position' => 10,
+                'value' => 10
+            ],
+            'beforeTen' => [
+                'position' => 'before ten',
+                'value' => 'first'
+            ],
+            'justSomewhere' => [
+                'position' => 'end',
+                'value' => 'some value'
+            ],
+            'theLast' => [
+                'position' => 'end 9999',
+                'value' => 'the lastest'
+            ]
+        ]);
+        $positionalArraySorter->toArray();
+    }
+
+    /**
+     * Few entries but without sorting props
+     * @Revs(20)
+     */
+    public function benchWithoutSortingProperties(): void
+    {
+        $positionalArraySorter = new PositionalArraySorter([
+            'ten' => [
+                'value' => 10
+            ],
+            'beforeTen' => [
+                'value' => 'first'
+            ],
+            'justSomewhere' => [
+                'value' => 'some value'
+            ],
+            'theLast' => [
+                'value' => 'the lastest'
+            ]
+        ]);
+        $positionalArraySorter->toArray();
+    }
+}


### PR DESCRIPTION
This includes the first set of benchmarks, mainly for testing phpbench but also gives some sensible insights about the framework.

To run these some more plumbing is needed in BuildEssentials and also the developement distribution. As the benchmarks are not automated yet, nothing should happen with this code for now and it's safe to add.

Two of the new Testing\RequestHandlers are used in benchmarks, the third is tentatively for functional tests so they all use the same basis. Using those needs to happen in BuildEssentials though.