### PR TITLE
BUGFIX: build correct node uri for multisite setup for localhost

### DIFF
--- a/Neos.Flow/Classes/Mvc/Routing/Dto/UriConstraints.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Dto/UriConstraints.php
@@ -399,7 +399,7 @@ final class UriConstraints
             if (empty($uri->getScheme())) {
                 $uri = $uri->withScheme($baseUri->getScheme());
             }
-            if (empty($uri->getHost()) || $uri->getHost() === self::HTTP_DEFAULT_HOST) {
+            if (empty($uri->getHost()) || ($uri->getHost() === self::HTTP_DEFAULT_HOST && !isset($this->constraints[self::CONSTRAINT_HOST]))) {
                 $uri = $uri->withHost($baseUri->getHost());
             }
             if (!isset($this->constraints[self::CONSTRAINT_PORT]) && $uri->getPort() === null) {

--- a/Neos.Flow/Classes/Mvc/Routing/Dto/UriConstraints.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Dto/UriConstraints.php
@@ -312,6 +312,11 @@ final class UriConstraints
     {
         $uri = new Uri('');
         $uriPath = '';
+        // Track whether the host was explicitly set by a constraint. This is needed because
+        // Guzzle's Uri::validateState() auto-assigns 'localhost' as the host whenever withScheme()
+        // is called with 'http' or 'https' and the host is empty. Without this flag we cannot
+        // distinguish between a Guzzle-default 'localhost' and an intentionally set host.
+        $hostSetByConstraint = false;
         if (isset($this->constraints[self::CONSTRAINT_SCHEME]) && $this->constraints[self::CONSTRAINT_SCHEME] !== $baseUri->getScheme()) {
             $forceAbsoluteUri = true;
             $uri = $uri->withScheme($this->constraints[self::CONSTRAINT_SCHEME]);
@@ -319,9 +324,10 @@ final class UriConstraints
         if (isset($this->constraints[self::CONSTRAINT_HOST]) && $this->constraints[self::CONSTRAINT_HOST] !== $baseUri->getHost()) {
             $forceAbsoluteUri = true;
             $uri = $uri->withHost($this->constraints[self::CONSTRAINT_HOST]);
+            $hostSetByConstraint = true;
         }
         if (isset($this->constraints[self::CONSTRAINT_HOST_PREFIX])) {
-            $host = !empty($uri->getHost()) ? $uri->getHost() : $baseUri->getHost();
+            $host = $hostSetByConstraint ? $uri->getHost() : $baseUri->getHost();
             $originalHost = $host;
             $prefix = $this->constraints[self::CONSTRAINT_HOST_PREFIX]['prefix'];
             $replacePrefixes = $this->constraints[self::CONSTRAINT_HOST_PREFIX]['replacePrefixes'];
@@ -335,10 +341,11 @@ final class UriConstraints
             if ($host !== $originalHost) {
                 $forceAbsoluteUri = true;
                 $uri = $uri->withHost($host);
+                $hostSetByConstraint = true;
             }
         }
         if (isset($this->constraints[self::CONSTRAINT_HOST_SUFFIX])) {
-            $host = !empty($uri->getHost()) ? $uri->getHost() : $baseUri->getHost();
+            $host = $hostSetByConstraint ? $uri->getHost() : $baseUri->getHost();
             $originalHost = $host;
             $suffix = $this->constraints[self::CONSTRAINT_HOST_SUFFIX]['suffix'];
             $replaceSuffixes = $this->constraints[self::CONSTRAINT_HOST_SUFFIX]['replaceSuffixes'];
@@ -357,6 +364,7 @@ final class UriConstraints
             if ($host !== $originalHost) {
                 $forceAbsoluteUri = true;
                 $uri = $uri->withHost($host);
+                $hostSetByConstraint = true;
             }
         }
         if (isset($this->constraints[self::CONSTRAINT_PORT]) && ($forceAbsoluteUri || $this->constraints[self::CONSTRAINT_PORT] !== $baseUri->getPort()) && ($baseUri->getPort() !== null || $this->constraints[self::CONSTRAINT_PORT] !== UriHelper::getDefaultPortForScheme($this->constraints[self::CONSTRAINT_SCHEME] ?? $baseUri->getScheme()))) {
@@ -396,11 +404,15 @@ final class UriConstraints
         $uri = $uri->withPath('/' . ltrim($uriPath, '/'));
 
         if ($forceAbsoluteUri) {
+            if (!$hostSetByConstraint) {
+                // No host constraint was applied: use the explicit CONSTRAINT_HOST value if one was
+                // set (it matched the baseUri host so the block above was skipped) or fall back to
+                // the baseUri host. This also corrects Guzzle's validateState() auto-assigning
+                // 'localhost' when withScheme('http'/'https') was called on a host-less URI.
+                $uri = $uri->withHost($this->constraints[self::CONSTRAINT_HOST] ?? $baseUri->getHost());
+            }
             if (empty($uri->getScheme())) {
                 $uri = $uri->withScheme($baseUri->getScheme());
-            }
-            if (empty($uri->getHost())) {
-                $uri = $uri->withHost(isset($this->constraints[self::CONSTRAINT_HOST]) ? $this->constraints[self::CONSTRAINT_HOST] : $baseUri->getHost());
             }
             if (!isset($this->constraints[self::CONSTRAINT_PORT]) && $uri->getPort() === null) {
                 $port = $baseUri->getPort() ?? UriHelper::getDefaultPortForScheme($uri->getScheme());

--- a/Neos.Flow/Classes/Mvc/Routing/Dto/UriConstraints.php
+++ b/Neos.Flow/Classes/Mvc/Routing/Dto/UriConstraints.php
@@ -399,8 +399,8 @@ final class UriConstraints
             if (empty($uri->getScheme())) {
                 $uri = $uri->withScheme($baseUri->getScheme());
             }
-            if (empty($uri->getHost()) || ($uri->getHost() === self::HTTP_DEFAULT_HOST && !isset($this->constraints[self::CONSTRAINT_HOST]))) {
-                $uri = $uri->withHost($baseUri->getHost());
+            if (empty($uri->getHost())) {
+                $uri = $uri->withHost(isset($this->constraints[self::CONSTRAINT_HOST]) ? $this->constraints[self::CONSTRAINT_HOST] : $baseUri->getHost());
             }
             if (!isset($this->constraints[self::CONSTRAINT_PORT]) && $uri->getPort() === null) {
                 $port = $baseUri->getPort() ?? UriHelper::getDefaultPortForScheme($uri->getScheme());

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/UriConstraintsTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/Dto/UriConstraintsTest.php
@@ -42,6 +42,9 @@ class UriConstraintsTest extends UnitTestCase
 
             ['constraints' => [UriConstraints::CONSTRAINT_HOST => 'some-domain.tld'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => '/'],
             ['constraints' => [UriConstraints::CONSTRAINT_HOST => 'some-other-domain.tld'], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => 'http://some-other-domain.tld/'],
+            // 'localhost' is HTTP_DEFAULT_HOST — an explicit withHost('localhost') must not be overwritten by the base URI host
+            ['constraints' => [UriConstraints::CONSTRAINT_HOST => 'localhost', UriConstraints::CONSTRAINT_PATH => '/some-path'], 'templateUri' => 'http://other.localhost:8081', 'forceAbsoluteUri' => false, 'expectedUri' => 'http://localhost:8081/some-path'],
+            ['constraints' => [UriConstraints::CONSTRAINT_HOST => 'localhost', UriConstraints::CONSTRAINT_PATH => '/some-path'], 'templateUri' => 'http://other.localhost:8081', 'forceAbsoluteUri' => true, 'expectedUri' => 'http://localhost:8081/some-path'],
 
             ['constraints' => [UriConstraints::CONSTRAINT_HOST_PREFIX => ['prefix' => 'en.', 'replacePrefixes' => []]], 'templateUri' => 'http://some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => 'http://en.some-domain.tld/'],
             ['constraints' => [UriConstraints::CONSTRAINT_HOST_PREFIX => ['prefix' => 'en.', 'replacePrefixes' => []]], 'templateUri' => 'http://en.some-domain.tld', 'forceAbsoluteUri' => false, 'expectedUri' => 'http://en.en.some-domain.tld/'],


### PR DESCRIPTION
When using a multi-site setup and linking from one site to another, the uri generation in development does not work correctly.

**Scenario:**
I have a neos site "main" with domain localhost, and "other" at domain other.localhost and want to link a node from main on other. 

**Expected behaviour:**
The generated link points to "localhost/some-node"

**Actual behaviour:**
The generated link points to "other.localhost/some-node"

**Changes:**
check if `CONSTRAINT_HOST` has been set before falling back to base uri

**Upgrade instructions**
There should be no breaking changes

**Review instructions**
- 

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
