### PR TITLE
BUGFIX: Enums throw `::__construct() does not exist` on compilation

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
@@ -87,6 +87,10 @@ class ConfigurationBuilder
                     continue;
                 }
 
+                if (enum_exists($classOrInterfaceName)) {
+                    continue;
+                }
+
                 if (interface_exists($classOrInterfaceName)) {
                     $interfaceName = $classOrInterfaceName;
                     $implementationClassName = $this->reflectionService->getDefaultImplementationClassNameForInterface($interfaceName);

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
@@ -87,7 +87,7 @@ class ConfigurationBuilder
                     continue;
                 }
 
-                if (enum_exists($classOrInterfaceName)) {
+                if (method_exist('enum_exists') && enum_exists($classOrInterfaceName)) {
                     continue;
                 }
 


### PR DESCRIPTION
`flow flow:core:compile`

```
Exception [0] in line 666 ReflectionService.php: Method Neos\Demo\Components\Headline\HeadlineType::__construct() does not exist

22 ReflectionMethod::__construct("Neos\Demo\Components\Headline\HeadlineType", "__construct")
21 Neos\Flow\Reflection\ReflectionService::getMethodAnnotations("Neos\Demo\Components\Headline\HeadlineType", "__construct", "Neos\Flow\Annotations\Autowiring")
20 Neos\Flow\Reflection\ReflectionService::getMethodAnnotation("Neos\Demo\Components\Headline\HeadlineType", "__construct", "Neos\Flow\Annotations\Autowiring")
19 Neos\Flow\ObjectManagement\Configuration\ConfigurationBuilder::autowireArguments(array|1681|)
18 Neos\Flow\ObjectManagement\Configuration\ConfigurationBuilder::buildObjectConfigurations(array|28|, array|32|)
17 Neos\Flow\ObjectManagement\CompileTimeObjectManager::initialize(array|165|)
16 Neos\Flow\Core\Booting\Scripts::initializeObjectManagerCompileTimeFinalize(Neos\Flow\Core\Bootstrap)
15 call_user_func(array|2|, Neos\Flow\Core\Bootstrap)
```

Adding the enum check works.

```php
if (enum_exists($classOrInterfaceName)) {
    continue;
}
```

The question is why does it only cause an error in my project? Because of the odd class path `Components` instead of `Classes`?
Anyways enum support was introduced via https://github.com/neos/flow-development-collection/pull/2702 and should not be a problem ...