### PR TITLE
TASK: Handle non-integer error codes in throwabe FileStorage

### DIFF
--- a/Neos.Flow/Classes/Log/ThrowableStorage/FileStorage.php
+++ b/Neos.Flow/Classes/Log/ThrowableStorage/FileStorage.php
@@ -219,11 +219,16 @@ class FileStorage implements ThrowableStorageInterface
      */
     protected function getErrorLogMessage(\Throwable $error)
     {
-        $errorCodeNumber = ($error->getCode() > 0) ? ' #' . $error->getCode() : '';
+        // getCode() does not always return an integer, e.g. in PDOException it can be a string 
+        if (is_int($error->getCode()) && $error->getCode() > 0) {
+            $errorCodeString = ' #' . $error->getCode();
+        } else {
+            $errorCodeString = ' [' . $error->getCode() . ']';
+        }
         $backTrace = $error->getTrace();
         $line = isset($backTrace[0]['line']) ? ' in line ' . $backTrace[0]['line'] . ' of ' . $backTrace[0]['file'] : '';
 
-        return 'Exception' . $errorCodeNumber . $line . ': ' . $error->getMessage();
+        return 'Exception' . $errorCodeString . $line . ': ' . $error->getMessage();
     }
 
     /**

--- a/Neos.Flow/Classes/Log/ThrowableStorage/FileStorage.php
+++ b/Neos.Flow/Classes/Log/ThrowableStorage/FileStorage.php
@@ -219,7 +219,7 @@ class FileStorage implements ThrowableStorageInterface
      */
     protected function getErrorLogMessage(\Throwable $error)
     {
-        // getCode() does not always return an integer, e.g. in PDOException it can be a string 
+        // getCode() does not always return an integer, e.g. in PDOException it can be a string
         if (is_int($error->getCode()) && $error->getCode() > 0) {
             $errorCodeString = ' #' . $error->getCode();
         } else {


### PR DESCRIPTION
This will no longer swallow certain error codes but instead emit them in the message.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
