### PR TITLE
TASK: fix xdebug path mapping file generation with multiple contexts

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Proxy/XdebugPathMappingBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/XdebugPathMappingBuilder.php
@@ -15,6 +15,7 @@ namespace Neos\Flow\ObjectManagement\Proxy;
 use Neos\Cache\Backend\SimpleFileBackend;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cache\CacheManager;
+use Neos\Flow\Core\Bootstrap;
 use Neos\Utility\Files;
 
 /**
@@ -22,11 +23,19 @@ use Neos\Utility\Files;
  */
 class XdebugPathMappingBuilder
 {
+    private const PERSISTED_DATA_FILENAME = '.xdebug-pathmap-data.serialized';
+
     /**
      * @Flow\Inject
      * @var CacheManager
      */
     protected $cacheManager;
+
+    /**
+     * @Flow\Inject
+     * @var Bootstrap
+     */
+    protected $bootstrap;
 
     /**
      * @var array
@@ -47,6 +56,11 @@ class XdebugPathMappingBuilder
         $this->cacheManager = $cacheManager;
     }
 
+    public function injectBootstrap(Bootstrap $bootstrap): void
+    {
+        $this->bootstrap = $bootstrap;
+    }
+
     /**
      * @param array<string, array{path: string, proxyClassIdentifier: string}> $compiledClasses
      * @return void
@@ -61,12 +75,61 @@ class XdebugPathMappingBuilder
             return;
         }
 
-        $cacheBackend = $this->cacheManager->getCache('Flow_Object_Classes')->getBackend();
-        if (!$cacheBackend instanceof SimpleFileBackend) {
+        $cacheDirectory = $this->getProxyCacheDirectory();
+        if ($cacheDirectory === null) {
             return;
         }
-        $cacheDirectory = $cacheBackend->getCacheDirectory();
 
+        // Persist the input data next to the proxy class cache. The proxy cache
+        // directory is typically mounted/persisted on the host, whereas the map
+        // output directory may live only in the container layer. Persisting here
+        // lets us re-emit the map after a restart without re-compiling.
+        file_put_contents(
+            Files::concatenatePaths([$cacheDirectory, self::PERSISTED_DATA_FILENAME]),
+            serialize($compiledClasses)
+        );
+
+        $this->writeMapFile($cacheDirectory, $compiledClasses);
+    }
+
+    /**
+     * Re-writes the path mapping file from previously persisted data when the
+     * map file is missing. Intended to recover from situations where the proxy
+     * cache is still warm (so no compile signal fires) but the `.xdebug/` map
+     * directory was wiped (e.g. docker container restart, manual cleanup).
+     */
+    public function buildFromPersistedDataIfMapMissing(): void
+    {
+        if (!$this->isXdebugPathMappingEnabled()) {
+            return;
+        }
+        $mapFilePath = $this->getMapFilePath();
+        if ($mapFilePath === null || file_exists($mapFilePath)) {
+            return;
+        }
+
+        $cacheDirectory = $this->getProxyCacheDirectory();
+        if ($cacheDirectory === null) {
+            return;
+        }
+
+        $persistedDataPath = Files::concatenatePaths([$cacheDirectory, self::PERSISTED_DATA_FILENAME]);
+        if (!file_exists($persistedDataPath)) {
+            return;
+        }
+
+        $compiledClasses = unserialize((string)file_get_contents($persistedDataPath), ['allowed_classes' => false]);
+        if (!is_array($compiledClasses) || $compiledClasses === []) {
+            return;
+        }
+        $this->writeMapFile($cacheDirectory, $compiledClasses);
+    }
+
+    /**
+     * @param array<string, array{path: string, proxyClassIdentifier: string}> $compiledClasses
+     */
+    private function writeMapFile(string $cacheDirectory, array $compiledClasses): void
+    {
         $mappingFileLines = [
             '# Created by Flow Framework during compile time proxy generation.',
             '#',
@@ -88,11 +151,30 @@ class XdebugPathMappingBuilder
         // Add an empty line to the end of the file
         $mappingFileLines[] = '';
 
+        $mapFilePath = $this->getMapFilePath();
+        if ($mapFilePath === null) {
+            return;
+        }
         Files::createDirectoryRecursively($this->getXdebugMappingFilePath());
-        file_put_contents(
-            Files::concatenatePaths([$this->getXdebugMappingFilePath(), 'flow.map']),
-            implode("\n", $mappingFileLines)
-        );
+        file_put_contents($mapFilePath, implode("\n", $mappingFileLines));
+    }
+
+    private function getProxyCacheDirectory(): ?string
+    {
+        $cacheBackend = $this->cacheManager->getCache('Flow_Object_Classes')->getBackend();
+        if (!$cacheBackend instanceof SimpleFileBackend) {
+            return null;
+        }
+        return $cacheBackend->getCacheDirectory();
+    }
+
+    private function getMapFilePath(): ?string
+    {
+        if ($this->bootstrap === null) {
+            return null;
+        }
+        $contextIdentifier = str_replace(['/', '\\'], '_', (string)$this->bootstrap->getContext());
+        return Files::concatenatePaths([$this->getXdebugMappingFilePath(), 'flow-' . $contextIdentifier . '.map']);
     }
 
     private function isXdebugPathMappingEnabled(): bool

--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -163,5 +163,25 @@ class Package extends BasePackage
             $annotationsCacheFlusher = $bootstrap->getObjectManager()->get(AnnotationsCacheFlusher::class);
             $annotationsCacheFlusher->flushConfigurationCachesByCompiledClass(array_keys($compiledClasses));
         });
