### PR TITLE
BUGFIX: Pass through enum mapping to ORM

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -1125,12 +1125,13 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
             $mapping['fieldName'] = $fieldName;
         }
 
-        $mapping['type'] = ($columnAnnotation->type === 'string') ? null : $columnAnnotation->type;
+        $mapping['type'] = $columnAnnotation->type;
         $mapping['scale'] = $columnAnnotation->scale;
         $mapping['length'] = $columnAnnotation->length;
         $mapping['unique'] = $columnAnnotation->unique;
         $mapping['nullable'] = $columnAnnotation->nullable;
         $mapping['precision'] = $columnAnnotation->precision;
+        $mapping['enumType'] = $columnAnnotation->enumType;
 
         if ($columnAnnotation->options) {
             $mapping['options'] = $columnAnnotation->options;

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/EnumForAProperty.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/EnumForAProperty.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Neos\Flow\Tests\Functional\Persistence\FixturesPHP8;
+
+enum EnumForAProperty: string
+{
+    case IS_A = 'A;';
+    case IS_B = 'B;';
+}

--- a/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEntity.php
+++ b/Neos.Flow/Tests/Functional/Persistence/FixturesPHP8/TestEntity.php
@@ -53,6 +53,9 @@ class TestEntity
     #[ORM\Embedded(class: "Neos\Flow\Tests\Functional\Persistence\FixturesPHP8\TestEmbeddable")]
     protected TestEmbeddable $embedded;
 
+    #[ORM\Column(type: 'string', enumType: EnumForAProperty::class)]
+    protected EnumForAProperty $enumForAProperty = EnumForAProperty::IS_A;
+
     /**
      * Constructor
      */
@@ -162,5 +165,15 @@ class TestEntity
     public function getEmbeddedValueObject(): TestEmbeddedValueObject
     {
         return $this->embeddedValueObject;
+    }
+
+    public function getEnumForAProperty(): EnumForAProperty
+    {
+        return $this->enumForAProperty;
+    }
+
+    public function setEnumForAProperty(EnumForAProperty $enumForAProperty): void
+    {
+        $this->enumForAProperty = $enumForAProperty;
     }
 }

--- a/Neos.Flow/Tests/Functional/Persistence/PersistenceTestPHP8.php
+++ b/Neos.Flow/Tests/Functional/Persistence/PersistenceTestPHP8.php
@@ -18,6 +18,8 @@ use Neos\Flow\Persistence\Doctrine\PersistenceManager;
 use Neos\Flow\Persistence\Doctrine\QueryResult;
 use Neos\Flow\Persistence\Exception;
 use Neos\Flow\Persistence\Exception\ObjectValidationFailedException;
+use Neos\Flow\Tests\Functional\Persistence\FixturesPHP8\EnumForAProperty;
+use Neos\Flow\Tests\Functional\Persistence\FixturesPHP8\TestEntity;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Utility\ObjectAccess;
 
@@ -719,6 +721,19 @@ class PersistenceTestPHP8 extends FunctionalTestCase
         $testEntity->setName('Another name');
         $this->testEntityRepository->update($testEntity);
         self::assertTrue($this->persistenceManager->hasUnpersistedChanges());
+    }
+
+    public function enumPropertyCanBePersisted()
+    {
+        $testEntity = new TestEntity();
+        $testEntity->setEnumForAProperty(EnumForAProperty::IS_B);
+        $this->testEntityRepository->add($testEntity);
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        /** @var FixturesPHP8\TestEntity $testEntity */
+        $testEntity = $this->testEntityRepository->findAll()->getFirst();
+        self::assertEquals(EnumForAProperty::IS_B, $testEntity->getEnumForAProperty());
     }
 
     /**


### PR DESCRIPTION
This change allows to use the enumType property for a `Column` attribute and thus use enums as types in entities with the mapping being handled by doctrine ORM. The special case for the "type" is no longer needed as it has been nullable in the attribute/annotation for some years now, so we can rely on a default null if you didn't configure the type, and therefore triggering our auto detection in this case. We need this special case removed to allow string backed enums to be mapped correctly, as we need to fix the type to string and bypass auto detection.

In 8.3 we could remove the special handling for type already, but enumType was not available in the lowest accepted ORM version, therefore I targeted 8.4 as the required ORM version contains enumType.