### PR TITLE
FEATURE: Add fromClassAndMethodName() to LogEnvironment

### DIFF
--- a/Neos.Flow/Classes/Log/Utility/LogEnvironment.php
+++ b/Neos.Flow/Classes/Log/Utility/LogEnvironment.php
@@ -15,27 +15,20 @@ namespace Neos\Flow\Log\Utility;
 
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\Flow\Package\PackageInterface;
 use Neos\Flow\Package\PackageKeyAwareInterface;
 use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Annotations as Flow;
 
 abstract class LogEnvironment
 {
-    /**
-     * @var array
-     */
-    protected static $packageKeys = [];
+    protected static array $packageKeys = [];
 
-    /**
-     * @var bool
-     */
-    protected static $initialized = false;
+    protected static bool $initialized = false;
 
     /**
      * Returns an array containing the log environment variables
-     * under the key FLOW_LOG_ENVIRONMENT to be set as part of the additional data
-     * in an log method call.
+     * under the key FLOW_LOG_ENVIRONMENT to be set as part of
+     * the additional data in an log method call.
      *
      * @param string $methodName
      * @return array
@@ -43,8 +36,8 @@ abstract class LogEnvironment
     public static function fromMethodName(string $methodName): array
     {
         if (strpos($methodName, '::') > 0) {
-            list($className, $functionName) = explode('::', $methodName);
-        } elseif (substr($methodName, -9, 9) === '{closure}') {
+            [$className, $functionName] = explode('::', $methodName);
+        } elseif (str_ends_with($methodName, '{closure}')) {
             $className = substr($methodName, 0, -9);
             $functionName = '{closure}';
         } else {
@@ -61,9 +54,21 @@ abstract class LogEnvironment
     }
 
     /**
-     * @param string $className
-     * @return string
+     * Returns an array containing the log environment variables
+     * under the key FLOW_LOG_ENVIRONMENT to be set as part of the
+     * additional data in an log method call.
      */
+    public static function fromClassAndMethodName(string $className, string $methodName): array
+    {
+        return [
+            'FLOW_LOG_ENVIRONMENT' => [
+                'packageKey' => self::getPackageKeyFromClassName($className),
+                'className' => $className,
+                'methodName' => $methodName
+            ]
+        ];
+    }
+
     protected static function getPackageKeyFromClassName(string $className): string
     {
         $packageKeys = static::getPackageKeys();
@@ -73,7 +78,7 @@ abstract class LogEnvironment
         $packageKeyCandidate = $determinedPackageKey;
 
         foreach ($classPathArray as $classPathSegment) {
-            $packageKeyCandidate = $packageKeyCandidate . '.' . $classPathSegment;
+            $packageKeyCandidate .= '.' . $classPathSegment;
 
             if (!isset($packageKeys[$packageKeyCandidate])) {
                 continue;
@@ -86,7 +91,6 @@ abstract class LogEnvironment
     }
 
     /**
-     * @return array
      * @Flow\CompileStatic
      */
     protected static function getPackageKeys(): array
@@ -99,7 +103,6 @@ abstract class LogEnvironment
             /** @var PackageManager $packageManager */
             $packageManager = Bootstrap::$staticObjectManager->get(PackageManager::class);
 
-            /** @var PackageInterface $package */
             foreach ($packageManager->getAvailablePackages() as $package) {
                 if ($package instanceof PackageKeyAwareInterface) {
                     self::$packageKeys[$package->getPackageKey()] = true;


### PR DESCRIPTION
This does some code cleanup and adds a new method `fromClassAndMethodName($className, $methodName)` to the `LogEnvironment`.

It be used like this:

    LogEnvironment::fromClassAndMethodName(__CLASS__, __METHOD__)

and will return useful data – as opposed to `LogEnvironment::fromMethodName(__METHOD__)`, which only works for static methods (`SomeClass::someMethod` or closures).

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
