### PR TITLE
TASK: Add missing type converters for backed enums

### DIFF
--- a/Neos.Flow/Classes/Property/TypeConverter/BackedEnumToIntConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/BackedEnumToIntConverter.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Property\TypeConverter;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+
+class BackedEnumToIntConverter extends AbstractTypeConverter
+{
+    protected $sourceTypes = [\BackedEnum::class];
+
+    protected $targetType = 'integer';
+
+    public function canConvertFrom($source, $targetType): bool
+    {
+        return is_int($source->value);
+    }
+
+    public function convertFrom(
+        $source,
+        $targetType,
+        array $convertedChildProperties = [],
+        ?PropertyMappingConfigurationInterface $configuration = null
+    ) {
+        return $source->value;
+    }
+}

--- a/Neos.Flow/Classes/Property/TypeConverter/BackedEnumToStringConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/BackedEnumToStringConverter.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Property\TypeConverter;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+
+class BackedEnumToStringConverter extends AbstractTypeConverter
+{
+    protected $sourceTypes = [\BackedEnum::class];
+
+    protected $targetType = 'string';
+
+    public function canConvertFrom($source, $targetType): bool
+    {
+        return is_string($source->value);
+    }
+
+    public function convertFrom(
+        $source,
+        $targetType,
+        array $convertedChildProperties = [],
+        ?PropertyMappingConfigurationInterface $configuration = null
+    ) {
+        return $source->value;
+    }
+}

