### PR TITLE
TASK: Add missing symfony polyfill replacements due to php82 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,8 @@
         "symfony/polyfill-php73": "*",
         "symfony/polyfill-php74": "*",
         "symfony/polyfill-php80": "*",
+        "symfony/polyfill-php81": "*",
+        "symfony/polyfill-php82": "*",
         "symfony/polyfill-mbstring": "*",
         "neos/cache": "self.version",
         "neos/eel": "self.version",


### PR DESCRIPTION
This change might need adjustments if one has a composer `replacement` in ones distribution as flow failed to provide it earlier. Updating could then cause a conflict as composer - i believe - only respects one replace directive to exist per package.

**Upgrade instructions**

Remove these replacements in your own composer.json

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
