### PR TITLE
BUGFIX: Union type handling

### DIFF
--- a/Neos.Flow/Tests/Functional/Reflection/Fixtures/DummyClassWithUnionTypeAnnotations.php
+++ b/Neos.Flow/Tests/Functional/Reflection/Fixtures/DummyClassWithUnionTypeAnnotations.php
@@ -1,0 +1,51 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Reflection\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Dummy class for the Reflection tests
+ *
+ */
+class DummyClassWithUnionTypeAnnotations
+{
+    /**
+     * @param string|false $parameterA
+     * @param false|DummyClassWithUnionTypeAnnotations $parameterB
+     * @param false | DummyClassWithUnionTypeAnnotations $parameterB1 Same as B but with spaces in between
+     * @param DummyClassWithUnionTypeAnnotations|null $parameterC
+     * @return void
+     */
+    public function methodWithUnionParameters($parameterA, $parameterB, $parameterB1, $parameterC)
+    {
+    }
+
+    /**
+     * @return string|false
+     */
+    public function methodWithUnionReturnTypeA()
+    {
+    }
+
+    /**
+     * @return false|DummyClassWithUnionTypeAnnotations
+     */
+    public function methodWithUnionReturnTypesB()
+    {
+    }
+
+    /**
+     * @return DummyClassWithUnionTypeAnnotations|null
+     */
+    public function methodWithUnionReturnTypesC()
+    {
+    }
+}

--- a/Neos.Flow/Tests/Functional/Reflection/Fixtures/DummyClassWithUnionTypeHints.php
+++ b/Neos.Flow/Tests/Functional/Reflection/Fixtures/DummyClassWithUnionTypeHints.php
@@ -1,5 +1,5 @@
 <?php
-namespace Neos\Flow\Tests\Functional\Reflection\Fixtures\PHP8;
+namespace Neos\Flow\Tests\Functional\Reflection\Fixtures;
 
 /*
  * This file is part of the Neos.Flow package.

--- a/Neos.Flow/Tests/Functional/Reflection/Fixtures/DummyClassWithUnionTypeHints.php
+++ b/Neos.Flow/Tests/Functional/Reflection/Fixtures/DummyClassWithUnionTypeHints.php
@@ -17,6 +17,13 @@ namespace Neos\Flow\Tests\Functional\Reflection\Fixtures;
  */
 class DummyClassWithUnionTypeHints
 {
+    public function methodWithUnionParameters(
+        string|false $parameterA,
+        false|DummyClassWithUnionTypeHints $parameterB,
+        null|DummyClassWithUnionTypeHints $parameterC
+    ): void {
+    }
+
     public function methodWithUnionReturnTypeA(): string|false
     {
     }

--- a/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
@@ -12,12 +12,12 @@ namespace Neos\Flow\Tests\Functional\Reflection;
  */
 
 use Neos\Flow\Reflection\ReflectionService;
+use Neos\Flow\Tests\Functional\Persistence;
+use Neos\Flow\Tests\Functional\Reflection;
 use Neos\Flow\Tests\Functional\Reflection\Fixtures\Model\SubEntity;
 use Neos\Flow\Tests\Functional\Reflection\Fixtures\Model\SubSubEntity;
 use Neos\Flow\Tests\Functional\Reflection\Fixtures\Model\SubSubSubEntity;
 use Neos\Flow\Tests\FunctionalTestCase;
-use Neos\Flow\Tests\Functional\Reflection;
-use Neos\Flow\Tests\Functional\Persistence;
 
 /**
  * Functional tests for the Reflection Service features
@@ -356,15 +356,12 @@ class ReflectionServiceTest extends FunctionalTestCase
      */
     public function unionReturnTypesWorkCorrectly()
     {
-        if (PHP_MAJOR_VERSION < 8) {
-            $this->markTestSkipped('Only for PHP 8 with UnionTypes');
-        }
-        $returnTypeA = $this->reflectionService->getMethodDeclaredReturnType(Reflection\Fixtures\PHP8\DummyClassWithUnionTypeHints::class, 'methodWithUnionReturnTypeA');
-        $returnTypeB = $this->reflectionService->getMethodDeclaredReturnType(Reflection\Fixtures\PHP8\DummyClassWithUnionTypeHints::class, 'methodWithUnionReturnTypesB');
-        $returnTypeC = $this->reflectionService->getMethodDeclaredReturnType(Reflection\Fixtures\PHP8\DummyClassWithUnionTypeHints::class, 'methodWithUnionReturnTypesC');
+        $returnTypeA = $this->reflectionService->getMethodDeclaredReturnType(Fixtures\DummyClassWithUnionTypeHints::class, 'methodWithUnionReturnTypeA');
+        $returnTypeB = $this->reflectionService->getMethodDeclaredReturnType(Fixtures\DummyClassWithUnionTypeHints::class, 'methodWithUnionReturnTypesB');
+        $returnTypeC = $this->reflectionService->getMethodDeclaredReturnType(Fixtures\DummyClassWithUnionTypeHints::class, 'methodWithUnionReturnTypesC');
 
         self::assertEquals('string|false', $returnTypeA);
-        self::assertEquals('\Neos\Flow\Tests\Functional\Reflection\Fixtures\PHP8\DummyClassWithUnionTypeHints|false', $returnTypeB);
-        self::assertEquals('?\Neos\Flow\Tests\Functional\Reflection\Fixtures\PHP8\DummyClassWithUnionTypeHints', $returnTypeC);
+        self::assertEquals('\Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyClassWithUnionTypeHints|false', $returnTypeB);
+        self::assertEquals('?\Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyClassWithUnionTypeHints', $returnTypeC);
     }
 }

