### PR TITLE
BUGFIX: Support IPv6 in `getTrustedClientIpAddress()`

### DIFF
--- a/Neos.Flow/Classes/Http/Middleware/TrustedProxiesMiddleware.php
+++ b/Neos.Flow/Classes/Http/Middleware/TrustedProxiesMiddleware.php
@@ -274,9 +274,20 @@ class TrustedProxiesMiddleware implements MiddlewareInterface
 
         $ipAddress = false;
         foreach (array_reverse($trustedIpHeader) as $headerIpAddress) {
-            $portPosition = strpos($headerIpAddress, ':');
-            $ipAddress = $portPosition !== false ? substr($headerIpAddress, 0, $portPosition) : $headerIpAddress;
-            if (!$this->ipIsTrustedProxy($ipAddress)) {
+            if (preg_match('/^\[([^]]+)]:(\d+)$/', $headerIpAddress, $matches)) { // IPv6 with port [ip]:port
+                $ipAddress = $matches[1];
+            } elseif (filter_var($headerIpAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) { // IPv6 without port
+                $ipAddress = $headerIpAddress;
+            } elseif (strpos($headerIpAddress, ':') !== false) { // IPv4 with port
+                $parts = explode(':', $headerIpAddress);
+                if (count($parts) === 2) {
+                    $ipAddress = $parts[0];
+                }
+            } elseif (filter_var($headerIpAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) { // IPv4 address
+                $ipAddress = $headerIpAddress;
+            }
+
+            if ($ipAddress !== false && !$this->ipIsTrustedProxy($ipAddress)) {
                 break;
             }
         }

--- a/Neos.Flow/Classes/Utility/Ip.php
+++ b/Neos.Flow/Classes/Utility/Ip.php
@@ -46,7 +46,7 @@ class Ip
             $bits = null;
             $subnet = $range;
         } else {
-            list($subnet, $bits) = explode('/', $range);
+            [$subnet, $bits] = explode('/', $range);
         }
 
         $ip = inet_pton($ip);
@@ -63,16 +63,16 @@ class Ip
 
         if ($bits === null) {
             return ($ip === $subnet);
-        } else {
-            for ($i = 0; $i < strlen($ip); $i++) {
-                $mask = 0;
-                if ($bits > 0) {
-                    $mask = ($bits >= 8) ? 255 : (256 - (1 << (8 - $bits)));
-                    $bits -= 8;
-                }
-                if ((ord($ip[$i]) & $mask) !== (ord($subnet[$i]) & $mask)) {
-                    return false;
-                }
+        }
+
+        for ($i = 0, $ipLength = strlen($ip); $i < $ipLength; $i++) {
+            $mask = 0;
+            if ($bits > 0) {
+                $mask = ($bits >= 8) ? 255 : (256 - (1 << (8 - $bits)));
+                $bits -= 8;
+            }
+            if ((ord($ip[$i]) & $mask) !== (ord($subnet[$i]) & $mask)) {
+                return false;
             }
         }
         return true;

--- a/Neos.Flow/Tests/Unit/Http/Middleware/TrustedProxiesMiddlewareTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Middleware/TrustedProxiesMiddlewareTest.php
@@ -347,6 +347,17 @@ class TrustedProxiesMiddlewareTest extends UnitTestCase
     /**
      * @test
      */
+    public function trustedClientIpV6AddressIsForwardedForAddressIfProxyTrusted()
+    {
+        $this->withTrustedProxiesSettings(['proxies' => ['127.0.0.1'], 'headers' => [TrustedProxiesMiddleware::HEADER_CLIENT_IP => 'X-Forwarded-For']]);
+        $request = $this->serverRequestFactory->createServerRequest('GET', new Uri('https://acme.com'), ['HTTP_X_FORWARDED_FOR' => '2001:db8:cafe::17']);
+        $trustedRequest = $this->callWithRequest($request);
+        self::assertEquals('2001:db8:cafe::17', $trustedRequest->getAttribute(ServerRequestAttributes::CLIENT_IP));
+    }
+
+    /**
+     * @test
+     */
     public function trustedClientIpAddressIsFirstForwardedForAddressIfAllProxiesTrusted()
     {
         $this->withTrustedProxiesSettings(['proxies' => '*', 'headers' => [TrustedProxiesMiddleware::HEADER_CLIENT_IP => 'X-Forwarded-For']]);

--- a/Neos.Flow/Tests/Unit/Http/Middleware/TrustedProxiesMiddlewareTest.php
+++ b/Neos.Flow/Tests/Unit/Http/Middleware/TrustedProxiesMiddlewareTest.php
@@ -349,6 +349,9 @@ class TrustedProxiesMiddlewareTest extends UnitTestCase
      */
     public function trustedClientIpV6AddressIsForwardedForAddressIfProxyTrusted()
     {
+        if (PHP_VERSION_ID < 80316 || (PHP_VERSION_ID >= 80400 && PHP_VERSION_ID < 80403)) {
+            $this->markTestSkipped('This test requires PHP 8.3.16+ or 8.4.3+, see https://github.com/neos/flow-development-collection/pull/3491#issuecomment-3423451375');
+        }
         $this->withTrustedProxiesSettings(['proxies' => ['127.0.0.1'], 'headers' => [TrustedProxiesMiddleware::HEADER_CLIENT_IP => 'X-Forwarded-For']]);
         $request = $this->serverRequestFactory->createServerRequest('GET', new Uri('https://acme.com'), ['HTTP_X_FORWARDED_FOR' => '2001:db8:cafe::17']);
         $trustedRequest = $this->callWithRequest($request);


### PR DESCRIPTION
When using IPv6, the method incorrectly returns invalid results. For an IPv6 address like `2001:db8:cafe::17` it would return `2001`, which is wrong.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
