### PR TITLE
BUGFIX: Context aware path mapping for xdebug

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Proxy/XdebugPathMappingBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/XdebugPathMappingBuilder.php
@@ -52,7 +52,7 @@ class XdebugPathMappingBuilder
      * @param string|null $flowContextName
      * @return void
      */
-    public function buildFromCompiledClasses(array $compiledClasses, ?string $flowContextName = null): void
+    public function buildFromCompiledClasses(array $compiledClasses, string $flowContextName): void
     {
         if ($compiledClasses === []) {
             return;
@@ -90,7 +90,7 @@ class XdebugPathMappingBuilder
         $mappingFileLines[] = '';
 
         Files::createDirectoryRecursively($this->getXdebugMappingFilePath());
-        $mappingFileName = $flowContextName !== null ? sprintf("%s.flow.map", str_replace("/", "_", $flowContextName)) : 'flow.map';
+        $mappingFileName = sprintf("%s.flow.map", str_replace("/", "_", $flowContextName));
         file_put_contents(
             Files::concatenatePaths([$this->getXdebugMappingFilePath(), $mappingFileName]),
             implode("\n", $mappingFileLines)

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/XdebugPathMappingBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/XdebugPathMappingBuilder.php
@@ -49,9 +49,10 @@ class XdebugPathMappingBuilder
 
     /**
      * @param array<string, array{path: string, proxyClassIdentifier: string}> $compiledClasses
+     * @param string|null $flowContextName
      * @return void
      */
-    public function buildFromCompiledClasses(array $compiledClasses): void
+    public function buildFromCompiledClasses(array $compiledClasses, ?string $flowContextName = null): void
     {
         if ($compiledClasses === []) {
             return;
@@ -89,8 +90,9 @@ class XdebugPathMappingBuilder
         $mappingFileLines[] = '';
 
         Files::createDirectoryRecursively($this->getXdebugMappingFilePath());
+        $mappingFileName = $flowContextName !== null ? sprintf("%s.flow.map", str_replace("/", "_", $flowContextName)) : 'flow.map';
         file_put_contents(
-            Files::concatenatePaths([$this->getXdebugMappingFilePath(), 'flow.map']),
+            Files::concatenatePaths([$this->getXdebugMappingFilePath(), $mappingFileName]),
             implode("\n", $mappingFileLines)
         );
     }

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/XdebugPathMappingBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/XdebugPathMappingBuilder.php
@@ -49,7 +49,7 @@ class XdebugPathMappingBuilder
 
     /**
      * @param array<string, array{path: string, proxyClassIdentifier: string}> $compiledClasses
-     * @param string|null $flowContextName
+     * @param string $flowContextName
      * @return void
      */
     public function buildFromCompiledClasses(array $compiledClasses, string $flowContextName): void

--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -158,7 +158,10 @@ class Package extends BasePackage
         $dispatcher->connect(AuthenticationProviderManager::class, 'successfullyAuthenticated', Context::class, 'refreshRoles');
         $dispatcher->connect(AuthenticationProviderManager::class, 'loggedOut', Context::class, 'refreshTokens');
 
-        $dispatcher->connect(Compiler::class, 'afterCompile', XdebugPathMappingBuilder::class, 'buildFromCompiledClasses');
+        $dispatcher->connect(Compiler::class, 'afterCompile', function (array $compiledClasses) use ($bootstrap) {
+            $xdebugPathMappingBuilder = $bootstrap->getObjectManager()->get(XdebugPathMappingBuilder::class);
+            $xdebugPathMappingBuilder->buildFromCompiledClasses($compiledClasses, (string) $bootstrap->getContext());
+        });
         $dispatcher->connect(Compiler::class, 'afterCompile', function (array $compiledClasses) use ($bootstrap) {
             $annotationsCacheFlusher = $bootstrap->getObjectManager()->get(AnnotationsCacheFlusher::class);
             $annotationsCacheFlusher->flushConfigurationCachesByCompiledClass(array_keys($compiledClasses));


### PR DESCRIPTION
This PR generates the mapping files per FlowContext. This ensures the mapping works even after context switching.

Replaces #3562