### PR TITLE
TASK: Drop code for PHP < 8

### DIFF
--- a/Neos.Flow/Classes/Property/TypeConverter/MediaTypeConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/MediaTypeConverter.php
@@ -92,19 +92,9 @@ class MediaTypeConverter extends AbstractTypeConverter implements MediaTypeConve
                 }
                 break;
             case 'xml':
-                // TODO: Remove those lines once the minimum PHP version is 8.0
-                if (PHP_MAJOR_VERSION < 8) {
-                    $entityLoaderValue = libxml_disable_entity_loader(true);
-                }
                 try {
                     $xmlElement = new \SimpleXMLElement(urldecode($requestBody), LIBXML_NOERROR);
-                    if (PHP_MAJOR_VERSION < 8) {
-                        libxml_disable_entity_loader($entityLoaderValue);
-                    }
                 } catch (\Exception $exception) {
-                    if (PHP_MAJOR_VERSION < 8) {
-                        libxml_disable_entity_loader($entityLoaderValue);
-                    }
                     return [];
                 }
                 $result = Arrays::convertObjectToArray($xmlElement);


### PR DESCRIPTION
This drops code that was only executed on PHP < 8.0, and thus will never ever be run again.
**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
