### PR TITLE
FEATURE: Enable Xdebug Path Mapping in Development context per default

### DIFF
--- a/Neos.Flow/Configuration/Development/Settings.yaml
+++ b/Neos.Flow/Configuration/Development/Settings.yaml
@@ -57,3 +57,6 @@ Neos:
               options:
                 logFileURL: '%FLOW_PATH_DATA%Logs/I18n_Development.log'
                 severityThreshold: '%LOG_DEBUG%'
+    object:
+      proxy:
+        enableXdebugPathMapping: true


### PR DESCRIPTION
Enables the Xdebug Path Mapping per default in Development context.

See: https://github.com/neos/flow-development-collection/pull/3535