### PR TITLE
BUGFIX: #3303 Flush reflection cache for removed php classes

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -377,6 +377,7 @@ class Scripts
         $cacheManager = new CacheManager();
         $cacheManager->setCacheConfigurations($configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_CACHES));
         $cacheManager->injectConfigurationManager($configurationManager);
+        $cacheManager->injectPackageManager($bootstrap->getEarlyInstance(PackageManager::class));
         $cacheManager->injectLogger($bootstrap->getEarlyInstance(PsrLoggerFactoryInterface::class)->get('systemLogger'));
         $cacheManager->injectEnvironment($environment);
         $cacheManager->injectCacheFactory($cacheFactory);

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1800,6 +1800,7 @@ class ReflectionService
         $this->classesCurrentlyBeingForgotten[$className] = true;
 
         if (class_exists($className)) {
+            // optimisation to flush only precisely the affected interfaces
             $interfaceNames = class_implements($className);
             foreach ($interfaceNames as $interfaceName) {
                 if (isset($this->classReflectionData[$interfaceName][self::DATA_INTERFACE_IMPLEMENTATIONS][$className])) {
@@ -1807,11 +1808,9 @@ class ReflectionService
                 }
             }
         } else {
-            foreach ($this->availableClassNames as $interfaceNames) {
-                foreach ($interfaceNames as $interfaceName) {
-                    if (isset($this->classReflectionData[$interfaceName][self::DATA_INTERFACE_IMPLEMENTATIONS][$className])) {
-                        unset($this->classReflectionData[$interfaceName][self::DATA_INTERFACE_IMPLEMENTATIONS][$className]);
-                    }
+            foreach ($this->classReflectionData as &$possibleInterfaceReflectionData) {
+                if (isset($possibleInterfaceReflectionData[self::DATA_INTERFACE_IMPLEMENTATIONS][$className])) {
+                    unset($possibleInterfaceReflectionData[self::DATA_INTERFACE_IMPLEMENTATIONS][$className]);
                 }
             }
         }

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -174,6 +174,11 @@ class ReflectionService
      */
     protected array $updatedReflectionData = [];
 
+    /**
+     * Array with removed reflection information (e.g. in Development context after classes were deleted)
+     */
+    protected array $removedReflectionDataClasses = [];
+
     protected bool $initialized = false;
 
     /**
@@ -1833,6 +1838,8 @@ class ReflectionService
 
         unset($this->classReflectionData[$className]);
         unset($this->classesCurrentlyBeingForgotten[$className]);
+
+        $this->removedReflectionDataClasses[$className] = true;
     }
 
     /**
@@ -2024,7 +2031,7 @@ class ReflectionService
             $this->reflectionDataRuntimeCache->set('__availableClassNames', $this->availableClassNames);
         }
 
-        if ($this->updatedReflectionData !== []) {
+        if ($this->updatedReflectionData !== [] || $this->removedReflectionDataClasses !== []) {
             $this->updateReflectionData();
         }
 
@@ -2092,7 +2099,7 @@ class ReflectionService
      */
     protected function updateReflectionData(): void
     {
-        $this->log(sprintf('Found %s classes whose reflection data was not cached previously.', count($this->updatedReflectionData)), LogLevel::DEBUG);
+        $this->log(sprintf('Found %s classes whose reflection data was not cached previously and %s classes which were deleted.', count($this->updatedReflectionData), count($this->removedReflectionDataClasses)), LogLevel::DEBUG);
 
         foreach (array_keys($this->updatedReflectionData) as $className) {
             $this->statusCache->set($this->produceCacheIdentifierFromClassName($className), '');


### PR DESCRIPTION
resolves #3303

There are a few layers to this bugfix.

1. Previously we ignored deleted files (see `file_exists`) and did not flush the `Flow_Reflection_Status` cache accordingly as we are not able to read the namespace from a deleted php file. Now we do a best effort reverse lookup by going through all psr-4 autoload configurations and calculate a namespace under which composer would have found this file.

2. We introduce a state `removedReflectionDataClasses` like `updatedReflectionData` which will be used to check if we have to update the `ReflectionData` cache.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

### How to test

We want to test `getAllImplementationClassNamesForInterface` as by the bugreport. And we can do this simply because we use it at a few places.

1. Open the Neos.Demo site (in development context)
2. Remove a not-so-important FlowQuery operation like `ReferencePropertyOperation` (which is not used on the homepage)
3. Reload the homepage
4. Expect everything be ok


Without this fix there will be an error thrown:

```
Exception in line 58 of Data/Temporary/Development/Cache/Code/Flow_Object_Classes/Neos_Eel_FlowQuery_OperationResolver.php: Class "Neos\ContentRepository\NodeAccess\FlowQueryOperations\ReferencePropertyOperation" not found

69 Neos\Eel\FlowQuery\OperationResolver_Original::buildOperationsAndFinalOperationNames(Neos\Flow\ObjectManagement\ObjectManager)
68 Neos\Eel\FlowQuery\OperationResolver_Original::initializeObject(1)
```

### How the fix works

With the fix applied we get the information that `"/Users/neos/Packages/Neos/Neos.ContentRepository.NodeAccess/Classes/FlowQueryOperations/ReferencePropertyOperation.php"` was removed. Then we can resolve that it belongs to the package `Neos.ContentRepository.NodeAccess` and reverse calculate its namespace/cache identifier (with underscores): `Neos_ContentRepository_NodeAccess_FlowQueryOperations_ReferencePropertyOperation`. Then we can flush the cache accordingly.

### Todo

- [ ] check if this is symlink safe! Like for user package in DistributionPackages


<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
