### PR TITLE
BUGFIX: Fix support for typo3fluid/fluid 2.15

### DIFF
--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CropViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CropViewHelperTest.php
@@ -14,7 +14,6 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Format;
 require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 
 use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
-use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 
 /**
  * Test for \Neos\FluidAdaptor\ViewHelpers\Format\CropViewHelper

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CropViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/CropViewHelperTest.php
@@ -14,6 +14,7 @@ namespace Neos\FluidAdaptor\Tests\Unit\ViewHelpers\Format;
 require_once(__DIR__ . '/../ViewHelperBaseTestcase.php');
 
 use Neos\FluidAdaptor\Tests\Unit\ViewHelpers\ViewHelperBaseTestcase;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 
 /**
  * Test for \Neos\FluidAdaptor\ViewHelpers\Format\CropViewHelper
@@ -37,7 +38,7 @@ class CropViewHelperTest extends ViewHelperBaseTestcase
      */
     public function viewHelperDoesNotCropTextIfMaxCharactersIsLargerThanNumberOfCharacters()
     {
-        $this->viewHelper->expects(self::once())->method('renderChildren')->will(self::returnValue('some text'));
+        $this->simulateViewHelperChildNodeContent($this->viewHelper, 'some text');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['maxCharacters' => 50]);
         $actualResult = $this->viewHelper->render();
         self::assertEquals('some text', $actualResult);
@@ -48,7 +49,7 @@ class CropViewHelperTest extends ViewHelperBaseTestcase
      */
     public function viewHelperAppendsEllipsisToTruncatedText()
     {
-        $this->viewHelper->expects(self::once())->method('renderChildren')->will(self::returnValue('some text'));
+        $this->simulateViewHelperChildNodeContent($this->viewHelper, 'some text');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['maxCharacters' => 5]);
         $actualResult = $this->viewHelper->render();
         self::assertEquals('some ...', $actualResult);
@@ -59,7 +60,7 @@ class CropViewHelperTest extends ViewHelperBaseTestcase
      */
     public function viewHelperAppendsCustomSuffix()
     {
-        $this->viewHelper->expects(self::once())->method('renderChildren')->will(self::returnValue('some text'));
+        $this->simulateViewHelperChildNodeContent($this->viewHelper, 'some text');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['maxCharacters' => 3, 'append' => '[custom suffix]']);
         $actualResult = $this->viewHelper->render();
         self::assertEquals('som[custom suffix]', $actualResult);
@@ -70,7 +71,7 @@ class CropViewHelperTest extends ViewHelperBaseTestcase
      */
     public function viewHelperAppendsSuffixEvenIfResultingTextIsLongerThanMaxCharacters()
     {
-        $this->viewHelper->expects(self::once())->method('renderChildren')->will(self::returnValue('some text'));
+        $this->simulateViewHelperChildNodeContent($this->viewHelper, 'some text');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['maxCharacters' => 8]);
         $actualResult = $this->viewHelper->render();
         self::assertEquals('some tex...', $actualResult);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/HtmlentitiesDecodeViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/HtmlentitiesDecodeViewHelperTest.php
