### PR TITLE
BUGFIX: `#[Flow\Route]` Annotation unset `@subpackage` instead of `null`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,9 +152,16 @@ jobs:
                   user: 'root'
                   password: 'neos'
                   dbname: 'flow_functional_testing'
+
+              # see Neos\Flow\Tests\Functional\Mvc\RoutingTest
               mvc:
                 routes:
-                  'Neos.Flow': TRUE
+                  "Neos.Flow:TestingAttributes":
+                    providerFactory: Neos\Flow\Mvc\Routing\AttributeRoutesProviderFactory
+                    providerOptions:
+                      classNames:
+                        - Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\*Controller
+                  "Neos.Flow": true
           EOF
           echo "Running in context '$FLOW_CONTEXT'"
           ./flow configuration:show
@@ -196,9 +203,16 @@ jobs:
                   charset: 'utf8'
                   defaultTableOptions:
                     charset: 'utf8'
+
+              # see Neos\Flow\Tests\Functional\Mvc\RoutingTest
               mvc:
                 routes:
-                  'Neos.Flow': TRUE
+                  "Neos.Flow:TestingAttributes":
+                    providerFactory: Neos\Flow\Mvc\Routing\AttributeRoutesProviderFactory
+                    providerOptions:
+                      classNames:
+                        - Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\*Controller
+                  "Neos.Flow": true
           EOF
 
       - name: Run unit tests (PGSQL)

--- a/Neos.Flow/Classes/Mvc/Routing/AttributeRoutesProvider.php
+++ b/Neos.Flow/Classes/Mvc/Routing/AttributeRoutesProvider.php
@@ -152,13 +152,13 @@ final class AttributeRoutesProvider implements RoutesProviderInterface
                             'uriPattern' => $annotation->uriPattern,
                             'httpMethods' => $annotation->httpMethods,
                             'defaults' => Arrays::arrayMergeRecursiveOverrule(
-                                [
+                                array_filter([
                                     '@package' => $controllerPackageKey,
                                     '@subpackage' => $subPackage,
                                     '@controller' => $controller,
                                     '@action' => $action,
                                     '@format' => 'html'
-                                ],
+                                ], fn ($value) => $value !== null),
                                 $annotation->defaults ?? []
                             )
                         ];

--- a/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/RoutingAnnotationTestBController.php
+++ b/Neos.Flow/Tests/Functional/Mvc/Fixtures/Controller/RoutingAnnotationTestBController.php
@@ -1,0 +1,29 @@
+<?php
+namespace Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\Controller\ActionController;
+
+/**
+ * A controller fixture
+ *
+ * @Flow\Scope("singleton")
+ */
+class RoutingAnnotationTestBController extends ActionController
+{
+    #[Flow\Route('neos/flow/test/annotation')]
+    public function annotatedAction()
+    {
+        return 'returned from "annotatedAction"';
+    }
+}

--- a/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
+++ b/Neos.Flow/Tests/Functional/Mvc/RoutingTest.php
@@ -21,6 +21,7 @@ use Neos\Flow\Mvc\Routing\Dto\RouteContext;
 use Neos\Flow\Mvc\Routing\Route;
 use Neos\Flow\Mvc\Routing\TestingRoutesProvider;
 use Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\ActionControllerTestAController;
+use Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\RoutingAnnotationTestBController;
 use Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\RoutingTestAController;
 use Neos\Flow\Tests\FunctionalTestCase;
 use Neos\Utility\Arrays;
@@ -48,11 +49,27 @@ class RoutingTest extends FunctionalTestCase
         parent::setUp();
         $this->serverRequestFactory = $this->objectManager->get(ServerRequestFactoryInterface::class);
 
