### PR TITLE
BUGFIX: Don’t load the same files twice in the static resource collection

### DIFF
--- a/Neos.Flow/Configuration/Settings.Resource.yaml
+++ b/Neos.Flow/Configuration/Settings.Resource.yaml
@@ -46,7 +46,6 @@ Neos:
           target: 'localWebDirectoryStaticResourcesTarget'
           pathPatterns:
             - '*/Resources/Public/'
-            - '*/Resources/Public/*'
 
         # Collection which contains all persistent resources
         persistent:


### PR DESCRIPTION
The second pattern included a 99% subset of the first pattern except the files in the public folders themselves. Therefore all files in subfolders were loaded twice in the `\Neos\Flow\ResourceManagement\Collection::getObjects` method and afterwards also published twice.

In a medium sized project the first pattern loaded 1165 files and the second pattern 1155 which were all duplicates.

An additional change is required to deduplicate paths loaded in the `Collection` class to prevent further configuration regressions for cases like this.

Resolves: #3417

**Review instructions**

* Delete the `Web/_Resources/Static` folder in a demo distribution
* Run `./flow resource:publish --collection static` 
* Reload the Neos backend and all the static resources like JS and CSS should still be there.
