### PR TITLE
BUGFIX: Prevent premature connection to database before `PersistenceManager::persistAllowedObjects`

### DIFF
--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -66,9 +66,11 @@ class Package extends BasePackage
         $dispatcher = $bootstrap->getSignalSlotDispatcher();
 
         $dispatcher->connect(Mvc\Dispatcher::class, 'afterControllerInvocation', function ($request) use ($bootstrap) {
-            // No auto-persistence if there is no PersistenceManager registered
+            // No auto-persistence if there is no PersistenceManager loaded
+            // This signal will not be fired at compile time, as it's only emitted for web requests which happen at runtime.
             if (
-                $bootstrap->getObjectManager()->has(Persistence\PersistenceManagerInterface::class)
+                /** @phpstan-ignore-next-line the object manager interface doesn't specify this method */
+                $bootstrap->getObjectManager()->hasInstance(Persistence\PersistenceManagerInterface::class)
             ) {
                 if (!$request instanceof Mvc\ActionRequest || SecurityHelper::hasSafeMethod($request->getHttpRequest()) !== true) {
                     $bootstrap->getObjectManager()->get(Persistence\PersistenceManagerInterface::class)->persistAll();


### PR DESCRIPTION
For every simple GET request `persistAllowedObjects` is called via the Package.php in flow. This results in building a db connection, even if there is nothing to do.

We first check if the `entityManager` is open and if the entity manager has not been used (something is heavily cached via middle-ware or sth) flows objectmanagement retrieves the entity manger.

Now in this retrieval process - even though doctrines connection is lazy itself - the connection will be made forcefully see `\Neos\Flow\Persistence\Doctrine\EntityManagerFactory::create` line 120 (https://github.com/neos/flow-development-collection/blob/11e2348125dd8286ff9ccc088e5d187dc9143bf5/Neos.Flow/Classes/Persistence/Doctrine/EntityManagerFactory.php#L120) or https://github.com/neos/flow-development-collection/blob/d93b6b09ca2071c87812a9ef4bc120201c44608a/Neos.Flow/Classes/Persistence/Doctrine/EntityManagerConfiguration.php#L229

This is ironic because if there is no connection - or no entity manager in the first place, the current process cannot have made any changes to the transaction.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
