### PR TITLE
BUGFIX: Check foreign keys explicit before removal

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: neos
         ports:
           - "3307:3306"
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
 
       mysql80:
         image: mysql:8.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: build
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master, '[0-9]+.[0-9]' ]
   pull_request:
@@ -13,7 +14,7 @@ jobs:
       contents: read # to fetch code (actions/checkout)
 
     if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip travis]')"
-    name: "PHP ${{ matrix.php-versions }} Test ${{ matrix.static-analysis != 'no' && 'static analysis ' || '' }}(deps: ${{ matrix.dependencies }})"
+    name: "PHP ${{ matrix.php-versions }} Test ${{ matrix.static-analysis != 'no' && 'static analysis ' || '' }}(deps: ${{ matrix.dependencies }}, mysqlport: ${{ matrix.mysqlport }})"
 
     continue-on-error: ${{ matrix.experimental == 'true' || matrix.experimental == true }}
 
@@ -21,41 +22,116 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
-        # see https://mariadb.com/kb/en/mariadb-server-release-dates/
-        # this should be a current release, e.g. the LTS version
-        mariadb-versions: ['11.8']
-        # see https://www.postgresql.org/support/versioning/
-        # this should be a current release
-        postgresql-versions: ['14-alpine']
         dependencies: ['highest']
         composer-arguments: [''] # to run --ignore-platform-reqs in experimental builds
         static-analysis: ['no']
         experimental: [false]
+        mysqlport: [3306]
+        pgsqlport: [5432]
         include:
           - php-versions: '8.0'
-            mariadb-versions: '' # skip mariadb setup
-            postgresql-versions: '' # skip postgresql setup
+            mysqlport: false # skip mariadb setup
+            psqlport: false # skip postgresql setup
             static-analysis: 'yes'
             experimental: true
             dependencies: 'highest'
 
           - php-versions: '8.5'
-            mariadb-versions: '12.2'
-            postgresql-versions: '18-alpine'
+            mysqlport: 3307
+            pgsqlport: 5433
             static-analysis: 'no'
             experimental: true
             dependencies: 'highest'
 
           # Build for minimum dependencies.
           - php-versions: '8.0'
-            mariadb-versions: '10.2'
-            postgresql-versions: '10-alpine'
+            mysqlport: 3306
+            pgsqlport: 5432
             static-analysis: 'no'
             experimental: false
             dependencies: 'lowest'
 
+          # MySQL
+          - php-versions: '8.4'
+            mysqlport: 3316
+            pgsqlport: false
+            static-analysis: 'no'
+            experimental: false
+            dependencies: 'highest'
+          - php-versions: '8.4'
+            mysqlport: 3317
+            pgsqlport: false
+            static-analysis: 'no'
+            experimental: false
+            dependencies: 'highest'
+
     runs-on: ubuntu-latest
     services:
+      mariadb10:
+        # see https://mariadb.com/kb/en/mariadb-server-release-dates/
+        # this should be a current release, e.g. the LTS version
+        image: mariadb:10.6
+        env:
+          MYSQL_USER: neos
+          MYSQL_PASSWORD: neos
+          MYSQL_DATABASE: flow_functional_testing
+          MYSQL_ROOT_PASSWORD: neos
+        ports:
+          - "3306:3306"
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      mariadb12:
+        # see https://mariadb.com/kb/en/mariadb-server-release-dates/
+        # this should be a current release, e.g. the LTS version
+        image: mariadb:12.2
+        env:
+          MYSQL_USER: neos
+          MYSQL_PASSWORD: neos
+          MYSQL_DATABASE: flow_functional_testing
+          MYSQL_ROOT_PASSWORD: neos
+        ports:
+          - "3307:3306"
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+      mysql80:
+        image: mysql:8.0
+        env:
+          MYSQL_USER: neos
+          MYSQL_PASSWORD: neos
+          MYSQL_DATABASE: flow_functional_testing
+          MYSQL_ROOT_PASSWORD: neos
+        ports:
+          - "3316:3306"
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      mysql84:
+        image: mysql:8.4
+        env:
+          MYSQL_USER: neos
+          MYSQL_PASSWORD: neos
+          MYSQL_DATABASE: flow_functional_testing
+          MYSQL_ROOT_PASSWORD: neos
+        ports:
+          - "3317:3306"
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      postgres14:
+        image: postgres:14-alpine
+        env:
+          POSTGRES_USER: neos
+          POSTGRES_PASSWORD: neos
+          POSTGRES_DB: flow_functional_testing
+        ports:
+          - "5432:5432"
+        options:  --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
+      postgres18:
+        # see https://www.postgresql.org/support/versioning/
+        # this should be a current release
+        image: postgres:18-alpine
+        env:
+          POSTGRES_USER: neos
+          POSTGRES_PASSWORD: neos
+          POSTGRES_DB: flow_functional_testing
+        ports:
+          - "5433:5432"
+        options:  --health-cmd=pg_isready --health-interval=10s --health-timeout=5s --health-retries=3
       redis:
         image: redis:alpine
         ports:
