### PR TITLE
BUGFIX: Allow smooth upgrades from var tags

### DIFF
--- a/Neos.Flow/Classes/Aop/Builder/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/Aop/Builder/ProxyClassBuilder.php
@@ -398,6 +398,10 @@ class ProxyClassBuilder
             $propertyName = $propertyIntroduction->getPropertyName();
             $declaringAspectClassName = $propertyIntroduction->getDeclaringAspectClassName();
             $possiblePropertyTypes = $this->reflectionService->getPropertyTagValues($declaringAspectClassName, $propertyName, 'var');
+            if (count($possiblePropertyTypes) === 0) {
+                $typeHint = $this->reflectionService->getPropertyType($declaringAspectClassName, $propertyName);
+                $possiblePropertyTypes = $typeHint !== null ? [$typeHint] : [];
+            }
             if (count($possiblePropertyTypes) > 0 && !$this->reflectionService->isPropertyAnnotatedWith($declaringAspectClassName, $propertyName, Flow\Transient::class)) {
                 $classSchema = $this->reflectionService->getClassSchema($targetClassName);
                 $classSchema?->addProperty($propertyName, $possiblePropertyTypes[0]);

--- a/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Configuration/ConfigurationBuilder.php
@@ -339,26 +339,50 @@ class ConfigurationBuilder
     protected function parsePropertyOfTypeObject($propertyName, $objectNameOrConfiguration, Configuration $parentObjectConfiguration)
     {
         if (is_array($objectNameOrConfiguration)) {
-            if (isset($objectNameOrConfiguration['name'])) {
-                $objectName = $objectNameOrConfiguration['name'];
-                unset($objectNameOrConfiguration['name']);
-            } else {
-                if (isset($objectNameOrConfiguration['factoryObjectName']) || isset($objectNameOrConfiguration['factoryMethodName'])) {
-                    $objectName = null;
-                } else {
-                    $annotations = $this->reflectionService->getPropertyTagValues($parentObjectConfiguration->getClassName(), $propertyName, 'var');
-                    if (count($annotations) !== 1) {
-                        throw new InvalidObjectConfigurationException(sprintf('Object %s (%s), for property "%s", contains neither object name, nor factory object name, and nor is the property properly @var - annotated.', $parentObjectConfiguration->getClassName(), $parentObjectConfiguration->getConfigurationSourceHint(), $propertyName), 1297097815);
-                    }
-                    $objectName = $annotations[0];
-                }
-            }
+            $objectName = $this->determineObjectNameOfProperty($objectNameOrConfiguration, $parentObjectConfiguration->getClassName(), $propertyName, $parentObjectConfiguration->getConfigurationSourceHint());
+            unset($objectNameOrConfiguration['name']);
             $objectConfiguration = $this->parseConfigurationArray($objectName, $objectNameOrConfiguration, $parentObjectConfiguration->getConfigurationSourceHint() . ', property "' . $propertyName . '"');
             $property = new ConfigurationProperty($propertyName, $objectConfiguration, ConfigurationProperty::PROPERTY_TYPES_OBJECT);
         } else {
             $property = new ConfigurationProperty($propertyName, $objectNameOrConfiguration, ConfigurationProperty::PROPERTY_TYPES_OBJECT);
         }
         return $property;
+    }
+
+    /**
+     * @param $objectNameOrConfiguration
+     * @param $parentClassName
+     * @param $propertyName
+     * @param string $configurationSourceHint
+     * @return string
+     * @throws InvalidObjectConfigurationException
+     * @throws \Neos\Flow\Reflection\Exception\ClassLoadingForReflectionFailedException
+     * @throws \Neos\Flow\Reflection\Exception\InvalidClassException
+     * @throws \ReflectionException
+     */
+    protected function determineObjectNameOfProperty($objectNameOrConfiguration, $parentClassName, $propertyName, string $configurationSourceHint): string
+    {
+        if (isset($objectNameOrConfiguration['name'])) {
+            return $objectNameOrConfiguration['name'];
+        }
+
+        if (isset($objectNameOrConfiguration['factoryObjectName']) || isset($objectNameOrConfiguration['factoryMethodName'])) {
+            return '';
+        }
+
+        $varTags = $this->reflectionService->getPropertyTagValues($parentClassName, $propertyName, 'var');
+        if (count($varTags) > 1) {
+            throw new InvalidObjectConfigurationException(sprintf('Object %s (%s), for property "%s", contains neither object name, nor factory object name, and nor is the property properly @var - annotated.', $parentClassName, $configurationSourceHint, $propertyName), 1297097815);
+        }
+        if (count($varTags) === 1) {
+            return $varTags[0];
+        }
+        $typeHint = $this->reflectionService->getPropertyType($parentClassName, $propertyName);
+        if ($typeHint === null) {
+            throw new InvalidObjectConfigurationException(sprintf('Object %s (%s), for property "%s", contains neither object name, nor factory object name, and neither is the property properly type hinted or @var - tagged.', $parentClassName, $configurationSourceHint, $propertyName), 1779793488);
+        }
+
+        return $typeHint;
     }
 
     /**
@@ -590,6 +614,7 @@ class ConfigurationBuilder
                             $enableLazyInjection = false; # See:  https://github.com/neos/flow-development-collection/issues/2114
                         }
                     }
+                    // This is already a fallback, getPropertyType is used first.
                     if ($objectName === null) {
                         $objectName = trim(implode('', $this->reflectionService->getPropertyTagValues($className, $propertyName, 'var')), ' \\');
                     }

--- a/Neos.Flow/Classes/Property/TypeConverter/ObjectConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ObjectConverter.php
@@ -156,8 +156,13 @@ class ObjectConverter extends AbstractTypeConverter
                     }
                     return $parsedType['type'] . ($parsedType['elementType'] !== null ? '<' . $parsedType['elementType'] . '>' : '');
                 }
+                $typeHint = $this->reflectionService->getPropertyType($targetType, $propertyName);
+                if ($typeHint !== null) {
+                    $parsedType = TypeHandling::parseType($typeHint);
+                    return $parsedType['type'];
+                }
 
-                throw new InvalidTargetException(sprintf('Public property "%s" had no proper type annotation (i.e. "@var") in target object of type "%s".', $propertyName, $targetType), 1406821818);
+                throw new InvalidTargetException(sprintf('Public property "%s" had no type hints or proper type tag (i.e. "@var") in target object of type "%s".', $propertyName, $targetType), 1406821818);
             }
         }
 

--- a/Neos.Flow/Classes/Reflection/ReflectionService.php
+++ b/Neos.Flow/Classes/Reflection/ReflectionService.php
@@ -846,7 +846,22 @@ class ReflectionService
     public function getPropertyTagValues(string $className, string $propertyName, string $tag): array
     {
         $className = $this->prepareClassReflectionForUsage($className);
-        return $this->classReflectionData[$className][self::DATA_CLASS_PROPERTIES][$propertyName][self::DATA_PROPERTY_TAGS_VALUES][$tag] ?? [];
+        $tagValues = $this->classReflectionData[$className][self::DATA_CLASS_PROPERTIES][$propertyName][self::DATA_PROPERTY_TAGS_VALUES][$tag] ?? [];
+        if ($tag !== 'var') {
+            return $tagValues;
+        }
+
+        if ($tagValues !== []) {
+            return $tagValues;
+        }
+
+        // Upgrade behavior for "var" tag requests also considering the type hints as fallback.
+        $propertyType = $this->getPropertyType($className, $propertyName);
+        if ($propertyType !== null) {
+            return [$propertyType];
+        }
+
+        return [];
     }
 
     /**

--- a/Neos.Flow/Classes/Validation/ValidatorResolver.php
+++ b/Neos.Flow/Classes/Validation/ValidatorResolver.php
@@ -296,20 +296,17 @@ class ValidatorResolver
             }
             $conjunctionValidator->addValidator($objectValidator);
             foreach ($this->reflectionService->getClassPropertyNames($targetClassName) as $classPropertyName) {
+                if ($this->reflectionService->isPropertyAnnotatedWith($targetClassName, $classPropertyName, Flow\IgnoreValidation::class)) {
+                    continue;
+                }
+
                 $classPropertyTagsValues = $this->reflectionService->getPropertyTagsValues($targetClassName, $classPropertyName);
                 if (!isset($classPropertyTagsValues['var'])) {
-                    try {
-                        $propertyReflection = new PropertyReflection($targetClassName, $classPropertyName);
-                    } catch (\ReflectionException $e) {
-                        throw new \RuntimeException(sprintf('Failed reflecting property %s from class %s while building base a validator conjunction: %s', $classPropertyName, $targetClassName, $e->getMessage()), 1651570561);
-                    }
-
-                    if (!$propertyReflection->hasType()) {
+                    $type = $this->reflectionService->getPropertyType($targetClassName, $classPropertyName);
+                    if ($type === null) {
                         throw new \InvalidArgumentException(sprintf('Failed building base validator conjunction for property %s in class %s because there is no @var annotation and no type declaration.', $classPropertyName, $targetClassName), 1363778104);
                     }
-                    /** @var \ReflectionNamedType $type */
-                    $type = $propertyReflection->getType();
-                    $classPropertyTagsValues['var'][] = $type->getName();
+                    $classPropertyTagsValues['var'][] = $this->reflectionService->getPropertyType($targetClassName, $classPropertyName);
                 }
                 try {
                     $parsedType = TypeHandling::parseType(trim(implode('', $classPropertyTagsValues['var']), ' \\'));
@@ -317,9 +314,6 @@ class ValidatorResolver
                     throw new \InvalidArgumentException(sprintf(' @var annotation of ' . $exception->getMessage(), 'class "' . $targetClassName . '", property "' . $classPropertyName . '"'), 1315564744, $exception);
                 }
 
-                if ($this->reflectionService->isPropertyAnnotatedWith($targetClassName, $classPropertyName, Flow\IgnoreValidation::class)) {
-                    continue;
-                }
                 if ($classSchema !== null
                     && $classSchema->hasProperty($classPropertyName)
                     && $classSchema->isPropertyTransient($classPropertyName)


### PR DESCRIPTION
Any property that gets reflected for "var" via `ReflectionService::getPropertyTagsValues` cannot sensibly be upgraded to use type hints only. This addition gives a sensible upgrade path by falling back to reflected type if no "var" tag was available.
In the long run this allows code to seamlessly change from var tags to type hints in all places.
