### PR TITLE
WIP: Extended Privilege syntax

### DIFF
--- a/Neos.Flow/Classes/Command/SecurityCommandController.php
+++ b/Neos.Flow/Classes/Command/SecurityCommandController.php
@@ -19,6 +19,7 @@ use Neos\Flow\Configuration\Exception\InvalidConfigurationTypeException;
 use Neos\Flow\Mvc\Controller\AbstractController;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Reflection\ReflectionService;
+use Neos\Flow\Security\Authorization\Privilege\Permission;
 use Neos\Flow\Security\Cryptography\RsaWalletServicePhp;
 use Neos\Flow\Security\Exception as SecurityException;
 use Neos\Flow\Security\Exception\NoSuchRoleException;
@@ -216,7 +217,7 @@ class SecurityCommandController extends CommandController
 
             /** @var Role $requestedRole */
             foreach ($requestedRoles as $requestedRole) {
-                $privilegeType = $requestedRole->getPrivilegeForTarget($definedPrivilege->getPrivilegeTarget()->getIdentifier());
+                $privilegeType = $requestedRole->getPrivilegeForTarget($definedPrivilege->getPrivilegeTarget()->identifier);
 
                 if ($privilegeType === null) {
                     continue;
@@ -315,9 +316,9 @@ class SecurityCommandController extends CommandController
             list($argumentName, $argumentValue) = explode(':', $argument, 2);
             $privilegeParameters[$argumentName] = $argumentValue;
         }
-        $privilege = $privilegeTargetInstance->createPrivilege(PrivilegeInterface::GRANT, $privilegeParameters);
+        $privilege = $privilegeTargetInstance->createPrivilege(Permission::GRANT, $privilegeParameters);
         if (!$privilege instanceof MethodPrivilegeInterface) {
-            $this->outputLine('The privilegeTarget "%s" does not refer to a MethodPrivilege but to a privilege of type "%s"', [$privilegeTarget, $privilege->getPrivilegeTarget()->getPrivilegeClassName()]);
+            $this->outputLine('The privilegeTarget "%s" does not refer to a MethodPrivilege but to a privilege of type "%s"', [$privilegeTarget, $privilege->getPrivilegeTarget()->privilegeClassName]);
             $this->quit(1);
         }
 
@@ -415,9 +416,9 @@ class SecurityCommandController extends CommandController
         } else {
             foreach ($privileges as $privilege) {
                 $target = $privilege->getPrivilegeTarget();
-                $this->outputLine(' * %s: <i>%s</i>', [$privilege->getPrivilegeTargetIdentifier(), strtoupper($privilege->getPermission())]);
-                if ($target->getLabel() !== $privilege->getPrivilegeTargetIdentifier()) {
-                    $this->outputFormatted($target->getLabel(), [], 5);
+                $this->outputLine(' * %s: <i>%s</i>', [$privilege->getPrivilegeTargetIdentifier(), $privilege->getPermission()->value]);
+                if ($target->label !== '') {
+                    $this->outputFormatted($target->label, [], 5);
                 }
             }
         }

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/AbstractPrivilege.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/AbstractPrivilege.php
@@ -140,7 +140,7 @@ abstract class AbstractPrivilege implements PrivilegeInterface
      */
     public function isAbstained()
     {
-        return $this->permission === self::ABSTAIN;
+        return $this->permission === Permission::ABSTAIN;
     }
 
     /**
@@ -149,7 +149,7 @@ abstract class AbstractPrivilege implements PrivilegeInterface
 
     public function isDenied()
     {
-        return $this->permission === self::DENY;
+        return $this->permission === Permission::DENY;
     }
 
     /**
@@ -169,7 +169,7 @@ abstract class AbstractPrivilege implements PrivilegeInterface
      */
     public function getPrivilegeTargetIdentifier()
     {
-        return $this->privilegeTarget->getIdentifier();
+        return $this->privilegeTarget->identifier;
     }
 
     /**

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/Permission.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/Permission.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Security\Authorization\Privilege;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * The permission of a privilege
+ */
+enum Permission : string
+{
+    case ABSTAIN = 'ABSTAIN';
+    case GRANT = 'GRANT';
+    case DENY = 'DENY';
+}

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/PrivilegeInterface.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/PrivilegeInterface.php
@@ -22,61 +22,37 @@ use Neos\Flow\Security\Exception\InvalidPrivilegeTypeException;
  */
 interface PrivilegeInterface extends CacheAwareInterface
 {
-    const ABSTAIN = 'abstain';
-    const GRANT = 'grant';
-    const DENY = 'deny';
+    /**
+     * @param array<string, mixed> $options privilege options with parameters replaced
+     */
+    public static function create(PrivilegeTarget $privilegeTarget, array $options, Permission $permission, ObjectManagerInterface $objectManager): self;
+
+    public function getPermission(): Permission;
 
     /**
-     * Note: We can't define constructors in interfaces, but this is assumed to exist in the concrete implementation!
-     *
-     * @param PrivilegeTarget $privilegeTarget
-     * @param string $matcher
-     * @param integer $permission One of the constants ABSTAIN, GRANT or DENY
-     * @param PrivilegeParameterInterface[] $parameters
+     * @deprecated with Flow 9.0 - use `$privilege::getPermission() === Permission::GRANT`
      */
-    // public function __construct(PrivilegeTarget $privilegeTarget, $matcher, $permission, array $parameters) {
+    public function isGranted(): bool;
 
     /**
-     * This object is created very early so we can't rely on AOP for the property injection
-     *
-     * @param ObjectManagerInterface $objectManager
-     * @return void
+     * @deprecated with Flow 9.0 - use `$privilege::getPermission() === Permission::ABSTAIN`
      */
-    public function injectObjectManager(ObjectManagerInterface $objectManager);
+    public function isAbstained(): bool;
 
     /**
-     * @return string
+     * @deprecated with Flow 9.0 - use `$privilege::getPermission() === Permission::DENY`
      */
-    public function getPermission();
-
-    /**
-     * @return boolean
-     */
-    public function isGranted();
-
-    /**
-     * @return boolean
-     */
-    public function isAbstained();
-
-    /**
-     * @return boolean
-     */
-    public function isDenied();
+    public function isDenied(): bool;
 
     /**
      * Returns the related privilege target
-     *
-     * @return PrivilegeTarget
      */
-    public function getPrivilegeTarget();
+    public function getPrivilegeTarget(): PrivilegeTarget;
 
     /**
      * Unique name of the related privilege target (for example "Neos.Flow:PublicMethods")
-     *
-     * @return string
      */
-    public function getPrivilegeTargetIdentifier();
+    public function getPrivilegeTargetIdentifier(): string;
 
     /**
      * A matcher string, describing the privilegeTarget (e.g. pointcut expression for methods or EEL expression for entities)

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/PrivilegeTarget.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/PrivilegeTarget.php
@@ -23,49 +23,25 @@ use Neos\Flow\Security\Exception as SecurityException;
 class PrivilegeTarget
 {
     /**
-     * @var string
-     */
-    protected $identifier;
-
-    /**
-     * @var string
-     */
-    protected $privilegeClassName;
-
-    /**
-     * @var string
-     */
-    protected $matcher;
-
-    /**
-     * @var Parameter\PrivilegeParameterDefinition[]
-     */
-    protected $parameterDefinitions;
-
-    /**
      * @var ObjectManagerInterface
      */
     protected $objectManager;
 
     /**
-     * @var string
-     */
-    protected $label;
-
-    /**
-     * @param string $identifier
-     * @param string $privilegeClassName
-     * @param string $matcher
+     * @param class-string<PrivilegeInterface> $privilegeClassName
+     * @param array<string, mixed> $options
      * @param Parameter\PrivilegeParameterDefinition[] $parameterDefinitions
-     * @param string $label
      */
-    public function __construct(string $identifier, string $privilegeClassName, string $matcher, array $parameterDefinitions = [], string $label = '')
-    {
-        $this->identifier = $identifier;
-        $this->label = empty($label) ? $identifier : $label;
-        $this->privilegeClassName = $privilegeClassName;
-        $this->matcher = $matcher;
-        $this->parameterDefinitions = $parameterDefinitions;
+    public function __construct(
+        public readonly string $identifier,
+        public readonly string $privilegeClassName,
+        public readonly array $options,
+        public readonly array $parameterDefinitions = [],
+        public readonly string $label = ''
+    ) {
+        if (!is_subclass_of($this->privilegeClassName, PrivilegeInterface::class)) {
+            throw new SecurityException(sprintf('Expected instance of %s, got "%s"', PrivilegeInterface::class, $this->privilegeClassName), 1395869340);
+        }
     }
 
     /**
@@ -80,7 +56,7 @@ class PrivilegeTarget
     }
 
     /**
-     * @return string
+     * @deprecated with Flow 9.0 - use the public property {@see self::identifier}
      */
     public function getIdentifier(): string
     {
@@ -88,7 +64,7 @@ class PrivilegeTarget
     }
 
     /**
-     * @return string
+     * @deprecated with Flow 9.0 - use the public property {@see self::privilegeClassName}
      */
     public function getPrivilegeClassName(): string
     {
@@ -96,14 +72,7 @@ class PrivilegeTarget
     }
 
     /**
-     * @return string
-     */
-    public function getMatcher(): string
-    {
-        return $this->matcher;
-    }
-
-    /**
+     * @deprecated with Flow 9.0 - use the public property {@see self::parameterDefinitions}
      * @return Parameter\PrivilegeParameterDefinition[]
      */
     public function getParameterDefinitions(): array
@@ -120,45 +89,41 @@ class PrivilegeTarget
     }
 
     /**
-     * @param string $permission one of "GRANT", "DENY" or "ABSTAIN"
+     * @param Permission|string $permissionOrString a Permission instance (or a string of "GRANT", "DENY" or "ABSTAIN" for backwards compatibility)
      * @param array $parameters Optional key/value array with parameter names and -values
      * @return PrivilegeInterface
      * @throws SecurityException
      */
-    public function createPrivilege(string $permission, array $parameters = []): PrivilegeInterface
+    public function createPrivilege(Permission|string $permissionOrString, array $parameters = []): PrivilegeInterface
     {
-        $permission = strtolower($permission);
-        if ($permission !== PrivilegeInterface::GRANT && $permission !== PrivilegeInterface::DENY && $permission !== PrivilegeInterface::ABSTAIN) {
-            throw new SecurityException(sprintf('permission must be either "GRANT", "DENY" or "ABSTAIN", given: "%s"', $permission), 1401878462);
+        if (is_string($permissionOrString)) {
+            $permission = Permission::tryFrom($permissionOrString);
+            if ($permission === null) {
+                throw new SecurityException(sprintf('permission must be either "GRANT", "DENY" or "ABSTAIN", given: "%s"', $permissionOrString), 1401878462);
+            }
+        } else {
+            $permission = $permissionOrString;
         }
 
-        $privilegeParameters = array_map($this->createParameterMapper($parameters), $this->parameterDefinitions);
-        $privilege = new $this->privilegeClassName($this, $this->matcher, $permission, $privilegeParameters);
-        if (!$privilege instanceof PrivilegeInterface) {
-            throw new SecurityException(sprintf('Expected instance of PrivilegeInterface, got "%s"', get_class($privilege)), 1395869340);
+        /** @var PrivilegeParameterInterface[] $privilegeParameters */
+        $privilegeParameters = array_map(fn (PrivilegeParameterDefinition $parameterDefinition) => $this->createParameter($parameterDefinition, $parameters), $this->parameterDefinitions);
+        $options = $this->options;
+        foreach ($privilegeParameters as $parameter) {
+            foreach ($options as $key => $option) {
+                if (is_string($option)) {
+                    $options[$key] = str_replace('{parameters.' . $parameter->getName() . '}', $parameter->getValue(), $option);
+                }
+            }
         }
-        $privilege->injectObjectManager($this->objectManager);
-
-        return $privilege;
+        return ($this->privilegeClassName)::create($this, $options, $permission, $this->objectManager);
     }
 
     /**
-     * @return string
+     * @deprecated with Flow 9.0 - use the public property {@see self::label}
      */
     public function getLabel(): string
     {
         return $this->label;
-    }
-
-    /**
-     * @param array $parameters
-     * @return \Closure
-     */
-    protected function createParameterMapper(array $parameters): \Closure
-    {
-        return function (PrivilegeParameterDefinition $parameterDefinition) use ($parameters) {
-            return $this->createParameter($parameterDefinition, $parameters);
-        };
     }
 
     /**

--- a/Neos.Flow/Classes/Security/Authorization/PrivilegePermissionResult.php
+++ b/Neos.Flow/Classes/Security/Authorization/PrivilegePermissionResult.php
@@ -71,7 +71,7 @@ class PrivilegePermissionResult
         }, $privilege->getParameters());
 
         $privilegeName = $privilege->getPrivilegeTargetIdentifier() . ($parameterStrings !== [] ? ' (with parameters: ' . implode(', ', $parameterStrings) . ')' : '');
-        $newResult->effectivePrivilegeIdentifiersWithPermission[] = sprintf('"%s": %s', $privilegeName, strtoupper($privilege->getPermission()));
+        $newResult->effectivePrivilegeIdentifiersWithPermission[] = sprintf('"%s": %s', $privilegeName, $privilege->getPermission()->value);
 
         return $newResult;
     }

--- a/Neos.Flow/Classes/Security/Policy/PolicyService.php
+++ b/Neos.Flow/Classes/Security/Policy/PolicyService.php
@@ -19,6 +19,7 @@ use Neos\Flow\Configuration\Exception\InvalidConfigurationTypeException;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Security\Authorization\Privilege\Parameter\PrivilegeParameterDefinition;
 use Neos\Flow\Security\Authorization\Privilege\Parameter\PrivilegeParameterInterface;
+use Neos\Flow\Security\Authorization\Privilege\Permission;
 use Neos\Flow\Security\Authorization\Privilege\PrivilegeTarget;
 use Neos\Flow\Security\Exception\NoSuchRoleException;
 use Neos\Flow\Security\Exception as SecurityException;
@@ -152,7 +153,7 @@ class PolicyService
             if ($privilegeTarget->hasParameters()) {
                 continue;
             }
-            $everybodyRole->addPrivilege($privilegeTarget->createPrivilege(PrivilegeInterface::ABSTAIN));
+            $everybodyRole->addPrivilege($privilegeTarget->createPrivilege(Permission::ABSTAIN));
         }
         $this->roles['Neos.Flow:Everybody'] = $everybodyRole;
 
@@ -205,7 +206,7 @@ class PolicyService
                 }
 
                 $label = $privilegeTargetConfiguration['label'] ?? $privilegeTargetIdentifier;
-                $privilegeTarget = new PrivilegeTarget($privilegeTargetIdentifier, $privilegeClassName, $privilegeTargetConfiguration['matcher'], $parameterDefinitions, $label);
+                $privilegeTarget = new PrivilegeTarget($privilegeTargetIdentifier, $privilegeClassName, $privilegeTargetConfiguration, $parameterDefinitions, $label);
                 $privilegeTarget->injectObjectManager($this->objectManager);
                 $this->privilegeTargets[$privilegeTargetIdentifier] = $privilegeTarget;
             }

--- a/Neos.Flow/Tests/Unit/Security/Authorization/PrivilegeManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authorization/PrivilegeManagerTest.php
@@ -17,6 +17,7 @@ use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Flow\Security\Authorization\Privilege\AbstractPrivilege;
 use Neos\Flow\Security\Authorization\Privilege\Method\MethodPrivilegeInterface;
 use Neos\Flow\Security\Authorization\Privilege\Method\MethodPrivilegeSubject;
+use Neos\Flow\Security\Authorization\Privilege\Permission;
 use Neos\Flow\Security\Authorization\Privilege\PrivilegeInterface;
 use Neos\Flow\Security\Authorization\PrivilegeManager;
 use Neos\Flow\Security\Context;
@@ -76,21 +77,21 @@ class PrivilegeManagerTest extends UnitTestCase
         $this->privilegeManager = new PrivilegeManager($this->mockObjectManager, $this->mockSecurityContext);
 
         $this->grantPrivilege = $this->getMockBuilder(AbstractPrivilege::class)->disableOriginalConstructor()->getMock();
-        $this->grantPrivilege->expects(self::any())->method('getPermission')->will(self::returnValue(PrivilegeInterface::GRANT));
+        $this->grantPrivilege->expects(self::any())->method('getPermission')->will(self::returnValue(Permission::GRANT));
         $this->grantPrivilege->expects(self::any())->method('matchesSubject')->will(self::returnValue(true));
         $this->grantPrivilege->expects(self::any())->method('getParameters')->will(self::returnValue([]));
         $this->grantPrivilege->expects(self::any())->method('isGranted')->will(self::returnValue(true));
         $this->grantPrivilege->expects(self::any())->method('isDenied')->will(self::returnValue(false));
 
         $this->denyPrivilege = $this->getMockBuilder(AbstractPrivilege::class)->disableOriginalConstructor()->getMock();
-        $this->denyPrivilege->expects(self::any())->method('getPermission')->will(self::returnValue(PrivilegeInterface::DENY));
+        $this->denyPrivilege->expects(self::any())->method('getPermission')->will(self::returnValue(Permission::DENY));
         $this->denyPrivilege->expects(self::any())->method('matchesSubject')->will(self::returnValue(true));
         $this->denyPrivilege->expects(self::any())->method('getParameters')->will(self::returnValue([]));
         $this->denyPrivilege->expects(self::any())->method('isGranted')->will(self::returnValue(false));
         $this->denyPrivilege->expects(self::any())->method('isDenied')->will(self::returnValue(true));
 
         $this->abstainPrivilege = $this->getMockBuilder(AbstractPrivilege::class)->disableOriginalConstructor()->getMock();
-        $this->abstainPrivilege->expects(self::any())->method('getPermission')->will(self::returnValue(PrivilegeInterface::ABSTAIN));
+        $this->abstainPrivilege->expects(self::any())->method('getPermission')->will(self::returnValue(Permission::ABSTAIN));
         $this->abstainPrivilege->expects(self::any())->method('matchesSubject')->will(self::returnValue(true));
         $this->abstainPrivilege->expects(self::any())->method('getParameters')->will(self::returnValue([]));
         $this->abstainPrivilege->expects(self::any())->method('isGranted')->will(self::returnValue(false));

--- a/Neos.Flow/Tests/Unit/Security/Policy/PolicyServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Policy/PolicyServiceTest.php
@@ -207,7 +207,7 @@ class PolicyServiceTest extends UnitTestCase
             ],
         ];
         self::assertCount(1, $this->policyService->getPrivilegeTargets());
-        self::assertSame('Some.PrivilegeTarget:Identifier', $this->policyService->getPrivilegeTargets()['Some.PrivilegeTarget:Identifier']->getIdentifier());
+        self::assertSame('Some.PrivilegeTarget:Identifier', $this->policyService->getPrivilegeTargets()['Some.PrivilegeTarget:Identifier']->identifier);
     }
 
     /**
@@ -236,7 +236,7 @@ class PolicyServiceTest extends UnitTestCase
 
         $privilegeTarget = $this->policyService->getPrivilegeTargetByIdentifier('Some.PrivilegeTarget:Identifier');
         self::assertInstanceOf(PrivilegeTarget::class, $privilegeTarget);
-        self::assertSame('Some.PrivilegeTarget:Identifier', $privilegeTarget->getIdentifier());
+        self::assertSame('Some.PrivilegeTarget:Identifier', $privilegeTarget->identifier);
     }
 
     /**


### PR DESCRIPTION
Extend privilege syntax to allow for custom, dedicated options:

e.g. instead of:

```yaml
privilegeTargets:
  'Neos\Neos\Security\Authorization\Privilege\EditNodePrivilege':
    'Neos.Demo:EditBlogNodes':
      matcher: 'default:blog'
```

this would allow for:

```yaml
privilegeTargets:
  'Neos\Neos\Security\Authorization\Privilege\EditNodePrivilege':
    'Neos.Demo:EditBlogNodes':
      contentRepository: 'default'
      subtreeTag: 'blog'
```
