### PR TITLE
!!! TASK: Use generator to yield information instead of stateful `onP…

### DIFF
--- a/Neos.Flow/Classes/ResourceManagement/Collection.php
+++ b/Neos.Flow/Classes/ResourceManagement/Collection.php
@@ -146,7 +146,10 @@ class Collection implements CollectionInterface
      */
     public function publish()
     {
-        $this->target->publishCollection($this);
+        $publisher = $this->target->publishCollection($this);
+        while ($publisher->valid()) {
+            $publisher->next();
+        }
     }
 
     /**

--- a/Neos.Flow/Classes/ResourceManagement/Target/FileSystemSymlinkTarget.php
+++ b/Neos.Flow/Classes/ResourceManagement/Target/FileSystemSymlinkTarget.php
@@ -32,21 +32,20 @@ class FileSystemSymlinkTarget extends FileSystemTarget
      * Publishes the whole collection to this target
      *
      * @param CollectionInterface $collection The collection to publish
-     * @return void
+     * @return \Generator<ResourcePublishResult>
      */
-    public function publishCollection(CollectionInterface $collection)
+    public function publishCollection(CollectionInterface $collection): \Generator
     {
         $storage = $collection->getStorage();
         if ($storage instanceof PackageStorage) {
             $iteration = 0;
             foreach ($storage->getPublicResourcePaths() as $packageKey => $path) {
                 $this->publishDirectory($path, $packageKey);
-                // Note that the callback is only invoked once per resource public directory of each package. Instead of for each storage object.
-                $this->invokeOnPublishCallbacks($iteration);
+                yield new ResourcePublishResult($iteration, sprintf('Package %s was published to %s', $packageKey, $path), compact('packageKey', 'path'));
                 $iteration++;
             }
         } else {
-            parent::publishCollection($collection);
+            yield from parent::publishCollection($collection);
         }
     }
 

--- a/Neos.Flow/Classes/ResourceManagement/Target/ResourcePublishResult.php
+++ b/Neos.Flow/Classes/ResourceManagement/Target/ResourcePublishResult.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\ResourceManagement\Target;
+
+/**
+ * Yielded by the implementation of an {@see TargetInterface} after each resource publishing
+ */
+final readonly class ResourcePublishResult
+{
+    public function __construct(
+        public int $iteration,
+        public string $message,
+        public mixed $metaData = null
+    ) {
+    }
+}

--- a/Neos.Flow/Classes/ResourceManagement/Target/TargetInterface.php
+++ b/Neos.Flow/Classes/ResourceManagement/Target/TargetInterface.php
@@ -30,9 +30,9 @@ interface TargetInterface
      * Publishes the whole collection to this target
      *
      * @param CollectionInterface $collection The collection to publish
-     * @return void
+     * @return \Generator<ResourcePublishResult> The publisher generator with the current publish result as value containing iteration information and metadata.
      */
-    public function publishCollection(CollectionInterface $collection);
+    public function publishCollection(CollectionInterface $collection): \Generator;
 
     /**
      * Publishes the given persistent resource from the given storage
@@ -68,11 +68,4 @@ interface TargetInterface
      * @throws Exception
      */
     public function getPublicPersistentResourceUri(PersistentResource $resource);
-
-    /**
-     * Registers a callback, which must be invoked by the implementation after each resource publishing
-     *
-     * @param \Closure(int $iteration): void $callback
-     */
-    public function onPublish(\Closure $callback): void;
 }


### PR DESCRIPTION
…ublish` callback registration

Followup to https://github.com/neos/flow-development-collection/pull/3229

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
