### PR TITLE
FEATURE: flow query directy field access without get 0

### DIFF
--- a/Neos.Eel/Tests/Unit/FlowQuery/FlowQueryTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/FlowQueryTest.php
@@ -44,6 +44,20 @@ class FlowQueryTest extends UnitTestCase
     /**
      * @test
      */
+    public function accessPropertiesDirectly()
+    {
+        $myObject = new \stdClass();
+        $myObject->stringProperty = 'abc';
+        $myObject2 = new \stdClass();
+        $myObject2->stringProperty = 'def';
+
+        $query = $this->createFlowQuery([$myObject, $myObject2]);
+        self::assertSame('abc', $query->getStringProperty());
+    }
+
+    /**
+     * @test
+     */
     public function firstReturnsFirstObject()
     {
         $myObject = new \stdClass();

--- a/Neos.Eel/Tests/Unit/FlowQuery/FlowQueryTest.php
+++ b/Neos.Eel/Tests/Unit/FlowQuery/FlowQueryTest.php
@@ -52,7 +52,7 @@ class FlowQueryTest extends UnitTestCase
         $myObject2->stringProperty = 'def';
 
         $query = $this->createFlowQuery([$myObject, $myObject2]);
-        self::assertSame('abc', $query->getStringProperty());
+        self::assertSame('abc', $query->stringProperty);
     }
 
     /**

--- a/Neos.Utility.ObjectHandling/Classes/ObjectAccess.php
+++ b/Neos.Utility.ObjectHandling/Classes/ObjectAccess.php
@@ -143,6 +143,10 @@ abstract class ObjectAccess
             return null;
         }
 
+        if (method_exists($subject, '__get')) {
+            return $subject->__get($propertyName);
+        }
+
         $cacheIdentifier = $className . '|' . $propertyName;
         self::initializePropertyGetterCache($cacheIdentifier, $subject, $propertyName);
 

--- a/Neos.Utility.ObjectHandling/Tests/Unit/Fixture/DummyClassWithCall.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/Fixture/DummyClassWithCall.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Utility\ObjectHandling\Tests\Unit\Fixture;
+
+class DummyClassWithCall
+{
+    public function __call($name, $arguments)
+    {
+        return sprintf('__call %s %s', $name, json_encode($arguments));
+    }
+}

--- a/Neos.Utility.ObjectHandling/Tests/Unit/Fixture/DummyClassWithCallAndGet.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/Fixture/DummyClassWithCallAndGet.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Utility\ObjectHandling\Tests\Unit\Fixture;
+
+class DummyClassWithCallAndGet
+{
+    public function __call($name, $arguments)
+    {
+        throw new \RuntimeException('should not be invoked');
+    }
+
+    public function __get($name)
+    {
+        return sprintf('__get %s', $name);
+    }
+}

--- a/Neos.Utility.ObjectHandling/Tests/Unit/ObjectAccessTest.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/ObjectAccessTest.php
@@ -14,6 +14,8 @@ namespace Neos\Utility\ObjectHandling\Tests\Unit;
 use Neos\Utility\Exception\PropertyNotAccessibleException;
 use Neos\Utility\ObjectAccess;
 use Neos\Utility\ObjectHandling\Tests\Unit\Fixture\ArrayAccessClass;
+use Neos\Utility\ObjectHandling\Tests\Unit\Fixture\DummyClassWithCall;
+use Neos\Utility\ObjectHandling\Tests\Unit\Fixture\DummyClassWithCallAndGet;
 use Neos\Utility\ObjectHandling\Tests\Unit\Fixture\DummyClassWithGettersAndSetters;
 use Neos\Utility\ObjectHandling\Tests\Unit\Fixture\ProxiedClassWithPrivateProperty;
 use Neos\Utility\ObjectHandling\Tests\Unit\Fixture\Model\EntityWithDoctrineProxy;
@@ -21,6 +23,8 @@ use Neos\Utility\TypeHandling;
 
 require_once('Fixture/DummyClassWithGettersAndSetters.php');
 require_once('Fixture/ArrayAccessClass.php');
+require_once('Fixture/DummyClassWithCallAndGet.php');
+require_once('Fixture/DummyClassWithCall.php');
 require_once('Fixture/Model/EntityWithDoctrineProxy.php');
 require_once('Fixture/ProxiedClassWithPrivateProperty.php');
 
@@ -272,6 +276,26 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
         $this->expectException(PropertyNotAccessibleException::class);
         $splObjectStorage = new \SplObjectStorage();
         ObjectAccess::getProperty($splObjectStorage, 'something');
+    }
+
+    /**
+     * @test
+     */
+    public function getPropertyInvokesMagicGetMethodIfExistent()
+    {
+        $dummyClassWithCallAndGet = new DummyClassWithCallAndGet();
+        $actualResult = ObjectAccess::getProperty($dummyClassWithCallAndGet, 'key');
+        self::assertEquals('__get key', $actualResult);
+    }
+
+    /**
+     * @test
+     */
+    public function getPropertyInvokesMagicCallMethod()
+    {
+        $classWithCall = new DummyClassWithCall();
+        $actualResult = ObjectAccess::getProperty($classWithCall, 'key');
+        self::assertEquals('__call getKey []', $actualResult);
     }
 
     /**
@@ -560,7 +584,7 @@ class ObjectAccessTest extends \PHPUnit\Framework\TestCase
     public function setPropertyUsingDirectAccessWorksOnPrivatePropertyOfProxyParent()
     {
         $proxyObject = new ProxiedClassWithPrivateProperty();
- 
+
         ObjectAccess::setProperty($proxyObject, 'property', 'changed', true);
         self::assertEquals('changed', $proxyObject->getProperty());
     }


### PR DESCRIPTION
The idea was to get rid of the unintuitive `get(0)` calls in cases were now we would like to fetch node fields directly like their identifier:

Currently:

```
q(node).parent().get(0).aggregateId
``` 

Proposed:

```
q(node).parent().aggregateId
``` 

The need for that was created as `.property('_identifier')` does not work anymore.

Further while we thought about this we came to the idea that all final operations - also the `property` operation could be replaced:


Currently:

```
q(node).parent().property('foo-bar')
``` 

Proposed:

```
q(node).parent().properties['foo-bar']
``` 

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
