### PR TITLE
BUGFIX: Drop use of `E_STRICT` to fix PHP 8.4 deprecation

### DIFF
--- a/Neos.Flow/Classes/Error/ErrorHandler.php
+++ b/Neos.Flow/Classes/Error/ErrorHandler.php
@@ -72,7 +72,6 @@ class ErrorHandler
             E_USER_ERROR         => 'User Error',
             E_USER_WARNING       => 'User Warning',
             E_USER_NOTICE        => 'User Notice',
-            E_STRICT             => 'Runtime Notice',
             E_RECOVERABLE_ERROR  => 'Catchable Fatal Error'
         ];
 

--- a/Neos.Flow/Configuration/Development/Settings.yaml
+++ b/Neos.Flow/Configuration/Development/Settings.yaml
@@ -29,7 +29,7 @@ Neos:
               logException: true
 
       errorHandler:
-        exceptionalErrors: ['%E_USER_ERROR%', '%E_RECOVERABLE_ERROR%', '%E_WARNING%', '%E_NOTICE%', '%E_USER_WARNING%', '%E_USER_NOTICE%', '%E_STRICT%']
+        exceptionalErrors: ['%E_USER_ERROR%', '%E_RECOVERABLE_ERROR%', '%E_WARNING%', '%E_NOTICE%', '%E_USER_WARNING%', '%E_USER_NOTICE%']
 
     log:
       psr3:

--- a/Neos.Flow/Configuration/Testing/Settings.yaml
+++ b/Neos.Flow/Configuration/Testing/Settings.yaml
@@ -20,7 +20,7 @@ Neos:
       exceptionHandler:
         className: 'Neos\Flow\Error\DebugExceptionHandler'
       errorHandler:
-        exceptionalErrors: ['%E_USER_ERROR%', '%E_RECOVERABLE_ERROR%', '%E_WARNING%', '%E_NOTICE%', '%E_USER_WARNING%', '%E_USER_NOTICE%', '%E_STRICT%']
+        exceptionalErrors: ['%E_USER_ERROR%', '%E_RECOVERABLE_ERROR%', '%E_WARNING%', '%E_NOTICE%', '%E_USER_WARNING%', '%E_USER_NOTICE%']
 
     log:
       psr3:


### PR DESCRIPTION
The use of `E_STRICT` is deprecated as of PHP 8.4, so this fixes deprecation warnings. Furthermore, the constant is no longer useful…

In PHP 5.4, the functionality of `E_STRICT` was incorporated into `E_ALL`, meaning strict standards notices are included in the `E_ALL` error level. As a result, there is no need to use `E_STRICT` separately starting with PHP 5.4. This change is documented in the PHP manual under the migration guide for PHP 7.0, which states:

> All of the E_STRICT notices have been reclassified to other levels.
> The E_STRICT constant is retained, so calls like
> `error_reporting(E_ALL|E_STRICT)` will not cause an error.

(see https://www.php.net/manual/en/migration70.incompatible)

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