@@ -60,7 +60,7 @@ class HtmlentitiesDecodeViewHelperTest extends ViewHelperBaseTestcase
      */
     public function renderUsesChildnodesAsSourceIfSpecified()
     {
-        $this->viewHelper->expects(self::atLeastOnce())->method('renderChildren')->will(self::returnValue('Some string'));
+        $this->simulateViewHelperChildNodeContent($this->viewHelper, 'Some string');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
         $actualResult = $this->viewHelper->render();
         self::assertEquals('Some string', $actualResult);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/HtmlentitiesViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/HtmlentitiesViewHelperTest.php
@@ -60,7 +60,7 @@ class HtmlentitiesViewHelperTest extends ViewHelperBaseTestcase
      */
     public function renderUsesChildnodesAsSourceIfSpecified()
     {
-        $this->viewHelper->expects(self::atLeastOnce())->method('renderChildren')->will(self::returnValue('Some string'));
+        $this->simulateViewHelperChildNodeContent($this->viewHelper, 'Some string');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
         $actualResult = $this->viewHelper->render();
         self::assertEquals('Some string', $actualResult);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/PaddingViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/PaddingViewHelperTest.php
@@ -37,7 +37,7 @@ class PaddingViewHelperTest extends ViewHelperBaseTestcase
      */
     public function stringsArePaddedWithBlanksByDefault()
     {
-        $this->viewHelper->expects(self::once())->method('renderChildren')->will(self::returnValue('foo'));
+        $this->simulateViewHelperChildNodeContent($this->viewHelper, 'foo');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['padLength' => 10]);
         $actualResult = $this->viewHelper->render();
         self::assertEquals('foo       ', $actualResult);
@@ -48,7 +48,7 @@ class PaddingViewHelperTest extends ViewHelperBaseTestcase
      */
     public function paddingStringCanBeSpecified()
     {
-        $this->viewHelper->expects(self::once())->method('renderChildren')->will(self::returnValue('foo'));
+        $this->simulateViewHelperChildNodeContent($this->viewHelper, 'foo');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['padLength' => 10, 'padString' => '-=']);
         $actualResult = $this->viewHelper->render();
         self::assertEquals('foo-=-=-=-', $actualResult);
@@ -59,7 +59,7 @@ class PaddingViewHelperTest extends ViewHelperBaseTestcase
      */
     public function stringIsNotTruncatedIfPadLengthIsBelowStringLength()
     {
-        $this->viewHelper->expects(self::once())->method('renderChildren')->will(self::returnValue('some long string'));
+        $this->simulateViewHelperChildNodeContent($this->viewHelper, 'some long string');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['padLength' => 5]);
         $actualResult = $this->viewHelper->render();
         self::assertEquals('some long string', $actualResult);
@@ -70,7 +70,7 @@ class PaddingViewHelperTest extends ViewHelperBaseTestcase
      */
     public function integersArePaddedCorrectly()
     {
-        $this->viewHelper->expects(self::once())->method('renderChildren')->will(self::returnValue(123));
+        $this->simulateViewHelperChildNodeContent($this->viewHelper, 123);
         $this->viewHelper = $this->prepareArguments($this->viewHelper, ['padLength' => 5, 'padString' => '0']);
         $actualResult = $this->viewHelper->render(5, '0');
         self::assertEquals('12300', $actualResult);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/UrlencodeViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Format/UrlencodeViewHelperTest.php
@@ -58,7 +58,7 @@ class UrlencodeViewHelperTest extends ViewHelperBaseTestcase
      */
     public function renderUsesChildnodesAsSourceIfSpecified()
     {
-        $this->viewHelper->expects(self::atLeastOnce())->method('renderChildren')->will(self::returnValue('Source'));
+        $this->simulateViewHelperChildNodeContent($this->viewHelper, 'Source');
         $this->viewHelper = $this->prepareArguments($this->viewHelper, []);
         $actualResult = $this->viewHelper->render();
         self::assertEquals('Source', $actualResult);

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/ViewHelperBaseTestcase.php
@@ -17,6 +17,8 @@ use Neos\FluidAdaptor\Core\ViewHelper\AbstractTagBasedViewHelper;
 use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
 use Neos\Http\Factories\ServerRequestFactory;
 use Neos\Http\Factories\UriFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use TYPO3Fluid\Fluid\Core\Parser\SyntaxTree\ViewHelperNode;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 
 /**
@@ -174,5 +176,13 @@ abstract class ViewHelperBaseTestcase extends \Neos\Flow\Tests\UnitTestCase
         $viewHelper->validateArguments();
         $viewHelper->initialize();
         return $viewHelper;
+    }
+
+    protected function simulateViewHelperChildNodeContent(AbstractViewHelper&MockObject $viewHelper, string|int $content): void
+    {
+        $viewHelper->method('renderChildren')->willReturn($content);
+        $mockThenViewHelperNode = $this->createMock(ViewHelperNode::class);
+        $mockThenViewHelperNode->method('evaluateChildNodes')->willReturn($content);
+        $viewHelper->setViewHelperNode($mockThenViewHelperNode);
     }
 }


### PR DESCRIPTION
Adjusts tests that mocked `AbstractViewHelper::renderChildren()` that is no longer invoked with version 2.15

Fixes: #3389