### PR TITLE
BUGFIX: Handle enums and attributes (Objects) in attribute arguments for proxy classes

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
@@ -17,7 +17,6 @@ use Neos\Cache\Frontend\PhpFrontend;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\CompileTimeObjectManager;
 use Neos\Flow\ObjectManagement\Exception\ProxyCompilerException;
-use Neos\Flow\ObjectManagement\Exception\UnsupportedAttributeException;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Tests\BaseTestCase;
 use ReflectionAttribute;

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
@@ -19,6 +19,7 @@ use Neos\Flow\ObjectManagement\CompileTimeObjectManager;
 use Neos\Flow\ObjectManagement\Exception\ProxyCompilerException;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Tests\BaseTestCase;
+use Neos\Utility\ObjectAccess;
 use ReflectionAttribute;
 use ReflectionClass;
 
@@ -342,18 +343,9 @@ return ' . var_export($this->storedProxyClasses, true) . ';';
                 $constructorParameters = [];
                 foreach ($constructor->getParameters() as $parameter) {
                     $parameterName = $parameter->getName();
-                    $parameterValue = null;
-                    if ($reflectionClass->hasProperty($parameterName) && $reflectionClass->getProperty($parameterName)->isPublic()) {
-                        $parameterValue = $value->$parameterName;
-                    } else {
-                        $getterMethodName = 'get' . ucfirst($parameterName);
-                        if ($reflectionClass->hasMethod($getterMethodName) && $reflectionClass->getMethod($getterMethodName)->isPublic()) {
-                            $parameterValue = $value->$getterMethodName();
-                        }
-                    }
+                    $parameterValue = ObjectAccess::getProperty($value, $parameterName);
                     if ($parameter->isDefaultValueAvailable()) {
-                        $parameterDefaultValue = $parameter->getDefaultValue();
-                        if ($parameterDefaultValue !== $parameterValue) {
+                        if ($parameterValue !== $parameter->getDefaultValue()) {
                             $parameterValueAsString = self::renderAttributeArgument($parameterValue);
                             $constructorParameters[$parameterName] = "{$parameterName}: {$parameterValueAsString}";
                         }

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
@@ -17,6 +17,7 @@ use Neos\Cache\Frontend\PhpFrontend;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\CompileTimeObjectManager;
 use Neos\Flow\ObjectManagement\Exception\ProxyCompilerException;
+use Neos\Flow\ObjectManagement\Exception\UnsupportedAttributeException;
 use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Tests\BaseTestCase;
 use ReflectionAttribute;
@@ -291,16 +292,93 @@ return ' . var_export($this->storedProxyClasses, true) . ';';
         if (count($attribute->getArguments()) > 0) {
             $argumentsAsString = [];
             foreach ($attribute->getArguments() as $argumentName => $argumentValue) {
-                $renderedArgumentValue = var_export($argumentValue, true);
-                if (is_numeric($argumentName)) {
-                    $argumentsAsString[] = $renderedArgumentValue;
+                $argumentAsString = self::renderAttributeArgument($argumentValue);
+                if (is_int($argumentName)) {
+                    $argumentsAsString[] = $argumentAsString;
                 } else {
-                    $argumentsAsString[] = "$argumentName: $renderedArgumentValue";
+                    $argumentsAsString[] = "$argumentName: $argumentAsString";
                 }
             }
             $attributeAsString .= '(' . implode(', ', $argumentsAsString) . ')';
         }
         return "#[$attributeAsString]";
+    }
+
+    private static function renderAttributeInstantiation(ReflectionAttribute $attribute): string
+    {
+        $attributeAsString = '\\' . $attribute->getName() . ':' . get_debug_type($attribute) ;
+        if (count($attribute->getArguments()) > 0) {
+            $argumentsAsString = [];
+            foreach ($attribute->getArguments() as $argumentName => $argumentValue) {
+                $argumentAsString = self::renderAttributeArgument($argumentValue);
+                if (is_int($argumentName)) {
+                    $argumentsAsString[] = $argumentAsString;
+                } else {
+                    $argumentsAsString[] = "$argumentName: $argumentAsString";
+                }
+            }
+            $attributeAsString .= '(' . implode(', ', $argumentsAsString) . ')';
+        } else {
+            $attributeAsString .= '()';
+        }
+        return "new $attributeAsString";
+    }
+
+    private static function renderAttributeArgument(mixed $value): string
+    {
+        if (is_object($value)) {
+            $reflectionClass = new ReflectionClass($value);
+            if ($reflectionClass->isEnum()) {
+                return '\\' . $reflectionClass->getName() . '::' . $value->name;
+            } else {
+                $fullyQualifiedName = '\\' . $reflectionClass->getName();
+                $constructor = $reflectionClass->getConstructor();
+                if (!$constructor) {
+                    return "new {$fullyQualifiedName}()";
+                }
+
+                // Try to reconstruct named arguments by matching constructor parameter names
+                // to public properties or getters ... this is obviously not perfect but probably
+                // ok in most attributes
+                $constructorParameters = [];
+                foreach ($constructor->getParameters() as $parameter) {
+                    $parameterName = $parameter->getName();
+                    $parameterValue = null;
+                    if ($reflectionClass->hasProperty($parameterName) && $reflectionClass->getProperty($parameterName)->isPublic()) {
+                        $parameterValue = $value->$parameterName;
+                    } else {
+                        $getterMethodName = 'get' . ucfirst($parameterName);
+                        if ($reflectionClass->hasMethod($getterMethodName) && $reflectionClass->getMethod($getterMethodName)->isPublic()) {
+                            $parameterValue = $value->$getterMethodName();
+                        }
+                    }
+                    if ($parameter->isDefaultValueAvailable()) {
+                        $parameterDefaultValue = $parameter->getDefaultValue();
+                        if ($parameterDefaultValue !== $parameterValue) {
+                            $parameterValueAsString = self::renderAttributeArgument($parameterValue);
+                            $constructorParameters[$parameterName] = "{$parameterName}: {$parameterValueAsString}";
+                        }
+                    } else {
+                        $parameterValueAsString = self::renderAttributeArgument($parameterValue);
+                        $constructorParameters[$parameterName] = "{$parameterName}: {$parameterValueAsString}";
+                    }
+                }
+
+                return "new {$fullyQualifiedName}(" . implode(', ', $constructorParameters) . ")";
+            }
+        } elseif (is_array($value)) {
+            $argumentsAsString = [];
+            foreach ($value as $subkey => $subvalue) {
+                $argumentAsString = self::renderAttributeArgument($subvalue);
+                if (is_int($subkey)) {
+                    $argumentsAsString[] = $argumentAsString;
+                } else {
+                    $argumentsAsString[] = "'$subkey' => $argumentAsString";
+                }
+            }
+            return '[' . implode(', ', $argumentsAsString) . ']';
+        }
+        return var_export($value, true);
     }
 
     /**

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
@@ -304,26 +304,6 @@ return ' . var_export($this->storedProxyClasses, true) . ';';
         return "#[$attributeAsString]";
     }
 
-    private static function renderAttributeInstantiation(ReflectionAttribute $attribute): string
-    {
-        $attributeAsString = '\\' . $attribute->getName() . ':' . get_debug_type($attribute) ;
-        if (count($attribute->getArguments()) > 0) {
-            $argumentsAsString = [];
-            foreach ($attribute->getArguments() as $argumentName => $argumentValue) {
-                $argumentAsString = self::renderAttributeArgument($argumentValue);
-                if (is_int($argumentName)) {
-                    $argumentsAsString[] = $argumentAsString;
-                } else {
-                    $argumentsAsString[] = "$argumentName: $argumentAsString";
-                }
-            }
-            $attributeAsString .= '(' . implode(', ', $argumentsAsString) . ')';
-        } else {
-            $attributeAsString .= '()';
-        }
-        return "new $attributeAsString";
-    }
-
     private static function renderAttributeArgument(mixed $value): string
     {
         if (is_object($value)) {

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
@@ -14,7 +14,6 @@ namespace Neos\Flow\ObjectManagement\Proxy;
 use Laminas\Code\Generator\DocBlockGenerator;
 use Laminas\Code\Generator\MethodGenerator;
 use Laminas\Code\Generator\ParameterGenerator;
-use Neos\Flow\ObjectManagement\Exception\UnsupportedAttributeException;
 
 /**
  * Class ProxyMethodGenerator
@@ -252,7 +251,6 @@ class ProxyMethodGenerator extends MethodGenerator
      *
      * @param \ReflectionMethod $reflectionMethod The \ReflectionMethod object to retrieve attributes from.
      * @return string The code for the attributes of the given \ReflectionMethod object.
-     * @throws UnsupportedAttributeException
      */
     protected function buildAttributesCode(\ReflectionMethod $reflectionMethod): string
     {
@@ -260,77 +258,9 @@ class ProxyMethodGenerator extends MethodGenerator
         $attributesCode = "";
 
         foreach ($reflectionMethod->getAttributes() as $attribute) {
-            $attributeName = "\\" . ltrim($attribute->getName(), '\\');
-            $argumentsString = $this->formatAttributesArguments($attribute->getArguments(), $reflectionMethod->name);
-            $attributesCode .= "{$indent}#[{$attributeName}({$argumentsString})]" . self::LINE_FEED;
+            $attributesCode .= $indent . Compiler::renderAttribute($attribute) . self::LINE_FEED;
         }
 
         return $attributesCode;
-    }
-
-    /**
-     * Formats the arguments of attributes into a string.
-     *
-     * @param array $arguments An array of arguments for attributes.
-     * @param string $methodName The current method name the proxy code is built for.
-     * @return string The formatted arguments as a string.
-     * @throws UnsupportedAttributeException
-     */
-    private function formatAttributesArguments(array $arguments, string $methodName): string
-    {
-        $formattedArguments = [];
-
-        foreach ($arguments as $key => $value) {
-            if (is_int($key)) {
-                $formattedArguments[] = $this->formatAttributeValue($value, $methodName);
-            } else {
-                $formattedArguments[] = "{$key}: " . $this->formatAttributeValue($value, $methodName);
-            }
-        }
-
-        return implode(', ', $formattedArguments);
-    }
-
-    /**
-     * Formats the given attribute value.
-     *
-     * @param mixed $value The value to be formatted.
-     * @param string $methodName The current method name the proxy code is built for.
-     * @return string The formatted attribute value.
-     */
-    private function formatAttributeValue(mixed $value, string $methodName): string
-    {
-        if (is_string($value)) {
-            return "\"$value\"";
-        }
-        if (is_bool($value)) {
-            return $value ? 'true' : 'false';
-        }
-        if (is_int($value)) {
-            return (string)$value;
-        }
-        if (is_float($value)) {
-            return (string)$value;
-        }
-        if ($value === null) {
-            return 'null';
-        }
-        if (is_array($value)) {
-            $formattedArrayElements = implode(', ', array_map(function ($key, $value) use ($methodName) {
-                return is_int($key)
-                    ? $this->formatAttributeValue($value, $methodName)
-                    : "\"{$key}\" => " . $this->formatAttributeValue($value, $methodName);
-            }, array_keys($value), $value));
-            return "[{$formattedArrayElements}]";
-        }
-        throw new UnsupportedAttributeException(
-            sprintf(
-                'Failed rendering proxy method %s::%s because an attribute contained an unsupported value type (%s)',
-                $this->getFullOriginalClassName(),
-                $methodName,
-                get_debug_type($value)
-            ),
-            1705501433
-        );
     }
 }

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Fixture/ExampleEnum.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Fixture/ExampleEnum.php
@@ -1,0 +1,8 @@
+<?php
+namespace Neos\Flow\Tests\Unit\ObjectManagement\Fixture;
+
+enum ExampleEnum
+{
+    case Foo;
+    case Bar;
+}

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/CompilerTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/CompilerTest.php
@@ -13,12 +13,14 @@ namespace Neos\Flow\Tests\Unit\ObjectManagement\Proxy;
 
 require_once(__DIR__ . '/../Fixture/FooBarAnnotation.php');
 
+use Neos\Flow\Annotations\Entity;
 use Neos\Flow\Annotations\Inject;
 use Neos\Flow\Annotations\Scope;
 use Neos\Flow\Annotations\Session;
 use Neos\Flow\Annotations\Signal;
 use Neos\Flow\Annotations\Validate;
 use Neos\Flow\ObjectManagement\Proxy\Compiler;
+use Neos\Flow\Tests\Unit\ObjectManagement\Fixture\ExampleEnum;
 use Neos\Flow\Tests\Unit\ObjectManagement\Fixture\FooBarAnnotation;
 use Neos\Flow\Tests\UnitTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -101,6 +103,79 @@ class CompilerTest extends UnitTestCase
     public function renderAnnotationRendersCorrectly($annotation, $expectedString): void
     {
         self::assertEquals($expectedString, Compiler::renderAnnotation($annotation));
+    }
+
+    public function attributes(): \Generator
+    {
+        $simple = $this->createMock(\ReflectionAttribute::class);
+        $simple->expects($this->any())->method('getName')->willReturn('Neos\Flow\Annotations\Entity');
+        $simple->expects($this->any())->method('getArguments')->willReturn([]);
+
+        yield 'L ' . __LINE__ . ': simple' => [
+            'attribute' => $simple,
+            'expectedResult' => '#[\Neos\Flow\Annotations\Entity]'
+        ];
+
+        $singleArgument = $this->createMock(\ReflectionAttribute::class);
+        $singleArgument->expects($this->any())->method('getName')->willReturn('Neos\Flow\Annotations\Scope');
+        $singleArgument->expects($this->any())->method('getArguments')->willReturn(['singleton']);
+
+        yield 'L ' . __LINE__ . ': with single argument' => [
+            'attribute' => $singleArgument,
+            'expectedResult' => '#[\Neos\Flow\Annotations\Scope(\'singleton\')]'
+        ];
+
+        $namedArguments = $this->createMock(\ReflectionAttribute::class);
+        $namedArguments->expects($this->any())->method('getName')->willReturn('Neos\Flow\Annotations\Inject');
+        $namedArguments->expects($this->any())->method('getArguments')->willReturn(['name' => 'SomeClass', 'lazy' => false]);
+
+        yield 'L ' . __LINE__ . ': with named arguments' => [
+            'attribute' => $namedArguments,
+            'expectedResult' => '#[\Neos\Flow\Annotations\Inject(name: \'SomeClass\', lazy: false)]'
+        ];
+
+        $nestedAttribute = $this->createMock(\ReflectionAttribute::class);
+        $nestedAttribute->expects($this->any())->method('getName')->willReturn('Neos\Flow\Annotations\Example');
+        $nestedAttribute->expects($this->any())->method('getArguments')->willReturn([
+            'attribute' => new Entity(),
+            'enum' => ExampleEnum::Foo,
+        ]);
+
+        yield 'L ' . __LINE__ . ': with nested attribute' => [
+            'attribute' => $nestedAttribute,
+            'expectedResult' => '#[\Neos\Flow\Annotations\Example(attribute: new \Neos\Flow\Annotations\Entity(), enum: \\Neos\Flow\Tests\Unit\ObjectManagement\Fixture\ExampleEnum::Foo)]'
+        ];
+
+        $nestedArrayOfAttributes = $this->createMock(\ReflectionAttribute::class);
+        $nestedArrayOfAttributes->expects($this->any())->method('getName')->willReturn('Neos\Flow\Annotations\Example');
+        $nestedArrayOfAttributes->expects($this->any())->method('getArguments')->willReturn([
+            'nestedArrayOfAttributes' => [new Entity(), new Scope('singleton'), new Inject(name: "SomeClass", lazy: false)]
+        ]);
+
+        yield 'L ' . __LINE__ . ': nested array arguments' => [
+            'attribute' => $nestedArrayOfAttributes,
+            'expectedResult' => '#[\Neos\Flow\Annotations\Example(nestedArrayOfAttributes: [new \Neos\Flow\Annotations\Entity(), new \Neos\Flow\Annotations\Scope(value: \'singleton\'), new \Neos\Flow\Annotations\Inject(name: \'SomeClass\', lazy: false)])]'
+        ];
+
+        $nestedNamedArrayArgumentAttribute = $this->createMock(\ReflectionAttribute::class);
+        $nestedNamedArrayArgumentAttribute->expects($this->any())->method('getName')->willReturn('Neos\Flow\Annotations\Example');
+        $nestedNamedArrayArgumentAttribute->expects($this->any())->method('getArguments')->willReturn([
+            'nestedNamedArray' => ['foo' => new Entity(), 'bar' => new Scope('singleton'), 'baz' => new Inject(name: "SomeClass", lazy: false)]
+        ]);
+
+        yield 'L ' . __LINE__ . ': nested array arguments' => [
+            'attribute' => $nestedNamedArrayArgumentAttribute,
+            'expectedResult' => '#[\Neos\Flow\Annotations\Example(nestedNamedArray: [\'foo\' => new \Neos\Flow\Annotations\Entity(), \'bar\' => new \Neos\Flow\Annotations\Scope(value: \'singleton\'), \'baz\' => new \Neos\Flow\Annotations\Inject(name: \'SomeClass\', lazy: false)])]'
+        ];
+    }
+
+    /**
+     * @dataProvider attributes()
+     * @test
+     */
+    public function renderAttributesRendersCorrectly(\ReflectionAttribute $attribute, string $expectedResult): void
+    {
+        $this->assertSame($expectedResult, Compiler::renderAttribute($attribute));
     }
 
     public function stripOpeningPhpTagCorrectlyStripsPhpTagDataProvider(): array


### PR DESCRIPTION
Handle Enums nested Attributes (actually any Objects) in attribute arguments for proxy classes.

Currently the Attributes for generated proxy classes have some limitations:
- Class Attributes: attribute values are exported via var_export which creates invalid code for attributes containing Enums or other Attributes as arguments
- Method Attributes: attributes of type Object will yield an UnsupportedAttribute Exception

This change addresses that by:
- creating Enums in generated code
- creating Objects via new () by inferring the constructor arguments from properties and getters
- handling this recursively in arrays

!!! This on itself does not add attribute support for persistence. See #3508 for that !!!

resolves: #3511
relates: #3075 

**Upgrade instructions**

No changes are needed only cases that previously yielded errors should work now.

**Review instructions**

The inference of constructor arguments from values obtained via ObjectAccess is close but not perfect. However it works in the cases we want to support like Doctrine Table Attributes and probably most other cases aswell. 

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
