### PR TITLE
BUGFIX: Avoid type error during `publishFile()`

### DIFF
--- a/Neos.Flow/Classes/ResourceManagement/Target/FileSystemTarget.php
+++ b/Neos.Flow/Classes/ResourceManagement/Target/FileSystemTarget.php
@@ -329,14 +329,18 @@ class FileSystemTarget implements TargetInterface
         }
 
         try {
-            $targetFileHandle = fopen($targetPathAndFilename, 'w');
-            $result = stream_copy_to_stream($sourceStream, $targetFileHandle);
-            fclose($targetFileHandle);
+            $targetFileHandle = fopen($targetPathAndFilename, 'wb');
+            if ($targetFileHandle === false) {
+                $result = false;
+            } else {
+                $result = stream_copy_to_stream($sourceStream, $targetFileHandle);
+                fclose($targetFileHandle);
+            }
         } catch (\Exception $exception) {
             $result = false;
         }
         if ($result === false) {
-            throw new TargetException(sprintf('Could not publish "%s" into resource publishing target "%s" because the source file could not be copied to the target location.', $sourceStream, $this->name), 1375258399, (isset($exception) ? $exception : null));
+            throw new TargetException(sprintf('Could not publish "%s" into resource publishing target "%s" because the source file could not be copied to the target location "%s".', $sourceStream, $this->name, $targetPathAndFilename), 1375258399, ($exception ?? null));
         }
 
         $this->logger->debug(sprintf('FileSystemTarget: Published file. (target: %s, file: %s)', $this->name, $relativeTargetPathAndFilename));


### PR DESCRIPTION
This avoids an error when the file cannot be opened or writing. That would result in
`stream_copy_to_stream(): Argument #2 ($to) must be of type resource, bool given`
for recent PHP versions.

**Review instructions**

Probably a bit tricky, but you need to create a scenario, where the target file already
exists and cannot be written to.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
