### PR TITLE
!!!TASK: Reduce complexity of ReflectionService

### DIFF
--- a/Neos.Flow/Classes/Aop/Builder/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/Aop/Builder/ProxyClassBuilder.php
@@ -441,10 +441,8 @@ class ProxyClassBuilder
      * @param ClassNameIndex $targetClassNameCandidates target class names for advices
      * @param ClassNameIndex $treatedSubClasses Already treated (sub) classes to avoid duplication
      * @return ClassNameIndex The new collection of already treated classes
-     * @throws ClassLoadingForReflectionFailedException
-     * @throws \ReflectionException
-     * @throws InvalidClassException
      * @throws CannotBuildObjectException
+     * @throws \ReflectionException
      */
     protected function proxySubClassesOfClassToEnsureAdvices(string $className, ClassNameIndex $targetClassNameCandidates, ClassNameIndex $treatedSubClasses): ClassNameIndex
     {

--- a/Neos.Flow/Classes/Cache/CacheManager.php
+++ b/Neos.Flow/Classes/Cache/CacheManager.php
@@ -374,9 +374,10 @@ class CacheManager
         $flushDoctrineProxyCache = false;
         $flushPolicyCache = false;
         if (count($modifiedClassNamesWithUnderscores) > 0) {
-            $reflectionStatusCache = $this->getCache('Flow_Reflection_Status');
+            $reflectionDataRuntimeCache = $this->getCache('Flow_Reflection_RuntimeData');
             foreach (array_keys($modifiedClassNamesWithUnderscores) as $classNameWithUnderscores) {
-                $reflectionStatusCache->remove($classNameWithUnderscores);
+                $this->logger->debug('File change detected, removing reflection for ' . $classNameWithUnderscores);
+                $reflectionDataRuntimeCache->remove($classNameWithUnderscores);
                 if ($flushDoctrineProxyCache === false && preg_match('/_Domain_Model_(.+)/', $classNameWithUnderscores) === 1) {
                     $flushDoctrineProxyCache = true;
                 }

--- a/Neos.Flow/Classes/Command/CacheCommandController.php
+++ b/Neos.Flow/Classes/Command/CacheCommandController.php
@@ -135,9 +135,6 @@ class CacheCommandController extends CommandController
      * from running, the removal of any temporary data can be forced by specifying
      * the option <b>--force</b>.
      *
-     * This command does not remove the precompiled data provided by frozen
-     * packages unless the <b>--force</b> option is used.
-     *
      * @param boolean $force Force flushing of any temporary data
      * @return void
      * @see neos.flow:cache:warmup
@@ -155,23 +152,6 @@ class CacheCommandController extends CommandController
         $this->outputLine('Flushed all caches for "' . $this->bootstrap->getContext() . '" context.');
         if ($this->lockManager->isSiteLocked()) {
             $this->lockManager->unlockSite();
-        }
-
-        $frozenPackages = [];
-        foreach (array_keys($this->packageManager->getAvailablePackages()) as $packageKey) {
-            if ($this->packageManager->isPackageFrozen($packageKey)) {
-                $frozenPackages[] = $packageKey;
-            }
-        }
-        if ($frozenPackages !== []) {
-            $this->outputFormatted(PHP_EOL . 'Please note that the following package' . (count($frozenPackages) === 1 ? ' is' : 's are') . ' currently frozen: ' . PHP_EOL);
-            $this->outputFormatted(implode(PHP_EOL, $frozenPackages) . PHP_EOL, [], 2);
-
-            $message = 'As code and configuration changes in these packages are not detected, the application may respond ';
-            $message .= 'unexpectedly if modifications were done anyway or the remaining code relies on these changes.' . PHP_EOL . PHP_EOL;
-            $message .= 'You may call <b>package:refreeze all</b> in order to refresh frozen packages or use the <b>--force</b> ';
-            $message .= 'option of this <b>cache:flush</b> command to flush caches if Flow becomes unresponsive.' . PHP_EOL;
-            $this->outputFormatted($message, [$frozenPackages]);
         }
 
         $this->sendAndExit(0);

--- a/Neos.Flow/Classes/Command/PackageCommandController.php
+++ b/Neos.Flow/Classes/Command/PackageCommandController.php
@@ -14,8 +14,6 @@ namespace Neos\Flow\Command;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cli\CommandController;
 use Neos\Flow\Composer\ComposerUtility;
-use Neos\Flow\Core\Booting\Scripts;
-use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Package\PackageInterface;
 use Neos\Flow\Package\PackageKeyAwareInterface;
 use Neos\Flow\Package\PackageManager;
@@ -33,40 +31,12 @@ class PackageCommandController extends CommandController
     protected $packageManager;
 
     /**
-     * @var array
-     */
-    protected $settings;
-
-    /**
-     * @var Bootstrap
-     */
-    protected $bootstrap;
-
-    /**
-     * @param array $settings The Flow settings
-     * @return void
-     */
-    public function injectSettings(array $settings)
-    {
-        $this->settings = $settings;
-    }
-
-    /**
      * @param PackageManager $packageManager
      * @return void
      */
     public function injectPackageManager(PackageManager $packageManager)
     {
         $this->packageManager = $packageManager;
-    }
-
-    /**
-     * @param Bootstrap $bootstrap
-     * @return void
-     */
-    public function injectBootstrap(Bootstrap $bootstrap)
-    {
-        $this->bootstrap = $bootstrap;
     }
 
     /**
@@ -112,9 +82,7 @@ class PackageCommandController extends CommandController
     public function listCommand(bool $loadingOrder = false)
     {
         $availablePackages = [];
-        $frozenPackages = [];
         $longestPackageKey = 0;
-        $freezeSupported = $this->bootstrap->getContext()->isDevelopment();
 
         foreach ($this->packageManager->getAvailablePackages() as $packageKey => $package) {
             if (strlen($packageKey) > $longestPackageKey) {
@@ -122,10 +90,6 @@ class PackageCommandController extends CommandController
             }
 
             $availablePackages[$packageKey] = $package;
-
-            if ($this->packageManager->isPackageFrozen($packageKey)) {
-                $frozenPackages[$packageKey] = $package;
-            }
         }
 
         if ($loadingOrder === false) {
@@ -135,13 +99,7 @@ class PackageCommandController extends CommandController
         $this->outputLine('PACKAGES:');
         /** @var PackageInterface|PackageKeyAwareInterface $package */
         foreach ($availablePackages as $package) {
-            $frozenState = ($freezeSupported && isset($frozenPackages[$package->getPackageKey()]) ? '* ' : '  ');
-            $this->outputLine(' ' . str_pad($package->getPackageKey(), $longestPackageKey + 3) . $frozenState . str_pad($package->getInstalledVersion(), 15));
-        }
-
-        if (count($frozenPackages) > 0 && $freezeSupported) {
-            $this->outputLine();
-            $this->outputLine(' * frozen package');
+            $this->outputLine(' ' . str_pad($package->getPackageKey(), $longestPackageKey + 3) . str_pad($package->getInstalledVersion(), 15));
         }
     }
 
@@ -165,47 +123,11 @@ class PackageCommandController extends CommandController
      * @return void
      * @see neos.flow:package:unfreeze
      * @see neos.flow:package:refreeze
+     * @deprecated since 8.4
      */
     public function freezeCommand(string $packageKey = 'all')
     {
-        if (!$this->bootstrap->getContext()->isDevelopment()) {
-            $this->outputLine('Package freezing is only supported in Development context.');
-            $this->quit(3);
-        }
-
-        $packagesToFreeze = [];
-
-        if ($packageKey === 'all') {
-            foreach (array_keys($this->packageManager->getAvailablePackages()) as $packageKey) {
-                if (!$this->packageManager->isPackageFrozen($packageKey)) {
-                    $packagesToFreeze[] = $packageKey;
-                }
-            }
-            if ($packagesToFreeze === []) {
-                $this->outputLine('Nothing to do, all packages were already frozen.');
-                $this->quit(0);
-            }
-        } elseif ($packageKey === 'blackberry') {
-            $this->outputLine('http://bit.ly/freeze-blackberry');
-            $this->quit(42);
-        } else {
-            if (!$this->packageManager->isPackageAvailable($packageKey)) {
-                $this->outputLine('Package "%s" is not available.', [$packageKey]);
-                $this->quit(2);
-            }
-
-            if ($this->packageManager->isPackageFrozen($packageKey)) {
-                $this->outputLine('Package "%s" was already frozen.', [$packageKey]);
-                $this->quit(0);
-            }
-
-            $packagesToFreeze = [$packageKey];
-        }
-
-        foreach ($packagesToFreeze as $packageKey) {
-            $this->packageManager->freezePackage($packageKey);
-            $this->outputLine('Froze package "%s".', [$packageKey]);
-        }
+        $this->outputLine('Package freezing is no longer supported, this command is deprecated and will be removed with 9.0.');
     }
 
     /**
@@ -222,47 +144,11 @@ class PackageCommandController extends CommandController
      * @return void
      * @see neos.flow:package:freeze
      * @see neos.flow:cache:flush
+     * @deprecated since 8.4
      */
     public function unfreezeCommand(string $packageKey = 'all')
     {
-        if (!$this->bootstrap->getContext()->isDevelopment()) {
-            $this->outputLine('Package freezing is only supported in Development context.');
-            $this->quit(3);
-        }
-
-        $packagesToUnfreeze = [];
-
-        if ($packageKey === 'all') {
-            foreach (array_keys($this->packageManager->getAvailablePackages()) as $packageKey) {
-                if ($this->packageManager->isPackageFrozen($packageKey)) {
-                    $packagesToUnfreeze[] = $packageKey;
-                }
-            }
-            if ($packagesToUnfreeze === []) {
-                $this->outputLine('Nothing to do, no packages were frozen.');
-                $this->quit(0);
-            }
-        } else {
-            if ($packageKey === null) {
-                $this->outputLine('You must specify a package to unfreeze.');
-                $this->quit(1);
-            }
-
-            if (!$this->packageManager->isPackageAvailable($packageKey)) {
-                $this->outputLine('Package "%s" is not available.', [$packageKey]);
-                $this->quit(2);
-            }
-            if (!$this->packageManager->isPackageFrozen($packageKey)) {
-                $this->outputLine('Package "%s" was not frozen.', [$packageKey]);
-                $this->quit(0);
-            }
-            $packagesToUnfreeze = [$packageKey];
-        }
-
-        foreach ($packagesToUnfreeze as $packageKey) {
-            $this->packageManager->unfreezePackage($packageKey);
-            $this->outputLine('Unfroze package "%s".', [$packageKey]);
-        }
+        $this->outputLine('Package freezing is no longer supported, this command is deprecated and will be removed with 9.0.');
     }
 
     /**
@@ -280,50 +166,11 @@ class PackageCommandController extends CommandController
      * @return void
      * @see neos.flow:package:freeze
      * @see neos.flow:cache:flush
+     * @deprecated since 8.4
      */
     public function refreezeCommand(string $packageKey = 'all')
     {
-        if (!$this->bootstrap->getContext()->isDevelopment()) {
-            $this->outputLine('Package freezing is only supported in Development context.');
-            $this->quit(3);
-        }
-
-        $packagesToRefreeze = [];
-
-        if ($packageKey === 'all') {
-            foreach (array_keys($this->packageManager->getAvailablePackages()) as $packageKey) {
-                if ($this->packageManager->isPackageFrozen($packageKey)) {
-                    $packagesToRefreeze[] = $packageKey;
-                }
-            }
-            if ($packagesToRefreeze === []) {
-                $this->outputLine('Nothing to do, no packages were frozen.');
-                $this->quit(0);
-            }
-        } else {
-            if ($packageKey === null) {
-                $this->outputLine('You must specify a package to refreeze.');
-                $this->quit(1);
-            }
-
-            if (!$this->packageManager->isPackageAvailable($packageKey)) {
-                $this->outputLine('Package "%s" is not available.', [$packageKey]);
-                $this->quit(2);
-            }
-            if (!$this->packageManager->isPackageFrozen($packageKey)) {
-                $this->outputLine('Package "%s" was not frozen.', [$packageKey]);
-                $this->quit(0);
-            }
-            $packagesToRefreeze = [$packageKey];
-        }
-
-        foreach ($packagesToRefreeze as $packageKey) {
-            $this->packageManager->refreezePackage($packageKey);
-            $this->outputLine('Refroze package "%s".', [$packageKey]);
-        }
-
-        Scripts::executeCommand('neos.flow:cache:flush', $this->settings, false);
-        $this->sendAndExit(0);
+        $this->outputLine('Package freezing is no longer supported, this command is deprecated and will be removed with 9.0.');
     }
 
     /**

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -247,7 +247,7 @@ class Scripts
         $throwableStorage = self::initializeExceptionStorage($bootstrap, $settings);
         $bootstrap->setEarlyInstance(ThrowableStorageInterface::class, $throwableStorage);
 
-        /** @var PsrLoggerFactoryInterface $psrLoggerFactoryName */
+        /** @var class-string $psrLoggerFactoryName */
         $psrLoggerFactoryName = $settings['log']['psr3']['loggerFactory'];
         $psrLogConfigurations = $settings['log']['psr3'][$psrLoggerFactoryName] ?? [];
         $psrLogFactory = $psrLoggerFactoryName::create($psrLogConfigurations);
@@ -578,10 +578,6 @@ class Scripts
 
         /** @var FlowPackageInterface $package */
         foreach ($packageManager->getFlowPackages() as $packageKey => $package) {
-            if ($packageManager->isPackageFrozen($packageKey)) {
-                continue;
-            }
-
             self::monitorDirectoryIfItExists($fileMonitors['Flow_ConfigurationFiles'], $package->getConfigurationPath(), '\.y(a)?ml$');
             self::monitorDirectoryIfItExists($fileMonitors['Flow_TranslationFiles'], $package->getResourcesPath() . 'Private/Translations/', '\.xlf');
 

--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -19,6 +19,7 @@ use Neos\Flow\Http\Helper\SecurityHelper;
 use Neos\Flow\ObjectManagement\Proxy;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\Flow\Package\PackageManager;
+use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Neos\Flow\ResourceManagement\ResourceRepository;
 use Neos\Flow\Security\Authentication\AuthenticationProviderManager;
@@ -88,10 +89,6 @@ class Package extends BasePackage
                     /** @var PackageManager $packageManager */
                     $packageManager = $bootstrap->getEarlyInstance(Package\PackageManager::class);
                     foreach ($packageManager->getFlowPackages() as $packageKey => $package) {
-                        if ($packageManager->isPackageFrozen($packageKey)) {
-                            continue;
-                        }
-
                         $publicResourcesPath = $package->getResourcesPath() . 'Public/';
                         if (is_dir($publicResourcesPath)) {
                             $publicResourcesFileMonitor->monitorDirectory($publicResourcesPath);
@@ -122,6 +119,7 @@ class Package extends BasePackage
         $dispatcher->connect(Core\Bootstrap::class, 'bootstrapShuttingDown', ObjectManagement\ObjectManagerInterface::class, 'shutdown');
         $dispatcher->connect(Core\Bootstrap::class, 'bootstrapShuttingDown', Configuration\ConfigurationManager::class, 'shutdown');
 
+        /** @see ReflectionService::saveToCache() */
         $dispatcher->connect(Core\Bootstrap::class, 'bootstrapShuttingDown', Reflection\ReflectionService::class, 'saveToCache');
 
         $dispatcher->connect(Command\CoreCommandController::class, 'finishedCompilationRun', Security\Authorization\Privilege\Method\MethodPrivilegePointcutFilter::class, 'savePolicyCache');

--- a/Neos.Flow/Classes/Package/PackageManager.php
+++ b/Neos.Flow/Classes/Package/PackageManager.php
@@ -232,19 +232,7 @@ class PackageManager
      */
     public function getFrozenPackages(): array
     {
-        $frozenPackages = [];
-        if ($this->bootstrap->getContext()->isDevelopment()) {
-            /** @var PackageInterface $package */
-            foreach ($this->packages as $packageKey => $package) {
-                if (isset($this->packageStatesConfiguration['packages'][$package->getComposerName()]['frozen']) &&
-                    $this->packageStatesConfiguration['packages'][$package->getComposerName()]['frozen'] === true
-                ) {
-                    $frozenPackages[$packageKey] = $package;
-                }
-            }
-        }
-
-        return $frozenPackages;
+        return [];
     }
 
     /**

--- a/Neos.Flow/Classes/Package/PackageManager.php
+++ b/Neos.Flow/Classes/Package/PackageManager.php
@@ -15,7 +15,6 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Composer\Exception\InvalidConfigurationException;
 use Neos\Flow\Composer\ComposerUtility;
 use Neos\Flow\Core\Bootstrap;
-use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\SignalSlot\Dispatcher;
 use Neos\Flow\SignalSlot\Exception\InvalidSlotException;
 use Neos\Utility\Exception\FilesException;
@@ -229,6 +228,7 @@ class PackageManager
      * precompiled reflection data in order to improve performance.
      *
      * @return array<PackageInterface>
+     * @deprecated since 8.4
      */
     public function getFrozenPackages(): array
     {
@@ -403,6 +403,7 @@ class PackageManager
      * @param string $toAbsolutePath
      * @return void
      * @throws FilesException
+     * @deprecated since 8.4
      */
     protected function movePackage($fromAbsolutePath, $toAbsolutePath): void
     {
@@ -412,94 +413,15 @@ class PackageManager
     }
 
     /**
-     * Freezes a package
-     *
-     * @param string $packageKey The package to freeze
-     * @return void
-     * @throws Exception\PackageStatesFileNotWritableException
-     * @throws Exception\UnknownPackageException
-     * @throws \Neos\Flow\Exception
-     * @throws FilesException
-     */
-    public function freezePackage($packageKey): void
-    {
-        if (!$this->bootstrap->getContext()->isDevelopment()) {
-            throw new \LogicException('Package freezing is only supported in Development context.', 1338810870);
-        }
-
-        if (!$this->isPackageAvailable($packageKey)) {
-            throw new Exception\UnknownPackageException('Package "' . $packageKey . '" is not available.', 1331715956);
-        }
-        if ($this->isPackageFrozen($packageKey)) {
-            return;
-        }
-
-        $package = $this->packages[$packageKey];
-        $this->bootstrap->getObjectManager()->get(ReflectionService::class)->freezePackageReflection($packageKey);
-
-        $this->packageStatesConfiguration['packages'][$package->getComposerName()]['frozen'] = true;
-        $this->savePackageStates($this->packageStatesConfiguration);
-    }
-
-    /**
      * Tells if a package is frozen
      *
      * @param string $packageKey The package to check
      * @return boolean
+     * @deprecated since 8.4
      */
     public function isPackageFrozen($packageKey): bool
     {
-        if (!isset($this->packages[$packageKey])) {
-            return false;
-        }
-        $composerName = $this->packages[$packageKey]->getComposerName();
-
-        return (
-            $this->bootstrap->getContext()->isDevelopment()
-            && isset($this->packageStatesConfiguration['packages'][$composerName]['frozen'])
-            && $this->packageStatesConfiguration['packages'][$composerName]['frozen'] === true
-        );
-    }
-
-    /**
-     * Unfreezes a package
-     *
-     * @param string $packageKey The package to unfreeze
-     * @return void
-     * @throws Exception\PackageStatesFileNotWritableException
-     * @throws \Neos\Flow\Exception
-     * @throws FilesException
-     */
-    public function unfreezePackage($packageKey): void
-    {
-        if (!$this->isPackageFrozen($packageKey)) {
-            return;
-        }
-        if (!isset($this->packages[$packageKey])) {
-            return;
-        }
-        $composerName = $this->packages[$packageKey]->getComposerName();
-
-        $this->bootstrap->getObjectManager()->get(ReflectionService::class)->unfreezePackageReflection($packageKey);
-
-        unset($this->packageStatesConfiguration['packages'][$composerName]['frozen']);
-        $this->savePackageStates($this->packageStatesConfiguration);
-    }
-
-    /**
-     * Refreezes a package
-     *
-     * @param string $packageKey The package to refreeze
-     * @return void
-     * @throws \Neos\Flow\Exception
-     */
-    public function refreezePackage($packageKey): void
-    {
-        if (!$this->isPackageFrozen($packageKey)) {
-            return;
-        }
-
-        $this->bootstrap->getObjectManager()->get(ReflectionService::class)->unfreezePackageReflection($packageKey);
+        return false;
     }
 
     /**

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1232,7 +1232,6 @@ class ReflectionService
         $visibility = $this->extractVisibility($property);
         $this->classReflectionData[$className][self::DATA_CLASS_PROPERTIES][$propertyName][self::DATA_PROPERTY_VISIBILITY] = $visibility;
 
-
         foreach ($property->getTagsValues() as $tagName => $tagValues) {
             $tagValues = $this->reflectPropertyTag($className, $property, $tagName, $tagValues);
             if ($tagValues === null) {

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1710,6 +1710,7 @@ class ReflectionService
         if (class_exists($className)) {
             $interfaceNames = class_implements($className);
             foreach ($interfaceNames as $interfaceName) {
+                $this->loadOrReflectClassIfNecessary($interfaceName);
                 if (isset($this->classReflectionData[$interfaceName][self::DATA_INTERFACE_IMPLEMENTATIONS][$className])) {
                     unset($this->classReflectionData[$interfaceName][self::DATA_INTERFACE_IMPLEMENTATIONS][$className]);
                 }
@@ -1717,6 +1718,7 @@ class ReflectionService
         } else {
             foreach ($this->availableClassNames as $interfaceNames) {
                 foreach ($interfaceNames as $interfaceName) {
+                    $this->loadOrReflectClassIfNecessary($interfaceName);
                     if (isset($this->classReflectionData[$interfaceName][self::DATA_INTERFACE_IMPLEMENTATIONS][$className])) {
                         unset($this->classReflectionData[$interfaceName][self::DATA_INTERFACE_IMPLEMENTATIONS][$className]);
                     }

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1789,15 +1789,15 @@ class ReflectionService
      */
     public function saveToCache(): void
     {
-        if (!$this->initialized) {
-            $this->initialize();
-        }
-
         if (empty($this->updatedReflectionData)) {
             return;
         }
 
-        $this->saveProductionData();
+        if (!$this->initialized) {
+            $this->initialize();
+        }
+
+        $this->updateCacheEntries();
     }
 
     /**
@@ -1805,7 +1805,7 @@ class ReflectionService
      *
      * @throws Exception
      */
-    protected function saveProductionData(): void
+    private function updateCacheEntries(): void
     {
         $classNames = [];
         foreach ($this->classReflectionData as $className => $reflectionData) {

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -17,8 +17,6 @@ use Doctrine\Common\Annotations\PhpParser;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Persistence\Proxy as DoctrineProxy;
-use Error;
-use InvalidArgumentException;
 use Neos\Cache\Exception;
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Annotations as Flow;
@@ -33,12 +31,6 @@ use Neos\Flow\Reflection\Exception\InvalidValueObjectException;
 use Neos\Utility\TypeHandling;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
-use ReflectionException;
-use ReflectionIntersectionType;
-use ReflectionNamedType;
-use ReflectionType;
-use ReflectionUnionType;
-use RuntimeException;
 
 /**
  * A service for acquiring reflection based information in a performant way. This
@@ -229,7 +221,7 @@ class ReflectionService
      * @throws InvalidClassException
      * @throws InvalidPropertyTypeException
      * @throws InvalidValueObjectException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     public function buildReflectionData(array $availableClassNames): void
     {
@@ -282,13 +274,13 @@ class ReflectionService
      * @return string|bool
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function getDefaultImplementationClassNameForInterface(string $interfaceName): string|bool
     {
         if (interface_exists($interfaceName) === false) {
-            throw new InvalidArgumentException('"' . $interfaceName . '" does not exist or is not the name of an interface.', 1238769559);
+            throw new \InvalidArgumentException('"' . $interfaceName . '" does not exist or is not the name of an interface.', 1238769559);
         }
         $interfaceName = $this->prepareClassReflectionForUsage($interfaceName);
 
@@ -318,13 +310,13 @@ class ReflectionService
      * @return array
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function getAllImplementationClassNamesForInterface(string $interfaceName): array
     {
         if (interface_exists($interfaceName) === false) {
-            throw new InvalidArgumentException('"' . $interfaceName . '" does not exist or is not the name of an interface.', 1238769560);
+            throw new \InvalidArgumentException('"' . $interfaceName . '" does not exist or is not the name of an interface.', 1238769560);
         }
         $interfaceName = $this->prepareClassReflectionForUsage($interfaceName);
 
@@ -339,13 +331,13 @@ class ReflectionService
      * @return array<class-string>
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function getAllSubClassNamesForClass(string $className): array
     {
         if (class_exists($className) === false) {
-            throw new InvalidArgumentException('"' . $className . '" does not exist or is not the name of a class.', 1257168042);
+            throw new \InvalidArgumentException('"' . $className . '" does not exist or is not the name of a class.', 1257168042);
         }
         $className = $this->prepareClassReflectionForUsage($className);
         return (isset($this->classReflectionData[$className][self::DATA_CLASS_SUBCLASSES])) ? array_keys($this->classReflectionData[$className][self::DATA_CLASS_SUBCLASSES]) : [];
@@ -390,7 +382,7 @@ class ReflectionService
      * @return array<object>
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     public function getClassAnnotations(string $className, string|null $annotationClassName = null): array
     {
@@ -425,7 +417,7 @@ class ReflectionService
      * @return object|null
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     public function getClassAnnotation(string $className, string $annotationClassName): ?object
     {
@@ -442,7 +434,7 @@ class ReflectionService
      *
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function isClassImplementationOf(string $className, string $interfaceName): bool
@@ -461,7 +453,7 @@ class ReflectionService
      * @param class-string $className
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function isClassAbstract(string $className): bool
@@ -476,7 +468,7 @@ class ReflectionService
      * @param class-string $className Name of the class to analyze
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function isClassFinal(string $className): bool
@@ -492,7 +484,7 @@ class ReflectionService
      * @return bool true if the class is readonly, otherwise false
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function isClassReadonly(string $className): bool
@@ -549,7 +541,7 @@ class ReflectionService
      * @return bool
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function isMethodFinal(string $className, string $methodName): bool
@@ -564,7 +556,7 @@ class ReflectionService
      * @param class-string $className
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function isMethodStatic(string $className, string $methodName): bool
@@ -577,7 +569,7 @@ class ReflectionService
      * @param class-string $className
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function isMethodPublic(string $className, string $methodName): bool
@@ -590,7 +582,7 @@ class ReflectionService
      * @param class-string $className
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function isMethodProtected(string $className, string $methodName): bool
@@ -603,7 +595,7 @@ class ReflectionService
      * @param class-string $className
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function isMethodPrivate(string $className, string $methodName): bool
@@ -615,7 +607,7 @@ class ReflectionService
     /**
      * Tells if the specified method is tagged with the given tag
      *
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function isMethodTaggedWith(string $className, string $methodName, string $tag): bool
@@ -646,7 +638,7 @@ class ReflectionService
      * @param string $methodName
      * @param class-string $annotationClassName
      * @return bool
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function isMethodAnnotatedWith(string $className, string $methodName, string $annotationClassName): bool
@@ -661,7 +653,7 @@ class ReflectionService
      * @param class-string|null $annotationClassName
      * @return array<object>
      *
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      *
      */
@@ -706,7 +698,7 @@ class ReflectionService
      * If multiple annotations are set on the target you will
      * get the first instance of them.
      *
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     public function getMethodAnnotation(string $className, string $methodName, string $annotationClassName): ?object
     {
@@ -725,7 +717,7 @@ class ReflectionService
      * @return array<string>
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function getClassPropertyNames(string $className): array
@@ -740,7 +732,7 @@ class ReflectionService
      * @param class-string $className
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function hasMethod(string $className, string $methodName): bool
@@ -752,7 +744,7 @@ class ReflectionService
     /**
      * Returns all tags and their values the specified method is tagged with
      *
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @deprecated since 8.4
      */
     public function getMethodTagsValues(string $className, string $methodName): array
@@ -773,7 +765,7 @@ class ReflectionService
      * @return array An array of parameter names and additional information or an empty array of no parameters were found
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function getMethodParameters(string $className, string $methodName): array
@@ -793,7 +785,7 @@ class ReflectionService
      * @return string|null The declared return type of the method or null if none was declared
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     public function getMethodDeclaredReturnType(string $className, string $methodName): ?string
     {
@@ -809,7 +801,7 @@ class ReflectionService
      * @return array<string>
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      *
      */
@@ -838,7 +830,7 @@ class ReflectionService
      * @return array
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function getPropertyTagsValues(string $className, string $propertyName): array
@@ -860,7 +852,7 @@ class ReflectionService
      * @return array
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      *
      */
@@ -882,7 +874,7 @@ class ReflectionService
      * @return string|null
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     public function getPropertyType(string $className, string $propertyName): ?string
     {
@@ -896,7 +888,7 @@ class ReflectionService
      * @return bool
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function isPropertyPrivate(string $className, string $propertyName): bool
@@ -915,7 +907,7 @@ class ReflectionService
      * @return bool
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function isPropertyTaggedWith(string $className, string $propertyName, string $tag): bool
@@ -933,7 +925,7 @@ class ReflectionService
      * @return bool
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function isPropertyAnnotatedWith(string $className, string $propertyName, string $annotationClassName): bool
@@ -951,7 +943,7 @@ class ReflectionService
      * @return array<string>
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function getPropertyNamesByAnnotation(string $className, string $annotationClassName): array
@@ -980,7 +972,7 @@ class ReflectionService
      * @return array<object>
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      * @api
      */
     public function getPropertyAnnotations(string $className, string $propertyName, string $annotationClassName = null): array
@@ -1009,7 +1001,7 @@ class ReflectionService
      * @return object|null
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     public function getPropertyAnnotation(string $className, string $propertyName, string $annotationClassName): ?object
     {
@@ -1053,7 +1045,7 @@ class ReflectionService
      * @return string
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     protected function prepareClassReflectionForUsage(string $className): string
     {
@@ -1077,7 +1069,7 @@ class ReflectionService
      * @throws InvalidClassException
      * @throws InvalidPropertyTypeException
      * @throws InvalidValueObjectException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     protected function reflectEmergedClasses(): void
     {
@@ -1147,7 +1139,7 @@ class ReflectionService
      * @param class-string $className
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     protected function reflectClass(string $className): void
     {
@@ -1250,8 +1242,8 @@ class ReflectionService
             }
             try {
                 $attributeInstance = $attribute->newInstance();
-            } catch (Error $error) {
-                throw new RuntimeException(sprintf('Attribute "%s" used in class "%s" was not found.', $attribute->getName(), $className), 1695635128, $error);
+            } catch (\Error $error) {
+                throw new \RuntimeException(sprintf('Attribute "%s" used in class "%s" was not found.', $attribute->getName(), $className), 1695635128, $error);
             }
             $this->classReflectionData[$className][self::DATA_CLASS_PROPERTIES][$propertyName][self::DATA_PROPERTY_ANNOTATIONS][$attribute->getName()][] = $attributeInstance;
         }
@@ -1282,7 +1274,7 @@ class ReflectionService
     /**
      * @throws InvalidClassException
      * @throws ClassLoadingForReflectionFailedException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     protected function addParentClass(string $className, ClassReflection $parentClass): void
     {
@@ -1296,7 +1288,7 @@ class ReflectionService
     /**
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     protected function addImplementedInterface(string $className, ClassReflection $interface): void
     {
@@ -1315,7 +1307,7 @@ class ReflectionService
     /**
      * @param class-string $className
      * @param MethodReflection $method
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     protected function reflectClassMethod(string $className, MethodReflection $method): void
     {
@@ -1487,7 +1479,7 @@ class ReflectionService
      * @throws InvalidClassException
      * @throws InvalidPropertyTypeException
      * @throws InvalidValueObjectException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     protected function buildClassSchemata(array $classNames): void
     {
@@ -1507,7 +1499,7 @@ class ReflectionService
      * @throws InvalidClassException
      * @throws InvalidPropertyTypeException
      * @throws InvalidValueObjectException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     protected function buildClassSchema(string $className): ClassSchema
     {
@@ -1550,7 +1542,7 @@ class ReflectionService
      * @throws ClassSchemaConstraintViolationException
      * @throws InvalidClassException
      * @throws InvalidPropertyTypeException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     protected function addPropertiesToClassSchema(ClassSchema $classSchema): void
     {
@@ -1582,7 +1574,7 @@ class ReflectionService
      * @throws ClassSchemaConstraintViolationException
      * @throws InvalidClassException
      * @throws InvalidPropertyTypeException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     protected function evaluateClassPropertyAnnotationsForSchema(ClassSchema $classSchema, string $propertyName): bool
     {
@@ -1639,7 +1631,7 @@ class ReflectionService
      * @throws ClassLoadingForReflectionFailedException
      * @throws ClassSchemaConstraintViolationException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     protected function completeRepositoryAssignments(): void
     {
@@ -1675,7 +1667,7 @@ class ReflectionService
      * @throws ClassLoadingForReflectionFailedException
      * @throws ClassSchemaConstraintViolationException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     protected function makeChildClassesAggregateRoot(ClassSchema $classSchema): void
     {
@@ -1696,7 +1688,7 @@ class ReflectionService
      * @throws ClassLoadingForReflectionFailedException
      * @throws Exception
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     protected function ensureAggregateRootInheritanceChainConsistency(): void
     {
@@ -1826,7 +1818,7 @@ class ReflectionService
      * @return void
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     protected function forgetChangedClasses(): void
     {
@@ -1845,7 +1837,7 @@ class ReflectionService
      *
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     private function forgetClass(string $className): void
     {
@@ -1912,7 +1904,7 @@ class ReflectionService
      * @param class-string $className
      * @throws ClassLoadingForReflectionFailedException
      * @throws InvalidClassException
-     * @throws ReflectionException
+     * @throws \ReflectionException
      */
     private function loadOrReflectClassIfNecessary(string $className): void
     {
@@ -2005,28 +1997,28 @@ class ReflectionService
     }
 
     /**
-     * @param ReflectionType|null $parameterType
+     * @param \ReflectionType|null $parameterType
      * @return string|null
      */
-    private function renderParameterType(?ReflectionType $parameterType = null): string|null
+    private function renderParameterType(?\ReflectionType $parameterType = null): string|null
     {
         return match (true) {
-            $parameterType instanceof ReflectionUnionType => implode('|', array_map(
-                function (ReflectionNamedType | ReflectionIntersectionType $type) {
-                    if ($type instanceof  ReflectionNamedType) {
+            $parameterType instanceof \ReflectionUnionType => implode('|', array_map(
+                function (\ReflectionNamedType|\ReflectionIntersectionType $type) {
+                    if ($type instanceof \ReflectionNamedType) {
                         return $type->getName();
                     }
                     return '(' . $this->renderParameterType($type) . ')';
                 },
                 $parameterType->getTypes()
             )),
-            $parameterType instanceof ReflectionIntersectionType => implode('&', array_map(
-                function (ReflectionNamedType $type) {
+            $parameterType instanceof \ReflectionIntersectionType => implode('&', array_map(
+                function (\ReflectionNamedType $type) {
                     return $this->renderParameterType($type);
                 },
                 $parameterType->getTypes()
             )),
-            $parameterType instanceof ReflectionNamedType => $parameterType->getName(),
+            $parameterType instanceof \ReflectionNamedType => $parameterType->getName(),
             default => null,
         };
     }

--- a/Neos.Flow/Classes/Reflection/ReflectionServiceFactory.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionServiceFactory.php
@@ -16,8 +16,6 @@ use Neos\Flow\Cache\CacheManager;
 use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Log\PsrLoggerFactoryInterface;
-use Neos\Flow\Package\PackageManager;
-use Neos\Flow\Utility\Environment;
 
 /**
  * Factory for getting an reflection service instance.
@@ -64,12 +62,8 @@ class ReflectionServiceFactory
         $reflectionService = new ReflectionService();
         $reflectionService->injectLogger($this->bootstrap->getEarlyInstance(PsrLoggerFactoryInterface::class)->get('systemLogger'));
         $reflectionService->injectSettings($settings);
-        $reflectionService->injectPackageManager($this->bootstrap->getEarlyInstance(PackageManager::class));
-        $reflectionService->setStatusCache($cacheManager->getCache('Flow_Reflection_Status'));
-        $reflectionService->setReflectionDataCompiletimeCache($cacheManager->getCache('Flow_Reflection_CompiletimeData'));
         $reflectionService->setReflectionDataRuntimeCache($cacheManager->getCache('Flow_Reflection_RuntimeData'));
         $reflectionService->setClassSchemataRuntimeCache($cacheManager->getCache('Flow_Reflection_RuntimeClassSchemata'));
-        $reflectionService->injectEnvironment($this->bootstrap->getEarlyInstance(Environment::class));
 
         $this->reflectionService = $reflectionService;
         return $reflectionService;

--- a/Neos.Flow/Configuration/Caches.yaml
+++ b/Neos.Flow/Configuration/Caches.yaml
@@ -93,16 +93,23 @@ Flow_Persistence_Doctrine_Results:
 Flow_Persistence_Doctrine_SecondLevel:
   backend: Neos\Cache\Backend\SimpleFileBackend
 
-# Flow_Reflection*
 #
+# DEPRECATED since 8.4
+# These caches will be removed in 9.0, they are unused so you can safely remove any configuration for them.
 #
 Flow_Reflection_Status:
   frontend: Neos\Cache\Frontend\StringFrontend
   backend: Neos\Cache\Backend\SimpleFileBackend
 Flow_Reflection_CompiletimeData:
   backend: Neos\Cache\Backend\SimpleFileBackend
-Flow_Reflection_RuntimeData: []
-Flow_Reflection_RuntimeClassSchemata: []
+
+# Flow_Reflection
+#
+#
+Flow_Reflection_RuntimeData:
+  backend: Neos\Cache\Backend\SimpleFileBackend
+Flow_Reflection_RuntimeClassSchemata:
+  backend: Neos\Cache\Backend\SimpleFileBackend
 
 # Flow_Resource_Status
 #

--- a/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
@@ -57,6 +57,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      * @throws
+     * @deprecated
      */
     public function theReflectionServiceCorrectlyBuildsMethodTagsValues(): void
     {

--- a/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
+++ b/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php
@@ -57,7 +57,7 @@ class ReflectionServiceTest extends FunctionalTestCase
     /**
      * @test
      * @throws
-     * @deprecated
+     * @deprecated since 8.4
      */
     public function theReflectionServiceCorrectlyBuildsMethodTagsValues(): void
     {

--- a/Neos.Flow/Tests/Unit/Cache/CacheManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Cache/CacheManagerTest.php
@@ -277,7 +277,7 @@ class CacheManagerTest extends UnitTestCase
     {
         $objectClassCache = $this->registerCache('Flow_Object_Classes');
         $objectConfigurationCache = $this->registerCache('Flow_Object_Configuration');
-        $this->registerCache('Flow_Reflection_Status');
+        $this->registerCache('Flow_Reflection_RuntimeData');
 
         $objectClassCache->expects(self::once())->method('remove')->with('Neos_Flow_Cache_CacheManager');
         $objectConfigurationCache->expects(self::once())->method('remove')->with('allCompiledCodeUpToDate');
@@ -294,7 +294,7 @@ class CacheManagerTest extends UnitTestCase
     {
         $objectClassCache = $this->registerCache('Flow_Object_Classes');
         $objectConfigurationCache = $this->registerCache('Flow_Object_Configuration');
-        $this->registerCache('Flow_Reflection_Status');
+        $this->registerCache('Flow_Reflection_RuntimeData');
 
         $objectClassCache->expects(self::once())->method('remove')->with('Neos_Flow_Tests_Unit_Cache_CacheManagerTest');
         $objectConfigurationCache->expects(self::once())->method('remove')->with('allCompiledCodeUpToDate');

--- a/Neos.Flow/Tests/Unit/Package/PackageManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Package/PackageManagerTest.php
@@ -470,36 +470,4 @@ class PackageManagerTest extends UnitTestCase
         $this->mockDispatcher->expects(self::once())->method('dispatch')->with(PackageManager::class, 'packageStatesUpdated');
         $this->packageManager->createPackage('Some.Package', [], 'vfs://Test/Packages/Application');
     }
-
-    /**
-     * @test
-     */
-    public function freezePackageEmitsPackageStatesUpdatedSignal()
-    {
-        $this->mockApplicationContext->expects(self::atLeastOnce())->method('isDevelopment')->will(self::returnValue(true));
-
-        $this->packageManager->createPackage('Some.Package', [
-            'name' => 'some/package'
-        ], 'vfs://Test/Packages/Application');
-
-        $this->mockDispatcher->expects(self::once())->method('dispatch')->with(PackageManager::class, 'packageStatesUpdated');
-        $this->packageManager->freezePackage('Some.Package');
-    }
-
-    /**
-     * @test
-     */
-    public function unfreezePackageEmitsPackageStatesUpdatedSignal()
-    {
-        $this->mockApplicationContext->expects(self::atLeastOnce())->method('isDevelopment')->will(self::returnValue(true));
-
-        $this->packageManager->createPackage('Some.Package', [
-            'name' => 'some/package',
-            'type' => 'neos-package'
-        ], 'vfs://Test/Packages/Application');
-        $this->packageManager->freezePackage('Some.Package');
-
-        $this->mockDispatcher->expects(self::once())->method('dispatch')->with(PackageManager::class, 'packageStatesUpdated');
-        $this->packageManager->unfreezePackage('Some.Package');
-    }
 }

--- a/Neos.FluidAdaptor/Classes/Package.php
+++ b/Neos.FluidAdaptor/Classes/Package.php
@@ -48,10 +48,6 @@ class Package extends BasePackage
                     $packageManager = $bootstrap->getEarlyInstance(PackageManager::class);
                     /** @var FlowPackageInterface $package */
                     foreach ($packageManager->getFlowPackages() as $packageKey => $package) {
-                        if ($packageManager->isPackageFrozen($packageKey)) {
-                            continue;
-                        }
-
                         foreach (['Templates', 'Partials', 'Layouts'] as $path) {
                             $templatesPath = $package->getResourcesPath() . 'Private/' . $path;
 


### PR DESCRIPTION
This change tackles some problems within the reflection service that stem from historically increasing complexity due to various caching mechanisms depending on application context and compile time status.

The aim was to cut down on this complexity, while ensuring that all existing use-cases continue working as intended.

This ultimately also fixes issue #3402 by providing the same reflection data across all possible contexts.

A few features and caches got deprecated with this change and could be breaking in the rare case you used the freeze package api in your code:

The entire concept of freezing a package is deprecated

What remains are the commands in the package controller, which are now all no-ops and deprecated to be removed with 9.0. This is to ensure deployment pipelines possibly calling freeze commands do not break with the 8.4 update.

Additionally the single method `PackageManager::isPackageFrozen` remains, while the rest was removed. None of the methods was ever api and it seems unlikely that someone used them in user-land code. `isPackageFrozen` however is at the very least used in Framework and Neos code and therefore remains until 9.0, but will now return false for every package.

Caches deprecated and unused

With the simplification two caches are no longer needed, both are still declared so that possibly existing cache configuration in user projects doesn't error, but both

`Flow_Reflection_Status`

and

`Flow_Reflection_CompiletimeData`

will no longer be used and any content can be removed.

The only reflection cache is now `Flow_Reflection_RuntimeData`, which makes the name somewhat deceptive as it is also used in compile time. To avoid backwards compatibility issues however it makes sense to keep the name for the foreseeable future.

Quick performance comparisons suggest that especially the initial compile from empty cache benefits from this change. Reflection updates in Development context afterwards seem to be on par with the existing code base.

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
