### PR TITLE
!!!TASK: Deprecate outdated doctrine functionality

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/DataTypes/ObjectArray.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/DataTypes/ObjectArray.php
@@ -22,6 +22,9 @@ use Neos\Utility\TypeHandling;
  * and strips singletons from the data to be stored.
  *
  * @Flow\Proxy(false)
+ *
+ * @deprecated will be removed in Flow 9. Checkout {@see JsonArrayType}
+ * This hasn't been used in the Flow/Neos codebase for a long time and there are no tests.
  */
 class ObjectArray extends Types\ArrayType
 {

--- a/Neos.Flow/Classes/Persistence/Doctrine/Repository.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Repository.php
@@ -161,6 +161,8 @@ abstract class Repository extends EntityRepository implements RepositoryInterfac
      * @param IterableResult $iterator
      * @param callable|null $callback
      * @return \Generator
+     *
+     * @deprecated Will be removed with Flow 9. The {@see findAllIterator} will return an \iterable directly
      */
     public function iterate(IterableResult $iterator, callable $callback = null): ?\Generator
     {

--- a/Neos.Flow/Classes/Persistence/Doctrine/Service.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Service.php
@@ -630,6 +630,7 @@ class Service
      *
      * @return string
      * @throws DBALException
+     * @deprecated will be removed in Flow 9. Compare the connection class name instead.
      */
     public function getDatabasePlatformName(): string
     {


### PR DESCRIPTION
In preparation of Flow 9 we deprecate some functionality we expose but that was deprecated in doctrine already, so we will remove it.