+        $routeSettings = $this->objectManager->get(ConfigurationManager::class)
+            ->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.Flow.mvc.routes');
+
         if (
-            ($this->objectManager->get(ConfigurationManager::class)
-                ->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.Flow.mvc.routes')['Neos.Flow'] ?? false) !== true
+            ($routeSettings['Neos.Flow'] ?? false) !== true
+            || !is_array($routeSettings['Neos.Flow:TestingAttributes'] ?? null)
         ) {
-            self::markTestSkipped(sprintf('In this distribution the Flow routes are not included into the global configuration and thus cannot be tested. Please set in Neos.Flow.mvc.routes "Neos.Flow": true.'));
+            self::markTestSkipped(<<<'EOF'
+            In this distribution the Neos.Flow or Flow\Annotation routes are not included into the global configuration and thus cannot be tested:
+            
+            Neos:
+              Flow:
+                mvc:
+                  routes:
+                    "Neos.Flow:TestingAttributes":
+                      providerFactory: Neos\Flow\Mvc\Routing\AttributeRoutesProviderFactory
+                      providerOptions:
+                        classNames:
+                          - Neos\Flow\Tests\Functional\Mvc\Fixtures\Controller\*Controller
+                    "Neos.Flow": true
+            EOF);
         }
     }
 
@@ -96,6 +113,19 @@ class RoutingTest extends FunctionalTestCase
         $actionRequest = $this->createActionRequest($request, $matchResults);
         self::assertEquals(ActionControllerTestAController::class, $actionRequest->getControllerObjectName());
         self::assertEquals('second', $actionRequest->getControllerActionName());
+    }
+
+    /**
+     * @test
+     */
+    public function routeToControllerWithAnnotatedAction()
+    {
+        $requestUri = 'http://localhost/neos/flow/test/annotation';
+        $request = $this->serverRequestFactory->createServerRequest('GET', new Uri($requestUri));
+        $matchResults = $this->router->route(new RouteContext($request, RouteParameters::createEmpty()));
+        $actionRequest = $this->createActionRequest($request, $matchResults);
+        self::assertEquals(RoutingAnnotationTestBController::class, $actionRequest->getControllerObjectName());
+        self::assertEquals('annotated', $actionRequest->getControllerActionName());
     }
 
     /**
@@ -358,6 +388,24 @@ class RoutingTest extends FunctionalTestCase
         $actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, false, '', RouteParameters::createEmpty()));
 
         self::assertSame('/neos/flow/test/http/foo', (string)$actualResult);
+    }
+
+    /**
+     * @test
+     */
+    public function routerMatchesRouteFromAnnotation()
+    {
+        $routeValues = [
+            '@package' => 'Neos.Flow',
+            '@subpackage' => 'Tests\Functional\Mvc\Fixtures',
+            '@controller' => 'RoutingAnnotationTestB',
+            '@action' => 'annotated',
+            '@format' => 'html'
+        ];
+        $baseUri = new Uri('http://localhost');
+        $actualResult = $this->router->resolve(new ResolveContext($baseUri, $routeValues, false, '', RouteParameters::createEmpty()));
+
+        self::assertSame('/neos/flow/test/annotation', (string)$actualResult);
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/AttributeRoutesProviderTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/AttributeRoutesProviderTest.php
@@ -110,7 +110,6 @@ class AttributeRoutesProviderTest extends UnitTestCase
         $expectedRoute1->setUriPattern('my/path');
         $expectedRoute1->setDefaults([
             '@package' => 'Vendor.Example',
-            '@subpackage' => null,
             '@controller' => 'Example',
             '@action' => 'special',
             '@format' => 'html',
@@ -121,7 +120,6 @@ class AttributeRoutesProviderTest extends UnitTestCase
         $expectedRoute2->setUriPattern('my/other/path');
         $expectedRoute2->setDefaults([
             '@package' => 'Vendor.Example',
-            '@subpackage' => null,
             '@controller' => 'Example',
             '@action' => 'special',
             '@format' => 'html',


### PR DESCRIPTION
There is an inconsistency with defined routes which can lead to not properly working resolving, so we herby leave out the `@subpackage` declaration as it should be instead of specifying the key without value.

If a route is defined manually configuration following things are logged in routes:match

```
Name: My.Api :: Configuration
Pattern: api/news

Results:
  @package: My.Api
  @controller: News
  @action: getNews

Matched Controller: ...
```

But the result is different when using the RouteAnnotation, then the `@subpackage` is apparently set which again can confuse the resolving.

```
Name: My.Api :: News :: getNews
Pattern: api/news

Results:
  @package: My.Api
  @subpackage:
  @controller: News
  @action: getNews
  @format: html

Matched Controller: ...
```

I found out that during resolving the `@subpackage` must be set explicitly to an empty string and cannot be left out or set to null.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