+
+        // Restore the xdebug path mapping file from persisted data when the
+        // proxy cache is warm (no afterCompile signal) but the map directory
+        // was wiped (e.g. docker container restart, manual cleanup).
+        $dispatcher->connect(Core\Booting\Sequence::class, 'afterInvokeStep', function (Step $step) use ($bootstrap) {
+            if ($step->getIdentifier() !== 'neos.flow:objectmanagement:runtime') {
+                return;
+            }
+            $objectManager = $bootstrap->getObjectManager();
+            $builder = $objectManager->get(XdebugPathMappingBuilder::class);
+            // XdebugPathMappingBuilder sits in the Neos\Flow\ObjectManagement
+            // namespace, which Compiler::$excludedSubPackages excludes from
+            // proxy generation. Runtime ObjectManager::get() returns a bare
+            // instance without DI, so setters must be invoked manually here.
+            $configurationManager = $objectManager->get(Configuration\ConfigurationManager::class);
+            $builder->injectBootstrap($bootstrap);
+            $builder->injectCacheManager($objectManager->get(Cache\CacheManager::class));
+            $builder->injectSettings($configurationManager->getConfiguration(Configuration\ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Neos.Flow'));
+            $builder->buildFromPersistedDataIfMapMissing();
+        });
     }
 }


### PR DESCRIPTION
Fixes two issues with the Xdebug path mapping file introduced in #3535:

1. **Multiple contexts overwrote each other.** Compiling in `Development` and then in `Testing` (or vice versa) produced a single `flow.map` containing only the last context's proxies, so breakpoints in proxy classes broke in whichever context was compiled second. The map file is now written per-context as `flow-<Context>.map` (e.g. `flow-Development.map`, `flow-Testing.map`), so each context can be debugged independently.

2. **Map file lost across container restarts.** The map directory often lives only in an short lasting container layer, while the proxy class cache is mounted from the host. After a restart the proxy cache was still warm — so no `afterCompile` signal fired — but the map file was gone, leaving Xdebug without a path mapping until the cache was flushed. The compiled-class input is now also serialized next to the proxy class cache as `.xdebug-pathmap-data.serialized`, and the map file is regenerated from that data on boot whenever it's missing.

related: #3535 

**Upgrade instructions**

If you previously pointed Xdebug at `flow.map`, update your Xdebug configuration to load the per-context file, e.g. `flow-Development.map`. The old `flow.map` is no longer produced.

**Review instructions**

To verify the multi-context fix:
1. Enable Xdebug path mapping as described in the [release notes from Flow 8.4.3](https://flowframework.readthedocs.io/en/8.4/TheDefinitiveGuide/PartV/ChangeLogs/843.html#id8)
2. Run `./flow flow:cache:flush --force` and then trigger a compile in `FLOW_CONTEXT=Development` (e.g. open the app).
3. Trigger a compile in `FLOW_CONTEXT=Testing` (e.g. run the test suite).
4. Confirm both `Data/Temporary/.../<...>/flow-Development.map` and `flow-Testing.map` exist and contain entries for their respective proxy classes.

To verify the restart-recovery fix:
1. With a warm proxy cache, delete the `.xdebug/` map directory (simulating a container restart).
2. Boot Flow again (any CLI command). The map file should be re-created from the persisted `.xdebug-pathmap-data.serialized` without recompiling proxies.

Note on the `Package.php` wiring: `XdebugPathMappingBuilder` lives under `Neos\Flow\ObjectManagement`, which is on `Compiler::$excludedSubPackages` and therefore has no DI proxy at runtime. The `afterInvokeStep` handler resolves the instance via `ObjectManager::get()` and invokes the inject* setters manually — this mirrors the pattern used for other early-boot services and is required for the call to work.
I'm not a big fan of how that looks, if anyone has another idea how to handle that, I'd be happy to change that part of the code.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
