### PR TITLE
BUGFIX: Set property to null via objects yaml

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
@@ -368,6 +368,8 @@ class ProxyClassBuilder
                         $preparedSetterArgument = var_export($propertyValue, true);
                     } elseif (is_bool($propertyValue)) {
                         $preparedSetterArgument = $propertyValue ? 'true' : 'false';
+                    } elseif ($propertyValue === null) {
+                        $preparedSetterArgument = 'null';
                     } else {
                         $preparedSetterArgument = $propertyValue;
                     }

--- a/Neos.Flow/Configuration/Testing/Objects.yaml
+++ b/Neos.Flow/Configuration/Testing/Objects.yaml
@@ -37,6 +37,8 @@ Neos\Flow\Tests\Functional\ObjectManagement\Fixtures\SingletonClassC:
       value: true
     protectedBooleanFalsePropertySetViaObjectsYaml:
       value: false
+    protectedNullPropertySetViaObjectsYaml:
+      value: null
     protectedArrayPropertyWithSetterSetViaObjectsYaml:
       value: {'and': 'something from Objects.yaml'}
   arguments:

--- a/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/DependencyInjectionTest.php
@@ -71,6 +71,7 @@ class DependencyInjectionTest extends FunctionalTestCase
         self::assertSame(['iAm' => ['aConfigured' => 'arrayValue']], $objectC->getProtectedArrayPropertySetViaObjectsYaml());
         self::assertTrue($objectC->getProtectedBooleanTruePropertySetViaObjectsYaml());
         self::assertFalse($objectC->getProtectedBooleanFalsePropertySetViaObjectsYaml());
+        self::assertNull($objectC->getProtectedNullPropertySetViaObjectsYaml());
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/SingletonClassC.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/SingletonClassC.php
@@ -61,6 +61,11 @@ class SingletonClassC
     protected $protectedBooleanFalsePropertySetViaObjectsYaml;
 
     /**
+     * @var null
+     */
+    protected $protectedNullPropertySetViaObjectsYaml;
+
+    /**
      * @var array
      */
     protected $protectedArrayPropertyWithSetterSetViaObjectsYaml = ['has' => 'some default value'];
@@ -121,6 +126,11 @@ class SingletonClassC
     public function getProtectedBooleanFalsePropertySetViaObjectsYaml()
     {
         return $this->protectedBooleanFalsePropertySetViaObjectsYaml;
+    }
+
+    public function getProtectedNullPropertySetViaObjectsYaml()
+    {
+        return $this->protectedNullPropertySetViaObjectsYaml;
     }
 
     /**


### PR DESCRIPTION
This is probably similar to an `autowiring: false` option, but this does not exist as far as i debugged things for separate properties via objects yaml

The idea was to have an optional object, which can be removed via settings

```php
#[Flow\Inject]
protected SomeService|null $someService = null;
```

```yaml
Foo\Bar\Buz:
  properties:
    someService:
      value: null
```

At the current state invalid php code is generated, see `= ;` which causes php to fail during parsing:

```php
if (\Neos\Utility\ObjectAccess::setProperty($this, 'someService', ) === false) { $this->someService = ;}
```

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
