### PR TITLE
BUGFIX: Explicitly normalize FK constraint names after table renames for MariaDB 12 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,7 +183,7 @@ jobs:
         #if: env.BEHAT == true
         run: |
           FLOW_CONTEXT=Testing/Behat ./flow doctrine:migrate
-          FLOW_CONTEXT=Testing/Behat ./flow behat:setup && ./flow doctrine:migrationversion --add --version all
+          FLOW_CONTEXT=Testing/Behat ./flow behat:setup
           bin/behat --stop-on-failure -f progress -c Packages/Framework/Neos.Flow/Tests/Behavior/behat.yml.dist
 
       - name: Setup Flow configuration (PGSQL)
@@ -221,7 +221,7 @@ jobs:
         #if: env.BEHAT == true
         run: |
           FLOW_CONTEXT=Testing/Behat ./flow doctrine:migrate
-          FLOW_CONTEXT=Testing/Behat ./flow behat:setup && ./flow doctrine:migrationversion --add --version all
+          FLOW_CONTEXT=Testing/Behat ./flow behat:setup
           bin/behat --stop-on-failure -f progress -c Packages/Framework/Neos.Flow/Tests/Behavior/behat.yml.dist
 
   buildall:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
 
           - php-versions: '8.5'
             mariadb-versions: '12.2'
-            postgresql-versions: '' # skip postgresql setup
+            postgresql-versions: '18-alpine'
             static-analysis: 'no'
             experimental: true
             dependencies: 'highest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
         # see https://mariadb.com/kb/en/mariadb-server-release-dates/
         # this should be a current release, e.g. the LTS version
-        mariadb-versions: ['10.6']
+        mariadb-versions: ['11.8']
         # see https://www.postgresql.org/support/versioning/
         # this should be a current release
         postgresql-versions: ['14-alpine']
@@ -36,6 +36,13 @@ jobs:
             mariadb-versions: '' # skip mariadb setup
             postgresql-versions: '' # skip postgresql setup
             static-analysis: 'yes'
+            experimental: true
+            dependencies: 'highest'
+
+          - php-versions: '8.5'
+            mariadb-versions: '12.2'
+            postgresql-versions: '' # skip postgresql setup
+            static-analysis: 'no'
             experimental: true
             dependencies: 'highest'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,8 @@ jobs:
         if: ${{ matrix.static-analysis == 'no' && matrix.dependencies != 'lowest' }}
         #if: env.BEHAT == true
         run: |
-          FLOW_CONTEXT=Testing/Behat ./flow behat:setup && ./flow doctrine:create && ./flow doctrine:migrationversion --add --version all
+          FLOW_CONTEXT=Testing/Behat ./flow doctrine:migrate
+          FLOW_CONTEXT=Testing/Behat ./flow behat:setup && ./flow doctrine:migrationversion --add --version all
           bin/behat --stop-on-failure -f progress -c Packages/Framework/Neos.Flow/Tests/Behavior/behat.yml.dist
 
       - name: Setup Flow configuration (PGSQL)
@@ -219,7 +220,8 @@ jobs:
         if: ${{ matrix.static-analysis == 'no' && matrix.dependencies != 'lowest' }}
         #if: env.BEHAT == true
         run: |
-          FLOW_CONTEXT=Testing/Behat ./flow behat:setup && ./flow doctrine:create && ./flow doctrine:migrationversion --add --version all
+          FLOW_CONTEXT=Testing/Behat ./flow doctrine:migrate
+          FLOW_CONTEXT=Testing/Behat ./flow behat:setup && ./flow doctrine:migrationversion --add --version all
           bin/behat --stop-on-failure -f progress -c Packages/Framework/Neos.Flow/Tests/Behavior/behat.yml.dist
 
   buildall:

--- a/Neos.Flow/Migrations/Mysql/Version20110824124835.php
+++ b/Neos.Flow/Migrations/Mysql/Version20110824124835.php
@@ -22,6 +22,12 @@ class Version20110824124835 extends AbstractMigration
         $this->addSql("RENAME TABLE flow3_resource_resourcepointer TO typo3_flow3_resource_resourcepointer");
         $this->addSql("RENAME TABLE flow3_resource_securitypublishingconfiguration TO typo3_flow3_security_authorization_resource_securitypublis_6180a");
         $this->addSql("RENAME TABLE flow3_security_account TO typo3_flow3_security_account");
