### PR TITLE
!!!TASK: Bootstrap instantiates request handlers internally

### DIFF
--- a/Neos.Flow/Classes/Cli/CommandRequestHandler.php
+++ b/Neos.Flow/Classes/Cli/CommandRequestHandler.php
@@ -51,10 +51,12 @@ class CommandRequestHandler implements RequestHandlerInterface
      */
     protected $response;
 
-    /**
-    * @param Bootstrap $bootstrap
-     */
-    public function __construct(Bootstrap $bootstrap)
+    public static function fromBootstrap(Bootstrap $bootstrap): RequestHandlerInterface
+    {
+        return new self($bootstrap);
+    }
+
+    private function __construct(Bootstrap $bootstrap)
     {
         $this->bootstrap = $bootstrap;
     }
@@ -75,7 +77,7 @@ class CommandRequestHandler implements RequestHandlerInterface
      *
      * @return integer The priority of the request handler.
      */
-    public function getPriority(): int
+    public static function getPriority(): int
     {
         return 100;
     }

--- a/Neos.Flow/Classes/Cli/SlaveRequestHandler.php
+++ b/Neos.Flow/Classes/Cli/SlaveRequestHandler.php
@@ -35,12 +35,12 @@ class SlaveRequestHandler implements RequestHandlerInterface
      */
     protected $bootstrap;
 
-    /**
-     * Constructor
-     *
-     * @param Bootstrap $bootstrap
-     */
-    public function __construct(Bootstrap $bootstrap)
+    public static function fromBootstrap(Bootstrap $bootstrap): RequestHandlerInterface
+    {
+        return new self($bootstrap);
+    }
+
+    private function __construct(Bootstrap $bootstrap)
     {
         $this->bootstrap = $bootstrap;
     }
@@ -61,7 +61,7 @@ class SlaveRequestHandler implements RequestHandlerInterface
      *
      * @return integer The priority of the request handler.
      */
-    public function getPriority(): int
+    public static function getPriority(): int
     {
         return 200;
     }

--- a/Neos.Flow/Classes/Core/RequestHandlerInterface.php
+++ b/Neos.Flow/Classes/Core/RequestHandlerInterface.php
@@ -42,5 +42,14 @@ interface RequestHandlerInterface
      * @return integer The priority of the request handler
      * @api
      */
-    public function getPriority();
+    public static function getPriority(): int;
+
+    /**
+     * This is the API to create an instance of a request handler the bootstrap will use internally.
+     *
+     * @param Bootstrap $bootstrap
+     * @return self
+     * @api
+     */
+    public static function fromBootstrap(Bootstrap $bootstrap): self;
 }

--- a/Neos.Flow/Classes/Http/RequestHandler.php
+++ b/Neos.Flow/Classes/Http/RequestHandler.php
@@ -14,6 +14,7 @@ namespace Neos\Flow\Http;
 use GuzzleHttp\Psr7\ServerRequest;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\Core\RequestHandlerInterface;
 use Neos\Flow\Http\Helper\ResponseInformationHelper;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -52,13 +53,15 @@ class RequestHandler implements HttpRequestHandlerInterface
      */
     public $exit;
 
