### PR TITLE
BUGFIX: Allow encryptionkey to be empty in schema validation

### DIFF
--- a/Neos.Flow/Configuration/Settings.Security.yaml
+++ b/Neos.Flow/Configuration/Settings.Security.yaml
@@ -100,7 +100,7 @@ Neos:
 
         # A private, unique key used for encryption tasks. Normally 40 characters long and received from a persistent
         # filesystem cache. If set to a non-empty string, the cache is not involved anymore.
-        encryptionKey: null
+        encryptionKey: ''
 
         hashingStrategies:
 


### PR DESCRIPTION
Fixes validation issues in pipeline due to #3426 