### PR TITLE
BUGFIX: #3442 ignore deprecations during binary check

### DIFF
--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -944,7 +944,8 @@ class Scripts
 
         exec(join(' ', $command), $output, $result);
 
-        $phpInformation = json_decode($output[0] ?? '{}', true) ?: [];
+        $resultWithJson = end($output); // For multiple lines use the last line, to skip possible emitted deprecations
+        $phpInformation = $resultWithJson ? json_decode($resultWithJson, true) : false;
 
         if ($result !== 0 || ($phpInformation['sapi'] ?? null) !== 'cli') {
             throw new Exception\SubProcessException(sprintf('PHP binary might not exist or is not suitable for cli usage. Command `%s` didnt succeed.', $phpCommand), 1689676967447);

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -874,9 +874,9 @@ class Scripts
         $output = [];
         exec(join(' ', $command), $output, $result);
 
-        if ($result === 0 && count($output) === 1) {
+        if ($result === 0 && $output !== []) {
             // Resolve any wrapper
-            $configuredPhpBinaryPathAndFilename = $output[0];
+            $configuredPhpBinaryPathAndFilename = end($output); // Last entry, skip possible emitted deprecations
         } else {
             // Resolve any symlinks that the configured php might be pointing to
             $configuredPhpBinaryPathAndFilename = realpath($phpBinaryPathAndFilename);
@@ -896,7 +896,7 @@ class Scripts
             // bypass with exec open_basedir restriction
             $output = [];
             exec(PHP_BINARY . ' -r "echo realpath(PHP_BINARY);"', $output);
-            $realPhpBinary = $output[0];
+            $realPhpBinary = end($output); // Last entry, skip possible emitted deprecations
         }
         if (strcmp($realPhpBinary, $configuredPhpBinaryPathAndFilename) !== 0) {
             throw new Exception\SubProcessException(sprintf(


### PR DESCRIPTION
fixes: https://github.com/neos/flow-development-collection/issues/3442

seems kinda hacky i dont know how else we can easily make the output parseable.
I guess we _could_ turn of deprecations and all error handling for that request but i dindt want to start the fun to make these parameters work cross platform (windows) so here is an easy fix.

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
