### PR TITLE
BUGFIX: Always add space between IP and severity in file logs

### DIFF
--- a/Neos.Flow.Log/Classes/Backend/FileBackend.php
+++ b/Neos.Flow.Log/Classes/Backend/FileBackend.php
@@ -239,7 +239,7 @@ class FileBackend extends AbstractBackend
         } else {
             $processId = ' ' . str_pad((string)getmypid(), 10);
         }
-        $ipAddress = ($this->logIpAddress === true) ? str_pad(($_SERVER['REMOTE_ADDR'] ?? ''), 15) : '';
+        $ipAddress = ($this->logIpAddress === true) ? str_pad(($_SERVER['REMOTE_ADDR'] ?? ''), 15) . ' ' : '';
         $severityLabel = $this->severityLabels[$severity] ?? 'UNKNOWN  ';
         $output = (new \DateTime())->format('y-m-d H:i:s') . $processId . ' ' . $ipAddress . $severityLabel . ' ' . str_pad((string)$packageKey, 20) . ' ' . $message;
 


### PR DESCRIPTION
For all IP addresses of length 15 or longer (most ipv6 addresses) no space was added between the IP address and the Severity.

This bugfix always adds a space character between IP and severity.

**Review instructions**

Check if IPv6 addresses are separated with a space in log files.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
