### PR TITLE
TASK: Correctly mark nullable method parameters as nullable

### DIFF
--- a/Neos.Cache/Classes/Backend/AbstractBackend.php
+++ b/Neos.Cache/Classes/Backend/AbstractBackend.php
@@ -61,7 +61,7 @@ abstract class AbstractBackend implements BackendInterface
      * @param array $options Configuration options - depends on the actual backend
      * @api
      */
-    public function __construct(EnvironmentConfiguration $environmentConfiguration = null, array $options = [])
+    public function __construct(?EnvironmentConfiguration $environmentConfiguration = null, array $options = [])
     {
         $this->environmentConfiguration = $environmentConfiguration;
 
@@ -144,7 +144,7 @@ abstract class AbstractBackend implements BackendInterface
      * @param integer $lifetime The lifetime in seconds
      * @return \DateTime The expiry time
      */
-    protected function calculateExpiryTime(int $lifetime = null): \DateTime
+    protected function calculateExpiryTime(?int $lifetime = null): \DateTime
     {
         if ($lifetime === self::UNLIMITED_LIFETIME || ($lifetime === null && $this->defaultLifetime === self::UNLIMITED_LIFETIME)) {
             return new \DateTime(self::DATETIME_EXPIRYTIME_UNLIMITED, new \DateTimeZone('UTC'));

--- a/Neos.Cache/Classes/Backend/ApcuBackend.php
+++ b/Neos.Cache/Classes/Backend/ApcuBackend.php
@@ -117,7 +117,7 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
      * @throws \InvalidArgumentException if the identifier is not valid
      * @api
      */
-    public function set(string $entryIdentifier, string $data, array $tags = [], int $lifetime = null): void
+    public function set(string $entryIdentifier, string $data, array $tags = [], ?int $lifetime = null): void
     {
         if (!$this->cache instanceof FrontendInterface) {
             throw new Exception('No cache frontend has been set yet via setCache().', 1232986818);

--- a/Neos.Cache/Classes/Backend/BackendInterface.php
+++ b/Neos.Cache/Classes/Backend/BackendInterface.php
@@ -57,7 +57,7 @@ interface BackendInterface
      * @throws \InvalidArgumentException if the identifier is not valid
      * @api
      */
-    public function set(string $entryIdentifier, string $data, array $tags = [], int $lifetime = null): void;
+    public function set(string $entryIdentifier, string $data, array $tags = [], ?int $lifetime = null): void;
 
     /**
      * Loads data from the cache.

--- a/Neos.Cache/Classes/Backend/FileBackend.php
+++ b/Neos.Cache/Classes/Backend/FileBackend.php
@@ -148,7 +148,7 @@ class FileBackend extends SimpleFileBackend implements PhpCapableBackendInterfac
      * @throws \InvalidArgumentException
      * @api
      */
-    public function set(string $entryIdentifier, string $data, array $tags = [], int $lifetime = null): void
+    public function set(string $entryIdentifier, string $data, array $tags = [], ?int $lifetime = null): void
     {
         if ($entryIdentifier !== basename($entryIdentifier)) {
             throw new \InvalidArgumentException('The specified entry identifier must not contain a path segment.', 1282073032);

--- a/Neos.Cache/Classes/Backend/MemcachedBackend.php
+++ b/Neos.Cache/Classes/Backend/MemcachedBackend.php
@@ -199,7 +199,7 @@ class MemcachedBackend extends IndependentAbstractBackend implements TaggableBac
      * @throws \InvalidArgumentException if the identifier is not valid or the final memcached key is longer than 250 characters
      * @api
      */
-    public function set(string $entryIdentifier, string $data, array $tags = [], int $lifetime = null): void
+    public function set(string $entryIdentifier, string $data, array $tags = [], ?int $lifetime = null): void
     {
         if (strlen($this->getPrefixedIdentifier($entryIdentifier)) > 250) {
             throw new \InvalidArgumentException('Could not set value. Key more than 250 characters (' . $this->getPrefixedIdentifier($entryIdentifier) . ').', 1232969508);

--- a/Neos.Cache/Classes/Backend/MultiBackend.php
+++ b/Neos.Cache/Classes/Backend/MultiBackend.php
@@ -41,7 +41,7 @@ class MultiBackend extends AbstractBackend
     protected ?LoggerInterface $logger = null;
     protected ?ThrowableStorageInterface $throwableStorage = null;
 
-    public function __construct(EnvironmentConfiguration $environmentConfiguration = null, array $options = [])
+    public function __construct(?EnvironmentConfiguration $environmentConfiguration = null, array $options = [])
     {
         parent::__construct($environmentConfiguration, $options);
 
@@ -96,7 +96,7 @@ class MultiBackend extends AbstractBackend
     /**
      * @throws Throwable
      */
-    public function set(string $entryIdentifier, string $data, array $tags = [], int $lifetime = null): void
+    public function set(string $entryIdentifier, string $data, array $tags = [], ?int $lifetime = null): void
     {
         $this->prepareBackends();
         foreach ($this->backends as $backend) {

--- a/Neos.Cache/Classes/Backend/NullBackend.php
+++ b/Neos.Cache/Classes/Backend/NullBackend.php
@@ -46,7 +46,7 @@ class NullBackend extends AbstractCacheBackend implements PhpCapableBackendInter
      * @return void
      * @api
      */
-    public function set(string $entryIdentifier, string $data, array $tags = [], int $lifetime = null): void
+    public function set(string $entryIdentifier, string $data, array $tags = [], ?int $lifetime = null): void
     {
     }
 

--- a/Neos.Cache/Classes/Backend/PdoBackend.php
+++ b/Neos.Cache/Classes/Backend/PdoBackend.php
@@ -182,7 +182,7 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
      * @throws FilesException
      * @api
      */
-    public function set(string $entryIdentifier, string $data, array $tags = [], int $lifetime = null): void
+    public function set(string $entryIdentifier, string $data, array $tags = [], ?int $lifetime = null): void
     {
         $this->connect();
 

--- a/Neos.Cache/Classes/Backend/RedisBackend.php
+++ b/Neos.Cache/Classes/Backend/RedisBackend.php
@@ -109,7 +109,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      * @throws CacheException
      * @api
      */
-    public function set(string $entryIdentifier, string $data, array $tags = [], int $lifetime = null): void
+    public function set(string $entryIdentifier, string $data, array $tags = [], ?int $lifetime = null): void
     {
         if ($this->isFrozen()) {
             throw new \RuntimeException(sprintf('Cannot add or modify cache entry because the backend of cache "%s" is frozen.', $this->cacheIdentifier), 1323344192);
@@ -493,7 +493,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
         $this->batchSize = (int)$batchSize;
     }
 
-    public function setRedis(\Redis $redis = null): void
+    public function setRedis(?\Redis $redis = null): void
     {
         if ($redis !== null) {
             $this->redis = $redis;

--- a/Neos.Cache/Classes/Backend/SimpleFileBackend.php
+++ b/Neos.Cache/Classes/Backend/SimpleFileBackend.php
@@ -145,7 +145,7 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
      * @throws \InvalidArgumentException
      * @api
      */
-    public function set(string $entryIdentifier, string $data, array $tags = [], int $lifetime = null): void
+    public function set(string $entryIdentifier, string $data, array $tags = [], ?int $lifetime = null): void
     {
         if ($entryIdentifier !== basename($entryIdentifier)) {
             throw new \InvalidArgumentException('The specified entry identifier must not contain a path segment.', 1334756735);
@@ -493,7 +493,7 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
      * @param int|null $maxlen
      * @return string|false The contents of the cache file or false on error
      */
-    protected function readCacheFile(string $cacheEntryPathAndFilename, int $offset = 0, int $maxlen = null)
+    protected function readCacheFile(string $cacheEntryPathAndFilename, int $offset = 0, ?int $maxlen = null)
     {
         for ($i = 0; $i < 3; $i++) {
             $data = false;

--- a/Neos.Cache/Classes/Backend/TransientMemoryBackend.php
+++ b/Neos.Cache/Classes/Backend/TransientMemoryBackend.php
@@ -45,7 +45,7 @@ class TransientMemoryBackend extends IndependentAbstractBackend implements Tagga
      * @throws Exception if no cache frontend has been set.
      * @api
      */
-    public function set(string $entryIdentifier, string $data, array $tags = [], int $lifetime = null): void
+    public function set(string $entryIdentifier, string $data, array $tags = [], ?int $lifetime = null): void
     {
         if (!$this->cache instanceof FrontendInterface) {
             throw new Exception('No cache frontend has been set yet via setCache().', 1238244992);

--- a/Neos.Cache/Classes/Frontend/FrontendInterface.php
+++ b/Neos.Cache/Classes/Frontend/FrontendInterface.php
@@ -56,7 +56,7 @@ interface FrontendInterface
      * @return void
      * @api
      */
-    public function set(string $entryIdentifier, $data, array $tags = [], int $lifetime = null);
+    public function set(string $entryIdentifier, $data, array $tags = [], ?int $lifetime = null);
 
     /**
      * Finds and returns data from the cache.

--- a/Neos.Cache/Classes/Frontend/PhpFrontend.php
+++ b/Neos.Cache/Classes/Frontend/PhpFrontend.php
@@ -92,7 +92,7 @@ class PhpFrontend extends StringFrontend
      * @throws \Neos\Cache\Exception
      * @api
      */
-    public function set(string $entryIdentifier, $sourceCode, array $tags = [], int $lifetime = null)
+    public function set(string $entryIdentifier, $sourceCode, array $tags = [], ?int $lifetime = null)
     {
         if (!$this->isValidEntryIdentifier($entryIdentifier)) {
             throw new \InvalidArgumentException('"' . $entryIdentifier . '" is not a valid cache entry identifier.', 1264023823);

--- a/Neos.Cache/Classes/Frontend/StringFrontend.php
+++ b/Neos.Cache/Classes/Frontend/StringFrontend.php
@@ -37,7 +37,7 @@ class StringFrontend extends AbstractFrontend
      * @throws \Neos\Cache\Exception
      * @api
      */
-    public function set(string $entryIdentifier, $string, array $tags = [], int $lifetime = null)
+    public function set(string $entryIdentifier, $string, array $tags = [], ?int $lifetime = null)
     {
         if (!$this->isValidEntryIdentifier($entryIdentifier)) {
             throw new \InvalidArgumentException('"' . $entryIdentifier . '" is not a valid cache entry identifier.', 1233057566);

--- a/Neos.Cache/Classes/Frontend/VariableFrontend.php
+++ b/Neos.Cache/Classes/Frontend/VariableFrontend.php
@@ -56,7 +56,7 @@ class VariableFrontend extends AbstractFrontend
      * @throws \Neos\Cache\Exception
      * @api
      */
-    public function set(string $entryIdentifier, $variable, array $tags = [], int $lifetime = null)
+    public function set(string $entryIdentifier, $variable, array $tags = [], ?int $lifetime = null)
     {
         if (!$this->isValidEntryIdentifier($entryIdentifier)) {
             throw new \InvalidArgumentException('"' . $entryIdentifier . '" is not a valid cache entry identifier.', 1233058264);

--- a/Neos.Cache/Tests/Unit/Backend/SimpleFileBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/SimpleFileBackendTest.php
@@ -61,7 +61,7 @@ class SimpleFileBackendTest extends BaseTestCase
      * @param FrontendInterface $mockCacheFrontend
      * @return SimpleFileBackend
      */
-    protected function getSimpleFileBackend(array $options = [], FrontendInterface $mockCacheFrontend = null)
+    protected function getSimpleFileBackend(array $options = [], ?FrontendInterface $mockCacheFrontend = null)
     {
         $simpleFileBackend = new SimpleFileBackend($this->mockEnvironmentConfiguration, $options);
 

--- a/Neos.Eel/Classes/Helper/ArrayHelper.php
+++ b/Neos.Eel/Classes/Helper/ArrayHelper.php
@@ -562,7 +562,7 @@ class ArrayHelper implements ProtectedContextAwareInterface
      * @param callable $callback Callback for testing if an element should be included in the result, current value and key will be passed as arguments
      * @return array The array with elements where callback returned true
      */
-    public function filter(iterable $array, callable $callback = null): array
+    public function filter(iterable $array, ?callable $callback = null): array
     {
         if ($array instanceof \Traversable) {
             $array = iterator_to_array($array);

--- a/Neos.Error.Messages/Classes/Result.php
+++ b/Neos.Error.Messages/Classes/Result.php
@@ -132,7 +132,7 @@ class Result
      * @return array<Error>
      * @api
      */
-    public function getErrors(string $messageTypeFilter = null): array
+    public function getErrors(?string $messageTypeFilter = null): array
     {
         return $this->filterMessages($this->errors, $messageTypeFilter);
     }
@@ -144,7 +144,7 @@ class Result
      * @return array<Warning>
      * @api
      */
-    public function getWarnings(string $messageTypeFilter = null): array
+    public function getWarnings(?string $messageTypeFilter = null): array
     {
         return $this->filterMessages($this->warnings, $messageTypeFilter);
     }
@@ -156,7 +156,7 @@ class Result
      * @return array<Notice>
      * @api
      */
-    public function getNotices(string $messageTypeFilter = null): array
+    public function getNotices(?string $messageTypeFilter = null): array
     {
         return $this->filterMessages($this->notices, $messageTypeFilter);
     }
@@ -168,7 +168,7 @@ class Result
      * @return Error
      * @api
      */
-    public function getFirstError(string $messageTypeFilter = null)
+    public function getFirstError(?string $messageTypeFilter = null)
     {
         $matchingErrors = $this->filterMessages($this->errors, $messageTypeFilter);
         reset($matchingErrors);
@@ -182,7 +182,7 @@ class Result
      * @return Warning
      * @api
      */
-    public function getFirstWarning(string $messageTypeFilter = null)
+    public function getFirstWarning(?string $messageTypeFilter = null)
     {
         $matchingWarnings = $this->filterMessages($this->warnings, $messageTypeFilter);
         reset($matchingWarnings);
@@ -196,7 +196,7 @@ class Result
      * @return Notice
      * @api
      */
-    public function getFirstNotice(string $messageTypeFilter = null)
+    public function getFirstNotice(?string $messageTypeFilter = null)
     {
         $matchingNotices = $this->filterMessages($this->notices, $messageTypeFilter);
         reset($matchingNotices);
@@ -213,7 +213,7 @@ class Result
      * @return Result
      * @api
      */
-    public function forProperty(string $propertyPath = null): Result
+    public function forProperty(?string $propertyPath = null): Result
     {
         if ($propertyPath === '' || $propertyPath === null) {
             return $this;
@@ -410,7 +410,7 @@ class Result
      * @param string $messageTypeFilter If specified only messages implementing the given class name are taken into account
      * @return void
      */
-    public function flattenTree(string $propertyName, array &$result, array $level = [], string $messageTypeFilter = null)
+    public function flattenTree(string $propertyName, array &$result, array $level = [], ?string $messageTypeFilter = null)
     {
         if (count($this->$propertyName) > 0) {
             $propertyPath = implode('.', $level);
@@ -429,7 +429,7 @@ class Result
      * @param string $messageTypeFilter If specified only messages implementing the given class name are taken into account
      * @return array the filtered message instances
      */
-    protected function filterMessages(array $messages, string $messageTypeFilter = null): array
+    protected function filterMessages(array $messages, ?string $messageTypeFilter = null): array
     {
         if ($messageTypeFilter === null) {
             return $messages;

--- a/Neos.Flow.Log/Classes/Backend/AnsiConsoleBackend.php
+++ b/Neos.Flow.Log/Classes/Backend/AnsiConsoleBackend.php
@@ -83,7 +83,7 @@ class AnsiConsoleBackend extends ConsoleBackend
      * @param string $methodName
      * @return void
      */
-    public function append(string $message, int $severity = LOG_INFO, $additionalData = null, string $packageKey = null, string $className = null, string $methodName = null): void
+    public function append(string $message, int $severity = LOG_INFO, $additionalData = null, ?string $packageKey = null, ?string $className = null, ?string $methodName = null): void
     {
         if ($severity > $this->severityThreshold) {
             return;

--- a/Neos.Flow.Log/Classes/Backend/BackendInterface.php
+++ b/Neos.Flow.Log/Classes/Backend/BackendInterface.php
@@ -42,7 +42,7 @@ interface BackendInterface
      * @return void
      * @api
      */
-    public function append(string $message, int $severity = LOG_INFO, $additionalData = null, string $packageKey = null, string $className = null, string $methodName = null): void;
+    public function append(string $message, int $severity = LOG_INFO, $additionalData = null, ?string $packageKey = null, ?string $className = null, ?string $methodName = null): void;
 
     /**
      * Carries out all actions necessary to cleanly close the logging backend, such as

--- a/Neos.Flow.Log/Classes/Backend/ConsoleBackend.php
+++ b/Neos.Flow.Log/Classes/Backend/ConsoleBackend.php
@@ -79,7 +79,7 @@ class ConsoleBackend extends AbstractBackend
      * @return void
      * @api
      */
-    public function append(string $message, int $severity = LOG_INFO, $additionalData = null, string $packageKey = null, string $className = null, string $methodName = null): void
+    public function append(string $message, int $severity = LOG_INFO, $additionalData = null, ?string $packageKey = null, ?string $className = null, ?string $methodName = null): void
     {
         if ($severity > $this->severityThreshold) {
             return;

--- a/Neos.Flow.Log/Classes/Backend/FileBackend.php
+++ b/Neos.Flow.Log/Classes/Backend/FileBackend.php
@@ -228,7 +228,7 @@ class FileBackend extends AbstractBackend
      * @return void
      * @api
      */
-    public function append(string $message, int $severity = LOG_INFO, $additionalData = null, string $packageKey = null, string $className = null, string $methodName = null): void
+    public function append(string $message, int $severity = LOG_INFO, $additionalData = null, ?string $packageKey = null, ?string $className = null, ?string $methodName = null): void
     {
         if ($severity > $this->severityThreshold) {
             return;

--- a/Neos.Flow.Log/Classes/Backend/JsonFileBackend.php
+++ b/Neos.Flow.Log/Classes/Backend/JsonFileBackend.php
@@ -29,7 +29,7 @@ class JsonFileBackend extends FileBackend
      * @param string $methodName Name of the method triggering the log (determined automatically if not specified)
      * @return void
      */
-    public function append(string $message, int $severity = LOG_INFO, $additionalData = null, string $packageKey = null, string $className = null, string $methodName = null): void
+    public function append(string $message, int $severity = LOG_INFO, $additionalData = null, ?string $packageKey = null, ?string $className = null, ?string $methodName = null): void
     {
 
         if ($severity > $this->severityThreshold) {

--- a/Neos.Flow.Log/Classes/Backend/NullBackend.php
+++ b/Neos.Flow.Log/Classes/Backend/NullBackend.php
@@ -43,7 +43,7 @@ class NullBackend extends AbstractBackend
      * @return void
      * @api
      */
-    public function append(string $message, int $severity = 1, $additionalData = null, string $packageKey = null, string $className = null, string $methodName = null): void
+    public function append(string $message, int $severity = 1, $additionalData = null, ?string $packageKey = null, ?string $className = null, ?string $methodName = null): void
     {
     }
 

--- a/Neos.Flow/Classes/Annotations/IgnoreValidation.php
+++ b/Neos.Flow/Classes/Annotations/IgnoreValidation.php
@@ -38,7 +38,7 @@ final class IgnoreValidation
      */
     public $evaluate = false;
 
-    public function __construct(string $argumentName = null, bool $evaluate = false)
+    public function __construct(?string $argumentName = null, bool $evaluate = false)
     {
         $this->argumentName = $argumentName ? ltrim($argumentName, '$') : null;
         $this->evaluate = $evaluate;

--- a/Neos.Flow/Classes/Annotations/Validate.php
+++ b/Neos.Flow/Classes/Annotations/Validate.php
@@ -47,7 +47,7 @@ final class Validate
      */
     public $validationGroups = ['Default'];
 
-    public function __construct(?string $argumentName = null, string $type = null, array $options = [], ?array $validationGroups = null)
+    public function __construct(?string $argumentName = null, ?string $type = null, array $options = [], ?array $validationGroups = null)
     {
         $this->type = $type;
 

--- a/Neos.Flow/Classes/Aop/Advice/AbstractAdvice.php
+++ b/Neos.Flow/Classes/Aop/Advice/AbstractAdvice.php
@@ -66,7 +66,7 @@ class AbstractAdvice implements AdviceInterface
      * @param ObjectManagerInterface $objectManager Only require if a runtime evaluations function is specified
      * @param \Closure $runtimeEvaluator Runtime evaluations function
      */
-    public function __construct(string $aspectObjectName, string $adviceMethodName, ObjectManagerInterface $objectManager = null, \Closure $runtimeEvaluator = null)
+    public function __construct(string $aspectObjectName, string $adviceMethodName, ?ObjectManagerInterface $objectManager = null, ?\Closure $runtimeEvaluator = null)
     {
         $this->aspectObjectName = $aspectObjectName;
         $this->adviceMethodName = $adviceMethodName;

--- a/Neos.Flow/Classes/Aop/Builder/AbstractMethodInterceptorBuilder.php
+++ b/Neos.Flow/Classes/Aop/Builder/AbstractMethodInterceptorBuilder.php
@@ -96,7 +96,7 @@ abstract class AbstractMethodInterceptorBuilder
      * @param boolean $useArgumentsArray If set, the $methodArguments array will be built from $arguments instead of using the actual parameter variables.
      * @return string The generated code to be used in an "array()" definition
      */
-    protected function buildMethodArgumentsArrayCode(string $className = null, string $methodName = null, bool $useArgumentsArray = false): string
+    protected function buildMethodArgumentsArrayCode(?string $className = null, ?string $methodName = null, bool $useArgumentsArray = false): string
     {
         if ($className === null || $methodName === null) {
             return '';
@@ -129,7 +129,7 @@ abstract class AbstractMethodInterceptorBuilder
      * @param string $className Name of the class the method is declared in
      * @return string The generated parameters code
      */
-    protected function buildSavedConstructorParametersCode(string $className = null): string
+    protected function buildSavedConstructorParametersCode(?string $className = null): string
     {
         if ($className === null) {
             return '';
@@ -156,7 +156,7 @@ abstract class AbstractMethodInterceptorBuilder
      * @param string $declaringClassName Name of the declaring class. This is usually the same as the $targetClassName. However, it is the introduction interface for introduced methods.
      * @return string PHP code to be used in the method interceptor
      */
-    protected function buildAdvicesCode(array $groupedAdvices, string $methodName = null, string $targetClassName = null, string $declaringClassName = null): string
+    protected function buildAdvicesCode(array $groupedAdvices, ?string $methodName = null, ?string $targetClassName = null, ?string $declaringClassName = null): string
     {
         $advicesCode = $this->buildMethodArgumentsArrayCode($declaringClassName, $methodName, ($methodName === '__construct'));
 

--- a/Neos.Flow/Classes/Aop/JoinPoint.php
+++ b/Neos.Flow/Classes/Aop/JoinPoint.php
@@ -74,7 +74,7 @@ class JoinPoint implements JoinPointInterface
      * @param mixed $result The result of the method invocations (only used for After Returning advices)
      * @param \Exception $exception The exception thrown (only used for After Throwing advices)
      */
-    public function __construct($proxy, string $className, string $methodName, array $methodArguments, Advice\AdviceChain $adviceChain = null, $result = null, \Exception $exception = null)
+    public function __construct($proxy, string $className, string $methodName, array $methodArguments, ?Advice\AdviceChain $adviceChain = null, $result = null, ?\Exception $exception = null)
     {
         $this->proxy = $proxy;
         $this->className = $className;

--- a/Neos.Flow/Classes/Aop/Pointcut/Pointcut.php
+++ b/Neos.Flow/Classes/Aop/Pointcut/Pointcut.php
@@ -71,7 +71,7 @@ class Pointcut implements PointcutFilterInterface
      * @param string $aspectClassName The name of the aspect class where the pointcut was declared (either explicitly or from an advice's pointcut expression)
      * @param string $pointcutMethodName (optional) If the pointcut is created from a pointcut declaration, the name of the method declaring the pointcut must be passed
      */
-    public function __construct(string $pointcutExpression, PointcutFilterComposite $pointcutFilterComposite, string $aspectClassName, string $pointcutMethodName = null)
+    public function __construct(string $pointcutExpression, PointcutFilterComposite $pointcutFilterComposite, string $aspectClassName, ?string $pointcutMethodName = null)
     {
         $this->pointcutExpression = $pointcutExpression;
         $this->pointcutFilterComposite = $pointcutFilterComposite;

--- a/Neos.Flow/Classes/Aop/Pointcut/PointcutMethodNameFilter.php
+++ b/Neos.Flow/Classes/Aop/Pointcut/PointcutMethodNameFilter.php
@@ -60,7 +60,7 @@ class PointcutMethodNameFilter implements PointcutFilterInterface
      * @param array $methodArgumentConstraints array of method constraints
      * @throws InvalidPointcutExpressionException
      */
-    public function __construct(string $methodNameFilterExpression, string $methodVisibility = null, array $methodArgumentConstraints = [])
+    public function __construct(string $methodNameFilterExpression, ?string $methodVisibility = null, array $methodArgumentConstraints = [])
     {
         $this->methodNameFilterExpression = $methodNameFilterExpression;
         if ($methodVisibility !== null && preg_match(self::PATTERN_MATCHVISIBILITYMODIFIER, $methodVisibility) !== 1) {

--- a/Neos.Flow/Classes/Cli/CommandController.php
+++ b/Neos.Flow/Classes/Cli/CommandController.php
@@ -209,7 +209,7 @@ class CommandController implements CommandControllerInterface
      * @return void
      * @throws StopCommandException
      */
-    protected function forward(string $commandName, string $controllerObjectName = null, array $arguments = [])
+    protected function forward(string $commandName, ?string $controllerObjectName = null, array $arguments = [])
     {
         $this->request->setDispatched(false);
         $this->request->setControllerCommandName($commandName);

--- a/Neos.Flow/Classes/Cli/ConsoleOutput.php
+++ b/Neos.Flow/Classes/Cli/ConsoleOutput.php
@@ -140,7 +140,7 @@ class ConsoleOutput
      * @param array $headers
      * @param string $headerTitle
      */
-    public function outputTable(array $rows, array $headers = null, string $headerTitle = null): void
+    public function outputTable(array $rows, ?array $headers = null, ?string $headerTitle = null): void
     {
         $table = $this->getTable();
         if ($headers !== null) {
@@ -164,7 +164,7 @@ class ConsoleOutput
      * @return integer|string|array Either the value for indexed arrays, the key for associative arrays or an array for multiple selections
      * @throws \InvalidArgumentException
      */
-    public function select($question, array $choices, $default = null, bool $multiSelect = false, int $attempts = null)
+    public function select($question, array $choices, $default = null, bool $multiSelect = false, ?int $attempts = null)
     {
         $question = new ChoiceQuestion($this->combineQuestion($question), $choices, $default);
         $question
@@ -183,7 +183,7 @@ class ConsoleOutput
      * @return mixed The user answer
      * @throws \RuntimeException If there is no data to read in the input stream
      */
-    public function ask($question, string $default = null)
+    public function ask($question, ?string $default = null)
     {
         $question = new Question($this->combineQuestion($question), $default);
 
@@ -251,7 +251,7 @@ class ConsoleOutput
      * @return mixed The response
      * @throws \Exception When any of the validators return an error
      */
-    public function askAndValidate($question, callable $validator, int $attempts = null, string $default = null)
+    public function askAndValidate($question, callable $validator, ?int $attempts = null, ?string $default = null)
     {
         $question = new Question($this->combineQuestion($question), $default);
         $question
@@ -276,7 +276,7 @@ class ConsoleOutput
      * @throws \Exception When any of the validators return an error
      * @throws \RuntimeException In case the fallback is deactivated and the response can not be hidden
      */
-    public function askHiddenResponseAndValidate($question, callable $validator, int $attempts = null, bool $fallback = true)
+    public function askHiddenResponseAndValidate($question, callable $validator, ?int $attempts = null, bool $fallback = true)
     {
         $question = new Question($this->combineQuestion($question));
         $question
@@ -294,7 +294,7 @@ class ConsoleOutput
      * @param integer $max Maximum steps. If NULL an indeterminate progress bar is rendered
      * @return void
      */
-    public function progressStart(int $max = null): void
+    public function progressStart(?int $max = null): void
     {
         $this->getProgressBar()->start($max);
     }

--- a/Neos.Flow/Classes/Command/CacheCommandController.php
+++ b/Neos.Flow/Classes/Command/CacheCommandController.php
@@ -430,7 +430,7 @@ class CacheCommandController extends CommandController
      * @return void
      * @throws NoSuchCacheException
      */
-    public function collectGarbageCommand(string $cacheIdentifier = null): void
+    public function collectGarbageCommand(?string $cacheIdentifier = null): void
     {
         if ($cacheIdentifier !== null) {
             $cache = $this->cacheManager->getCache($cacheIdentifier);

--- a/Neos.Flow/Classes/Command/ConfigurationCommandController.php
+++ b/Neos.Flow/Classes/Command/ConfigurationCommandController.php
@@ -64,7 +64,7 @@ class ConfigurationCommandController extends CommandController
      * @param string $path path to subconfiguration separated by "." like "Neos.Flow"
      * @return void
      */
-    public function showCommand(string $type = 'Settings', string $path = null)
+    public function showCommand(string $type = 'Settings', ?string $path = null)
     {
         $availableConfigurationTypes = $this->configurationManager->getAvailableConfigurationTypes();
         if (in_array($type, $availableConfigurationTypes)) {
@@ -125,7 +125,7 @@ class ConfigurationCommandController extends CommandController
      * @param boolean $verbose if true, output more verbose information on the schema files which were used
      * @return void
      */
-    public function validateCommand(string $type = null, string $path = null, bool $verbose = false)
+    public function validateCommand(?string $type = null, ?string $path = null, bool $verbose = false)
     {
         if ($type === null) {
             $this->outputLine('Validating <b>all</b> configuration');
@@ -188,7 +188,7 @@ class ConfigurationCommandController extends CommandController
      * @param string $yaml YAML file to create a schema for
      * @return void
      */
-    public function generateSchemaCommand(string $type = null, string $path = null, string $yaml = null)
+    public function generateSchemaCommand(?string $type = null, ?string $path = null, ?string $yaml = null)
     {
         $data = null;
         if ($yaml !== null && is_file($yaml) && is_readable($yaml)) {

--- a/Neos.Flow/Classes/Command/CoreCommandController.php
+++ b/Neos.Flow/Classes/Command/CoreCommandController.php
@@ -257,7 +257,7 @@ class CoreCommandController extends CommandController
      * @return void
      * @see neos.flow:doctrine:migrate
      */
-    public function migrateCommand(string $package, bool $status = false, string $packagesPath = null, string $version = null, bool $verbose = false, bool $force = false)
+    public function migrateCommand(string $package, bool $status = false, ?string $packagesPath = null, ?string $version = null, bool $verbose = false, bool $force = false)
     {
         // This command will never be really called. It rather acts as a stub for rendering the
         // documentation for this command. In reality, the "flow" command line script will already

--- a/Neos.Flow/Classes/Command/DatabaseCommandController.php
+++ b/Neos.Flow/Classes/Command/DatabaseCommandController.php
@@ -86,7 +86,7 @@ class DatabaseCommandController extends CommandController
      * @throws DBALException
      * @throws StopActionException
      */
-    public function setCharsetCommand(string $characterSet = 'utf8mb4', string $collation = 'utf8mb4_unicode_ci', string $output = null, bool $verbose = false)
+    public function setCharsetCommand(string $characterSet = 'utf8mb4', string $collation = 'utf8mb4_unicode_ci', ?string $output = null, bool $verbose = false)
     {
         if (!in_array($this->persistenceSettings['backendOptions']['driver'], ['pdo_mysql', 'mysqli'])) {
             $this->outputLine('Database charset/collation fixing is only supported on MySQL.');
@@ -118,7 +118,7 @@ class DatabaseCommandController extends CommandController
      * @throws ConnectionException
      * @throws DBALException
      */
-    protected function convertToCharacterSetAndCollation(string $characterSet, string $collation, string $outputPathAndFilename = null, bool $verbose = false)
+    protected function convertToCharacterSetAndCollation(string $characterSet, string $collation, ?string $outputPathAndFilename = null, bool $verbose = false)
     {
         $statements = ['SET foreign_key_checks = 0'];
 

--- a/Neos.Flow/Classes/Command/DoctrineCommandController.php
+++ b/Neos.Flow/Classes/Command/DoctrineCommandController.php
@@ -144,7 +144,7 @@ class DoctrineCommandController extends CommandController
      * @see neos.flow:doctrine:update
      * @see neos.flow:doctrine:migrate
      */
-    public function createCommand(string $output = null): void
+    public function createCommand(?string $output = null): void
     {
         if (!$this->isDatabaseConfigured()) {
             $this->outputLine('Database schema creation has been SKIPPED, the driver and host backend options are not set in /Configuration/Settings.yaml.');
@@ -173,7 +173,7 @@ class DoctrineCommandController extends CommandController
      * @see neos.flow:doctrine:create
      * @see neos.flow:doctrine:migrate
      */
-    public function updateCommand(bool $unsafeMode = false, string $output = null): void
+    public function updateCommand(bool $unsafeMode = false, ?string $output = null): void
     {
         if (!$this->isDatabaseConfigured()) {
             $this->outputLine('Database schema update has been SKIPPED, the driver and host backend options are not set in /Configuration/Settings.yaml.');
@@ -202,7 +202,7 @@ class DoctrineCommandController extends CommandController
      * @throws \Doctrine\ORM\ORMException
      * @see neos.flow:doctrine:validate
      */
-    public function entityStatusCommand(bool $dumpMappingData = false, string $entityClassName = null): void
+    public function entityStatusCommand(bool $dumpMappingData = false, ?string $entityClassName = null): void
     {
         $info = $this->doctrineService->getEntityStatus();
 
@@ -255,7 +255,7 @@ class DoctrineCommandController extends CommandController
      * @return void
      * @throws StopCommandException
      */
-    public function dqlCommand(int $depth = 3, string $hydrationMode = 'array', int $offset = null, int $limit = null): void
+    public function dqlCommand(int $depth = 3, string $hydrationMode = 'array', ?int $offset = null, ?int $limit = null): void
     {
         if (!$this->isDatabaseConfigured()) {
             $this->outputLine('DQL query is not possible, the driver and host backend options are not set in /Configuration/Settings.yaml.');
@@ -316,7 +316,7 @@ class DoctrineCommandController extends CommandController
      * @see neos.flow:doctrine:migrationgenerate
      * @see neos.flow:doctrine:migrationversion
      */
-    public function migrateCommand(string $version = 'latest', string $output = null, bool $dryRun = false, bool $quiet = false): void
+    public function migrateCommand(string $version = 'latest', ?string $output = null, bool $dryRun = false, bool $quiet = false): void
     {
         if (!$this->isDatabaseConfigured()) {
             $this->outputLine('Doctrine migration not possible, the driver and host backend options are not set in /Configuration/Settings.yaml.');
@@ -363,7 +363,7 @@ class DoctrineCommandController extends CommandController
      * @see neos.flow:doctrine:migrationgenerate
      * @see neos.flow:doctrine:migrationversion
      */
-    public function migrationExecuteCommand(string $version, string $direction = 'up', string $output = null, bool $dryRun = false): void
+    public function migrationExecuteCommand(string $version, string $direction = 'up', ?string $output = null, bool $dryRun = false): void
     {
         if (!$this->isDatabaseConfigured()) {
             $this->outputLine('Doctrine migration not possible, the driver and host backend options are not set in /Configuration/Settings.yaml.');
@@ -448,7 +448,7 @@ class DoctrineCommandController extends CommandController
      * @see neos.flow:doctrine:migrationexecute
      * @see neos.flow:doctrine:migrationversion
      */
-    public function migrationGenerateCommand(bool $diffAgainstCurrent = true, string $filterExpression = null, bool $force = false): void
+    public function migrationGenerateCommand(bool $diffAgainstCurrent = true, ?string $filterExpression = null, bool $force = false): void
     {
         if (!$this->isDatabaseConfigured()) {
             $this->outputLine('Doctrine migration generation has been SKIPPED, the driver and host backend options are not set in /Configuration/Settings.yaml.');

--- a/Neos.Flow/Classes/Command/HelpCommandController.php
+++ b/Neos.Flow/Classes/Command/HelpCommandController.php
@@ -82,7 +82,7 @@ class HelpCommandController extends CommandController
      * @return void
      * @throws StopActionException
      */
-    public function helpCommand(string $commandIdentifier = null)
+    public function helpCommand(?string $commandIdentifier = null)
     {
         $exceedingArguments = $this->request->getExceedingArguments();
         if (count($exceedingArguments) > 0 && $commandIdentifier === null) {

--- a/Neos.Flow/Classes/Command/ResourceCommandController.php
+++ b/Neos.Flow/Classes/Command/ResourceCommandController.php
@@ -78,7 +78,7 @@ class ResourceCommandController extends CommandController
      * @param string $collection If specified, only resources of this collection are published. Example: 'persistent'
      * @return void
      */
-    public function publishCommand(string $collection = null)
+    public function publishCommand(?string $collection = null)
     {
         try {
             if ($collection === null) {

--- a/Neos.Flow/Classes/Command/RoutingCommandController.php
+++ b/Neos.Flow/Classes/Command/RoutingCommandController.php
@@ -168,7 +168,7 @@ class RoutingCommandController extends CommandController
      * @return void
      * @throws StopCommandException | InvalidRoutePartValueException
      */
-    public function resolveCommand(string $package, string $controller = null, string $action = null, string $format = null, string $subpackage = null, string $additionalArguments = null, string $parameters = null, string $baseUri = null, bool $forceAbsoluteUri = null): void
+    public function resolveCommand(string $package, ?string $controller = null, ?string $action = null, ?string $format = null, ?string $subpackage = null, ?string $additionalArguments = null, ?string $parameters = null, ?string $baseUri = null, ?bool $forceAbsoluteUri = null): void
     {
         $routeValues = [
             '@package' => $package,
@@ -266,7 +266,7 @@ class RoutingCommandController extends CommandController
      * @param string|null $parameters Route parameters as JSON string. Make sure to specify this option as described in the description in order to prevent parsing issues
      * @throws InvalidRoutePartValueException | StopCommandException
      */
-    public function matchCommand(string $uri, string $method = null, string $parameters = null): void
+    public function matchCommand(string $uri, ?string $method = null, ?string $parameters = null): void
     {
         $method = $method ?? 'GET';
         $requestUri = new Uri($uri);

--- a/Neos.Flow/Classes/Command/SchemaCommandController.php
+++ b/Neos.Flow/Classes/Command/SchemaCommandController.php
@@ -46,7 +46,7 @@ class SchemaCommandController extends CommandController
      * @param boolean $verbose if true, output more verbose information on the schema files which were used
      * @return void
      */
-    public function validateCommand(string $configurationFile = null, string $schemaFile = 'resource://Neos.Flow/Private/Schema/Schema.schema.yaml', bool $verbose = false)
+    public function validateCommand(?string $configurationFile = null, string $schemaFile = 'resource://Neos.Flow/Private/Schema/Schema.schema.yaml', bool $verbose = false)
     {
         $this->outputLine('Validating <b>' . $configurationFile . '</b> with schema  <b>' . $schemaFile . '</b>');
         $this->outputLine();

--- a/Neos.Flow/Classes/Command/SignalCommandController.php
+++ b/Neos.Flow/Classes/Command/SignalCommandController.php
@@ -37,7 +37,7 @@ class SignalCommandController extends CommandController
      * @param string $methodName if specified, only signals matching the given method name will be shown. This is only useful in conjunction with the "--class-name" option.
      * @return void
      */
-    public function listConnectedCommand(string $className = null, string $methodName = null): void
+    public function listConnectedCommand(?string $className = null, ?string $methodName = null): void
     {
         $this->outputFormatted('<b>Connected signals with their slots.</b>');
         $this->outputLine();

--- a/Neos.Flow/Classes/Command/TypeConverterCommandController.php
+++ b/Neos.Flow/Classes/Command/TypeConverterCommandController.php
@@ -38,7 +38,7 @@ class TypeConverterCommandController extends CommandController
      * @param string $target Filter by target type
      * @return void
      */
-    public function listCommand(string $source = null, string $target = null)
+    public function listCommand(?string $source = null, ?string $target = null)
     {
         $this->outputLine();
         if ($source !== null) {

--- a/Neos.Flow/Classes/Composer/ComposerUtility.php
+++ b/Neos.Flow/Classes/Composer/ComposerUtility.php
@@ -43,7 +43,7 @@ class ComposerUtility
      * @param string $configurationPath Optional. Only return the part of the manifest indexed by configurationPath
      * @return array|mixed
      */
-    public static function getComposerManifest(string $manifestPath, string $configurationPath = null)
+    public static function getComposerManifest(string $manifestPath, ?string $configurationPath = null)
     {
         $composerManifest = static::readComposerManifest($manifestPath);
         if ($composerManifest === null) {

--- a/Neos.Flow/Classes/Configuration/ConfigurationManager.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationManager.php
@@ -288,7 +288,7 @@ class ConfigurationManager
      * @return mixed The configuration or NULL if the configuration doesn't exist
      * @throws Exception\InvalidConfigurationTypeException on invalid configuration types
      */
-    public function getConfiguration(string $configurationType, string $configurationPath = null)
+    public function getConfiguration(string $configurationType, ?string $configurationPath = null)
     {
         if (empty($this->configurations[$configurationType])) {
             $this->loadConfiguration($configurationType, $this->packages);
@@ -468,7 +468,7 @@ class ConfigurationManager
      *
      * @param string $cachePathAndFilename The file to save the cache
      */
-    protected function writeConfigurationCacheFile(string $cachePathAndFilename, string $configurationType = null): void
+    protected function writeConfigurationCacheFile(string $cachePathAndFilename, ?string $configurationType = null): void
     {
         if (!file_exists(dirname($cachePathAndFilename))) {
             Files::createDirectoryRecursively(dirname($cachePathAndFilename));

--- a/Neos.Flow/Classes/Configuration/ConfigurationSchemaValidator.php
+++ b/Neos.Flow/Classes/Configuration/ConfigurationSchemaValidator.php
@@ -70,7 +70,7 @@ class ConfigurationSchemaValidator
      * @return \Neos\Error\Messages\Result the result of the validation
      * @throws Exception\SchemaValidationException
      */
-    public function validate(string $configurationType = null, string $path = null, array &$loadedSchemaFiles = []): Result
+    public function validate(?string $configurationType = null, ?string $path = null, array &$loadedSchemaFiles = []): Result
     {
         if ($configurationType === null) {
             $configurationTypes = $this->configurationManager->getAvailableConfigurationTypes();
@@ -95,7 +95,7 @@ class ConfigurationSchemaValidator
      * @return \Neos\Error\Messages\Result
      * @throws Exception\SchemaValidationException
      */
-    protected function validateSingleType(string $configurationType, string $path = null, array&$loadedSchemaFiles = []): Result
+    protected function validateSingleType(string $configurationType, ?string $path = null, array&$loadedSchemaFiles = []): Result
     {
         $availableConfigurationTypes = $this->configurationManager->getAvailableConfigurationTypes();
         if (in_array($configurationType, $availableConfigurationTypes) === false) {

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -637,7 +637,7 @@ class Scripts
      * @param string $filenamePattern Optional pattern for filenames to consider for file monitoring (regular expression). @see FileMonitor::monitorDirectory()
      * @return void
      */
-    protected static function monitorDirectoryIfItExists(FileMonitor $fileMonitor, string $path, string $filenamePattern = null)
+    protected static function monitorDirectoryIfItExists(FileMonitor $fileMonitor, string $path, ?string $filenamePattern = null)
     {
         if (is_dir($path)) {
             $fileMonitor->monitorDirectory($path, $filenamePattern);

--- a/Neos.Flow/Classes/Core/Bootstrap.php
+++ b/Neos.Flow/Classes/Core/Bootstrap.php
@@ -82,7 +82,7 @@ class Bootstrap
      * @param string $context The application context, for example "Production" or "Development"
      * @param \Composer\Autoload\ClassLoader $composerAutoloader Composer autoloader
      */
-    public function __construct(string $context, \Composer\Autoload\ClassLoader $composerAutoloader = null)
+    public function __construct(string $context, ?\Composer\Autoload\ClassLoader $composerAutoloader = null)
     {
         // Load the composer autoloader first if not provided
         $composerAutoloader = $composerAutoloader ?? require(__DIR__ . '/../../../../Libraries/autoload.php');

--- a/Neos.Flow/Classes/Core/ProxyClassLoader.php
+++ b/Neos.Flow/Classes/Core/ProxyClassLoader.php
@@ -106,7 +106,7 @@ class ProxyClassLoader
      * @param ApplicationContext $context
      * @return void
      */
-    public function initializeAvailableProxyClasses(ApplicationContext $context = null)
+    public function initializeAvailableProxyClasses(?ApplicationContext $context = null)
     {
         if ($context === null) {
             return;

--- a/Neos.Flow/Classes/Error/Debugger.php
+++ b/Neos.Flow/Classes/Error/Debugger.php
@@ -606,7 +606,7 @@ use Neos\Flow\Error\Debugger;
  * @return void|string if $return is true, the variable dump is returned. By default, the dump is directly displayed, and nothing is returned.
  * @api
  */
-function var_dump($variable, string $title = null, bool $return = false, bool $plaintext = null)
+function var_dump($variable, ?string $title = null, bool $return = false, ?bool $plaintext = null)
 {
     if ($plaintext === null) {
         $plaintext = (FLOW_SAPITYPE === 'CLI');

--- a/Neos.Flow/Classes/Http/BaseUriProvider.php
+++ b/Neos.Flow/Classes/Http/BaseUriProvider.php
@@ -75,7 +75,7 @@ class BaseUriProvider
      * @return UriInterface
      * @throws Exception
      */
-    public function getConfiguredBaseUriOrFallbackToCurrentRequest(ServerRequestInterface $fallbackRequest = null): UriInterface
+    public function getConfiguredBaseUriOrFallbackToCurrentRequest(?ServerRequestInterface $fallbackRequest = null): UriInterface
     {
         $baseUri = $this->getConfiguredBaseUri();
         if ($baseUri instanceof UriInterface) {

--- a/Neos.Flow/Classes/Http/Helper/UploadedFilesHelper.php
+++ b/Neos.Flow/Classes/Http/Helper/UploadedFilesHelper.php
@@ -68,7 +68,7 @@ abstract class UploadedFilesHelper
      * @param string $collectionName
      * @return FlowUploadedFile
      */
-    protected static function upcastUploadedFile(UploadedFileInterface $uploadedFile, $originallySubmittedResource = null, string $collectionName = null): FlowUploadedFile
+    protected static function upcastUploadedFile(UploadedFileInterface $uploadedFile, $originallySubmittedResource = null, ?string $collectionName = null): FlowUploadedFile
     {
         // If upload failed, just accessing the stream will throwin guzzle
         $stream = $uploadedFile->getError() === UPLOAD_ERR_OK ? $uploadedFile->getStream() : Utils::streamFor(null);
@@ -128,7 +128,7 @@ abstract class UploadedFilesHelper
      * @param string $firstLevelFieldName
      * @return array An array of paths (as arrays) in the format ["key1", "key2", "key3"] ...
      */
-    protected static function calculateFieldPathsAsArray(array $structure, string $firstLevelFieldName = null): array
+    protected static function calculateFieldPathsAsArray(array $structure, ?string $firstLevelFieldName = null): array
     {
         $fieldPaths = [];
         foreach ($structure as $key => $subStructure) {

--- a/Neos.Flow/Classes/I18n/FormatResolver.php
+++ b/Neos.Flow/Classes/I18n/FormatResolver.php
@@ -98,7 +98,7 @@ class FormatResolver
      * @throws Exception\IndexOutOfBoundsException When trying to format nonexistent value
      * @api
      */
-    public function resolvePlaceholders($textWithPlaceholders, array $arguments, Locale $locale = null)
+    public function resolvePlaceholders($textWithPlaceholders, array $arguments, ?Locale $locale = null)
     {
         if ($locale === null) {
             $locale = $this->localizationService->getConfiguration()->getDefaultLocale();

--- a/Neos.Flow/Classes/I18n/LocaleTypeConverter.php
+++ b/Neos.Flow/Classes/I18n/LocaleTypeConverter.php
@@ -48,7 +48,7 @@ class LocaleTypeConverter extends AbstractTypeConverter
      * @return Locale
      * @api
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         return new Locale($source);
     }

--- a/Neos.Flow/Classes/I18n/Service.php
+++ b/Neos.Flow/Classes/I18n/Service.php
@@ -124,7 +124,7 @@ class Service
      * @see Configuration::setFallbackRule()
      * @api
      */
-    public function getLocalizedFilename($pathAndFilename, Locale $locale = null, $strict = false)
+    public function getLocalizedFilename($pathAndFilename, ?Locale $locale = null, $strict = false)
     {
         if ($locale === null) {
             $locale = $this->configuration->getCurrentLocale();
@@ -177,7 +177,7 @@ class Service
      * @see Configuration::setFallbackRule()
      * @api
      */
-    public function getXliffFilenameAndPath($path, $sourceName, Locale $locale = null)
+    public function getXliffFilenameAndPath($path, $sourceName, ?Locale $locale = null)
     {
         if ($locale === null) {
             $locale = $this->configuration->getCurrentLocale();

--- a/Neos.Flow/Classes/I18n/Translator.php
+++ b/Neos.Flow/Classes/I18n/Translator.php
@@ -123,7 +123,7 @@ class Translator
      * @throws Exception\InvalidFormatPlaceholderException
      * @api
      */
-    public function translateByOriginalLabel($originalLabel, array $arguments = [], $quantity = null, Locale $locale = null, string $sourceName = 'Main', string $packageKey = 'Neos.Flow')
+    public function translateByOriginalLabel($originalLabel, array $arguments = [], $quantity = null, ?Locale $locale = null, string $sourceName = 'Main', string $packageKey = 'Neos.Flow')
     {
         if ($locale === null) {
             $locale = $this->localizationService->getConfiguration()->getCurrentLocale();
@@ -181,7 +181,7 @@ class Translator
      * @api
      * @see Translator::translateByOriginalLabel()
      */
-    public function translateById($labelId, array $arguments = [], $quantity = null, Locale $locale = null, $sourceName = 'Main', $packageKey = 'Neos.Flow')
+    public function translateById($labelId, array $arguments = [], $quantity = null, ?Locale $locale = null, $sourceName = 'Main', $packageKey = 'Neos.Flow')
     {
         if ($locale === null) {
             $locale = $this->localizationService->getConfiguration()->getCurrentLocale();

--- a/Neos.Flow/Classes/Mvc/RequestMatcher.php
+++ b/Neos.Flow/Classes/Mvc/RequestMatcher.php
@@ -61,7 +61,7 @@ class RequestMatcher
      * @param ActionRequest $actionRequest
      * @param RequestMatcher $parentMatcher
      */
-    public function __construct(ActionRequest $actionRequest = null, $parentMatcher = null)
+    public function __construct(?ActionRequest $actionRequest = null, $parentMatcher = null)
     {
         $this->request = $actionRequest;
         $this->parentMatcher = $parentMatcher;

--- a/Neos.Flow/Classes/Mvc/Routing/Dto/MatchResult.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Dto/MatchResult.php
@@ -39,7 +39,7 @@ final class MatchResult
      * @param mixed $matchedValue
      * @param RouteTags $tags
      */
-    public function __construct($matchedValue, RouteTags $tags = null, RouteLifetime $lifetime = null)
+    public function __construct($matchedValue, ?RouteTags $tags = null, ?RouteLifetime $lifetime = null)
     {
         $this->matchedValue = $matchedValue;
         $this->tags = $tags;

--- a/Neos.Flow/Classes/Mvc/Routing/Dto/ResolveResult.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Dto/ResolveResult.php
@@ -53,7 +53,7 @@ final class ResolveResult
      * @param UriConstraints $uriConstraints
      * @param RouteTags $tags
      */
-    public function __construct(string $resolvedValue, UriConstraints $uriConstraints = null, RouteTags $tags = null, RouteLifetime $lifetime = null)
+    public function __construct(string $resolvedValue, ?UriConstraints $uriConstraints = null, ?RouteTags $tags = null, ?RouteLifetime $lifetime = null)
     {
         $this->resolvedValue = $resolvedValue;
         $this->uriConstraints = $uriConstraints;

--- a/Neos.Flow/Classes/Mvc/Routing/Router.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Router.php
@@ -100,7 +100,7 @@ class Router implements RouterInterface
      * @param array $routesConfiguration The routes configuration or NULL if it should be fetched from configuration
      * @return void
      */
-    public function setRoutesConfiguration(array $routesConfiguration = null)
+    public function setRoutesConfiguration(?array $routesConfiguration = null)
     {
         $this->routesConfiguration = $routesConfiguration;
         $this->routesCreated = false;

--- a/Neos.Flow/Classes/Mvc/Routing/RouterCachingService.php
+++ b/Neos.Flow/Classes/Mvc/Routing/RouterCachingService.php
@@ -114,7 +114,7 @@ class RouterCachingService
      * @param RouteLifetime|null $matchedLifetime
      * @return void
      */
-    public function storeMatchResults(RouteContext $routeContext, array $matchResults, RouteTags $matchedTags = null, RouteLifetime $matchedLifetime = null)
+    public function storeMatchResults(RouteContext $routeContext, array $matchResults, ?RouteTags $matchedTags = null, ?RouteLifetime $matchedLifetime = null)
     {
         if ($this->containsObject($matchResults)) {
             return;
@@ -152,7 +152,7 @@ class RouterCachingService
      * @param RouteLifetime|null $resolvedLifetime
      * @return void
      */
-    public function storeResolvedUriConstraints(ResolveContext $resolveContext, UriConstraints $uriConstraints, RouteTags $resolvedTags = null, RouteLifetime $resolvedLifetime = null)
+    public function storeResolvedUriConstraints(ResolveContext $resolveContext, UriConstraints $uriConstraints, ?RouteTags $resolvedTags = null, ?RouteLifetime $resolvedLifetime = null)
     {
         $routeValues = $this->convertObjectsToHashes($resolveContext->getRouteValues());
         if ($routeValues === null) {

--- a/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
+++ b/Neos.Flow/Classes/Mvc/Routing/UriBuilder.php
@@ -289,7 +289,7 @@ class UriBuilder
      * @throws Exception\MissingActionNameException if $actionName parameter is empty
      * @throws \Neos\Flow\Http\Exception
      */
-    public function uriFor(string $actionName, array $controllerArguments = [], string $controllerName = null, string $packageKey = null, string $subPackageKey = null)
+    public function uriFor(string $actionName, array $controllerArguments = [], ?string $controllerName = null, ?string $packageKey = null, ?string $subPackageKey = null)
     {
         if (empty($actionName)) {
             throw new Exception\MissingActionNameException('The URI Builder could not build a URI linking to an action controller because no action name was specified. Please check the stack trace to see which code or template was requesting the link and check the arguments passed to the URI Builder.', 1354629891);

--- a/Neos.Flow/Classes/Package/PackageFactory.php
+++ b/Neos.Flow/Classes/Package/PackageFactory.php
@@ -32,7 +32,7 @@ class PackageFactory
      * @return PackageInterface|PackageKeyAwareInterface
      * @throws Exception\CorruptPackageException
      */
-    public function create($packagesBasePath, $packagePath, $packageKey, $composerName, array $autoloadConfiguration = [], array $packageClassInformation = null)
+    public function create($packagesBasePath, $packagePath, $packageKey, $composerName, array $autoloadConfiguration = [], ?array $packageClassInformation = null)
     {
         $absolutePackagePath = Files::concatenatePaths([$packagesBasePath, $packagePath]) . '/';
 

--- a/Neos.Flow/Classes/Package/PackageManager.php
+++ b/Neos.Flow/Classes/Package/PackageManager.php
@@ -881,7 +881,7 @@ class PackageManager
      * @param string $autoloadNamespace
      * @return string
      */
-    protected function derivePackageKey(string $composerName, string $packageType = null, string $packagePath = '', string $autoloadNamespace = null): string
+    protected function derivePackageKey(string $composerName, ?string $packageType = null, string $packagePath = '', ?string $autoloadNamespace = null): string
     {
         $packageKey = '';
 

--- a/Neos.Flow/Classes/Persistence/Doctrine/ArrayTypeConverter.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/ArrayTypeConverter.php
@@ -69,7 +69,7 @@ class ArrayTypeConverter extends AbstractTypeConverter
      * @throws TypeConverterException thrown in case a developer error occurred
      * @api
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         $result = [];
         $convertElements = $configuration->getConfigurationValue(ArrayTypeConverter::class, self::CONFIGURATION_CONVERT_ELEMENTS);

--- a/Neos.Flow/Classes/Persistence/Doctrine/Logging/SqlLogger.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Logging/SqlLogger.php
@@ -35,7 +35,7 @@ class SqlLogger implements \Doctrine\DBAL\Logging\SQLLogger
      * @param array $types The SQL parameter types.
      * @return void
      */
-    public function startQuery($sql, array $params = null, array $types = null)
+    public function startQuery($sql, ?array $params = null, ?array $types = null)
     {
         if ($this->logger instanceof DependencyProxy) {
             $this->logger->_activateDependency();

--- a/Neos.Flow/Classes/Persistence/Doctrine/PersistenceManager.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/PersistenceManager.php
@@ -201,7 +201,7 @@ class PersistenceManager extends AbstractPersistenceManager
      * @throws ORMException
      * @api
      */
-    public function getObjectByIdentifier($identifier, string $objectType = null, bool $useLazyLoading = false)
+    public function getObjectByIdentifier($identifier, ?string $objectType = null, bool $useLazyLoading = false)
     {
         if ($objectType === null) {
             throw new \RuntimeException('Using only the identifier is not supported by Doctrine 2. Give classname as well or use repository to query identifier.', 1296646103);

--- a/Neos.Flow/Classes/Persistence/Doctrine/Repository.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Repository.php
@@ -64,7 +64,7 @@ abstract class Repository extends EntityRepository implements RepositoryInterfac
      * @param EntityManagerInterface $entityManager The EntityManager to use.
      * @param ClassMetadata|null $classMetadata The class descriptor.
      */
-    public function __construct(EntityManagerInterface $entityManager, ClassMetadata $classMetadata = null)
+    public function __construct(EntityManagerInterface $entityManager, ?ClassMetadata $classMetadata = null)
     {
         if ($classMetadata === null) {
             if (defined('static::ENTITY_CLASSNAME') === false) {
@@ -162,7 +162,7 @@ abstract class Repository extends EntityRepository implements RepositoryInterfac
      * @param callable|null $callback
      * @return \Generator
      */
-    public function iterate(IterableResult $iterator, callable $callback = null): ?\Generator
+    public function iterate(IterableResult $iterator, ?callable $callback = null): ?\Generator
     {
         $iteration = 0;
         foreach ($iterator as $object) {

--- a/Neos.Flow/Classes/Persistence/Doctrine/Service.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Service.php
@@ -196,7 +196,7 @@ class Service
      * @param int|null $maxResult
      * @return mixed
      */
-    public function runDql(string $dql, int $hydrationMode = \Doctrine\ORM\Query::HYDRATE_OBJECT, int $firstResult = null, int $maxResult = null)
+    public function runDql(string $dql, int $hydrationMode = \Doctrine\ORM\Query::HYDRATE_OBJECT, ?int $firstResult = null, ?int $maxResult = null)
     {
         $query = $this->entityManager->createQuery($dql);
         if ($firstResult !== null) {
@@ -306,7 +306,7 @@ class Service
      * @return string
      * @throws DBALException
      */
-    public function executeMigrations(string $version = 'latest', string $outputPathAndFilename = null, $dryRun = false, $quiet = false): string
+    public function executeMigrations(string $version = 'latest', ?string $outputPathAndFilename = null, $dryRun = false, $quiet = false): string
     {
         $this->initializeMetadataStorage();
 
@@ -413,7 +413,7 @@ class Service
      * @return string
      * @throws DBALException
      */
-    public function executeMigration(string $version, string $direction = 'up', string $outputPathAndFilename = null, bool $dryRun = false): string
+    public function executeMigration(string $version, string $direction = 'up', ?string $outputPathAndFilename = null, bool $dryRun = false): string
     {
         $this->initializeMetadataStorage();
 
@@ -604,7 +604,7 @@ class Service
      * @return array Path to the new file
      * @throws DBALException
      */
-    public function generateMigration(bool $diffAgainstCurrent = true, string $filterExpression = null): array
+    public function generateMigration(bool $diffAgainstCurrent = true, ?string $filterExpression = null): array
     {
         $fqcn = $this->getDependencyFactory()->getClassNameGenerator()->generateClassName(self::DOCTRINE_MIGRATIONSNAMESPACE);
 

--- a/Neos.Flow/Classes/Persistence/PersistenceManagerInterface.php
+++ b/Neos.Flow/Classes/Persistence/PersistenceManagerInterface.php
@@ -99,7 +99,7 @@ interface PersistenceManagerInterface
      * @return object|null The object for the identifier if it is known, or NULL
      * @api
      */
-    public function getObjectByIdentifier($identifier, string $objectType = null, bool $useLazyLoading = false);
+    public function getObjectByIdentifier($identifier, ?string $objectType = null, bool $useLazyLoading = false);
 
     /**
      * Converts the given object into an array containing the identity of the domain object.

--- a/Neos.Flow/Classes/Property/PropertyMapper.php
+++ b/Neos.Flow/Classes/Property/PropertyMapper.php
@@ -108,7 +108,7 @@ class PropertyMapper
      * @throws SecurityException
      * @api
      */
-    public function convert($source, $targetType, PropertyMappingConfigurationInterface $configuration = null)
+    public function convert($source, $targetType, ?PropertyMappingConfigurationInterface $configuration = null)
     {
         if ($configuration === null) {
             $configuration = $this->buildPropertyMappingConfiguration();

--- a/Neos.Flow/Classes/Property/TypeConverter/AbstractTypeConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/AbstractTypeConverter.php
@@ -86,7 +86,7 @@ abstract class AbstractTypeConverter implements TypeConverterInterface
      * @return string
      * @api
      */
-    public function getTargetTypeForSource($source, $originalTargetType, PropertyMappingConfigurationInterface $configuration = null)
+    public function getTargetTypeForSource($source, $originalTargetType, ?PropertyMappingConfigurationInterface $configuration = null)
     {
         return $originalTargetType;
     }

--- a/Neos.Flow/Classes/Property/TypeConverter/ArrayConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ArrayConverter.php
@@ -120,7 +120,7 @@ class ArrayConverter extends AbstractTypeConverter
      * @throws TypeConverterException
      * @api
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         if (is_array($source)) {
             return $source;
@@ -184,7 +184,7 @@ class ArrayConverter extends AbstractTypeConverter
      * @return string
      * @throws InvalidPropertyMappingConfigurationException
      */
-    protected function getStringDelimiter(PropertyMappingConfigurationInterface $configuration = null)
+    protected function getStringDelimiter(?PropertyMappingConfigurationInterface $configuration = null)
     {
         if ($configuration === null) {
             return self::DEFAULT_STRING_DELIMITER;
@@ -205,7 +205,7 @@ class ArrayConverter extends AbstractTypeConverter
      * @return string
      * @throws InvalidPropertyMappingConfigurationException
      */
-    protected function getStringFormat(PropertyMappingConfigurationInterface $configuration = null)
+    protected function getStringFormat(?PropertyMappingConfigurationInterface $configuration = null)
     {
         if ($configuration === null) {
             return self::DEFAULT_STRING_FORMAT;
@@ -226,7 +226,7 @@ class ArrayConverter extends AbstractTypeConverter
      * @return string
      * @throws InvalidPropertyMappingConfigurationException
      */
-    protected function getResourceExportType(PropertyMappingConfigurationInterface $configuration = null)
+    protected function getResourceExportType(?PropertyMappingConfigurationInterface $configuration = null)
     {
         if ($configuration === null) {
             return self::DEFAULT_RESOURCE_EXPORT_TYPE;

--- a/Neos.Flow/Classes/Property/TypeConverter/ArrayFromObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ArrayFromObjectConverter.php
@@ -95,7 +95,7 @@ class ArrayFromObjectConverter extends AbstractTypeConverter
      * @return mixed|Error the target type, or an error object if a user-error occurred
      * @api
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         $properties = ObjectAccess::getGettableProperties($source);
         if ($source instanceof DoctrineProxy) {

--- a/Neos.Flow/Classes/Property/TypeConverter/ArrayObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ArrayObjectConverter.php
@@ -51,7 +51,7 @@ class ArrayObjectConverter extends AbstractTypeConverter
      * @throws InvalidSourceException
      * @api
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null): array
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null): array
     {
         if (!($source instanceof \ArrayObject)) {
             throw new InvalidSourceException('Source was not an instance of ArrayObject.', 1648456200);

--- a/Neos.Flow/Classes/Property/TypeConverter/BooleanConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/BooleanConverter.php
@@ -51,7 +51,7 @@ class BooleanConverter extends AbstractTypeConverter
      * @return boolean
      * @api
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         if (is_bool($source)) {
             return $source;

--- a/Neos.Flow/Classes/Property/TypeConverter/CollectionConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/CollectionConverter.php
@@ -54,7 +54,7 @@ class CollectionConverter extends AbstractTypeConverter
      * @return ArrayCollection
      * @api
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         return new ArrayCollection($convertedChildProperties);
     }

--- a/Neos.Flow/Classes/Property/TypeConverter/DateTimeConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/DateTimeConverter.php
@@ -121,7 +121,7 @@ class DateTimeConverter extends AbstractTypeConverter
      * @throws InvalidPropertyMappingConfigurationException
      * @throws TypeConverterException
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         $dateFormat = $this->getDefaultDateFormat($configuration);
         $isFormatSpecified = false;
@@ -197,7 +197,7 @@ class DateTimeConverter extends AbstractTypeConverter
      * @return string
      * @throws InvalidPropertyMappingConfigurationException
      */
-    protected function getDefaultDateFormat(PropertyMappingConfigurationInterface $configuration = null)
+    protected function getDefaultDateFormat(?PropertyMappingConfigurationInterface $configuration = null)
     {
         if ($configuration === null) {
             return self::DEFAULT_DATE_FORMAT;

--- a/Neos.Flow/Classes/Property/TypeConverter/DenormalizingObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/DenormalizingObjectConverter.php
@@ -40,7 +40,7 @@ final class DenormalizingObjectConverter implements TypeConverterInterface
      * @return string
      * @api
      */
-    public function getTargetTypeForSource($source, $originalTargetType, PropertyMappingConfigurationInterface $configuration = null)
+    public function getTargetTypeForSource($source, $originalTargetType, ?PropertyMappingConfigurationInterface $configuration = null)
     {
         return $originalTargetType;
     }
@@ -142,7 +142,7 @@ final class DenormalizingObjectConverter implements TypeConverterInterface
      * @throws TypeConverterException thrown in case a developer error occurred
      * @api
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         return self::convertFromSource($source, $targetType);
     }

--- a/Neos.Flow/Classes/Property/TypeConverter/FloatConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/FloatConverter.php
@@ -130,7 +130,7 @@ class FloatConverter extends AbstractTypeConverter
      * @throws InvalidPropertyMappingConfigurationException
      * @api
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         if ($source === null || $source === '') {
             return null;

--- a/Neos.Flow/Classes/Property/TypeConverter/IntegerConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/IntegerConverter.php
@@ -52,7 +52,7 @@ class IntegerConverter extends AbstractTypeConverter
      * @return integer|Error
      * @api
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         if ($source instanceof \DateTimeInterface) {
             return $source->format('U');

--- a/Neos.Flow/Classes/Property/TypeConverter/MediaTypeConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/MediaTypeConverter.php
@@ -53,7 +53,7 @@ class MediaTypeConverter extends AbstractTypeConverter implements MediaTypeConve
      * @return array|string|integer Note that this TypeConverter may return a non-array in case of JSON media type, even though he declares to only convert to array
      * @api
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         $mediaType = null;
         if ($configuration !== null) {

--- a/Neos.Flow/Classes/Property/TypeConverter/ObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ObjectConverter.php
@@ -180,7 +180,7 @@ class ObjectConverter extends AbstractTypeConverter
      * @throws InvalidDataTypeException
      * @throws InvalidPropertyMappingConfigurationException
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         $object = $this->buildObject($convertedChildProperties, $targetType);
         foreach ($convertedChildProperties as $propertyName => $propertyValue) {
@@ -210,7 +210,7 @@ class ObjectConverter extends AbstractTypeConverter
      * @throws InvalidPropertyMappingConfigurationException
      * @throws \InvalidArgumentException
      */
-    public function getTargetTypeForSource($source, $originalTargetType, PropertyMappingConfigurationInterface $configuration = null)
+    public function getTargetTypeForSource($source, $originalTargetType, ?PropertyMappingConfigurationInterface $configuration = null)
     {
         $targetType = $originalTargetType;
 

--- a/Neos.Flow/Classes/Property/TypeConverter/PersistentObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/PersistentObjectConverter.php
@@ -159,7 +159,7 @@ class PersistentObjectConverter extends ObjectConverter
      * @return object|TargetNotFoundError the converted entity/value object or an instance of TargetNotFoundError if the object could not be resolved
      * @throws \InvalidArgumentException|InvalidTargetException
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         /** @var class-string $targetType */
         if (is_array($source)) {
@@ -230,7 +230,7 @@ class PersistentObjectConverter extends ObjectConverter
      * @return object|TargetNotFoundError
      * @throws InvalidPropertyMappingConfigurationException
      */
-    protected function handleArrayData(array $source, $targetType, array &$convertedChildProperties, PropertyMappingConfigurationInterface $configuration = null)
+    protected function handleArrayData(array $source, $targetType, array &$convertedChildProperties, ?PropertyMappingConfigurationInterface $configuration = null)
     {
         if (!isset($source['__identity'])) {
             if ($this->reflectionService->isClassAnnotatedWith($targetType, ValueObject::class) === true) {

--- a/Neos.Flow/Classes/Property/TypeConverter/PersistentObjectSerializer.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/PersistentObjectSerializer.php
@@ -56,7 +56,7 @@ class PersistentObjectSerializer extends AbstractTypeConverter
      * @param PropertyMappingConfigurationInterface|null $configuration
      * @return mixed The identifier for the object if it is known, or NULL
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         return $this->persistenceManager->getIdentifierByObject($source);
     }

--- a/Neos.Flow/Classes/Property/TypeConverter/ScalarTypeToObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ScalarTypeToObjectConverter.php
@@ -83,7 +83,7 @@ class ScalarTypeToObjectConverter extends AbstractTypeConverter
      * @param PropertyMappingConfigurationInterface|null $configuration
      * @return object
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         return new $targetType($source);
     }

--- a/Neos.Flow/Classes/Property/TypeConverter/SessionConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/SessionConverter.php
@@ -74,7 +74,7 @@ class SessionConverter extends AbstractTypeConverter
      * @param PropertyMappingConfigurationInterface|null $configuration
      * @return object the target type
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         return $this->sessionManager->getSession($source);
     }

--- a/Neos.Flow/Classes/Property/TypeConverter/StringConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/StringConverter.php
@@ -100,7 +100,7 @@ class StringConverter extends AbstractTypeConverter
      * @throws InvalidPropertyMappingConfigurationException
      * @api
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         if ($source instanceof \DateTimeInterface) {
             $dateFormat = $this->getDateFormat($configuration);
@@ -131,7 +131,7 @@ class StringConverter extends AbstractTypeConverter
      * @return string
      * @throws InvalidPropertyMappingConfigurationException
      */
-    protected function getDateFormat(PropertyMappingConfigurationInterface $configuration = null)
+    protected function getDateFormat(?PropertyMappingConfigurationInterface $configuration = null)
     {
         if ($configuration === null) {
             return self::DEFAULT_DATE_FORMAT;
@@ -156,7 +156,7 @@ class StringConverter extends AbstractTypeConverter
      * @return string
      * @throws InvalidPropertyMappingConfigurationException
      */
-    protected function getCsvDelimiter(PropertyMappingConfigurationInterface $configuration = null)
+    protected function getCsvDelimiter(?PropertyMappingConfigurationInterface $configuration = null)
     {
         if ($configuration === null) {
             return self::DEFAULT_CSV_DELIMITER;
@@ -181,7 +181,7 @@ class StringConverter extends AbstractTypeConverter
      * @return string
      * @throws InvalidPropertyMappingConfigurationException
      */
-    protected function getArrayFormat(PropertyMappingConfigurationInterface $configuration = null)
+    protected function getArrayFormat(?PropertyMappingConfigurationInterface $configuration = null)
     {
         if ($configuration === null) {
             return self::DEFAULT_ARRAY_FORMAT;

--- a/Neos.Flow/Classes/Property/TypeConverter/TypedArrayConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/TypedArrayConverter.php
@@ -63,7 +63,7 @@ class TypedArrayConverter extends AbstractTypeConverter
      * @return array
      * @api
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         return $convertedChildProperties;
     }

--- a/Neos.Flow/Classes/Property/TypeConverter/UriTypeConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/UriTypeConverter.php
@@ -50,7 +50,7 @@ class UriTypeConverter extends AbstractTypeConverter
      * @param PropertyMappingConfigurationInterface|null $configuration
      * @return Uri|Error if the input format is not supported or could not be converted for other reasons
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         try {
             return new Uri($source);

--- a/Neos.Flow/Classes/Property/TypeConverterInterface.php
+++ b/Neos.Flow/Classes/Property/TypeConverterInterface.php
@@ -49,7 +49,7 @@ interface TypeConverterInterface
      * @return string
      * @api
      */
-    public function getTargetTypeForSource($source, $originalTargetType, PropertyMappingConfigurationInterface $configuration = null);
+    public function getTargetTypeForSource($source, $originalTargetType, ?PropertyMappingConfigurationInterface $configuration = null);
 
     /**
      * Return the priority of this TypeConverter. TypeConverters with a high priority are chosen before low priority.
@@ -110,5 +110,5 @@ interface TypeConverterInterface
      * @throws Exception\TypeConverterException thrown in case a developer error occurred
      * @api
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null);
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null);
 }

--- a/Neos.Flow/Classes/ResourceManagement/Collection.php
+++ b/Neos.Flow/Classes/ResourceManagement/Collection.php
@@ -155,7 +155,7 @@ class Collection implements CollectionInterface
      * @param callable $callback Function called after each object
      * @return \Generator<StorageObject>
      */
-    public function getObjects(callable $callback = null)
+    public function getObjects(?callable $callback = null)
     {
         if ($this->storage instanceof PackageStorage && $this->pathPatterns !== []) {
             foreach ($this->pathPatterns as $pathPattern) {

--- a/Neos.Flow/Classes/ResourceManagement/Publishing/MessageCollector.php
+++ b/Neos.Flow/Classes/ResourceManagement/Publishing/MessageCollector.php
@@ -107,7 +107,7 @@ class MessageCollector
      * @return void
      * @api
      */
-    public function flush(callable $callback = null): void
+    public function flush(?callable $callback = null): void
     {
         foreach ($this->messages as $message) {
             /** @var Message $message */

--- a/Neos.Flow/Classes/ResourceManagement/ResourceRepository.php
+++ b/Neos.Flow/Classes/ResourceManagement/ResourceRepository.php
@@ -144,7 +144,7 @@ class ResourceRepository extends Repository
      * @param callable $callback
      * @return \Generator
      */
-    public function iterate(IterableResult $iterator, callable $callback = null)
+    public function iterate(IterableResult $iterator, ?callable $callback = null)
     {
         $iteration = 0;
         foreach ($iterator as $object) {

--- a/Neos.Flow/Classes/ResourceManagement/ResourceTypeConverter.php
+++ b/Neos.Flow/Classes/ResourceManagement/ResourceTypeConverter.php
@@ -153,7 +153,7 @@ class ResourceTypeConverter extends AbstractTypeConverter
      * @throws Exception\InvalidResourceDataException
      * @throws InvalidPropertyMappingConfigurationException
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         if (empty($source)) {
             return null;
@@ -181,7 +181,7 @@ class ResourceTypeConverter extends AbstractTypeConverter
      * @param PropertyMappingConfigurationInterface|null $configuration
      * @return PersistentResource|null|FlowError
      */
-    protected function handleFileUploads(array $source, PropertyMappingConfigurationInterface $configuration = null)
+    protected function handleFileUploads(array $source, ?PropertyMappingConfigurationInterface $configuration = null)
     {
         if (!isset($source['error']) || $source['error'] === \UPLOAD_ERR_NO_FILE) {
             if (isset($source['originallySubmittedResource']) && isset($source['originallySubmittedResource']['__identity'])) {
@@ -226,7 +226,7 @@ class ResourceTypeConverter extends AbstractTypeConverter
      * @throws Exception\InvalidResourceDataException
      * @throws InvalidPropertyMappingConfigurationException
      */
-    protected function handleHashAndData(array $source, PropertyMappingConfigurationInterface $configuration = null)
+    protected function handleHashAndData(array $source, ?PropertyMappingConfigurationInterface $configuration = null)
     {
         $hash = null;
         $resource = null;
@@ -278,7 +278,7 @@ class ResourceTypeConverter extends AbstractTypeConverter
      * @param PropertyMappingConfigurationInterface|null $configuration
      * @return PersistentResource|null|FlowError
      */
-    protected function handleUploadedFile(UploadedFileInterface $source, PropertyMappingConfigurationInterface $configuration = null)
+    protected function handleUploadedFile(UploadedFileInterface $source, ?PropertyMappingConfigurationInterface $configuration = null)
     {
         if ($source instanceof FlowUploadedFile && $source->getError() === UPLOAD_ERR_NO_FILE && $source->getOriginallySubmittedResource() !== null) {
             $identifier = is_array($source->getOriginallySubmittedResource()) ? $source->getOriginallySubmittedResource()['__identity'] : $source->getOriginallySubmittedResource();
@@ -329,7 +329,7 @@ class ResourceTypeConverter extends AbstractTypeConverter
      * @return string
      * @throws InvalidPropertyMappingConfigurationException
      */
-    protected function getCollectionName($source, PropertyMappingConfigurationInterface $configuration = null)
+    protected function getCollectionName($source, ?PropertyMappingConfigurationInterface $configuration = null)
     {
         if ($configuration === null) {
             return ResourceManager::DEFAULT_PERSISTENT_COLLECTION_NAME;

--- a/Neos.Flow/Classes/ResourceManagement/Storage/FileSystemStorage.php
+++ b/Neos.Flow/Classes/ResourceManagement/Storage/FileSystemStorage.php
@@ -133,7 +133,7 @@ class FileSystemStorage implements StorageInterface
      * @param callable|null $callback Function called after each iteration
      * @return \Generator<StorageObject>
      */
-    public function getObjects(callable $callback = null)
+    public function getObjects(?callable $callback = null)
     {
         foreach ($this->resourceManager->getCollectionsByStorage($this) as $collection) {
             yield from $this->getObjectsByCollection($collection, $callback);
@@ -147,7 +147,7 @@ class FileSystemStorage implements StorageInterface
      * @param callable|null $callback Function called after each iteration
      * @return \Generator<StorageObject>
      */
-    public function getObjectsByCollection(CollectionInterface $collection, callable $callback = null)
+    public function getObjectsByCollection(CollectionInterface $collection, ?callable $callback = null)
     {
         $iterator = $this->resourceRepository->findByCollectionNameIterator($collection->getName());
         $iteration = 0;

--- a/Neos.Flow/Classes/ResourceManagement/Storage/PackageStorage.php
+++ b/Neos.Flow/Classes/ResourceManagement/Storage/PackageStorage.php
@@ -45,7 +45,7 @@ class PackageStorage extends FileSystemStorage
      * @param callable $callback Function called after each iteration
      * @return \Generator<StorageObject>
      */
-    public function getObjects(callable $callback = null)
+    public function getObjects(?callable $callback = null)
     {
         return $this->getObjectsByPathPattern('*');
     }
@@ -57,7 +57,7 @@ class PackageStorage extends FileSystemStorage
      * @param callable $callback Function called after each object
      * @return \Generator<StorageObject>
      */
-    public function getObjectsByPathPattern($pattern, callable $callback = null)
+    public function getObjectsByPathPattern($pattern, ?callable $callback = null)
     {
         $directories = [];
 

--- a/Neos.Flow/Classes/ResourceManagement/Target/FileSystemSymlinkTarget.php
+++ b/Neos.Flow/Classes/ResourceManagement/Target/FileSystemSymlinkTarget.php
@@ -35,7 +35,7 @@ class FileSystemSymlinkTarget extends FileSystemTarget
      * @param callable $callback Function called after each resource publishing
      * @return void
      */
-    public function publishCollection(CollectionInterface $collection, callable $callback = null)
+    public function publishCollection(CollectionInterface $collection, ?callable $callback = null)
     {
         $storage = $collection->getStorage();
         if ($storage instanceof PackageStorage) {

--- a/Neos.Flow/Classes/ResourceManagement/Target/FileSystemTarget.php
+++ b/Neos.Flow/Classes/ResourceManagement/Target/FileSystemTarget.php
@@ -193,7 +193,7 @@ class FileSystemTarget implements TargetInterface
      * @param callable $callback Function called after each resource publishing
      * @return void
      */
-    public function publishCollection(CollectionInterface $collection, callable $callback = null)
+    public function publishCollection(CollectionInterface $collection, ?callable $callback = null)
     {
         $storage = $collection->getStorage();
         $this->checkAndRemovePackageSymlinks($storage);

--- a/Neos.Flow/Classes/Security/Account.php
+++ b/Neos.Flow/Classes/Security/Account.php
@@ -314,7 +314,7 @@ class Account
      * @return void
      * @api
      */
-    public function setExpirationDate(\DateTime $expirationDate = null)
+    public function setExpirationDate(?\DateTime $expirationDate = null)
     {
         $this->expirationDate = $expirationDate;
     }

--- a/Neos.Flow/Classes/Security/Authentication/Controller/AbstractAuthenticationController.php
+++ b/Neos.Flow/Classes/Security/Authentication/Controller/AbstractAuthenticationController.php
@@ -118,7 +118,7 @@ abstract class AbstractAuthenticationController extends ActionController
      * @param AuthenticationRequiredException $exception The exception thrown while the authentication process
      * @return void
      */
-    protected function onAuthenticationFailure(AuthenticationRequiredException $exception = null)
+    protected function onAuthenticationFailure(?AuthenticationRequiredException $exception = null)
     {
         $this->controllerContext->getFlashMessageContainer()->addMessage(new Error('Authentication failed!', ($exception === null ? 1347016771 : $exception->getCode())));
     }
@@ -137,7 +137,7 @@ abstract class AbstractAuthenticationController extends ActionController
      * @param ActionRequest $originalRequest The request that was intercepted by the security framework, NULL if there was none
      * @return string
      */
-    abstract protected function onAuthenticationSuccess(ActionRequest $originalRequest = null);
+    abstract protected function onAuthenticationSuccess(?ActionRequest $originalRequest = null);
 
 
     /**

--- a/Neos.Flow/Classes/Security/Authentication/Token/AbstractToken.php
+++ b/Neos.Flow/Classes/Security/Authentication/Token/AbstractToken.php
@@ -68,7 +68,7 @@ abstract class AbstractToken implements TokenInterface
      *
      * @param array|null $options
      */
-    public function __construct(array $options = null)
+    public function __construct(?array $options = null)
     {
         $this->options = $options ?? [];
     }
@@ -189,7 +189,7 @@ abstract class AbstractToken implements TokenInterface
      * @param Account $account An account object
      * @return void
      */
-    public function setAccount(Account $account = null)
+    public function setAccount(?Account $account = null)
     {
         $this->account = $account;
     }

--- a/Neos.Flow/Classes/Security/Authentication/TokenInterface.php
+++ b/Neos.Flow/Classes/Security/Authentication/TokenInterface.php
@@ -149,7 +149,7 @@ interface TokenInterface
      * @param Account $account An account object
      * @return void
      */
-    public function setAccount(Account $account = null);
+    public function setAccount(?Account $account = null);
 
     /**
      * Returns a string representation of the token for logging purposes.

--- a/Neos.Flow/Classes/Security/Authorization/PrivilegeManager.php
+++ b/Neos.Flow/Classes/Security/Authorization/PrivilegeManager.php
@@ -154,7 +154,7 @@ class PrivilegeManager implements PrivilegeManagerInterface
      * @param PrivilegeInterface|null $privilege
      * @return PrivilegePermissionResult
      */
-    protected function applyPrivilegeToResult(PrivilegePermissionResult $result, PrivilegeInterface $privilege = null): PrivilegePermissionResult
+    protected function applyPrivilegeToResult(PrivilegePermissionResult $result, ?PrivilegeInterface $privilege = null): PrivilegePermissionResult
     {
         return $result->withPrivilege($privilege);
     }

--- a/Neos.Flow/Classes/Security/Authorization/PrivilegePermissionResult.php
+++ b/Neos.Flow/Classes/Security/Authorization/PrivilegePermissionResult.php
@@ -47,7 +47,7 @@ class PrivilegePermissionResult
      * @param PrivilegeInterface $privilege
      * @return PrivilegePermissionResult
      */
-    public function withPrivilege(PrivilegeInterface $privilege = null): PrivilegePermissionResult
+    public function withPrivilege(?PrivilegeInterface $privilege = null): PrivilegePermissionResult
     {
         $newResult = clone $this;
         if ($privilege === null) {

--- a/Neos.Flow/Classes/Security/Context.php
+++ b/Neos.Flow/Classes/Security/Context.php
@@ -576,7 +576,7 @@ class Context
      * @return void
      * @Flow\Session(autoStart=true)
      */
-    public function setInterceptedRequest(ActionRequest $interceptedRequest = null)
+    public function setInterceptedRequest(?ActionRequest $interceptedRequest = null)
     {
         if ($this->initialized === false) {
             $this->initialize();

--- a/Neos.Flow/Classes/Security/DummyContext.php
+++ b/Neos.Flow/Classes/Security/DummyContext.php
@@ -222,7 +222,7 @@ class DummyContext extends Context
      * @return void
      * @Flow\Session(autoStart=true)
      */
-    public function setInterceptedRequest(ActionRequest $interceptedRequest = null)
+    public function setInterceptedRequest(?ActionRequest $interceptedRequest = null)
     {
         $this->interceptedRequest = $interceptedRequest;
     }

--- a/Neos.Flow/Classes/Security/Policy/RoleConverter.php
+++ b/Neos.Flow/Classes/Security/Policy/RoleConverter.php
@@ -56,7 +56,7 @@ class RoleConverter extends AbstractTypeConverter
      * @param PropertyMappingConfigurationInterface|null $configuration
      * @return object the target type
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         try {
             $role = $this->policyService->getRole($source);

--- a/Neos.Flow/Classes/Security/SessionDataContainer.php
+++ b/Neos.Flow/Classes/Security/SessionDataContainer.php
@@ -92,7 +92,7 @@ class SessionDataContainer
      *
      * @param ActionRequest $interceptedRequest
      */
-    public function setInterceptedRequest(ActionRequest $interceptedRequest = null): void
+    public function setInterceptedRequest(?ActionRequest $interceptedRequest = null): void
     {
         $this->interceptedRequest = $interceptedRequest;
     }

--- a/Neos.Flow/Classes/Validation/ValidatorResolver.php
+++ b/Neos.Flow/Classes/Validation/ValidatorResolver.php
@@ -160,7 +160,7 @@ class ValidatorResolver
      * @throws Exception\InvalidTypeHintException
      * @throws Exception\InvalidValidationOptionsException
      */
-    public function buildMethodArgumentsValidatorConjunctions($className, $methodName, array $methodParameters = null, array $methodValidateAnnotations = null)
+    public function buildMethodArgumentsValidatorConjunctions($className, $methodName, ?array $methodParameters = null, ?array $methodValidateAnnotations = null)
     {
         $validatorConjunctions = [];
 

--- a/Neos.Flow/Scripts/Migrations/Manager.php
+++ b/Neos.Flow/Scripts/Migrations/Manager.php
@@ -331,7 +331,7 @@ class Manager
      * @param string $eventIdentifier one of the EVENT_* constants
      * @param array $eventData optional arguments to be passed to the handler closure
      */
-    protected function triggerEvent($eventIdentifier, array $eventData = null)
+    protected function triggerEvent($eventIdentifier, ?array $eventData = null)
     {
         if (!isset($this->eventCallbacks[$eventIdentifier])) {
             return;

--- a/Neos.Flow/Tests/Functional/Aop/Fixtures/TargetClass01.php
+++ b/Neos.Flow/Tests/Functional/Aop/Fixtures/TargetClass01.php
@@ -132,7 +132,7 @@ class TargetClass01 implements SayHelloInterface
      * @param Fixtures\Name $name
      * @return void
      */
-    public function setCurrentName(Fixtures\Name $name = null)
+    public function setCurrentName(?Fixtures\Name $name = null)
     {
         $this->currentName = $name;
     }

--- a/Neos.Flow/Tests/Functional/Command/PyStringNodeConverter.php
+++ b/Neos.Flow/Tests/Functional/Command/PyStringNodeConverter.php
@@ -45,7 +45,7 @@ class PyStringNodeConverter extends AbstractTypeConverter
      * @return TableNode
      * @api
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         return new TableNode(json_decode($source, true));
     }

--- a/Neos.Flow/Tests/Functional/Command/TableNodeConverter.php
+++ b/Neos.Flow/Tests/Functional/Command/TableNodeConverter.php
@@ -45,7 +45,7 @@ class TableNodeConverter extends AbstractTypeConverter
      * @return TableNode
      * @api
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         return new TableNode(json_decode($source, true));
     }

--- a/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/ActionControllerTestBController.php
+++ b/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/ActionControllerTestBController.php
@@ -57,7 +57,7 @@ class ActionControllerTestBController extends ActionController
      * @param TestObjectArgument $argument
      * @return string
      */
-    public function optionalObjectAction(TestObjectArgument $argument = null)
+    public function optionalObjectAction(?TestObjectArgument $argument = null)
     {
         if ($argument === null) {
             return 'null';
@@ -69,7 +69,7 @@ class ActionControllerTestBController extends ActionController
      * @param TestObjectArgument|null $argument
      * @return string
      */
-    public function optionalAnnotatedObjectAction(TestObjectArgument $argument = null)
+    public function optionalAnnotatedObjectAction(?TestObjectArgument $argument = null)
     {
         if ($argument === null) {
             return 'null';
@@ -265,7 +265,7 @@ class ActionControllerTestBController extends ActionController
      * @param \DateTime $argument
      * @return string
      */
-    public function optionalDateAction(\DateTime $argument = null)
+    public function optionalDateAction(?\DateTime $argument = null)
     {
         if ($argument === null) {
             return 'null';

--- a/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
@@ -66,7 +66,7 @@ class RoutingTest extends FunctionalTestCase
      * @param array $matchResults
      * @return ActionRequest
      */
-    protected function createActionRequest(ServerRequestInterface $httpRequest, array $matchResults = null): ActionRequest
+    protected function createActionRequest(ServerRequestInterface $httpRequest, ?array $matchResults = null): ActionRequest
     {
         $actionRequest = ActionRequest::fromHttpRequest($httpRequest);
         if ($matchResults !== null) {
@@ -203,7 +203,7 @@ class RoutingTest extends FunctionalTestCase
      * @test
      * @dataProvider routeTestsDataProvider
      */
-    public function routeTests($requestUri, $expectedMatchingRouteName, $expectedControllerObjectName = null, array $expectedArguments = null)
+    public function routeTests($requestUri, $expectedMatchingRouteName, $expectedControllerObjectName = null, ?array $expectedArguments = null)
     {
         $request = $this->serverRequestFactory->createServerRequest('GET', new Uri($requestUri));
         try {

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/ExtendedTypesEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/ExtendedTypesEntity.php
@@ -106,7 +106,7 @@ class ExtendedTypesEntity
      * @param \DateTime $date
      * @return $this
      */
-    public function setDate(\DateTime $date = null)
+    public function setDate(?\DateTime $date = null)
     {
         $this->date = $date;
         return $this;
@@ -124,7 +124,7 @@ class ExtendedTypesEntity
      * @param \DateTime $dateTimeTz
      * @return $this
      */
-    public function setDateTimeTz(\DateTime $dateTimeTz = null)
+    public function setDateTimeTz(?\DateTime $dateTimeTz = null)
     {
         $this->dateTimeTz = $dateTimeTz;
         return $this;
@@ -142,7 +142,7 @@ class ExtendedTypesEntity
      * @param \DateTime $dateTime
      * @return $this
      */
-    public function setDateTime(\DateTime $dateTime = null)
+    public function setDateTime(?\DateTime $dateTime = null)
     {
         $this->dateTime = $dateTime;
         return $this;
@@ -160,7 +160,7 @@ class ExtendedTypesEntity
      * @param \DateTimeImmutable $dateTime
      * @return $this
      */
-    public function setDateTimeImmutable(\DateTimeImmutable $dateTime = null)
+    public function setDateTimeImmutable(?\DateTimeImmutable $dateTime = null)
     {
         $this->dateTimeImmutable = $dateTime;
         return $this;
@@ -178,7 +178,7 @@ class ExtendedTypesEntity
      * @param \DateTimeInterface $dateTime
      * @return $this
      */
-    public function setDateTimeInterface(\DateTimeInterface $dateTime = null)
+    public function setDateTimeInterface(?\DateTimeInterface $dateTime = null)
     {
         $this->dateTimeInterface = $dateTime;
         return $this;
@@ -196,7 +196,7 @@ class ExtendedTypesEntity
      * @param CommonObject $commonObject
      * @return $this
      */
-    public function setCommonObject(CommonObject $commonObject = null)
+    public function setCommonObject(?CommonObject $commonObject = null)
     {
         $this->commonObject = $commonObject;
         return $this;
@@ -214,7 +214,7 @@ class ExtendedTypesEntity
      * @param array $simpleArray
      * @return $this
      */
-    public function setSimpleArray(array $simpleArray = null)
+    public function setSimpleArray(?array $simpleArray = null)
     {
         $this->simpleArray = $simpleArray;
         return $this;
@@ -232,7 +232,7 @@ class ExtendedTypesEntity
      * @param array $jsonArray
      * @return $this
      */
-    public function setJsonArray(array $jsonArray = null)
+    public function setJsonArray(?array $jsonArray = null)
     {
         $this->jsonArray = $jsonArray;
         return $this;

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Image.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Image.php
@@ -61,7 +61,7 @@ class Image
     /**
      * @param CleanupObject $relatedObject
      */
-    public function setRelatedObject(CleanupObject $relatedObject = null)
+    public function setRelatedObject(?CleanupObject $relatedObject = null)
     {
         $this->relatedObject = $relatedObject;
     }

--- a/Neos.Flow/Tests/Functional/Property/Fixtures/BoolToIntConverter.php
+++ b/Neos.Flow/Tests/Functional/Property/Fixtures/BoolToIntConverter.php
@@ -43,7 +43,7 @@ class BoolToIntConverter extends AbstractTypeConverter
      * @param PropertyMappingConfigurationInterface|null $configuration
      * @return bool|Error
      */
-    public function convertFrom($source, $targetType, array $convertedChildProperties = [], PropertyMappingConfigurationInterface $configuration = null)
+    public function convertFrom($source, $targetType, array $convertedChildProperties = [], ?PropertyMappingConfigurationInterface $configuration = null)
     {
         return $source ? 42 : -42;
     }

--- a/Neos.Flow/Tests/Functional/Property/PropertyMapperTest.php
+++ b/Neos.Flow/Tests/Functional/Property/PropertyMapperTest.php
@@ -353,7 +353,7 @@ class PropertyMapperTest extends FunctionalTestCase
      * @test
      * @dataProvider invalidTypeConverterConfigurationsForOverridingTargetTypes
      */
-    public function mappingToFieldsFromSubclassThrowsExceptionIfTypeConverterOptionIsInvalidOrNotSet(PropertyMappingConfigurationInterface $configuration = null)
+    public function mappingToFieldsFromSubclassThrowsExceptionIfTypeConverterOptionIsInvalidOrNotSet(?PropertyMappingConfigurationInterface $configuration = null)
     {
         $this->expectException(Exception::class);
         $source = [

--- a/Neos.Flow/Tests/Functional/Security/Fixtures/Controller/AuthenticationController.php
+++ b/Neos.Flow/Tests/Functional/Security/Fixtures/Controller/AuthenticationController.php
@@ -26,7 +26,7 @@ class AuthenticationController extends AbstractAuthenticationController
      * @param ActionRequest $originalRequest
      * @return string
      */
-    public function onAuthenticationSuccess(ActionRequest $originalRequest = null)
+    public function onAuthenticationSuccess(?ActionRequest $originalRequest = null)
     {
         if ($originalRequest !== null) {
             $this->redirectToRequest($originalRequest);
@@ -38,7 +38,7 @@ class AuthenticationController extends AbstractAuthenticationController
      * @param AuthenticationRequiredException $exception
      * @throws FlowException
      */
-    public function onAuthenticationFailure(AuthenticationRequiredException $exception = null)
+    public function onAuthenticationFailure(?AuthenticationRequiredException $exception = null)
     {
         throw new FlowException('Failure Method Exception', 42);
     }

--- a/Neos.Flow/Tests/Functional/Security/Fixtures/Controller/HttpBasicTestController.php
+++ b/Neos.Flow/Tests/Functional/Security/Fixtures/Controller/HttpBasicTestController.php
@@ -26,7 +26,7 @@ class HttpBasicTestController extends AbstractAuthenticationController
      * @param ActionRequest $originalRequest
      * @return string
      */
-    public function onAuthenticationSuccess(ActionRequest $originalRequest = null)
+    public function onAuthenticationSuccess(?ActionRequest $originalRequest = null)
     {
         if ($originalRequest !== null) {
             $this->redirectToRequest($originalRequest);
@@ -42,7 +42,7 @@ class HttpBasicTestController extends AbstractAuthenticationController
      * @param AuthenticationRequiredException $exception
      * @throws FlowException
      */
-    public function onAuthenticationFailure(AuthenticationRequiredException $exception = null)
+    public function onAuthenticationFailure(?AuthenticationRequiredException $exception = null)
     {
         throw new FlowException('Failure Method Exception', 42);
     }

--- a/Neos.Flow/Tests/Functional/Security/Fixtures/Controller/UsernamePasswordTestController.php
+++ b/Neos.Flow/Tests/Functional/Security/Fixtures/Controller/UsernamePasswordTestController.php
@@ -26,7 +26,7 @@ class UsernamePasswordTestController extends AbstractAuthenticationController
      * @param ActionRequest $originalRequest
      * @return string
      */
-    public function onAuthenticationSuccess(ActionRequest $originalRequest = null)
+    public function onAuthenticationSuccess(?ActionRequest $originalRequest = null)
     {
         if ($originalRequest !== null) {
             $this->redirectToRequest($originalRequest);
@@ -42,7 +42,7 @@ class UsernamePasswordTestController extends AbstractAuthenticationController
      * @param AuthenticationRequiredException $exception
      * @throws FlowException
      */
-    public function onAuthenticationFailure(AuthenticationRequiredException $exception = null)
+    public function onAuthenticationFailure(?AuthenticationRequiredException $exception = null)
     {
         throw new FlowException('UsernamePasswordTestController failure!', 27);
     }

--- a/Neos.Flow/Tests/FunctionalTestCase.php
+++ b/Neos.Flow/Tests/FunctionalTestCase.php
@@ -359,7 +359,7 @@ abstract class FunctionalTestCase extends \Neos\Flow\Tests\BaseTestCase
      * @return Route
      * @api
      */
-    protected function registerRoute($name, $uriPattern, array $defaults, $appendExceedingArguments = false, array $httpMethods = null)
+    protected function registerRoute($name, $uriPattern, array $defaults, $appendExceedingArguments = false, ?array $httpMethods = null)
     {
         $route = new Route();
         $route->setName($name);

--- a/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Configuration/ConfigurationManagerTest.php
@@ -1784,7 +1784,7 @@ class ConfigurationManagerTest extends UnitTestCase
      * @param array $methods
      * @return ConfigurationManager|MockObject
      */
-    protected function getAccessibleConfigurationManager(array $methods = [], ApplicationContext $customContext = null)
+    protected function getAccessibleConfigurationManager(array $methods = [], ?ApplicationContext $customContext = null)
     {
         return $this->getAccessibleMock(ConfigurationManager::class, $methods, [$customContext ?? $this->mockContext]);
     }

--- a/Neos.Flow/Tests/Unit/Http/Middleware/SecurityEntryPointMiddlewareTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Middleware/SecurityEntryPointMiddlewareTest.php
@@ -357,7 +357,7 @@ class SecurityEntryPointMiddlewareTest extends UnitTestCase
      * @test
      * @dataProvider processMergesArgumentsWithRoutingMatchResultsDataProvider()
      */
-    public function processMergesArgumentsWithRoutingMatchResults(array $requestArguments, array $requestBodyArguments, array $routingMatchResults = null, array $expectedArguments)
+    public function processMergesArgumentsWithRoutingMatchResults(array $requestArguments, array $requestBodyArguments, ?array $routingMatchResults = null, array $expectedArguments)
     {
         $this->mockActionRequest->expects(self::once())->method('setArguments')->with($expectedArguments);
         $this->buildMockHttpRequest($requestArguments, $requestBodyArguments);

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Fixtures/MockRoutePartHandler.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Fixtures/MockRoutePartHandler.php
@@ -30,7 +30,7 @@ class MockRoutePartHandler extends DynamicRoutePart
      */
     private $resolveValueClosure;
 
-    public function __construct(\Closure $matchValueClosure = null, \Closure $resolveValueClosure = null)
+    public function __construct(?\Closure $matchValueClosure = null, ?\Closure $resolveValueClosure = null)
     {
         $this->matchValueClosure = $matchValueClosure;
         $this->resolveValueClosure = $resolveValueClosure;

--- a/Neos.Flow/Tests/Unit/Reflection/Fixture/Model/EntityWithDoctrineProxy.php
+++ b/Neos.Flow/Tests/Unit/Reflection/Fixture/Model/EntityWithDoctrineProxy.php
@@ -78,7 +78,7 @@ class EntityWithDoctrineProxy extends Entity implements \Doctrine\ORM\Proxy\Prox
      * {@inheritDoc}
      * @internal generated method: use only when explicitly handling proxy specific loading logic
      */
-    public function __setInitializer(\Closure $initializer = null)
+    public function __setInitializer(?\Closure $initializer = null)
     {
         $this->__initializer__ = $initializer;
     }
@@ -96,7 +96,7 @@ class EntityWithDoctrineProxy extends Entity implements \Doctrine\ORM\Proxy\Prox
      * {@inheritDoc}
      * @internal generated method: use only when explicitly handling proxy specific loading logic
      */
-    public function __setCloner(\Closure $cloner = null)
+    public function __setCloner(?\Closure $cloner = null)
     {
         $this->__cloner__ = $cloner;
     }

--- a/Neos.FluidAdaptor/Classes/Command/DocumentationCommandController.php
+++ b/Neos.FluidAdaptor/Classes/Command/DocumentationCommandController.php
@@ -45,7 +45,7 @@ class DocumentationCommandController extends CommandController
      * @param string $xsdDomain Domain used in the XSD schema (for example "http://yourdomain.org"). Defaults to "https://neos.io".
      * @return void
      */
-    public function generateXsdCommand(string $phpNamespace, string $xsdNamespace = null, string $targetFile = null, string $xsdDomain = ''): void
+    public function generateXsdCommand(string $phpNamespace, ?string $xsdNamespace = null, ?string $targetFile = null, string $xsdDomain = ''): void
     {
         $xsdDomain = trim($xsdDomain);
         $parsedDomain = parse_url($xsdDomain);

--- a/Neos.FluidAdaptor/Classes/View/AbstractTemplateView.php
+++ b/Neos.FluidAdaptor/Classes/View/AbstractTemplateView.php
@@ -123,7 +123,7 @@ abstract class AbstractTemplateView extends \TYPO3Fluid\Fluid\View\AbstractTempl
      * @param array $options
      * @throws Exception
      */
-    public function __construct(array $options = null)
+    public function __construct(?array $options = null)
     {
         if ($options === null) {
             $options = [];

--- a/Neos.FluidAdaptor/Classes/View/StandaloneView.php
+++ b/Neos.FluidAdaptor/Classes/View/StandaloneView.php
@@ -79,7 +79,7 @@ class StandaloneView extends AbstractTemplateView
      * @param array $options
      * @throws \Neos\FluidAdaptor\Exception
      */
-    public function __construct(ActionRequest $request = null, array $options = [])
+    public function __construct(?ActionRequest $request = null, array $options = [])
     {
         $this->request = $request;
         parent::__construct($options);

--- a/Neos.FluidAdaptor/Tests/Functional/Form/Fixtures/Controller/FormController.php
+++ b/Neos.FluidAdaptor/Tests/Functional/Form/Fixtures/Controller/FormController.php
@@ -44,7 +44,7 @@ class FormController extends \Neos\Flow\Mvc\Controller\ActionController
      * @return void
      * @Flow\IgnoreValidation("$fooPost")
      */
-    public function editAction(\Neos\FluidAdaptor\Tests\Functional\Form\Fixtures\Domain\Model\Post $fooPost = null)
+    public function editAction(?\Neos\FluidAdaptor\Tests\Functional\Form\Fixtures\Domain\Model\Post $fooPost = null)
     {
         $this->view->assign('fooPost', $fooPost);
     }

--- a/Neos.FluidAdaptor/Tests/Functional/View/Fixtures/View/StandaloneView.php
+++ b/Neos.FluidAdaptor/Tests/Functional/View/Fixtures/View/StandaloneView.php
@@ -25,7 +25,7 @@ class StandaloneView extends \Neos\FluidAdaptor\View\StandaloneView
      * @param string $fileIdentifierPrefix
      * @param array $options
      */
-    public function __construct(\Neos\Flow\Mvc\ActionRequest $request = null, $fileIdentifierPrefix = '', array $options = [])
+    public function __construct(?\Neos\Flow\Mvc\ActionRequest $request = null, $fileIdentifierPrefix = '', array $options = [])
     {
         $this->fileIdentifierPrefix = $fileIdentifierPrefix;
         parent::__construct($request, $options);

--- a/Neos.FluidAdaptor/Tests/Unit/View/TemplatePathsTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/View/TemplatePathsTest.php
@@ -452,7 +452,7 @@ class TemplatePathsTest extends UnitTestCase
      * @param string $pattern
      * @param string $expectedResult
      */
-    public function expandGenericPathPatternTests($package, $subPackage, $controller, $format, $templateRootPath, array $templateRootPaths = null, $partialRootPath, array $partialRootPaths = null, $layoutRootPath, array $layoutRootPaths = null, $bubbleControllerAndSubpackage, $formatIsOptional, $pattern, $expectedResult)
+    public function expandGenericPathPatternTests($package, $subPackage, $controller, $format, $templateRootPath, ?array $templateRootPaths = null, $partialRootPath, ?array $partialRootPaths = null, $layoutRootPath, ?array $layoutRootPaths = null, $bubbleControllerAndSubpackage, $formatIsOptional, $pattern, $expectedResult)
     {
         $options = [];
         if ($templateRootPath !== null) {

--- a/Neos.Http.Factories/Classes/UploadedFileFactoryTrait.php
+++ b/Neos.Http.Factories/Classes/UploadedFileFactoryTrait.php
@@ -15,7 +15,7 @@ trait UploadedFileFactoryTrait
     /**
      * @inheritDoc
      */
-    public function createUploadedFile(StreamInterface $stream, int $size = null, int $error = \UPLOAD_ERR_OK, string $clientFilename = null, string $clientMediaType = null): UploadedFileInterface
+    public function createUploadedFile(StreamInterface $stream, ?int $size = null, int $error = \UPLOAD_ERR_OK, ?string $clientFilename = null, ?string $clientMediaType = null): UploadedFileInterface
     {
         return new FlowUploadedFile($stream, $size ?: 0, $error, $clientFilename, $clientMediaType);
     }

--- a/Neos.Utility.Files/Classes/Files.php
+++ b/Neos.Utility.Files/Classes/Files.php
@@ -86,7 +86,7 @@ abstract class Files
      * @return array Filenames including full path
      * @api
      */
-    public static function readDirectoryRecursively(string $path, string $suffix = null, bool $returnRealPath = false, bool $returnDotFiles = false): array
+    public static function readDirectoryRecursively(string $path, ?string $suffix = null, bool $returnRealPath = false, bool $returnDotFiles = false): array
     {
         return iterator_to_array(self::getRecursiveDirectoryGenerator($path, $suffix, $returnRealPath, $returnDotFiles));
     }
@@ -99,7 +99,7 @@ abstract class Files
      * @return \Generator
      * @throws FilesException
      */
-    public static function getRecursiveDirectoryGenerator(string $path, string $suffix = null, bool $returnRealPath = false, bool $returnDotFiles = false)
+    public static function getRecursiveDirectoryGenerator(string $path, ?string $suffix = null, bool $returnRealPath = false, bool $returnDotFiles = false)
     {
         if (!is_dir($path)) {
             throw new FilesException('"' . $path . '" is no directory.', 1207253462);
@@ -177,7 +177,7 @@ abstract class Files
      * @api
      * @throws FilesException
      */
-    public static function removeEmptyDirectoriesOnPath(string $path, string $basePath = null)
+    public static function removeEmptyDirectoriesOnPath(string $path, ?string $basePath = null)
     {
         if ($basePath !== null) {
             $basePath = rtrim($basePath, '/');
@@ -444,7 +444,7 @@ abstract class Files
      * @param string $thousandsSeparator thousands separator of the resulting string
      * @return string the size string, e.g. "1,024 MB"
      */
-    public static function bytesToSizeString($bytes, int $decimals = null, string $decimalSeparator = null, string $thousandsSeparator = null): string
+    public static function bytesToSizeString($bytes, ?int $decimals = null, ?string $decimalSeparator = null, ?string $thousandsSeparator = null): string
     {
         if (!is_int($bytes) && !is_float($bytes)) {
             if (is_numeric($bytes)) {

--- a/Neos.Utility.MediaTypes/Tests/Unit/MediaTypesTest.php
+++ b/Neos.Utility.MediaTypes/Tests/Unit/MediaTypesTest.php
@@ -170,7 +170,7 @@ class MediaTypesTest extends \PHPUnit\Framework\TestCase
      * @test
      * @dataProvider mediaTypesWithAndWithoutParameters
      */
-    public function trimMediaTypeReturnsJustTheTypeAndSubTypeWithoutParameters(string $mediaType, string $expectedResult = null)
+    public function trimMediaTypeReturnsJustTheTypeAndSubTypeWithoutParameters(string $mediaType, ?string $expectedResult = null)
     {
         $actualResult = MediaTypes::trimMediaType($mediaType);
         self::assertSame($expectedResult, $actualResult);

--- a/Neos.Utility.ObjectHandling/Tests/Unit/Fixture/Model/EntityWithDoctrineProxy.php
+++ b/Neos.Utility.ObjectHandling/Tests/Unit/Fixture/Model/EntityWithDoctrineProxy.php
@@ -90,7 +90,7 @@ class EntityWithDoctrineProxy extends Entity implements Proxy
      * {@inheritDoc}
      * @internal generated method: use only when explicitly handling proxy specific loading logic
      */
-    public function __setInitializer(\Closure $initializer = null)
+    public function __setInitializer(?\Closure $initializer = null)
     {
         $this->__initializer__ = $initializer;
     }
@@ -108,7 +108,7 @@ class EntityWithDoctrineProxy extends Entity implements Proxy
      * {@inheritDoc}
      * @internal generated method: use only when explicitly handling proxy specific loading logic
      */
-    public function __setCloner(\Closure $cloner = null)
+    public function __setCloner(?\Closure $cloner = null)
     {
         $this->__cloner__ = $cloner;
     }

--- a/Neos.Utility.OpcodeCache/Classes/OpcodeCacheHelper.php
+++ b/Neos.Utility.OpcodeCache/Classes/OpcodeCacheHelper.php
@@ -83,7 +83,7 @@ abstract class OpcodeCacheHelper
      * @param string $absolutePathAndFilename Absolute path towards the PHP file to clear.
      * @return void
      */
-    public static function clearAllActive(string $absolutePathAndFilename = null)
+    public static function clearAllActive(?string $absolutePathAndFilename = null)
     {
         if (self::$initialized === false) {
             self::initialize();

--- a/Neos.Utility.Unicode/Classes/Functions.php
+++ b/Neos.Utility.Unicode/Classes/Functions.php
@@ -46,7 +46,7 @@ abstract class Functions
      * @return string The processed string
      * @api
      */
-    public static function substr(string $string, int $start, int $length = null)
+    public static function substr(string $string, int $start, ?int $length = null)
     {
         if ($length === 0) {
             return '';
@@ -158,7 +158,7 @@ abstract class Functions
      * @return string|array
      * @api
      */
-    public static function pathinfo(string $path, int $options = null)
+    public static function pathinfo(string $path, ?int $options = null)
     {
         $currentLocale = setlocale(LC_CTYPE, 0);
         // Before we have a setting for setlocale, his should suffice for pathinfo


### PR DESCRIPTION
Replaces #3427 

This PR will correctly mark implicit nullable types as nullable, which will remove deprecation warnings in PHP 8.4.

I've used rector to migrate all occurrences.
https://getrector.com/rule-detail/explicit-nullable-param-type-rector

See also for Neos: https://github.com/neos/neos-development-collection/pull/5433

Note: We should run the rector migration again on 9.0 after upmerging this PR


Thanks to @Benjamin-K for bringing this up and providing the first PR (#3427).