### PR TITLE
BUGFIX: Silence warning in `readCacheFile()`

### DIFF
--- a/Neos.Cache/Classes/Backend/SimpleFileBackend.php
+++ b/Neos.Cache/Classes/Backend/SimpleFileBackend.php
@@ -498,7 +498,7 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
         for ($i = 0; $i < 3; $i++) {
             $data = false;
             try {
-                $file = fopen($cacheEntryPathAndFilename, 'rb');
+                $file = @fopen($cacheEntryPathAndFilename, 'rb');
                 if ($file === false) {
                     continue;
                 }


### PR DESCRIPTION
readCacheFile() in SimpleFileBackend does fopen(). It wraps it into a try-catch clause and checks the result, but it still produces a warning if the file does not exist:

`Warning: fopen(/application/Data/Temporary/…): Failed to open stream: No such file or directory`

The only way to suppress that warning is to use the shut-up operator (`@`) in this place. Given that everything that can go wrong here is taken care of, I think this is fine.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
