### PR TITLE
TASK: Use migrations in pipeline and fixed migrations for MariaDB 12.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,6 +156,9 @@ jobs:
           working-directory: ${{ env.FLOW_DIST_FOLDER }}
           flow-context: ${{ env.FLOW_CONTEXT }}
 
+      - name: Run migrations to test if they work
+        run: FLOW_CONTEXT=Testing ./flow doctrine:migrate
+
       - name: Run functional tests
         run: composer test-func -- --verbose
 

--- a/Neos.Flow/Migrations/Mysql/Version20110923125535.php
+++ b/Neos.Flow/Migrations/Mysql/Version20110923125535.php
@@ -24,7 +24,11 @@ class Version20110923125535 extends AbstractMigration
         $this->addSql("CREATE INDEX IDX_B4D45B323CB65D1 ON typo3_flow3_resource_resource (resourcepointer)");
 
         if ($this->isPartyPackageInstalled()) {
-            $this->addSql("ALTER TABLE typo3_flow3_security_account DROP FOREIGN KEY typo3_flow3_security_account_ibfk_1");
+            foreach ($this->sm->listTableForeignKeys('typo3_flow3_security_account') as $foreignKey) {
+                if (in_array('party_abstractparty', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                    $this->addSql("ALTER TABLE typo3_flow3_security_account DROP FOREIGN KEY " . $foreignKey->getName());
+                }
+            }
             $this->addSql("DROP INDEX IDX_44D0753B38110E12 ON typo3_flow3_security_account");
         }
         $this->addSql("ALTER TABLE typo3_flow3_security_account CHANGE party_abstractparty party VARCHAR(40) DEFAULT NULL");
@@ -49,7 +53,11 @@ class Version20110923125535 extends AbstractMigration
         $this->addSql("CREATE INDEX IDX_11FFD19FD0275681 ON typo3_flow3_resource_resource (flow3_resource_resourcepointer)");
 
         if ($this->isPartyPackageInstalled()) {
-            $this->addSql("ALTER TABLE typo3_flow3_security_account DROP FOREIGN KEY typo3_flow3_security_account_ibfk_1");
+            foreach ($this->sm->listTableForeignKeys('typo3_flow3_security_account') as $foreignKey) {
+                if (in_array('party', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                    $this->addSql("ALTER TABLE typo3_flow3_security_account DROP FOREIGN KEY " . $foreignKey->getName());
+                }
+            }
             $this->addSql("DROP INDEX IDX_65EFB31C89954EE0 ON typo3_flow3_security_account");
         }
         $this->addSql("ALTER TABLE typo3_flow3_security_account CHANGE party party_abstractparty VARCHAR(40) DEFAULT NULL");

--- a/Neos.Flow/Migrations/Mysql/Version20150206114820.php
+++ b/Neos.Flow/Migrations/Mysql/Version20150206114820.php
@@ -21,7 +21,11 @@ class Version20150206114820 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
 
         if ($this->isPartyPackageInstalled()) {
-            $this->addSql("ALTER TABLE typo3_flow_security_account DROP FOREIGN KEY typo3_flow_security_account_ibfk_1");
+            foreach ($this->sm->listTableForeignKeys('typo3_flow_security_account') as $foreignKey) {
+                if (in_array('party', array_map('strtolower', $foreignKey->getLocalColumns()), true)) {
+                    $this->addSql("ALTER TABLE typo3_flow_security_account DROP FOREIGN KEY " . $foreignKey->getName());
+                }
+            }
             $indexes = $this->sm->listTableIndexes('typo3_flow_security_account');
             if (array_key_exists('idx_65efb31c89954ee0', $indexes)) {
                 $this->addSql("DROP INDEX IDX_65EFB31C89954EE0 ON typo3_flow_security_account");


### PR DESCRIPTION
**What I did**

Some old Flow migrations dropped foreign keys by their hardcoded auto-generated names (e.g. `..._ibfk_1`). These names are no longer reliable: on MariaDB 12+, renaming a table no longer renames its auto-generated foreign key/index names along with it, so the constraint names the migrations expect may not exist and the migrations fail.

Instead of relying on hardcoded constraint names, the affected migrations now look up the actual foreign keys on the table via the schema manager and drop the one defined on the relevant column. This works regardless of what the constraint is actually named, making the migrations compatible with MySQL, MariaDB < 12 and MariaDB ≥ 12 alike.

**Why the CI change**

Until now this breakage went unnoticed because the pipeline never executed the Doctrine migrations. The build workflow now runs `./flow doctrine:migrate` before the functional tests, so the full migration chain is verified on every build.