### PR TITLE
BUGFIX: Static compile attribute routes

### DIFF
--- a/Neos.Flow/Classes/Mvc/Routing/AttributeRoutesProvider.php
+++ b/Neos.Flow/Classes/Mvc/Routing/AttributeRoutesProvider.php
@@ -98,7 +98,7 @@ final class AttributeRoutesProvider implements RoutesProviderInterface
 
     /**
      * @param ObjectManagerInterface $objectManager
-     * @return array<string, array<int, mixed>
+     * @return array<string, array<int, mixed>>
      * @throws InvalidActionNameException
      * @throws InvalidControllerException
      * @throws \Neos\Flow\Utility\Exception

--- a/Neos.Flow/Classes/Mvc/Routing/AttributeRoutesProvider.php
+++ b/Neos.Flow/Classes/Mvc/Routing/AttributeRoutesProvider.php
@@ -69,7 +69,6 @@ final class AttributeRoutesProvider implements RoutesProviderInterface
      * @param array<string> $classNames
      */
     public function __construct(
-        public readonly ReflectionService $reflectionService,
         public readonly ObjectManagerInterface $objectManager,
         public readonly array $classNames,
     ) {
@@ -93,7 +92,7 @@ final class AttributeRoutesProvider implements RoutesProviderInterface
             $routes = [...$routes, ...$routesForClass];
         }
 
-        $routes = array_map(static fn(array $routeConfiguration): Route => Route::fromConfiguration($routeConfiguration), $routes);
+        $routes = array_map(static fn (array $routeConfiguration): Route => Route::fromConfiguration($routeConfiguration), $routes);
         return Routes::create(...$routes);
     }
 

--- a/Neos.Flow/Classes/Mvc/Routing/AttributeRoutesProviderFactory.php
+++ b/Neos.Flow/Classes/Mvc/Routing/AttributeRoutesProviderFactory.php
@@ -15,12 +15,10 @@ declare(strict_types=1);
 namespace Neos\Flow\Mvc\Routing;
 
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Flow\Reflection\ReflectionService;
 
 class AttributeRoutesProviderFactory implements RoutesProviderFactoryInterface
 {
     public function __construct(
-        public readonly ReflectionService $reflectionService,
         public readonly ObjectManagerInterface $objectManager,
     ) {
     }
@@ -31,7 +29,6 @@ class AttributeRoutesProviderFactory implements RoutesProviderFactoryInterface
     public function createRoutesProvider(array $options): RoutesProviderInterface
     {
         return new AttributeRoutesProvider(
-            $this->reflectionService,
             $this->objectManager,
             $options['classNames'] ?? [],
         );

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/AttributeRoutesProviderTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/AttributeRoutesProviderTest.php
@@ -35,8 +35,12 @@ class AttributeRoutesProviderTest extends UnitTestCase
         $this->mockReflectionService = $this->createMock(ReflectionService::class);
         $this->mockObjectManager = $this->createMock(ObjectManagerInterface::class);
 
+        $this->mockObjectManager->expects(self::any())
+            ->method('get')
+            ->with(ReflectionService::class)
+            ->willReturn($this->mockReflectionService);
+
         $this->annotationRoutesProvider = new Routing\AttributeRoutesProvider(
-            $this->mockReflectionService,
             $this->mockObjectManager,
             ['Vendor\\Example\\Controller\\*']
         );
@@ -136,10 +140,22 @@ class AttributeRoutesProviderTest extends UnitTestCase
      */
     public function annotationsOutsideClassNamesAreIgnored(): void
     {
+        $controllerclassName = 'Neos\Flow\Mvc\Controller\StandardController';
+
+        $this->mockObjectManager->expects(self::once())
+            ->method('getCaseSensitiveObjectName')
+            ->with($controllerclassName)
+            ->willReturn($controllerclassName);
+
+        $this->mockObjectManager->expects(self::once())
+            ->method('getPackageKeyByObjectName')
+            ->with($controllerclassName)
+            ->willReturn('Neos.Flow');
+
         $this->mockReflectionService->expects($this->once())
             ->method('getClassesContainingMethodsAnnotatedWith')
             ->with(Flow\Route::class)
-            ->willReturn(['Vendor\Other\Controller\ExampleController']);
+            ->willReturn([$controllerclassName]);
 
         $this->assertEquals(Routes::empty(), $this->annotationRoutesProvider->getRoutes());
     }


### PR DESCRIPTION
The necessary reflection data used to build the routes from attributes is not available at (Production) runtime. This is an issue in itself but not trivial to fix, therefore we fix this here by using the `CompileStatic` attribute to bring the necessary data over from compile time.

Fixes: #3400
