### PR TITLE
TASK: Add documentation how work with psr responses in controller

### DIFF
--- a/Neos.Flow/Classes/Mvc/ActionResponse.php
+++ b/Neos.Flow/Classes/Mvc/ActionResponse.php
@@ -28,13 +28,44 @@ use GuzzleHttp\Psr7\Response;
  * via `$this->response` {@see AbstractController::$response} and pass it along to places.
  * But this behaviour is deprecated!
  *
- * Instead, you can directly return a PSR repose {@see \GuzzleHttp\Psr7\Response} from a controller:
+ * Instead of modifying the repose via $this->response like
+ *
+ * - $this->response->addHttpHeader
+ * - $this->response->setHttpHeader
+ * - $this->response->setContentType
+ * - $this->response->setStatusCode
+ *
+ * you can directly return a PSR repose {@see \GuzzleHttp\Psr7\Response} from a controller.
+ *
+ * *set status code and contents and additional header:*
  *
  * ```php
  * public function myAction()
  * {
  *     return (new Response(status: 200, body: $output))
  *         ->withAddedHeader('X-My-Header', 'foo');
+ * }
+ * ```
+ *
+ * *modify a view response with additional header:*
+ *
+ * ```php
+ * public function myAction()
+ * {
+ *     $response = $this->view->render();
+ *     if (!$response instanceof Response) {
+ *         $response = new Response(body: $response);
+ *     }
+ *     return $response->withAddedHeader('X-My-Header', 'foo');
+ * }
+ * ```
+ *
+ * *render json without using the legacy json view:*
+ *
+ * ```php
+ * public function myAction()
+ * {
+ *     return new Response(body: json_encode($data, JSON_THROW_ON_ERROR), headers: ['Content-Type' => 'application/json']);
  * }
  * ```
  *

--- a/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
+++ b/Neos.Flow/Classes/Mvc/Controller/AbstractController.php
@@ -11,6 +11,7 @@ namespace Neos\Flow\Mvc\Controller;
  * source code.
  */
 
+use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Utils;
 use Neos\Error\Messages as Error;
 use Neos\Flow\Annotations as Flow;
@@ -63,6 +64,17 @@ abstract class AbstractController implements ControllerInterface
 
     /**
      * The legacy response which will is provide by this action controller
+     *
+     * Legacy ways to modify a repose:
+     *
+     * - $this->response->addHttpHeader
+     * - $this->response->setHttpHeader
+     * - $this->response->setContentType
+     * - $this->response->setStatusCode
+     *
+     * Please return a new {@see Response} instead from your controller action.
+     * Documentation to adjust your code is provided in {@see ActionResponse}.
+     *
      * @var ActionResponse
      * @deprecated with Flow 9 {@see ActionResponse}
      */

--- a/Neos.Flow/Classes/Mvc/View/JsonView.php
+++ b/Neos.Flow/Classes/Mvc/View/JsonView.php
@@ -23,7 +23,16 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * A JSON view
  *
- * @deprecated please use json_encode instead
+ * please return a new response instead in your controller and set the Content-Type to application/json
+ *
+ * ```php
+ * public function myAction()
+ * {
+ *     return new Response(body: json_encode($data, JSON_THROW_ON_ERROR), headers: ['Content-Type' => 'application/json']);
+ * }
+ * ```
+ *
+ * @deprecated with Flow 9.0 please use the native json_encode instead, without relying on the flow object conversion magic
  */
 class JsonView extends AbstractView
 {


### PR DESCRIPTION
There was some confusion how to replace `$this->response` when modifying view results.

The suggested pattern now is more explicit instead of providing any form of helper like:

```php
abstract class ResponseInformationHelper
{
    public static function response(Response|StreamInterface $response): Response
    {
        return $response instanceof Response ? $response : new Response(body: $response);
    }
}
```

Instead this will be written explicitly:

```php
$response = $this->view->render();
if (!$response instanceof Response) {
    $response = new Response(body: $response);
}
return $response
    ->withHeader('My-Header', 'foo');
```

Also this change inlines `ActionController::renderView` as the method signature is now really odd and unusable or understandable from the outside. `$this->view` should instead be used instead like when also assigning variables.


Related changes that lead to the new patterns:

- https://github.com/neos/flow-development-collection/pull/3286
- https://github.com/neos/flow-development-collection/pull/3311


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