--- a/Neos.Flow/Classes/Property/TypeConverter/ScalarTypeToBackedEnumConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ScalarTypeToBackedEnumConverter.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Property\TypeConverter;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Property\PropertyMappingConfigurationInterface;
+
+class ScalarTypeToBackedEnumConverter extends AbstractTypeConverter
+{
+    protected $sourceTypes = ['string', 'integer'];
+
+    protected $targetType = \BackedEnum::class;
+
+    public function canConvertFrom($source, $targetType): bool
+    {
+        $backingType = (new \ReflectionEnum($targetType))->getBackingType()?->getName();
+        return (
+            is_int($source) && $backingType === 'int'
+            || is_string($source) && $backingType === 'string'
+        ) && $targetType::tryFrom($source) instanceof $targetType;
+    }
+
+    public function convertFrom(
+        $source,
+        $targetType,
+        array $convertedChildProperties = [],
+        ?PropertyMappingConfigurationInterface $configuration = null
+    ) {
+        return $targetType::from($source);
+    }
+}

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/BackedEnumToIntConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/BackedEnumToIntConverterTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+require_once(__DIR__ . '/Fixture/ExampleIntBackedEnum.php');
+require_once(__DIR__ . '/Fixture/ExampleStringBackedEnum.php');
+
+use Neos\Flow\Property\TypeConverter\BackedEnumToIntConverter;
+use Neos\Flow\Property\TypeConverter\BackedEnumToStringConverter;
+use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\ExampleIntBackedEnum;
+use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\ExampleStringBackedEnum;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test case for the BackedEnumToIntConverter
+ *
+ * @covers \Neos\Flow\Property\TypeConverter\BackedEnumToIntConverter<extended>
+ */
+class BackedEnumToIntConverterTest extends TestCase
+{
+    /**
+     * @dataProvider canConvertFromProvider
+     */
+    public function testCanConvertFrom(ExampleIntBackedEnum|ExampleStringBackedEnum $source, string $targetType, bool $expectedResult): void
+    {
+        Assert::assertSame(
+            $expectedResult,
+            (new BackedEnumToIntConverter())->canConvertFrom($source, $targetType),
+        );
+    }
+
+    /**
+     * @return iterable<string,array{source: string|int, targetType: string, expectedResult: string}>
+     */
+    public static function canConvertFromProvider(): iterable
+    {
+        yield 'IntBackedEnum -> int' => [
+            'source' => ExampleIntBackedEnum::DEFAULT,
+            'targetType' => 'integer',
+            'expectedResult' => true,
+        ];
+
+        yield 'StringBackedEnum -> int' => [
+            'source' => ExampleStringBackedEnum::DEFAULT,
+            'targetType' => 'integer',
+            'expectedResult' => false,
+        ];
+    }
+    /**
+     * @dataProvider convertFromProvider
+     */
+    public function testConvertFrom(ExampleIntBackedEnum|ExampleStringBackedEnum $source, string $targetType, string|int $expectedResult): void
+    {
+        Assert::assertSame(
+            $expectedResult,
+            (new BackedEnumToStringConverter())->convertFrom($source, $targetType),
+        );
+    }
+
+    /**
+     * @return iterable<string,array{source: string|int, targetType: string, expectedResult: string}>
+     */
+    public static function convertFromProvider(): iterable
+    {
+        yield 'IntBackedEnum -> int' => [
+            'source' => ExampleIntBackedEnum::DEFAULT,
+            'targetType' => 'integer',
+            'expectedResult' => 42,
+        ];
+    }
+}

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/BackedEnumToStringConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/BackedEnumToStringConverterTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+require_once(__DIR__ . '/Fixture/ExampleIntBackedEnum.php');
+require_once(__DIR__ . '/Fixture/ExampleStringBackedEnum.php');
+
+use Neos\Flow\Property\TypeConverter\BackedEnumToStringConverter;
+use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\ExampleIntBackedEnum;
+use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\ExampleStringBackedEnum;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test case for the BackedEnumToStringConverter
+ *
+ * @covers \Neos\Flow\Property\TypeConverter\BackedEnumToStringConverter<extended>
+ */
+class BackedEnumToStringConverterTest extends TestCase
+{
+    /**
+     * @dataProvider canConvertFromProvider
+     */
+    public function testCanConvertFrom(ExampleIntBackedEnum|ExampleStringBackedEnum $source, string $targetType, bool $expectedResult): void
+    {
+        Assert::assertSame(
+            $expectedResult,
+            (new BackedEnumToStringConverter())->canConvertFrom($source, $targetType),
+        );
+    }
+
+    /**
+     * @return iterable<string,array{source: string|int, targetType: string, expectedResult: string}>
+     */
+    public static function canConvertFromProvider(): iterable
+    {
+        yield 'IntBackedEnum -> string' => [
+            'source' => ExampleIntBackedEnum::DEFAULT,
+            'targetType' => 'string',
+            'expectedResult' => false,
+        ];
+
+        yield 'StringBackedEnum -> string' => [
+            'source' => ExampleStringBackedEnum::DEFAULT,
+            'targetType' => 'string',
+            'expectedResult' => true,
+        ];
+    }
+    /**
+     * @dataProvider convertFromProvider
+     */
+    public function testConvertFrom(ExampleIntBackedEnum|ExampleStringBackedEnum $source, string $targetType, string|int $expectedResult): void
+    {
+        Assert::assertSame(
+            $expectedResult,
+            (new BackedEnumToStringConverter())->convertFrom($source, $targetType),
+        );
+    }
+
+    /**
+     * @return iterable<string,array{source: string|int, targetType: string, expectedResult: string}>
+     */
+    public static function convertFromProvider(): iterable
+    {
+        yield 'StringBackedEnum -> string' => [
+            'source' => ExampleStringBackedEnum::DEFAULT,
+            'targetType' => 'string',
+            'expectedResult' => 'default',
+        ];
+    }
+}

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/ExampleIntBackedEnum.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/ExampleIntBackedEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+enum ExampleIntBackedEnum: int
+{
+    case DEFAULT = 42;
+}

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/ExampleStringBackedEnum.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/Fixture/ExampleStringBackedEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+enum ExampleStringBackedEnum: string
+{
+    case DEFAULT = 'default';
+}