+
+        // Explicitly normalize the FK constraint name after the table rename.
+        // Old MariaDB auto-renamed it (typo3_flow3_resource_resource_ibfk_1 already set); MariaDB 12+ does not (flow3_resource_resource_ibfk_1 still present).
+        $this->addSql("ALTER TABLE typo3_flow3_resource_resource DROP FOREIGN KEY IF EXISTS flow3_resource_resource_ibfk_1");
+        $this->addSql("ALTER TABLE typo3_flow3_resource_resource DROP FOREIGN KEY IF EXISTS typo3_flow3_resource_resource_ibfk_1");
+        $this->addSql("ALTER TABLE typo3_flow3_resource_resource ADD CONSTRAINT typo3_flow3_resource_resource_ibfk_1 FOREIGN KEY (flow3_resource_resourcepointer) REFERENCES typo3_flow3_resource_resourcepointer (hash)");
     }
 
     /**
@@ -37,5 +43,10 @@ class Version20110824124835 extends AbstractMigration
         $this->addSql("RENAME TABLE typo3_flow3_resource_resourcepointer TO flow3_resource_resourcepointer");
         $this->addSql("RENAME TABLE typo3_flow3_security_authorization_resource_securitypublis_6180a TO flow3_resource_securitypublishingconfiguration");
         $this->addSql("RENAME TABLE typo3_flow3_security_account TO flow3_security_account");
+
+        // Explicitly normalize the FK constraint name after the table rename back.
+        $this->addSql("ALTER TABLE flow3_resource_resource DROP FOREIGN KEY IF EXISTS typo3_flow3_resource_resource_ibfk_1");
+        $this->addSql("ALTER TABLE flow3_resource_resource DROP FOREIGN KEY IF EXISTS flow3_resource_resource_ibfk_1");
+        $this->addSql("ALTER TABLE flow3_resource_resource ADD CONSTRAINT flow3_resource_resource_ibfk_1 FOREIGN KEY (flow3_resource_resourcepointer) REFERENCES flow3_resource_resourcepointer (hash)");
     }
 }

--- a/Neos.Flow/Migrations/Mysql/Version20120930203452.php
+++ b/Neos.Flow/Migrations/Mysql/Version20120930203452.php
@@ -59,6 +59,12 @@ class Version20120930203452 extends AbstractMigration
         $this->addSql("RENAME TABLE typo3_flow3_security_account TO typo3_flow_security_account");
         $this->addSql("RENAME TABLE typo3_flow3_security_authorization_resource_securitypubli_6180a TO typo3_flow_security_authorization_resource_securitypublis_861cb");
         $this->addSql("RENAME TABLE typo3_flow3_security_policy_role TO typo3_flow_security_policy_role");
+
+        // Explicitly normalize the FK constraint name after the table rename.
+        // Old MariaDB auto-renamed it (typo3_flow_resource_resource_ibfk_1 already set); MariaDB 12+ does not (typo3_flow3_resource_resource_ibfk_1 still present).
+        $this->addSql("ALTER TABLE typo3_flow_resource_resource DROP FOREIGN KEY IF EXISTS typo3_flow3_resource_resource_ibfk_1");
+        $this->addSql("ALTER TABLE typo3_flow_resource_resource DROP FOREIGN KEY IF EXISTS typo3_flow_resource_resource_ibfk_1");
+        $this->addSql("ALTER TABLE typo3_flow_resource_resource ADD CONSTRAINT typo3_flow_resource_resource_ibfk_1 FOREIGN KEY (resourcepointer) REFERENCES typo3_flow_resource_resourcepointer (hash)");
     }
 
     /**
@@ -110,5 +116,10 @@ class Version20120930203452 extends AbstractMigration
         $this->addSql("RENAME TABLE typo3_flow_security_account TO typo3_flow3_security_account");
         $this->addSql("RENAME TABLE typo3_flow_security_authorization_resource_securitypublis_861cb TO typo3_flow3_security_authorization_resource_securitypubli_6180a");
         $this->addSql("RENAME TABLE typo3_flow_security_policy_role TO typo3_flow3_security_policy_role");
+
+        // Explicitly normalize the FK constraint name after the table rename back.
+        $this->addSql("ALTER TABLE typo3_flow3_resource_resource DROP FOREIGN KEY IF EXISTS typo3_flow_resource_resource_ibfk_1");
+        $this->addSql("ALTER TABLE typo3_flow3_resource_resource DROP FOREIGN KEY IF EXISTS typo3_flow3_resource_resource_ibfk_1");
+        $this->addSql("ALTER TABLE typo3_flow3_resource_resource ADD CONSTRAINT typo3_flow3_resource_resource_ibfk_1 FOREIGN KEY (resourcepointer) REFERENCES typo3_flow3_resource_resourcepointer (hash)");
     }
 }


### PR DESCRIPTION
MariaDB 12.x stopped auto-renaming InnoDB FK constraint names during RENAME TABLE. Two migrations that rename the resource_resource table were followed by downstream migrations expecting the new constraint name — which never materialized on MariaDB 12.x.                                       

To get both versions working we now drop both possible index-name versions directly after the rename and recreate the index with the new - expected name.

For better visibility, consitency and support I also changed the pipeline:
* Add build configurations for PHP 8.5 with MariaDB 12.3 and Postgres 18
* Change default version for MariaDB to latest LTS 11.8

Fixes: #3543 