--- a/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
@@ -409,4 +409,68 @@ class ReflectionServiceTest extends FunctionalTestCase
             $methodWithUnionParametersReduced
         );
     }
+
+    /**
+     * @test
+     */
+    public function unionReturnTypeAnnotationsWorkCorrectly()
+    {
+        $returnTypes = [
+            'returnTypeA' => $this->reflectionService->getMethodDeclaredReturnType(Fixtures\DummyClassWithUnionTypeAnnotations::class, 'methodWithUnionReturnTypeA'),
+            'returnTypeB' => $this->reflectionService->getMethodDeclaredReturnType(Fixtures\DummyClassWithUnionTypeAnnotations::class, 'methodWithUnionReturnTypesB'),
+            'returnTypeC' => $this->reflectionService->getMethodDeclaredReturnType(Fixtures\DummyClassWithUnionTypeAnnotations::class, 'methodWithUnionReturnTypesC'),
+        ];
+
+        self::assertEquals(
+            [
+                'returnTypeA' => 'string|false',
+                'returnTypeB' => '\Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyClassWithUnionTypeAnnotations|false',
+                'returnTypeC' => '?\Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyClassWithUnionTypeAnnotations',
+            ],
+            $returnTypes
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function unionParameterTypeAnnotationsWorkCorrectly()
+    {
+        $methodWithUnionParameters = $this->reflectionService->getMethodParameters(Fixtures\DummyClassWithUnionTypeAnnotations::class, 'methodWithUnionParameters');
+
+        $methodWithUnionParametersReduced = array_map(
+            fn (array $item) => [
+                'type' => $item['type'],
+                'class' => $item['class'],
+                'allowsNull' => $item['allowsNull'],
+            ],
+            $methodWithUnionParameters
+        );
+
+        self::assertEquals(
+            [
+                'parameterA' => [
+                    'type' => 'string|false',
+                    'class' => 'string|false',
+                    'allowsNull' => false,
+                ],
+                'parameterB' => [
+                    'type' => 'Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyClassWithUnionTypeAnnotations|false',
+                    'class' => 'Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyClassWithUnionTypeAnnotations|false',
+                    'allowsNull' => false,
+                ],
+                'parameterB1' => [
+                    'type' => 'Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyClassWithUnionTypeAnnotations|false',
+                    'class' => 'Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyClassWithUnionTypeAnnotations|false',
+                    'allowsNull' => false,
+                ],
+                'parameterC' => [
+                    'type' => 'Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyClassWithUnionTypeAnnotations',
+                    'class' => 'Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyClassWithUnionTypeAnnotations',
+                    'allowsNull' => true,
+                ],
+            ],
+            $methodWithUnionParametersReduced
+        );
+    }
 }

--- a/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
@@ -356,12 +356,57 @@ class ReflectionServiceTest extends FunctionalTestCase
      */
     public function unionReturnTypesWorkCorrectly()
     {
-        $returnTypeA = $this->reflectionService->getMethodDeclaredReturnType(Fixtures\DummyClassWithUnionTypeHints::class, 'methodWithUnionReturnTypeA');
-        $returnTypeB = $this->reflectionService->getMethodDeclaredReturnType(Fixtures\DummyClassWithUnionTypeHints::class, 'methodWithUnionReturnTypesB');
-        $returnTypeC = $this->reflectionService->getMethodDeclaredReturnType(Fixtures\DummyClassWithUnionTypeHints::class, 'methodWithUnionReturnTypesC');
+        $returnTypes = [
+            'returnTypeA' => $this->reflectionService->getMethodDeclaredReturnType(Fixtures\DummyClassWithUnionTypeHints::class, 'methodWithUnionReturnTypeA'),
+            'returnTypeB' => $this->reflectionService->getMethodDeclaredReturnType(Fixtures\DummyClassWithUnionTypeHints::class, 'methodWithUnionReturnTypesB'),
+            'returnTypeC' => $this->reflectionService->getMethodDeclaredReturnType(Fixtures\DummyClassWithUnionTypeHints::class, 'methodWithUnionReturnTypesC'),
+        ];
 
-        self::assertEquals('string|false', $returnTypeA);
-        self::assertEquals('\Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyClassWithUnionTypeHints|false', $returnTypeB);
-        self::assertEquals('?\Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyClassWithUnionTypeHints', $returnTypeC);
+        self::assertEquals(
+            [
+                'returnTypeA' => 'string|false',
+                'returnTypeB' => '\Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyClassWithUnionTypeHints|false',
+                'returnTypeC' => '?\Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyClassWithUnionTypeHints',
+            ],
+            $returnTypes
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function unionParameterTypesWorkCorrectly()
+    {
+        $methodWithUnionParameters = $this->reflectionService->getMethodParameters(Fixtures\DummyClassWithUnionTypeHints::class, 'methodWithUnionParameters');
+
+        $methodWithUnionParametersReduced = array_map(
+            fn (array $item) => [
+                'type' => $item['type'],
+                'class' => $item['class'],
+                'allowsNull' => $item['allowsNull'],
+            ],
+            $methodWithUnionParameters
+        );
+
+        self::assertEquals(
+            [
+                'parameterA' => [
+                    'type' => 'string|false',
+                    'class' => 'string|false',
+                    'allowsNull' => false,
+                ],
+                'parameterB' => [
+                    'type' => 'Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyClassWithUnionTypeHints|false',
+                    'class' => 'Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyClassWithUnionTypeHints|false',
+                    'allowsNull' => false,
+                ],
+                'parameterC' => [
+                    'type' => 'Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyClassWithUnionTypeHints',
+                    'class' => 'Neos\Flow\Tests\Functional\Reflection\Fixtures\DummyClassWithUnionTypeHints',
+                    'allowsNull' => true,
+                ],
+            ],
+            $methodWithUnionParametersReduced
+        );
     }
 }


### PR DESCRIPTION
Demonstrate broken union types from annotations via test.

1. commit - remove rule that tests union types only with php 8 ... all green
2. commit - add a method with union type parameter hints and test thererfore ... still green
3. commit - add a class similar to 2. but with @param and @return annotations instead of type-hints  ... tests verify that the same types are detected as with type hints  ... and fail

Please note tha added case `parameterB1`  is equel to **parameterB** but demonstrates the different handlung of spaces in annotations that lead to detecting `mixed` type.

see: #3440

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
