### PR TITLE
BUGFIX: Avoid passing null to strtolower()

### DIFF
--- a/Neos.FluidAdaptor/Classes/ViewHelpers/FormViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/FormViewHelper.php
@@ -143,9 +143,9 @@ class FormViewHelper extends AbstractFormViewHelper
         }
         $this->tag->addAttribute('action', $this->getFormActionUri());
 
-        if (strtolower($this->arguments['method']) === 'get') {
+        if (strtolower((string)$this->arguments['method']) === 'get') {
             $this->tag->addAttribute('method', 'get');
-        } elseif (strtolower($this->arguments['method']) === 'dialog') {
+        } elseif (strtolower((string)$this->arguments['method']) === 'dialog') {
             $this->tag->addAttribute('method', 'dialog');
         } else {
             $this->tag->addAttribute('method', 'post');
@@ -161,13 +161,13 @@ class FormViewHelper extends AbstractFormViewHelper
         $formContent = $this->renderChildren();
 
         $requiredEnctype = $this->viewHelperVariableContainer->get(FormViewHelper::class, 'required-enctype');
-        if ($requiredEnctype !== '' && $requiredEnctype !== strtolower($this->arguments['enctype'])) {
+        if ($requiredEnctype !== '' && $requiredEnctype !== strtolower((string)$this->arguments['enctype'])) {
             throw new WrongEnctypeException('The form you are trying to render requires an enctype of "' . $requiredEnctype . '". Please specify the correct enctype when using file uploads.', 1522706399);
         }
 
         // wrap hidden field in div container in order to create XHTML valid output
         $content = chr(10) . '<div style="display: none">';
-        if (strtolower($this->arguments['method']) === 'get') {
+        if (strtolower((string)$this->arguments['method']) === 'get') {
             $content .= $this->renderHiddenActionUriQueryParameters();
         }
         $content .= $this->renderHiddenIdentityField($this->arguments['object'], $this->getFormObjectName());
@@ -541,7 +541,7 @@ class FormViewHelper extends AbstractFormViewHelper
      */
     protected function renderCsrfTokenField()
     {
-        if (strtolower($this->arguments['method']) === 'get') {
+        if (strtolower((string)$this->arguments['method']) === 'get') {
             return '';
         }
         if (!$this->securityContext->isInitialized() || !$this->authenticationManager->isAuthenticated()) {


### PR DESCRIPTION
Avoids `Deprecated: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated` warnings, in case the arguments have not been set.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~~
