### PR TITLE
TASK: Uniquify exception codes in Abstract(Template)View

### DIFF
--- a/Neos.Flow/Classes/Mvc/View/AbstractView.php
+++ b/Neos.Flow/Classes/Mvc/View/AbstractView.php
@@ -84,7 +84,7 @@ abstract class AbstractView implements ViewInterface
             $this->supportedOptions,
             function ($supportedOptionData, $supportedOptionName, $options) {
                 if (isset($supportedOptionData[3]) && !array_key_exists($supportedOptionName, $options)) {
-                    throw new Exception('Required view option not set: ' . $supportedOptionName, 1359625876);
+                    throw new Exception('Required view option not set: ' . $supportedOptionName, 1359625877);
                 }
             },
             $options
@@ -112,7 +112,7 @@ abstract class AbstractView implements ViewInterface
     public function getOption($optionName)
     {
         if (!array_key_exists($optionName, $this->supportedOptions)) {
-            throw new Exception(sprintf('The view option "%s" you\'re trying to get doesn\'t exist in class "%s".', $optionName, get_class($this)), 1359625876);
+            throw new Exception(sprintf('The view option "%s" you\'re trying to get doesn\'t exist in class "%s".', $optionName, get_class($this)), 1359625878);
         }
 
         return $this->options[$optionName];
@@ -129,7 +129,7 @@ abstract class AbstractView implements ViewInterface
     public function setOption($optionName, $value)
     {
         if (!array_key_exists($optionName, $this->supportedOptions)) {
-            throw new Exception(sprintf('The view option "%s" you\'re trying to set doesn\'t exist in class "%s".', $optionName, get_class($this)), 1359625876);
+            throw new Exception(sprintf('The view option "%s" you\'re trying to set doesn\'t exist in class "%s".', $optionName, get_class($this)), 1359625879);
         }
 
         $this->options[$optionName] = $value;

--- a/Neos.FluidAdaptor/Classes/View/AbstractTemplateView.php
+++ b/Neos.FluidAdaptor/Classes/View/AbstractTemplateView.php
@@ -216,7 +216,7 @@ abstract class AbstractTemplateView extends \TYPO3Fluid\Fluid\View\AbstractTempl
     {
         // check for options given but not supported
         if (($unsupportedOptions = array_diff_key($options, $this->supportedOptions)) !== []) {
-            throw new Exception(sprintf('The view options "%s" you\'re trying to set don\'t exist in class "%s".', implode(',', array_keys($unsupportedOptions)), get_class($this)), 1359625876);
+            throw new Exception(sprintf('The view options "%s" you\'re trying to set don\'t exist in class "%s".', implode(',', array_keys($unsupportedOptions)), get_class($this)), 1359625880);
         }
 
         // check for required options being set
@@ -224,7 +224,7 @@ abstract class AbstractTemplateView extends \TYPO3Fluid\Fluid\View\AbstractTempl
             $this->supportedOptions,
             function ($supportedOptionData, $supportedOptionName, $options) {
                 if (isset($supportedOptionData[3]) && !array_key_exists($supportedOptionName, $options)) {
-                    throw new Exception('Required view option not set: ' . $supportedOptionName, 1359625876);
+                    throw new Exception('Required view option not set: ' . $supportedOptionName, 1359625881);
                 }
             },
             $options
@@ -261,7 +261,7 @@ abstract class AbstractTemplateView extends \TYPO3Fluid\Fluid\View\AbstractTempl
     public function getOption($optionName)
     {
         if (!array_key_exists($optionName, $this->supportedOptions)) {
-            throw new \Neos\Flow\Mvc\Exception(sprintf('The view option "%s" you\'re trying to get doesn\'t exist in class "%s".', $optionName, get_class($this)), 1359625876);
+            throw new \Neos\Flow\Mvc\Exception(sprintf('The view option "%s" you\'re trying to get doesn\'t exist in class "%s".', $optionName, get_class($this)), 1359625882);
         }
 
         return $this->options[$optionName];
@@ -278,7 +278,7 @@ abstract class AbstractTemplateView extends \TYPO3Fluid\Fluid\View\AbstractTempl
     public function setOption($optionName, $value)
     {
         if (!array_key_exists($optionName, $this->supportedOptions)) {
-            throw new \Neos\Flow\Mvc\Exception(sprintf('The view option "%s" you\'re trying to set doesn\'t exist in class "%s".', $optionName, get_class($this)), 1359625876);
+            throw new \Neos\Flow\Mvc\Exception(sprintf('The view option "%s" you\'re trying to set doesn\'t exist in class "%s".', $optionName, get_class($this)), 1359625883);
         }
 
         $this->options[$optionName] = $value;


### PR DESCRIPTION
Exception codes are supposed to be unique, so this makes sure those places get a code of their own.

**Upgrade instructions**

If you rely on that exception code (`1359625876`) for whatever reason, consider taking the new codes into account, too:

- `1359625877`
- `1359625878`
- `1359625879`
- `1359625880`
- `1359625881`
- `1359625882`
- `1359625883`

**Review instructions**

You could check if any of the new codes is in use already, in turn… 😬

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
