### PR TITLE
BUGFIX: `configuration:show` with non array value crashing when accesed via `--path`

### DIFF
--- a/Neos.Flow/Classes/Command/ConfigurationCommandController.php
+++ b/Neos.Flow/Classes/Command/ConfigurationCommandController.php
@@ -78,7 +78,7 @@ class ConfigurationCommandController extends CommandController
                 $this->outputLine('<b>Configuration "%s" was empty!</b>', [$typeAndPath]);
                 return;
             }
-            $configuration = self::truncateArrayAtDepth($configuration, $depth);
+            $configuration = is_array($configuration) ? self::truncateArrayAtDepth($configuration, $depth) : $configuration;
             $yaml = Yaml::dump($configuration, 99);
             $this->outputLine('<b>Configuration "%s":</b>', [$typeAndPath]);
             $this->outputLine();


### PR DESCRIPTION

fixup like https://github.com/neos/flow-development-collection/pull/3483

a bool for example

```
flow configuration:show --path Neos.Neos.Ui.frontendDevelopmentMode
```

should output `true`

but

> Neos\Flow\Command\ConfigurationCommandController_Original::truncateArrayAtDepth(): Argument #1 ($array) must be of type array, true given

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
