### PR TITLE
BUGFIX: Fix race condition during log rotation -> the `.lock` file is not properly locked

### DIFF
--- a/Neos.Flow.Log/Classes/Backend/FileBackend.php
+++ b/Neos.Flow.Log/Classes/Backend/FileBackend.php
@@ -191,10 +191,11 @@ class FileBackend extends AbstractBackend
      */
     protected function rotateLogFile(): void
     {
-        if (file_exists($this->logFileUrl . '.lock')) {
+        $lockResource = fopen($this->logFileUrl . '.lock', 'w+');
+
+        $exclusiveNonBlockingLockResult = flock($lockResource, LOCK_EX | LOCK_NB);
+        if ($exclusiveNonBlockingLockResult === false) {
             return;
-        } else {
-            touch($this->logFileUrl . '.lock');
         }
 
         if ($this->logFilesToKeep === 0) {


### PR DESCRIPTION
See https://discuss.neos.io/t/unlink-system-development-log-10-no-such-file/7140/2

Multiple processes writing logs can easily run into the following error when its time to rotate the logs:

```
Warning: rename(Data/Logs/System_Development.log.3,Data/Logs/System_Development.log.4): No such file or directory in Packages/Framework/Neos.Flow.Log/Classes/Backend/FileBackend.php line 217

  Type: Neos\Flow\Error\Exception
  Code: 1
  File: Packages/Framework/Neos.Flow/Classes/Error/ErrorHandler.php
  Line: 80
```

During log rotation we attempt to use a lock via `file_exists` but its not an atomic operation how we use it https://github.com/neos/flow-development-collection/blob/54cea0a2cafb9ee1475ae2fdbc1fd3a1830ddc86/Neos.Flow.Log/Classes/Backend/FileBackend.php#L194-L198 `file_exists` could be true for two processes at the same time in a race condition and both processes would `touch` (create) the lock file.

Instead, we need to use a atomic locking via `flock`

```
$lockResource = fopen($this->logFileUrl . '.lock', 'w+');

$exclusiveNonBlockingLockResult = flock($lockResource, LOCK_EX | LOCK_NB);
if ($exclusiveNonBlockingLockResult === false) {
   // someone else is on it
   return;
}

// do something only this process is supposed to do...

if (!flock($setupLockResource, LOCK_UN)) {
    throw new \RuntimeException('failed to release lock');
}
```

Tested on MacOs with 3 simultaneous shells running each a flow command that writes logs in a shell while loop.

I hope windows supports `flock($lockResource, LOCK_EX | LOCK_NB);` to exclusively claim a lock without waiting for it if its claimed.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
