### PR TITLE
BUGFIX: Silence warnings in SimpleFileBackend

### DIFF
--- a/Neos.Cache/Classes/Backend/SimpleFileBackend.php
+++ b/Neos.Cache/Classes/Backend/SimpleFileBackend.php
@@ -221,7 +221,7 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
             // In the worst case, the unlink will just fail due to concurrent access and the caller needs to deal with that.
             return unlink($fileName);
         }
-        $file = fopen($fileName, 'rb');
+        $file = @fopen($fileName, 'rb');
         if ($file === false) {
             return false;
         }
@@ -542,7 +542,7 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
                 // It's important that we use the 'c' flag below, as `fopen` will otherwise truncate the file
                 // if it already exists. If we used 'w' and then didn't get the lock, the file would end up empty.
                 // https://www.php.net/manual/en/function.fopen.php#refsect1-function.fopen-parameters
-                $file = fopen($cacheEntryPathAndFilename, 'cb');
+                $file = @fopen($cacheEntryPathAndFilename, 'cb');
                 if ($file === false) {
                     continue;
                 }


### PR DESCRIPTION
`SimpleFileBackend` does `fopen()` in a few places. It wraps it into a try-catch clause and checks the result, but it still produces a warning if the file does not exist:

`Warning: fopen(/application/Data/Temporary/…): Failed to open stream: No such file or directory`

The only way to suppress that warning is to use the shut-up operator (`@`) in these places.

See neos/flow-development-collection#3438

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~~
