### PR TITLE
Avoid race-condition when reading localeCollection

### DIFF
--- a/Neos.Flow/Classes/I18n/Service.php
+++ b/Neos.Flow/Classes/I18n/Service.php
@@ -83,8 +83,10 @@ class Service
         $this->configuration = new Configuration($this->settings['defaultLocale']);
         $this->configuration->setFallbackRule($this->settings['fallbackRule']);
 
-        if ($this->cache->has('availableLocales')) {
-            $this->localeCollection = $this->cache->get('availableLocales');
+        $cachedCollection = $this->cache->get('availableLocales');
+
+        if ($cachedCollection !== false) {
+            $this->localeCollection = $cachedCollection;
         } elseif (isset($this->settings['availableLocales']) && !empty($this->settings['availableLocales'])) {
             $this->generateAvailableLocalesCollectionFromSettings();
             $this->cache->set('availableLocales', $this->localeCollection);

--- a/Neos.Flow/Tests/Unit/I18n/ServiceTest.php
+++ b/Neos.Flow/Tests/Unit/I18n/ServiceTest.php
@@ -174,7 +174,7 @@ class ServiceTest extends UnitTestCase
         ]];
 
         $mockCache = $this->createMock(VariableFrontend::class);
-        $mockCache->expects(self::once())->method('has')->with('availableLocales')->will(self::returnValue(false));
+        $mockCache->expects(self::once())->method('get')->with('availableLocales')->will(self::returnValue(false));
 
         $service = $this->getAccessibleMock(I18n\Service::class, ['dummy']);
         $service->_set('localeBasePath', 'vfs://Foo/');
@@ -221,7 +221,7 @@ class ServiceTest extends UnitTestCase
         ]];
 
         $mockCache = $this->getMockBuilder(VariableFrontend::class)->disableOriginalConstructor()->getMock();
-        $mockCache->expects(self::once())->method('has')->with('availableLocales')->will(self::returnValue(false));
+        $mockCache->expects(self::once())->method('get')->with('availableLocales')->will(self::returnValue(false));
 
         $service = $this->getAccessibleMock(I18n\Service::class, ['dummy']);
         $service->_set('localeBasePath', 'vfs://Foo/');


### PR DESCRIPTION
The previous implementation was an example of a check-then-act race-condition: There is no guarantee that the cached value still exists when it is subsequently read out.

This would cause errors later when `$this->localeCollection` could suddenly have the value `false`.

See #3188 for more context.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
