### PR TITLE
FEATURE: Introduce EEL tracer for handling Neos9 deprecations

### DIFF
--- a/Neos.Eel/Classes/Context.php
+++ b/Neos.Eel/Classes/Context.php
@@ -94,7 +94,6 @@ class Context
         if ($this->value === null) {
             return null;
         } elseif (is_object($this->value)) {
-            $this->tracer?->recordMethodCall($this->value, $method);
             $callback = [$this->value, $method];
         } elseif (is_array($this->value)) {
             if (!array_key_exists($method, $this->value)) {
@@ -111,6 +110,14 @@ class Context
         for ($i = 0; $i < $argumentsCount; $i++) {
             if ($arguments[$i] instanceof Context) {
                 $arguments[$i] = $arguments[$i]->unwrap();
+            }
+        }
+        if ($this->tracer !== null) {
+            // optional experimental tracing
+            if (is_object($this->value)) {
+                $this->tracer->recordMethodCall($this->value, $method, $arguments);
+            } else {
+                $this->tracer->recordFunctionCall($callback, $method, $arguments);
             }
         }
         return call_user_func_array($callback, $arguments);

--- a/Neos.Eel/Classes/EelInvocationTracerInterface.php
+++ b/Neos.Eel/Classes/EelInvocationTracerInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Neos\Eel;
+
+/**
+ * @internal experimental tracer for eel. Could be used for example to collect and log deprecations.
+ */
+interface EelInvocationTracerInterface
+{
+    public function recordPropertyAccess(object $object, string $propertyName): void;
+
+    public function recordMethodCall(object $object, string $methodName): void;
+}

--- a/Neos.Eel/Classes/EelInvocationTracerInterface.php
+++ b/Neos.Eel/Classes/EelInvocationTracerInterface.php
@@ -9,5 +9,13 @@ interface EelInvocationTracerInterface
 {
     public function recordPropertyAccess(object $object, string $propertyName): void;
 
-    public function recordMethodCall(object $object, string $methodName): void;
+    /**
+     * @param array<int, mixed> $arguments
+     */
+    public function recordMethodCall(object $object, string $methodName, array $arguments): void;
+
+    /**
+     * @param array<int, mixed> $arguments
+     */
+    public function recordFunctionCall(callable $function, string $functionName, array $arguments): void;
 }

--- a/Neos.Eel/Classes/Utility.php
+++ b/Neos.Eel/Classes/Utility.php
@@ -90,7 +90,7 @@ class Utility
      * @return mixed
      * @throws Exception
      */
-    public static function evaluateEelExpression($expression, EelEvaluatorInterface $eelEvaluator, array $contextVariables, array $defaultContextConfiguration = [])
+    public static function evaluateEelExpression($expression, EelEvaluatorInterface $eelEvaluator, array $contextVariables, array $defaultContextConfiguration = [], ?EelInvocationTracerInterface $tracer = null)
     {
         $eelExpression = self::parseEelExpression($expression);
         if ($eelExpression === null) {
@@ -100,7 +100,7 @@ class Utility
         $defaultContextVariables = self::getDefaultContextVariables($defaultContextConfiguration);
         $contextVariables = array_merge($defaultContextVariables, $contextVariables);
 
-        $context = new ProtectedContext($contextVariables);
+        $context = new ProtectedContext($contextVariables, $tracer);
         $context->allow('q');
 
         // Allow functions on the uppermost context level to allow calling them without


### PR DESCRIPTION
Related https://github.com/neos/neos-development-collection/issues/5022

In todays weekly @bwaidelich and me discussed a concrete way how to log deprecations like `node.indentifier` in Neos 8.4 and 9.0

The idea is to add a tracer to eel, that will be implemented in Fusion. Technically we would need to add an abstraction to Neos.Fusion as well to not access the Node from there as this is architecturally illegal but to simplify the code and in light that this is just considered for temporary time we propose to implement it as such:

```php
<?php

namespace Neos\Fusion\Core;

use Neos\Flow\Annotations as Flow;
use Psr\Log\LoggerInterface;

final class Neos9RuntimeMigrationTracer implements EelInvocationTracerInterface
{
    /** @Flow\Inject */
    protected LoggerInterface $logger;

    private const DEPRECATED_NODE_PROPERTIES = [
        'identifier' => true,
        'nodetype' => true,
        // ...
    ];

    public function __construct(
        private readonly string $eelExpression,
        private readonly bool $showMercy
    ) {
    }

    public function recordPropertyAccess(object $object, string $propertyName): void
    {
        if (
            $object instanceof \Neos\ContentRepository\Domain\Model\Node
            && array_key_exists(strtolower($propertyName), self::DEPRECATED_NODE_PROPERTIES)
        ) {
            $this->logDeprecationOrThrowException(
                sprintf('"node.%s" is deprecated in "%s"', $propertyName, $this->eelExpression)
            );
        }
    }

    public function recordMethodCall(object $object, string $methodName): void
    {
    }

    private function logDeprecationOrThrowException(string $message): void
    {
        if ($this->showMercy) {
            $this->logger->debug($message);
        } else {
            throw new \RuntimeException($message);
        }
    }
}
```


and instantiate this `Neos9RuntimeMigrationTracer` (name tbd) in `\Neos\Fusion\Core\Runtime::evaluateEelExpression`

```diff
- return EelUtility::evaluateEelExpression($expression, $this->eelEvaluator, $contextVariables);
+ $tracer =.$this->settings['enableDeprecationTracer'] ? new Neos9RuntimeMigrationTracer($expression, $this->settings['strictEelMode'] ?? false) : null;
+ return EelUtility::evaluateEelExpression($expression, $this->eelEvaluator, $contextVariables, $tracer);
```



**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
