### PR TITLE
TASK: Use Symfony ConsoleLogger instead of Doctrine

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/Service.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Service.php
@@ -32,7 +32,6 @@ use Doctrine\Migrations\Metadata\AvailableMigrationsList;
 use Doctrine\Migrations\Metadata\ExecutedMigration;
 use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\MigratorConfiguration;
-use Doctrine\Migrations\Tools\Console\ConsoleLogger;
 use Doctrine\Migrations\Tools\Console\Exception\InvalidOptionUsage;
 use Doctrine\Migrations\Tools\Console\Exception\VersionAlreadyExists;
 use Doctrine\Migrations\Tools\Console\Exception\VersionDoesNotExist;
@@ -54,6 +53,7 @@ use Neos\Utility\Files;
 use Neos\Utility\ObjectAccess;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 


### PR DESCRIPTION
Resolves: https://github.com/neos/flow-development-collection/issues/3404

In next minor release (3.9) doctrine/migration will remove the ConsoleLogger
See: https://github.com/doctrine/migrations/pull/1449

To prevent any issues after release of this we replace the ConsoleLogger of doctrine with ConsoleLogger of Symfony.