### PR TITLE
BUGFIX: RuntimeSequenceHttpRequestHandler::$httpRequest must not be accessed before initialization

### DIFF
--- a/Neos.Flow/Classes/Testing/RequestHandler/RuntimeSequenceHttpRequestHandler.php
+++ b/Neos.Flow/Classes/Testing/RequestHandler/RuntimeSequenceHttpRequestHandler.php
@@ -27,7 +27,7 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class RuntimeSequenceHttpRequestHandler extends RuntimeSequenceInvokingRequestHandler implements HttpRequestHandlerInterface
 {
-    private ServerRequestInterface|null $httpRequest;
+    private ServerRequestInterface|null $httpRequest = null;
 
     /**
      * @param ServerRequestInterface $request


### PR DESCRIPTION
if in testing context the throwable storage is invoked the default  $requestInformationRenderer will cause `getHttpRequest` to be called

Now there is a null check, but its useless with php strict defined properties:

Typed property Neos\Flow\Testing\RequestHandler\RuntimeSequenceHttpRequestHandler::$httpRequest must not be accessed before initialization

Either we must use `isset` or default initialise the value to `null`

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
