### PR TITLE
TASK: Fix reflection test

### DIFF
--- a/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
@@ -216,6 +216,7 @@ class ReflectionServiceTest extends FunctionalTestCase
                 'allowsNull' => false,
                 'defaultValue' => null,
                 'scalarDeclaration' => false,
+                'annotations' => [],
             ],
             'param2' => [
                 'position' => 1,
@@ -227,6 +228,7 @@ class ReflectionServiceTest extends FunctionalTestCase
                 'allowsNull' => false,
                 'defaultValue' => null,
                 'scalarDeclaration' => false,
+                'annotations' => [],
             ],
             'param3' => [
                 'position' => 2,
@@ -238,6 +240,7 @@ class ReflectionServiceTest extends FunctionalTestCase
                 'allowsNull' => true,
                 'defaultValue' => null,
                 'scalarDeclaration' => false,
+                'annotations' => [],
             ],
         ];
         self::assertSame($expectedResult, $methodParameters);


### PR DESCRIPTION
With 9.0 we get more data from `ReflectionService::getMethodParameters` so the test needs to get adapted.

See: https://github.com/neos/flow-development-collection/pull/3086