-    /**
-     * @param Bootstrap $bootstrap
-     */
-    public function __construct(Bootstrap $bootstrap)
+    public static function fromBootstrap(Bootstrap $bootstrap): RequestHandlerInterface
+    {
+        return new self($bootstrap);
+    }
+
+    private function __construct(Bootstrap $bootstrap)
     {
         $this->bootstrap = $bootstrap;
-        $this->exit = function () {
+        $this->exit = static function () {
             exit();
         };
     }
@@ -81,7 +84,7 @@ class RequestHandler implements HttpRequestHandlerInterface
      * @return integer The priority of the request handler.
      * @api
      */
-    public function getPriority()
+    public static function getPriority(): int
     {
         return 100;
     }

--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -49,17 +49,17 @@ class Package extends BasePackage
         $context = $bootstrap->getContext();
 
         if (PHP_SAPI === 'cli') {
-            $bootstrap->registerRequestHandler(new Cli\SlaveRequestHandler($bootstrap));
-            $bootstrap->registerRequestHandler(new Cli\CommandRequestHandler($bootstrap));
+            $bootstrap->registerRequestHandlerClassName(Cli\SlaveRequestHandler::class);
+            $bootstrap->registerRequestHandlerClassName(Cli\CommandRequestHandler::class);
         } else {
-            $bootstrap->registerRequestHandler(new Http\RequestHandler($bootstrap));
+            $bootstrap->registerRequestHandlerClassName(Http\RequestHandler::class);
         }
 
         if ($context->isTesting()) {
             // TODO: This is technically not necessary as we can register the request handler in the functional bootstrap
             // A future commit will remove this aftter BuildEssentials is adapted
             /** @phpstan-ignore-next-line composer doesnt autoload this class */
-            $bootstrap->registerRequestHandler(new Tests\FunctionalTestRequestHandler($bootstrap));
+            $bootstrap->registerRequestHandlerClassName(Tests\FunctionalTestRequestHandler::class);
         }
 
         $bootstrap->registerCompiletimeCommand('neos.flow:core:*');

--- a/Neos.Flow/Classes/Testing/RequestHandler/EmptyRequestHandler.php
+++ b/Neos.Flow/Classes/Testing/RequestHandler/EmptyRequestHandler.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Neos\Flow\Testing\RequestHandler;
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Core\RequestHandlerInterface;
 use Neos\Flow\Tests\PhpBench\Core\BootstrapBench;
 
@@ -24,6 +25,15 @@ use Neos\Flow\Tests\PhpBench\Core\BootstrapBench;
  */
 final class EmptyRequestHandler implements RequestHandlerInterface
 {
+    public static function fromBootstrap(Bootstrap $bootstrap): RequestHandlerInterface
+    {
+        return new self();
+    }
+
+    private function __construct()
+    {
+    }
+
     public function handleRequest(): void
     {
     }
@@ -33,7 +43,7 @@ final class EmptyRequestHandler implements RequestHandlerInterface
         return true;
     }
 
-    public function getPriority(): int
+    public static function getPriority(): int
     {
         return 0;
     }

--- a/Neos.Flow/Classes/Testing/RequestHandler/RuntimeSequenceInvokingRequestHandler.php
+++ b/Neos.Flow/Classes/Testing/RequestHandler/RuntimeSequenceInvokingRequestHandler.php
@@ -27,12 +27,12 @@ class RuntimeSequenceInvokingRequestHandler implements RequestHandlerInterface
 {
     protected Bootstrap $bootstrap;
 
-    /**
-     * Constructor
-     *
-     * @param \Neos\Flow\Core\Bootstrap $bootstrap
-     */
-    public function __construct(Bootstrap $bootstrap)
+    public static function fromBootstrap(Bootstrap $bootstrap): RequestHandlerInterface
+    {
+        return new self($bootstrap);
+    }
+
+    private function __construct(Bootstrap $bootstrap)
     {
         $this->bootstrap = $bootstrap;
     }
@@ -56,7 +56,7 @@ class RuntimeSequenceInvokingRequestHandler implements RequestHandlerInterface
      *
      * @return integer The priority of the request handler.
      */
-    public function getPriority(): int
+    public static function getPriority(): int
     {
         return 0;
     }

--- a/Neos.Flow/Tests/FunctionalTestRequestHandler.php
+++ b/Neos.Flow/Tests/FunctionalTestRequestHandler.php
@@ -14,6 +14,7 @@ namespace Neos\Flow\Tests;
 use GuzzleHttp\Psr7\ServerRequest;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\Core\RequestHandlerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
@@ -45,12 +46,12 @@ class FunctionalTestRequestHandler implements \Neos\Flow\Http\HttpRequestHandler
      */
     protected $httpRequest;
 
-    /**
-     * Constructor
-     *
-     * @param \Neos\Flow\Core\Bootstrap $bootstrap
-     */
-    public function __construct(Bootstrap $bootstrap)
+    public static function fromBootstrap(Bootstrap $bootstrap): RequestHandlerInterface
+    {
+        return new self($bootstrap);
+    }
+
+    private function __construct(Bootstrap $bootstrap)
     {
         $this->bootstrap = $bootstrap;
     }
@@ -74,7 +75,7 @@ class FunctionalTestRequestHandler implements \Neos\Flow\Http\HttpRequestHandler
      *
      * @return integer The priority of the request handler.
      */
-    public function getPriority()
+    public static function getPriority(): int
     {
         return 0;
     }

--- a/Neos.Flow/Tests/PhpBench/Core/BootstrapBench.php
+++ b/Neos.Flow/Tests/PhpBench/Core/BootstrapBench.php
@@ -41,7 +41,6 @@ class BootstrapBench extends FrameworkEnabledBenchmark
     public function benchBootstrapRunWithoutBootSequence(): void
     {
         $flowBootstrap = new Bootstrap(TestableFramework::getApplicationContext());
-        $flowBootstrap->registerRequestHandler(new EmptyRequestHandler());
         $flowBootstrap->setPreselectedRequestHandlerClassName(EmptyRequestHandler::class);
         $flowBootstrap->run();
     }
@@ -57,7 +56,6 @@ class BootstrapBench extends FrameworkEnabledBenchmark
     public function benchBootstrapRunWithRuntimeBootSequence(): void
     {
         $flowBootstrap = new Bootstrap(TestableFramework::getApplicationContext());
-        $flowBootstrap->registerRequestHandler(new RuntimeSequenceInvokingRequestHandler($flowBootstrap));
         $flowBootstrap->setPreselectedRequestHandlerClassName(RuntimeSequenceInvokingRequestHandler::class);
         $flowBootstrap->run();
     }


### PR DESCRIPTION
It seems unnecessarily complex to have code register a request handler as build instance. Instead it is now registered by class name. The Flow Bootstrap will then create instances while determining the best matching request handler. To facilitate this being lazy the RequestHandlerInterface::getPriority method is now declared static so that we can decide beforehand if the priority is higher than any previously found best match.
Depending on possibly request handlers and specifically in all preselected cases this all reduces the amount of created objects and possibly the amount of canHandle calls. A microptimization but which affects all requests. Primary concern was to make registration easier and internalize instantiation.

As small simplification the
`Bootstrap->setPreselectedRequestHandlerClassName` will also register the given class name as possible request handler removing one step.

This is breaking if you have your own request handler implementation. The `getPrioritty` method needs to declare an `int` return type and must be static. Additionally the registration happens via `Bootstrap->registerRequestHandlerClassName(YourRequestHandler::class)`.
Also the RequestHandler now needs a static constructor 
`RequestHandlerInterface::fromBootstrap(Bootstrap $bootstrap): self` that the Bootstrap will call when instantiating one.

If the RequestHandler for some reason was used as a bridge to the outside world and the instance carried more information besides the bootstrap, you can "sneak in" your instance with anything you want by setting it via 
`Bootstrap->setEarlyInstance(YourRequestHandler::class, $yourInstance)` and this will be used instead of creating a new instance via the static constructor. You still need to register the class as possible request handler though.
