### PR TITLE
TASK: Adjust log level of authentication messages

### DIFF
--- a/Neos.Flow/Classes/Security/Aspect/LoggingAspect.php
+++ b/Neos.Flow/Classes/Security/Aspect/LoggingAspect.php
@@ -127,14 +127,14 @@ class LoggingAspect
 
         switch ($token->getAuthenticationStatus()) {
             case TokenInterface::AUTHENTICATION_SUCCESSFUL:
-                $this->securityLogger->notice(sprintf('Successfully authenticated token: %s', $token), $this->getLogEnvironmentFromJoinPoint($joinPoint));
+                $this->securityLogger->info(sprintf('Successfully authenticated token: %s', $token), $this->getLogEnvironmentFromJoinPoint($joinPoint));
                 $this->alreadyLoggedAuthenticateCall = true;
                 break;
             case TokenInterface::WRONG_CREDENTIALS:
-                $this->securityLogger->warning(sprintf('Wrong credentials given for token: %s', $token), $this->getLogEnvironmentFromJoinPoint($joinPoint));
+                $this->securityLogger->notice(sprintf('Wrong credentials given for token: %s', $token), $this->getLogEnvironmentFromJoinPoint($joinPoint));
                 break;
             case TokenInterface::NO_CREDENTIALS_GIVEN:
-                $this->securityLogger->warning(sprintf('No credentials given or no account found for token: %s', $token), $this->getLogEnvironmentFromJoinPoint($joinPoint));
+                $this->securityLogger->notice(sprintf('No credentials given or no account found for token: %s', $token), $this->getLogEnvironmentFromJoinPoint($joinPoint));
                 break;
         }
     }


### PR DESCRIPTION
The level of "successfully authenticated token" messages was lowered to "info" and "wrong credentials" messages to "notice".

Successful authentication of a user is a normal operation and can happen many times within minutes or seconds in highly frequented websites and applications. More often than not, those messages don't require the attention of an administrator. To make it easier for filtering out those messages, the level should really be "info", since it is informational.