@@ -66,14 +142,6 @@ jobs:
         ports:
           - "11211:11211"
         # options: --health-cmd "timeout 5 bash -c 'cat < /dev/null > /dev/udp/127.0.0.1/11211'" --health-interval 10s --health-timeout 5s --health-retries 5
-      postgres:
-        image: ${{ ( matrix.postgresql-versions != '' ) && format('postgres:{0}', matrix.postgresql-versions) || '' }}
-        env:
-          POSTGRES_DB: flow_functional_testing
-          POSTGRES_USER: neos
-          POSTGRES_PASSWORD: neos
-        ports:
-          - 5432:5432
 
     env:
       FLOW_CONTEXT: Testing
@@ -101,15 +169,6 @@ jobs:
           extensions: mbstring, xml, json, zlib, iconv, intl, pdo_sqlite, mysql, pgsql, redis, memcached, memcache, apcu
           coverage: xdebug #optional
           ini-values: date.timezone="Africa/Tunis", opcache.fast_shutdown=0, apc.enable_cli=on
-
-      - name: Setup MariaDB ${{ matrix.mariadb-versions }}
-        if: ${{ matrix.mariadb-versions != '' }}
-        uses: getong/mariadb-action@v1.1
-        with:
-          mariadb version: ${{ matrix.mariadb-versions }}
-          collation server: 'utf8mb4_unicode_ci'
-          mysql database: 'flow_functional_testing'
-          mysql root password: 'neos'
 
       - name: Checkout development distribution
         uses: actions/checkout@v4
@@ -145,6 +204,7 @@ jobs:
         run: echo "FLOW_CONTEXT=${{ env.FLOW_CONTEXT }}" >> $GITHUB_ENV
 
       - name: Setup Flow configuration
+        if: ${{ matrix.mysqlport != false }}
         run: |
           rm -f Configuration/Routes.yaml
           rm -f Configuration/Testing/Settings.yaml
@@ -154,6 +214,7 @@ jobs:
               persistence:
                 backendOptions:
                   host: '127.0.0.1'
+                  port: ${{ matrix.mysqlport }}
                   driver: pdo_mysql
                   user: 'root'
                   password: 'neos'
@@ -175,11 +236,11 @@ jobs:
         run: composer test-unit -- --verbose
 
       - name: Run functional tests
-        if: matrix.static-analysis == 'no'
+        if: ${{ matrix.static-analysis == 'no' && matrix.mysqlport != false }}
         run: composer test-func -- --verbose
 
       - name: Run behat tests
-        if: ${{ matrix.static-analysis == 'no' && matrix.dependencies != 'lowest' }}
+        if: ${{ matrix.static-analysis == 'no' && matrix.dependencies != 'lowest' && matrix.mysqlport != false }}
         #if: env.BEHAT == true
         run: |
           FLOW_CONTEXT=Testing/Behat ./flow doctrine:migrate
@@ -187,6 +248,7 @@ jobs:
           bin/behat --stop-on-failure -f progress -c Packages/Framework/Neos.Flow/Tests/Behavior/behat.yml.dist
 
       - name: Setup Flow configuration (PGSQL)
+        if: ${{ matrix.pgsqlport != false }}
         run: |
           rm -f Configuration/Testing/Settings.yaml
           cat <<EOF >> Configuration/Testing/Settings.yaml
@@ -195,7 +257,7 @@ jobs:
               persistence:
                 backendOptions:
                   host: '127.0.0.1'
-                  port: 5432
+                  port:  ${{ matrix.pgsqlport }}
                   driver: pdo_pgsql
                   user: 'neos'
                   password: 'neos'
@@ -209,15 +271,15 @@ jobs:
           EOF
 
       - name: Run unit tests (PGSQL)
-        if: matrix.static-analysis == 'no'
+        if: ${{ matrix.static-analysis == 'no' && matrix.pgsqlport != false }}
         run: composer test-unit -- --verbose
 
       - name: Run functional tests (PGSQL)
-        if: matrix.static-analysis == 'no'
+        if: ${{ matrix.static-analysis == 'no' && matrix.pgsqlport != false }}
         run: composer test-func -- --verbose
 
       - name: Run behat tests (PGSQL)
-        if: ${{ matrix.static-analysis == 'no' && matrix.dependencies != 'lowest' }}
+        if: ${{ matrix.static-analysis == 'no' && matrix.dependencies != 'lowest' && matrix.pgsqlport != false }}
         #if: env.BEHAT == true
         run: |
           FLOW_CONTEXT=Testing/Behat ./flow doctrine:migrate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read # to fetch code (actions/checkout)
 
     if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip travis]')"
