### PR TITLE
BUGFIX: Remove singleton annotation on validators

### DIFF
--- a/Neos.Flow/Classes/Validation/Validator/AlphanumericValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/AlphanumericValidator.php
@@ -17,7 +17,6 @@ use Neos\Flow\Annotations as Flow;
  * Validator for alphanumeric strings.
  *
  * @api
- * @Flow\Scope("singleton")
  */
 class AlphanumericValidator extends AbstractValidator
 {

--- a/Neos.Flow/Classes/Validation/Validator/EmailAddressValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/EmailAddressValidator.php
@@ -22,7 +22,6 @@ use Neos\Flow\Annotations as Flow;
  * Validator for email addresses
  *
  * @api
- * @Flow\Scope("singleton")
  */
 class EmailAddressValidator extends AbstractValidator
 {

--- a/Neos.Flow/Classes/Validation/Validator/FloatValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/FloatValidator.php
@@ -17,7 +17,6 @@ use Neos\Flow\Annotations as Flow;
  * Validator for floats.
  *
  * @api
- * @Flow\Scope("singleton")
  */
 class FloatValidator extends AbstractValidator
 {

--- a/Neos.Flow/Classes/Validation/Validator/IntegerValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/IntegerValidator.php
@@ -17,7 +17,6 @@ use Neos\Flow\Annotations as Flow;
  * Validator for integers.
  *
  * @api
- * @Flow\Scope("singleton")
  */
 class IntegerValidator extends AbstractValidator
 {

--- a/Neos.Flow/Classes/Validation/Validator/LabelValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/LabelValidator.php
@@ -21,7 +21,6 @@ use Neos\Flow\Annotations as Flow;
  * line characters or HTML tags. This validator is for such uses.
  *
  * @api
- * @Flow\Scope("singleton")
  */
 class LabelValidator extends AbstractValidator
 {

--- a/Neos.Flow/Classes/Validation/Validator/LocaleIdentifierValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/LocaleIdentifierValidator.php
@@ -20,7 +20,6 @@ use Neos\Flow\I18n\Locale;
  * This validator validates a string based on the expressions of the
  * Flow I18n implementation.
  *
- * @Flow\Scope("singleton")
  */
 class LocaleIdentifierValidator extends AbstractValidator
 {

--- a/Neos.Flow/Classes/Validation/Validator/NotEmptyValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/NotEmptyValidator.php
@@ -17,7 +17,6 @@ use Neos\Flow\Annotations as Flow;
  * Validator for not empty values.
  *
  * @api
- * @Flow\Scope("singleton")
  */
 class NotEmptyValidator extends AbstractValidator
 {

--- a/Neos.Flow/Classes/Validation/Validator/RawValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/RawValidator.php
@@ -17,7 +17,6 @@ use Neos\Flow\Annotations as Flow;
  * A validator which accepts any input.
  *
  * @api
- * @Flow\Scope("singleton")
  */
 class RawValidator extends AbstractValidator
 {

--- a/Neos.Flow/Classes/Validation/Validator/StringValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/StringValidator.php
@@ -17,7 +17,6 @@ use Neos\Flow\Annotations as Flow;
  * Validator for strings.
  *
  * @api
- * @Flow\Scope("singleton")
  */
 class StringValidator extends AbstractValidator
 {

--- a/Neos.Flow/Classes/Validation/Validator/TextValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/TextValidator.php
@@ -17,7 +17,6 @@ use Neos\Flow\Annotations as Flow;
  * Validator for "plain" text.
  *
  * @api
- * @Flow\Scope("singleton")
  */
 class TextValidator extends AbstractValidator
 {

--- a/Neos.Flow/Classes/Validation/Validator/UuidValidator.php
+++ b/Neos.Flow/Classes/Validation/Validator/UuidValidator.php
@@ -17,7 +17,6 @@ use Neos\Flow\Annotations as Flow;
  * Validator for Universally Unique Identifiers.
  *
  * @api
- * @Flow\Scope("singleton")
  */
 class UuidValidator extends AbstractValidator
 {


### PR DESCRIPTION
Fixes #2879 

The validators are not meant to be singleton. The singleton annotations causes issues if you try to set options via `Flow\Validate` annotation or try to create a validator with `ValidatorResolver->createValidator()`.

Technically a singleton would work for validators without options. But the advantage in not constructing them every time, seems to be negligible.