### PR TITLE
TASK: Improve PHP-check error message

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -872,7 +872,7 @@ class Scripts
 
         // Try to resolve which binary file PHP is pointing to
         $output = [];
-        exec(join(' ', $command), $output, $result);
+        exec(implode(' ', $command), $output, $result);
 
         if ($result === 0 && count($output) === 1) {
             // Resolve any wrapper
@@ -942,12 +942,13 @@ class Scripts
         EOF;
         $command[] = '2>&1'; // Output errors in response
 
-        exec(join(' ', $command), $output, $result);
+        $commandString = implode(' ', $command);
+        exec($commandString, $output, $result);
 
         $phpInformation = json_decode($output[0] ?? '{}', true) ?: [];
 
         if ($result !== 0 || ($phpInformation['sapi'] ?? null) !== 'cli') {
-            throw new Exception\SubProcessException(sprintf('PHP binary might not exist or is not suitable for cli usage. Command `%s` didnt succeed.', $phpCommand), 1689676967447);
+            throw new Exception\SubProcessException(sprintf('PHP binary might not exist or is not suitable for CLI usage. Command `%s` did not succeed.', $commandString), 1689676967447);
         }
 
         /**


### PR DESCRIPTION
This will output the actual command used to check the PHP binary in `ensureWebSubrequestsUseCurrentlyRunningPhpVersion` with the exception, to ease debugging.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