--- a/Neos.Flow/Tests/Unit/Property/TypeConverter/ScalarTypeToBackedEnumConverterTest.php
+++ b/Neos.Flow/Tests/Unit/Property/TypeConverter/ScalarTypeToBackedEnumConverterTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Tests\Unit\Property\TypeConverter;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+require_once(__DIR__ . '/Fixture/ExampleIntBackedEnum.php');
+require_once(__DIR__ . '/Fixture/ExampleStringBackedEnum.php');
+
+use Neos\Flow\Property\TypeConverter\ScalarTypeToBackedEnumConverter;
+use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\ExampleIntBackedEnum;
+use Neos\Flow\Tests\Unit\Property\TypeConverter\Fixture\ExampleStringBackedEnum;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test case for the ScalarTypeToBackedEnumConverter
+ *
+ * @covers \Neos\Flow\Property\TypeConverter\ScalarTypeToBackedEnumConverter<extended>
+ */
+class ScalarTypeToBackedEnumConverterTest extends TestCase
+{
+    /**
+     * @dataProvider canConvertFromProvider
+     */
+    public function testCanConvertFrom(string|int $source, string $targetType, bool $expectedResult): void
+    {
+        Assert::assertSame(
+            $expectedResult,
+            (new ScalarTypeToBackedEnumConverter())->canConvertFrom($source, $targetType),
+        );
+    }
+
+    /**
+     * @return iterable<string,array{source: string|int, targetType: string, expectedResult: string}>
+     */
+    public static function canConvertFromProvider(): iterable
+    {
+        yield 'string -> IntBackedEnum' => [
+            'source' => 'default',
+            'targetType' => ExampleIntBackedEnum::class,
+            'expectedResult' => false,
+        ];
+
+        yield 'non-case int -> IntBackedEnum' => [
+            'source' => 43,
+            'targetType' => ExampleIntBackedEnum::class,
+            'expectedResult' => false,
+        ];
+
+        yield 'case int -> IntBackedEnum' => [
+            'source' => 42,
+            'targetType' => ExampleIntBackedEnum::class,
+            'expectedResult' => true,
+        ];
+
+        yield 'case int -> StringBackedEnum' => [
+            'source' => 42,
+            'targetType' => ExampleStringBackedEnum::class,
+            'expectedResult' => false,
+        ];
+
+        yield 'non-case string -> StringBackedEnum' => [
+            'source' => 'other',
+            'targetType' => ExampleStringBackedEnum::class,
+            'expectedResult' => false,
+        ];
+
+        yield 'case string -> StringBackedEnum' => [
+            'source' => 'default',
+            'targetType' => ExampleStringBackedEnum::class,
+            'expectedResult' => true,
+        ];
+    }
+    /**
+     * @dataProvider convertFromProvider
+     */
+    public function testConvertFrom(string|int $source, string $targetType, ExampleIntBackedEnum|ExampleStringBackedEnum $expectedResult): void
+    {
+        Assert::assertSame(
+            $expectedResult,
+            (new ScalarTypeToBackedEnumConverter())->convertFrom($source, $targetType),
+        );
+    }
+
+    /**
+     * @return iterable<string,array{source: string|int, targetType: string, expectedResult: string}>
+     */
+    public static function convertFromProvider(): iterable
+    {
+        yield 'case int -> IntBackedEnum' => [
+            'source' => 42,
+            'targetType' => ExampleIntBackedEnum::class,
+            'expectedResult' => ExampleIntBackedEnum::DEFAULT,
+        ];
+
+        yield 'case string -> StringBackedEnum' => [
+            'source' => 'default',
+            'targetType' => ExampleStringBackedEnum::class,
+            'expectedResult' => ExampleStringBackedEnum::DEFAULT,
+        ];
+    }
+}


### PR DESCRIPTION
As with PHP 8.1 enums were introduced and with 8.2 \ReflectionEnum gives the necessary metadata, we can now properly implement property mapper type converters for backed enums.

Which is what I did.

**Upgrade instructions**

none

**Review instructions**

none

**Checklist**

- [X] Code follows the PSR-12 coding style
- [X] Tests have been created, run and adjusted as needed
- [X] The PR is created against the 9.0 branch
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