-    name: "PHP ${{ matrix.php-versions }} Test ${{ matrix.static-analysis != 'no' && 'static analysis ' || '' }}(deps: ${{ matrix.dependencies }}, mysqlport: ${{ matrix.mysqlport }})"
+    name: "PHP ${{ matrix.php-versions }} Test ${{ matrix.static-analysis != 'no' && 'static analysis ' || '' }}(deps: ${{ matrix.dependencies }}, mysql: ${{ matrix.mysqlport }}, pgsql: ${{ matrix.pgsqlport }})"
 
     continue-on-error: ${{ matrix.experimental == 'true' || matrix.experimental == true }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         include:
           - php-versions: '8.0'
             mysqlport: false # skip mariadb setup
-            psqlport: false # skip postgresql setup
+            pgsqlport: false # skip postgresql setup
             static-analysis: 'yes'
             experimental: true
             dependencies: 'highest'

--- a/Neos.Flow/Migrations/Mysql/Version20110824124835.php
+++ b/Neos.Flow/Migrations/Mysql/Version20110824124835.php
@@ -17,16 +17,21 @@ class Version20110824124835 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
+        // Explicitly normalize the FK constraint name after the table rename.
+        // Old MariaDB auto-renamed it (typo3_flow3_resource_resource_ibfk_1 already set); MariaDB 12+ does not (flow3_resource_resource_ibfk_1 still present).
+        // Drop before rename and re-add after
+        foreach ($this->sm->listTableForeignKeys('flow3_resource_resource') as $foreignKey) {
+            if (in_array('flow3_resource_resourcepointer', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE flow3_resource_resource DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
+
         $this->addSql("RENAME TABLE flow3_policy_role TO typo3_flow3_security_policy_role");
         $this->addSql("RENAME TABLE flow3_resource_resource TO typo3_flow3_resource_resource");
         $this->addSql("RENAME TABLE flow3_resource_resourcepointer TO typo3_flow3_resource_resourcepointer");
         $this->addSql("RENAME TABLE flow3_resource_securitypublishingconfiguration TO typo3_flow3_security_authorization_resource_securitypublis_6180a");
         $this->addSql("RENAME TABLE flow3_security_account TO typo3_flow3_security_account");
 
-        // Explicitly normalize the FK constraint name after the table rename.
-        // Old MariaDB auto-renamed it (typo3_flow3_resource_resource_ibfk_1 already set); MariaDB 12+ does not (flow3_resource_resource_ibfk_1 still present).
-        $this->addSql("ALTER TABLE typo3_flow3_resource_resource DROP FOREIGN KEY IF EXISTS flow3_resource_resource_ibfk_1");
-        $this->addSql("ALTER TABLE typo3_flow3_resource_resource DROP FOREIGN KEY IF EXISTS typo3_flow3_resource_resource_ibfk_1");
         $this->addSql("ALTER TABLE typo3_flow3_resource_resource ADD CONSTRAINT typo3_flow3_resource_resource_ibfk_1 FOREIGN KEY (flow3_resource_resourcepointer) REFERENCES typo3_flow3_resource_resourcepointer (hash)");
     }
 
@@ -38,15 +43,19 @@ class Version20110824124835 extends AbstractMigration
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
+        // Explicitly normalize the FK constraint name after the table rename back.
+        foreach ($this->sm->listTableForeignKeys('typo3_flow3_resource_resource') as $foreignKey) {
+            if (in_array('flow3_resource_resourcepointer', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_flow3_resource_resource DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
+
         $this->addSql("RENAME TABLE typo3_flow3_security_policy_role TO flow3_policy_role");
         $this->addSql("RENAME TABLE typo3_flow3_resource_resource TO flow3_resource_resource");
         $this->addSql("RENAME TABLE typo3_flow3_resource_resourcepointer TO flow3_resource_resourcepointer");
         $this->addSql("RENAME TABLE typo3_flow3_security_authorization_resource_securitypublis_6180a TO flow3_resource_securitypublishingconfiguration");
         $this->addSql("RENAME TABLE typo3_flow3_security_account TO flow3_security_account");
 
-        // Explicitly normalize the FK constraint name after the table rename back.
-        $this->addSql("ALTER TABLE flow3_resource_resource DROP FOREIGN KEY IF EXISTS typo3_flow3_resource_resource_ibfk_1");
-        $this->addSql("ALTER TABLE flow3_resource_resource DROP FOREIGN KEY IF EXISTS flow3_resource_resource_ibfk_1");
         $this->addSql("ALTER TABLE flow3_resource_resource ADD CONSTRAINT flow3_resource_resource_ibfk_1 FOREIGN KEY (flow3_resource_resourcepointer) REFERENCES flow3_resource_resourcepointer (hash)");
     }
 }

--- a/Neos.Flow/Migrations/Mysql/Version20120930203452.php
+++ b/Neos.Flow/Migrations/Mysql/Version20120930203452.php
@@ -51,6 +51,15 @@ class Version20120930203452 extends AbstractMigration
             $this->addSql($sql);
         }
 
+        // Explicitly normalize the FK constraint name after the table rename.
+        // Old MariaDB auto-renamed it (typo3_flow_resource_resource_ibfk_1 already set); MariaDB 12+ does not (typo3_flow3_resource_resource_ibfk_1 still present).
+        // Drop before rename and re-add after
+        foreach ($this->sm->listTableForeignKeys('typo3_flow3_resource_resource') as $foreignKey) {
+            if (in_array('resourcepointer', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_flow3_resource_resource DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
+
         // rename tables
         $this->addSql("RENAME TABLE typo3_flow3_mvc_routing_objectpathmapping TO typo3_flow_mvc_routing_objectpathmapping");
         $this->addSql("RENAME TABLE typo3_flow3_resource_publishing_abstractpublishingconfiguration TO typo3_flow_resource_publishing_abstractpublishingconfiguration");
@@ -60,10 +69,6 @@ class Version20120930203452 extends AbstractMigration
         $this->addSql("RENAME TABLE typo3_flow3_security_authorization_resource_securitypubli_6180a TO typo3_flow_security_authorization_resource_securitypublis_861cb");
         $this->addSql("RENAME TABLE typo3_flow3_security_policy_role TO typo3_flow_security_policy_role");
 
-        // Explicitly normalize the FK constraint name after the table rename.
-        // Old MariaDB auto-renamed it (typo3_flow_resource_resource_ibfk_1 already set); MariaDB 12+ does not (typo3_flow3_resource_resource_ibfk_1 still present).
-        $this->addSql("ALTER TABLE typo3_flow_resource_resource DROP FOREIGN KEY IF EXISTS typo3_flow3_resource_resource_ibfk_1");
-        $this->addSql("ALTER TABLE typo3_flow_resource_resource DROP FOREIGN KEY IF EXISTS typo3_flow_resource_resource_ibfk_1");
         $this->addSql("ALTER TABLE typo3_flow_resource_resource ADD CONSTRAINT typo3_flow_resource_resource_ibfk_1 FOREIGN KEY (resourcepointer) REFERENCES typo3_flow_resource_resourcepointer (hash)");
     }
 
@@ -108,6 +113,13 @@ class Version20120930203452 extends AbstractMigration
             $this->addSql($sql);
         }
 
+        // Explicitly normalize the FK constraint name after the table rename back.
+        foreach ($this->sm->listTableForeignKeys('typo3_flow_resource_resource') as $foreignKey) {
+            if (in_array('resourcepointer', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                $this->addSql("ALTER TABLE typo3_flow_resource_resource DROP FOREIGN KEY " . $foreignKey->getName());
+            }
+        }
+
         // rename tables
         $this->addSql("RENAME TABLE typo3_flow_mvc_routing_objectpathmapping TO typo3_flow3_mvc_routing_objectpathmapping");
         $this->addSql("RENAME TABLE typo3_flow_resource_publishing_abstractpublishingconfiguration TO typo3_flow3_resource_publishing_abstractpublishingconfiguration");
@@ -117,9 +129,6 @@ class Version20120930203452 extends AbstractMigration
         $this->addSql("RENAME TABLE typo3_flow_security_authorization_resource_securitypublis_861cb TO typo3_flow3_security_authorization_resource_securitypubli_6180a");
         $this->addSql("RENAME TABLE typo3_flow_security_policy_role TO typo3_flow3_security_policy_role");
 
-        // Explicitly normalize the FK constraint name after the table rename back.
-        $this->addSql("ALTER TABLE typo3_flow3_resource_resource DROP FOREIGN KEY IF EXISTS typo3_flow_resource_resource_ibfk_1");
-        $this->addSql("ALTER TABLE typo3_flow3_resource_resource DROP FOREIGN KEY IF EXISTS typo3_flow3_resource_resource_ibfk_1");
         $this->addSql("ALTER TABLE typo3_flow3_resource_resource ADD CONSTRAINT typo3_flow3_resource_resource_ibfk_1 FOREIGN KEY (resourcepointer) REFERENCES typo3_flow3_resource_resourcepointer (hash)");
     }
 }


### PR DESCRIPTION
After fixing #3543 we introduced an incompatibility with MySQL 8.x. This replaces the proprietary "IF EXISTS" with explit check of FK existence to be compatible with both databases.

It also added the MySQL database to the ci pipeline.