### PR TITLE
BUGFIX: Fix method param type expansion for partial annotation coverage

### DIFF
--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1930,10 +1930,11 @@ class ReflectionService
             $parameterInformation[self::DATA_PARAMETER_DEFAULT_VALUE] = $parameter->getDefaultValue();
         }
         $paramAnnotations = $method->isTaggedWith('param') ? $method->getTagValues('param') : [];
-        if (isset($paramAnnotations[$parameter->getPosition()])) {
-            $explodedParameters = explode(' ', $paramAnnotations[$parameter->getPosition()]);
-            if (count($explodedParameters) >= 2) {
+        foreach ($paramAnnotations as $paramAnnotation) {
+            $explodedParameters = explode(' ', $paramAnnotation);
+            if (count($explodedParameters) >= 2 && $explodedParameters[1] === '$' . $parameter->getName()) {
                 $parameterType = $this->expandType($method->getDeclaringClass(), $explodedParameters[0]);
+                break;
             }
         }
         if (!isset($parameterInformation[self::DATA_PARAMETER_TYPE]) && $parameterType !== null) {

--- a/Neos.Flow/Tests/Functional/Reflection/Fixtures/Model/EntityWithUseStatements.php
+++ b/Neos.Flow/Tests/Functional/Reflection/Fixtures/Model/EntityWithUseStatements.php
@@ -74,4 +74,11 @@ class EntityWithUseStatements
     public function simpleType($parameter)
     {
     }
+
+    /**
+     * @param array<SubSubEntity> $param2 some description
+     */
+    public function multipleParamsWithPartialAnnotationCoverage(SubEntity $param1, array $param2, SubSubSubEntity|null $param3 = null): void
+    {
+    }
 }

--- a/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
@@ -227,7 +227,7 @@ class ReflectionServiceTest extends FunctionalTestCase
                 'array' => true,
                 'byReference' => false,
                 'allowsNull' => false,
-                'defaultValue' => NULL,
+                'defaultValue' => null,
                 'scalarDeclaration' => false,
             ],
             'param3' => [
@@ -238,7 +238,7 @@ class ReflectionServiceTest extends FunctionalTestCase
                 'array' => false,
                 'byReference' => false,
                 'allowsNull' => true,
-                'defaultValue' => NULL,
+                'defaultValue' => null,
                 'scalarDeclaration' => false,
             ],
         ];

--- a/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
@@ -12,6 +12,9 @@ namespace Neos\Flow\Tests\Functional\Reflection;
  */
 
 use Neos\Flow\Reflection\ReflectionService;
+use Neos\Flow\Tests\Functional\Reflection\Fixtures\Model\SubEntity;
+use Neos\Flow\Tests\Functional\Reflection\Fixtures\Model\SubSubEntity;
+use Neos\Flow\Tests\Functional\Reflection\Fixtures\Model\SubSubSubEntity;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Flow\Tests\Functional\Reflection;
 use Neos\Flow\Tests\Functional\Persistence;
@@ -195,6 +198,51 @@ class ReflectionServiceTest extends FunctionalTestCase
         $expectedType = Reflection\Fixtures\Model\SubEntity::class . '|null';
         $actualType = $methodParameters['parameter']['type'];
         self::assertSame($expectedType, $actualType);
+    }
+
+    /**
+     * @test
+     * @see https://github.com/neos/flow-development-collection/issues/3423
+     */
+    public function methodParameterTypeExpansionWorksWithParamsWithPartialAnnotationCoverage()
+    {
+        $methodParameters = $this->reflectionService->getMethodParameters(Reflection\Fixtures\Model\EntityWithUseStatements::class, 'multipleParamsWithPartialAnnotationCoverage');
+        $expectedResult = [
+            'param1' => [
+                'position' => 0,
+                'optional' => false,
+                'type' => SubEntity::class,
+                'class' => SubEntity::class,
+                'array' => false,
+                'byReference' => false,
+                'allowsNull' => false,
+                'defaultValue' => null,
+                'scalarDeclaration' => false,
+            ],
+            'param2' => [
+                'position' => 1,
+                'optional' => false,
+                'type' => 'array<' . SubSubEntity::class . '>',
+                'class' => null,
+                'array' => true,
+                'byReference' => false,
+                'allowsNull' => false,
+                'defaultValue' => NULL,
+                'scalarDeclaration' => false,
+            ],
+            'param3' => [
+                'position' => 2,
+                'optional' => true,
+                'type' => SubSubSubEntity::class,
+                'class' => SubSubSubEntity::class,
+                'array' => false,
+                'byReference' => false,
+                'allowsNull' => true,
+                'defaultValue' => NULL,
+                'scalarDeclaration' => false,
+            ],
+        ];
+        self::assertSame($expectedResult, $methodParameters);
     }
 
     /**


### PR DESCRIPTION
Adjusts the behavior of `ReflectionService::getMethodParameters()` such that `@param` annotations are mapped to the corresponding method argument based in their _name_ instead of the _index_.

Fixes: #3423