### PR TITLE
FEATURE: Add option to set username for RedisBackend

### DIFF
--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -612,7 +612,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
             $prefixLength = strlen($prefix);
             $keys = $this->redis->keys($prefix . '*');
             if (is_array($keys)) {
-                $entryIdentifiers = array_map(static fn(string $key) => substr($key, $prefixLength), $keys);
+                $entryIdentifiers = array_map(static fn (string $key) => substr($key, $prefixLength), $keys);
             } else {
                 $entryIdentifiers = [];
             }

--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -34,6 +34,7 @@ use Neos\Error\Messages\Result;
  *  - port:            The TCP port of the redis server (will be ignored if connecting to a socket)
  *  - database:        The database index that will be used. By default,
  *                     Redis has 16 databases with index number 0 - 15
+ *  - username:         The username needed for the redis clients to connect to the server (hostname)
  *  - password:        The password needed for redis clients to connect to the server (hostname)
  *  - batchSize:       Maximum number of parameters per query for batch operations
  *
@@ -68,6 +69,8 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
     protected int $port = 6379;
 
     protected int $database = 0;
+
+    protected string $username = '';
 
     protected string $password = '';
 
@@ -192,8 +195,8 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      * old entries for the identifier still exist, they are removed as well.
      *
      * @param string $entryIdentifier Specifies the cache entry to remove
-     * @throws \RuntimeException
      * @return boolean true if (at least) an entry could be removed or false if no entry was found
+     * @throws \RuntimeException
      * @api
      */
     public function remove(string $entryIdentifier): bool
@@ -257,8 +260,8 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      * Removes all cache entries of this cache which are tagged by the specified tag.
      *
      * @param string $tag The tag the entries must have
-     * @throws \RuntimeException
      * @return integer The number of entries which have been affected by this flush
+     * @throws \RuntimeException
      * @api
      */
     public function flushByTag(string $tag): int
@@ -290,8 +293,8 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      * Removes all cache entries of this cache which are tagged by the specified tags.
      *
      * @param array<string> $tags The tag the entries must have
-     * @throws \RuntimeException
      * @return integer The number of entries which have been affected by this flush
+     * @throws \RuntimeException
      * @api
      */
     public function flushByTags(array $tags): int
@@ -468,6 +471,11 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
         $this->database = (int)$database;
     }
 
+    public function setUsername(string $username): void
+    {
+        $this->username = $username;
+    }
+
     public function setPassword(string $password): void
     {
         $this->password = $password;
@@ -500,7 +508,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
         if (empty($value)) {
             return $value;
         }
-        return $this->useCompression() ? gzdecode((string) $value) : $value;
+        return $this->useCompression() ? gzdecode((string)$value) : $value;
     }
 
     private function compress(string $value): string
@@ -535,8 +543,16 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
             }
         }
 
