### PR TITLE
TASK: Replace broken signal "compiledClasses" with "afterCompile"

### DIFF
--- a/Neos.Flow/Classes/Cache/AnnotationsCacheFlusher.php
+++ b/Neos.Flow/Classes/Cache/AnnotationsCacheFlusher.php
@@ -16,8 +16,8 @@ namespace Neos\Flow\Cache;
 use Neos\Cache\Exception\NoSuchCacheException;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Configuration\ConfigurationManager;
-use Neos\Flow\Reflection\ReflectionService;
 use Neos\Flow\Log\Utility\LogEnvironment;
+use Neos\Flow\Reflection\ReflectionService;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -58,6 +58,26 @@ final class AnnotationsCacheFlusher
      */
     private $annotationToCachesMap = [];
 
+    public function injectLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+    }
+
+    public function injectConfigurationManager(ConfigurationManager $configurationManager): void
+    {
+        $this->configurationManager = $configurationManager;
+    }
+
+    public function injectCacheManager(CacheManager $cacheManager): void
+    {
+        $this->cacheManager = $cacheManager;
+    }
+
+    public function injectReflectionService(ReflectionService $reflectionService): void
+    {
+        $this->reflectionService = $reflectionService;
+    }
+
     /**
      * Register an annotation that should trigger a cache flush
      *
@@ -70,11 +90,11 @@ final class AnnotationsCacheFlusher
     }
 
     /**
-     * A slot that flushes caches as needed if classes with specific annotations have changed @see registerAnnotation()
-     *
-     * @param array<string> $classNames The full class names of the classes that got compiled
+     * A slot that flushes caches as needed if classes with specific annotations have changed @param array<string> $classNames The full class names of the classes that got compiled
      * @return void
      * @throws NoSuchCacheException
+     * @see registerAnnotation()
+     *
      */
     public function flushConfigurationCachesByCompiledClass(array $classNames): void
     {

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
@@ -15,6 +15,7 @@ use Neos\Cache\Frontend\PhpFrontend;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\CompileTimeObjectManager;
 use Neos\Flow\Reflection\ReflectionService;
+use Neos\Flow\SignalSlot\Dispatcher as SignalSlotDispatcher;
 use Neos\Flow\Tests\BaseTestCase;
 
 /**
@@ -45,6 +46,11 @@ class Compiler
      * @var ReflectionService
      */
     protected $reflectionService;
+
+    /**
+     * @var SignalSlotDispatcher
+     */
+    private $signalSlotDispatcher;
 
     /**
      * @var array
@@ -108,6 +114,15 @@ class Compiler
     public function injectReflectionService(ReflectionService $reflectionService)
     {
         $this->reflectionService = $reflectionService;
+    }
+
+    /**
+     * @param SignalSlotDispatcher $signalSlotDispatcher
+     * @return void
+     */
+    public function injectSignalSlotDispatcher(SignalSlotDispatcher $signalSlotDispatcher)
+    {
+        $this->signalSlotDispatcher = $signalSlotDispatcher;
     }
 
     /**
@@ -188,32 +203,36 @@ class Compiler
         $compiledClasses = [];
         foreach ($this->objectManager->getRegisteredClassNames() as $fullOriginalClassNames) {
             foreach ($fullOriginalClassNames as $fullOriginalClassName) {
+                $proxyClassIdentifier = str_replace('\\', '_', $fullOriginalClassName);
+                $class = new \ReflectionClass($fullOriginalClassName);
+                $classPathAndFilename = $class->getFileName();
                 if (isset($this->proxyClasses[$fullOriginalClassName])) {
                     $proxyClassCode = $this->proxyClasses[$fullOriginalClassName]->render();
                     if ($proxyClassCode !== '') {
-                        $class = new \ReflectionClass($fullOriginalClassName);
-                        $classPathAndFilename = $class->getFileName();
                         $this->cacheOriginalClassFileAndProxyCode($fullOriginalClassName, $classPathAndFilename, $proxyClassCode);
-                        $this->storedProxyClasses[str_replace('\\', '_', $fullOriginalClassName)] = true;
-                        $compiledClasses[] = $fullOriginalClassName;
+                        $this->storedProxyClasses[$proxyClassIdentifier] = true;
+                        $compiledClasses[$fullOriginalClassName] = ['path' => $classPathAndFilename, 'proxyClassIdentifier' => $proxyClassIdentifier];
                     }
                 } else {
-                    if ($this->classesCache->has(str_replace('\\', '_', $fullOriginalClassName))) {
-                        $this->storedProxyClasses[str_replace('\\', '_', $fullOriginalClassName)] = true;
+                    if ($this->classesCache->has($proxyClassIdentifier)) {
+                        $this->storedProxyClasses[$proxyClassIdentifier] = true;
+                        $compiledClasses[$fullOriginalClassName] = ['path' => $classPathAndFilename, 'proxyClassIdentifier' => $proxyClassIdentifier];
                     }
                 }
             }
         }
-        $this->emitCompiledClasses($compiledClasses);
+        $this->emitAfterCompile($compiledClasses);
         return count($compiledClasses);
     }
 
     /**
-     * @param array<string> $classNames
-     * @Flow\Signal
+     * Signal emitted after the proxy classes have been compiled.
+     *
+     * @param array<string, array{path: string, proxyClassIdentifier: string}> $compiledClasses The list of compiled classes with the classname as key and their original file path and cache identifier as value.
      */
-    public function emitCompiledClasses(array $classNames)
+    public function emitAfterCompile(array $compiledClasses): void
     {
+        $this->signalSlotDispatcher->dispatch(__CLASS__, 'afterCompile', [$compiledClasses]);
     }
 
     /**

--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -16,7 +16,7 @@ use Neos\Flow\Configuration\Loader\AppendLoader;
 use Neos\Flow\Configuration\Source\YamlSource;
 use Neos\Flow\Core\Booting\Step;
 use Neos\Flow\Http\Helper\SecurityHelper;
-use Neos\Flow\ObjectManagement\Proxy;
+use Neos\Flow\ObjectManagement\Proxy\Compiler;
 use Neos\Flow\Package\Package as BasePackage;
 use Neos\Flow\Package\PackageManager;
 use Neos\Flow\ResourceManagement\ResourceManager;
@@ -157,9 +157,9 @@ class Package extends BasePackage
         $dispatcher->connect(AuthenticationProviderManager::class, 'successfullyAuthenticated', Context::class, 'refreshRoles');
         $dispatcher->connect(AuthenticationProviderManager::class, 'loggedOut', Context::class, 'refreshTokens');
 
-        $dispatcher->connect(Proxy\Compiler::class, 'compiledClasses', function (array $classNames) use ($bootstrap) {
+        $dispatcher->connect(Compiler::class, 'afterCompile', function (array $compiledClasses) use ($bootstrap) {
             $annotationsCacheFlusher = $bootstrap->getObjectManager()->get(AnnotationsCacheFlusher::class);
-            $annotationsCacheFlusher->flushConfigurationCachesByCompiledClass($classNames);
+            $annotationsCacheFlusher->flushConfigurationCachesByCompiledClass(array_keys($compiledClasses));
         });
     }
 }


### PR DESCRIPTION
This replaces the broken signal `compiledClasses`, which has never worked as it was missing the manual signal dispatch, because the Compiler is not proxied.

This is a preparation for https://github.com/neos/flow-development-collection/issues/3480, which needs a new slighlty different signal.

This also fixes the AnnotationCacheFlusher dependency injection, to get this working again.