### PR TITLE
BUGFIX: out of memory error when using AbsorbingHandler

### DIFF
--- a/Neos.Flow/Classes/Error/Debugger.php
+++ b/Neos.Flow/Classes/Error/Debugger.php
@@ -402,7 +402,6 @@ class Debugger
         $exception = new \Exception();
         $callstack = $exception->getTraceAsString();
         if (substr_count($callstack, __METHOD__) > 3) {
-
             $explanation = <<<'EOT'
                 There seems to be an error while rendering the stack trace, see https://github.com/neos/neos-development-collection/issues/5576 .
                 This might happen due to broken __toString() methods: an error occurs -> we generate the log here -> call __toString() again -> error occurs again -> we generate the log here again -> call __toString() again -> ...

--- a/Neos.Flow/Classes/Error/Debugger.php
+++ b/Neos.Flow/Classes/Error/Debugger.php
@@ -399,6 +399,18 @@ class Debugger
      */
     protected static function getBacktraceCodePlaintext(array $trace, bool $includeCode = true): string
     {
+        $exception = new \Exception();
+        $callstack = $exception->getTraceAsString();
+        if (substr_count($callstack, __METHOD__) > 3) {
+
+            $explanation = <<<'EOT'
+                There seems to be an error while rendering the stack trace, see https://github.com/neos/neos-development-collection/issues/5576 .
+                This might happen due to broken __toString() methods: an error occurs -> we generate the log here -> call __toString() again -> error occurs again -> we generate the log here again -> call __toString() again -> ...
+                Inspect the other log file in Data/Logs/Exceptions with the same creation time to find the original error.
+            EOT;
+            return __METHOD__ . " already on the call stack 3 times, aborting now\n" . $explanation;
+        }
+
         $backtraceCode = '';
         foreach ($trace as $index => $step) {
             $class = isset($step['class']) ? $step['class'] . '::' : '';


### PR DESCRIPTION
Exceptions while rendering error stack traces no longer exhaust all memory and crash.

Resolves https://github.com/neos/flow-development-collection/issues/3487

**Review instructions**

You find details in https://github.com/neos/flow-development-collection/issues/3487

**Checklist**

- [x] Code follows the PSR-2 coding style
- ~~Tests have been created, run and adjusted as needed~~
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
    - bug was introduced in _9.0_
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