-        if ($this->password !== '' && !$redis->auth($this->password)) {
-            throw new CacheException('Redis authentication failed.', 1502366200);
+        if ($this->username !== '' && $this->password !== '') {
+            $result = $redis->auth([$this->username, $this->password]);
+            if ($result === false) {
+                throw new CacheException(sprintf('Redis authentication failed, using username "%s" and a %s bytes long password.', $this->username, strlen($this->password)), 1725607160);
+            }
+        } elseif ($this->password !== '') {
+            $result = $redis->auth($this->password);
+            if ($result === false) {
+                throw new CacheException(sprintf('Redis authentication failed, using a %s bytes long password.', strlen($this->password)), 1502366200);
+            }
         }
         $redis->select($this->database);
         return $redis;
@@ -596,7 +612,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
             $prefixLength = strlen($prefix);
             $keys = $this->redis->keys($prefix . '*');
             if (is_array($keys)) {
-                $entryIdentifiers = array_map(static fn (string $key) => substr($key, $prefixLength), $keys);
+                $entryIdentifiers = array_map(static fn(string $key) => substr($key, $prefixLength), $keys);
             } else {
                 $entryIdentifiers = [];
             }

--- a/Neos.Cache/Tests/Functional/Backend/RedisBackendAuthenticationTest.php
+++ b/Neos.Cache/Tests/Functional/Backend/RedisBackendAuthenticationTest.php
@@ -40,8 +40,6 @@ use RedisException;
  */
 class RedisBackendAuthenticationTest extends BaseTestCase
 {
-
-
     /**
      * Set up test case
      *
@@ -110,5 +108,4 @@ class RedisBackendAuthenticationTest extends BaseTestCase
             ['hostname' => '127.0.0.1', 'database' => 0, 'username' => 'test_password', 'password' => 'incorrect_password']
         );
     }
-
 }

--- a/Neos.Cache/Tests/Functional/Backend/RedisBackendAuthenticationTest.php
+++ b/Neos.Cache/Tests/Functional/Backend/RedisBackendAuthenticationTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Neos\Cache\Tests\Functional\Backend;
+
+include_once(__DIR__ . '/../../BaseTestCase.php');
+
+/*
+ * This file is part of the Neos.Cache package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Exception;
+use Neos\Cache\Backend\RedisBackend;
+use Neos\Cache\EnvironmentConfiguration;
+use Neos\Cache\Tests\BaseTestCase;
+use RedisException;
+
+/**
+ * Testcase for the redis cache backend
+ *
+ * These tests use an actual Redis instance and will place and remove keys in db 0!
+ * Since all keys have the 'TestCache:' prefix, running the tests should have
+ * no side effects on non-related cache entries.
+ *
+ * Tests require Redis listening on 127.0.0.1:6379. Furthermore, the following users are required
+ * default:<no_password>
+ * test_no_password:<no_password>
+ * test_password:<secret_password>
+ *
+ * The users can be added by:
+ * acl setuser test_no_password on > ~* &* +@all
+ * acl setuser test_password on >secret_password ~* &* +@all
+ *
+ * @requires extension redis
+ */
+class RedisBackendAuthenticationTest extends BaseTestCase
+{
+
+
+    /**
+     * Set up test case
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $phpredisVersion = phpversion('redis');
+        if (version_compare($phpredisVersion, '5.0.0', '<')) {
+            $this->markTestSkipped(sprintf('phpredis extension version %s is not supported. Please update to version 5.0.0+.', $phpredisVersion));
+        }
+        try {
+            if (!@fsockopen('127.0.0.1', 6379)) {
+                $this->markTestSkipped('redis server not reachable');
+            }
+        } catch (Exception $e) {
+            $this->markTestSkipped('redis server not reachable');
+        }
+    }
+
+
+    /**
+     * @test
+     */
+    public function defaultUserNoPassword()
+    {
+        $backend = new RedisBackend(
+            new EnvironmentConfiguration('Redis a wonderful color Testing', '/some/path', PHP_MAXPATHLEN),
+            ['hostname' => '127.0.0.1', 'database' => 0]
+        );
+        $this->assertInstanceOf('Neos\Cache\Backend\RedisBackend', $backend);
+    }
+
+    /**
+     * @test
+     */
+    public function usernameNoPassword()
+    {
+        $backend = new RedisBackend(
+            new EnvironmentConfiguration('Redis a wonderful color Testing', '/some/path', PHP_MAXPATHLEN),
+            ['hostname' => '127.0.0.1', 'database' => 0, 'username' => 'test_no_password']
+        );
+        $this->assertInstanceOf('Neos\Cache\Backend\RedisBackend', $backend);
+    }
+
+    /**
+     * @test
+     */
+    public function usernamePassword()
+    {
+        $backend = new RedisBackend(
+            new EnvironmentConfiguration('Redis a wonderful color Testing', '/some/path', PHP_MAXPATHLEN),
+            ['hostname' => '127.0.0.1', 'database' => 0, 'username' => 'test_password', 'password' => 'secret_password']
+        );
+        $this->assertInstanceOf('Neos\Cache\Backend\RedisBackend', $backend);
+    }
+
+    /**
+     * @test
+     */
+    public function incorrectUsernamePassword()
+    {
+        $this->expectException(RedisException::class);
+        $backend = new RedisBackend(
+            new EnvironmentConfiguration('Redis a wonderful color Testing', '/some/path', PHP_MAXPATHLEN),
+            ['hostname' => '127.0.0.1', 'database' => 0, 'username' => 'test_password', 'password' => 'incorrect_password']
+        );
+    }
+
+}

--- a/Neos.Cache/Tests/Functional/Backend/RedisBackendAuthenticationTest.php
+++ b/Neos.Cache/Tests/Functional/Backend/RedisBackendAuthenticationTest.php
@@ -19,6 +19,7 @@ use Neos\Cache\Backend\RedisBackend;
 use Neos\Cache\EnvironmentConfiguration;
 use Neos\Cache\Tests\BaseTestCase;
 use RedisException;
+use Redis;
 
 /**
  * Testcase for the redis cache backend
@@ -40,6 +41,50 @@ use RedisException;
  */
 class RedisBackendAuthenticationTest extends BaseTestCase
 {
+
+    /**
+     * @var Redis|null
+     */
+    protected static ?Redis $redis = null;
+
+    /**
+     * Create required Redis users for the test suite
+     */
+    public static function setUpBeforeClass(): void
+    {
+        try {
+            self::$redis = new Redis();
+            self::$redis->connect('127.0.0.1', 6379);
+
+            // clean state before
+            @self::$redis->rawCommand('ACL', 'DELUSER', 'test_no_password');
+            @self::$redis->rawCommand('ACL', 'DELUSER', 'test_password');
+
+            // add users
+            self::$redis->rawCommand('ACL', 'SETUSER', 'test_no_password', 'on', '>', '~*', '&*', '+@all');
+            self::$redis->rawCommand('ACL', 'SETUSER', 'test_password', 'on', '>secret_password', '~*', '&*', '+@all');
+        } catch (Exception $e) {
+            self::markTestSkipped('Could not prepare Redis users: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Tear down Redis users after the suite has run
+     */
+    public static function tearDownAfterClass(): void
+    {
+        if (self::$redis instanceof Redis) {
+            try {
+                self::$redis->rawCommand('ACL', 'DELUSER', 'test_no_password');
+                self::$redis->rawCommand('ACL', 'DELUSER', 'test_password');
+            } catch (Exception $e) {
+                // ignore
+            }
+            self::$redis->close();
+            self::$redis = null;
+        }
+    }
+
     /**
      * Set up test case
      *
@@ -59,7 +104,6 @@ class RedisBackendAuthenticationTest extends BaseTestCase
             $this->markTestSkipped('redis server not reachable');
         }
     }
-
 
     /**
      * @test

--- a/Neos.Cache/Tests/Functional/Backend/RedisBackendAuthenticationTest.php
+++ b/Neos.Cache/Tests/Functional/Backend/RedisBackendAuthenticationTest.php
@@ -41,7 +41,6 @@ use Redis;
  */
 class RedisBackendAuthenticationTest extends BaseTestCase
 {
-
     /**
      * @var Redis|null
      */

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
@@ -567,7 +567,7 @@ Options
 |                  | unit tests and should not be    |           |           |           |
 |                  | used if possible.               |           |           |           |
 +------------------+---------------------------------+-----------+-----------+-----------+
-| username         | Username to use for the         | No        |           |           |
+| username         | Username to use for the         | No        | string    |           |
 |                  | database connection.            |           |           |           |
 +------------------+---------------------------------+-----------+-----------+-----------+
 | password         | Password used to connect to the | No        | string    |           |
@@ -580,7 +580,7 @@ Options
 | compressionLevel | Set gzip compression level to a | No        | integer   | 0         |
 |                  | specific value.                 |           | (0 to 9)  |           |
 +------------------+---------------------------------+-----------+-----------+-----------+
-| batchSize        | Maximum number of parameters    | No        | int       | 100000    |
+| batchSize        | Maximum number of parameters    | No        | integer   | 100000    |
 |                  | per query for batch operations. |           |           |           |
 |                  |                                 |           |           |           |
 |                  | Redis supports up to            |           |           |           |

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
@@ -567,6 +567,9 @@ Options
 |                  | unit tests and should not be    |           |           |           |
 |                  | used if possible.               |           |           |           |
 +------------------+---------------------------------+-----------+-----------+-----------+
+| username         | Username to use for the         | No        |           |           |
+|                  | database connection.            |           |           |           |
++------------------+---------------------------------+-----------+-----------+-----------+
 | password         | Password used to connect to the | No        | string    |           |
 |                  | redis instance if the redis     |           |           |           |
 |                  | server needs authentication.    |           |           |           |


### PR DESCRIPTION
Adds an optional option to specify an username in the configuration options for the redis backend. Added basic test cases for redis authentication.

**Review instructions**
This PR re-opens https://github.com/neos/flow-development-collection/pull/3347 and addresses the stated feedback