### PR TITLE
BUGFIX: Add debug info to exception if backend creation fails

### DIFF
--- a/Neos.Cache/Classes/CacheFactory.php
+++ b/Neos.Cache/Classes/CacheFactory.php
@@ -57,7 +57,11 @@ class CacheFactory implements CacheFactoryInterface
      */
     public function create(string $cacheIdentifier, string $cacheObjectName, string $backendObjectName, array $backendOptions = []): FrontendInterface
     {
-        $backend = $this->instantiateBackend($backendObjectName, $backendOptions, $this->environmentConfiguration);
+        try {
+            $backend = $this->instantiateBackend($backendObjectName, $backendOptions, $this->environmentConfiguration);
+        } catch (\Throwable $throwable) {
+            throw new \RuntimeException(sprintf('Cannot instantiate backend "%s" for cache "%s"', $backendObjectName, $cacheIdentifier), 1773330049, $throwable);
+        }
         $cache = $this->instantiateCache($cacheIdentifier, $cacheObjectName, $backend);
         $backend->setCache($cache);
 


### PR DESCRIPTION
we use `setProperties` in the AbstractBackend to map all options to the backend class. Now there might be a setter for that option but the value is not guaranteed to match the type.

Now a type error is thrown which itself doesnt give a hint where something is wrong:

> Neos\Cache\Backend\RedisBackend::setHostname(): Argument #1 ($hostname) must be of type string, false given

I have encountered this many times especially in combination with Caches configured with env variables that are not set and thus `false`.

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
