### PR TITLE
BUGFIX: Replace skip migrations with simple return

### DIFF
--- a/Neos.Flow/Migrations/Mysql/Version20141113173712.php
+++ b/Neos.Flow/Migrations/Mysql/Version20141113173712.php
@@ -18,7 +18,9 @@ class Version20141113173712 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
         // skip execution of corresponding sql queries if migration has been applied already (see https://review.typo3.org/36299)
-        $this->skipIf(array_key_exists('roleidentifiers', $this->sm->listTableColumns('typo3_flow_security_account')), 'Migration not needed, already applied earlier.');
+        if(array_key_exists('roleidentifiers', $this->sm->listTableColumns('typo3_flow_security_account'))) {
+            return;
+        }
 
         $this->addSql("ALTER TABLE typo3_flow_security_account ADD roleidentifiers LONGTEXT DEFAULT NULL COMMENT '(DC2Type:simple_array)'");
         $this->addSql("ALTER TABLE typo3_flow_security_account_roles_join DROP FOREIGN KEY FK_ADF11BBC23A1047C");

--- a/Neos.Flow/Migrations/Postgresql/Version20141113145146.php
+++ b/Neos.Flow/Migrations/Postgresql/Version20141113145146.php
@@ -18,7 +18,9 @@ class Version20141113145146 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "postgresql");
 
         // skip execution of corresponding sql queries if migration has been applied already (see https://review.typo3.org/36299)
-        $this->skipIf(array_key_exists('roleidentifiers', $this->sm->listTableColumns('typo3_flow_security_account')), 'Migration not needed, already applied earlier.');
+        if(array_key_exists('roleidentifiers', $this->sm->listTableColumns('typo3_flow_security_account'))) {
+            return;
+        }
 
         $this->addSql("ALTER TABLE typo3_flow_security_account_roles_join DROP CONSTRAINT fk_adf11bbc23a1047c");
         $this->addSql("ALTER TABLE typo3_flow_security_policy_role_parentroles_join DROP CONSTRAINT fk_d459c58e23a1047c");


### PR DESCRIPTION
If we use the skip migrations feature of doctrine, the migrations never get marked as applied. Which leads to situations, where your migration status will never be clean. So I replaced all skipif with a simple return.

See also: https://github.com/doctrine/migrations/issues/1179