### PR TITLE
!!! TASK: Upgrade psr/container and psr/http-message dependencies to `^2.0`

### DIFF
--- a/Neos.Flow/Classes/Http/ContentStream.php
+++ b/Neos.Flow/Classes/Http/ContentStream.php
@@ -69,7 +69,7 @@ class ContentStream implements StreamInterface
      *
      * @return void
      */
-    public function close()
+    public function close(): void
     {
         if (!$this->resource) {
             return;
@@ -119,7 +119,7 @@ class ContentStream implements StreamInterface
      *
      * @return int|null Returns the size in bytes if known, or null if unknown.
      */
-    public function getSize()
+    public function getSize(): ?int
     {
         if (!$this->isValidResource($this->resource)) {
             return null;
@@ -136,7 +136,7 @@ class ContentStream implements StreamInterface
      * @return int Position of the file pointer
      * @throws \RuntimeException on error.
      */
-    public function tell()
+    public function tell(): int
     {
         $this->ensureResourceOpen();
 
@@ -153,7 +153,7 @@ class ContentStream implements StreamInterface
      *
      * @return bool
      */
-    public function eof()
+    public function eof(): bool
     {
         if (!$this->isValidResource($this->resource)) {
             return true;
@@ -167,7 +167,7 @@ class ContentStream implements StreamInterface
      *
      * @return bool
      */
-    public function isSeekable()
+    public function isSeekable(): bool
     {
         if (!$this->isValidResource($this->resource)) {
             return false;
@@ -188,10 +188,9 @@ class ContentStream implements StreamInterface
      *     PHP $whence values for `fseek()`.  SEEK_SET: Set position equal to
      *     offset bytes SEEK_CUR: Set position to current location plus offset
      *     SEEK_END: Set position to end-of-stream plus offset.
-     * @return bool
      * @throws \RuntimeException on failure.
      */
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
         $this->ensureResourceOpen();
 
@@ -205,7 +204,7 @@ class ContentStream implements StreamInterface
             throw new \RuntimeException('Error seeking within stream', 1453892231);
         }
 
-        return true;
+        return;
     }
 
     /**
@@ -218,9 +217,9 @@ class ContentStream implements StreamInterface
      * @link http://www.php.net/manual/en/function.fseek.php
      * @throws \RuntimeException on failure.
      */
-    public function rewind()
+    public function rewind(): void
     {
-        return $this->seek(0);
+        $this->seek(0);
     }
 
     /**
@@ -228,7 +227,7 @@ class ContentStream implements StreamInterface
      *
      * @return bool
      */
-    public function isWritable()
+    public function isWritable(): bool
     {
         if (!$this->isValidResource($this->resource)) {
             return false;
@@ -253,7 +252,7 @@ class ContentStream implements StreamInterface
      * @return int Returns the number of bytes written to the stream.
      * @throws \RuntimeException on failure.
      */
-    public function write($string)
+    public function write($string): int
     {
         if (!$this->isWritable()) {
             throw new \RuntimeException('Stream is not writable', 1453892241);
@@ -273,7 +272,7 @@ class ContentStream implements StreamInterface
      *
      * @return bool
      */
-    public function isReadable()
+    public function isReadable(): bool
     {
         if (!$this->isValidResource($this->resource)) {
             return false;
@@ -295,7 +294,7 @@ class ContentStream implements StreamInterface
      *     if no bytes are available.
      * @throws \RuntimeException if an error occurs.
      */
-    public function read($length)
+    public function read($length): string
     {
         $this->ensureResourceReadable();
 
@@ -315,7 +314,7 @@ class ContentStream implements StreamInterface
      * @throws \RuntimeException if unable to read or an error occurs while
      *     reading.
      */
-    public function getContents()
+    public function getContents(): string
     {
         $this->ensureResourceReadable();
 
@@ -334,12 +333,12 @@ class ContentStream implements StreamInterface
      * stream_get_meta_data() function.
      *
      * @link http://php.net/manual/en/function.stream-get-meta-data.php
-     * @param string $key Specific metadata to retrieve.
+     * @param string|null $key Specific metadata to retrieve.
      * @return array|mixed|null Returns an associative array if no key is
      *     provided. Returns a specific key value if a key is provided and the
      *     value is found, or null if the key is not found.
      */
-    public function getMetadata($key = null)
+    public function getMetadata(?string $key = null)
     {
         if ($key === null) {
             return stream_get_meta_data($this->resource);
@@ -395,7 +394,7 @@ class ContentStream implements StreamInterface
      * @see http://php.net/manual/en/language.oop5.magic.php#object.tostring
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if (!$this->isReadable()) {
             return '';

--- a/Neos.Flow/Classes/Http/UploadedFile.php
+++ b/Neos.Flow/Classes/Http/UploadedFile.php
@@ -127,7 +127,7 @@ class UploadedFile implements UploadedFileInterface
      * @throws RuntimeException if the upload was not successful.
      * @api PSR-7
      */
-    public function getStream()
+    public function getStream(): StreamInterface
     {
         $this->throwExceptionIfNotAccessible();
 
@@ -172,7 +172,7 @@ class UploadedFile implements UploadedFileInterface
      *     the second or subsequent call to the method.
      * @api PSR-7
      */
-    public function moveTo($targetPath)
+    public function moveTo($targetPath): void
     {
         $this->throwExceptionIfNotAccessible();
 
@@ -203,7 +203,7 @@ class UploadedFile implements UploadedFileInterface
      * @return int|null The file size in bytes or null if unknown.
      * @api PSR-7
      */
-    public function getSize()
+    public function getSize(): ?int
     {
         return $this->size;
     }
@@ -223,7 +223,7 @@ class UploadedFile implements UploadedFileInterface
      * @return int One of PHP's UPLOAD_ERR_XXX constants.
      * @api PSR-7
      */
-    public function getError()
+    public function getError(): int
     {
         return $this->error;
     }
@@ -242,7 +242,7 @@ class UploadedFile implements UploadedFileInterface
      *     was provided.
      * @api PSR-7
      */
-    public function getClientFilename()
+    public function getClientFilename(): ?string
     {
         return $this->clientFilename;
     }
@@ -259,7 +259,7 @@ class UploadedFile implements UploadedFileInterface
      *
      * @api PSR-7
      */
-    public function getClientMediaType()
+    public function getClientMediaType(): ?string
     {
         return $this->clientMediaType;
     }

--- a/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
@@ -164,7 +164,7 @@ class ObjectManager implements ObjectManagerInterface
      * @param string $objectName
      * @return bool
      */
-    public function has($objectName): bool
+    public function has(string $objectName): bool
     {
         return $this->isRegistered($objectName);
     }
@@ -200,7 +200,7 @@ class ObjectManager implements ObjectManagerInterface
      * @throws InvalidConfigurationTypeException
      * @api
      */
-    public function get($objectName, ...$constructorArguments): object
+    public function get(string $objectName, ...$constructorArguments): object
     {
         if (!empty($constructorArguments) && isset($this->objects[$objectName]) && $this->objects[$objectName][self::KEY_SCOPE] !== ObjectConfiguration::SCOPE_PROTOTYPE) {
             throw new \InvalidArgumentException('You cannot provide constructor arguments for singleton objects via get(). If you need to pass arguments to the constructor, define them in the Objects.yaml configuration.', 1298049934);

--- a/Neos.Flow/Classes/ObjectManagement/ObjectManagerInterface.php
+++ b/Neos.Flow/Classes/ObjectManagement/ObjectManagerInterface.php
@@ -50,7 +50,7 @@ interface ObjectManagerInterface extends ContainerInterface
      * @return T The object instance
      * @api
      */
-    public function get($objectName, ...$constructorArguments);
+    public function get(string $objectName, ...$constructorArguments);
 
     /**
      * This is the PSR-11 ContainerInterface equivalent to `isRegistered`.
@@ -59,7 +59,7 @@ interface ObjectManagerInterface extends ContainerInterface
      * @return bool
      * @see isRegistered
      */
-    public function has($objectName);
+    public function has(string $objectName): bool;
 
     /**
      * Returns true if an object with the given name has already

--- a/Neos.Flow/Tests/Unit/Validation/Validator/FileSizeValidatorTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/Validator/FileSizeValidatorTest.php
@@ -38,7 +38,7 @@ class FileSizeValidatorTest extends AbstractValidatorTestcase
         return $mock;
     }
 
-    protected function createUploadedFileInterfaceMock(string $filesize): UploadedFileInterface
+    protected function createUploadedFileInterfaceMock(int $filesize): UploadedFileInterface
     {
         $mock = $this->createMock(UploadedFileInterface::class);
         $mock->expects($this->once())->method('getSize')->willReturn($filesize);

--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -33,7 +33,7 @@
 
         "psr/http-message": "^1.0",
         "psr/http-factory": "^1.0",
-        "psr/container": "^1.0",
+        "psr/container": "^2.0",
         "psr/log": "^2.0 || ^3.0",
         "psr/http-server-middleware": "^1.0",
         "psr/http-server-handler": "^1.0",

--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -31,7 +31,7 @@
 
         "neos/composer-plugin": "^2.0",
 
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^2.0",
         "psr/http-factory": "^1.0",
         "psr/container": "^2.0",
         "psr/log": "^2.0 || ^3.0",

--- a/Neos.Http.Factories/composer.json
+++ b/Neos.Http.Factories/composer.json
@@ -8,7 +8,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "psr/http-factory": "^1.0",
+        "psr/http-factory": "^2.0",
         "guzzlehttp/psr7": "^1.8.4 || ^2.1.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "neos/composer-plugin": "^2.0",
         "psr/http-message": "^1.0",
         "psr/http-factory": "^1.0",
-        "psr/container": "^1.0",
+        "psr/container": "^2.0",
         "psr/http-server-middleware": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-client": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "ext-xml": "*",
         "ext-xmlreader": "*",
         "neos/composer-plugin": "^2.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^2.0",
         "psr/http-factory": "^1.0",
         "psr/container": "^2.0",
         "psr/http-server-middleware": "^1.0",


### PR DESCRIPTION
- [x] Upgrade psr/container dependency from `^1.0` to `^2.0`
- [x] Upgrade psr/http-message dependency from `^1.0` to `^2.0`

resolves: #3497

**Upgrade instructions**

If you extend any of the interfaces in the upgraded packages you will have to add the return type informations to the methods you implement and override. Behavior has not been changed but return types.

**Review instructions**

Not sure wether this can be added to 9.x or wether this has to wait for 10.0. I mark this as breaky for now.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
