### PR TITLE
FEATURE: Add DecendantOfNodetype Condition Generator

### DIFF
--- a/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/DecendantOfNodetypeConditionGenerator.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/DecendantOfNodetypeConditionGenerator.php
@@ -1,0 +1,50 @@
+<?php
+namespace Neos\Flow\Security\Authorization\Privilege\Entity\Doctrine;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\ORM\Query\Filter\SQLFilter as DoctrineSqlFilter;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A SQL generator to create a condition matching anything.
+ */
+class DecendantOfNodetypeConditionGenerator implements SqlGeneratorInterface
+{
+
+    private array $nodetypes;
+
+    /**
+     * @param array $nodetypes
+     */
+    public function __construct(array $nodetypes)
+    {
+        $this->nodetypes = $nodetypes;
+    }
+
+    /**
+     * Returns an SQL query part that is basically a no-op in order to match any entity
+     *
+     * @param DoctrineSqlFilter $sqlFilter
+     * @param ClassMetadata $targetEntity
+     * @param string $targetTableAlias
+     * @return string
+     */
+    public function getSql(DoctrineSqlFilter $sqlFilter, ClassMetadata $targetEntity, $targetTableAlias)
+    {
+        $nodetypeList = implode("','", $this->nodetypes);
+
+        return "select * from public.neos_contentrepository_domain_model_nodedata n1
+        JOIN public.neos_contentrepository_domain_model_nodedata n2 ON n1.path LIKE CONCAT('%', n2.path, '%')
+        WHERE n2.nodetype in ('" . $nodetypeList . "')";
+    }
+}

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/DecendantOfNodetypeConditionGenerator.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/DecendantOfNodetypeConditionGenerator.php
@@ -20,7 +20,6 @@ use Neos\Flow\Annotations as Flow;
  */
 class DecendantOfNodetypeConditionGenerator implements SqlGeneratorInterface
 {
-
     private array $nodetypes;
 
     /**


### PR DESCRIPTION
This change adds the DecendantOfNodetypeConditionGenerator which will be used by the isDescendantOfNodetype privilege target matcher in the neos-development-collection repository.

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

A test for the isDescendantOfNodetype privilege target matcher can be found in the commit in the "neos-development-collection" repository.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
