### PR TITLE
TASK: Remove obsolete sorting of big arrays in reflection service

### DIFF
--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -265,8 +265,9 @@ class ReflectionService
         if (!$this->initialized) {
             $this->initialize();
         }
-
-        return array_keys($this->classReflectionData);
+        $classNames = array_keys($this->classReflectionData);
+        sort($classNames);
+        return $classNames;
     }
 
     /**
@@ -1093,8 +1094,6 @@ class ReflectionService
         }
         $classNamesToReflect = array_merge([], ...$availableClassnames);
         $reflectedClassNames = array_keys($this->classReflectionData);
-        sort($classNamesToReflect);
-        sort($reflectedClassNames);
         $newClassNames = array_diff($classNamesToReflect, $reflectedClassNames);
         if ($newClassNames === []) {
             return;
@@ -1213,10 +1212,6 @@ class ReflectionService
         foreach ($class->getMethods() as $method) {
             $this->reflectClassMethod($className, $method);
         }
-        // Sort reflection data so that the cache data is deterministic. This is
-        // important for comparisons when checking if classes have changed in a
-        // Development context.
-        ksort($this->classReflectionData);
         $this->updatedReflectionData[$className] = true;
     }
 


### PR DESCRIPTION
While cleaning up code in the reflection service https://github.com/neos/flow-development-collection/pull/3447 i noticed the sorting calls and suspected that they have become obsolete over the time. Especially as the reflection was refactored now and that some explanations seem dated.

> after reflecting each class we sort classReflectionData which can be avoided
> but we still ensure that getAllClassNames returns all classes sorted.
> For using `array_diff` to get the $newClassNames we dont need sorting

Locally removing the sort calls is just fine but the CI throws this exception.

```
There was 1 failure:

1) Neos\Flow\Tests\Functional\Reflection\ReflectionServiceTest::aggregateRootAssignmentsInHierarchiesAreCorrect
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Neos\Flow\Tests\Functional\Reflection\Fixtures\Repository\SubSubEntityRepository'
+'Neos\Flow\Tests\Functional\Reflection\Fixtures\Repository\SuperEntityRepository'

/home/runner/work/flow-development-collection/flow-development-collection/flow-development-distribution/Packages/Framework/Neos.Flow/Tests/Functional/Reflection/ReflectionServiceTest.php:90
/home/runner/work/flow-development-collection/flow-development-collection/flow-development-distribution/bin/phpunit:122
```


**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
