### PR TITLE
BUGFIX: Add missing validation labels

### DIFF
--- a/Neos.Flow/Resources/Private/Translations/de/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/de/ValidationErrors.xlf
@@ -248,6 +248,11 @@
 				<source>The image orientation "{0}" is not allowed</source>
         <target state="final">Das Bildformat "{0}" ist nicht erlaubt</target>
       </trans-unit>
+      <!-- Package "Neos.Form" -->
+      <trans-unit id="1327865764" xml:space="preserve">
+				<source>The file extension "{0}" is not allowed.</source>
+            <target state="translated">Die Dateiendung "{0}" ist nicht erlaubt.</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Neos.Flow/Resources/Private/Translations/en/ValidationErrors.xlf
+++ b/Neos.Flow/Resources/Private/Translations/en/ValidationErrors.xlf
@@ -219,6 +219,10 @@
 				<source>The image orientation "{0}" is not allowed</source>
 			</trans-unit>
 
+			<!-- Package "Neos.Form" -->
+			<trans-unit id="1327865764" xml:space="preserve">
+				<source>The file extension "{0}" is not allowed.</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>


### PR DESCRIPTION
When you use Neos.Form and the Neos.Form.FusionRenderer with the File Upload, there’s a chance that the file extension isn’t valid. In that case, the validation error should be displayed, but the labels are in Flow, and the label for the case is missing.

This change adds the missing label for the validation error message.

Fixes: #3430