### PR TITLE
TASK: Configurable Flow support for Xdebug native path mapping

### DIFF
--- a/Neos.Flow/Classes/Cache/AnnotationsCacheFlusher.php
+++ b/Neos.Flow/Classes/Cache/AnnotationsCacheFlusher.php
@@ -90,11 +90,11 @@ final class AnnotationsCacheFlusher
     }
 
     /**
-     * A slot that flushes caches as needed if classes with specific annotations have changed @param array<string> $classNames The full class names of the classes that got compiled
+     * A slot that flushes caches as needed if classes with specific annotations have changed @see registerAnnotation()
+     *
+     * @param array<string> $classNames The full class names of the classes that got compiled
      * @return void
      * @throws NoSuchCacheException
-     * @see registerAnnotation()
-     *
      */
     public function flushConfigurationCachesByCompiledClass(array $classNames): void
     {

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/XdebugPathMappingBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/XdebugPathMappingBuilder.php
@@ -72,7 +72,7 @@ class XdebugPathMappingBuilder
             '#',
             '# Ensure you are using xdebug >= v3.5 with enabled path mapping.',
             '# Configuration in your php.ini:',
-            '# xdebug.mode = develop',
+            '# xdebug.mode = debug',
             '# xdebug.path_mapping = 1',
             '#',
             '# ----------------------------------------------------------------',

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/XdebugPathMappingBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/XdebugPathMappingBuilder.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Neos\Flow\ObjectManagement\Proxy;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Cache\Backend\SimpleFileBackend;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Cache\CacheManager;
+use Neos\Utility\Files;
+
+/**
+ * @Flow\Scope("singleton")
+ */
+class XdebugPathMappingBuilder
+{
+    /**
+     * @Flow\Inject
+     * @var CacheManager
+     */
+    protected $cacheManager;
+
+    /**
+     * @var array
+     */
+    protected $settings;
+
+    /**
+     * @param array $settings
+     * @return void
+     */
+    public function injectSettings(array $settings): void
+    {
+        $this->settings = $settings;
+    }
+
+    public function injectCacheManager(CacheManager $cacheManager): void
+    {
+        $this->cacheManager = $cacheManager;
+    }
+
+    /**
+     * @param array<string, array{path: string, proxyClassIdentifier: string}> $compiledClasses
+     * @return void
+     */
+    public function buildFromCompiledClasses(array $compiledClasses): void
+    {
+        if ($compiledClasses === []) {
+            return;
+        }
+
+        if (!$this->isXdebugPathMappingEnabled()) {
+            return;
+        }
+
+        $cacheBackend = $this->cacheManager->getCache('Flow_Object_Classes')->getBackend();
+        if (!$cacheBackend instanceof SimpleFileBackend) {
+            return;
+        }
+        $cacheDirectory = $cacheBackend->getCacheDirectory();
+
+        $mappingFileLines = [
+            '# Created by Flow Framework during compile time proxy generation.',
+            '#',
+            '# Ensure you are using xdebug >= v3.5 with enabled path mapping.',
+            '# Configuration in your php.ini:',
+            '# xdebug.mode = develop',
+            '# xdebug.path_mapping = 1',
+            '#',
+            '# ----------------------------------------------------------------',
+            sprintf('# Last update: %s', date('Y-m-d H:i:s')),
+            sprintf('remote_prefix:%s', $cacheDirectory),
+            sprintf('local_prefix:%s', FLOW_PATH_ROOT),
+        ];
+        foreach ($compiledClasses as $data) {
+            $localPath = str_replace(FLOW_PATH_ROOT, '', $data['path']);
+            $remotePath = $data['proxyClassIdentifier'];
+            $mappingFileLines[] = sprintf("%s.php = %s", $remotePath, $localPath);
+        }
+        // Add an empty line to the end of the file
+        $mappingFileLines[] = '';
+
+        Files::createDirectoryRecursively($this->getXdebugMappingFilePath());
+        file_put_contents(
+            Files::concatenatePaths([$this->getXdebugMappingFilePath(), 'flow.map']),
+            implode("\n", $mappingFileLines)
+        );
+    }
+
+    private function isXdebugPathMappingEnabled(): bool
+    {
+        return isset($this->settings['object']['proxy']['enableXdebugPathMapping']) && $this->settings['object']['proxy']['enableXdebugPathMapping'] === true;
+    }
+
+    private function getXdebugMappingFilePath(): string
+    {
+        return Files::concatenatePaths([FLOW_PATH_ROOT, '.xdebug']);
+    }
+}

--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -17,6 +17,7 @@ use Neos\Flow\Configuration\Source\YamlSource;
 use Neos\Flow\Core\Booting\Step;
 use Neos\Flow\Http\Helper\SecurityHelper;
 use Neos\Flow\ObjectManagement\Proxy\Compiler;
+use Neos\Flow\ObjectManagement\Proxy\XdebugPathMappingBuilder;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\Flow\Package\PackageManager;
 use Neos\Flow\ResourceManagement\ResourceManager;
@@ -157,6 +158,7 @@ class Package extends BasePackage
         $dispatcher->connect(AuthenticationProviderManager::class, 'successfullyAuthenticated', Context::class, 'refreshRoles');
         $dispatcher->connect(AuthenticationProviderManager::class, 'loggedOut', Context::class, 'refreshTokens');
 
+        $dispatcher->connect(Compiler::class, 'afterCompile', XdebugPathMappingBuilder::class, 'buildFromCompiledClasses');
         $dispatcher->connect(Compiler::class, 'afterCompile', function (array $compiledClasses) use ($bootstrap) {
             $annotationsCacheFlusher = $bootstrap->getObjectManager()->get(AnnotationsCacheFlusher::class);
             $annotationsCacheFlusher->flushConfigurationCachesByCompiledClass(array_keys($compiledClasses));

--- a/Neos.Flow/Configuration/Settings.Object.yaml
+++ b/Neos.Flow/Configuration/Settings.Object.yaml
@@ -23,3 +23,9 @@ Neos:
       # by specifying corresponding regular expressions that don't match classes to exclude.
       #
       includeClasses: []
+
+      proxy:
+        # If enabled, a mapping file for Xdebug (>= v3.5) will be created in the .xdebug directory
+        # of the Flow root. This file can be used to map proxy classes to their original
+        # source files for debugging. Should only be enabled in development environments.
+        enableXdebugPathMapping: false

--- a/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.object.schema.yaml
+++ b/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.object.schema.yaml
@@ -7,3 +7,7 @@ properties:
     additionalProperties:
       type: array
       items: { type: string, required: true }
+  'proxy':
+    type: dictionary
+    properties:
+      'enableXdebugPathMapping': { type: boolean, required: true }


### PR DESCRIPTION
**Adds Flow support for Xdebug native path mapping (>= 3.5).**

If enabled (disabled by default for now), the XdebugPathMappingBuilder connects to the "afterCompile" signal and builds a `./xdebug/flow.map` to provide the path mapping information for xdebug.

Example (.xdebug/flow.map)
```
# Created by Flow Framework during compile time proxy generation.
#
# Ensure you are using xdebug >= v3.5 with enabled path mapping.
# Configuration in your php.ini:
# xdebug.mode = develop
# xdebug.path_mapping = 1
#
# ----------------------------------------------------------------
# Last update: 2026-03-03 22:49:57
remote_prefix:/var/www/html/Data/Temporary/Development/SubContextDdev/Cache/Code/Flow_Object_Classes/
local_prefix:/var/www/html/
Neos_Diff_Diff.php = Packages/Neos/Neos.Diff/Classes/Diff.php
Neos_Diff_SequenceMatcher.php = Packages/Neos/Neos.Diff/Classes/SequenceMatcher.php
Neos_Diff_Renderer_Html_HtmlInlineRenderer.php = Packages/Neos/Neos.Diff/Classes/Renderer/Html/HtmlInlineRenderer.php
Neos_Diff_Renderer_Html_HtmlSideBySideRenderer.php = Packages/Neos/Neos.Diff/Classes/Renderer/Html/HtmlSideBySideRenderer.php
...
```

**Configuration**
```
Neos:
  Flow:
    object:
      proxy:
        enableXdebugPathMapping: true
```
_Should be only enabled in development context._

**Why targeting 8.3?**
Even if this is a new feature, we wanted to provide this all developers as soon as possible. So we add this already to 8.3 but disabled by default, to be non-breaking.
We will enable the path mapping file generation by default in development context beginning with Flow 9.2. 

**How to use**
You need xdebug in v3.5+ with enabled path mapping. Also the xdebug mode needs to be not "OFF". The php.ini configuration could be:
```
xdebug.mode = develop
xdebug.path_mapping = 1
```

See: https://xdebug.org/funding/001-native-path-mapping

Depends on: #3538
Fixes: #3480 