### PR TITLE
TASK: Also read property names from annotations

### DIFF
--- a/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriver.php
@@ -522,11 +522,17 @@ class FlowAnnotationDriver implements DoctrineMappingDriverInterface, PointcutFi
         foreach ($joinColumns as &$joinColumn) {
             if ($joinColumn['referencedColumnName'] === null || $joinColumn['referencedColumnName'] === 'id') {
                 if ($direction === self::MAPPING_REGULAR) {
-                    $idProperties = $this->reflectionService->getPropertyNamesByTag($mapping['targetEntity'], 'id');
+                    $idProperties = array_unique(array_merge(
+                        $this->reflectionService->getPropertyNamesByAnnotation($mapping['targetEntity'], ORM\Id::class),
+                        $this->reflectionService->getPropertyNamesByTag($mapping['targetEntity'], 'id')
+                    ));
                     $joinColumnName = $this->buildJoinTableColumnName($mapping['targetEntity']);
                 } else {
                     $className = $this->getUnproxiedClassName($property->getDeclaringClass()->getName());
-                    $idProperties = $this->reflectionService->getPropertyNamesByTag($className, 'id');
+                    $idProperties = array_unique(array_merge(
+                        $this->reflectionService->getPropertyNamesByAnnotation($mapping['targetEntity'], ORM\Id::class),
+                        $this->reflectionService->getPropertyNamesByTag($mapping['targetEntity'], 'id')
+                    ));
                     $joinColumnName = $this->buildJoinTableColumnName($className);
                 }
                 if (count($idProperties) === 0) {


### PR DESCRIPTION
When collecting id properties for join columns
also read properies annotated with the Id
mapping from Doctrine ORM

resolved: #3558

**Review instructions**

Create a model `A` with a relation to another model `B`.

Before the patch:
The model `B` must have the `@Id` tag to a property.

After the patch:
The model `B` can now use `[ORM\Id]` annotation

The property is now considered a `ID Property`