### PR TITLE
FEATURE: Add setting for encryption key

### DIFF
--- a/Neos.Flow/Classes/Security/Cryptography/HashService.php
+++ b/Neos.Flow/Classes/Security/Cryptography/HashService.php
@@ -63,6 +63,9 @@ class HashService
     public function injectSettings(array $settings)
     {
         $this->strategySettings = $settings['security']['cryptography']['hashingStrategies'];
+        if (!empty($settings['security']['cryptography']['encryptionKey'])) {
+            $this->encryptionKey = $settings['security']['cryptography']['encryptionKey'];
+        }
     }
 
     /**

--- a/Neos.Flow/Configuration/Settings.Security.yaml
+++ b/Neos.Flow/Configuration/Settings.Security.yaml
@@ -98,6 +98,10 @@ Neos:
 
       cryptography:
 
+        # A private, unique key used for encryption tasks. Normally 40 characters long and received from a persistent
+        # filesystem cache. If set to a non-empty string, the cache is not involved anymore.
+        encryptionKey: ''
+
         hashingStrategies:
 
           # The default strategy will be used to hash or validate passwords if no specific strategy is given

--- a/Neos.Flow/Configuration/Settings.Security.yaml
+++ b/Neos.Flow/Configuration/Settings.Security.yaml
@@ -100,7 +100,7 @@ Neos:
 
         # A private, unique key used for encryption tasks. Normally 40 characters long and received from a persistent
         # filesystem cache. If set to a non-empty string, the cache is not involved anymore.
-        encryptionKey: ''
+        encryptionKey: null
 
         hashingStrategies:
 

--- a/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.security.schema.yaml
+++ b/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.security.schema.yaml
@@ -74,6 +74,8 @@ properties:
     additionalProperties: false
     required: true
     properties:
+      'encryptionKey': { type: string, required: true }
+
       'hashingStrategies':
         type: dictionary
         additionalProperties: { type: string, format: class-name }


### PR DESCRIPTION
With this the encryption key can be defined in a setting. When defined it is not received from cache anymore.

```yaml
Neos:
  Flow:
    security:
      cryptography:
        encryptionKey: 'something-random-usually-40-chars-long'
```

Ideally set this from an environment variable, so it doesn't have to be in your codebase…

Resolves: #3425

**Upgrade instructions**

None – but feel free to use the new feature. For existing projects, set the encryption key to the value found in the cache, `Data/Persistent/Cache/Data/Flow_Security_Cryptography_HashService/encryptionKey` usually.

**Review instructions**

Set the new setting to a non-empty string and see that `\Neos\Flow\Security\Cryptography\HashService::generateHmac()` returns a Hmac generated with your new encryption key.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
