### PR TITLE
BUGFIX: Avoid insecure composer/composer versions

### DIFF
--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -49,7 +49,7 @@
         "symfony/dom-crawler": "^5.1",
         "symfony/console": "^5.1",
 
-        "composer/composer": "^2.2.8",
+        "composer/composer": "~2.2.24 || ^2.7.7",
 
         "egulias/email-validator": "^2.1.17 || ^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/dom-crawler": "^5.1",
         "symfony/console": "^5.1",
         "neos/composer-plugin": "^2.0",
-        "composer/composer": "^2.2.8",
+        "composer/composer": "~2.2.24 || ^2.7.7",
         "egulias/email-validator": "^2.1.17 || ^3.0",
         "typo3fluid/fluid": "~2.7.0",
         "guzzlehttp/psr7": "^1.8.4",


### PR DESCRIPTION
This adjusts the dependency to `~2.2.24 || ^2.7.7` to avoid versions vulnerable to multiple command injections via malicious branch names.

More details in:

- https://blog.packagist.com/composer-2-7-7/
- https://github.com/advisories/GHSA-v9qv-c7wm-wgmf
- https://github.com/advisories/GHSA-47f6-5gq3-vx9c

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] ~Tests have been created, run and adjusted as needed~
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
