### PR TITLE
FEATURE: Introduce --help flag option for existing CLI commands

### DIFF
--- a/Neos.Flow/Classes/Cli/RequestBuilder.php
+++ b/Neos.Flow/Classes/Cli/RequestBuilder.php
@@ -118,13 +118,6 @@ class RequestBuilder
         $request = new Request();
         $request->setControllerObjectName(HelpCommandController::class);
 
-        if (is_array($commandLine) && in_array('--help', $commandLine, true)) {
-            $request->setControllerCommandName('help');
-            $request->setArguments(['commandIdentifier' => $commandLine[0]]);
-            $request->setControllerObjectName(HelpCommandController::class);
-            return $request;
-        }
-
         if (is_array($commandLine) === true) {
             $rawCommandLineArguments = $commandLine;
         } else {
@@ -147,14 +140,23 @@ class RequestBuilder
                 }
             }
         }
-        if (count($rawCommandLineArguments) === 0) {
+        $firstArgument = count($rawCommandLineArguments) ? trim(array_shift($rawCommandLineArguments)) : null;
+        if (
+            $firstArgument === null
+            || $firstArgument === '--help'
+        ) {
             $request->setControllerCommandName('helpStub');
 
             return $request;
         }
-        $commandIdentifier = trim(array_shift($rawCommandLineArguments));
+        if (in_array('--help', $rawCommandLineArguments, true)) {
+            $request->setControllerCommandName('help');
+            $request->setArguments(['commandIdentifier' => $firstArgument]);
+            return $request;
+        }
+
         try {
-            $command = $this->commandManager->getCommandByIdentifier($commandIdentifier);
+            $command = $this->commandManager->getCommandByIdentifier($firstArgument);
         } catch (CommandException $exception) {
             $request->setArgument('exception', $exception);
             $request->setControllerCommandName('error');
@@ -195,6 +197,9 @@ class RequestBuilder
         $requiredArguments = [];
         $optionalArguments = [];
         foreach ($commandMethodParameters as $parameterName => $parameterInfo) {
+            if ($parameterName === 'help') {
+                throw new \RuntimeException(sprintf('The option --help is reserved in %s::%s', $controllerObjectName, $commandMethodName), 1730715152);
+            }
             if ($parameterInfo['optional'] === false) {
                 $requiredArguments[strtolower($parameterName)] = [
                     'parameterName' => $parameterName,

--- a/Neos.Flow/Classes/Cli/RequestBuilder.php
+++ b/Neos.Flow/Classes/Cli/RequestBuilder.php
@@ -118,8 +118,7 @@ class RequestBuilder
         $request = new Request();
         $request->setControllerObjectName(HelpCommandController::class);
 
-        // @TODO: Can this be implemented even better/cleaner?
-        if (in_array('--help', $commandLine)) {
+        if (is_array($commandLine) && in_array('--help', $commandLine, true)) {
             $request->setControllerCommandName('help');
             $request->setArguments(['commandIdentifier' => $commandLine[0]]);
             $request->setControllerObjectName(HelpCommandController::class);

--- a/Neos.Flow/Classes/Cli/RequestBuilder.php
+++ b/Neos.Flow/Classes/Cli/RequestBuilder.php
@@ -118,6 +118,14 @@ class RequestBuilder
         $request = new Request();
         $request->setControllerObjectName(HelpCommandController::class);
 
+        // @TODO: Can this be implemented even better/cleaner?
+        if (in_array('--help', $commandLine)) {
+            $request->setControllerCommandName('help');
+            $request->setArguments(['commandIdentifier' => $commandLine[0]]);
+            $request->setControllerObjectName(HelpCommandController::class);
+            return $request;
+        }
+
         if (is_array($commandLine) === true) {
             $rawCommandLineArguments = $commandLine;
         } else {

--- a/Neos.Flow/Classes/Command/HelpCommandController.php
+++ b/Neos.Flow/Classes/Command/HelpCommandController.php
@@ -124,7 +124,7 @@ class HelpCommandController extends CommandController
 
         $this->outputLine('* = compile time command');
         $this->outputLine();
-        $this->outputLine('See "%s help <commandidentifier>" for more information about a specific command.', [$this->getFlowInvocationString()]);
+        $this->outputLine('Use "%s [command] --help" for more information about a command.', [$this->getFlowInvocationString()]);
         $this->outputLine();
     }
 
@@ -212,11 +212,10 @@ class HelpCommandController extends CommandController
         if (count($optionDescriptions) > 0) {
             $this->outputLine();
             $this->outputLine('<b>OPTIONS:</b>');
+            $optionDescriptions[] = vsprintf('  %-20s %s', ['--help', 'Shows detailed information about this command']);
             foreach ($optionDescriptions as $optionDescription) {
                 $this->outputLine($optionDescription);
             }
-            $this->outputLine('--help');
-            $this->outputLine('Shows information about the specific command and which parameters are available');
         }
 
         if ($command->getDescription() !== '') {
@@ -262,7 +261,7 @@ class HelpCommandController extends CommandController
         }
         $this->outputLine();
         $this->outputLine('Enter "%s help" for an overview of all available commands', [$this->getFlowInvocationString()]);
-        $this->outputLine('or "%s help <commandIdentifier>" for a detailed description of the corresponding command.', [$this->getFlowInvocationString()]);
+        $this->outputLine('or "%s <commandIdentifier> --help" for a detailed description of the corresponding command.', [$this->getFlowInvocationString()]);
         $this->quit(1);
     }
 

--- a/Neos.Flow/Classes/Command/HelpCommandController.php
+++ b/Neos.Flow/Classes/Command/HelpCommandController.php
@@ -215,6 +215,8 @@ class HelpCommandController extends CommandController
             foreach ($optionDescriptions as $optionDescription) {
                 $this->outputLine($optionDescription);
             }
+            $this->outputLine('--help');
+            $this->outputLine('Shows information about the specific command and which parameters are available');
         }
 
         if ($command->getDescription() !== '') {


### PR DESCRIPTION
<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

_None_

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

This change introduces a new way of using the help function for existing Flow/Neos CLI commands.

Currently you always used:

```bash
./flow help user:create
```

With this change it is possible to use the new `--help` flag as an alternative at **the end** of a CLI command:

```bash
./flow user:create --help
```

But of course the first way will also still work!

### Demo

https://github.com/neos/flow-development-collection/assets/39345336/4f93f5cf-0435-4344-b37a-0a76b6df7824

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
