### PR TITLE
TASK: Allow to return closure value from `withoutAuthorizationChecks()`

### DIFF
--- a/Neos.Flow/Classes/Security/Authentication/Provider/PersistedUsernamePasswordProvider.php
+++ b/Neos.Flow/Classes/Security/Authentication/Provider/PersistedUsernamePasswordProvider.php
@@ -12,7 +12,6 @@ namespace Neos\Flow\Security\Authentication\Provider;
  */
 
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Security\Account;
 use Neos\Flow\Security\AccountRepository;
 use Neos\Flow\Security\Authentication\Token\UsernamePasswordTokenInterface;
 use Neos\Flow\Security\Authentication\TokenInterface;
@@ -86,9 +85,6 @@ class PersistedUsernamePasswordProvider extends AbstractProvider
             throw new UnsupportedAuthenticationTokenException(sprintf('This provider cannot authenticate the given token. The token must implement %s', UsernamePasswordTokenInterface::class), 1217339840);
         }
 
-        /** @var Account|null $account */
-        $account = null;
-
         if ($authenticationToken->getAuthenticationStatus() !== TokenInterface::AUTHENTICATION_SUCCESSFUL) {
             $authenticationToken->setAuthenticationStatus(TokenInterface::NO_CREDENTIALS_GIVEN);
         }
@@ -101,8 +97,8 @@ class PersistedUsernamePasswordProvider extends AbstractProvider
         }
 
         $providerName = $this->options['lookupProviderName'] ?? $this->name;
-        $this->securityContext->withoutAuthorizationChecks(function () use ($username, &$account, $providerName) {
-            $account = $this->accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName($username, $providerName);
+        $account = $this->securityContext->withoutAuthorizationChecks(function () use ($username, $providerName) {
+            return $this->accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName($username, $providerName);
         });
 
         $authenticationToken->setAuthenticationStatus(TokenInterface::WRONG_CREDENTIALS);

--- a/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/PropertyConditionGenerator.php
+++ b/Neos.Flow/Classes/Security/Authorization/Privilege/Entity/Doctrine/PropertyConditionGenerator.php
@@ -553,8 +553,8 @@ class PropertyConditionGenerator implements SqlGeneratorInterface
             $objectAccess = explode('.', $expression, 3);
             $globalObjectsRegisteredClassName = $this->globalObjects[$objectAccess[1]];
             $globalObject = $this->objectManager->get($globalObjectsRegisteredClassName);
-            $this->securityContext->withoutAuthorizationChecks(function () use ($globalObject, $objectAccess, &$globalObjectValue) {
-                $globalObjectValue = $this->getObjectValueByPath($globalObject, $objectAccess[2]);
+            $globalObjectValue = $this->securityContext->withoutAuthorizationChecks(function () use ($globalObject, $objectAccess) {
+                return $this->getObjectValueByPath($globalObject, $objectAccess[2]);
             });
 
             return $globalObjectValue;

--- a/Neos.Flow/Classes/Security/Context.php
+++ b/Neos.Flow/Classes/Security/Context.php
@@ -202,22 +202,22 @@ class Context
      * Lets you switch off authorization checks (CSRF token, policies, content security, ...) for the runtime of $callback
      *
      * Usage:
-     * $this->securityContext->withoutAuthorizationChecks(function () use ($accountRepository, $username, $providerName, &$account) {
-     *   // this will disable the PersistenceQueryRewritingAspect for this one call
-     *   $account = $accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName($username, $providerName)
-     * });
      *
-     * @param \Closure $callback
-     * @return void
-     * @throws \Exception
+     *     $account = $this->securityContext->withoutAuthorizationChecks(function () use ($accountRepository, $username, $providerName) {
+     *       // this will disable the PersistenceQueryRewritingAspect for this one call
+     *       return $accountRepository->findActiveByAccountIdentifierAndAuthenticationProviderName($username, $providerName)
+     *     });
+     *
+     * @template T
+     * @param \Closure(): T $callback
+     * @return T the return value of $callback
      */
-    public function withoutAuthorizationChecks(\Closure $callback)
+    public function withoutAuthorizationChecks(\Closure $callback): mixed
     {
         $authorizationChecksAreAlreadyDisabled = $this->authorizationChecksDisabled;
         $this->authorizationChecksDisabled = true;
         try {
-            /** @noinspection PhpUndefinedMethodInspection */
-            $callback->__invoke();
+            return $callback();
         } finally {
             $this->authorizationChecksDisabled = $authorizationChecksAreAlreadyDisabled;
         }

--- a/Neos.Flow/Tests/Functional/Command/BehatHelperCommandController.php
+++ b/Neos.Flow/Tests/Functional/Command/BehatHelperCommandController.php
@@ -67,11 +67,10 @@ class BehatHelperCommandController extends CommandController
             $mappedArguments[] = $this->propertyMapper->convert($rawMethodArguments[$i+1], $rawMethodArguments[$i]);
         }
 
-        $result = null;
         try {
             if ($withoutSecurityChecks === true) {
-                $this->securityContext->withoutAuthorizationChecks(function () use ($testHelper, $methodName, $mappedArguments, &$result) {
-                    $result = call_user_func_array([$testHelper, $methodName], $mappedArguments);
+                $result = $this->securityContext->withoutAuthorizationChecks(function () use ($testHelper, $methodName, $mappedArguments) {
+                    return call_user_func_array([$testHelper, $methodName], $mappedArguments);
                 });
             } else {
                 $result = call_user_func_array([$testHelper, $methodName], $mappedArguments);


### PR DESCRIPTION
to avoid having to use references

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
