### PR TITLE
BUGFIX: Fix use of `$this->response->set...` in controllers

### DIFF
--- a/Neos.Flow/Classes/Mvc/ActionRequest.php
+++ b/Neos.Flow/Classes/Mvc/ActionRequest.php
@@ -106,12 +106,6 @@ class ActionRequest
     protected $format = '';
 
     /**
-     * If this request has been changed and needs to be dispatched again
-     * @var boolean
-     */
-    protected $dispatched = false;
-
-    /**
      * The parent request – either another sub ActionRequest a main ActionRequest or null
      * @var ?ActionRequest
      */
@@ -654,14 +648,6 @@ class ActionRequest
     public function getFormat(): string
     {
         return $this->format;
-    }
-
-    /**
-     * Resets the dispatched status to false
-     */
-    public function __clone()
-    {
-        $this->dispatched = false;
     }
 
     /**

--- a/Neos.Flow/Classes/Mvc/ActionRequest.php
+++ b/Neos.Flow/Classes/Mvc/ActionRequest.php
@@ -658,7 +658,7 @@ class ActionRequest
      */
     public function __sleep()
     {
-        $properties = ['controllerPackageKey', 'controllerSubpackageKey', 'controllerName', 'controllerActionName', 'arguments', 'internalArguments', 'pluginArguments', 'argumentNamespace', 'format', 'dispatched'];
+        $properties = ['controllerPackageKey', 'controllerSubpackageKey', 'controllerName', 'controllerActionName', 'arguments', 'internalArguments', 'pluginArguments', 'argumentNamespace', 'format'];
         if ($this->parentRequest instanceof ActionRequest) {
             $properties[] = 'parentRequest';
         }

--- a/Neos.Flow/Classes/Mvc/Controller/ActionController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ActionController.php
@@ -257,7 +257,7 @@ class ActionController extends AbstractController
             $this->initializeView($this->view);
         }
 
-        $httpResponse = $this->callActionMethod($request, $this->arguments, $response->buildHttpResponse());
+        $httpResponse = $this->callActionMethod($request, $this->arguments, $response);
 
         if (!$httpResponse->hasHeader('Content-Type')) {
             $httpResponse = $httpResponse->withHeader('Content-Type', $this->negotiatedMediaType);
@@ -514,7 +514,7 @@ class ActionController extends AbstractController
      * @param Arguments $arguments
      * @param ResponseInterface $httpResponse The most likely empty response, previously available as $this->response
      */
-    protected function callActionMethod(ActionRequest $request, Arguments $arguments, ResponseInterface $httpResponse): ResponseInterface
+    protected function callActionMethod(ActionRequest $request, Arguments $arguments, ActionResponse $response): ResponseInterface
     {
         $preparedArguments = [];
         foreach ($arguments as $argument) {
@@ -554,6 +554,9 @@ class ActionController extends AbstractController
                 $actionResult = $this->{$this->errorMethodName}();
             }
         }
+
+        // freeze $response previously available as $this->response
+        $httpResponse = $response->buildHttpResponse();
 
         if ($actionResult instanceof ResponseInterface) {
             return $actionResult;

--- a/Neos.Flow/Classes/Mvc/Controller/ActionController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/ActionController.php
@@ -512,7 +512,7 @@ class ActionController extends AbstractController
      *
      * @param ActionRequest $request
      * @param Arguments $arguments
-     * @param ResponseInterface $httpResponse The most likely empty response, previously available as $this->response
+     * @param ActionResponse $response The most likely empty response, previously available as $this->response
      */
     protected function callActionMethod(ActionRequest $request, Arguments $arguments, ActionResponse $response): ResponseInterface
     {

--- a/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/ActionControllerTest.php
@@ -130,6 +130,16 @@ class ActionControllerTest extends FunctionalTestCase
     }
 
     /**
+     * @test
+     */
+    public function requestAndResponseAreAvailableInTheAction()
+    {
+        $response = $this->browser->request('http://localhost/test/mvc/actioncontrollertesta/fifth?argument=the-value');
+        self::assertEquals('Fifth action (fifth) with: "the-value"', $response->getBody()->getContents());
+        self::assertEquals('Hello World', $response->getHeaderLine('X-Foo'));
+    }
+
+    /**
      * Bug #36913
      *
      * @test

--- a/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/ActionControllerTestAController.php
+++ b/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/ActionControllerTestAController.php
@@ -66,6 +66,15 @@ class ActionControllerTestAController extends ActionController
     }
 
     /**
+     * Tests response and request
+     */
+    public function fifthAction()
+    {
+        $this->response->setHttpHeader('X-Foo', 'Hello World');
+        return sprintf('Fifth action (%s) with: "%s"', $this->request->getControllerActionName(), $this->request->getArgument('argument'));
+    }
+
+    /**
      * @param string $putArgument
      * @param string $getArgument
      * @return string


### PR DESCRIPTION
Regression from https://github.com/neos/flow-development-collection/pull/3311


And remove declaration of obsolete $dispatched state (followup to https://github.com/neos/flow-development-collection/pull/3294)


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
