### PR TITLE
BUGFIX: Support ORM attributes

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -11,8 +11,6 @@ namespace Neos\Flow\Persistence\Doctrine\Mapping\Driver;
  * source code.
  */
 
-use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\IndexedReader;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver as DoctrineMappingDriverInterface;
 use Doctrine\ORM\EntityManagerInterface;
@@ -58,7 +56,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
     protected $reflectionService;
 
     /**
-     * @var AnnotationReader
+     * @var FlowAnotationReader
      */
     protected $reader;
 
@@ -78,21 +76,13 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
     protected $tableNameLengthLimit = null;
 
     /**
-     * Initializes a new AnnotationDriver that uses the given AnnotationReader for reading
-     * docblock annotations.
-     */
-    public function __construct()
-    {
-        $this->reader = new IndexedReader(new AnnotationReader());
-    }
-
-    /**
      * @param ReflectionService $reflectionService
      * @return void
      */
     public function injectReflectionService(ReflectionService $reflectionService)
     {
         $this->reflectionService = $reflectionService;
+        $this->reader = new FlowAnotationReader($reflectionService);
     }
 
     /**

--- a/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -79,7 +79,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
      * @param ReflectionService $reflectionService
      * @return void
      */
-    public function injectReflectionService(ReflectionService $reflectionService)
+    public function injectReflectionService(ReflectionService $reflectionService): void
     {
         $this->reflectionService = $reflectionService;
         $this->reader = new FlowAnotationReader($reflectionService);
@@ -89,7 +89,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
      * @param EntityManagerInterface $entityManager
      * @return void
      */
-    public function setEntityManager(EntityManagerInterface $entityManager)
+    public function setEntityManager(EntityManagerInterface $entityManager): void
     {
         $this->entityManager = $entityManager;
     }
@@ -101,7 +101,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
      * @return ClassSchema
      * @throws ClassSchemaNotFoundException
      */
-    protected function getClassSchema($className)
+    protected function getClassSchema($className): ClassSchema
     {
         $classSchema = $this->reflectionService->getClassSchema($className);
         if (!$classSchema) {
@@ -119,13 +119,13 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
      * @return boolean
      * @throws ClassSchemaNotFoundException
      */
-    protected function isAggregateRoot($className, $propertySourceHint)
+    protected function isAggregateRoot($className, $propertySourceHint): bool
     {
         $className = $this->getUnproxiedClassName($className);
         try {
             return $this->getClassSchema($className)->isAggregateRoot();
         } catch (ClassSchemaNotFoundException $exception) {
-            throw new ClassSchemaNotFoundException('No class schema found for "' . $className . '". The class should probably marked as entity or value object! This happened while examining "' . $propertySourceHint . '"', 1340185197);
+            throw new ClassSchemaNotFoundException('No class schema found for "' . $className . '". The class should probably marked as entity or value object! This happened while examining "' . $propertySourceHint . '"', 1340185197, $exception);
         }
     }
 
@@ -137,7 +137,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
      * @return boolean
      * @throws ClassSchemaNotFoundException
      */
-    protected function isValueObject($className, $propertySourceHint)
+    protected function isValueObject($className, $propertySourceHint): bool
     {
         $className = $this->getUnproxiedClassName($className);
         try {
@@ -158,7 +158,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
      * @throws ORM\MappingException
      * @throws \UnexpectedValueException
      */
-    public function loadMetadataForClass($className, ClassMetadata $metadata)
+    public function loadMetadataForClass($className, ClassMetadata $metadata): void
     {
         /**
          * This is the actual type we have at this point, but we cannot change the
@@ -347,7 +347,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
             $inheritanceTypeAnnotation = $classAnnotations[ORM\InheritanceType::class];
             $inheritanceType = constant('Doctrine\ORM\Mapping\ClassMetadata::INHERITANCE_TYPE_' . strtoupper($inheritanceTypeAnnotation->value));
 
-            if ($inheritanceType !== ORM\ClassMetadata::INHERITANCE_TYPE_NONE) {
+            if ($inheritanceType !== ORM\ClassMetadataInfo::INHERITANCE_TYPE_NONE) {
                 // Evaluate DiscriminatorColumn annotation
                 if (isset($classAnnotations[ORM\DiscriminatorColumn::class])) {
                     $discriminatorColumnAnnotation = $classAnnotations[ORM\DiscriminatorColumn::class];
@@ -384,7 +384,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
                     $metadata->setDiscriminatorColumn($discriminatorColumn);
                     $metadata->setDiscriminatorMap($discriminatorMap);
                 } else {
-                    $inheritanceType = ORM\ClassMetadata::INHERITANCE_TYPE_NONE;
+                    $inheritanceType = ORM\ClassMetadataInfo::INHERITANCE_TYPE_NONE;
                 }
             }
 
@@ -396,7 +396,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
             $changeTrackingAnnotation = $classAnnotations[ORM\ChangeTrackingPolicy::class];
             $metadata->setChangeTrackingPolicy(constant('Doctrine\ORM\Mapping\ClassMetadata::CHANGETRACKING_' . strtoupper($changeTrackingAnnotation->value)));
         } else {
-            $metadata->setChangeTrackingPolicy(ORM\ClassMetadata::CHANGETRACKING_DEFERRED_EXPLICIT);
+            $metadata->setChangeTrackingPolicy(ORM\ClassMetadataInfo::CHANGETRACKING_DEFERRED_EXPLICIT);
         }
 
         // Evaluate annotations on properties/fields
@@ -437,7 +437,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
      * @param integer $lengthLimit
      * @return string
      */
-    public function inferTableNameFromClassName($className, $lengthLimit = null)
+    public function inferTableNameFromClassName($className, $lengthLimit = null): string
     {
         return $this->truncateIdentifier(strtolower(str_replace('\\', '_', $className)), $lengthLimit, $className);
     }
@@ -448,20 +448,15 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
      * @param string $className
      * @return string
      */
-    public static function inferDiscriminatorTypeFromClassName($className)
+    public static function inferDiscriminatorTypeFromClassName($className): string
     {
         return strtolower(str_replace('Domain_Model_', '', str_replace('\\', '_', $className)));
     }
 
     /**
      * Truncate an identifier if needed and append a hash to ensure uniqueness.
-     *
-     * @param string $identifier
-     * @param integer $lengthLimit
-     * @param string $hashSource
-     * @return string
      */
-    protected function truncateIdentifier($identifier, $lengthLimit = null, $hashSource = null)
+    protected function truncateIdentifier(string $identifier, ?int $lengthLimit = null, ?string $hashSource = null): string
     {
         if ($lengthLimit === null) {
             $lengthLimit = $this->getMaxIdentifierLength();
@@ -475,12 +470,8 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
 
     /**
      * Given a class and property name a table name is returned. That name should be reasonably unique.
-     *
-     * @param string $className Model class name the table corresponds to
-     * @param string $propertyName Name of the property to be joined
-     * @return string Truncated database table name
      */
-    protected function inferJoinTableNameFromClassAndPropertyName($className, $propertyName)
+    protected function inferJoinTableNameFromClassAndPropertyName(string $className, string $propertyName): string
     {
         $prefix = $this->inferTableNameFromClassName($className);
         $suffix = '_' . strtolower($propertyName . '_join');
@@ -499,15 +490,12 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
 
     /**
      * Build a name for a column in a jointable.
-     *
-     * @param string $className
-     * @return string
      */
-    protected function buildJoinTableColumnName($className)
+    protected function buildJoinTableColumnName(string $className): string
     {
         if (preg_match('/^(?P<PackageNamespace>\w+(?:\\\\\w+)*)\\\\Domain\\\\Model\\\\(?P<ModelNamePrefix>(\w+\\\\)?)(?P<ModelName>\w+)$/', $className, $matches)) {
             $packageNamespaceParts = explode('\\', $matches['PackageNamespace']);
-            $tableName = strtolower(strtr($packageNamespaceParts[count($packageNamespaceParts) - 1], '\\', '_') . ($matches['ModelNamePrefix'] !== '' ? '_' . strtr(rtrim($matches['ModelNamePrefix'], '\\'), '\\', '_') : '') . '_' . $matches['ModelName']);
+            $tableName = strtolower(str_replace('\\', '_', $packageNamespaceParts[count($packageNamespaceParts) - 1]) . ($matches['ModelNamePrefix'] !== '' ? '_' . strtr(rtrim($matches['ModelNamePrefix'], '\\'), '\\', '_') : '') . '_' . $matches['ModelName']);
         } else {
             $classNameParts = explode('\\', $className);
             $tableName = strtolower($classNameParts[1] . '_' . implode('_', array_slice($classNameParts, -2, 2)));
@@ -520,13 +508,9 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
      * Check if the referenced column name is set (and valid) and if not make sure
      * it is initialized properly.
      *
-     * @param array $joinColumns
-     * @param array $mapping
-     * @param \ReflectionProperty $property
-     * @param integer $direction regular or inverse mapping (use is to be coded)
-     * @return array
+     * @param int $direction regular or inverse mapping (use is to be coded)
      */
-    protected function buildJoinColumnsIfNeeded(array $joinColumns, array $mapping, \ReflectionProperty $property, $direction = self::MAPPING_REGULAR)
+    protected function buildJoinColumnsIfNeeded(array $joinColumns, array $mapping, \ReflectionProperty $property, int $direction = self::MAPPING_REGULAR): array
     {
         if ($joinColumns === []) {
             $joinColumns[] = [
@@ -560,11 +544,9 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
     /**
      * Evaluate the property annotations and amend the metadata accordingly.
      *
-     * @param ORM\ClassMetadataInfo $metadata
-     * @return void
      * @throws ORM\MappingException
      */
-    protected function evaluatePropertyAnnotations(ORM\ClassMetadataInfo $metadata)
+    protected function evaluatePropertyAnnotations(ORM\ClassMetadataInfo $metadata): void
     {
         $className = $metadata->name;
 
@@ -843,14 +825,8 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
 
     /**
      * Evaluate JoinTable annotations and fill missing bits as needed.
-     *
-     * @param ORM\JoinTable $joinTableAnnotation
-     * @param \ReflectionProperty $property
-     * @param string $className
-     * @param array $mapping
-     * @return array
      */
-    protected function evaluateJoinTableAnnotation(ORM\JoinTable $joinTableAnnotation, \ReflectionProperty $property, $className, array $mapping)
+    protected function evaluateJoinTableAnnotation(ORM\JoinTable $joinTableAnnotation, \ReflectionProperty $property, string $className, array $mapping): array
     {
         $joinTable = [
             'name' => $joinTableAnnotation->name,
@@ -894,14 +870,11 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
     }
 
     /**
-     * Check for and build JoinColummn/JoinColumns annotations.
+     * Check for and build JoinColumn/JoinColumns annotations.
      *
      * If no annotations are found, a default is returned.
-     *
-     * @param \ReflectionProperty $property
-     * @return array
      */
-    protected function evaluateJoinColumnAnnotations(\ReflectionProperty $property)
+    protected function evaluateJoinColumnAnnotations(\ReflectionProperty $property): array
     {
         $joinColumns = [];
 
@@ -918,12 +891,8 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
 
     /**
      * Evaluate the association overrides annotations and amend the metadata accordingly.
-     *
-     * @param array $classAnnotations
-     * @param ORM\ClassMetadataInfo $metadata
-     * @return void
      */
-    protected function evaluateOverridesAnnotations(array $classAnnotations, ORM\ClassMetadataInfo $metadata)
+    protected function evaluateOverridesAnnotations(array $classAnnotations, ORM\ClassMetadataInfo $metadata): void
     {
         if (isset($classAnnotations[ORM\AssociationOverrides::class])) {
             $associationOverridesAnnotation = $classAnnotations[ORM\AssociationOverrides::class];
@@ -978,13 +947,9 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
     /**
      * Evaluate the EntityListeners annotation and amend the metadata accordingly.
      *
-     * @param \ReflectionClass $class
-     * @param ORM\ClassMetadata $metadata
-     * @param array $classAnnotations
-     * @return void
      * @throws ORM\MappingException
      */
-    protected function evaluateEntityListenersAnnotation(\ReflectionClass $class, ORM\ClassMetadata $metadata, array $classAnnotations)
+    protected function evaluateEntityListenersAnnotation(\ReflectionClass $class, ORM\ClassMetadata $metadata, array $classAnnotations): void
     {
         if (isset($classAnnotations[ORM\EntityListeners::class])) {
             $entityListenersAnnotation = $classAnnotations[ORM\EntityListeners::class];
@@ -1019,12 +984,8 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
 
     /**
      * Evaluate the lifecycle annotations and amend the metadata accordingly.
-     *
-     * @param \ReflectionClass $class
-     * @param ORM\ClassMetadataInfo $metadata
-     * @return void
      */
-    protected function evaluateLifeCycleAnnotations(\ReflectionClass $class, ORM\ClassMetadataInfo $metadata)
+    protected function evaluateLifeCycleAnnotations(\ReflectionClass $class, ORM\ClassMetadataInfo $metadata): void
     {
         foreach ($class->getMethods() as $method) {
             if ($method->isPublic()) {
@@ -1042,11 +1003,8 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
 
     /**
      * Returns an array of callbacks for lifecycle annotations on the given method.
-     *
-     * @param \ReflectionMethod $method
-     * @return array
      */
-    protected function getMethodCallbacks(\ReflectionMethod $method)
+    protected function getMethodCallbacks(\ReflectionMethod $method): array
     {
         $callbacks = [];
         $annotations = $this->reader->getMethodAnnotations($method);
@@ -1090,10 +1048,8 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
 
     /**
      * Derive maximum identifier length from doctrine DBAL
-     *
-     * @return integer
      */
-    protected function getMaxIdentifierLength()
+    protected function getMaxIdentifierLength(): int
     {
         if ($this->tableNameLengthLimit === null) {
             $this->tableNameLengthLimit = $this->entityManager->getConnection()->getDatabasePlatform()->getMaxIdentifierLength();
@@ -1105,13 +1061,10 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
     /**
      * Returns whether the class with the specified name is transient. Only non-transient
      * classes, that is entities and mapped superclasses, should have their metadata loaded.
-     *
-     * @param string $className
-     * @return boolean
      */
-    public function isTransient($className)
+    public function isTransient(string $className): bool
     {
-        return strpos($className, Compiler::ORIGINAL_CLASSNAME_SUFFIX) !== false ||
+        return str_contains($className, Compiler::ORIGINAL_CLASSNAME_SUFFIX) ||
             (
                 !$this->reflectionService->isClassAnnotatedWith($className, Flow\Entity::class) &&
                 !$this->reflectionService->isClassAnnotatedWith($className, Flow\ValueObject::class) &&
@@ -1123,10 +1076,8 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
 
     /**
      * Returns the names of all mapped (non-transient) classes known to this driver.
-     *
-     * @return array
      */
-    public function getAllClassNames()
+    public function getAllClassNames(): array
     {
         if (is_array($this->classNames)) {
             return $this->classNames;
@@ -1152,12 +1103,8 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
 
     /**
      * Parse the given JoinColumn into an array
-     *
-     * @param ORM\JoinColumn $joinColumnAnnotation
-     * @param string $propertyName
-     * @return array
      */
-    protected function joinColumnToArray(ORM\JoinColumn $joinColumnAnnotation, $propertyName = null)
+    protected function joinColumnToArray(ORM\JoinColumn $joinColumnAnnotation, ?string $propertyName = null): array
     {
         return [
             'name' => $joinColumnAnnotation->name === null ? $propertyName : $joinColumnAnnotation->name,
@@ -1171,13 +1118,8 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
 
     /**
      * Parse the given Column into an array
-     *
-     * @param ORM\Column $columnAnnotation
-     * @param array $mapping
-     * @param string $fieldName
-     * @return array
      */
-    protected function addColumnToMappingArray(ORM\Column $columnAnnotation, array $mapping = [], $fieldName = null)
+    protected function addColumnToMappingArray(ORM\Column $columnAnnotation, array $mapping = [], ?string $fieldName = null): array
     {
         if ($fieldName !== null) {
             $mapping['fieldName'] = $fieldName;
@@ -1207,15 +1149,10 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
 
     /**
      * Returns the classname after stripping a potentially present Compiler::ORIGINAL_CLASSNAME_SUFFIX.
-     *
-     * @param string $className
-     * @return string
      */
-    protected function getUnproxiedClassName($className)
+    protected function getUnproxiedClassName(string $className): string
     {
-        $className = preg_replace('/' . Compiler::ORIGINAL_CLASSNAME_SUFFIX . '$/', '', $className);
-
-        return $className;
+        return preg_replace('/' . Compiler::ORIGINAL_CLASSNAME_SUFFIX . '$/', '', $className);
     }
 
     /**
@@ -1226,7 +1163,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
      * @return integer The fetch mode as defined in ClassMetadata
      * @throws ORM\MappingException If the fetch mode is not valid
      */
-    private function getFetchMode($className, $fetchMode)
+    private function getFetchMode($className, $fetchMode): int
     {
         $fetchMode = strtoupper($fetchMode);
         if (!defined('Doctrine\ORM\Mapping\ClassMetadata::FETCH_' . $fetchMode)) {
@@ -1245,7 +1182,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
      * @param mixed $pointcutQueryIdentifier Some identifier for this query - must at least differ from a previous identifier. Used for circular reference detection.
      * @return boolean true if the class has *no* Id properties
      */
-    public function matches($className, $methodName, $methodDeclaringClassName, $pointcutQueryIdentifier)
+    public function matches($className, $methodName, $methodDeclaringClassName, $pointcutQueryIdentifier): bool
     {
         $class = new \ReflectionClass($className);
         foreach ($class->getProperties() as $property) {
@@ -1262,7 +1199,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
      *
      * @return boolean true if this filter has runtime evaluations
      */
-    public function hasRuntimeEvaluationsDefinition()
+    public function hasRuntimeEvaluationsDefinition(): bool
     {
         return false;
     }
@@ -1272,7 +1209,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
      *
      * @return array Runtime evaluations
      */
-    public function getRuntimeEvaluationsDefinition()
+    public function getRuntimeEvaluationsDefinition(): array
     {
         return [];
     }
@@ -1283,7 +1220,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
      * @param ClassNameIndex $classNameIndex
      * @return ClassNameIndex
      */
-    public function reduceTargetClassNames(ClassNameIndex $classNameIndex)
+    public function reduceTargetClassNames(ClassNameIndex $classNameIndex): ClassNameIndex
     {
         return $classNameIndex;
     }

--- a/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -133,9 +133,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
     {
         $className = $this->getUnproxiedClassName($className);
         try {
-            $classSchema = $this->getClassSchema($className);
-
-            return $classSchema->isAggregateRoot();
+            return $this->getClassSchema($className)->isAggregateRoot();
         } catch (ClassSchemaNotFoundException $exception) {
             throw new ClassSchemaNotFoundException('No class schema found for "' . $className . '". The class should probably marked as entity or value object! This happened while examining "' . $propertySourceHint . '"', 1340185197);
         }
@@ -157,7 +155,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
 
             return $classSchema->getModelType() === ClassSchema::MODELTYPE_VALUEOBJECT;
         } catch (ClassSchemaNotFoundException $exception) {
-            throw new ClassSchemaNotFoundException('No class schema found for "' . $className . '". The class should probably marked as entity or value object! This happened while examining "' . $propertySourceHint . '"', 1340185197);
+            throw new ClassSchemaNotFoundException('No class schema found for "' . $className . '". The class should probably marked as entity or value object! This happened while examining "' . $propertySourceHint . '"', 1340185197, $exception);
         }
     }
 

--- a/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -158,7 +158,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
      * @throws ORM\MappingException
      * @throws \UnexpectedValueException
      */
-    public function loadMetadataForClass($className, ClassMetadata $metadata): void
+    public function loadMetadataForClass($className, ClassMetadata $metadata)
     {
         /**
          * This is the actual type we have at this point, but we cannot change the
@@ -1062,7 +1062,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
      * Returns whether the class with the specified name is transient. Only non-transient
      * classes, that is entities and mapped superclasses, should have their metadata loaded.
      */
-    public function isTransient(string $className): bool
+    public function isTransient($className)
     {
         return str_contains($className, Compiler::ORIGINAL_CLASSNAME_SUFFIX) ||
             (
@@ -1077,7 +1077,7 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
     /**
      * Returns the names of all mapped (non-transient) classes known to this driver.
      */
-    public function getAllClassNames(): array
+    public function getAllClassNames()
     {
         if (is_array($this->classNames)) {
             return $this->classNames;

--- a/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnotationReader.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnotationReader.php
@@ -14,6 +14,7 @@ namespace Neos\Flow\Persistence\Doctrine\Mapping\Driver;
  */
 
 use Doctrine\Common\Annotations\Reader;
+use Neos\Flow\ObjectManagement\Proxy\Compiler;
 use Neos\Flow\Reflection\ReflectionService;
 use ReflectionClass;
 use ReflectionMethod;
@@ -36,8 +37,9 @@ class FlowAnotationReader implements Reader
      */
     public function getClassAnnotations(ReflectionClass $class)
     {
+        $className = $this->getUnproxiedClassName($class->getName());
         $indexedAnnotations = [];
-        foreach ($this->reflectionService->getClassAnnotations($class->getName()) as $annotation) {
+        foreach ($this->reflectionService->getClassAnnotations($className) as $annotation) {
             $indexedAnnotations[get_class($annotation)] = $annotation;
         }
         return $indexedAnnotations;
@@ -53,7 +55,8 @@ class FlowAnotationReader implements Reader
      */
     public function getClassAnnotation(ReflectionClass $class, $annotationName)
     {
-        return $this->reflectionService->getClassAnnotation($class->getName(), $annotationName);
+        $className = $this->getUnproxiedClassName($class->getName());
+        return $this->reflectionService->getClassAnnotation($className, $annotationName);
     }
 
     /**
@@ -64,8 +67,9 @@ class FlowAnotationReader implements Reader
      */
     public function getMethodAnnotations(ReflectionMethod $method)
     {
+        $className = $this->getUnproxiedClassName($method->class);
         $indexedAnnotations = [];
-        foreach ($this->reflectionService->getMethodAnnotations($method->class, $method->getName()) as $annotation) {
+        foreach ($this->reflectionService->getMethodAnnotations($className, $method->getName()) as $annotation) {
             $indexedAnnotations[get_class($annotation)] = $annotation;
         }
         return $indexedAnnotations;
@@ -81,7 +85,8 @@ class FlowAnotationReader implements Reader
      */
     public function getMethodAnnotation(ReflectionMethod $method, $annotationName)
     {
-        return $this->reflectionService->getMethodAnnotation($method->class, $method->getName(), $annotationName);
+        $className = $this->getUnproxiedClassName($method->class);
+        return $this->reflectionService->getMethodAnnotation($className, $method->getName(), $annotationName);
     }
 
     /**
@@ -92,8 +97,9 @@ class FlowAnotationReader implements Reader
      */
     public function getPropertyAnnotations(ReflectionProperty $property)
     {
+        $className = $this->getUnproxiedClassName($property->class);
         $indexedAnnotations = [];
-        foreach ($this->reflectionService->getPropertyAnnotations($property->class, $property->getName()) as $annotation) {
+        foreach ($this->reflectionService->getPropertyAnnotations($className, $property->getName()) as $annotation) {
             $indexedAnnotations[get_class($annotation)] = $annotation;
         }
         return $indexedAnnotations;
@@ -109,6 +115,18 @@ class FlowAnotationReader implements Reader
      */
     public function getPropertyAnnotation(ReflectionProperty $property, $annotationName)
     {
-        return $this->reflectionService->getPropertyAnnotation($property->class, $property->getName(), $annotationName);
+        $className = $this->getUnproxiedClassName($property->class);
+        return $this->reflectionService->getPropertyAnnotation($className, $property->getName(), $annotationName);
+    }
+
+    /**
+     * Returns the classname after stripping a potentially present Compiler::ORIGINAL_CLASSNAME_SUFFIX.
+     *
+     * @param string $className
+     * @return string
+     */
+    protected function getUnproxiedClassName($className)
+    {
+        return preg_replace('/' . Compiler::ORIGINAL_CLASSNAME_SUFFIX . '$/', '', $className);
     }
 }

--- a/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnotationReader.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnotationReader.php
@@ -1,0 +1,114 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Mapping\Driver;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\Common\Annotations\Reader;
+use Neos\Flow\Reflection\ReflectionService;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+
+class FlowAnotationReader implements Reader
+{
+    private ReflectionService $reflectionService;
+
+    public function __construct(ReflectionService $reflectionService)
+    {
+        $this->reflectionService = $reflectionService;
+    }
+
+    /**
+     * Gets the annotations applied to a class.
+     *
+     * @param ReflectionClass $class The ReflectionClass of the class from which the class annotations should be read.
+     * @return array<object> An array of Annotations.
+     */
+    public function getClassAnnotations(ReflectionClass $class)
+    {
+        $indexedAnnotations = [];
+        foreach ($this->reflectionService->getClassAnnotations($class->getName()) as $annotation) {
+            $indexedAnnotations[get_class($annotation)] = $annotation;
+        }
+        return $indexedAnnotations;
+    }
+
+    /**
+     * Gets a class annotation.
+     *
+     * @param ReflectionClass $class The ReflectionClass of the class from which the class annotations should be read.
+     * @param class-string<T> $annotationName The name of the annotation.
+     * @return T|null The Annotation or NULL, if the requested annotation does not exist.
+     * @template T
+     */
+    public function getClassAnnotation(ReflectionClass $class, $annotationName)
+    {
+        return $this->reflectionService->getClassAnnotation($class->getName(), $annotationName);
+    }
+
+    /**
+     * Gets the annotations applied to a method.
+     *
+     * @param ReflectionMethod $method The ReflectionMethod of the method from which the annotations should be read.
+     * @return array<object> An array of Annotations.
+     */
+    public function getMethodAnnotations(ReflectionMethod $method)
+    {
+        $indexedAnnotations = [];
+        foreach ($this->reflectionService->getMethodAnnotations($method->class, $method->getName()) as $annotation) {
+            $indexedAnnotations[get_class($annotation)] = $annotation;
+        }
+        return $indexedAnnotations;
+    }
+
+    /**
+     * Gets a method annotation.
+     *
+     * @param ReflectionMethod $method The ReflectionMethod to read the annotations from.
+     * @param class-string<T> $annotationName The name of the annotation.
+     * @return T|null The Annotation or NULL, if the requested annotation does not exist.
+     * @template T
+     */
+    public function getMethodAnnotation(ReflectionMethod $method, $annotationName)
+    {
+        return $this->reflectionService->getMethodAnnotation($method->class, $method->getName(), $annotationName);
+    }
+
+    /**
+     * Gets the annotations applied to a property.
+     *
+     * @param ReflectionProperty $property The ReflectionProperty of the property from which the annotations should be read.
+     * @return array<object> An array of Annotations.
+     */
+    public function getPropertyAnnotations(ReflectionProperty $property)
+    {
+        $indexedAnnotations = [];
+        foreach ($this->reflectionService->getPropertyAnnotations($property->class, $property->getName()) as $annotation) {
+            $indexedAnnotations[get_class($annotation)] = $annotation;
+        }
+        return $indexedAnnotations;
+    }
+
+    /**
+     * Gets a property annotation.
+     *
+     * @param ReflectionProperty $property The ReflectionProperty to read the annotations from.
+     * @param class-string<T> $annotationName The name of the annotation.
+     * @return T|null The Annotation or NULL, if the requested annotation does not exist.
+     * @template T
+     */
+    public function getPropertyAnnotation(ReflectionProperty $property, $annotationName)
+    {
+        return $this->reflectionService->getPropertyAnnotation($property->class, $property->getName(), $annotationName);
+    }
+}

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1572,6 +1572,8 @@ class ReflectionService
         if (count($varTagValues) > 1) {
             throw new InvalidPropertyTypeException('More than one @var annotation given for "' . $className . '::$' . $propertyName . '"', 1367334366);
         }
+        // We need var tags for typed arrays or collections as those cannot be
+        // expressed natively so they have to take precedence
         if (count($varTagValues) === 0) {
             $declaredType = $this->getPropertyType($className, $propertyName);
         } else {

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -1568,16 +1568,19 @@ class ReflectionService
             return false;
         }
 
-        if (!$this->isPropertyTaggedWith($className, $propertyName, 'var')) {
-            return false;
-        }
-
         $varTagValues = $this->getPropertyTagValues($className, $propertyName, 'var');
         if (count($varTagValues) > 1) {
             throw new InvalidPropertyTypeException('More than one @var annotation given for "' . $className . '::$' . $propertyName . '"', 1367334366);
         }
+        if (count($varTagValues) === 0) {
+            $declaredType = $this->getPropertyType($className, $propertyName);
+        } else {
+            $declaredType = strtok(trim(current($varTagValues), " \n\t"), " \n\t");
+        }
 
-        $declaredType = strtok(trim(current($varTagValues), " \n\t"), " \n\t");
+        if (!$declaredType) {
+            return false;
+        }
 
         if ($this->isPropertyAnnotatedWith($className, $propertyName, ORM\Id::class)) {
             $skipArtificialIdentity = true;

--- a/Neos.Flow/Tests/Functional/Persistence/Aspect/PersistenceMagicAspectTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Aspect/PersistenceMagicAspectTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Aspect;
 
 /*
@@ -21,7 +23,7 @@ use Neos\Flow\Tests\FunctionalTestCase;
 class PersistenceMagicAspectTest extends FunctionalTestCase
 {
     /**
-     * @var boolean
+     * @var bool
      */
     protected static $testablePersistenceEnabled = true;
 
@@ -32,23 +34,23 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {
-            $this->markTestSkipped('Doctrine persistence is not enabled');
+            static::markTestSkipped('Doctrine persistence is not enabled');
         }
     }
 
     /**
      * @test
      */
-    public function aspectIntroducesUuidIdentifierToEntities()
+    public function aspectIntroducesUuidIdentifierToEntities(): void
     {
         $entity = new Fixtures\AnnotatedIdentitiesEntity();
-        $this->assertStringMatchesFormat('%x%x%x%x%x%x%x%x-%x%x%x%x-%x%x%x%x-%x%x%x%x-%x%x%x%x%x%x%x%x', $this->persistenceManager->getIdentifierByObject($entity));
+        static::assertStringMatchesFormat('%x%x%x%x%x%x%x%x-%x%x%x%x-%x%x%x%x-%x%x%x%x-%x%x%x%x%x%x%x%x', $this->persistenceManager->getIdentifierByObject($entity));
     }
 
     /**
      * @test
      */
-    public function aspectDoesNotIntroduceUuidIdentifierToEntitiesWithCustomIdProperties()
+    public function aspectDoesNotIntroduceUuidIdentifierToEntitiesWithCustomIdProperties(): void
     {
         $entity = new Fixtures\AnnotatedIdEntity();
         self::assertNull($this->persistenceManager->getIdentifierByObject($entity));
@@ -57,23 +59,24 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function aspectFlagsClonedEntities()
+    public function aspectFlagsClonedEntities(): void
     {
         $entity = new Fixtures\AnnotatedIdEntity();
         $clonedEntity = clone $entity;
-        self::assertObjectNotHasAttribute('Flow_Persistence_clone', $entity);
-        $this->assertObjectHasAttribute('Flow_Persistence_clone', $clonedEntity);
+        self::assertObjectNotHasProperty('Flow_Persistence_clone', $entity);
+        static::assertObjectHasProperty('Flow_Persistence_clone', $clonedEntity);
+        /** @noinspection PhpUndefinedFieldInspection */
         self::assertTrue($clonedEntity->Flow_Persistence_clone);
     }
 
     /**
      * @test
      */
-    public function valueHashIsGeneratedForValueObjects()
+    public function valueHashIsGeneratedForValueObjects(): void
     {
         $valueObject = new Fixtures\TestValueObject('value');
 
-        $this->assertObjectHasAttribute('Persistence_Object_Identifier', $valueObject);
+        static::assertObjectHasProperty('Persistence_Object_Identifier', $valueObject);
         self::assertNotEmpty($this->persistenceManager->getIdentifierByObject($valueObject));
     }
 
@@ -81,13 +84,13 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
      * @test
      * @dataProvider sameValueObjectDataProvider
      */
-    public function valueObjectsWithTheSamePropertyValuesAreEqual($closure)
+    public function valueObjectsWithTheSamePropertyValuesAreEqual(\Closure $closure): void
     {
         [$valueObject1, $valueObject2] = $closure();
         self::assertEquals($this->persistenceManager->getIdentifierByObject($valueObject1), $this->persistenceManager->getIdentifierByObject($valueObject2));
     }
 
-    public function sameValueObjectDataProvider()
+    public function sameValueObjectDataProvider(): array
     {
         // These need to be provided as closures so that the construction happens inside the test and not outside of the test environment.
         return [
@@ -101,13 +104,13 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
      * @test
      * @dataProvider differentValueObjectDataProvider
      */
-    public function valueObjectWithDifferentPropertyValuesAreNotEqual($closure)
+    public function valueObjectWithDifferentPropertyValuesAreNotEqual(\Closure $closure): void
     {
         [$valueObject1, $valueObject2] = $closure();
         self::assertNotEquals($this->persistenceManager->getIdentifierByObject($valueObject1), $this->persistenceManager->getIdentifierByObject($valueObject2));
     }
 
-    public function differentValueObjectDataProvider()
+    public function differentValueObjectDataProvider(): array
     {
         // These need to be provided as closures so that the construction happens inside the test and not outside of the test environment.
         return [
@@ -120,7 +123,7 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function valueHashMustBeUniqueForEachClassIndependentOfPropertiesOrValues()
+    public function valueHashMustBeUniqueForEachClassIndependentOfPropertiesOrValues(): void
     {
         $valueObject1 = new Fixtures\TestValueObjectWithConstructorLogic('value1', 'value2');
         $valueObject2 = new Fixtures\TestValueObjectWithConstructorLogicAndInversedPropertyOrder('value2', 'value1');
@@ -131,7 +134,7 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function transientPropertiesAreDisregardedForValueHashGeneration()
+    public function transientPropertiesAreDisregardedForValueHashGeneration(): void
     {
         $valueObject1 = new Fixtures\TestValueObjectWithTransientProperties('value1', 'thisDoesntRegardPersistenceWhatSoEver');
         $valueObject2 = new Fixtures\TestValueObjectWithTransientProperties('value1', 'reallyThisPropertyIsTransient');
@@ -142,7 +145,7 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function dateTimeIsDifferentDependingOnTheTimeZone()
+    public function dateTimeIsDifferentDependingOnTheTimeZone(): void
     {
         $valueObject1 = new Fixtures\TestValueObjectWithDateTimeProperty(new \DateTime('01.01.2013 00:00', new \DateTimeZone('GMT')));
         $valueObject2 = new Fixtures\TestValueObjectWithDateTimeProperty(new \DateTime('01.01.2013 00:00', new \DateTimeZone('CEST')));
@@ -155,7 +158,7 @@ class PersistenceMagicAspectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function subValueObjectsAreIncludedInTheValueHash()
+    public function subValueObjectsAreIncludedInTheValueHash(): void
     {
         $subValueObject1 = new Fixtures\TestValueObject('value');
         $subValueObject2 = new Fixtures\TestValueObject('value');

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/AggregateTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/AggregateTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Doctrine;
 
 /*
@@ -21,7 +23,7 @@ use Neos\Flow\Tests\FunctionalTestCase;
 class AggregateTest extends FunctionalTestCase
 {
     /**
-     * @var boolean
+     * @var bool
      */
     protected static $testablePersistenceEnabled = true;
 
@@ -42,7 +44,7 @@ class AggregateTest extends FunctionalTestCase
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {
-            $this->markTestSkipped('Doctrine persistence is not enabled');
+            static::markTestSkipped('Doctrine persistence is not enabled');
         }
         $this->postRepository = $this->objectManager->get(Fixtures\PostRepository::class);
         $this->commentRepository = $this->objectManager->get(Fixtures\CommentRepository::class);
@@ -51,7 +53,7 @@ class AggregateTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function entitiesWithinAggregateAreRemovedAutomaticallyWithItsRootEntity()
+    public function entitiesWithinAggregateAreRemovedAutomaticallyWithItsRootEntity(): void
     {
         $image = new Fixtures\Image();
         $post = new Fixtures\Post();
@@ -74,7 +76,7 @@ class AggregateTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function entitiesWithOwnRepositoryAreNotRemovedIfRelatedRootEntityIsRemoved()
+    public function entitiesWithOwnRepositoryAreNotRemovedIfRelatedRootEntityIsRemoved(): void
     {
         $comment = new Fixtures\Comment();
         $this->commentRepository->add($comment);
@@ -102,7 +104,7 @@ class AggregateTest extends FunctionalTestCase
      *
      * @test
      */
-    public function valueObjectsAreNotCascadeRemovedWhenARelatedEntityIsDeleted()
+    public function valueObjectsAreNotCascadeRemovedWhenARelatedEntityIsDeleted(): void
     {
         $post1 = new Fixtures\Post();
         $post1->setAuthor(new Fixtures\TestValueObject('Some Name'));
@@ -124,7 +126,7 @@ class AggregateTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function unidirectionalOneToManyRelationsAreMapped()
+    public function unidirectionalOneToManyRelationsAreMapped(): void
     {
         $tag1 = new Fixtures\Tag('Tag1');
         $tag2 = new Fixtures\Tag('Tag2');
@@ -148,7 +150,7 @@ class AggregateTest extends FunctionalTestCase
         $this->persistenceManager->clearState();
 
         $retrievedTag2 = $this->persistenceManager->getObjectByIdentifier($tag2identifier, Fixtures\Tag::class);
-        self::assertTrue($retrievedTag2 === null, 'Tag not deleted');
+        self::assertNull($retrievedTag2, 'Tag not deleted');
 
         $post = $this->postRepository->find($postIdentifier);
         $this->postRepository->remove($post);
@@ -156,6 +158,6 @@ class AggregateTest extends FunctionalTestCase
         $this->persistenceManager->clearState();
 
         $retrievedTag1 = $this->persistenceManager->getObjectByIdentifier($tag1identifier, Fixtures\Tag::class);
-        self::assertTrue($retrievedTag1 === null, 'Tag not orphan removed');
+        self::assertNull($retrievedTag1, 'Tag not orphan removed');
     }
 }

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/IndexedCollectionTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/IndexedCollectionTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Doctrine;
 
 /*
@@ -31,7 +33,7 @@ class IndexedCollectionTest extends FunctionalTestCase
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {
-            $this->markTestSkipped('Doctrine persistence is not enabled');
+            static::markTestSkipped('Doctrine persistence is not enabled');
         }
     }
 
@@ -40,7 +42,7 @@ class IndexedCollectionTest extends FunctionalTestCase
      *
      * @test
      */
-    public function collectionsWithIndexAttributeAreIndexed()
+    public function collectionsWithIndexAttributeAreIndexed(): void
     {
         $entityWithIndexedRelation = new Fixtures\EntityWithIndexedRelation();
         for ($i = 0; $i < 3; $i++) {
@@ -62,7 +64,7 @@ class IndexedCollectionTest extends FunctionalTestCase
 
         $entityWithIndexedRelation = $this->persistenceManager->getObjectByIdentifier($id, Fixtures\EntityWithIndexedRelation::class);
         for ($i = 0; $i < 3; $i++) {
-            self::assertArrayHasKey('Author' . (string) $i, $entityWithIndexedRelation->getAnnotatedIdentitiesEntities());
+            self::assertArrayHasKey('Author' . $i, $entityWithIndexedRelation->getAnnotatedIdentitiesEntities());
         }
         self::assertArrayNotHasKey(0, $entityWithIndexedRelation->getAnnotatedIdentitiesEntities());
 

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/LazyLoadingTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/LazyLoadingTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Doctrine;
 
 /*
@@ -11,6 +13,7 @@ namespace Neos\Flow\Tests\Functional\Persistence\Doctrine;
  * source code.
  */
 
+use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures;
 use Neos\Flow\Tests\FunctionalTestCase;
@@ -21,7 +24,7 @@ use Neos\Flow\Tests\FunctionalTestCase;
 class LazyLoadingTest extends FunctionalTestCase
 {
     /**
-     * @var boolean
+     * @var bool
      */
     protected static $testablePersistenceEnabled = true;
 
@@ -42,7 +45,7 @@ class LazyLoadingTest extends FunctionalTestCase
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {
-            $this->markTestSkipped('Doctrine persistence is not enabled');
+            static::markTestSkipped('Doctrine persistence is not enabled');
         }
         $this->postRepository = $this->objectManager->get(Fixtures\PostRepository::class);
         $this->testEntityRepository = $this->objectManager->get(Fixtures\TestEntityRepository::class);
@@ -51,7 +54,7 @@ class LazyLoadingTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function dependencyInjectionIsCorrectlyInitializedEvenIfADoctrineProxyGetsInitializedOnTheFlyFromTheOutside()
+    public function dependencyInjectionIsCorrectlyInitializedEvenIfADoctrineProxyGetsInitializedOnTheFlyFromTheOutside(): void
     {
         $entity = new Fixtures\TestEntity();
         $entity->setName('Andi');
@@ -77,7 +80,7 @@ class LazyLoadingTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function aopIsCorrectlyInitializedEvenIfADoctrineProxyGetsInitializedOnTheFlyFromTheOutside()
+    public function aopIsCorrectlyInitializedEvenIfADoctrineProxyGetsInitializedOnTheFlyFromTheOutside(): void
     {
         $entity = new Fixtures\TestEntity();
         $entity->setName('Andi');
@@ -97,13 +100,13 @@ class LazyLoadingTest extends FunctionalTestCase
 
         $loadedRelatedEntity = $loadedEntity->getRelatedEntity();
 
-        self::assertEquals($loadedRelatedEntity->sayHello(), 'Hello Andi!');
+        self::assertEquals('Hello Andi!', $loadedRelatedEntity->sayHello());
     }
 
     /**
      * @test
      */
-    public function shutdownObjectMethodIsRegisterdForDoctrineProxy()
+    public function shutdownObjectMethodIsRegisteredForDoctrineProxy(): void
     {
         $image = new Fixtures\Image();
         $post = new Fixtures\Post();
@@ -115,8 +118,7 @@ class LazyLoadingTest extends FunctionalTestCase
 
         $postIdentifier = $this->persistenceManager->getIdentifierByObject($post);
 
-        unset($post);
-        unset($image);
+        unset($post, $image);
 
         /*
          * When hydrating the post a DoctrineProxy is generated for the image.
@@ -136,7 +138,7 @@ class LazyLoadingTest extends FunctionalTestCase
          * When shutting down the ObjectManager shutdownObject() on Fixtures\Image is called
          * and toggles the state on the cleanupObject
          */
-        \Neos\Flow\Core\Bootstrap::$staticObjectManager->shutdown();
+        Bootstrap::$staticObjectManager->shutdown();
 
         self::assertTrue($cleanupObject->getState());
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriverTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriverTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Doctrine\Mapping\Driver;
 
 /*
@@ -11,7 +13,12 @@ namespace Neos\Flow\Tests\Functional\Persistence\Doctrine\Mapping\Driver;
  * source code.
  */
 
+use Doctrine\DBAL\Schema\SchemaException;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\ORM\Tools\Exception\NotSupported;
 use Doctrine\ORM\Tools\SchemaTool;
 use Neos\Flow\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriver;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
@@ -34,14 +41,15 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {
-            $this->markTestSkipped('Doctrine persistence is not enabled');
+            static::markTestSkipped('Doctrine persistence is not enabled');
         }
     }
 
     /**
      * @test
+     * @throws MappingException
      */
-    public function lifecycleEventAnnotationsAreDetected()
+    public function lifecycleEventAnnotationsAreDetected(): void
     {
         $classMetadata = new ClassMetadata(Fixtures\Post::class);
         $driver = $this->objectManager->get(FlowAnnotationDriver::class);
@@ -51,8 +59,9 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
 
     /**
      * @test
+     * @throws MappingException
      */
-    public function lifecycleEventAnnotationsAreDetectedWithoutHasLifecycleCallbacks()
+    public function lifecycleEventAnnotationsAreDetectedWithoutHasLifecycleCallbacks(): void
     {
         $classMetadata = new ClassMetadata(Fixtures\Comment::class);
         $driver = $this->objectManager->get(FlowAnnotationDriver::class);
@@ -62,48 +71,52 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
 
     /**
      * @test
+     * @throws MappingException
      */
-    public function lifecycleCallbacksAreNotRegisteredForUnproxiedEntities()
+    public function lifecycleCallbacksAreNotRegisteredForUnproxiedEntities(): void
     {
         $classMetadata = new ClassMetadata(Fixtures\UnproxiedTestEntity::class);
         $driver = $this->objectManager->get(FlowAnnotationDriver::class);
         $driver->loadMetadataForClass(Fixtures\UnproxiedTestEntity::class, $classMetadata);
-        self::assertFalse($classMetadata->hasLifecycleCallbacks(\Doctrine\ORM\Events::postLoad));
+        self::assertFalse($classMetadata->hasLifecycleCallbacks(Events::postLoad));
     }
 
     /**
      * @test
+     * @throws MappingException
      */
-    public function inheritanceTypeIsNotChangedIfNoSubclassesOfNonAbstractClassExist()
+    public function inheritanceTypeIsNotChangedIfNoSubclassesOfNonAbstractClassExist(): void
     {
         $classMetadata = new ClassMetadata(Fixtures\Post::class);
         $driver = $this->objectManager->get(FlowAnnotationDriver::class);
         $driver->loadMetadataForClass(Fixtures\Post::class, $classMetadata);
-        self::assertSame(\Doctrine\ORM\Mapping\ClassMetadata::INHERITANCE_TYPE_JOINED, $classMetadata->inheritanceType);
+        self::assertSame(ClassMetadataInfo::INHERITANCE_TYPE_JOINED, $classMetadata->inheritanceType);
     }
 
     /**
      * @test
+     * @throws MappingException
      */
-    public function inheritanceTypeIsSetToNoneIfNoSubclassesOfAbstractClassExist()
+    public function inheritanceTypeIsSetToNoneIfNoSubclassesOfAbstractClassExist(): void
     {
         $classMetadata = new ClassMetadata(Fixtures\AbstractEntity::class);
         $driver = $this->objectManager->get(FlowAnnotationDriver::class);
         $driver->loadMetadataForClass(Fixtures\AbstractEntity::class, $classMetadata);
-        self::assertSame(\Doctrine\ORM\Mapping\ClassMetadata::INHERITANCE_TYPE_NONE, $classMetadata->inheritanceType);
+        self::assertSame(ClassMetadataInfo::INHERITANCE_TYPE_NONE, $classMetadata->inheritanceType);
     }
 
     /**
      * @test
+     * @throws MappingException
      */
-    public function compositePrimaryKeyOverEntityRelationIsRegistered()
+    public function compositePrimaryKeyOverEntityRelationIsRegistered(): void
     {
         $classMetadata = new ClassMetadata(Fixtures\CompositeKeyTestEntity::class);
         $driver = $this->objectManager->get(FlowAnnotationDriver::class);
         $driver->loadMetadataForClass(Fixtures\CompositeKeyTestEntity::class, $classMetadata);
         self::assertTrue($classMetadata->isIdentifierComposite);
         self::assertTrue($classMetadata->containsForeignIdentifier);
-        self::assertEquals($classMetadata->identifier, ['name', 'relatedEntity']);
+        self::assertEquals(['name', 'relatedEntity'], $classMetadata->identifier);
     }
 
     /**
@@ -113,8 +126,9 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
      * - using joincolumn without name on single associations uses the property name
      *
      * @test
+     * @throws MappingException
      */
-    public function columnNamesAreBuiltCorrectly()
+    public function columnNamesAreBuiltCorrectly(): void
     {
         $expectedTitleMapping = [
             'fieldName' => 'title',
@@ -176,7 +190,7 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
         }
 
         $commentAssociationMapping = $classMetadata->getAssociationMapping('comment');
-        self::assertEquals(1, count($commentAssociationMapping['joinColumns']));
+        self::assertCount(1, $commentAssociationMapping['joinColumns']);
         foreach (array_keys($expectedCommentAssociationMapping) as $key) {
             self::assertEquals($expectedCommentAssociationMapping[$key], $commentAssociationMapping[$key], 'mapping for "comment" not as expected');
         }
@@ -186,8 +200,9 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
      * The "related_post_id" column given manually must be kept.
      *
      * @test
+     * @throws MappingException
      */
-    public function joinColumnAnnotationsAreObserved()
+    public function joinColumnAnnotationsAreObserved(): void
     {
         $expectedRelatedAssociationMapping = [
             'fieldName' => 'related',
@@ -237,8 +252,9 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
      * The "indexBy" annotation of EntityWithIndexedRelation must be kept
      *
      * @test
+     * @throws MappingException
      */
-    public function doctrineIndexByAnnotationIsObserved()
+    public function doctrineIndexByAnnotationIsObserved(): void
     {
         $classMetadata = new ClassMetadata(Fixtures\EntityWithIndexedRelation::class);
         $driver = $this->objectManager->get(FlowAnnotationDriver::class);
@@ -257,8 +273,9 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
 
     /**
      * @test
+     * @throws MappingException
      */
-    public function introducedPropertiesAreObservedCorrectly()
+    public function introducedPropertiesAreObservedCorrectly(): void
     {
         $classMetadata = new ClassMetadata(TargetClass04::class);
         $driver = $this->objectManager->get(FlowAnnotationDriver::class);
@@ -272,8 +289,11 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
 
     /**
      * @test
+     * @throws SchemaException
+     * @throws NotSupported
+     * @throws MappingException
      */
-    public function oneToOneRelationsAreMappedCorrectly()
+    public function oneToOneRelationsAreMappedCorrectly(): void
     {
         $classMetadata = new ClassMetadata(Fixtures\OneToOneEntity::class);
         $driver = $this->objectManager->get(FlowAnnotationDriver::class);
@@ -303,10 +323,9 @@ class FlowAnnotationDriverTest extends FunctionalTestCase
         $entityManager = $this->objectManager->get(EntityManagerInterface::class);
         $schemaTool = new SchemaTool($entityManager);
         $schema = $schemaTool->getSchemaFromMetadata([$entityManager->getClassMetadata(Fixtures\OneToOneEntity2::class)]);
-        /* @var $foreignKey \Doctrine\DBAL\Schema\ForeignKeyConstraint */
         foreach ($schema->getTable('persistence_onetooneentity2')->getForeignKeys() as $foreignKey) {
             if ($foreignKey->getForeignTableName() === 'persistence_onetooneentity') {
-                self::assertTrue(false);
+                self::fail();
             }
         }
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/PersistClonedRelatedEntitiesTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/PersistClonedRelatedEntitiesTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Doctrine;
 
 /*
@@ -21,7 +23,7 @@ use Neos\Flow\Tests\FunctionalTestCase;
 class PersistClonedRelatedEntitiesTest extends FunctionalTestCase
 {
     /**
-     * @var boolean
+     * @var bool
      */
     protected static $testablePersistenceEnabled = true;
 
@@ -37,7 +39,7 @@ class PersistClonedRelatedEntitiesTest extends FunctionalTestCase
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {
-            $this->markTestSkipped('Doctrine persistence is not enabled');
+            static::markTestSkipped('Doctrine persistence is not enabled');
         }
         $this->testEntityRepository = $this->objectManager->get(Fixtures\TestEntityRepository::class);
     }
@@ -45,7 +47,7 @@ class PersistClonedRelatedEntitiesTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function relatedEntitiesCanBePersistedWhenFetchedAsDoctrineProxy()
+    public function relatedEntitiesCanBePersistedWhenFetchedAsDoctrineProxy(): void
     {
         $entity = new Fixtures\TestEntity();
         $entity->setName('Andi');
@@ -74,7 +76,7 @@ class PersistClonedRelatedEntitiesTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function embeddablesInsideClonedProxiedEntitiesAreCorrectlyLoaded()
+    public function embeddablesInsideClonedProxiedEntitiesAreCorrectlyLoaded(): void
     {
         $entity = new Fixtures\TestEntity();
         $entity->setName('Andi');

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/QueryTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/QueryTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Doctrine;
 
 /*
@@ -14,6 +16,9 @@ namespace Neos\Flow\Tests\Functional\Persistence\Doctrine;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Persistence\Doctrine\Query;
 use Neos\Flow\Tests\Functional\Persistence\Fixtures;
+use Neos\Flow\Tests\Functional\Persistence\Fixtures\SubEntity;
+use Neos\Flow\Tests\Functional\Persistence\Fixtures\TestEntity;
+use Neos\Flow\Tests\Functional\Persistence\Fixtures\TestEntityRepository;
 use Neos\Flow\Tests\FunctionalTestCase;
 
 /**
@@ -23,7 +28,7 @@ use Neos\Flow\Tests\FunctionalTestCase;
 class QueryTest extends FunctionalTestCase
 {
     /**
-     * @var boolean
+     * @var bool
      */
     protected static $testablePersistenceEnabled = true;
 
@@ -34,16 +39,16 @@ class QueryTest extends FunctionalTestCase
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {
-            $this->markTestSkipped('Doctrine persistence is not enabled');
+            static::markTestSkipped('Doctrine persistence is not enabled');
         }
     }
 
     /**
      * @test
      */
-    public function simpleQueryCanBeSerializedAndDeserialized()
+    public function simpleQueryCanBeSerializedAndDeserialized(): void
     {
-        $query = new Query(Fixtures\TestEntity::class);
+        $query = new Query(TestEntity::class);
         $serializedQuery = serialize($query);
         $unserializedQuery = unserialize($serializedQuery);
 
@@ -53,18 +58,18 @@ class QueryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function simpleQueryCanBeExecutedAfterDeserialization()
+    public function simpleQueryCanBeExecutedAfterDeserialization(): void
     {
-        $testEntityRepository = new Fixtures\TestEntityRepository();
+        $testEntityRepository = new TestEntityRepository();
         $testEntityRepository->removeAll();
 
-        $testEntity1 = new Fixtures\TestEntity();
+        $testEntity1 = new TestEntity();
         $testEntity1->setName('Flow');
         $testEntityRepository->add($testEntity1);
 
         $this->persistenceManager->persistAll();
 
-        $query = new Query(Fixtures\TestEntity::class);
+        $query = new Query(TestEntity::class);
         $serializedQuery = serialize($query);
         $unserializedQuery = unserialize($serializedQuery);
 
@@ -75,9 +80,9 @@ class QueryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function moreComplexQueryCanBeSerializedAndDeserialized()
+    public function moreComplexQueryCanBeSerializedAndDeserialized(): void
     {
-        $query = new Query(Fixtures\TestEntity::class);
+        $query = new Query(TestEntity::class);
         $query->matching($query->equals('name', 'some'));
 
         $serializedQuery = serialize($query);
@@ -89,22 +94,22 @@ class QueryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function moreComplexQueryCanBeExecutedAfterDeserialization()
+    public function moreComplexQueryCanBeExecutedAfterDeserialization(): void
     {
-        $testEntityRepository = new Fixtures\TestEntityRepository();
+        $testEntityRepository = new TestEntityRepository();
         $testEntityRepository->removeAll();
 
-        $testEntity1 = new Fixtures\TestEntity();
+        $testEntity1 = new TestEntity();
         $testEntity1->setName('Flow');
         $testEntityRepository->add($testEntity1);
 
-        $testEntity2 = new Fixtures\TestEntity();
+        $testEntity2 = new TestEntity();
         $testEntity2->setName('some');
         $testEntityRepository->add($testEntity2);
 
         $this->persistenceManager->persistAll();
 
-        $query = new Query(Fixtures\TestEntity::class);
+        $query = new Query(TestEntity::class);
         $query->matching($query->equals('name', 'Flow'));
 
         $serializedQuery = serialize($query);
@@ -116,26 +121,26 @@ class QueryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function countIncludesAllResultsByDefault()
+    public function countIncludesAllResultsByDefault(): void
     {
-        $testEntityRepository = new Fixtures\TestEntityRepository();
+        $testEntityRepository = new TestEntityRepository();
         $testEntityRepository->removeAll();
 
-        $testEntity1 = new Fixtures\TestEntity();
+        $testEntity1 = new TestEntity();
         $testEntity1->setName('Flow');
         $testEntityRepository->add($testEntity1);
 
-        $testEntity2 = new Fixtures\TestEntity();
+        $testEntity2 = new TestEntity();
         $testEntity2->setName('some');
         $testEntityRepository->add($testEntity2);
 
-        $testEntity3 = new Fixtures\TestEntity();
+        $testEntity3 = new TestEntity();
         $testEntity3->setName('more');
         $testEntityRepository->add($testEntity3);
 
         $this->persistenceManager->persistAll();
 
-        $query = new Query(Fixtures\TestEntity::class);
+        $query = new Query(TestEntity::class);
 
         self::assertEquals(3, $query->execute()->count());
     }
@@ -143,26 +148,26 @@ class QueryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function countRespectsLimitConstraint()
+    public function countRespectsLimitConstraint(): void
     {
-        $testEntityRepository = new Fixtures\TestEntityRepository();
+        $testEntityRepository = new TestEntityRepository();
         $testEntityRepository->removeAll();
 
-        $testEntity1 = new Fixtures\TestEntity();
+        $testEntity1 = new TestEntity();
         $testEntity1->setName('Flow');
         $testEntityRepository->add($testEntity1);
 
-        $testEntity2 = new Fixtures\TestEntity();
+        $testEntity2 = new TestEntity();
         $testEntity2->setName('some');
         $testEntityRepository->add($testEntity2);
 
-        $testEntity3 = new Fixtures\TestEntity();
+        $testEntity3 = new TestEntity();
         $testEntity3->setName('more');
         $testEntityRepository->add($testEntity3);
 
         $this->persistenceManager->persistAll();
 
-        $query = new Query(Fixtures\TestEntity::class);
+        $query = new Query(TestEntity::class);
 
         self::assertEquals(2, $query->setLimit(2)->execute()->count());
     }
@@ -170,26 +175,26 @@ class QueryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function countRespectsOffsetConstraint()
+    public function countRespectsOffsetConstraint(): void
     {
-        $testEntityRepository = new Fixtures\TestEntityRepository();
+        $testEntityRepository = new TestEntityRepository();
         $testEntityRepository->removeAll();
 
-        $testEntity1 = new Fixtures\TestEntity();
+        $testEntity1 = new TestEntity();
         $testEntity1->setName('Flow');
         $testEntityRepository->add($testEntity1);
 
-        $testEntity2 = new Fixtures\TestEntity();
+        $testEntity2 = new TestEntity();
         $testEntity2->setName('some');
         $testEntityRepository->add($testEntity2);
 
-        $testEntity3 = new Fixtures\TestEntity();
+        $testEntity3 = new TestEntity();
         $testEntity3->setName('more');
         $testEntityRepository->add($testEntity3);
 
         $this->persistenceManager->persistAll();
 
-        $query = new Query(Fixtures\TestEntity::class);
+        $query = new Query(TestEntity::class);
 
         self::assertEquals(1, $query->setOffset(2)->execute()->count());
     }
@@ -197,21 +202,21 @@ class QueryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinctQueryOnlyReturnsDistinctEntities()
+    public function distinctQueryOnlyReturnsDistinctEntities(): void
     {
-        $testEntityRepository = new Fixtures\TestEntityRepository();
+        $testEntityRepository = new TestEntityRepository();
         $testEntityRepository->removeAll();
 
-        $testEntity = new Fixtures\TestEntity();
+        $testEntity = new TestEntity();
         $testEntity->setName('Flow');
 
-        $subEntity1 = new Fixtures\SubEntity();
+        $subEntity1 = new SubEntity();
         $subEntity1->setContent('value');
         $subEntity1->setParentEntity($testEntity);
         $testEntity->addSubEntity($subEntity1);
         $this->persistenceManager->add($subEntity1);
 
-        $subEntity2 = new Fixtures\SubEntity();
+        $subEntity2 = new SubEntity();
         $subEntity2->setContent('value');
         $subEntity2->setParentEntity($testEntity);
         $testEntity->addSubEntity($subEntity2);
@@ -219,10 +224,10 @@ class QueryTest extends FunctionalTestCase
 
         $testEntityRepository->add($testEntity);
 
-        $testEntity2 = new Fixtures\TestEntity();
+        $testEntity2 = new TestEntity();
         $testEntity2->setName('Flow');
 
-        $subEntity3 = new Fixtures\SubEntity();
+        $subEntity3 = new SubEntity();
         $subEntity3->setContent('value');
         $subEntity3->setParentEntity($testEntity2);
         $testEntity2->addSubEntity($subEntity3);
@@ -232,31 +237,31 @@ class QueryTest extends FunctionalTestCase
 
         $this->persistenceManager->persistAll();
 
-        $query = new Query(Fixtures\TestEntity::class);
+        $query = new Query(TestEntity::class);
         $entities = $query->matching($query->equals('subEntities.content', 'value'))->setDistinct()->setLimit(2)->execute()->toArray();
 
-        self::assertEquals(2, count($entities));
+        self::assertCount(2, $entities);
     }
 
     /**
      * @test
      */
-    public function subpropertyQueriesReuseJoinAlias()
+    public function subpropertyQueriesReuseJoinAlias(): void
     {
-        $testEntityRepository = new \Neos\Flow\Tests\Functional\Persistence\Fixtures\TestEntityRepository();
+        $testEntityRepository = new TestEntityRepository();
         $testEntityRepository->removeAll();
 
-        $testEntity = new \Neos\Flow\Tests\Functional\Persistence\Fixtures\TestEntity;
+        $testEntity = new TestEntity();
         $testEntity->setName('Flow');
 
-        $subEntity1 = new \Neos\Flow\Tests\Functional\Persistence\Fixtures\SubEntity;
+        $subEntity1 = new SubEntity();
         $subEntity1->setContent('foo');
         $subEntity1->setSomeProperty('nope');
         $subEntity1->setParentEntity($testEntity);
         $testEntity->addSubEntity($subEntity1);
         $this->persistenceManager->add($subEntity1);
 
-        $subEntity2 = new \Neos\Flow\Tests\Functional\Persistence\Fixtures\SubEntity;
+        $subEntity2 = new SubEntity();
         $subEntity2->setContent('bar');
         $subEntity2->setSomeProperty('yup');
         $subEntity2->setParentEntity($testEntity);
@@ -265,10 +270,10 @@ class QueryTest extends FunctionalTestCase
 
         $testEntityRepository->add($testEntity);
 
-        $testEntity2 = new \Neos\Flow\Tests\Functional\Persistence\Fixtures\TestEntity;
+        $testEntity2 = new TestEntity();
         $testEntity2->setName('Flow');
 
-        $subEntity3 = new \Neos\Flow\Tests\Functional\Persistence\Fixtures\SubEntity;
+        $subEntity3 = new SubEntity();
         $subEntity3->setContent('foo');
         $subEntity3->setSomeProperty('yup');
         $subEntity3->setParentEntity($testEntity2);
@@ -279,31 +284,31 @@ class QueryTest extends FunctionalTestCase
 
         $this->persistenceManager->persistAll();
 
-        $query = new Query(\Neos\Flow\Tests\Functional\Persistence\Fixtures\TestEntity::class);
+        $query = new Query(TestEntity::class);
         // Read as "All entities with subEntity with *both* content = 'foo' AND someProperty = 'yup'
         // isntead of "All entities with any subEntity with content 'foo' AND any subEntity with someProperty = 'yup'
         $constraint = $query->logicalAnd($query->equals('subEntities.content', 'foo'), $query->equals('subEntities.someProperty', 'yup'));
         $entities = $query->matching($constraint)->execute()->toArray();
 
-        self::assertEquals(1, count($entities));
+        self::assertCount(1, $entities);
     }
 
     /**
      * @test
      */
-    public function embeddedValueObjectQueryingWorks()
+    public function embeddedValueObjectQueryingWorks(): void
     {
-        $testEntityRepository = new Fixtures\TestEntityRepository();
+        $testEntityRepository = new TestEntityRepository();
         $testEntityRepository->removeAll();
 
-        $testEntity = new Fixtures\TestEntity();
+        $testEntity = new TestEntity();
         $testEntity->setName('Flow1');
 
         $valueObject1 = new Fixtures\TestEmbeddedValueObject('vo');
         $testEntity->setEmbeddedValueObject($valueObject1);
         $testEntityRepository->add($testEntity);
 
-        $testEntity2 = new Fixtures\TestEntity();
+        $testEntity2 = new TestEntity();
         $testEntity2->setName('Flow2');
 
         $valueObject2 = new Fixtures\TestEmbeddedValueObject('vo');
@@ -313,17 +318,18 @@ class QueryTest extends FunctionalTestCase
 
         $this->persistenceManager->persistAll();
 
-        $query = new Query(Fixtures\TestEntity::class);
+        $query = new Query(TestEntity::class);
         $entities = $query->matching($query->equals('embeddedValueObject.value', 'vo'))->execute()->toArray();
 
-        $this->assertEquals(2, count($entities));
+        static::assertCount(2, $entities);
     }
 
     /**
      * @test
      */
-    public function comlexQueryWithJoinsCanBeExecutedAfterDeserialization()
+    public function comlexQueryWithJoinsCanBeExecutedAfterDeserialization(): void
     {
+        /** @noinspection PhpParamsInspection */
         $postEntityRepository = new Fixtures\PostRepository();
         $postEntityRepository->removeAll();
 
@@ -356,21 +362,21 @@ class QueryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function countReturnsCorrectNumberOfEntities()
+    public function countReturnsCorrectNumberOfEntities(): void
     {
-        $testEntityRepository = new \Neos\Flow\Tests\Functional\Persistence\Fixtures\TestEntityRepository();
+        $testEntityRepository = new TestEntityRepository();
         $testEntityRepository->removeAll();
 
-        $testEntity = new \Neos\Flow\Tests\Functional\Persistence\Fixtures\TestEntity;
+        $testEntity = new TestEntity();
         $testEntity->setName('Flow');
 
-        $subEntity1 = new \Neos\Flow\Tests\Functional\Persistence\Fixtures\SubEntity;
+        $subEntity1 = new SubEntity();
         $subEntity1->setContent('foo');
         $subEntity1->setParentEntity($testEntity);
         $testEntity->addSubEntity($subEntity1);
         $this->persistenceManager->add($subEntity1);
 
-        $subEntity2 = new \Neos\Flow\Tests\Functional\Persistence\Fixtures\SubEntity;
+        $subEntity2 = new SubEntity();
         $subEntity2->setContent('foo');
         $subEntity2->setParentEntity($testEntity);
         $testEntity->addSubEntity($subEntity2);
@@ -380,7 +386,7 @@ class QueryTest extends FunctionalTestCase
 
         $this->persistenceManager->persistAll();
 
-        $query = new Query(\Neos\Flow\Tests\Functional\Persistence\Fixtures\TestEntity::class);
+        $query = new Query(TestEntity::class);
 
         $constraint = $query->logicalAnd($query->equals('subEntities.content', 'foo'));
         $result = $query->matching($constraint)->execute();
@@ -388,11 +394,11 @@ class QueryTest extends FunctionalTestCase
         $count = $result->count();
         $arrayCount = $result->toArray();
 
-        self::assertEquals(1, count($arrayCount), 'This correctly returns 1');
+        self::assertCount(1, $arrayCount, 'This correctly returns 1');
         self::assertEquals(1, $count, 'this returns 2');
     }
 
-    protected function assertQueryEquals(Query $expected, Query $actual)
+    protected function assertQueryEquals(Query $expected, Query $actual): void
     {
         self::assertEquals($expected->getConstraint(), $actual->getConstraint());
         self::assertEquals($expected->getOrderings(), $actual->getOrderings());

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/RepositoryTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/RepositoryTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Doctrine;
 
 /*
@@ -24,7 +26,7 @@ use Neos\Flow\Tests\FunctionalTestCase;
 class RepositoryTest extends FunctionalTestCase
 {
     /**
-     * @var boolean
+     * @var bool
      */
     protected static $testablePersistenceEnabled = true;
 
@@ -50,14 +52,14 @@ class RepositoryTest extends FunctionalTestCase
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {
-            $this->markTestSkipped('Doctrine persistence is not enabled');
+            static::markTestSkipped('Doctrine persistence is not enabled');
         }
     }
 
     /**
      * @test
      */
-    public function modificationsOnRetrievedEntitiesAreNotPersistedAutomatically()
+    public function modificationsOnRetrievedEntitiesAreNotPersistedAutomatically(): void
     {
         $this->postRepository = $this->objectManager->get(Fixtures\PostRepository::class);
 
@@ -88,7 +90,7 @@ class RepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function modificationsOnRetrievedEntitiesArePersistedIfUpdateHasBeenCalled()
+    public function modificationsOnRetrievedEntitiesArePersistedIfUpdateHasBeenCalled(): void
     {
         $this->postRepository = $this->objectManager->get(Fixtures\PostRepository::class);
 
@@ -112,7 +114,7 @@ class RepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function instancesOfTheManagedTypeCanBeAddedAndRetrieved()
+    public function instancesOfTheManagedTypeCanBeAddedAndRetrieved(): void
     {
         $this->superEntityRepository = $this->objectManager->get(Fixtures\SuperEntityRepository::class);
 
@@ -129,7 +131,7 @@ class RepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function subTypesOfTheManagedTypeCanBeAddedAndRetrieved()
+    public function subTypesOfTheManagedTypeCanBeAddedAndRetrieved(): void
     {
         $this->superEntityRepository = $this->objectManager->get(Fixtures\SuperEntityRepository::class);
 
@@ -146,7 +148,7 @@ class RepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function subTypesOfTheManagedTypeCanBeRemoved()
+    public function subTypesOfTheManagedTypeCanBeRemoved(): void
     {
         $this->superEntityRepository = $this->objectManager->get(Fixtures\SuperEntityRepository::class);
 
@@ -167,7 +169,7 @@ class RepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function subTypesOfTheManagedTypeCanBeUpdated()
+    public function subTypesOfTheManagedTypeCanBeUpdated(): void
     {
         $this->superEntityRepository = $this->objectManager->get(Fixtures\SuperEntityRepository::class);
 
@@ -191,7 +193,7 @@ class RepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function countAllCountsSubTypesOfTheManagedType()
+    public function countAllCountsSubTypesOfTheManagedType(): void
     {
         $this->superEntityRepository = $this->objectManager->get(Fixtures\SuperEntityRepository::class);
 
@@ -211,7 +213,7 @@ class RepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function findAllReturnsSubTypesOfTheManagedType()
+    public function findAllReturnsSubTypesOfTheManagedType(): void
     {
         $this->superEntityRepository = $this->objectManager->get(Fixtures\SuperEntityRepository::class);
 
@@ -231,7 +233,7 @@ class RepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function findAllIteratorReturnsSubTypesOfTheManagedType()
+    public function findAllIteratorReturnsSubTypesOfTheManagedType(): void
     {
         $this->superEntityRepository = $this->objectManager->get(Fixtures\SuperEntityRepository::class);
 
@@ -258,7 +260,7 @@ class RepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function findByIdentifierReturnsSubTypesOfTheManagedType()
+    public function findByIdentifierReturnsSubTypesOfTheManagedType(): void
     {
         $this->superEntityRepository = $this->objectManager->get(Fixtures\SuperEntityRepository::class);
 
@@ -276,7 +278,7 @@ class RepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function addingASuperTypeToAMoreSpecificRepositoryThrowsAnException()
+    public function addingASuperTypeToAMoreSpecificRepositoryThrowsAnException(): void
     {
         $this->expectException(IllegalObjectTypeException::class);
         $this->subSubEntityRepository = $this->objectManager->get(Fixtures\SubSubEntityRepository::class);
@@ -288,7 +290,7 @@ class RepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function usingASpecificRepositoryForSubTypesWorks()
+    public function usingASpecificRepositoryForSubTypesWorks(): void
     {
         $this->superEntityRepository = $this->objectManager->get(Fixtures\SuperEntityRepository::class);
         $this->subSubEntityRepository = $this->objectManager->get(Fixtures\SubSubEntityRepository::class);
@@ -309,7 +311,7 @@ class RepositoryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function findAllReturnsQueryResult()
+    public function findAllReturnsQueryResult(): void
     {
         $this->postRepository = $this->objectManager->get(Fixtures\PostRepository::class);
         self::assertInstanceOf(Repository::class, $this->postRepository, 'Repository under test should be a Doctrine Repository');

--- a/Neos.Flow/Tests/Functional/Persistence/Doctrine/ValueObjectTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Doctrine/ValueObjectTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Doctrine;
 
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
@@ -10,7 +12,7 @@ use Neos\Flow\Tests\FunctionalTestCase;
 class ValueObjectTest extends FunctionalTestCase
 {
     /**
-     * @var boolean
+     * @var bool
      */
     protected static $testablePersistenceEnabled = true;
 
@@ -21,7 +23,7 @@ class ValueObjectTest extends FunctionalTestCase
     {
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {
-            $this->markTestSkipped('Doctrine persistence is not enabled');
+            static::markTestSkipped('Doctrine persistence is not enabled');
         }
     }
 
@@ -36,7 +38,7 @@ class ValueObjectTest extends FunctionalTestCase
      *
      * @test
      */
-    public function valueObjectsGetDeduplicatedAndCanBePersisted()
+    public function valueObjectsGetDeduplicatedAndCanBePersisted(): void
     {
         for ($i = 0; $i < 2; $i++) {
             $testEntity = new TestEntity();

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/AbstractEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/AbstractEntity.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/AnnotatedIdEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/AnnotatedIdEntity.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -37,7 +39,7 @@ class AnnotatedIdEntity
     /**
      * @return string
      */
-    public function getId()
+    public function getId(): string
     {
         return $this->id;
     }
@@ -45,7 +47,7 @@ class AnnotatedIdEntity
     /**
      * @param string $title
      */
-    public function setTitle($title)
+    public function setTitle($title): void
     {
         $this->title = $title;
     }
@@ -53,7 +55,7 @@ class AnnotatedIdEntity
     /**
      * @return string
      */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->title;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/AnnotatedIdentitiesEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/AnnotatedIdentitiesEntity.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -35,7 +37,7 @@ class AnnotatedIdentitiesEntity
     /**
      * @param string $author
      */
-    public function setAuthor($author)
+    public function setAuthor($author): void
     {
         $this->author = $author;
     }
@@ -43,7 +45,7 @@ class AnnotatedIdentitiesEntity
     /**
      * @return string
      */
-    public function getAuthor()
+    public function getAuthor(): string
     {
         return $this->author;
     }
@@ -51,7 +53,7 @@ class AnnotatedIdentitiesEntity
     /**
      * @param string $title
      */
-    public function setTitle($title)
+    public function setTitle($title): void
     {
         $this->title = $title;
     }
@@ -59,7 +61,7 @@ class AnnotatedIdentitiesEntity
     /**
      * @return string
      */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->title;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/CleanupObject.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/CleanupObject.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -14,19 +16,19 @@ namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 class CleanupObject
 {
     /**
-     * @var boolean
+     * @var bool
      */
     protected $state = false;
 
-    public function toggleState()
+    public function toggleState(): void
     {
         $this->state = !$this->state;
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
-    public function getState()
+    public function getState(): bool
     {
         return $this->state;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Comment.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Comment.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -30,7 +32,7 @@ class Comment
      * @return string
      * @ORM\PrePersist
      */
-    public function getContent()
+    public function getContent(): string
     {
         return $this->content;
     }
@@ -39,7 +41,7 @@ class Comment
      * @param string $content
      * @return void
      */
-    public function setContent($content)
+    public function setContent($content): void
     {
         $this->content = $content;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/CommentRepository.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/CommentRepository.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -23,5 +25,5 @@ class CommentRepository extends Repository
     /**
      * @var string
      */
-    const ENTITY_CLASSNAME = Comment::class;
+    public const ENTITY_CLASSNAME = Comment::class;
 }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/CommonObject.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/CommonObject.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -10,8 +12,6 @@ namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
  * information, please view the LICENSE file which was distributed with this
  * source code.
  */
-
-use Neos\Flow\Annotations as Flow;
 
 /**
  * Class CommonObject
@@ -28,7 +28,7 @@ class CommonObject
      * @param string $foo
      * @return $this
      */
-    public function setFoo($foo = null)
+    public function setFoo($foo = null): self
     {
         $this->foo = $foo;
         return $this;
@@ -37,7 +37,7 @@ class CommonObject
     /**
      * @return string
      */
-    public function getFoo()
+    public function getFoo(): string
     {
         return $this->foo;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/CompositeKeyTestEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/CompositeKeyTestEntity.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -39,7 +41,7 @@ class CompositeKeyTestEntity
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -48,7 +50,7 @@ class CompositeKeyTestEntity
      * @param string $name
      * @return void
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -57,7 +59,7 @@ class CompositeKeyTestEntity
      * @param TestEntity $relatedEntity
      * @return void
      */
-    public function setRelatedEntity(TestEntity $relatedEntity)
+    public function setRelatedEntity(TestEntity $relatedEntity): void
     {
         $this->relatedEntity = $relatedEntity;
     }
@@ -65,7 +67,7 @@ class CompositeKeyTestEntity
     /**
      * @return TestEntity
      */
-    public function getRelatedEntity()
+    public function getRelatedEntity(): TestEntity
     {
         return $this->relatedEntity;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/EntityWithIndexedRelation.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/EntityWithIndexedRelation.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -46,33 +48,33 @@ class EntityWithIndexedRelation
     }
 
     /**
-     * @param \Doctrine\Common\Collections\Collection $annotatedIdentitiesEntities
+     * @param Collection $annotatedIdentitiesEntities
      */
-    public function setAnnotatedIdentitiesEntities($annotatedIdentitiesEntities)
+    public function setAnnotatedIdentitiesEntities($annotatedIdentitiesEntities): void
     {
         $this->annotatedIdentitiesEntities = $annotatedIdentitiesEntities;
     }
 
     /**
-     * @return \Doctrine\Common\Collections\Collection
+     * @return ArrayCollection|Collection
      */
-    public function getAnnotatedIdentitiesEntities()
+    public function getAnnotatedIdentitiesEntities(): ArrayCollection|Collection
     {
         return $this->annotatedIdentitiesEntities;
     }
 
     /**
-     * @param \Doctrine\Common\Collections\Collection $relatedIndexEntities
+     * @param Collection $relatedIndexEntities
      */
-    public function setRelatedIndexEntities($relatedIndexEntities)
+    public function setRelatedIndexEntities($relatedIndexEntities): void
     {
         $this->relatedIndexEntities = $relatedIndexEntities;
     }
 
     /**
-     * @return \Doctrine\Common\Collections\Collection
+     * @return ArrayCollection|Collection
      */
-    public function getRelatedIndexEntities()
+    public function getRelatedIndexEntities(): ArrayCollection|Collection
     {
         return $this->relatedIndexEntities;
     }
@@ -81,7 +83,7 @@ class EntityWithIndexedRelation
      * @param string $sorting
      * @param RelatedIndexEntity $relatedIndexEntity
      */
-    public function setRelatedIndexEntity($sorting, RelatedIndexEntity $relatedIndexEntity)
+    public function setRelatedIndexEntity($sorting, RelatedIndexEntity $relatedIndexEntity): void
     {
         $relatedIndexEntity->setSorting($sorting);
         $relatedIndexEntity->setEntityWithIndexedRelation($this);

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/EventListener.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/EventListener.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -11,6 +13,9 @@ namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
  * source code.
  */
 
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Event\PreFlushEventArgs;
 use Neos\Flow\Annotations as Flow;
 
 /**
@@ -26,17 +31,17 @@ class EventListener
 
     public $postFlushCalled = false;
 
-    public function preFlush(\Doctrine\ORM\Event\PreFlushEventArgs $args)
+    public function preFlush(PreFlushEventArgs $args): void
     {
         $this->preFlushCalled = true;
     }
 
-    public function onFlush(\Doctrine\ORM\Event\OnFlushEventArgs $args)
+    public function onFlush(OnFlushEventArgs $args): void
     {
         $this->onFlushCalled = true;
     }
 
-    public function postFlush(\Doctrine\ORM\Event\PostFlushEventArgs $args)
+    public function postFlush(PostFlushEventArgs $args): void
     {
         $this->postFlushCalled = true;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/EventSubscriber.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/EventSubscriber.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -11,6 +13,9 @@ namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
  * source code.
  */
 
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Event\PreFlushEventArgs;
 use Neos\Flow\Annotations as Flow;
 use Doctrine\ORM\Events;
 
@@ -32,22 +37,22 @@ class EventSubscriber implements \Doctrine\Common\EventSubscriber
      *
      * @return array
      */
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return [Events::preFlush, Events::onFlush, Events::postFlush];
     }
 
-    public function preFlush(\Doctrine\ORM\Event\PreFlushEventArgs $args)
+    public function preFlush(PreFlushEventArgs $args): void
     {
         $this->preFlushCalled = true;
     }
 
-    public function onFlush(\Doctrine\ORM\Event\OnFlushEventArgs $args)
+    public function onFlush(OnFlushEventArgs $args): void
     {
         $this->onFlushCalled = true;
     }
 
-    public function postFlush(\Doctrine\ORM\Event\PostFlushEventArgs $args)
+    public function postFlush(PostFlushEventArgs $args): void
     {
         $this->postFlushCalled = true;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/ExtendedTypesEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/ExtendedTypesEntity.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -88,160 +90,160 @@ class ExtendedTypesEntity
      * @param \DateTime $time
      * @return $this
      */
-    public function setTime(\DateTime $time)
+    public function setTime(\DateTime $time): self
     {
         $this->time = $time;
         return $this;
     }
 
     /**
-     * @return \DateTime
+     * @return ?\DateTime
      */
-    public function getTime()
+    public function getTime(): ?\DateTime
     {
         return $this->time;
     }
 
     /**
-     * @param \DateTime $date
+     * @param \DateTime|null $date
      * @return $this
      */
-    public function setDate(?\DateTime $date = null)
+    public function setDate(?\DateTime $date = null): self
     {
         $this->date = $date;
         return $this;
     }
 
     /**
-     * @return \DateTime
+     * @return ?\DateTime
      */
-    public function getDate()
+    public function getDate(): ?\DateTime
     {
         return $this->date;
     }
 
     /**
-     * @param \DateTime $dateTimeTz
+     * @param \DateTime|null $dateTimeTz
      * @return $this
      */
-    public function setDateTimeTz(?\DateTime $dateTimeTz = null)
+    public function setDateTimeTz(?\DateTime $dateTimeTz = null): self
     {
         $this->dateTimeTz = $dateTimeTz;
         return $this;
     }
 
     /**
-     * @return \DateTime
+     * @return ?\DateTime
      */
-    public function getDateTimeTz()
+    public function getDateTimeTz(): ?\DateTime
     {
         return $this->dateTimeTz;
     }
 
     /**
-     * @param \DateTime $dateTime
+     * @param \DateTime|null $dateTime
      * @return $this
      */
-    public function setDateTime(?\DateTime $dateTime = null)
+    public function setDateTime(?\DateTime $dateTime = null): self
     {
         $this->dateTime = $dateTime;
         return $this;
     }
 
     /**
-     * @return \DateTime
+     * @return ?\DateTime
      */
-    public function getDateTime()
+    public function getDateTime(): ?\DateTime
     {
         return $this->dateTime;
     }
 
     /**
-     * @param \DateTimeImmutable $dateTime
+     * @param \DateTimeImmutable|null $dateTime
      * @return $this
      */
-    public function setDateTimeImmutable(?\DateTimeImmutable $dateTime = null)
+    public function setDateTimeImmutable(?\DateTimeImmutable $dateTime = null): self
     {
         $this->dateTimeImmutable = $dateTime;
         return $this;
     }
 
     /**
-     * @return \DateTimeImmutable
+     * @return ?\DateTimeImmutable
      */
-    public function getDateTimeImmutable()
+    public function getDateTimeImmutable(): ?\DateTimeImmutable
     {
         return $this->dateTimeImmutable;
     }
 
     /**
-     * @param \DateTimeInterface $dateTime
+     * @param \DateTimeInterface|null $dateTime
      * @return $this
      */
-    public function setDateTimeInterface(?\DateTimeInterface $dateTime = null)
+    public function setDateTimeInterface(?\DateTimeInterface $dateTime = null): self
     {
         $this->dateTimeInterface = $dateTime;
         return $this;
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return ?\DateTimeInterface
      */
-    public function getDateTimeInterface()
+    public function getDateTimeInterface(): ?\DateTimeInterface
     {
         return $this->dateTimeInterface;
     }
 
     /**
-     * @param CommonObject $commonObject
+     * @param CommonObject|null $commonObject
      * @return $this
      */
-    public function setCommonObject(?CommonObject $commonObject = null)
+    public function setCommonObject(?CommonObject $commonObject = null): self
     {
         $this->commonObject = $commonObject;
         return $this;
     }
 
     /**
-     * @return CommonObject
+     * @return ?CommonObject
      */
-    public function getCommonObject()
+    public function getCommonObject(): ?CommonObject
     {
         return $this->commonObject;
     }
 
     /**
-     * @param array $simpleArray
+     * @param array|null $simpleArray
      * @return $this
      */
-    public function setSimpleArray(?array $simpleArray = null)
+    public function setSimpleArray(?array $simpleArray = null): self
     {
         $this->simpleArray = $simpleArray;
         return $this;
     }
 
     /**
-     * @return array
+     * @return ?array
      */
-    public function getSimpleArray()
+    public function getSimpleArray(): ?array
     {
         return $this->simpleArray;
     }
 
     /**
-     * @param array $jsonArray
+     * @param array|null $jsonArray
      * @return $this
      */
-    public function setJsonArray(?array $jsonArray = null)
+    public function setJsonArray(?array $jsonArray = null): self
     {
         $this->jsonArray = $jsonArray;
         return $this;
     }
 
     /**
-     * @return array
+     * @return ?array
      */
-    public function getJsonArray()
+    public function getJsonArray(): ?array
     {
         return $this->jsonArray;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/ExtendedTypesEntityRepository.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/ExtendedTypesEntityRepository.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Image.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Image.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -36,7 +38,7 @@ class Image
     /**
      * @return string
      */
-    public function getData()
+    public function getData(): string
     {
         return $this->data;
     }
@@ -45,7 +47,7 @@ class Image
      * @param string $data
      * @return void
      */
-    public function setData($data)
+    public function setData($data): void
     {
         $this->data = $data;
     }
@@ -53,20 +55,20 @@ class Image
     /**
      * @return CleanupObject
      */
-    public function getRelatedObject()
+    public function getRelatedObject(): CleanupObject
     {
         return $this->relatedObject;
     }
 
     /**
-     * @param CleanupObject $relatedObject
+     * @param CleanupObject|null $relatedObject
      */
-    public function setRelatedObject(?CleanupObject $relatedObject = null)
+    public function setRelatedObject(?CleanupObject $relatedObject = null): void
     {
         $this->relatedObject = $relatedObject;
     }
 
-    public function shutdownObject()
+    public function shutdownObject(): void
     {
         if ($this->relatedObject instanceof CleanupObject) {
             $this->relatedObject->toggleState();

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/ObjectHoldingAnEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/ObjectHoldingAnEntity.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 class ObjectHoldingAnEntity

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/OneToOneEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/OneToOneEntity.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/OneToOneEntity2.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/OneToOneEntity2.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Post.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Post.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -82,7 +84,7 @@ class Post
      * @return string
      * @ORM\PrePersist
      */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->title;
     }
@@ -91,7 +93,7 @@ class Post
      * @param string $title
      * @return void
      */
-    public function setTitle($title)
+    public function setTitle($title): void
     {
         $this->title = $title;
     }
@@ -99,7 +101,7 @@ class Post
     /**
      * @param Image $image
      */
-    public function setImage($image)
+    public function setImage($image): void
     {
         $this->image = $image;
     }
@@ -107,7 +109,7 @@ class Post
     /**
      * @return Image
      */
-    public function getImage()
+    public function getImage(): Image
     {
         return $this->image;
     }
@@ -116,7 +118,7 @@ class Post
      * @param $comment
      * @return void
      */
-    public function setComment($comment)
+    public function setComment($comment): void
     {
         $this->comment = $comment;
     }
@@ -124,7 +126,7 @@ class Post
     /**
      * @return Comment
      */
-    public function getComment()
+    public function getComment(): Comment
     {
         return $this->comment;
     }
@@ -132,7 +134,7 @@ class Post
     /**
      * @param Tag $tag
      */
-    public function addTag(Tag $tag)
+    public function addTag(Tag $tag): void
     {
         $this->tags->add($tag);
     }
@@ -140,15 +142,15 @@ class Post
     /**
      * @param Tag $tag
      */
-    public function removeTag(Tag $tag)
+    public function removeTag(Tag $tag): void
     {
         $this->tags->removeElement($tag);
     }
 
     /**
-     * @return Collection
+     * @return ArrayCollection|Collection
      */
-    public function getTags()
+    public function getTags(): ArrayCollection|Collection
     {
         return $this->tags;
     }
@@ -156,7 +158,7 @@ class Post
     /**
      * @return TestValueObject
      */
-    public function getAuthor()
+    public function getAuthor(): TestValueObject
     {
         return $this->author;
     }
@@ -164,7 +166,7 @@ class Post
     /**
      * @param TestValueObject $author
      */
-    public function setAuthor(TestValueObject $author)
+    public function setAuthor(TestValueObject $author): void
     {
         $this->author = $author;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/PostRepository.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/PostRepository.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -22,5 +24,5 @@ class PostRepository extends Repository
     /**
      * @var string
      */
-    const ENTITY_CLASSNAME = Post::class;
+    public const ENTITY_CLASSNAME = Post::class;
 }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/RelatedIndexEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/RelatedIndexEntity.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -36,7 +38,7 @@ class RelatedIndexEntity
     /**
      * @return string
      */
-    public function getSorting()
+    public function getSorting(): string
     {
         return $this->sorting;
     }
@@ -44,7 +46,7 @@ class RelatedIndexEntity
     /**
      * @param string $sorting
      */
-    public function setSorting($sorting)
+    public function setSorting($sorting): void
     {
         $this->sorting = $sorting;
     }
@@ -52,7 +54,7 @@ class RelatedIndexEntity
     /**
      * @param EntityWithIndexedRelation $entityWithIndexedRelation
      */
-    public function setEntityWithIndexedRelation($entityWithIndexedRelation)
+    public function setEntityWithIndexedRelation($entityWithIndexedRelation): void
     {
         $this->entityWithIndexedRelation = $entityWithIndexedRelation;
     }
@@ -60,7 +62,7 @@ class RelatedIndexEntity
     /**
      * @return EntityWithIndexedRelation
      */
-    public function getEntityWithIndexedRelation()
+    public function getEntityWithIndexedRelation(): EntityWithIndexedRelation
     {
         return $this->entityWithIndexedRelation;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/SubEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/SubEntity.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -42,15 +44,15 @@ class SubEntity extends SuperEntity
      * @param TestEntity $parentEntity
      * @return void
      */
-    public function setParentEntity(TestEntity $parentEntity)
+    public function setParentEntity(TestEntity $parentEntity): void
     {
         $this->parentEntity = $parentEntity;
     }
 
     /**
-     * @return TestEntity
+     * @return ?TestEntity
      */
-    public function getParentEntity()
+    public function getParentEntity(): ?TestEntity
     {
         return $this->parentEntity;
     }
@@ -58,7 +60,7 @@ class SubEntity extends SuperEntity
     /**
      * @return \DateTime
      */
-    public function getDate()
+    public function getDate(): \DateTime
     {
         return $this->date;
     }
@@ -66,7 +68,7 @@ class SubEntity extends SuperEntity
     /**
      * @param \DateTime $date
      */
-    public function setDate($date)
+    public function setDate($date): void
     {
         $this->date = $date;
     }
@@ -74,7 +76,7 @@ class SubEntity extends SuperEntity
     /**
      * @return string
      */
-    public function getSomeProperty()
+    public function getSomeProperty(): string
     {
         return $this->someProperty;
     }
@@ -82,7 +84,7 @@ class SubEntity extends SuperEntity
     /**
      * @param string $someProperty
      */
-    public function setSomeProperty($someProperty)
+    public function setSomeProperty($someProperty): void
     {
         $this->someProperty = $someProperty;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/SubSubEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/SubSubEntity.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/SubSubEntityRepository.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/SubSubEntityRepository.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -24,7 +26,7 @@ class SubSubEntityRepository extends Repository
     /**
      * @var string
      */
-    const ENTITY_CLASSNAME = SubSubEntity::class;
+    public const ENTITY_CLASSNAME = SubSubEntity::class;
 
     public function findAll(): QueryResultInterface
     {

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/SuperEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/SuperEntity.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -31,7 +33,7 @@ class SuperEntity
     /**
      * @return string
      */
-    public function getContent()
+    public function getContent(): string
     {
         return $this->content;
     }
@@ -40,7 +42,7 @@ class SuperEntity
      * @param string $content
      * @return void
      */
-    public function setContent($content)
+    public function setContent($content): void
     {
         $this->content = $content;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/SuperEntityRepository.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/SuperEntityRepository.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -23,5 +25,5 @@ class SuperEntityRepository extends Repository
     /**
      * @var string
      */
-    const ENTITY_CLASSNAME = SuperEntity::class;
+    public const ENTITY_CLASSNAME = SuperEntity::class;
 }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/Tag.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/Tag.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -33,7 +35,7 @@ class Tag
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestEmbeddable.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestEmbeddable.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -12,7 +14,6 @@ namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
  */
 
 use Doctrine\ORM\Mapping as ORM;
-use Neos\Flow\Annotations as Flow;
 
 /**
  * A simple Doctrine ORM 2.5 embeddable for persistence tests
@@ -40,7 +41,7 @@ class TestEmbeddable
     /**
      * @return string
      */
-    public function getValue()
+    public function getValue(): string
     {
         return $this->value;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestEmbeddedValueObject.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestEmbeddedValueObject.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -38,7 +40,7 @@ class TestEmbeddedValueObject
     /**
      * @return string
      */
-    public function getValue()
+    public function getValue(): string
     {
         return $this->value;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestEntity.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -91,7 +93,7 @@ class TestEntity
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -100,7 +102,7 @@ class TestEntity
      * @param string $name
      * @return void
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -108,7 +110,7 @@ class TestEntity
     /**
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }
@@ -116,7 +118,7 @@ class TestEntity
     /**
      * @param string $description
      */
-    public function setDescription($description)
+    public function setDescription($description): void
     {
         $this->description = $description;
     }
@@ -125,7 +127,7 @@ class TestEntity
      * @param array $arrayProperty
      * @return void
      */
-    public function setArrayProperty($arrayProperty)
+    public function setArrayProperty($arrayProperty): void
     {
         $this->arrayProperty = $arrayProperty;
     }
@@ -133,7 +135,7 @@ class TestEntity
     /**
      * @return array
      */
-    public function getArrayProperty()
+    public function getArrayProperty(): array
     {
         return $this->arrayProperty;
     }
@@ -141,7 +143,7 @@ class TestEntity
     /**
      * @return string
      */
-    public function sayHello()
+    public function sayHello(): string
     {
         return 'Hello';
     }
@@ -150,15 +152,15 @@ class TestEntity
      * @param TestEntity $relatedEntity
      * @return void
      */
-    public function setRelatedEntity(TestEntity $relatedEntity)
+    public function setRelatedEntity(TestEntity $relatedEntity): void
     {
         $this->relatedEntity = $relatedEntity;
     }
 
     /**
-     * @return TestEntity
+     * @return ?TestEntity
      */
-    public function getRelatedEntity()
+    public function getRelatedEntity(): ?TestEntity
     {
         return $this->relatedEntity;
     }
@@ -167,7 +169,7 @@ class TestEntity
      * @param Collection<ImportedSubEntity> $subEntities
      * @return void
      */
-    public function setSubEntities(Collection $subEntities)
+    public function setSubEntities(Collection $subEntities): void
     {
         $this->subEntities = $subEntities;
     }
@@ -176,15 +178,15 @@ class TestEntity
      * @param ImportedSubEntity $subEntity
      * @return void
      */
-    public function addSubEntity(ImportedSubEntity $subEntity)
+    public function addSubEntity(ImportedSubEntity $subEntity): void
     {
         $this->subEntities->add($subEntity);
     }
 
     /**
-     * @return Collection<ImportedSubEntity>
+     * @return ArrayCollection|Collection
      */
-    public function getRelatedEntities()
+    public function getRelatedEntities(): ArrayCollection|Collection
     {
         return $this->subEntities;
     }
@@ -192,7 +194,7 @@ class TestEntity
     /**
      * @return ObjectManagerInterface
      */
-    public function getObjectManager()
+    public function getObjectManager(): ObjectManagerInterface
     {
         return $this->objectManager;
     }
@@ -201,7 +203,7 @@ class TestEntity
      * @param TestValueObject $relatedValueObject
      * @return void
      */
-    public function setRelatedValueObject($relatedValueObject)
+    public function setRelatedValueObject($relatedValueObject): void
     {
         $this->relatedValueObject = $relatedValueObject;
     }
@@ -209,7 +211,7 @@ class TestEntity
     /**
      * @return TestValueObject
      */
-    public function getRelatedValueObject()
+    public function getRelatedValueObject(): TestValueObject
     {
         return $this->relatedValueObject;
     }
@@ -217,7 +219,7 @@ class TestEntity
     /**
      * @return TestEmbeddable
      */
-    public function getEmbedded()
+    public function getEmbedded(): TestEmbeddable
     {
         return $this->embedded;
     }
@@ -225,7 +227,7 @@ class TestEntity
     /**
      * @param TestEmbeddable $embedded
      */
-    public function setEmbedded($embedded)
+    public function setEmbedded($embedded): void
     {
         $this->embedded = $embedded;
     }
@@ -234,7 +236,7 @@ class TestEntity
      * @param TestEmbeddedValueObject $embeddedValueObject
      * @return void
      */
-    public function setEmbeddedValueObject($embeddedValueObject)
+    public function setEmbeddedValueObject($embeddedValueObject): void
     {
         $this->embeddedValueObject = $embeddedValueObject;
     }
@@ -242,7 +244,7 @@ class TestEntity
     /**
      * @return TestEmbeddedValueObject
      */
-    public function getEmbeddedValueObject()
+    public function getEmbeddedValueObject(): TestEmbeddedValueObject
     {
         return $this->embeddedValueObject;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestEntityAspect.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestEntityAspect.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -26,7 +28,7 @@ class TestEntityAspect
      * @param JoinPointInterface $joinPoint
      * @return string
      */
-    public function concreteMethodInAbstractClassAdvice(JoinPointInterface $joinPoint)
+    public function concreteMethodInAbstractClassAdvice(JoinPointInterface $joinPoint): string
     {
         $result = $joinPoint->getAdviceChain()->proceed($joinPoint);
         return $result . ' Andi!';

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestEntityRepository.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestEntityRepository.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestValueObject.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestValueObject.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestValueObjectWithConstructorLogic.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestValueObjectWithConstructorLogic.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestValueObjectWithConstructorLogicAndInversedPropertyOrder.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestValueObjectWithConstructorLogicAndInversedPropertyOrder.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestValueObjectWithDateTimeProperty.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestValueObjectWithDateTimeProperty.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestValueObjectWithSubValueObjectProperties.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestValueObjectWithSubValueObjectProperties.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestValueObjectWithTransientProperties.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/TestValueObjectWithTransientProperties.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*

--- a/Neos.Flow/Tests/Functional/Persistence/Fixtures/UnproxiedTestEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/Fixtures/UnproxiedTestEntity.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence\Fixtures;
 
 /*
@@ -45,7 +47,7 @@ class UnproxiedTestEntity
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -54,7 +56,7 @@ class UnproxiedTestEntity
      * @param string $name
      * @return void
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/AbstractEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/AbstractEntity.php
@@ -1,0 +1,25 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A sample entity for tests
+ *
+ * @Flow\Entity
+ * @ORM\InheritanceType("JOINED")
+ */
+abstract class AbstractEntity
+{
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/AbstractEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/AbstractEntity.php
@@ -16,10 +16,9 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A sample entity for tests
- *
- * @Flow\Entity
- * @ORM\InheritanceType("JOINED")
  */
+#[Flow\Entity]
+#[ORM\InheritanceType('JOINED')]
 abstract class AbstractEntity
 {
 }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/AnnotatedIdEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/AnnotatedIdEntity.php
@@ -16,44 +16,28 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * A sample entity that has a property with a Id annotation
- *
- * @Flow\Entity
  */
+#[Flow\Entity]
 class AnnotatedIdEntity
 {
-    /**
-     * @ORM\Id
-     * @ORM\GeneratedValue
-     * @ORM\SequenceGenerator(sequenceName="annotatedidentity_seq")
-     * @var string
-     */
-    protected $id;
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\SequenceGenerator(sequenceName: 'annotatedidentity_seq')]
+    protected string $id;
 
-    /**
-     * @var string
-     */
-    protected $title;
+    protected string $title;
 
-    /**
-     * @return string
-     */
-    public function getId()
+    public function getId(): string
     {
         return $this->id;
     }
 
-    /**
-     * @param string $title
-     */
-    public function setTitle($title)
+    public function setTitle(string $title): void
     {
         $this->title = $title;
     }
 
-    /**
-     * @return string
-     */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->title;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/AnnotatedIdEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/AnnotatedIdEntity.php
@@ -1,0 +1,60 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * A sample entity that has a property with a Id annotation
+ *
+ * @Flow\Entity
+ */
+class AnnotatedIdEntity
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\SequenceGenerator(sequenceName="annotatedidentity_seq")
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param string $title
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/AnnotatedIdentitiesEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/AnnotatedIdentitiesEntity.php
@@ -15,51 +15,32 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A sample entity that has properties with an Identity annotation
- *
- * @Flow\Entity
  */
+#[Flow\Entity]
 class AnnotatedIdentitiesEntity
 {
-    /**
-     * @Flow\Identity
-     * @var string
-     */
-    protected $author;
+    #[Flow\Identity]
+    protected string $author;
 
-    /**
-     * @Flow\Identity
-     * @var string
-     */
-    protected $title;
+    #[Flow\Identity]
+    protected string $title;
 
-    /**
-     * @param string $author
-     */
-    public function setAuthor($author)
+    public function setAuthor(string $author): void
     {
         $this->author = $author;
     }
 
-    /**
-     * @return string
-     */
-    public function getAuthor()
+    public function getAuthor(): string
     {
         return $this->author;
     }
 
-    /**
-     * @param string $title
-     */
-    public function setTitle($title)
+    public function setTitle(string $title): void
     {
         $this->title = $title;
     }
 
-    /**
-     * @return string
-     */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->title;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/AnnotatedIdentitiesEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/AnnotatedIdentitiesEntity.php
@@ -1,0 +1,66 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A sample entity that has properties with an Identity annotation
+ *
+ * @Flow\Entity
+ */
+class AnnotatedIdentitiesEntity
+{
+    /**
+     * @Flow\Identity
+     * @var string
+     */
+    protected $author;
+
+    /**
+     * @Flow\Identity
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * @param string $author
+     */
+    public function setAuthor($author)
+    {
+        $this->author = $author;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAuthor()
+    {
+        return $this->author;
+    }
+
+    /**
+     * @param string $title
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/CleanupObject.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/CleanupObject.php
@@ -13,20 +13,14 @@ namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
 
 class CleanupObject
 {
-    /**
-     * @var boolean
-     */
-    protected $state = false;
+    protected bool $state = false;
 
-    public function toggleState()
+    public function toggleState(): void
     {
         $this->state = !$this->state;
     }
 
-    /**
-     * @return boolean
-     */
-    public function getState()
+    public function getState(): bool
     {
         return $this->state;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/CleanupObject.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/CleanupObject.php
@@ -1,0 +1,33 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+class CleanupObject
+{
+    /**
+     * @var boolean
+     */
+    protected $state = false;
+
+    public function toggleState()
+    {
+        $this->state = !$this->state;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getState()
+    {
+        return $this->state;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/Comment.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/Comment.php
@@ -16,30 +16,19 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * A sample entity for tests
- *
- * @Flow\Entity
  */
+#[Flow\Entity]
 class Comment
 {
-    /**
-     * @var string
-     */
-    protected $content = '';
+    protected string $content = '';
 
-    /**
-     * @return string
-     * @ORM\PrePersist
-     */
-    public function getContent()
+    #[ORM\PrePersist]
+    public function getContent(): string
     {
         return $this->content;
     }
 
-    /**
-     * @param string $content
-     * @return void
-     */
-    public function setContent($content)
+    public function setContent(string $content): void
     {
         $this->content = $content;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/Comment.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/Comment.php
@@ -1,0 +1,46 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * A sample entity for tests
+ *
+ * @Flow\Entity
+ */
+class Comment
+{
+    /**
+     * @var string
+     */
+    protected $content = '';
+
+    /**
+     * @return string
+     * @ORM\PrePersist
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
+
+    /**
+     * @param string $content
+     * @return void
+     */
+    public function setContent($content)
+    {
+        $this->content = $content;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/CommentRepository.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/CommentRepository.php
@@ -1,0 +1,27 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Persistence\Repository;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A repository for comments
+ * @Flow\Scope("singleton")
+ */
+class CommentRepository extends Repository
+{
+    /**
+     * @var string
+     */
+    const ENTITY_CLASSNAME = Comment::class;
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/CommentRepository.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/CommentRepository.php
@@ -16,8 +16,8 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A repository for comments
- * @Flow\Scope("singleton")
  */
+#[Flow\Scope('singleton')]
 class CommentRepository extends Repository
 {
     /**

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/CommonObject.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/CommonObject.php
@@ -1,0 +1,44 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * Class CommonObject
+ * Representation of an object handled as "\Doctrine\DBAL\Types\Type::OBJECT"
+ */
+class CommonObject
+{
+    /**
+     * @var string
+     */
+    protected $foo;
+
+    /**
+     * @param string $foo
+     * @return $this
+     */
+    public function setFoo($foo = null)
+    {
+        $this->foo = $foo;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/CommonObject.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/CommonObject.php
@@ -19,25 +19,15 @@ use Neos\Flow\Annotations as Flow;
  */
 class CommonObject
 {
-    /**
-     * @var string
-     */
-    protected $foo;
+    protected ?string $foo;
 
-    /**
-     * @param string $foo
-     * @return $this
-     */
-    public function setFoo($foo = null)
+    public function setFoo(?string $foo = null): self
     {
         $this->foo = $foo;
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getFoo()
+    public function getFoo(): ?string
     {
         return $this->foo;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/CommonObject.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/CommonObject.php
@@ -11,8 +11,6 @@ namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
  * source code.
  */
 
-use Neos\Flow\Annotations as Flow;
-
 /**
  * Class CommonObject
  * Representation of an object handled as "\Doctrine\DBAL\Types\Type::OBJECT"

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/CompositeKeyTestEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/CompositeKeyTestEntity.php
@@ -16,56 +16,35 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A simple entity for persistence tests
- *
- * @Flow\Entity
- * @ORM\Table(name="persistence_php8_compsitekeytestentity")
  */
+#[Flow\Entity]
+#[ORM\Table(name: 'persistence_php8_compsitekeytestentity')]
 class CompositeKeyTestEntity
 {
-    /**
-     * @var string
-     * @ORM\Id
-     * @ORM\Column(length=20)
-     */
-    protected $name = '';
+    #[ORM\Id]
+    #[ORM\Column(length: 20)]
+    protected string $name = '';
 
-    /**
-     * @var TestEntity
-     * @ORM\Id
-     * @ORM\ManyToOne
-     */
-    protected $relatedEntity;
+    #[ORM\Id]
+    #[ORM\ManyToOne]
+    protected TestEntity $relatedEntity;
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @param string $name
-     * @return void
-     */
-    public function setName($name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
 
-    /**
-     * @param TestEntity $relatedEntity
-     * @return void
-     */
-    public function setRelatedEntity(TestEntity $relatedEntity)
+    public function setRelatedEntity(TestEntity $relatedEntity): void
     {
         $this->relatedEntity = $relatedEntity;
     }
 
-    /**
-     * @return TestEntity
-     */
-    public function getRelatedEntity()
+    public function getRelatedEntity(): TestEntity
     {
         return $this->relatedEntity;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/CompositeKeyTestEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/CompositeKeyTestEntity.php
@@ -1,0 +1,72 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A simple entity for persistence tests
+ *
+ * @Flow\Entity
+ * @ORM\Table(name="persistence_php8_compsitekeytestentity")
+ */
+class CompositeKeyTestEntity
+{
+    /**
+     * @var string
+     * @ORM\Id
+     * @ORM\Column(length=20)
+     */
+    protected $name = '';
+
+    /**
+     * @var TestEntity
+     * @ORM\Id
+     * @ORM\ManyToOne
+     */
+    protected $relatedEntity;
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return void
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @param TestEntity $relatedEntity
+     * @return void
+     */
+    public function setRelatedEntity(TestEntity $relatedEntity)
+    {
+        $this->relatedEntity = $relatedEntity;
+    }
+
+    /**
+     * @return TestEntity
+     */
+    public function getRelatedEntity()
+    {
+        return $this->relatedEntity;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/EntityWithIndexedRelation.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/EntityWithIndexedRelation.php
@@ -1,0 +1,90 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A sample entity that has a property with an indexed relation
+ *
+ * @Flow\Scope("prototype")
+ * @Flow\Entity
+ */
+class EntityWithIndexedRelation
+{
+    /**
+     * @var Collection<AnnotatedIdentitiesEntity>
+     * @ORM\ManyToMany(indexBy="author")
+     */
+    protected $annotatedIdentitiesEntities;
+
+    /**
+     * @var Collection<RelatedIndexEntity>
+     * @ORM\OneToMany(indexBy="sorting", mappedBy="entityWithIndexedRelation")
+     */
+    protected $relatedIndexEntities;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->annotatedIdentitiesEntities = new ArrayCollection();
+        $this->relatedIndexEntities = new ArrayCollection();
+    }
+
+    /**
+     * @param \Doctrine\Common\Collections\Collection $annotatedIdentitiesEntities
+     */
+    public function setAnnotatedIdentitiesEntities($annotatedIdentitiesEntities)
+    {
+        $this->annotatedIdentitiesEntities = $annotatedIdentitiesEntities;
+    }
+
+    /**
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function getAnnotatedIdentitiesEntities()
+    {
+        return $this->annotatedIdentitiesEntities;
+    }
+
+    /**
+     * @param \Doctrine\Common\Collections\Collection $relatedIndexEntities
+     */
+    public function setRelatedIndexEntities($relatedIndexEntities)
+    {
+        $this->relatedIndexEntities = $relatedIndexEntities;
+    }
+
+    /**
+     * @return \Doctrine\Common\Collections\Collection
+     */
+    public function getRelatedIndexEntities()
+    {
+        return $this->relatedIndexEntities;
+    }
+
+    /**
+     * @param string $sorting
+     * @param RelatedIndexEntity $relatedIndexEntity
+     */
+    public function setRelatedIndexEntity($sorting, RelatedIndexEntity $relatedIndexEntity)
+    {
+        $relatedIndexEntity->setSorting($sorting);
+        $relatedIndexEntity->setEntityWithIndexedRelation($this);
+        $this->relatedIndexEntities->set($sorting, $relatedIndexEntity);
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/EntityWithIndexedRelation.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/EntityWithIndexedRelation.php
@@ -18,23 +18,23 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A sample entity that has a property with an indexed relation
- *
- * @Flow\Scope("prototype")
- * @Flow\Entity
  */
+#[Flow\Scope('prototype')]
+#[Flow\Entity]
 class EntityWithIndexedRelation
 {
     /**
      * @var Collection<AnnotatedIdentitiesEntity>
-     * @ORM\ManyToMany(indexBy="author")
      */
-    protected $annotatedIdentitiesEntities;
+    #[ORM\ManyToMany(indexBy: 'author')]
+    protected Collection $annotatedIdentitiesEntities;
 
     /**
      * @var Collection<RelatedIndexEntity>
      * @ORM\OneToMany(indexBy="sorting", mappedBy="entityWithIndexedRelation")
      */
-    protected $relatedIndexEntities;
+    #[ORM\OneToMany(indexBy: 'sorting', mappedBy: 'entityWithIndexedRelation')]
+    protected Collection $relatedIndexEntities;
 
     /**
      * Constructor
@@ -46,42 +46,38 @@ class EntityWithIndexedRelation
     }
 
     /**
-     * @param \Doctrine\Common\Collections\Collection $annotatedIdentitiesEntities
+     * @param Collection<AnnotatedIdentitiesEntity> $annotatedIdentitiesEntities
      */
-    public function setAnnotatedIdentitiesEntities($annotatedIdentitiesEntities)
+    public function setAnnotatedIdentitiesEntities(Collection $annotatedIdentitiesEntities): void
     {
         $this->annotatedIdentitiesEntities = $annotatedIdentitiesEntities;
     }
 
     /**
-     * @return \Doctrine\Common\Collections\Collection
+     * @return Collection<AnnotatedIdentitiesEntity>
      */
-    public function getAnnotatedIdentitiesEntities()
+    public function getAnnotatedIdentitiesEntities(): Collection
     {
         return $this->annotatedIdentitiesEntities;
     }
 
     /**
-     * @param \Doctrine\Common\Collections\Collection $relatedIndexEntities
+     * @param Collection<RelatedIndexEntity> $relatedIndexEntities
      */
-    public function setRelatedIndexEntities($relatedIndexEntities)
+    public function setRelatedIndexEntities(Collection $relatedIndexEntities): void
     {
         $this->relatedIndexEntities = $relatedIndexEntities;
     }
 
     /**
-     * @return \Doctrine\Common\Collections\Collection
+     * @return Collection<RelatedIndexEntity>
      */
-    public function getRelatedIndexEntities()
+    public function getRelatedIndexEntities(): Collection
     {
         return $this->relatedIndexEntities;
     }
 
-    /**
-     * @param string $sorting
-     * @param RelatedIndexEntity $relatedIndexEntity
-     */
-    public function setRelatedIndexEntity($sorting, RelatedIndexEntity $relatedIndexEntity)
+    public function setRelatedIndexEntity(string $sorting, RelatedIndexEntity $relatedIndexEntity): void
     {
         $relatedIndexEntity->setSorting($sorting);
         $relatedIndexEntity->setEntityWithIndexedRelation($this);

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/EventListener.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/EventListener.php
@@ -1,0 +1,43 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A sample event subscriber
+ *
+ * @Flow\Scope("singleton")
+ */
+class EventListener
+{
+    public $preFlushCalled = false;
+
+    public $onFlushCalled = false;
+
+    public $postFlushCalled = false;
+
+    public function preFlush(\Doctrine\ORM\Event\PreFlushEventArgs $args)
+    {
+        $this->preFlushCalled = true;
+    }
+
+    public function onFlush(\Doctrine\ORM\Event\OnFlushEventArgs $args)
+    {
+        $this->onFlushCalled = true;
+    }
+
+    public function postFlush(\Doctrine\ORM\Event\PostFlushEventArgs $args)
+    {
+        $this->postFlushCalled = true;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/EventListener.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/EventListener.php
@@ -11,13 +11,15 @@ namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
  * source code.
  */
 
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Event\PreFlushEventArgs;
 use Neos\Flow\Annotations as Flow;
 
 /**
  * A sample event subscriber
- *
- * @Flow\Scope("singleton")
  */
+#[Flow\Scope('singleton')]
 class EventListener
 {
     public $preFlushCalled = false;
@@ -26,17 +28,17 @@ class EventListener
 
     public $postFlushCalled = false;
 
-    public function preFlush(\Doctrine\ORM\Event\PreFlushEventArgs $args)
+    public function preFlush(PreFlushEventArgs $args)
     {
         $this->preFlushCalled = true;
     }
 
-    public function onFlush(\Doctrine\ORM\Event\OnFlushEventArgs $args)
+    public function onFlush(OnFlushEventArgs $args)
     {
         $this->onFlushCalled = true;
     }
 
-    public function postFlush(\Doctrine\ORM\Event\PostFlushEventArgs $args)
+    public function postFlush(PostFlushEventArgs $args)
     {
         $this->postFlushCalled = true;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/EventSubscriber.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/EventSubscriber.php
@@ -11,14 +11,16 @@ namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
  * source code.
  */
 
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Event\PreFlushEventArgs;
 use Neos\Flow\Annotations as Flow;
 use Doctrine\ORM\Events;
 
 /**
  * A sample event subscriber
- *
- * @Flow\Scope("singleton")
  */
+#[Flow\Scope('singleton')]
 class EventSubscriber implements \Doctrine\Common\EventSubscriber
 {
     public $preFlushCalled = false;
@@ -37,17 +39,17 @@ class EventSubscriber implements \Doctrine\Common\EventSubscriber
         return [Events::preFlush, Events::onFlush, Events::postFlush];
     }
 
-    public function preFlush(\Doctrine\ORM\Event\PreFlushEventArgs $args)
+    public function preFlush(PreFlushEventArgs $args)
     {
         $this->preFlushCalled = true;
     }
 
-    public function onFlush(\Doctrine\ORM\Event\OnFlushEventArgs $args)
+    public function onFlush(OnFlushEventArgs $args)
     {
         $this->onFlushCalled = true;
     }
 
-    public function postFlush(\Doctrine\ORM\Event\PostFlushEventArgs $args)
+    public function postFlush(PostFlushEventArgs $args)
     {
         $this->postFlushCalled = true;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/EventSubscriber.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/EventSubscriber.php
@@ -1,0 +1,54 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Doctrine\ORM\Events;
+
+/**
+ * A sample event subscriber
+ *
+ * @Flow\Scope("singleton")
+ */
+class EventSubscriber implements \Doctrine\Common\EventSubscriber
+{
+    public $preFlushCalled = false;
+
+    public $onFlushCalled = false;
+
+    public $postFlushCalled = false;
+
+    /**
+     * Returns an array of events this subscriber wants to listen to.
+     *
+     * @return array
+     */
+    public function getSubscribedEvents()
+    {
+        return [Events::preFlush, Events::onFlush, Events::postFlush];
+    }
+
+    public function preFlush(\Doctrine\ORM\Event\PreFlushEventArgs $args)
+    {
+        $this->preFlushCalled = true;
+    }
+
+    public function onFlush(\Doctrine\ORM\Event\OnFlushEventArgs $args)
+    {
+        $this->onFlushCalled = true;
+    }
+
+    public function postFlush(\Doctrine\ORM\Event\PostFlushEventArgs $args)
+    {
+        $this->postFlushCalled = true;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/ExtendedTypesEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/ExtendedTypesEntity.php
@@ -34,7 +34,7 @@ class ExtendedTypesEntity
     #[ORM\Column(type: 'simple_array', nullable: true)]
     protected ?array $simpleArray;
 
-    #[ORM\Column(type: 'json_array', nullable: true)]
+    #[ORM\Column(type: 'flow_json_array', nullable: true)]
     protected ?array $jsonArray;
 
     #[ORM\Column(type: 'datetime', nullable: true)]

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/ExtendedTypesEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/ExtendedTypesEntity.php
@@ -1,0 +1,248 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Testing advanced properties of types:
+ *
+ * \Doctrine\DBAL\Types\Type::SIMPLE_ARRAY
+ * \Doctrine\DBAL\Types\Type::JSON_ARRAY
+ * \Doctrine\DBAL\Types\Type::DATETIME
+ * \Doctrine\DBAL\Types\Type::DATETIMETZ
+ * \Doctrine\DBAL\Types\Type::DATE
+ * \Doctrine\DBAL\Types\Type::TIME
+ * \Doctrine\DBAL\Types\Type::OBJECT
+ *
+ * @Flow\Entity
+ */
+class ExtendedTypesEntity
+{
+    /**
+     * @var CommonObject
+     * @ORM\Column(type="object", nullable=true)
+     */
+    protected $commonObject;
+
+    /**
+     * @var array
+     * @ORM\Column(type="simple_array", nullable=true)
+     */
+    protected $simpleArray;
+
+    /**
+     * @var array
+     * @ORM\Column(type="json_array", nullable=true)
+     */
+    protected $jsonArray;
+
+    /**
+     * @var \DateTime
+     * @ORM\Column(type="datetime", nullable=true)
+     */
+    protected $dateTime;
+
+    /**
+     * @var \DateTime
+     * @ORM\Column(type="datetimetz", nullable=true)
+     */
+    protected $dateTimeTz;
+
+    /**
+     * @var \DateTime
+     * @ORM\Column(type="date", nullable=true)
+     */
+    protected $date;
+
+    /**
+     * @var \DateTime
+     * @ORM\Column(type="time", nullable=true)
+     */
+    protected $time;
+
+    /**
+     * @var \DateTimeImmutable
+     * @ORM\Column(nullable=true)
+     */
+    protected $dateTimeImmutable;
+
+    /**
+     * This is possible for b/c - see #1673
+     * @var \DateTimeInterface
+     * @ORM\Column(nullable=true)
+     */
+    protected $dateTimeInterface;
+
+    /**
+     * @param \DateTime $time
+     * @return $this
+     */
+    public function setTime(\DateTime $time)
+    {
+        $this->time = $time;
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getTime()
+    {
+        return $this->time;
+    }
+
+    /**
+     * @param \DateTime $date
+     * @return $this
+     */
+    public function setDate(?\DateTime $date = null)
+    {
+        $this->date = $date;
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    /**
+     * @param \DateTime $dateTimeTz
+     * @return $this
+     */
+    public function setDateTimeTz(?\DateTime $dateTimeTz = null)
+    {
+        $this->dateTimeTz = $dateTimeTz;
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getDateTimeTz()
+    {
+        return $this->dateTimeTz;
+    }
+
+    /**
+     * @param \DateTime $dateTime
+     * @return $this
+     */
+    public function setDateTime(?\DateTime $dateTime = null)
+    {
+        $this->dateTime = $dateTime;
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getDateTime()
+    {
+        return $this->dateTime;
+    }
+
+    /**
+     * @param \DateTimeImmutable $dateTime
+     * @return $this
+     */
+    public function setDateTimeImmutable(?\DateTimeImmutable $dateTime = null)
+    {
+        $this->dateTimeImmutable = $dateTime;
+        return $this;
+    }
+
+    /**
+     * @return \DateTimeImmutable
+     */
+    public function getDateTimeImmutable()
+    {
+        return $this->dateTimeImmutable;
+    }
+
+    /**
+     * @param \DateTimeInterface $dateTime
+     * @return $this
+     */
+    public function setDateTimeInterface(?\DateTimeInterface $dateTime = null)
+    {
+        $this->dateTimeInterface = $dateTime;
+        return $this;
+    }
+
+    /**
+     * @return \DateTimeInterface
+     */
+    public function getDateTimeInterface()
+    {
+        return $this->dateTimeInterface;
+    }
+
+    /**
+     * @param CommonObject $commonObject
+     * @return $this
+     */
+    public function setCommonObject(?CommonObject $commonObject = null)
+    {
+        $this->commonObject = $commonObject;
+        return $this;
+    }
+
+    /**
+     * @return CommonObject
+     */
+    public function getCommonObject()
+    {
+        return $this->commonObject;
+    }
+
+    /**
+     * @param array $simpleArray
+     * @return $this
+     */
+    public function setSimpleArray(?array $simpleArray = null)
+    {
+        $this->simpleArray = $simpleArray;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSimpleArray()
+    {
+        return $this->simpleArray;
+    }
+
+    /**
+     * @param array $jsonArray
+     * @return $this
+     */
+    public function setJsonArray(?array $jsonArray = null)
+    {
+        $this->jsonArray = $jsonArray;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getJsonArray()
+    {
+        return $this->jsonArray;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/ExtendedTypesEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/ExtendedTypesEntity.php
@@ -24,224 +24,135 @@ use Doctrine\ORM\Mapping as ORM;
  * \Doctrine\DBAL\Types\Type::DATE
  * \Doctrine\DBAL\Types\Type::TIME
  * \Doctrine\DBAL\Types\Type::OBJECT
- *
- * @Flow\Entity
  */
+#[Flow\Entity]
 class ExtendedTypesEntity
 {
-    /**
-     * @var CommonObject
-     * @ORM\Column(type="object", nullable=true)
-     */
-    protected $commonObject;
+    #[ORM\Column(type: 'object', nullable: true)]
+    protected ?CommonObject $commonObject;
 
-    /**
-     * @var array
-     * @ORM\Column(type="simple_array", nullable=true)
-     */
-    protected $simpleArray;
+    #[ORM\Column(type: 'simple_array', nullable: true)]
+    protected ?array $simpleArray;
 
-    /**
-     * @var array
-     * @ORM\Column(type="json_array", nullable=true)
-     */
-    protected $jsonArray;
+    #[ORM\Column(type: 'json_array', nullable: true)]
+    protected ?array $jsonArray;
 
-    /**
-     * @var \DateTime
-     * @ORM\Column(type="datetime", nullable=true)
-     */
-    protected $dateTime;
+    #[ORM\Column(type: 'datetime', nullable: true)]
+    protected ?\DateTime $dateTime;
 
-    /**
-     * @var \DateTime
-     * @ORM\Column(type="datetimetz", nullable=true)
-     */
-    protected $dateTimeTz;
+    #[ORM\Column(type: 'datetimetz', nullable: true)]
+    protected ?\DateTime $dateTimeTz;
 
-    /**
-     * @var \DateTime
-     * @ORM\Column(type="date", nullable=true)
-     */
-    protected $date;
+    #[ORM\Column(type: 'date', nullable: true)]
+    protected ?\DateTime $date;
 
-    /**
-     * @var \DateTime
-     * @ORM\Column(type="time", nullable=true)
-     */
-    protected $time;
+    #[ORM\Column(type: 'time', nullable: true)]
+    protected ?\DateTime $time;
 
-    /**
-     * @var \DateTimeImmutable
-     * @ORM\Column(nullable=true)
-     */
-    protected $dateTimeImmutable;
+    #[ORM\Column(nullable: true)]
+    protected ?\DateTimeImmutable $dateTimeImmutable;
 
     /**
      * This is possible for b/c - see #1673
-     * @var \DateTimeInterface
-     * @ORM\Column(nullable=true)
      */
-    protected $dateTimeInterface;
+    #[ORM\Column(nullable: true)]
+    protected \DateTimeInterface $dateTimeInterface;
 
-    /**
-     * @param \DateTime $time
-     * @return $this
-     */
-    public function setTime(\DateTime $time)
+    public function setTime(?\DateTime $time): self
     {
         $this->time = $time;
         return $this;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getTime()
+    public function getTime(): ?\DateTime
     {
         return $this->time;
     }
 
-    /**
-     * @param \DateTime $date
-     * @return $this
-     */
-    public function setDate(?\DateTime $date = null)
+    public function setDate(?\DateTime $date = null): self
     {
         $this->date = $date;
         return $this;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getDate()
+    public function getDate(): ?\DateTime
     {
         return $this->date;
     }
 
-    /**
-     * @param \DateTime $dateTimeTz
-     * @return $this
-     */
-    public function setDateTimeTz(?\DateTime $dateTimeTz = null)
+    public function setDateTimeTz(?\DateTime $dateTimeTz = null): self
     {
         $this->dateTimeTz = $dateTimeTz;
         return $this;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getDateTimeTz()
+    public function getDateTimeTz(): ?\DateTime
     {
         return $this->dateTimeTz;
     }
 
-    /**
-     * @param \DateTime $dateTime
-     * @return $this
-     */
-    public function setDateTime(?\DateTime $dateTime = null)
+    public function setDateTime(?\DateTime $dateTime = null): self
     {
         $this->dateTime = $dateTime;
         return $this;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getDateTime()
+    public function getDateTime(): ?\DateTime
     {
         return $this->dateTime;
     }
 
-    /**
-     * @param \DateTimeImmutable $dateTime
-     * @return $this
-     */
-    public function setDateTimeImmutable(?\DateTimeImmutable $dateTime = null)
+    public function setDateTimeImmutable(?\DateTimeImmutable $dateTime = null): self
     {
         $this->dateTimeImmutable = $dateTime;
         return $this;
     }
 
-    /**
-     * @return \DateTimeImmutable
-     */
-    public function getDateTimeImmutable()
+    public function getDateTimeImmutable(): ?\DateTimeImmutable
     {
         return $this->dateTimeImmutable;
     }
 
-    /**
-     * @param \DateTimeInterface $dateTime
-     * @return $this
-     */
-    public function setDateTimeInterface(?\DateTimeInterface $dateTime = null)
+    public function setDateTimeInterface(?\DateTimeInterface $dateTime = null): self
     {
         $this->dateTimeInterface = $dateTime;
         return $this;
     }
 
-    /**
-     * @return \DateTimeInterface
-     */
-    public function getDateTimeInterface()
+    public function getDateTimeInterface(): ?\DateTimeInterface
     {
         return $this->dateTimeInterface;
     }
 
-    /**
-     * @param CommonObject $commonObject
-     * @return $this
-     */
-    public function setCommonObject(?CommonObject $commonObject = null)
+    public function setCommonObject(?CommonObject $commonObject = null): self
     {
         $this->commonObject = $commonObject;
         return $this;
     }
 
-    /**
-     * @return CommonObject
-     */
-    public function getCommonObject()
+    public function getCommonObject(): ?CommonObject
     {
         return $this->commonObject;
     }
 
-    /**
-     * @param array $simpleArray
-     * @return $this
-     */
-    public function setSimpleArray(?array $simpleArray = null)
+    public function setSimpleArray(?array $simpleArray = null): self
     {
         $this->simpleArray = $simpleArray;
         return $this;
     }
 
-    /**
-     * @return array
-     */
-    public function getSimpleArray()
+    public function getSimpleArray(): ?array
     {
         return $this->simpleArray;
     }
 
-    /**
-     * @param array $jsonArray
-     * @return $this
-     */
-    public function setJsonArray(?array $jsonArray = null)
+    public function setJsonArray(?array $jsonArray = null): self
     {
         $this->jsonArray = $jsonArray;
         return $this;
     }
 
-    /**
-     * @return array
-     */
-    public function getJsonArray()
+    public function getJsonArray(): ?array
     {
         return $this->jsonArray;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/ExtendedTypesEntityRepository.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/ExtendedTypesEntityRepository.php
@@ -1,0 +1,23 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Persistence\Repository;
+
+/**
+ * A repository for the test entities
+ * @Flow\Scope("singleton")
+ */
+class ExtendedTypesEntityRepository extends Repository
+{
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/ExtendedTypesEntityRepository.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/ExtendedTypesEntityRepository.php
@@ -16,8 +16,8 @@ use Neos\Flow\Persistence\Repository;
 
 /**
  * A repository for the test entities
- * @Flow\Scope("singleton")
  */
+#[Flow\Scope('singleton')]
 class ExtendedTypesEntityRepository extends Repository
 {
 }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/Image.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/Image.php
@@ -1,0 +1,75 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * A sample entity for tests
+ *
+ * @Flow\Entity
+ */
+class Image
+{
+    /**
+     * @var string
+     * @ORM\Column(nullable=true)
+     */
+    protected $data;
+
+    /**
+     * @Flow\Transient
+     * @var CleanupObject
+     */
+    protected $relatedObject;
+
+    /**
+     * @return string
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param string $data
+     * @return void
+     */
+    public function setData($data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * @return CleanupObject
+     */
+    public function getRelatedObject()
+    {
+        return $this->relatedObject;
+    }
+
+    /**
+     * @param CleanupObject $relatedObject
+     */
+    public function setRelatedObject(?CleanupObject $relatedObject = null)
+    {
+        $this->relatedObject = $relatedObject;
+    }
+
+    public function shutdownObject()
+    {
+        if ($this->relatedObject instanceof CleanupObject) {
+            $this->relatedObject->toggleState();
+        }
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/Image.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/Image.php
@@ -16,52 +16,32 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * A sample entity for tests
- *
- * @Flow\Entity
  */
+#[FLow\Entity]
 class Image
 {
-    /**
-     * @var string
-     * @ORM\Column(nullable=true)
-     */
-    protected $data;
+    #[ORM\Column(nullable: true)]
+    protected ?string $data;
 
-    /**
-     * @Flow\Transient
-     * @var CleanupObject
-     */
-    protected $relatedObject;
+    #[Flow\Transient]
+    protected ?CleanupObject $relatedObject;
 
-    /**
-     * @return string
-     */
-    public function getData()
+    public function getData(): ?string
     {
         return $this->data;
     }
 
-    /**
-     * @param string $data
-     * @return void
-     */
-    public function setData($data)
+    public function setData(?string $data): void
     {
         $this->data = $data;
     }
 
-    /**
-     * @return CleanupObject
-     */
-    public function getRelatedObject()
+    public function getRelatedObject(): ?CleanupObject
     {
         return $this->relatedObject;
     }
 
-    /**
-     * @param CleanupObject $relatedObject
-     */
-    public function setRelatedObject(?CleanupObject $relatedObject = null)
+    public function setRelatedObject(?CleanupObject $relatedObject = null): void
     {
         $this->relatedObject = $relatedObject;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/ObjectHoldingAnEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/ObjectHoldingAnEntity.php
@@ -3,8 +3,5 @@ namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
 
 class ObjectHoldingAnEntity
 {
-    /**
-     * @var TestEntity
-     */
-    public $testEntity;
+    public TestEntity $testEntity;
 }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/ObjectHoldingAnEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/ObjectHoldingAnEntity.php
@@ -1,0 +1,10 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+class ObjectHoldingAnEntity
+{
+    /**
+     * @var TestEntity
+     */
+    public $testEntity;
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/OneToOneEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/OneToOneEntity.php
@@ -1,0 +1,45 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A simple entity for persistence tests of OneToOne relations.
+ *
+ * @Flow\Entity
+ * @ORM\Table(name="persistence_php8_onetooneentity")
+ */
+class OneToOneEntity
+{
+    /**
+     * Self-referencing
+     * @var OneToOneEntity
+     * @ORM\OneToOne
+     */
+    protected $selfReferencing;
+
+    /**
+     * Bidirectional relation owning side
+     * @var OneToOneEntity2
+     * @ORM\OneToOne(inversedBy="bidirectionalRelation")
+     */
+    protected $bidirectionalRelation;
+
+    /**
+     * Unidirectional relation
+     * @var OneToOneEntity2
+     * @ORM\OneToOne
+     */
+    protected $unidirectionalRelation;
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/OneToOneEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/OneToOneEntity.php
@@ -16,30 +16,26 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A simple entity for persistence tests of OneToOne relations.
- *
- * @Flow\Entity
- * @ORM\Table(name="persistence_php8_onetooneentity")
  */
+#[Flow\Entity]
+#[ORM\Table(name: 'persistence_php8_onetooneentity')]
 class OneToOneEntity
 {
     /**
      * Self-referencing
-     * @var OneToOneEntity
-     * @ORM\OneToOne
      */
-    protected $selfReferencing;
+    #[ORM\OneToOne]
+    protected OneToOneEntity $selfReferencing;
 
     /**
      * Bidirectional relation owning side
-     * @var OneToOneEntity2
-     * @ORM\OneToOne(inversedBy="bidirectionalRelation")
      */
-    protected $bidirectionalRelation;
+    #[ORM\OneToOne(inversedBy: 'bidirectionalRelation')]
+    protected OneToOneEntity2 $bidirectionalRelation;
 
     /**
      * Unidirectional relation
-     * @var OneToOneEntity2
-     * @ORM\OneToOne
      */
-    protected $unidirectionalRelation;
+    #[ORM\OneToOne]
+    protected OneToOneEntity2 $unidirectionalRelation;
 }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/OneToOneEntity2.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/OneToOneEntity2.php
@@ -1,0 +1,31 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A simple entity for persistence tests of OneToOne relations.
+ *
+ * @Flow\Entity
+ * @ORM\Table(name="persistence_php8_onetooneentity2")
+ */
+class OneToOneEntity2
+{
+    /**
+     * Bidirectional relation inverse side
+     * @var OneToOneEntity
+     * @ORM\OneToOne(mappedBy="bidirectionalRelation")
+     */
+    protected $bidirectionalRelation;
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/OneToOneEntity2.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/OneToOneEntity2.php
@@ -16,16 +16,14 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A simple entity for persistence tests of OneToOne relations.
- *
- * @Flow\Entity
- * @ORM\Table(name="persistence_php8_onetooneentity2")
  */
+#[Flow\Entity]
+#[ORM\Table(name: 'persistence_php8_onetooneentity2')]
 class OneToOneEntity2
 {
     /**
      * Bidirectional relation inverse side
-     * @var OneToOneEntity
-     * @ORM\OneToOne(mappedBy="bidirectionalRelation")
      */
-    protected $bidirectionalRelation;
+    #[ORM\OneToOne(mappedBy: 'bidirectionalRelation')]
+    protected OneToOneEntity $bidirectionalRelation;
 }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/Post.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/Post.php
@@ -47,13 +47,10 @@ class Post
     protected Collection $tags;
 
     /**
-     * Still annotated because nested Attributes require PHP 8.1
-     * @todo Adjust to attributes for Flow 8.4 when the min PHP version will be 8.1
-     *
      * @var Collection<Post>
-     * @ORM\ManyToMany
-     * @ORM\JoinTable(inverseJoinColumns={@ORM\JoinColumn(name="related_post_id")})
      */
+    #[ORM\ManyToMany]
+    #[ORM\JoinTable(inverseJoinColumns: [new ORM\JoinColumn(name: 'related_post_id')])]
     protected Collection $related;
 
     /**

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/Post.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/Post.php
@@ -18,58 +18,49 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A sample entity for tests
- *
- * @Flow\Entity
- * @ORM\HasLifecycleCallbacks
- * @ORM\InheritanceType("JOINED")
  */
+#[Flow\Entity]
+#[ORM\HasLifecycleCallbacks]
+#[ORM\InheritanceType('JOINED')]
 class Post
 {
-    /**
-     * @var string
-     */
-    protected $title = '';
+    protected string $title = '';
 
-    /**
-     * @var Image
-     * @ORM\OneToOne
-     */
-    protected $image;
+    #[ORM\OneToOne]
+    protected Image $image;
 
-    /**
-     * @var Image
-     * @ORM\OneToOne
-     */
-    protected $thumbnail;
+    #[ORM\OneToOne]
+    protected Image $thumbnail;
 
     /**
      * Yeah, only one comment allowed for a post ;-)
      * But that's the easiest option for our functional test.
-     *
-     * @var Comment
-     * @ORM\OneToOne
-     * @ORM\JoinColumn(onDelete="SET NULL")
      */
-    protected $comment;
+    #[ORM\OneToOne]
+    #[ORM\JoinColumn(onDelete: 'SET NULL')]
+    protected Comment $comment;
 
     /**
      * @var Collection<Tag>
-     * @ORM\OneToMany
      */
-    protected $tags;
+    #[ORM\OneToMany]
+    protected Collection $tags;
 
     /**
+     * Still annotated because nested Attributes require PHP 8.1
+     * @todo Adjust to attributes for Flow 8.4 when the min PHP version will be 8.1
+     *
      * @var Collection<Post>
      * @ORM\ManyToMany
      * @ORM\JoinTable(inverseJoinColumns={@ORM\JoinColumn(name="related_post_id")})
      */
-    protected $related;
+    protected Collection $related;
 
     /**
      * @var TestValueObject
-     * @ORM\ManyToOne
      */
-    protected $author;
+    #[ORM\ManyToOne]
+    protected TestValueObject $author;
 
     public function __construct()
     {
@@ -77,93 +68,58 @@ class Post
         $this->related = new ArrayCollection();
     }
 
-    /**
-     * @return string
-     * @ORM\PrePersist
-     */
-    public function getTitle()
+    #[ORM\PrePersist]
+    public function getTitle(): string
     {
         return $this->title;
     }
 
-    /**
-     * @param string $title
-     * @return void
-     */
-    public function setTitle($title)
+    public function setTitle(string $title): void
     {
         $this->title = $title;
     }
 
-    /**
-     * @param Image $image
-     */
-    public function setImage($image)
+    public function setImage(Image $image): void
     {
         $this->image = $image;
     }
 
-    /**
-     * @return Image
-     */
-    public function getImage()
+    public function getImage(): Image
     {
         return $this->image;
     }
 
-    /**
-     * @param $comment
-     * @return void
-     */
-    public function setComment($comment)
+    public function setComment(Comment $comment): void
     {
         $this->comment = $comment;
     }
 
-    /**
-     * @return Comment
-     */
-    public function getComment()
+    public function getComment(): Comment
     {
         return $this->comment;
     }
 
-    /**
-     * @param Tag $tag
-     */
-    public function addTag(Tag $tag)
+    public function addTag(Tag $tag): void
     {
         $this->tags->add($tag);
     }
 
-    /**
-     * @param Tag $tag
-     */
-    public function removeTag(Tag $tag)
+    public function removeTag(Tag $tag): void
     {
         $this->tags->removeElement($tag);
     }
 
-    /**
-     * @return Collection
-     */
-    public function getTags()
+    public function getTags(): Collection
     {
         return $this->tags;
     }
 
-    /**
-     * @return TestValueObject
-     */
-    public function getAuthor()
+    public function getAuthor(): TestValueObject
     {
         return $this->author;
     }
 
-    /**
-     * @param TestValueObject $author
-     */
-    public function setAuthor(TestValueObject $author)
+    public function setAuthor(TestValueObject $author): void
     {
         $this->author = $author;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/Post.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/Post.php
@@ -1,0 +1,170 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A sample entity for tests
+ *
+ * @Flow\Entity
+ * @ORM\HasLifecycleCallbacks
+ * @ORM\InheritanceType("JOINED")
+ */
+class Post
+{
+    /**
+     * @var string
+     */
+    protected $title = '';
+
+    /**
+     * @var Image
+     * @ORM\OneToOne
+     */
+    protected $image;
+
+    /**
+     * @var Image
+     * @ORM\OneToOne
+     */
+    protected $thumbnail;
+
+    /**
+     * Yeah, only one comment allowed for a post ;-)
+     * But that's the easiest option for our functional test.
+     *
+     * @var Comment
+     * @ORM\OneToOne
+     * @ORM\JoinColumn(onDelete="SET NULL")
+     */
+    protected $comment;
+
+    /**
+     * @var Collection<Tag>
+     * @ORM\OneToMany
+     */
+    protected $tags;
+
+    /**
+     * @var Collection<Post>
+     * @ORM\ManyToMany
+     * @ORM\JoinTable(inverseJoinColumns={@ORM\JoinColumn(name="related_post_id")})
+     */
+    protected $related;
+
+    /**
+     * @var TestValueObject
+     * @ORM\ManyToOne
+     */
+    protected $author;
+
+    public function __construct()
+    {
+        $this->tags = new ArrayCollection();
+        $this->related = new ArrayCollection();
+    }
+
+    /**
+     * @return string
+     * @ORM\PrePersist
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param string $title
+     * @return void
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * @param Image $image
+     */
+    public function setImage($image)
+    {
+        $this->image = $image;
+    }
+
+    /**
+     * @return Image
+     */
+    public function getImage()
+    {
+        return $this->image;
+    }
+
+    /**
+     * @param $comment
+     * @return void
+     */
+    public function setComment($comment)
+    {
+        $this->comment = $comment;
+    }
+
+    /**
+     * @return Comment
+     */
+    public function getComment()
+    {
+        return $this->comment;
+    }
+
+    /**
+     * @param Tag $tag
+     */
+    public function addTag(Tag $tag)
+    {
+        $this->tags->add($tag);
+    }
+
+    /**
+     * @param Tag $tag
+     */
+    public function removeTag(Tag $tag)
+    {
+        $this->tags->removeElement($tag);
+    }
+
+    /**
+     * @return Collection
+     */
+    public function getTags()
+    {
+        return $this->tags;
+    }
+
+    /**
+     * @return TestValueObject
+     */
+    public function getAuthor()
+    {
+        return $this->author;
+    }
+
+    /**
+     * @param TestValueObject $author
+     */
+    public function setAuthor(TestValueObject $author)
+    {
+        $this->author = $author;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/PostRepository.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/PostRepository.php
@@ -1,0 +1,26 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Persistence\Doctrine\Repository;
+
+/**
+ * A repository for posts
+ * @Neos\Flow\Annotations\Scope("singleton")
+ */
+class PostRepository extends Repository
+{
+    /**
+     * @var string
+     */
+    const ENTITY_CLASSNAME = Post::class;
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/PostRepository.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/PostRepository.php
@@ -15,8 +15,8 @@ use Neos\Flow\Persistence\Doctrine\Repository;
 
 /**
  * A repository for posts
- * @Neos\Flow\Annotations\Scope("singleton")
  */
+#[\Neos\Flow\Annotations\Scope('singleton')]
 class PostRepository extends Repository
 {
     /**

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/RelatedIndexEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/RelatedIndexEntity.php
@@ -16,51 +16,32 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A test entity used by Entity with IndexedRelation
- *
- * @Flow\Scope("prototype")
- * @Flow\Entity
  */
+#[Flow\Scope('prototype')]
+#[Flow\Entity]
 class RelatedIndexEntity
 {
-    /**
-     * @var string
-     */
-    protected $sorting;
+    protected string $sorting;
 
-    /**
-     * @var EntityWithIndexedRelation
-     * @ORM\ManyToOne
-     */
-    protected $entityWithIndexedRelation;
+    #[ORM\ManyToOne]
+    protected EntityWithIndexedRelation $entityWithIndexedRelation;
 
-    /**
-     * @return string
-     */
-    public function getSorting()
+    public function getSorting(): string
     {
         return $this->sorting;
     }
 
-    /**
-     * @param string $sorting
-     */
-    public function setSorting($sorting)
+    public function setSorting(string $sorting): void
     {
         $this->sorting = $sorting;
     }
 
-    /**
-     * @param EntityWithIndexedRelation $entityWithIndexedRelation
-     */
-    public function setEntityWithIndexedRelation($entityWithIndexedRelation)
+    public function setEntityWithIndexedRelation(EntityWithIndexedRelation $entityWithIndexedRelation): void
     {
         $this->entityWithIndexedRelation = $entityWithIndexedRelation;
     }
 
-    /**
-     * @return EntityWithIndexedRelation
-     */
-    public function getEntityWithIndexedRelation()
+    public function getEntityWithIndexedRelation(): EntityWithIndexedRelation
     {
         return $this->entityWithIndexedRelation;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/RelatedIndexEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/RelatedIndexEntity.php
@@ -1,0 +1,67 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A test entity used by Entity with IndexedRelation
+ *
+ * @Flow\Scope("prototype")
+ * @Flow\Entity
+ */
+class RelatedIndexEntity
+{
+    /**
+     * @var string
+     */
+    protected $sorting;
+
+    /**
+     * @var EntityWithIndexedRelation
+     * @ORM\ManyToOne
+     */
+    protected $entityWithIndexedRelation;
+
+    /**
+     * @return string
+     */
+    public function getSorting()
+    {
+        return $this->sorting;
+    }
+
+    /**
+     * @param string $sorting
+     */
+    public function setSorting($sorting)
+    {
+        $this->sorting = $sorting;
+    }
+
+    /**
+     * @param EntityWithIndexedRelation $entityWithIndexedRelation
+     */
+    public function setEntityWithIndexedRelation($entityWithIndexedRelation)
+    {
+        $this->entityWithIndexedRelation = $entityWithIndexedRelation;
+    }
+
+    /**
+     * @return EntityWithIndexedRelation
+     */
+    public function getEntityWithIndexedRelation()
+    {
+        return $this->entityWithIndexedRelation;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/SubEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/SubEntity.php
@@ -1,0 +1,89 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * A sample entity for tests
+ *
+ * @Flow\Entity
+ */
+class SubEntity extends SuperEntity
+{
+    /**
+     * @var TestEntity
+     * @ORM\ManyToOne(inversedBy="subEntities")
+     */
+    protected $parentEntity;
+
+    /**
+     * @var \DateTime
+     * @ORM\Column(nullable=true)
+     */
+    protected $date;
+
+    /**
+     * @var string
+     */
+    protected $someProperty = '';
+
+    /**
+     * @param TestEntity $parentEntity
+     * @return void
+     */
+    public function setParentEntity(TestEntity $parentEntity)
+    {
+        $this->parentEntity = $parentEntity;
+    }
+
+    /**
+     * @return TestEntity
+     */
+    public function getParentEntity()
+    {
+        return $this->parentEntity;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    /**
+     * @param \DateTime $date
+     */
+    public function setDate($date)
+    {
+        $this->date = $date;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSomeProperty()
+    {
+        return $this->someProperty;
+    }
+
+    /**
+     * @param string $someProperty
+     */
+    public function setSomeProperty($someProperty)
+    {
+        $this->someProperty = $someProperty;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/SubEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/SubEntity.php
@@ -16,73 +16,44 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * A sample entity for tests
- *
- * @Flow\Entity
  */
+#[Flow\Entity]
 class SubEntity extends SuperEntity
 {
-    /**
-     * @var TestEntity
-     * @ORM\ManyToOne(inversedBy="subEntities")
-     */
-    protected $parentEntity;
+    #[ORM\ManyToOne(inversedBy: 'subEntities')]
+    protected TestEntity $parentEntity;
 
-    /**
-     * @var \DateTime
-     * @ORM\Column(nullable=true)
-     */
-    protected $date;
+    #[ORM\Column(nullable: true)]
+    protected \DateTime $date;
 
-    /**
-     * @var string
-     */
-    protected $someProperty = '';
+    protected string $someProperty = '';
 
-    /**
-     * @param TestEntity $parentEntity
-     * @return void
-     */
-    public function setParentEntity(TestEntity $parentEntity)
+    public function setParentEntity(TestEntity $parentEntity): void
     {
         $this->parentEntity = $parentEntity;
     }
 
-    /**
-     * @return TestEntity
-     */
-    public function getParentEntity()
+    public function getParentEntity(): TestEntity
     {
         return $this->parentEntity;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getDate()
+    public function getDate(): \DateTime
     {
         return $this->date;
     }
 
-    /**
-     * @param \DateTime $date
-     */
-    public function setDate($date)
+    public function setDate(\DateTime $date): void
     {
         $this->date = $date;
     }
 
-    /**
-     * @return string
-     */
-    public function getSomeProperty()
+    public function getSomeProperty(): string
     {
         return $this->someProperty;
     }
 
-    /**
-     * @param string $someProperty
-     */
-    public function setSomeProperty($someProperty)
+    public function setSomeProperty(string $someProperty): void
     {
         $this->someProperty = $someProperty;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/SubSubEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/SubSubEntity.php
@@ -15,9 +15,8 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A sample entity for tests
- *
- * @Flow\Entity
  */
+#[Flow\Entity]
 class SubSubEntity extends SubEntity
 {
 }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/SubSubEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/SubSubEntity.php
@@ -1,0 +1,23 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A sample entity for tests
+ *
+ * @Flow\Entity
+ */
+class SubSubEntity extends SubEntity
+{
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/SubSubEntityRepository.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/SubSubEntityRepository.php
@@ -17,8 +17,8 @@ use Neos\Flow\Persistence\QueryResultInterface;
 
 /**
  * A repository for SubSubEntity
- * @Flow\Scope("singleton")
  */
+#[Flow\Scope('singleton')]
 class SubSubEntityRepository extends Repository
 {
     /**

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/SubSubEntityRepository.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/SubSubEntityRepository.php
@@ -1,0 +1,37 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Persistence\Doctrine\Repository;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Persistence\QueryResultInterface;
+
+/**
+ * A repository for SubSubEntity
+ * @Flow\Scope("singleton")
+ */
+class SubSubEntityRepository extends Repository
+{
+    /**
+     * @var string
+     */
+    const ENTITY_CLASSNAME = SubSubEntity::class;
+
+    public function findAll(): QueryResultInterface
+    {
+        $result = parent::findAll();
+        foreach ($result as $instance) {
+            $instance->setContent($instance->getContent() . ' - touched by SubSubEntityRepository');
+        }
+        return $result;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/SuperEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/SuperEntity.php
@@ -1,0 +1,47 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A sample entity for tests
+ *
+ * @Flow\Entity
+ * @ORM\InheritanceType("JOINED")
+ */
+class SuperEntity
+{
+    /**
+     * @var string
+     * @Flow\Validate(type="NotEmpty")
+     */
+    protected $content;
+
+    /**
+     * @return string
+     */
+    public function getContent()
+    {
+        return $this->content;
+    }
+
+    /**
+     * @param string $content
+     * @return void
+     */
+    public function setContent($content)
+    {
+        $this->content = $content;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/SuperEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/SuperEntity.php
@@ -16,31 +16,20 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A sample entity for tests
- *
- * @Flow\Entity
- * @ORM\InheritanceType("JOINED")
  */
+#[Flow\Entity]
+#[ORM\InheritanceType('JOINED')]
 class SuperEntity
 {
-    /**
-     * @var string
-     * @Flow\Validate(type="NotEmpty")
-     */
-    protected $content;
+    #[Flow\Validate(type: 'NotEmpty')]
+    protected string $content;
 
-    /**
-     * @return string
-     */
-    public function getContent()
+    public function getContent(): string
     {
         return $this->content;
     }
 
-    /**
-     * @param string $content
-     * @return void
-     */
-    public function setContent($content)
+    public function setContent(string $content): void
     {
         $this->content = $content;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/SuperEntityRepository.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/SuperEntityRepository.php
@@ -1,0 +1,27 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Persistence\Doctrine\Repository;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A repository for SuperEntity and SubEntity
+ * @Flow\Scope("singleton")
+ */
+class SuperEntityRepository extends Repository
+{
+    /**
+     * @var string
+     */
+    const ENTITY_CLASSNAME = SuperEntity::class;
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/SuperEntityRepository.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/SuperEntityRepository.php
@@ -16,8 +16,8 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A repository for SuperEntity and SubEntity
- * @Flow\Scope("singleton")
  */
+#[Flow\Scope('singleton')]
 class SuperEntityRepository extends Repository
 {
     /**

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/Tag.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/Tag.php
@@ -15,25 +15,18 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A sample entity for tests
- *
- * @Flow\Entity
  */
+#[Flow\Entity]
 class Tag
 {
-    /**
-     * @var string
-     */
-    protected $name = '';
+    protected string $name = '';
 
     public function __construct(string $name)
     {
         $this->name = $name;
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/Tag.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/Tag.php
@@ -1,0 +1,40 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A sample entity for tests
+ *
+ * @Flow\Entity
+ */
+class Tag
+{
+    /**
+     * @var string
+     */
+    protected $name = '';
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEmbeddable.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEmbeddable.php
@@ -1,0 +1,47 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A simple Doctrine ORM 2.5 embeddable for persistence tests
+ *
+ * @ORM\Embeddable
+ */
+class TestEmbeddable
+{
+    /**
+     * @var string
+     * TODO: Making this nullable is just a workaround for when the parent class is proxied and cloned,
+     *       which will currently lead to the embeddable being null.
+     * @ORM\Column(nullable=true)
+     */
+    protected $value;
+
+    /**
+     * @param string $value The string value of this value object
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEmbeddable.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEmbeddable.php
@@ -16,31 +16,23 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A simple Doctrine ORM 2.5 embeddable for persistence tests
- *
- * @ORM\Embeddable
  */
+#[ORM\Embeddable]
 class TestEmbeddable
 {
     /**
-     * @var string
      * TODO: Making this nullable is just a workaround for when the parent class is proxied and cloned,
      *       which will currently lead to the embeddable being null.
-     * @ORM\Column(nullable=true)
      */
-    protected $value;
+    #[ORM\Column(nullable: true)]
+    protected string $value;
 
-    /**
-     * @param string $value The string value of this value object
-     */
-    public function __construct($value)
+    public function __construct(string $value)
     {
         $this->value = $value;
     }
 
-    /**
-     * @return string
-     */
-    public function getValue()
+    public function getValue(): string
     {
         return $this->value;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEmbeddedValueObject.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEmbeddedValueObject.php
@@ -16,29 +16,19 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A simple embedded value object for persistence tests
- *
- * @Flow\ValueObject(embedded=true)
  */
+#[Flow\ValueObject(embedded: true)]
 class TestEmbeddedValueObject
 {
-    /**
-     * @var string
-     * @ORM\Column(nullable=true)
-     */
-    protected $value;
+    #[ORM\Column(nullable: true)]
+    protected string $value;
 
-    /**
-     * @param string $value The string value of this value object
-     */
-    public function __construct($value = '')
+    public function __construct(string $value = '')
     {
         $this->value = $value;
     }
 
-    /**
-     * @return string
-     */
-    public function getValue()
+    public function getValue(): string
     {
         return $this->value;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEmbeddedValueObject.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEmbeddedValueObject.php
@@ -1,0 +1,45 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A simple embedded value object for persistence tests
+ *
+ * @Flow\ValueObject(embedded=true)
+ */
+class TestEmbeddedValueObject
+{
+    /**
+     * @var string
+     * @ORM\Column(nullable=true)
+     */
+    protected $value;
+
+    /**
+     * @param string $value The string value of this value object
+     */
+    public function __construct($value = '')
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEntity.php
@@ -1,0 +1,249 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Flow\Tests\Functional\Persistence\FixturesPHP8\SubEntity as ImportedSubEntity;
+
+/**
+ * A simple entity for persistence tests
+ *
+ * @Flow\Entity
+ * @ORM\Table(name="persistence_php8_testentity")
+ */
+class TestEntity
+{
+    /**
+     * @var ObjectManagerInterface
+     * @Flow\Inject
+     */
+    protected $objectManager;
+
+    /**
+     * @var string
+     * @Flow\Validate(type="StringLength", options={"minimum"=3})
+     */
+    protected $name = '';
+
+    /**
+     * @var TestEntity
+     * @ORM\ManyToOne
+     */
+    protected $relatedEntity;
+
+    /**
+     * @var Collection<ImportedSubEntity>
+     * @ORM\OneToMany(mappedBy="parentEntity", cascade={"all"})
+     */
+    protected $subEntities;
+
+    /**
+     * @var TestValueObject
+     * @ORM\ManyToOne
+     */
+    protected $relatedValueObject;
+
+    /**
+     * @var string
+     * @Flow\Validate(type="NotEmpty", validationGroups={"SomeOther"})
+     */
+    protected $description = 'This is some text';
+
+    /**
+     * @var TestEmbeddedValueObject
+     */
+    protected $embeddedValueObject;
+
+    /**
+     * @var array
+     */
+    protected $arrayProperty = [];
+
+    /**
+     * @var TestEmbeddable
+     * @ORM\Embedded(class="Neos\Flow\Tests\Functional\Persistence\FixturesPHP8\TestEmbeddable")
+     */
+    protected $embedded;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->subEntities = new ArrayCollection();
+        $this->embedded = new TestEmbeddable('');
+        $this->embeddedValueObject = new TestEmbeddedValueObject();
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return void
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param string $description
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
+
+    /**
+     * @param array $arrayProperty
+     * @return void
+     */
+    public function setArrayProperty($arrayProperty)
+    {
+        $this->arrayProperty = $arrayProperty;
+    }
+
+    /**
+     * @return array
+     */
+    public function getArrayProperty()
+    {
+        return $this->arrayProperty;
+    }
+
+    /**
+     * @return string
+     */
+    public function sayHello()
+    {
+        return 'Hello';
+    }
+
+    /**
+     * @param TestEntity $relatedEntity
+     * @return void
+     */
+    public function setRelatedEntity(TestEntity $relatedEntity)
+    {
+        $this->relatedEntity = $relatedEntity;
+    }
+
+    /**
+     * @return TestEntity
+     */
+    public function getRelatedEntity()
+    {
+        return $this->relatedEntity;
+    }
+
+    /**
+     * @param Collection<ImportedSubEntity> $subEntities
+     * @return void
+     */
+    public function setSubEntities(Collection $subEntities)
+    {
+        $this->subEntities = $subEntities;
+    }
+
+    /**
+     * @param ImportedSubEntity $subEntity
+     * @return void
+     */
+    public function addSubEntity(ImportedSubEntity $subEntity)
+    {
+        $this->subEntities->add($subEntity);
+    }
+
+    /**
+     * @return Collection<ImportedSubEntity>
+     */
+    public function getRelatedEntities()
+    {
+        return $this->subEntities;
+    }
+
+    /**
+     * @return ObjectManagerInterface
+     */
+    public function getObjectManager()
+    {
+        return $this->objectManager;
+    }
+
+    /**
+     * @param TestValueObject $relatedValueObject
+     * @return void
+     */
+    public function setRelatedValueObject($relatedValueObject)
+    {
+        $this->relatedValueObject = $relatedValueObject;
+    }
+
+    /**
+     * @return TestValueObject
+     */
+    public function getRelatedValueObject()
+    {
+        return $this->relatedValueObject;
+    }
+
+    /**
+     * @return TestEmbeddable
+     */
+    public function getEmbedded()
+    {
+        return $this->embedded;
+    }
+
+    /**
+     * @param TestEmbeddable $embedded
+     */
+    public function setEmbedded($embedded)
+    {
+        $this->embedded = $embedded;
+    }
+
+    /**
+     * @param TestEmbeddedValueObject $embeddedValueObject
+     * @return void
+     */
+    public function setEmbeddedValueObject($embeddedValueObject)
+    {
+        $this->embeddedValueObject = $embeddedValueObject;
+    }
+
+    /**
+     * @return TestEmbeddedValueObject
+     */
+    public function getEmbeddedValueObject()
+    {
+        return $this->embeddedValueObject;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEntity.php
@@ -20,63 +20,38 @@ use Neos\Flow\Tests\Functional\Persistence\FixturesPHP8\SubEntity as ImportedSub
 
 /**
  * A simple entity for persistence tests
- *
- * @Flow\Entity
- * @ORM\Table(name="persistence_php8_testentity")
  */
+#[Flow\Entity]
+#[ORM\Table(name: 'persistence_php8_testentity')]
 class TestEntity
 {
-    /**
-     * @var ObjectManagerInterface
-     * @Flow\Inject
-     */
-    protected $objectManager;
+    #[Flow\Inject]
+    protected ObjectManagerInterface $objectManager;
 
-    /**
-     * @var string
-     * @Flow\Validate(type="StringLength", options={"minimum"=3})
-     */
-    protected $name = '';
+    #[Flow\Validate(type: "StringLength", options:["minimum" => 3])]
+    protected string $name = '';
 
-    /**
-     * @var TestEntity
-     * @ORM\ManyToOne
-     */
-    protected $relatedEntity;
+    #[ORM\ManyToOne]
+    protected TestEntity $relatedEntity;
 
     /**
      * @var Collection<ImportedSubEntity>
-     * @ORM\OneToMany(mappedBy="parentEntity", cascade={"all"})
      */
-    protected $subEntities;
+    #[ORM\OneToMany(mappedBy: "parentEntity", cascade: ["all"])]
+    protected Collection $subEntities;
 
-    /**
-     * @var TestValueObject
-     * @ORM\ManyToOne
-     */
-    protected $relatedValueObject;
+    #[ORM\ManyToOne]
+    protected TestValueObject $relatedValueObject;
 
-    /**
-     * @var string
-     * @Flow\Validate(type="NotEmpty", validationGroups={"SomeOther"})
-     */
-    protected $description = 'This is some text';
+    #[Flow\Validate(type: "NotEmpty", validationGroups: ["SomeOther"])]
+    protected string $description = 'This is some text';
 
-    /**
-     * @var TestEmbeddedValueObject
-     */
-    protected $embeddedValueObject;
+    protected TestEmbeddedValueObject $embeddedValueObject;
 
-    /**
-     * @var array
-     */
-    protected $arrayProperty = [];
+    protected array $arrayProperty = [];
 
-    /**
-     * @var TestEmbeddable
-     * @ORM\Embedded(class="Neos\Flow\Tests\Functional\Persistence\FixturesPHP8\TestEmbeddable")
-     */
-    protected $embedded;
+    #[ORM\Embedded(class: "Neos\Flow\Tests\Functional\Persistence\FixturesPHP8\TestEmbeddable")]
+    protected TestEmbeddable $embedded;
 
     /**
      * Constructor
@@ -88,95 +63,60 @@ class TestEntity
         $this->embeddedValueObject = new TestEmbeddedValueObject();
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @param string $name
-     * @return void
-     */
-    public function setName($name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
 
-    /**
-     * @return string
-     */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }
 
-    /**
-     * @param string $description
-     */
-    public function setDescription($description)
+    public function setDescription(string $description): void
     {
         $this->description = $description;
     }
 
-    /**
-     * @param array $arrayProperty
-     * @return void
-     */
-    public function setArrayProperty($arrayProperty)
+    public function setArrayProperty(array $arrayProperty): void
     {
         $this->arrayProperty = $arrayProperty;
     }
 
-    /**
-     * @return array
-     */
-    public function getArrayProperty()
+    public function getArrayProperty(): array
     {
         return $this->arrayProperty;
     }
 
-    /**
-     * @return string
-     */
-    public function sayHello()
+    public function sayHello(): string
     {
         return 'Hello';
     }
 
-    /**
-     * @param TestEntity $relatedEntity
-     * @return void
-     */
-    public function setRelatedEntity(TestEntity $relatedEntity)
+    public function setRelatedEntity(TestEntity $relatedEntity): void
     {
         $this->relatedEntity = $relatedEntity;
     }
 
-    /**
-     * @return TestEntity
-     */
-    public function getRelatedEntity()
+    public function getRelatedEntity(): TestEntity
     {
         return $this->relatedEntity;
     }
 
     /**
      * @param Collection<ImportedSubEntity> $subEntities
-     * @return void
      */
-    public function setSubEntities(Collection $subEntities)
+    public function setSubEntities(Collection $subEntities): void
     {
         $this->subEntities = $subEntities;
     }
 
-    /**
-     * @param ImportedSubEntity $subEntity
-     * @return void
-     */
-    public function addSubEntity(ImportedSubEntity $subEntity)
+    public function addSubEntity(ImportedSubEntity $subEntity): void
     {
         $this->subEntities->add($subEntity);
     }
@@ -184,65 +124,42 @@ class TestEntity
     /**
      * @return Collection<ImportedSubEntity>
      */
-    public function getRelatedEntities()
+    public function getRelatedEntities(): Collection
     {
         return $this->subEntities;
     }
 
-    /**
-     * @return ObjectManagerInterface
-     */
-    public function getObjectManager()
+    public function getObjectManager(): ObjectManagerInterface
     {
         return $this->objectManager;
     }
 
-    /**
-     * @param TestValueObject $relatedValueObject
-     * @return void
-     */
-    public function setRelatedValueObject($relatedValueObject)
+    public function setRelatedValueObject(TestValueObject $relatedValueObject): void
     {
         $this->relatedValueObject = $relatedValueObject;
     }
 
-    /**
-     * @return TestValueObject
-     */
-    public function getRelatedValueObject()
+    public function getRelatedValueObject(): TestValueObject
     {
         return $this->relatedValueObject;
     }
 
-    /**
-     * @return TestEmbeddable
-     */
-    public function getEmbedded()
+    public function getEmbedded(): TestEmbeddable
     {
         return $this->embedded;
     }
 
-    /**
-     * @param TestEmbeddable $embedded
-     */
-    public function setEmbedded($embedded)
+    public function setEmbedded(TestEmbeddable $embedded): void
     {
         $this->embedded = $embedded;
     }
 
-    /**
-     * @param TestEmbeddedValueObject $embeddedValueObject
-     * @return void
-     */
-    public function setEmbeddedValueObject($embeddedValueObject)
+    public function setEmbeddedValueObject(TestEmbeddedValueObject $embeddedValueObject): void
     {
         $this->embeddedValueObject = $embeddedValueObject;
     }
 
-    /**
-     * @return TestEmbeddedValueObject
-     */
-    public function getEmbeddedValueObject()
+    public function getEmbeddedValueObject(): TestEmbeddedValueObject
     {
         return $this->embeddedValueObject;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEntityAspect.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEntityAspect.php
@@ -1,0 +1,34 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Aop\JoinPointInterface;
+
+/**
+ * An aspect for testing aop within entities
+ *
+ * @Flow\Aspect
+ */
+class TestEntityAspect
+{
+    /**
+     * @Flow\Around("method(public Neos\Flow\Tests\Functional\Persistence\FixturesPHP8\TestEntity->sayHello())")
+     * @param JoinPointInterface $joinPoint
+     * @return string
+     */
+    public function concreteMethodInAbstractClassAdvice(JoinPointInterface $joinPoint)
+    {
+        $result = $joinPoint->getAdviceChain()->proceed($joinPoint);
+        return $result . ' Andi!';
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEntityAspect.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEntityAspect.php
@@ -16,17 +16,12 @@ use Neos\Flow\Aop\JoinPointInterface;
 
 /**
  * An aspect for testing aop within entities
- *
- * @Flow\Aspect
  */
+#[Flow\Aspect]
 class TestEntityAspect
 {
-    /**
-     * @Flow\Around("method(public Neos\Flow\Tests\Functional\Persistence\FixturesPHP8\TestEntity->sayHello())")
-     * @param JoinPointInterface $joinPoint
-     * @return string
-     */
-    public function concreteMethodInAbstractClassAdvice(JoinPointInterface $joinPoint)
+    #[Flow\Around('method(public Neos\Flow\Tests\Functional\Persistence\FixturesPHP8\TestEntity->sayHello())')]
+    public function concreteMethodInAbstractClassAdvice(JoinPointInterface $joinPoint): string
     {
         $result = $joinPoint->getAdviceChain()->proceed($joinPoint);
         return $result . ' Andi!';

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEntityRepository.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEntityRepository.php
@@ -1,0 +1,28 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Persistence\QueryInterface;
+use Neos\Flow\Persistence\Repository;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A repository for the test entities
+ * @Flow\Scope("singleton")
+ */
+class TestEntityRepository extends Repository
+{
+    /**
+     * @var array
+     */
+    protected $defaultOrderings = ['name' => QueryInterface::ORDER_ASCENDING];
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEntityRepository.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEntityRepository.php
@@ -17,8 +17,8 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A repository for the test entities
- * @Flow\Scope("singleton")
  */
+#[Flow\Scope('singleton')]
 class TestEntityRepository extends Repository
 {
     /**

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObject.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObject.php
@@ -16,10 +16,9 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A simple value object for persistence tests
- *
- * @Flow\ValueObject(embedded=false)
- * @ORM\Table(name="persistence_php8_testvalueobject")
  */
+#[Flow\ValueObject(embedded: false)]
+#[ORM\Table(name: 'persistence_php8_testvalueobject')]
 class TestValueObject
 {
     /**

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObject.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObject.php
@@ -1,0 +1,37 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A simple value object for persistence tests
+ *
+ * @Flow\ValueObject(embedded=false)
+ * @ORM\Table(name="persistence_php8_testvalueobject")
+ */
+class TestValueObject
+{
+    /**
+     * @var string
+     */
+    protected $value;
+
+    /**
+     * @param string $value The string value of this value object
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObjectWithConstructorLogic.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObjectWithConstructorLogic.php
@@ -1,0 +1,55 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A simple value object for persistence tests
+ *
+ * @Flow\ValueObject(embedded=false)
+ * @ORM\Table(name="persistence_php8_testvalueobjectwithconstructorlogic")
+ */
+class TestValueObjectWithConstructorLogic
+{
+    /**
+     * @var string
+     */
+    protected $value1;
+
+    /**
+     * @var string
+     */
+    protected $value2;
+
+    /**
+     * @var int
+     */
+    protected $calculatedValue;
+
+    /**
+     * @param string $value1
+     * @param string $value2
+     */
+    public function __construct($value1, $value2)
+    {
+        $this->value1 = trim($value1);
+        $this->value2 = trim($value2);
+
+        if (strlen($value1) > 5) {
+            $this->calculatedValue = 100;
+        } else {
+            $this->calculatedValue = 50;
+        }
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObjectWithConstructorLogic.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObjectWithConstructorLogic.php
@@ -16,10 +16,9 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A simple value object for persistence tests
- *
- * @Flow\ValueObject(embedded=false)
- * @ORM\Table(name="persistence_php8_testvalueobjectwithconstructorlogic")
  */
+#[Flow\ValueObject(embedded: false)]
+#[ORM\Table(name: 'persistence_php8_testvalueobjectwithconstructorlogic')]
 class TestValueObjectWithConstructorLogic
 {
     /**

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObjectWithConstructorLogicAndInversedPropertyOrder.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObjectWithConstructorLogicAndInversedPropertyOrder.php
@@ -1,0 +1,55 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A simple value object for persistence tests
+ *
+ * @Flow\ValueObject(embedded=false)
+ * @ORM\Table(name="persistence_php8_testvalueobjectwithconstructorlogic2")
+ */
+class TestValueObjectWithConstructorLogicAndInversedPropertyOrder
+{
+    /**
+     * @var int
+     */
+    protected $calculatedValue;
+
+    /**
+     * @var string
+     */
+    protected $value2;
+
+    /**
+     * @var string
+     */
+    protected $value1;
+
+    /**
+     * @param string $value2
+     * @param string $value1
+     */
+    public function __construct($value2, $value1)
+    {
+        $this->value1 = trim($value1);
+        $this->value2 = trim($value2);
+
+        if (strlen($value1) > 5) {
+            $this->calculatedValue = 100;
+        } else {
+            $this->calculatedValue = 50;
+        }
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObjectWithConstructorLogicAndInversedPropertyOrder.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObjectWithConstructorLogicAndInversedPropertyOrder.php
@@ -16,32 +16,18 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A simple value object for persistence tests
- *
- * @Flow\ValueObject(embedded=false)
- * @ORM\Table(name="persistence_php8_testvalueobjectwithconstructorlogic2")
  */
+#[Flow\ValueObject(embedded: false)]
+#[ORM\Table(name: 'persistence_php8_testvalueobjectwithconstructorlogic2')]
 class TestValueObjectWithConstructorLogicAndInversedPropertyOrder
 {
-    /**
-     * @var int
-     */
-    protected $calculatedValue;
+    protected int $calculatedValue;
 
-    /**
-     * @var string
-     */
-    protected $value2;
+    protected string $value2;
 
-    /**
-     * @var string
-     */
-    protected $value1;
+    protected string $value1;
 
-    /**
-     * @param string $value2
-     * @param string $value1
-     */
-    public function __construct($value2, $value1)
+    public function __construct(string $value2, string $value1)
     {
         $this->value1 = trim($value1);
         $this->value2 = trim($value2);

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObjectWithDateTimeProperty.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObjectWithDateTimeProperty.php
@@ -1,0 +1,37 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A simple value object for persistence tests
+ *
+ * @Flow\ValueObject(embedded=false)
+ * @ORM\Table(name="persistence_php8_testvalueobjectwithdatetimeproperty")
+ */
+class TestValueObjectWithDateTimeProperty
+{
+    /**
+     * @var \DateTime
+     */
+    protected $value1;
+
+    /**
+     * @param \DateTime $value1
+     */
+    public function __construct($value1)
+    {
+        $this->value1 = $value1;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObjectWithDateTimeProperty.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObjectWithDateTimeProperty.php
@@ -16,21 +16,14 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A simple value object for persistence tests
- *
- * @Flow\ValueObject(embedded=false)
- * @ORM\Table(name="persistence_php8_testvalueobjectwithdatetimeproperty")
  */
+#[Flow\ValueObject(embedded: false)]
+#[ORM\Table(name: 'persistence_php8_testvalueobjectwithdatetimeproperty')]
 class TestValueObjectWithDateTimeProperty
 {
-    /**
-     * @var \DateTime
-     */
-    protected $value1;
+    protected \DateTime $value1;
 
-    /**
-     * @param \DateTime $value1
-     */
-    public function __construct($value1)
+    public function __construct(\DateTime $value1)
     {
         $this->value1 = $value1;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObjectWithSubValueObjectProperties.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObjectWithSubValueObjectProperties.php
@@ -16,10 +16,9 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A simple value object for persistence tests
- *
- * @Flow\ValueObject(embedded=false)
- * @ORM\Table(name="persistence_php8_testvalueobjectwithsubvalueobjectproperties")
  */
+#[Flow\ValueObject(embedded: false)]
+#[ORM\Table(name: 'persistence_php8_testvalueobjectwithsubvalueobjectproperties')]
 class TestValueObjectWithSubValueObjectProperties
 {
     /**

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObjectWithSubValueObjectProperties.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObjectWithSubValueObjectProperties.php
@@ -1,0 +1,44 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A simple value object for persistence tests
+ *
+ * @Flow\ValueObject(embedded=false)
+ * @ORM\Table(name="persistence_php8_testvalueobjectwithsubvalueobjectproperties")
+ */
+class TestValueObjectWithSubValueObjectProperties
+{
+    /**
+     * @var TestValueObject
+     */
+    protected $value1;
+
+    /**
+     * @var string
+     */
+    protected $value2;
+
+    /**
+     * @param TestValueObject $value1
+     * @param string $value2
+     */
+    public function __construct(TestValueObject $value1, $value2)
+    {
+        $this->value1 = $value1;
+        $this->value2 = trim($value2);
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObjectWithTransientProperties.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObjectWithTransientProperties.php
@@ -16,10 +16,9 @@ use Neos\Flow\Annotations as Flow;
 
 /**
  * A simple value object for persistence tests
- *
- * @Flow\ValueObject(embedded=false)
- * @ORM\Table(name="persistence_php8_testvalueobjectwithtransientproperties")
  */
+#[Flow\ValueObject(embedded: false)]
+#[ORM\Table(name: 'persistence_php8_testvalueobjectwithtransientproperties')]
 class TestValueObjectWithTransientProperties
 {
     /**

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObjectWithTransientProperties.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestValueObjectWithTransientProperties.php
@@ -1,0 +1,62 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A simple value object for persistence tests
+ *
+ * @Flow\ValueObject(embedded=false)
+ * @ORM\Table(name="persistence_php8_testvalueobjectwithtransientproperties")
+ */
+class TestValueObjectWithTransientProperties
+{
+    /**
+     * @var string
+     */
+    protected $value1;
+
+    /**
+     * @Flow\Transient
+     * @var string
+     */
+    protected $value2;
+
+    /**
+     * @Flow\Inject
+     * @var TestEntityRepository
+     */
+    protected $dependency;
+
+    /**
+     * @var int
+     */
+    protected $calculatedValue;
+
+    /**
+     * @param string $value1
+     * @param string $value2
+     */
+    public function __construct($value1, $value2)
+    {
+        $this->value1 = trim($value1);
+        $this->value2 = trim($value2);
+
+        if (strlen($this->value1) > 5) {
+            $this->calculatedValue = 100;
+        } else {
+            $this->calculatedValue = 50;
+        }
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/UnproxiedTestEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/UnproxiedTestEntity.php
@@ -17,44 +17,30 @@ use Neos\Flow\Utility\Algorithms;
 
 /**
  * A simple entity for persistence tests that is not proxied (no AOP/DI)
- *
- * @Flow\Entity
- * @Flow\Proxy(false)
- * @ORM\Table(name="persistence_php8_unproxiedtestentity")
  */
+#[Flow\Entity]
+#[Flow\Proxy(false)]
+#[ORM\Table(name: "persistence_php8_unproxiedtestentity")]
 class UnproxiedTestEntity
 {
-    /**
-     * @var string
-     * @ORM\Id
-     * @ORM\Column(length=40)
-     */
-    protected $uuid;
+    #[ORM\Id]
+    #[ORM\Column(length: 40)]
+    protected string $uuid;
 
-    /**
-     * @var string
-     * @Flow\Validate(type="StringLength", options={"minimum"=3})
-     */
-    protected $name = '';
+    #[Flow\Validate(type: "StringLength", options: ["minimum" => 3])]
+    protected string $name = '';
 
     public function __construct()
     {
         $this->uuid = Algorithms::generateUUID();
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @param string $name
-     * @return void
-     */
-    public function setName($name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/UnproxiedTestEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/UnproxiedTestEntity.php
@@ -1,0 +1,61 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\Mapping as ORM;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Utility\Algorithms;
+
+/**
+ * A simple entity for persistence tests that is not proxied (no AOP/DI)
+ *
+ * @Flow\Entity
+ * @Flow\Proxy(false)
+ * @ORM\Table(name="persistence_php8_unproxiedtestentity")
+ */
+class UnproxiedTestEntity
+{
+    /**
+     * @var string
+     * @ORM\Id
+     * @ORM\Column(length=40)
+     */
+    protected $uuid;
+
+    /**
+     * @var string
+     * @Flow\Validate(type="StringLength", options={"minimum"=3})
+     */
+    protected $name = '';
+
+    public function __construct()
+    {
+        $this->uuid = Algorithms::generateUUID();
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     * @return void
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
+++ b/Neos.Flow/Tests/Functional/Persistence/PersistenceTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Functional\Persistence;
 
 /*
@@ -17,6 +19,7 @@ use Neos\Flow\Configuration\ConfigurationManager;
 use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Persistence\Doctrine\QueryResult;
 use Neos\Flow\Persistence\Exception;
+use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Flow\Persistence\Exception\ObjectValidationFailedException;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Utility\ObjectAccess;
@@ -28,7 +31,7 @@ use Neos\Utility\ObjectAccess;
 class PersistenceTest extends FunctionalTestCase
 {
     /**
-     * @var boolean
+     * @var bool
      */
     protected static $testablePersistenceEnabled = true;
 
@@ -49,13 +52,15 @@ class PersistenceTest extends FunctionalTestCase
 
     /**
      * @return void
+     * @throws \Neos\Flow\Exception
+     * @throws \Neos\Flow\Exception
      */
     protected function setUp(): void
     {
         $this->earlyEntityManager = self::$bootstrap->getObjectManager()->get(EntityManagerInterface::class);
         parent::setUp();
         if (!$this->persistenceManager instanceof PersistenceManager) {
-            $this->markTestSkipped('Doctrine persistence is not enabled');
+            static::markTestSkipped('Doctrine persistence is not enabled');
         }
         $this->testEntityRepository = new Fixtures\TestEntityRepository();
         $this->extendedTypesEntityRepository = new Fixtures\ExtendedTypesEntityRepository();
@@ -64,7 +69,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function entityManagerIsSingletonInstanceInPersistenceManager()
+    public function entityManagerIsSingletonInstanceInPersistenceManager(): void
     {
         $this->earlyEntityManager->persist(new Fixtures\TestEntity());
         self::assertTrue($this->persistenceManager->hasUnpersistedChanges());
@@ -73,7 +78,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function entitiesArePersistedAndReconstituted()
+    public function entitiesArePersistedAndReconstituted(): void
     {
         $this->removeExampleEntities();
         $this->insertExampleEntity();
@@ -85,7 +90,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function executingAQueryWillOnlyExecuteItLazily()
+    public function executingAQueryWillOnlyExecuteItLazily(): void
     {
         $this->removeExampleEntities();
         $this->insertExampleEntity();
@@ -102,7 +107,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function serializingAQueryResultWillResetCachedResult()
+    public function serializingAQueryResultWillResetCachedResult(): void
     {
         $this->removeExampleEntities();
         $this->insertExampleEntity();
@@ -116,26 +121,26 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function resultCanStillBeTraversedAfterSerialization()
+    public function resultCanStillBeTraversedAfterSerialization(): void
     {
         $this->removeExampleEntities();
         $this->insertExampleEntity();
 
         $allResults = $this->testEntityRepository->findAll();
-        self::assertEquals(1, count($allResults->toArray()), 'Not correct number of entities found before running test.');
+        self::assertCount(1, $allResults->toArray(), 'Not correct number of entities found before running test.');
 
         $unserializedResults = unserialize(serialize($allResults));
-        self::assertEquals(1, count($unserializedResults->toArray()));
+        self::assertCount(1, $unserializedResults->toArray());
         self::assertEquals('Flow', $unserializedResults[0]->getName());
     }
 
     /**
      * @test
      */
-    public function getFirstShouldNotHaveSideEffects()
+    public function getFirstShouldNotHaveSideEffects(): void
     {
         $this->removeExampleEntities();
-        $this->insertExampleEntity('Flow');
+        $this->insertExampleEntity();
         $this->insertExampleEntity('Neos');
 
         $allResults = $this->testEntityRepository->findAll();
@@ -148,7 +153,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function aClonedEntityWillGetANewIdentifier()
+    public function aClonedEntityWillGetANewIdentifier(): void
     {
         $testEntity = new Fixtures\TestEntity();
         $firstIdentifier = $this->persistenceManager->getIdentifierByObject($testEntity);
@@ -161,7 +166,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function persistedEntitiesLyingInArraysAreNotSerializedButReferencedByTheirIdentifierAndReloadedFromPersistenceOnWakeup()
+    public function persistedEntitiesLyingInArraysAreNotSerializedButReferencedByTheirIdentifierAndReloadedFromPersistenceOnWakeup(): void
     {
         $testEntityLyingInsideTheArray = new Fixtures\TestEntity();
         $testEntityLyingInsideTheArray->setName('Flow');
@@ -198,7 +203,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function objectsWithPersistedEntitiesCanBeSerializedMultipleTimes()
+    public function objectsWithPersistedEntitiesCanBeSerializedMultipleTimes(): void
     {
         $persistedEntity = new Fixtures\TestEntity();
         $persistedEntity->setName('Flow');
@@ -211,14 +216,14 @@ class PersistenceTest extends FunctionalTestCase
         for ($i = 0; $i < 2; $i++) {
             $serializedData = serialize($objectHoldingTheEntity);
             $unserializedObjectHoldingTheEntity = unserialize($serializedData);
-            $this->assertInstanceOf(Fixtures\TestEntity::class, $unserializedObjectHoldingTheEntity->testEntity);
+            static::assertInstanceOf(Fixtures\TestEntity::class, $unserializedObjectHoldingTheEntity->testEntity);
         }
     }
 
     /**
      * @test
      */
-    public function newEntitiesWhichAreNotAddedToARepositoryYetAreAlreadyKnownToGetObjectByIdentifier()
+    public function newEntitiesWhichAreNotAddedToARepositoryYetAreAlreadyKnownToGetObjectByIdentifier(): void
     {
         $expectedEntity = new Fixtures\TestEntity();
         $uuid = $this->persistenceManager->getIdentifierByObject($expectedEntity);
@@ -229,7 +234,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function valueObjectsWithTheSameValueAreOnlyPersistedOnce()
+    public function valueObjectsWithTheSameValueAreOnlyPersistedOnce(): void
     {
         $valueObject1 = new Fixtures\TestValueObject('sameValue');
         $valueObject2 = new Fixtures\TestValueObject('sameValue');
@@ -253,7 +258,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function alreadyPersistedValueObjectsAreCorrectlyReused()
+    public function alreadyPersistedValueObjectsAreCorrectlyReused(): void
     {
         $valueObject1 = new Fixtures\TestValueObject('sameValue');
         $testEntity1 = new Fixtures\TestEntity();
@@ -287,10 +292,10 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function embeddedValueObjectsAreActuallyEmbedded()
+    public function embeddedValueObjectsAreActuallyEmbedded(): void
     {
-        /* @var $entityManager EntityManagerInterface */
-        $entityManager = $this->objectManager->get(\Doctrine\ORM\EntityManagerInterface::class);
+        /* @var EntityManagerInterface $entityManager */
+        $entityManager = $this->objectManager->get(EntityManagerInterface::class);
         $schemaTool = new SchemaTool($entityManager);
         $classMetaData = $entityManager->getClassMetadata(Fixtures\TestEntity::class);
         self::assertTrue($classMetaData->hasField('embeddedValueObject.value'), 'ClassMetadata is not correctly embedded');
@@ -306,7 +311,7 @@ class PersistenceTest extends FunctionalTestCase
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();
 
-        /* @var $testEntity Fixtures\TestEntity */
+        /* @var Fixtures\TestEntity $testEntity */
         $testEntity = $this->testEntityRepository->findAll()->getFirst();
         self::assertEquals('someValue', $testEntity->getEmbeddedValueObject()->getValue());
     }
@@ -314,7 +319,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function validationIsDoneForNewEntities()
+    public function validationIsDoneForNewEntities(): void
     {
         $this->expectException(ObjectValidationFailedException::class);
         $this->removeExampleEntities();
@@ -326,7 +331,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function validationIsDoneForReconstitutedEntities()
+    public function validationIsDoneForReconstitutedEntities(): void
     {
         $this->expectException(ObjectValidationFailedException::class);
         $this->removeExampleEntities();
@@ -344,7 +349,7 @@ class PersistenceTest extends FunctionalTestCase
      *
      * @test
      */
-    public function validationIsDoneForReconstitutedEntitiesWhichAreLazyLoadingProxies()
+    public function validationIsDoneForReconstitutedEntitiesWhichAreLazyLoadingProxies(): void
     {
         $this->expectException(ObjectValidationFailedException::class);
         $this->removeExampleEntities();
@@ -368,7 +373,7 @@ class PersistenceTest extends FunctionalTestCase
      * @test
      * @doesNotPerformAssertions
      */
-    public function validationIsOnlyDoneForPropertiesWhichAreInTheDefaultOrPersistencePropertyGroup()
+    public function validationIsOnlyDoneForPropertiesWhichAreInTheDefaultOrPersistencePropertyGroup(): void
     {
         $this->removeExampleEntities();
         $this->insertExampleEntity();
@@ -385,7 +390,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function eventSubscribersAreProperlyExecuted()
+    public function eventSubscribersAreProperlyExecuted(): void
     {
         $this->removeExampleEntities();
         $this->insertExampleEntity();
@@ -399,7 +404,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function eventListenersAreProperlyExecuted()
+    public function eventListenersAreProperlyExecuted(): void
     {
         $this->removeExampleEntities();
         $this->insertExampleEntity();
@@ -413,7 +418,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function persistAllThrowsExceptionIfNonAllowedObjectsAreDirtyAndFlagIsSet()
+    public function persistAllThrowsExceptionIfNonAllowedObjectsAreDirtyAndFlagIsSet(): void
     {
         $this->expectException(Exception::class);
         $testEntity = new Fixtures\TestEntity();
@@ -425,7 +430,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function persistAllThrowsExceptionIfNonAllowedObjectsAreUpdatedAndFlagIsSet()
+    public function persistAllThrowsExceptionIfNonAllowedObjectsAreUpdatedAndFlagIsSet(): void
     {
         $this->expectException(Exception::class);
         $this->removeExampleEntities();
@@ -442,7 +447,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function persistAllThrowsNoExceptionIfAllowedObjectsAreDirtyAndFlagIsSet()
+    public function persistAllThrowsNoExceptionIfAllowedObjectsAreDirtyAndFlagIsSet(): void
     {
         $testEntity = new Fixtures\TestEntity();
         $testEntity->setName('Surfer girl');
@@ -456,7 +461,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function extendedTypesEntityIsIsReconstitutedWithProperties()
+    public function extendedTypesEntityIsIsReconstitutedWithProperties(): void
     {
         $extendedTypesEntity = new Fixtures\ExtendedTypesEntity();
 
@@ -482,10 +487,10 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function commonObjectIsPersistedAndIsReconstituted()
+    public function commonObjectIsPersistedAndIsReconstituted(): void
     {
         if ($this->objectManager->get(ConfigurationManager::class)->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.Flow.persistence.backendOptions.driver') === 'pdo_pgsql') {
-            $this->markTestSkipped('Doctrine ORM on PostgreSQL cannot store serialized data, thus storing objects with Type::OBJECT would fail. See http://www.doctrine-project.org/jira/browse/DDC-3241');
+            static::markTestSkipped('Doctrine ORM on PostgreSQL cannot store serialized data, thus storing objects with Type::OBJECT would fail. See http://www.doctrine-project.org/jira/browse/DDC-3241');
         }
 
         $commonObject = new Fixtures\CommonObject();
@@ -509,7 +514,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function jsonArrayIsPersistedAndIsReconstituted()
+    public function jsonArrayIsPersistedAndIsReconstituted(): void
     {
         $extendedTypesEntity = new Fixtures\ExtendedTypesEntity();
         $extendedTypesEntity->setJsonArray(['foo' => 'bar']);
@@ -529,7 +534,7 @@ class PersistenceTest extends FunctionalTestCase
      * @test
      * @see http://doctrine-orm.readthedocs.org/en/latest/cookbook/working-with-datetime.html#default-timezone-gotcha
      */
-    public function dateTimeIsPersistedAndIsReconstitutedWithTimeDiffIfSystemTimeZoneDifferentToDateTimeObjectsTimeZone()
+    public function dateTimeIsPersistedAndIsReconstitutedWithTimeDiffIfSystemTimeZoneDifferentToDateTimeObjectsTimeZone(): void
     {
         // Make sure running in specific mode independent from testing env settings
         ini_set('date.timezone', 'Arctic/Longyearbyen');
@@ -556,7 +561,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function dateTimeIsPersistedAndIsReconstituted()
+    public function dateTimeIsPersistedAndIsReconstituted(): void
     {
         $dateTimeTz = new \DateTime('2008-11-16 19:03:30', new \DateTimeZone(ini_get('date.timezone')));
         $extendedTypesEntity = new Fixtures\ExtendedTypesEntity();
@@ -576,7 +581,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function immutableDateTimeIsPersistedAndIsReconstituted()
+    public function immutableDateTimeIsPersistedAndIsReconstituted(): void
     {
         $dateTimeTz = new \DateTimeImmutable('2008-11-16 19:03:30', new \DateTimeZone(ini_get('date.timezone')));
         $extendedTypesEntity = new Fixtures\ExtendedTypesEntity();
@@ -598,7 +603,7 @@ class PersistenceTest extends FunctionalTestCase
      * See #1673
      * @test
      */
-    public function dateTimeInterfaceIsPersistedAndIsReconstitutedAsDateTime()
+    public function dateTimeInterfaceIsPersistedAndIsReconstitutedAsDateTime(): void
     {
         $dateTimeTz = new \DateTimeImmutable('2008-11-16 19:03:30', new \DateTimeZone(ini_get('date.timezone')));
         $extendedTypesEntity = new Fixtures\ExtendedTypesEntity();
@@ -624,9 +629,9 @@ class PersistenceTest extends FunctionalTestCase
      * But since flow does not support multiple db endpoints this is a test just for mysql.
      * In case of mysql, Doctrine handles datetimetz fields simply the same way as datetime does (pure string with date and time but without tz)
      */
-    public function dateTimeTzIsPersistedAndIsReconstituted()
+    public function dateTimeTzIsPersistedAndIsReconstituted(): void
     {
-        $this->markTestIncomplete('We need different tests at least for two types of database. 1. mysql without timezone support. 2. a db with timezone support.');
+        static::markTestIncomplete('We need different tests at least for two types of database. 1. mysql without timezone support. 2. a db with timezone support.');
 
         // Make sure running in specific mode independent from testing env settings
         ini_set('date.timezone', 'Arctic/Longyearbyen');
@@ -653,7 +658,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function dateIsPersistedAndIsReconstituted()
+    public function dateIsPersistedAndIsReconstituted(): void
     {
         $dateTime = new \DateTime('2008-11-16 19:03:30');
         $extendedTypesEntity = new Fixtures\ExtendedTypesEntity();
@@ -671,7 +676,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timeIsPersistedAndIsReconstituted()
+    public function timeIsPersistedAndIsReconstituted(): void
     {
         $dateTime = new \DateTime('2008-11-16 19:03:30');
         $extendedTypesEntity = new Fixtures\ExtendedTypesEntity();
@@ -689,7 +694,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function simpleArrayIsPersistedAndIsReconstituted()
+    public function simpleArrayIsPersistedAndIsReconstituted(): void
     {
         $extendedTypesEntity = new Fixtures\ExtendedTypesEntity();
         $extendedTypesEntity->setSimpleArray(['foo' => 'bar']);
@@ -708,7 +713,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function hasUnpersistedChangesReturnsTrueAfterObjectUpdate()
+    public function hasUnpersistedChangesReturnsTrueAfterObjectUpdate(): void
     {
         $this->removeExampleEntities();
         $this->insertExampleEntity();
@@ -725,8 +730,10 @@ class PersistenceTest extends FunctionalTestCase
      * Helper which inserts example data into the database.
      *
      * @param string $name
+     * @throws IllegalObjectTypeException
+     * @throws IllegalObjectTypeException
      */
-    protected function insertExampleEntity($name = 'Flow')
+    protected function insertExampleEntity($name = 'Flow'): void
     {
         $testEntity = new Fixtures\TestEntity();
         $testEntity->setName($name);
@@ -739,7 +746,7 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * Remove all example entities to enforce a clean state
      */
-    protected function removeExampleEntities()
+    protected function removeExampleEntities(): void
     {
         $this->testEntityRepository->removeAll();
         $this->persistenceManager->persistAll();
@@ -749,9 +756,9 @@ class PersistenceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doctrineEmbeddablesAreActuallyEmbedded()
+    public function doctrineEmbeddablesAreActuallyEmbedded(): void
     {
-        /* @var $entityManager EntityManagerInterface */
+        /* @var EntityManagerInterface $entityManager */
         $entityManager = $this->objectManager->get(EntityManagerInterface::class);
         $schemaTool = new SchemaTool($entityManager);
         $metaData = $entityManager->getClassMetadata(Fixtures\TestEntity::class);
@@ -768,7 +775,7 @@ class PersistenceTest extends FunctionalTestCase
         $this->persistenceManager->persistAll();
         $this->persistenceManager->clearState();
 
-        /* @var $testEntity Fixtures\TestEntity */
+        /* @var Fixtures\TestEntity $testEntity */
         $testEntity = $this->testEntityRepository->findAll()->getFirst();
         self::assertEquals('someValue', $testEntity->getEmbedded()->getValue());
     }

--- a/Neos.Flow/Tests/Functional/Persistence/PersistenceTestPHP8.php
+++ b/Neos.Flow/Tests/Functional/Persistence/PersistenceTestPHP8.php
@@ -1,0 +1,775 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Persistence;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Neos\Flow\Configuration\ConfigurationManager;
+use Neos\Flow\Persistence\Doctrine\PersistenceManager;
+use Neos\Flow\Persistence\Doctrine\QueryResult;
+use Neos\Flow\Persistence\Exception;
+use Neos\Flow\Persistence\Exception\ObjectValidationFailedException;
+use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Utility\ObjectAccess;
+
+/**
+ * Testcase for persistence
+ *
+ */
+class PersistenceTestPHP8 extends FunctionalTestCase
+{
+    /**
+     * @var boolean
+     */
+    protected static $testablePersistenceEnabled = true;
+
+    /**
+     * @var FixturesPHP8\TestEntityRepository
+     */
+    protected $testEntityRepository;
+
+    /**
+     * @var FixturesPHP8\ExtendedTypesEntityRepository
+     */
+    protected $extendedTypesEntityRepository;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    protected $earlyEntityManager;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->earlyEntityManager = self::$bootstrap->getObjectManager()->get(EntityManagerInterface::class);
+        parent::setUp();
+        if (!$this->persistenceManager instanceof PersistenceManager) {
+            $this->markTestSkipped('Doctrine persistence is not enabled');
+        }
+        $this->testEntityRepository = new FixturesPHP8\TestEntityRepository();
+        $this->extendedTypesEntityRepository = new FixturesPHP8\ExtendedTypesEntityRepository();
+    }
+
+    /**
+     * @test
+     */
+    public function entityManagerIsSingletonInstanceInPersistenceManager()
+    {
+        $this->earlyEntityManager->persist(new FixturesPHP8\TestEntity());
+        self::assertTrue($this->persistenceManager->hasUnpersistedChanges());
+    }
+
+    /**
+     * @test
+     */
+    public function entitiesArePersistedAndReconstituted()
+    {
+        $this->removeExampleEntities();
+        $this->insertExampleEntity();
+
+        $testEntity = $this->testEntityRepository->findAll()->getFirst();
+        self::assertEquals('Flow', $testEntity->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function executingAQueryWillOnlyExecuteItLazily()
+    {
+        $this->removeExampleEntities();
+        $this->insertExampleEntity();
+
+        $allResults = $this->testEntityRepository->findAll();
+        self::assertInstanceOf(QueryResult::class, $allResults);
+        self::assertNull(ObjectAccess::getProperty($allResults, 'rows', true), 'Query Result did not load the result collection lazily.');
+
+        $allResultsArray = $allResults->toArray();
+        self::assertStringContainsString('Flow', $allResultsArray[0]->getName());
+        self::assertIsArray(ObjectAccess::getProperty($allResults, 'rows', true));
+    }
+
+    /**
+     * @test
+     */
+    public function serializingAQueryResultWillResetCachedResult()
+    {
+        $this->removeExampleEntities();
+        $this->insertExampleEntity();
+
+        $allResults = $this->testEntityRepository->findAll();
+
+        $unserializedResults = unserialize(serialize($allResults));
+        self::assertNull(ObjectAccess::getProperty($unserializedResults, 'rows', true), 'Query Result did not flush the result collection after serialization.');
+    }
+
+    /**
+     * @test
+     */
+    public function resultCanStillBeTraversedAfterSerialization()
+    {
+        $this->removeExampleEntities();
+        $this->insertExampleEntity();
+
+        $allResults = $this->testEntityRepository->findAll();
+        self::assertEquals(1, count($allResults->toArray()), 'Not correct number of entities found before running test.');
+
+        $unserializedResults = unserialize(serialize($allResults));
+        self::assertEquals(1, count($unserializedResults->toArray()));
+        self::assertEquals('Flow', $unserializedResults[0]->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function getFirstShouldNotHaveSideEffects()
+    {
+        $this->removeExampleEntities();
+        $this->insertExampleEntity('Flow');
+        $this->insertExampleEntity('Neos');
+
+        $allResults = $this->testEntityRepository->findAll();
+        self::assertEquals('Flow', $allResults->getFirst()->getName());
+
+        $numberOfTotalResults = count($allResults->toArray());
+        self::assertEquals(2, $numberOfTotalResults);
+    }
+
+    /**
+     * @test
+     */
+    public function aClonedEntityWillGetANewIdentifier()
+    {
+        $testEntity = new FixturesPHP8\TestEntity();
+        $firstIdentifier = $this->persistenceManager->getIdentifierByObject($testEntity);
+
+        $clonedEntity = clone $testEntity;
+        $secondIdentifier = $this->persistenceManager->getIdentifierByObject($clonedEntity);
+        self::assertNotEquals($firstIdentifier, $secondIdentifier);
+    }
+
+    /**
+     * @test
+     */
+    public function persistedEntitiesLyingInArraysAreNotSerializedButReferencedByTheirIdentifierAndReloadedFromPersistenceOnWakeup()
+    {
+        $testEntityLyingInsideTheArray = new FixturesPHP8\TestEntity();
+        $testEntityLyingInsideTheArray->setName('Flow');
+
+        $arrayProperty = [
+            'some' => [
+                'nestedArray' => [
+                    'key' => $testEntityLyingInsideTheArray
+                ]
+            ]
+        ];
+
+        $testEntityWithArrayProperty = new FixturesPHP8\TestEntity();
+        $testEntityWithArrayProperty->setName('dummy');
+        $testEntityWithArrayProperty->setArrayProperty($arrayProperty);
+
+        $this->testEntityRepository->add($testEntityLyingInsideTheArray);
+        $this->testEntityRepository->add($testEntityWithArrayProperty);
+
+        $this->persistenceManager->persistAll();
+
+        $serializedData = serialize($testEntityWithArrayProperty);
+
+        $testEntityLyingInsideTheArray->setName('Neos');
+        $this->persistenceManager->persistAll();
+
+        $testEntityWithArrayPropertyUnserialized = unserialize($serializedData);
+        $arrayPropertyAfterUnserialize = $testEntityWithArrayPropertyUnserialized->getArrayProperty();
+
+        self::assertNotSame($testEntityWithArrayProperty, $testEntityWithArrayPropertyUnserialized);
+        self::assertEquals('Neos', $arrayPropertyAfterUnserialize['some']['nestedArray']['key']->getName(), 'The entity inside the array property has not been updated to the current persistend state after wakeup.');
+    }
+
+    /**
+     * @test
+     */
+    public function objectsWithPersistedEntitiesCanBeSerializedMultipleTimes()
+    {
+        $persistedEntity = new FixturesPHP8\TestEntity();
+        $persistedEntity->setName('Flow');
+        $this->testEntityRepository->add($persistedEntity);
+        $this->persistenceManager->persistAll();
+
+        $objectHoldingTheEntity = new FixturesPHP8\ObjectHoldingAnEntity();
+        $objectHoldingTheEntity->testEntity = $persistedEntity;
+
+        for ($i = 0; $i < 2; $i++) {
+            $serializedData = serialize($objectHoldingTheEntity);
+            $unserializedObjectHoldingTheEntity = unserialize($serializedData);
+            $this->assertInstanceOf(FixturesPHP8\TestEntity::class, $unserializedObjectHoldingTheEntity->testEntity);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function newEntitiesWhichAreNotAddedToARepositoryYetAreAlreadyKnownToGetObjectByIdentifier()
+    {
+        $expectedEntity = new FixturesPHP8\TestEntity();
+        $uuid = $this->persistenceManager->getIdentifierByObject($expectedEntity);
+        $actualEntity = $this->persistenceManager->getObjectByIdentifier($uuid, FixturesPHP8\TestEntity::class);
+        self::assertSame($expectedEntity, $actualEntity);
+    }
+
+    /**
+     * @test
+     */
+    public function valueObjectsWithTheSameValueAreOnlyPersistedOnce()
+    {
+        $valueObject1 = new FixturesPHP8\TestValueObject('sameValue');
+        $valueObject2 = new FixturesPHP8\TestValueObject('sameValue');
+
+        $testEntity1 = new FixturesPHP8\TestEntity();
+        $testEntity1->setRelatedValueObject($valueObject1);
+        $testEntity2 = new FixturesPHP8\TestEntity();
+        $testEntity2->setRelatedValueObject($valueObject2);
+
+        $this->testEntityRepository->add($testEntity1);
+        $this->testEntityRepository->add($testEntity2);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        $testEntities = $this->testEntityRepository->findAll();
+
+        self::assertSame($testEntities[0]->getRelatedValueObject(), $testEntities[1]->getRelatedValueObject());
+    }
+
+    /**
+     * @test
+     */
+    public function alreadyPersistedValueObjectsAreCorrectlyReused()
+    {
+        $valueObject1 = new FixturesPHP8\TestValueObject('sameValue');
+        $testEntity1 = new FixturesPHP8\TestEntity();
+        $testEntity1->setRelatedValueObject($valueObject1);
+
+        $this->testEntityRepository->add($testEntity1);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        $valueObject2 = new FixturesPHP8\TestValueObject('sameValue');
+        $testEntity2 = new FixturesPHP8\TestEntity();
+        $testEntity2->setRelatedValueObject($valueObject2);
+
+        $valueObject3 = new FixturesPHP8\TestValueObject('sameValue');
+        $testEntity3 = new FixturesPHP8\TestEntity();
+        $testEntity3->setRelatedValueObject($valueObject3);
+
+        $this->testEntityRepository->add($testEntity2);
+        $this->testEntityRepository->add($testEntity3);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        $testEntities = $this->testEntityRepository->findAll();
+
+        self::assertSame($testEntities[0]->getRelatedValueObject(), $testEntities[1]->getRelatedValueObject());
+        self::assertSame($testEntities[1]->getRelatedValueObject(), $testEntities[2]->getRelatedValueObject());
+    }
+
+    /**
+     * @test
+     */
+    public function embeddedValueObjectsAreActuallyEmbedded()
+    {
+        /* @var $entityManager EntityManagerInterface */
+        $entityManager = $this->objectManager->get(\Doctrine\ORM\EntityManagerInterface::class);
+        $schemaTool = new SchemaTool($entityManager);
+        $classMetaData = $entityManager->getClassMetadata(FixturesPHP8\TestEntity::class);
+        self::assertTrue($classMetaData->hasField('embeddedValueObject.value'), 'ClassMetadata is not correctly embedded');
+        $schema = $schemaTool->getSchemaFromMetadata([$classMetaData]);
+        self::assertTrue($schema->getTable('persistence_php8_testentity')->hasColumn('embeddedvalueobjectvalue'), 'Database schema is missing embedded field');
+
+        $valueObject = new FixturesPHP8\TestEmbeddedValueObject('someValue');
+        $testEntity = new FixturesPHP8\TestEntity();
+        $testEntity->setEmbeddedValueObject($valueObject);
+
+        $this->testEntityRepository->add($testEntity);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        /* @var $testEntity FixturesPHP8\TestEntity */
+        $testEntity = $this->testEntityRepository->findAll()->getFirst();
+        self::assertEquals('someValue', $testEntity->getEmbeddedValueObject()->getValue());
+    }
+
+    /**
+     * @test
+     */
+    public function validationIsDoneForNewEntities()
+    {
+        $this->expectException(ObjectValidationFailedException::class);
+        $this->removeExampleEntities();
+        $this->insertExampleEntity('A');
+
+        $this->persistenceManager->persistAll();
+    }
+
+    /**
+     * @test
+     */
+    public function validationIsDoneForReconstitutedEntities()
+    {
+        $this->expectException(ObjectValidationFailedException::class);
+        $this->removeExampleEntities();
+        $this->insertExampleEntity();
+        $this->persistenceManager->persistAll();
+
+        $firstResult = $this->testEntityRepository->findAll()->getFirst();
+        $firstResult->setName('A');
+        $this->testEntityRepository->update($firstResult);
+        $this->persistenceManager->persistAll();
+    }
+
+    /**
+     * Testcase for issue #32830 - Validation on persist breaks with Doctrine Lazy Loading Proxies
+     *
+     * @test
+     */
+    public function validationIsDoneForReconstitutedEntitiesWhichAreLazyLoadingProxies()
+    {
+        $this->expectException(ObjectValidationFailedException::class);
+        $this->removeExampleEntities();
+        $this->insertExampleEntity();
+        $this->persistenceManager->persistAll();
+        $theObject = $this->testEntityRepository->findOneByName('Flow');
+        $theObjectIdentifier = $this->persistenceManager->getIdentifierByObject($theObject);
+
+        // Here, we completely reset the persistence manager again and work
+        // only with the Object Identifier
+        $this->persistenceManager->clearState();
+
+        $entityManager = $this->objectManager->get(EntityManagerInterface::class);
+        $lazyLoadedEntity = $entityManager->getReference(FixturesPHP8\TestEntity::class, $theObjectIdentifier);
+        $lazyLoadedEntity->setName('a');
+        $this->testEntityRepository->update($lazyLoadedEntity);
+        $this->persistenceManager->persistAll();
+    }
+
+    /**
+     * @test
+     * @doesNotPerformAssertions
+     */
+    public function validationIsOnlyDoneForPropertiesWhichAreInTheDefaultOrPersistencePropertyGroup()
+    {
+        $this->removeExampleEntities();
+        $this->insertExampleEntity();
+        $this->persistenceManager->persistAll();
+        $testEntity = $this->testEntityRepository->findOneByName('Flow');
+
+        // We now make the TestEntities Description *invalid*, and still
+        // expect that the saving works without exception.
+        $testEntity->setDescription('');
+        $this->testEntityRepository->update($testEntity);
+        $this->persistenceManager->persistAll();
+    }
+
+    /**
+     * @test
+     */
+    public function eventSubscribersAreProperlyExecuted()
+    {
+        $this->removeExampleEntities();
+        $this->insertExampleEntity();
+        $this->persistenceManager->persistAll();
+        $eventSubscriber = $this->objectManager->get(FixturesPHP8\EventSubscriber::class);
+        self::assertTrue($eventSubscriber->preFlushCalled, 'Assert that preFlush event was triggered.');
+        self::assertTrue($eventSubscriber->onFlushCalled, 'Assert that onFlush event was triggered.');
+        self::assertTrue($eventSubscriber->postFlushCalled, 'Assert that postFlush event was triggered.');
+    }
+
+    /**
+     * @test
+     */
+    public function eventListenersAreProperlyExecuted()
+    {
+        $this->removeExampleEntities();
+        $this->insertExampleEntity();
+        $this->persistenceManager->persistAll();
+        $eventSubscriber = $this->objectManager->get(FixturesPHP8\EventListener::class);
+        self::assertTrue($eventSubscriber->preFlushCalled, 'Assert that preFlush event was triggered.');
+        self::assertTrue($eventSubscriber->onFlushCalled, 'Assert that onFlush event was triggered.');
+        self::assertTrue($eventSubscriber->postFlushCalled, 'Assert that postFlush event was triggered.');
+    }
+
+    /**
+     * @test
+     */
+    public function persistAllThrowsExceptionIfNonAllowedObjectsAreDirtyAndFlagIsSet()
+    {
+        $this->expectException(Exception::class);
+        $testEntity = new FixturesPHP8\TestEntity();
+        $testEntity->setName('Surfer girl');
+        $this->testEntityRepository->add($testEntity);
+        $this->persistenceManager->persistAll(true);
+    }
+
+    /**
+     * @test
+     */
+    public function persistAllThrowsExceptionIfNonAllowedObjectsAreUpdatedAndFlagIsSet()
+    {
+        $this->expectException(Exception::class);
+        $this->removeExampleEntities();
+        $this->insertExampleEntity();
+        $this->persistenceManager->persistAll();
+
+        /** @var FixturesPHP8\TestEntity $testEntity */
+        $testEntity = $this->testEntityRepository->findAll()->getFirst();
+        $testEntity->setName('Another name');
+        $this->testEntityRepository->update($testEntity);
+        $this->persistenceManager->persistAll(true);
+    }
+
+    /**
+     * @test
+     */
+    public function persistAllThrowsNoExceptionIfAllowedObjectsAreDirtyAndFlagIsSet()
+    {
+        $testEntity = new FixturesPHP8\TestEntity();
+        $testEntity->setName('Surfer girl');
+        $this->testEntityRepository->add($testEntity);
+
+        $this->persistenceManager->allowObject($testEntity);
+        $this->persistenceManager->persistAll(true);
+        self::assertTrue(true);
+    }
+
+    /**
+     * @test
+     */
+    public function extendedTypesEntityIsIsReconstitutedWithProperties()
+    {
+        $extendedTypesEntity = new FixturesPHP8\ExtendedTypesEntity();
+
+        $this->persistenceManager->add($extendedTypesEntity);
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        /**  @var FixturesPHP8\ExtendedTypesEntity $persistedExtendedTypesEntity */
+        $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
+
+        self::assertInstanceOf(FixturesPHP8\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertNull($persistedExtendedTypesEntity->getCommonObject(), 'Common Object');
+        self::assertNull($persistedExtendedTypesEntity->getDateTime(), 'DateTime');
+        self::assertNull($persistedExtendedTypesEntity->getDateTimeTz(), 'DateTimeTz');
+        self::assertNull($persistedExtendedTypesEntity->getDate(), 'Date');
+        self::assertNull($persistedExtendedTypesEntity->getTime(), 'Time');
+
+        // These types always returns an array, never NULL, even if the property is nullable
+        self::assertEquals([], $persistedExtendedTypesEntity->getSimpleArray(), 'Simple Array');
+        self::assertEquals([], $persistedExtendedTypesEntity->getJsonArray(), 'Json Array');
+    }
+
+    /**
+     * @test
+     */
+    public function commonObjectIsPersistedAndIsReconstituted()
+    {
+        if ($this->objectManager->get(ConfigurationManager::class)->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.Flow.persistence.backendOptions.driver') === 'pdo_pgsql') {
+            $this->markTestSkipped('Doctrine ORM on PostgreSQL cannot store serialized data, thus storing objects with Type::OBJECT would fail. See http://www.doctrine-project.org/jira/browse/DDC-3241');
+        }
+
+        $commonObject = new FixturesPHP8\CommonObject();
+        $commonObject->setFoo('foo');
+
+        $extendedTypesEntity = new FixturesPHP8\ExtendedTypesEntity();
+        $extendedTypesEntity->setCommonObject($commonObject);
+
+        $this->persistenceManager->add($extendedTypesEntity);
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        /**  @var FixturesPHP8\ExtendedTypesEntity $persistedExtendedTypesEntity */
+        $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
+
+        self::assertInstanceOf(FixturesPHP8\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertInstanceOf(FixturesPHP8\CommonObject::class, $persistedExtendedTypesEntity->getCommonObject());
+        self::assertEquals('foo', $persistedExtendedTypesEntity->getCommonObject()->getFoo());
+    }
+
+    /**
+     * @test
+     */
+    public function jsonArrayIsPersistedAndIsReconstituted()
+    {
+        $extendedTypesEntity = new FixturesPHP8\ExtendedTypesEntity();
+        $extendedTypesEntity->setJsonArray(['foo' => 'bar']);
+
+        $this->persistenceManager->add($extendedTypesEntity);
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        /**  @var FixturesPHP8\ExtendedTypesEntity $persistedExtendedTypesEntity */
+        $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
+
+        self::assertInstanceOf(FixturesPHP8\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertEquals(['foo' => 'bar'], $persistedExtendedTypesEntity->getJsonArray());
+    }
+
+    /**
+     * @test
+     * @see http://doctrine-orm.readthedocs.org/en/latest/cookbook/working-with-datetime.html#default-timezone-gotcha
+     */
+    public function dateTimeIsPersistedAndIsReconstitutedWithTimeDiffIfSystemTimeZoneDifferentToDateTimeObjectsTimeZone()
+    {
+        // Make sure running in specific mode independent from testing env settings
+        ini_set('date.timezone', 'Arctic/Longyearbyen');
+
+        $dateTimeTz = new \DateTime('2008-11-16 19:03:30', new \DateTimeZone('UTC'));
+        $extendedTypesEntity = new FixturesPHP8\ExtendedTypesEntity();
+        $extendedTypesEntity->setDateTime($dateTimeTz);
+        $this->persistenceManager->add($extendedTypesEntity);
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        /**  @var FixturesPHP8\ExtendedTypesEntity $persistedExtendedTypesEntity */
+        $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
+
+        // Restore test env timezone
+        ini_restore('date.timezone');
+
+        self::assertInstanceOf(FixturesPHP8\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertInstanceOf('DateTime', $persistedExtendedTypesEntity->getDateTime());
+        self::assertNotEquals($dateTimeTz->getTimestamp(), $persistedExtendedTypesEntity->getDateTime()->getTimestamp());
+        self::assertEquals('Arctic/Longyearbyen', $persistedExtendedTypesEntity->getDateTime()->getTimezone()->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function dateTimeIsPersistedAndIsReconstituted()
+    {
+        $dateTimeTz = new \DateTime('2008-11-16 19:03:30', new \DateTimeZone(ini_get('date.timezone')));
+        $extendedTypesEntity = new FixturesPHP8\ExtendedTypesEntity();
+        $extendedTypesEntity->setDateTime($dateTimeTz);
+        $this->persistenceManager->add($extendedTypesEntity);
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        /**  @var FixturesPHP8\ExtendedTypesEntity $persistedExtendedTypesEntity */
+        $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
+        self::assertInstanceOf(FixturesPHP8\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertInstanceOf('DateTime', $persistedExtendedTypesEntity->getDateTime());
+        self::assertEquals($dateTimeTz->getTimestamp(), $persistedExtendedTypesEntity->getDateTime()->getTimestamp());
+        self::assertEquals(ini_get('date.timezone'), $persistedExtendedTypesEntity->getDateTime()->getTimezone()->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function immutableDateTimeIsPersistedAndIsReconstituted()
+    {
+        $dateTimeTz = new \DateTimeImmutable('2008-11-16 19:03:30', new \DateTimeZone(ini_get('date.timezone')));
+        $extendedTypesEntity = new FixturesPHP8\ExtendedTypesEntity();
+        $extendedTypesEntity->setDateTimeImmutable($dateTimeTz);
+        $this->persistenceManager->add($extendedTypesEntity);
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        /**  @var FixturesPHP8\ExtendedTypesEntity $persistedExtendedTypesEntity */
+        $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
+        self::assertInstanceOf(FixturesPHP8\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertInstanceOf('DateTimeImmutable', $persistedExtendedTypesEntity->getDateTimeImmutable());
+        self::assertEquals($dateTimeTz->getTimestamp(), $persistedExtendedTypesEntity->getDateTimeImmutable()->getTimestamp());
+        self::assertEquals(ini_get('date.timezone'), $persistedExtendedTypesEntity->getDateTimeImmutable()->getTimezone()->getName());
+    }
+
+    /**
+     * This test covers a b/c "feature" that automatically maps var \DateTimeInterface to doctrine `datetime` type without a ORM\Column annotation
+     * See #1673
+     * @test
+     */
+    public function dateTimeInterfaceIsPersistedAndIsReconstitutedAsDateTime()
+    {
+        $dateTimeTz = new \DateTimeImmutable('2008-11-16 19:03:30', new \DateTimeZone(ini_get('date.timezone')));
+        $extendedTypesEntity = new FixturesPHP8\ExtendedTypesEntity();
+        $extendedTypesEntity->setDateTimeInterface($dateTimeTz);
+        $this->persistenceManager->add($extendedTypesEntity);
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        /**  @var FixturesPHP8\ExtendedTypesEntity $persistedExtendedTypesEntity */
+        $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
+        self::assertInstanceOf(FixturesPHP8\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        // We don't get the same instance out that we put in.
+        self::assertInstanceOf('DateTime', $persistedExtendedTypesEntity->getDateTimeInterface());
+        self::assertEquals($dateTimeTz->getTimestamp(), $persistedExtendedTypesEntity->getDateTimeInterface()->getTimestamp());
+        self::assertEquals(ini_get('date.timezone'), $persistedExtendedTypesEntity->getDateTimeInterface()->getTimezone()->getName());
+    }
+
+    /**
+     * @test
+     * @todo We need different tests at least for two types of database.
+     * * 1. mysql without timezone support.
+     * * 2. a db with timezone support.
+     * But since flow does not support multiple db endpoints this is a test just for mysql.
+     * In case of mysql, Doctrine handles datetimetz fields simply the same way as datetime does (pure string with date and time but without tz)
+     */
+    public function dateTimeTzIsPersistedAndIsReconstituted()
+    {
+        $this->markTestIncomplete('We need different tests at least for two types of database. 1. mysql without timezone support. 2. a db with timezone support.');
+
+        // Make sure running in specific mode independent from testing env settings
+        ini_set('date.timezone', 'Arctic/Longyearbyen');
+
+        $dateTimeTz = new \DateTime('2008-11-16 19:03:30', new \DateTimeZone('UTC'));
+        $extendedTypesEntity = new FixturesPHP8\ExtendedTypesEntity();
+        $extendedTypesEntity->setDateTimeTz($dateTimeTz);
+        $this->persistenceManager->add($extendedTypesEntity);
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        /**  @var FixturesPHP8\ExtendedTypesEntity $persistedExtendedTypesEntity */
+        $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
+
+        // Restore test env timezone
+        ini_restore('date.timezone');
+
+        self::assertInstanceOf(FixturesPHP8\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertInstanceOf('DateTime', $persistedExtendedTypesEntity->getDateTimeTz());
+        self::assertNotEquals($dateTimeTz->getTimestamp(), $persistedExtendedTypesEntity->getDateTimeTz()->getTimestamp());
+        self::assertEquals(ini_get('datetime.timezone'), $persistedExtendedTypesEntity->getDateTimeTz()->getTimezone()->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function dateIsPersistedAndIsReconstituted()
+    {
+        $dateTime = new \DateTime('2008-11-16 19:03:30');
+        $extendedTypesEntity = new FixturesPHP8\ExtendedTypesEntity();
+        $extendedTypesEntity->setDate($dateTime);
+        $this->persistenceManager->add($extendedTypesEntity);
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        /**  @var FixturesPHP8\ExtendedTypesEntity $persistedExtendedTypesEntity */
+        $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
+        self::assertInstanceOf(FixturesPHP8\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertEquals('2008-11-16', $persistedExtendedTypesEntity->getDate()->format('Y-m-d'));
+    }
+
+    /**
+     * @test
+     */
+    public function timeIsPersistedAndIsReconstituted()
+    {
+        $dateTime = new \DateTime('2008-11-16 19:03:30');
+        $extendedTypesEntity = new FixturesPHP8\ExtendedTypesEntity();
+        $extendedTypesEntity->setTime($dateTime);
+        $this->persistenceManager->add($extendedTypesEntity);
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        /**  @var FixturesPHP8\ExtendedTypesEntity $persistedExtendedTypesEntity */
+        $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
+        self::assertInstanceOf(FixturesPHP8\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertEquals('19:03:30', $persistedExtendedTypesEntity->getTime()->format('H:i:s'));
+    }
+
+    /**
+     * @test
+     */
+    public function simpleArrayIsPersistedAndIsReconstituted()
+    {
+        $extendedTypesEntity = new FixturesPHP8\ExtendedTypesEntity();
+        $extendedTypesEntity->setSimpleArray(['foo' => 'bar']);
+
+        $this->persistenceManager->add($extendedTypesEntity);
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        /**  @var FixturesPHP8\ExtendedTypesEntity $persistedExtendedTypesEntity */
+        $persistedExtendedTypesEntity = $this->extendedTypesEntityRepository->findAll()->getFirst();
+
+        self::assertInstanceOf(FixturesPHP8\ExtendedTypesEntity::class, $persistedExtendedTypesEntity);
+        self::assertEquals(['bar'], $persistedExtendedTypesEntity->getSimpleArray());
+    }
+
+    /**
+     * @test
+     */
+    public function hasUnpersistedChangesReturnsTrueAfterObjectUpdate()
+    {
+        $this->removeExampleEntities();
+        $this->insertExampleEntity();
+        $this->persistenceManager->persistAll();
+
+        /** @var FixturesPHP8\TestEntity $testEntity */
+        $testEntity = $this->testEntityRepository->findAll()->getFirst();
+        $testEntity->setName('Another name');
+        $this->testEntityRepository->update($testEntity);
+        self::assertTrue($this->persistenceManager->hasUnpersistedChanges());
+    }
+
+    /**
+     * Helper which inserts example data into the database.
+     *
+     * @param string $name
+     */
+    protected function insertExampleEntity($name = 'Flow')
+    {
+        $testEntity = new FixturesPHP8\TestEntity();
+        $testEntity->setName($name);
+        $this->testEntityRepository->add($testEntity);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+    }
+
+    /**
+     * Remove all example entities to enforce a clean state
+     */
+    protected function removeExampleEntities()
+    {
+        $this->testEntityRepository->removeAll();
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+    }
+
+    /**
+     * @test
+     */
+    public function doctrineEmbeddablesAreActuallyEmbedded()
+    {
+        /* @var $entityManager EntityManagerInterface */
+        $entityManager = $this->objectManager->get(EntityManagerInterface::class);
+        $schemaTool = new SchemaTool($entityManager);
+        $metaData = $entityManager->getClassMetadata(FixturesPHP8\TestEntity::class);
+        self::assertTrue($metaData->hasField('embedded.value'), 'ClassMetadata does not contain embedded value');
+        $schema = $schemaTool->getSchemaFromMetadata([$metaData]);
+        self::assertTrue($schema->getTable('persistence_php8_testentity')->hasColumn('embedded_value'), 'Database schema does not contain embedded value field');
+
+        $embeddable = new FixturesPHP8\TestEmbeddable('someValue');
+        $testEntity = new FixturesPHP8\TestEntity();
+        $testEntity->setEmbedded($embeddable);
+
+        $this->testEntityRepository->add($testEntity);
+
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        /* @var $testEntity FixturesPHP8\TestEntity */
+        $testEntity = $this->testEntityRepository->findAll()->getFirst();
+        self::assertEquals('someValue', $testEntity->getEmbedded()->getValue());
+    }
+}

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriverTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriverTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Neos\Flow\Tests\Unit\Persistence\Doctrine\Mapping\Driver;
 
 /*
@@ -14,6 +16,10 @@ namespace Neos\Flow\Tests\Unit\Persistence\Doctrine\Mapping\Driver;
 use Neos\Flow\Persistence\Doctrine\Mapping\Driver\FlowAnnotationDriver;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\Flow\Security;
+use PHPUnit\Framework\MockObject\MockObject;
+use Doctrine\ORM\EntityManager;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 /**
  * Testcase for the Flow annotation driver
@@ -25,10 +31,9 @@ class FlowAnnotationDriverTest extends UnitTestCase
      *
      * @return array
      */
-    public function classNameToTableNameMappings()
+    public function classNameToTableNameMappings(): array
     {
         return [
-            [\Neos\Party\Domain\Model\Person::class, 'neos_party_domain_model_person'],
             ['SomePackage\Domain\Model\Blob', 'somepackage_domain_model_blob'],
             [Security\Policy\Role::class, 'neos_flow_security_policy_role'],
             [Security\Account::class, 'neos_flow_security_account'],
@@ -40,10 +45,11 @@ class FlowAnnotationDriverTest extends UnitTestCase
      * @test
      * @dataProvider classNameToTableNameMappings
      */
-    public function testInferTableNameFromClassName($className, $tableName)
+    public function testInferTableNameFromClassName($className, $tableName): void
     {
+        /** @var FlowAnnotationDriver|MockObject $driver */
         $driver = $this->getAccessibleMock(FlowAnnotationDriver::class, ['getMaxIdentifierLength']);
-        $driver->expects(self::any())->method('getMaxIdentifierLength')->will(self::returnValue(64));
+        $driver->expects(self::any())->method('getMaxIdentifierLength')->willReturn(64);
         self::assertEquals($tableName, $driver->inferTableNameFromClassName($className));
     }
 
@@ -52,10 +58,9 @@ class FlowAnnotationDriverTest extends UnitTestCase
      *
      * @return array
      */
-    public function classAndPropertyNameToJoinTableNameMappings()
+    public function classAndPropertyNameToJoinTableNameMappings(): array
     {
         return [
-            [64, \Neos\Party\Domain\Model\Person::class, 'propertyName', 'neos_party_domain_model_person_propertyname_join'],
             [64, 'SomePackage\Domain\Model\Blob', 'propertyName', 'somepackage_domain_model_blob_propertyname_join'],
             [64, Security\Policy\Role::class, 'propertyName', 'neos_flow_security_policy_role_propertyname_join'],
             [64, Security\Account::class, 'propertyName', 'neos_flow_security_account_propertyname_join'],
@@ -69,11 +74,12 @@ class FlowAnnotationDriverTest extends UnitTestCase
      * @test
      * @dataProvider classAndPropertyNameToJoinTableNameMappings
      */
-    public function testInferJoinTableNameFromClassAndPropertyName($maxIdentifierLength, $className, $propertyName, $expectedTableName)
+    public function testInferJoinTableNameFromClassAndPropertyName($maxIdentifierLength, $className, $propertyName, $expectedTableName): void
     {
         $driver = $this->getAccessibleMock(FlowAnnotationDriver::class, ['getMaxIdentifierLength']);
-        $driver->expects(self::any())->method('getMaxIdentifierLength')->will(self::returnValue($maxIdentifierLength));
+        $driver->method('getMaxIdentifierLength')->willReturn($maxIdentifierLength);
 
+        /** @noinspection PhpUndefinedMethodInspection */
         $actualTableName = $driver->_call('inferJoinTableNameFromClassAndPropertyName', $className, $propertyName);
         self::assertEquals($expectedTableName, $actualTableName);
         self::assertTrue(strlen($actualTableName) <= $maxIdentifierLength);
@@ -82,17 +88,19 @@ class FlowAnnotationDriverTest extends UnitTestCase
     /**
      * @test
      */
-    public function getMaxIdentifierLengthAsksDoctrineForValue()
+    public function getMaxIdentifierLengthAsksDoctrineForValue(): void
     {
-        $mockDatabasePlatform = $this->getMockForAbstractClass('Doctrine\DBAL\Platforms\AbstractPlatform', [], '', true, true, true, ['getMaxIdentifierLength']);
-        $mockDatabasePlatform->expects(self::atLeastOnce())->method('getMaxIdentifierLength')->will(self::returnValue(2048));
-        $mockConnection = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
-        $mockConnection->expects(self::atLeastOnce())->method('getDatabasePlatform')->will(self::returnValue($mockDatabasePlatform));
-        $mockEntityManager = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
-        $mockEntityManager->expects(self::atLeastOnce())->method('getConnection')->will(self::returnValue($mockConnection));
+        $mockDatabasePlatform = $this->getMockForAbstractClass(AbstractPlatform::class, [], '', true, true, true, ['getMaxIdentifierLength']);
+        $mockDatabasePlatform->expects(self::atLeastOnce())->method('getMaxIdentifierLength')->willReturn(2048);
+        $mockConnection = $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
+        $mockConnection->expects(self::atLeastOnce())->method('getDatabasePlatform')->willReturn($mockDatabasePlatform);
+        $mockEntityManager = $this->getMockBuilder(EntityManager::class)->disableOriginalConstructor()->getMock();
+        $mockEntityManager->expects(self::atLeastOnce())->method('getConnection')->willReturn($mockConnection);
 
         $driver = $this->getAccessibleMock(FlowAnnotationDriver::class, ['dummy']);
+        /** @noinspection PhpUndefinedMethodInspection */
         $driver->_set('entityManager', $mockEntityManager);
+        /** @noinspection PhpUndefinedMethodInspection */
         self::assertEquals(2048, $driver->_call('getMaxIdentifierLength'));
     }
 }

--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -44,7 +44,7 @@
         "ramsey/uuid": "^3.0 || ^4.0",
         "laminas/laminas-code": "^4.10",
 
-        "doctrine/orm": "^2.12.0",
+        "doctrine/orm": "^2.17.0",
         "doctrine/migrations": "^3.0",
         "doctrine/dbal": "^2.13 || ^3",
         "doctrine/common": "^3.1.0",

--- a/Neos.Flow/composer.json
+++ b/Neos.Flow/composer.json
@@ -47,7 +47,7 @@
         "doctrine/orm": "^2.12.0",
         "doctrine/migrations": "^3.0",
         "doctrine/dbal": "^2.13 || ^3",
-        "doctrine/common": "^3.0.3",
+        "doctrine/common": "^3.1.0",
         "doctrine/annotations": "^1.12",
 
         "symfony/yaml": "^5.1||^6.0",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "psr/http-client": "^1.0",
         "ramsey/uuid": "^3.0 || ^4.0",
         "laminas/laminas-code": "^4.10",
-        "doctrine/orm": "^2.12.0",
+        "doctrine/orm": "^2.17.0",
         "doctrine/migrations": "^3.0",
         "doctrine/dbal": "^2.13 || ^3",
         "doctrine/common": "^3.1.0",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "doctrine/orm": "^2.12.0",
         "doctrine/migrations": "^3.0",
         "doctrine/dbal": "^2.13 || ^3",
-        "doctrine/common": "^3.0.3",
+        "doctrine/common": "^3.1.0",
         "doctrine/annotations": "^1.12",
         "symfony/yaml": "^5.1||^6.0",
         "symfony/dom-crawler": "^5.1||^6.0",


### PR DESCRIPTION
Hopefully fixes #2602 and allows to use PHP attributes to configure Doctrine ORM, not only annotations like before.

**Upgrade instructions**

No change should be needed.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~~
