### PR TITLE
TASK: Fix typos in documentation and some strings

### DIFF
--- a/Neos.Cache/Readme.md
+++ b/Neos.Cache/Readme.md
@@ -2,7 +2,7 @@
 
 This is a generic cache package for use in projects.
 It implements [PSR-6](https://github.com/php-fig/cache) and [PSR-16](https://github.com/php-fig/simple-cache) but 
-also brings own interfaces used in Flow and Neos which support additional featuers.
+also brings own interfaces used in Flow and Neos which support additional features.
 
 #### Note
 

--- a/Neos.Eel/Classes/Helper/ArrayHelper.php
+++ b/Neos.Eel/Classes/Helper/ArrayHelper.php
@@ -18,7 +18,7 @@ use Neos\Eel\ProtectedContextAwareInterface;
 /**
  * Array helpers for Eel contexts
  *
- * The implementation uses the JavaScript specificiation where applicable, including EcmaScript 6 proposals.
+ * The implementation uses the JavaScript specification where applicable, including EcmaScript 6 proposals.
  *
  * See https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array for a documentation and
  * specification of the JavaScript implementation.
@@ -575,7 +575,7 @@ class ArrayHelper implements ProtectedContextAwareInterface
     }
 
     /**
-     * Check if at least one element in an array passes a test given by the calback,
+     * Check if at least one element in an array passes a test given by the callback,
      * passing each element and key as arguments
      *
      * Example::
@@ -598,7 +598,7 @@ class ArrayHelper implements ProtectedContextAwareInterface
     }
 
     /**
-     * Check if all elements in an array pass a test given by the calback,
+     * Check if all elements in an array pass a test given by the callback,
      * passing each element and key as arguments
      *
      * Example::

--- a/Neos.Eel/Classes/Helper/ArrayHelper.php
+++ b/Neos.Eel/Classes/Helper/ArrayHelper.php
@@ -483,7 +483,7 @@ class ArrayHelper implements ProtectedContextAwareInterface
     }
 
     /**
-     * Set the specified key in the the array
+     * Set the specified key in the array
      *
      * @param iterable $array
      * @param string|integer $key the key that should be set

--- a/Neos.Eel/Classes/Helper/MathHelper.php
+++ b/Neos.Eel/Classes/Helper/MathHelper.php
@@ -17,7 +17,7 @@ use Neos\Eel\ProtectedContextAwareInterface;
 /**
  * Math helpers for Eel contexts
  *
- * The implementation sticks to the JavaScript specificiation including EcmaScript 6 proposals.
+ * The implementation sticks to the JavaScript specification including EcmaScript 6 proposals.
  *
  * See https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math for a documentation and
  * specification of the JavaScript implementation.
@@ -367,7 +367,7 @@ class MathHelper implements ProtectedContextAwareInterface
     }
 
     /**
-     * Get a random foating point number between 0 (inclusive) and 1 (exclusive)
+     * Get a random floating point number between 0 (inclusive) and 1 (exclusive)
      *
      * That means a result will always be less than 1 and greater or equal to 0, the same way Math.random() works in
      * JavaScript.

--- a/Neos.Flow/Classes/Command/SchemaCommandController.php
+++ b/Neos.Flow/Classes/Command/SchemaCommandController.php
@@ -39,7 +39,7 @@ class SchemaCommandController extends CommandController
     protected $packageManager;
 
     /**
-     * Validate the given configurationfile againt a schema file
+     * Validate the given configuration file against a schema file
      *
      * @param string $configurationFile path to the validated configuration file
      * @param string $schemaFile path to the schema file

--- a/Neos.Flow/Classes/Command/SessionCommandController.php
+++ b/Neos.Flow/Classes/Command/SessionCommandController.php
@@ -73,8 +73,8 @@ class SessionCommandController extends CommandController
     }
 
     /**
-     * Run garbage collection for sesions.
-     * This command will remove session-data and -metadate of outdated sessions
+     * Run garbage collection for sessions.
+     * This command will remove session-data and -metadata of outdated sessions
      * identified by lastActivityTimestamp being older than inactivityTimeout
      *
      * !!! This is usually done automatically after shutdown for the percentage

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -885,7 +885,7 @@ class Scripts
         // if the configured PHP binary is empty here, the file does not exist.
         if ($configuredPhpBinaryPathAndFilename === false || strlen($configuredPhpBinaryPathAndFilename) === 0) {
             throw new Exception\SubProcessException(
-                sprintf('The configured PHP binary "%s" via setting the "Neos.Flow.core.phpBinaryPathAndFilename" doesnt exist.', $phpBinaryPathAndFilename),
+                sprintf('The configured PHP binary "%s" via setting the "Neos.Flow.core.phpBinaryPathAndFilename" doesn\'t exist.', $phpBinaryPathAndFilename),
                 1689676923331
             );
         }
@@ -964,7 +964,7 @@ class Scripts
         if (!$versionsAlmostEqual($phpInformation['version'], PHP_VERSION)) {
             throw new FlowException(sprintf(
                 'You are executing Neos/Flow with a PHP version different from the one Flow is configured to use internally. ' .
-                'Flow is running with with PHP "%s", while the PHP version Flow is configured to use for subrequests is "%s". Make sure to configure Flow to ' .
+                'Flow is running with PHP "%s", while the PHP version Flow is configured to use for subrequests is "%s". Make sure to configure Flow to ' .
                 'use the same PHP version by setting the "Neos.Flow.core.phpBinaryPathAndFilename" configuration option to a PHP-CLI binary of the version ' .
                 '%s. Flush the caches by removing the folder Data/Temporary before executing Flow/Neos again.',
                 PHP_VERSION,

--- a/Neos.Flow/Classes/Core/Booting/Scripts.php
+++ b/Neos.Flow/Classes/Core/Booting/Scripts.php
@@ -101,7 +101,7 @@ class Scripts
 
     /**
      * Register the class loader into the Doctrine AnnotationRegistry so
-     * the DocParser is able to load annation classes from packages.
+     * the DocParser is able to load annotation classes from packages.
      *
      * @param Bootstrap $bootstrap
      * @return void

--- a/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
+++ b/Neos.Flow/Classes/Http/Client/InternalRequestEngine.php
@@ -126,12 +126,12 @@ class InternalRequestEngine implements RequestEngineInterface
         }
 
         $requestHandler = $this->bootstrap->getActiveRequestHandler();
-        /** @phpstan-ignore-next-line composer doesnt autoload this class */
+        /** @phpstan-ignore-next-line composer doesn't autoload this class */
         if (!$requestHandler instanceof FunctionalTestRequestHandler) {
             throw new Http\Exception('The browser\'s internal request engine has only been designed for use within functional tests.', 1335523749);
         }
 
-        /** @phpstan-ignore-next-line composer doesnt autoload this class */
+        /** @phpstan-ignore-next-line composer doesn't autoload this class */
         $requestHandler->setHttpRequest($httpRequest);
         $this->securityContext->clearContext();
         $this->validatorResolver->reset();
@@ -143,7 +143,7 @@ class InternalRequestEngine implements RequestEngineInterface
          */
         $middlewaresChain = $objectManager->get(Http\Middleware\MiddlewaresChain::class);
         $middlewaresChain->onStep(function (ServerRequestInterface $request) use ($requestHandler) {
-            /** @phpstan-ignore-next-line composer doesnt autoload this class */
+            /** @phpstan-ignore-next-line composer doesn't autoload this class */
             $requestHandler->setHttpRequest($request);
         });
 

--- a/Neos.Flow/Classes/I18n/Locale.php
+++ b/Neos.Flow/Classes/I18n/Locale.php
@@ -74,7 +74,7 @@ class Locale
     protected $region = null;
 
     /**
-     * The optional variant identifier - one of the registered registered variants according to BCP47
+     * The optional variant identifier - one of the registered variants according to BCP47
      *
      * @var string
      * @see http://rfc.net/bcp47.html

--- a/Neos.Flow/Classes/ObjectManagement/CompileTimeObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/CompileTimeObjectManager.php
@@ -117,7 +117,7 @@ class CompileTimeObjectManager extends ObjectManager
     }
 
     /**
-     * Initializes the the object configurations and some other parts of this Object Manager.
+     * Initializes the object configurations and some other parts of this Object Manager.
      *
      * @param PackageInterface[] $packages An array of active packages to consider
      * @return void

--- a/Neos.Flow/Classes/Package.php
+++ b/Neos.Flow/Classes/Package.php
@@ -56,7 +56,7 @@ class Package extends BasePackage
         }
 
         if ($context->isTesting()) {
-            /** @phpstan-ignore-next-line composer doesnt autoload this class */
+            /** @phpstan-ignore-next-line composer doesn't autoload this class */
             $bootstrap->registerRequestHandler(new Tests\FunctionalTestRequestHandler($bootstrap));
         }
 
@@ -136,7 +136,7 @@ class Package extends BasePackage
             }
         });
 
-        /** @phpstan-ignore-next-line composer doesnt autoload this class */
+        /** @phpstan-ignore-next-line composer doesn't autoload this class */
         $dispatcher->connect(Tests\FunctionalTestCase::class, 'functionalTestTearDown', Mvc\Routing\RouterCachingService::class, 'flushCaches');
 
         $dispatcher->connect(Configuration\ConfigurationManager::class, 'configurationManagerReady', function (Configuration\ConfigurationManager $configurationManager) {

--- a/Neos.Flow/Classes/Persistence/Doctrine/Repository.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Repository.php
@@ -254,7 +254,7 @@ abstract class Repository extends EntityRepository implements RepositoryInterfac
      *  'bar' => \Neos\Flow\Persistence\QueryInterface::ORDER_DESCENDING
      * )
      *
-     * @param array $defaultOrderings The property names to order by by default
+     * @param array $defaultOrderings The property names to order by default
      * @return void
      * @api
      */

--- a/Neos.Flow/Classes/Persistence/Doctrine/Repository.php
+++ b/Neos.Flow/Classes/Persistence/Doctrine/Repository.php
@@ -254,7 +254,7 @@ abstract class Repository extends EntityRepository implements RepositoryInterfac
      *  'bar' => \Neos\Flow\Persistence\QueryInterface::ORDER_DESCENDING
      * )
      *
-     * @param array $defaultOrderings The property names to order by default
+     * @param array $defaultOrderings The property names to "order by" by default
      * @return void
      * @api
      */

--- a/Neos.Flow/Classes/Persistence/Repository.php
+++ b/Neos.Flow/Classes/Persistence/Repository.php
@@ -174,7 +174,7 @@ abstract class Repository implements RepositoryInterface
      *  'bar' => \Neos\Flow\Persistence\QueryInterface::ORDER_DESCENDING
      * )
      *
-     * @param array $defaultOrderings The property names to order by default
+     * @param array $defaultOrderings The property names to "order by" by default
      * @return void
      * @api
      */

--- a/Neos.Flow/Classes/Persistence/Repository.php
+++ b/Neos.Flow/Classes/Persistence/Repository.php
@@ -174,7 +174,7 @@ abstract class Repository implements RepositoryInterface
      *  'bar' => \Neos\Flow\Persistence\QueryInterface::ORDER_DESCENDING
      * )
      *
-     * @param array $defaultOrderings The property names to order by by default
+     * @param array $defaultOrderings The property names to order by default
      * @return void
      * @api
      */

--- a/Neos.Flow/Classes/Persistence/RepositoryInterface.php
+++ b/Neos.Flow/Classes/Persistence/RepositoryInterface.php
@@ -93,7 +93,7 @@ interface RepositoryInterface
      *  'bar' => \Neos\Flow\Persistence\QueryInterface::ORDER_DESCENDING
      * )
      *
-     * @param array $defaultOrderings The property names to order by by default
+     * @param array $defaultOrderings The property names to order by default
      * @return void
      * @api
      */

--- a/Neos.Flow/Classes/Persistence/RepositoryInterface.php
+++ b/Neos.Flow/Classes/Persistence/RepositoryInterface.php
@@ -93,7 +93,7 @@ interface RepositoryInterface
      *  'bar' => \Neos\Flow\Persistence\QueryInterface::ORDER_DESCENDING
      * )
      *
-     * @param array $defaultOrderings The property names to order by default
+     * @param array $defaultOrderings The property names to "order by" by default
      * @return void
      * @api
      */

--- a/Neos.Flow/Classes/Property/TypeConverter/ArrayConverter.php
+++ b/Neos.Flow/Classes/Property/TypeConverter/ArrayConverter.php
@@ -22,7 +22,7 @@ use Neos\Flow\ResourceManagement\PersistentResource;
  * Converter which transforms various types to arrays.
  *
  * * If the source is an array, it is returned unchanged.
- * * If the source is a string, is is converted depending on CONFIGURATION_STRING_FORMAT,
+ * * If the source is a string, it is converted depending on CONFIGURATION_STRING_FORMAT,
  *   which can be STRING_FORMAT_CSV or STRING_FORMAT_JSON. For CSV the delimiter can be
  *   set via CONFIGURATION_STRING_DELIMITER.
  * * If the source is a PersistentResource object, it is converted to an array. The actual resource

--- a/Neos.Flow/Classes/Security/Authentication/Token/AbstractToken.php
+++ b/Neos.Flow/Classes/Security/Authentication/Token/AbstractToken.php
@@ -97,7 +97,7 @@ abstract class AbstractToken implements TokenInterface
     /**
      * Returns true if this token is currently authenticated
      *
-     * @return boolean true if this this token is currently authenticated
+     * @return boolean true if this token is currently authenticated
      */
     public function isAuthenticated()
     {

--- a/Neos.Flow/Classes/Security/Authentication/TokenInterface.php
+++ b/Neos.Flow/Classes/Security/Authentication/TokenInterface.php
@@ -58,7 +58,7 @@ interface TokenInterface
     /**
      * Returns true if this token is currently authenticated
      *
-     * @return boolean true if this this token is currently authenticated
+     * @return boolean true if this token is currently authenticated
      */
     public function isAuthenticated();
 

--- a/Neos.Flow/Documentation/StyleGuide/StyleAndUsage.rst
+++ b/Neos.Flow/Documentation/StyleGuide/StyleAndUsage.rst
@@ -143,7 +143,7 @@ Capitalize:
 Command Line
 ------------
 
-Write as two separate words when referring to the noun and use the hypenated form ``command-line``
+Write as two separate words when referring to the noun and use the hyphenated form ``command-line``
 for and adjective.
 
 Commas
@@ -204,6 +204,6 @@ dash with the word (or number) before it and the word (or number) after it.
 Kickstarter
 -----------
 
-A small application provided by the Kickstart paackage, which generates scaffolding for packages,
+A small application provided by the Kickstart package, which generates scaffolding for packages,
 models, controllers and more.
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartI/ConceptsOfModernProgramming.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartI/ConceptsOfModernProgramming.rst
@@ -375,7 +375,7 @@ sure that each entity is only once in memory.
 Despite the object being created and retrieved multiple times
 during its lifecycle, it logically continues to exist, even when it is
 stored in the database. It is only because of performance and safety
-reasons that is is not stored in main memory, but in a database. Thus,
+reasons that it is not stored in main memory, but in a database. Thus,
 Domain-Driven Design distinguishes *creation* of an
 object from *reconstitution* from database: In the
 first case, the constructor is called, in the second case the

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartI/EssentialDesignPatterns.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartI/EssentialDesignPatterns.rst
@@ -51,7 +51,7 @@ Dependency Injection
 In AOP there is focus on building reusable components that can be wired together
 to create a cohesive architecture. This goal becomes increasingly difficult
 because as the size and complexity of an application expands, so does its
-dependencies. One technique to aliviate dependency management is through
+dependencies. One technique to alleviate dependency management is through
 Dependency Injection (DI).
 
 Dependency Injection (DI) is a technique by which a package can request and gain
@@ -60,7 +60,7 @@ service provided within a framework to instantiate and provide access to
 package interfaces upon request.
 
 DI enables a package to control what dependencies it requires while allowing the
-framework or another third party system to handle the fullfillment of each
+framework or another third party system to handle the fulfillment of each
 dependency. This is know as Inversion of Control (IoC). IoC delegates the
 responsibility of dependency resolution to the framework while each package
 specifies which dependencies it needs.

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartII/Installation.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartII/Installation.rst
@@ -181,7 +181,7 @@ Configure AllowOverride and MultiViews
 --------------------------------------
 
 Because Flow provides an ``.htaccess`` file with ``mod_rewrite`` rules in it,
-you need to make sure that the directory grants the neccessary rights:
+you need to make sure that the directory grants the necessary rights:
 
 *httpd.conf*:
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartII/View.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartII/View.rst
@@ -255,7 +255,7 @@ one template and omit the ``<f:layout>`` and ``<f:section>`` tags.
 The main job of this template is to display a list of the most recent posts.
 An ``<f:if>`` condition makes sure that the list of posts is only rendered if
 ``blog`` actually contains posts. But currently the view doesn't know anything
-about a blog - you need to adapt the the ``PostController`` to assign the current blog::
+about a blog - you need to adapt the ``PostController`` to assign the current blog::
 
 *Classes/Acme/Blog/Controller/PostController.php*:
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/AspectOrientedProgramming.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/AspectOrientedProgramming.rst
@@ -169,7 +169,7 @@ Pointcut expression
 	pointcut- and advice declarations.
 
 Target
-	A class or method being adviced by one or more aspects is referred to as a
+	A class or method being advised by one or more aspects is referred to as a
 	target class /-method.
 
 Introduction
@@ -192,7 +192,7 @@ After returning advice
 	exception, the after returning advice is not executed.
 
 After throwing advice
-	An after throwing advice is only executed if the target method throwed an
+	An after throwing advice is only executed if the target method threw an
 	exception. The after throwing advice may fetch the exception type from the
 	join point object.
 
@@ -250,10 +250,10 @@ Manager to fulfill its task.
 Flow uses PHP's reflection capabilities to analyze declarations of aspects,
 pointcuts and advices and implements method interceptors as a dynamic proxy. In
 accordance to the GoF patterns [#]_, the proxy classes act as a placeholders for
-the target object. They are true subclasses of the original and override adviced
+the target object. They are true subclasses of the original and override advised
 methods by implementing an interceptor method. The proxy classes are generated
 automatically by the AOP framework and cached for further use. If a class has
-been adviced by some aspect, the Object Manager will only deliver instances of
+been advised by some aspect, the Object Manager will only deliver instances of
 the proxy class instead of the original.
 
 The approach of storing generated proxy classes in files provides the whole
@@ -344,7 +344,7 @@ the pointcut matches and advices which refer to this pointcut become active.
 Pointcut designators
 --------------------
 
-A pointcut expression always consists of two parts: The poincut designator and
+A pointcut expression always consists of two parts: The pointcut designator and
 its parameter(s). The following designators are supported by Flow:
 
 method()
@@ -720,7 +720,7 @@ advices may read the result of the target method, but can't modify it.
 	/**
 	 * After returning advice
 	 *
-	 * @Flow\AfterReturning("method(public Example\News\FeedAgregator->[import|update].*()) || Example\MyPackage\MyAspect->someOtherPointcut")
+	 * @Flow\AfterReturning("method(public Example\News\FeedAggregator->[import|update].*()) || Example\MyPackage\MyAspect->someOtherPointcut")
 	 */
 	public function myAfterReturningAdvice(\Neos\Flow\AOP\JoinPointInterface $joinPoint): void
 	{

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Caching.rst
@@ -89,7 +89,7 @@ If entry two is changed, a simple backend logic could be created, which drops al
 entries tagged with "news_2", in this case the first entry would be invalidated while the
 second entry still exists in the cache after the operation. While there is always exactly
 one identifier for each cache entry, an arbitrary number of tags can be assigned to an
-entry and one specific tag can be assigned to mulitple cache entries. All tags a cache
+entry and one specific tag can be assigned to multiple cache entries. All tags a cache
 entry has are given to the cache when the entry is stored (set).
 
 System Architecture
@@ -459,7 +459,7 @@ to clean up hard disk space or memory.
 	This backend is php-capable. Nevertheless it cannot be used to store the proxy-classes
 	from the ``Flow_Object_Classes`` Cache. It can be used for other code-caches like
 	``Fluid_TemplateCache``, ``Eel_Expression_Code`` or ``Flow_Aop_RuntimeExpressions``.
-	This can be usefull in certain situations to avoid file operations on production
+	This can be useful in certain situations to avoid file operations on production
 	environments. If you want to use this backend for code-caching make sure that
 	``allow_url_include`` is enabled in php.ini
 
@@ -539,7 +539,7 @@ system. It is recommended to build this from the git repository. Currently redis
 	This backend is php-capable. Nevertheless it cannot be used to store the proxy-classes
 	from the ``FLOW_Object_Classes`` Cache. It can be used for other code-caches like
 	``Fluid_TemplateCache``, ``Eel_Expression_Code`` or ``Flow_Aop_RuntimeExpressions``.
-	This can be usefull in certain situations to avoid file operations on production
+	This can be useful in certain situations to avoid file operations on production
 	environments. If you want to use this backend for code-caching make sure that
 	``allow_url_include`` is enabled in php.ini
 
@@ -615,7 +615,7 @@ Both cases lead to corrupted caches: If, for example, a tags-to-identifier entry
 which should be removed and they will not be deleted. This results in old data delivered
 by the cache. Additionally, there is currently no implementation of the garbage collection
 which can rebuild cache integrity. It is thus important to monitor a memcached system for
-evictions and server outages and to clear clear caches if that happens.
+evictions and server outages and to clear caches if that happens.
 
 Furthermore memcache has no sort of namespacing. To distinguish entries of multiple caches
 from each other, every entry is prefixed with the cache name. This can lead to very long
@@ -645,7 +645,7 @@ all.
 	This backend is php-capable. Nevertheless it cannot be used to store the proxy-classes
 	from the ``FLOW_Object_Classes`` Cache. It can be used for other code-caches like
 	``Fluid_TemplateCache``, ``Eel_Expression_Code`` or ``Flow_Aop_RuntimeExpressions``.
-	This can be usefull in certain situations to avoid file operations on production
+	This can be useful in certain situations to avoid file operations on production
 	environments. If you want to use this backend for code-caching make sure that
 	``allow_url_include`` is enabled in php.ini
 
@@ -770,7 +770,7 @@ The next operation (for example, a "get()" or "set()" call) will use the next he
 backend. If there is only one backend left and it causes an error, MultiBackend will
 still try to use it on the next operation.
 
-You can disable the the removal of unhealthy backends with a backend option.
+You can disable the removal of unhealthy backends with a backend option.
 
 Options
 ~~~~~~~
@@ -957,4 +957,4 @@ PSR-6 CacheItemPool PSR-16 SimpleCache implementations for a given cache identif
 	$this->cacheItemPool = $this->cacheManager->getCacheItemPool('MyPackage_CacheItemPool');
 
 .. warning::
-   While possible it is not advisible to access the same cache with different interfaces as the storage formats may differ!
+   While possible it is not advisable to access the same cache with different interfaces as the storage formats may differ!

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/CommandLine.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/CommandLine.rst
@@ -268,7 +268,7 @@ is rendered by using the information provided by the method code and DocComment:
 
 * the first line of the DocComment contains the short description of the command
 * the second line must be empty
-* the the following lines contain the long description
+* the following lines contain the long description
 * the descriptions of the @param annotations are used for the argument
   descriptions
 * the type specified in the @param annotations is used for validation and to

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Configuration.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Configuration.rst
@@ -155,7 +155,7 @@ Some examples:
 
 **Type of environment variables**
 
-Evnironment variables are replaced via PHPs ``getenv()`` function. Thus, they always evaluate to *strings*.
+Environment variables are replaced via PHPs ``getenv()`` function. Thus, they always evaluate to *strings*.
 Unless a mentioned environment variable does not exist, in which case it evaluates to ``false``.
 With version 8.1 Flow allows to cast the type of an environment variable to an *Integer*, *Float*, *Boolean*
 or *String* explicitly, specifying the *type* in the replacement string:
@@ -449,7 +449,7 @@ with the following deviations from the specification:
 * The "format" constraint for string type has additional class-name and
   instance-name options.
 * The "dependencies" constraint of the spec is not implemented.
-* Similar to "patternProperties" "formatProperties" can be specified specified
+* Similar to "patternProperties" "formatProperties" can be specified
   for dictionaries
 
 .. warning::
@@ -484,7 +484,7 @@ Here is an example of a schema, from *Neos.Flow.core.schema.yaml*:
 It declares the constraints for the *Neos.Flow.core* setting:
 
 * the setting is a dictionary (an associative array in PHP nomenclature)
-* properties not defined in the schema are not not allowed
+* properties not defined in the schema are not allowed
 * the properties ``context`` and ``phpBinaryPathAndFilename`` are both required
   and of type string
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
@@ -357,7 +357,7 @@ Arguments
 
 The ``ActionRequest`` features a few methods for retrieving and setting arguments. These arguments are the result of merging any
 GET, POST and PUT arguments and even the information about uploaded files. Note that these arguments have already been processed
-by the validation and property mapping layerns and thus are suitable for being used in controller actions. If you, however, need to
+by the validation and property mapping layers and thus are suitable for being used in controller actions. If you, however, need to
 access the raw data, you can access these via the ``getCookieParams()``, ``getQueryParams()``, ``getUploadedFiles()`` and ``getParsedBody()``
 methods of the ``HttpRequest``  respectively.
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Http.rst
@@ -403,7 +403,7 @@ Additionally Flow respects the ``X-HTTP-Method`` respectively ``X-HTTP-Method-Ov
 Trusted Proxies
 ~~~~~~~~~~~~~~~
 
-If your server is behind a reverse proxy or a CDN, some of the request information like the the host name, the port,
+If your server is behind a reverse proxy or a CDN, some of the request information like the host name, the port,
 the protocol and the original client IP address are provided via additional request headers.
 Since those headers can also easily be sent by an adversary, possibly bypassing security measurements, you should make
 sure that those headers are only accepted from trusted proxies.

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ModelViewController.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ModelViewController.rst
@@ -378,7 +378,7 @@ supported:
 * ``initializeView()``
 
 The first method executed after the base initialization is ``initializeAction()``.
-The Action Controller only provides an empty method which can be overriden by a
+The Action Controller only provides an empty method which can be overridden by a
 concrete Action Controller. The information about action method arguments and
 the corresponding validators has already been collected at this point, but any
 arguments sent through the request have not yet been mapped or validated. Therefore,
@@ -646,7 +646,7 @@ The general syntax of a view configuration looks like this:
 	    fusionPathPatterns:
 	      - 'resource://Neos.Fusion/Private/Fusion'
 	      - 'resource://My.Package/Private/Fusion'
-	    fusionPath: 'yourProtoype'
+	    fusionPath: 'yourPrototype'
 
 The requestFilter is based on Neos.Eel allowing you to match arbitrary requests
 so that you can override View configuration for various scenarios.
@@ -672,7 +672,7 @@ You can combine any of these matchers with boolean operators:
 	(isPackage("My.Foo") || isPackage('My.Bar')) && isFormat("html")
 
 The order of the configurations is in most cases unimportant. Each matcher has a
-specific weight similar to CSS specifity (ID, class, inline, important) to determine
+specific weight similar to CSS specificity (ID, class, inline, important) to determine
 which configuration outweighs the other. For each match resulting matcher the weight
 will be increased by a certain value.
 
@@ -716,7 +716,7 @@ Validation
 ----------
 
 Arguments which were sent along with the HTTP request are usually sanitized and
-valdidated before they are passed to an action method of a controller. Behind the
+validated before they are passed to an action method of a controller. Behind the
 scenes, the :doc:`Property Mapper <PropertyMapping>` is used for mapping and
 validating the raw input. During this process, the validators are invoked:
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ObjectManagement.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ObjectManagement.rst
@@ -598,7 +598,7 @@ Lazy Dependency Injection
 Using Property Injection is, in its current implementation, the most performant way
 to inject a dependency. As an important additional benefit you also get Lazy
 Dependency Injection: instead of loading the class of the dependency, instantiating
-and intializing it, a ``proxy`` is injected instead. This object waits until it
+and initializing it, a ``proxy`` is injected instead. This object waits until it
 will be accessed the first time. Once you start using the dependency, the proxy
 will build or retrieve the real dependency, call the requested method and return
 the result. On all following method calls, the real object will be used.
@@ -985,7 +985,7 @@ should be active and are done:
 	MyCompany\MyPackage\GreeterInterface:
 	  className: 'Neos\OtherPackage\GreeterWithCompliments'
 
-The the same code as above will get the improved ``GreeterWithCompliments``
+The same code as above will get the improved ``GreeterWithCompliments``
 instead of the simple ``Greeter`` now.
 
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Persistence.rst
@@ -327,7 +327,7 @@ conventions need to be followed:
 * Domain models should reside in a *Domain/Model* directory
 * Repositories should reside in a *Domain/Repository* directory and be named
   ``<ModelName>Repository``
-* Aside from ``Model`` versus ``Repository`` the qualified class class names should be the
+* Aside from ``Model`` versus ``Repository`` the qualified class names should be the
   same for corresponding classes
 * Repositories must implement ``\Neos\Flow\Persistence\RepositoryInterface`` (which is
   already the case when extending ``\Neos\Flow\Persistence\Repository`` or
@@ -469,7 +469,7 @@ Inside a single aggregate `OneToMany` relations are normally best modeled unidir
 Bidirectional relations always are harder to manage correctly and can easily lead to
 unintentional traversal of entity hierarchies with all the drawbacks.
 
-Since Doctrines `OneToMany` annotation is always bidrectional and also dictates the owning
+Since Doctrines `OneToMany` annotation is always bidirectional and also dictates the owning
 side of the relation (at the unexpected side from a modeling PoV), it is not straightforward
 to model this correctly.
 
@@ -730,7 +730,7 @@ doctrine configuration and EventManager classes, that you can change before the 
 EntityManager is instantiated.
 
 The `afterDoctrineEntityManagerCreation` signal provides the doctrine configuration and
-EntityManager instance, in order to to further set options.
+EntityManager instance, in order to further set options.
 
 .. note:: All above configuration options through the settings are actually implemented as slots to the
   before mentioned signals. If you want to take some look how this works, check the
@@ -1081,7 +1081,7 @@ This will result in output that looks similar to the following:
 
 As you can see you need to specify the migration ``--version`` you want to execute. If you
 want to revert a migration, you need to give the ``--direction`` as shown above, the
-default is to migrate "up". The ``--dry-run`` and and ``--output`` options work as with
+default is to migrate "up". The ``--dry-run`` and ``--output`` options work as with
 ``flow:doctrine:migrate``.
 
 Creating migrations

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/PropertyMapping.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/PropertyMapping.rst
@@ -438,7 +438,7 @@ That's why two parts need to be configured for enabling the recursive behavior: 
 to specify the allowed properties using one of the ``allowProperties(), allowAllProperties()``
 or ``allowAllPropertiesExcept()`` methods.
 
-Second, you need to configure the the PersistentObjectConverter using the two options
+Second, you need to configure the PersistentObjectConverter using the two options
 ``CONFIGURATION_MODIFICATION_ALLOWED`` and ``CONFIGURATION_CREATION_ALLOWED``. They
 must be used to explicitly activate the modification or creation of objects. By
 default, the ``PersistentObjectConverter`` does only fetch objects from the persistence,

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ResourceManagement.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/ResourceManagement.rst
@@ -23,7 +23,7 @@ Storage
 
 The file contents belonging to a specific ``PersistentResource`` need to be stored in some place, they
 are not stored in the database together with the object. Applications should be able to store this
-content in several places as needed, therefor the concept of a *Storage* exists.
+content in several places as needed, therefore the concept of a *Storage* exists.
 A *Storage* is configured via ``Settings.yaml``:
 
 .. code-block:: yaml
@@ -75,7 +75,7 @@ persistent storage above is configured like this:
               baseUri: '_Resources/Persistent/'
 
 This configures the ``Target`` named ``localWebDirectoryPersistentResourcesTarget``. Resources using this
-target will be published into the the given ``path`` which is inside the public web folder of Flow.
+target will be published into the given ``path`` which is inside the public web folder of Flow.
 The class ``Neos\Flow\ResourceManagement\Target\FileSystemSymlinkTarget`` is the implementation responsible for
 publishing the resources and providing public URIs to it. From the name you can guess that it creates
 symlinks to the resources stored on the local filesystem to save space. Other ``Target`` implementations
@@ -375,7 +375,7 @@ method in the ``ResourceManager`` like this:
 
 	$resourceUri = $this->resourceManager->getPublicPackageResourceUri('Acme.Demo', 'Images/Icons/FooIcon.png');
 
-The same can be done in Fluid templates by using the the built-in resource ViewHelper:
+The same can be done in Fluid templates by using the built-in resource ViewHelper:
 
 .. code-block:: html
 
@@ -412,7 +412,7 @@ One advantage of using the sha1 hash of the resource content as part of the path
 resource changes it gets a new path and is displayed correctly regardless of the cache
 settings in the user's web browser.
 
-If you need to access a resource`s data directly in your code you can aquire a stream via the ``getStream()``
+If you need to access a resource`s data directly in your code you can acquire a stream via the ``getStream()``
 method of the ``PersistentResource``. If a stream is not enough and you need a file path to work with
 the ``createTemporaryLocalCopy()`` will return one for you.
 

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Security.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Security.rst
@@ -208,7 +208,7 @@ Flow ships with the following authentication tokens:
 
 #. ``UsernamePassword``: Extracts username & password from a POST parameter.
    Options: ``usernamePostField`` and ``passwordPostField``
-#. ``UsernamePasswordHttpBasic``: Extracts username & password from the the ``Authorization``
+#. ``UsernamePasswordHttpBasic``: Extracts username & password from the ``Authorization``
    header (Basic auth). This token is sessionless (see below)
 #. ``BearerToken``: Extracts a rfc6750 bearer token (See: `RFC 6750 <https://tools.ietf.org/html/rfc6750>`_) from a given
    ``Authorization`` header. This token is sessionless (see below) and has no configuration options.
@@ -589,7 +589,7 @@ There is another configuration option for authentication providers called ``toke
 which can be specified in the provider settings. By this option you can specify which
 token should be used for a provider. Remember the token is responsible for the credentials
 retrieval, i.e. if you want to authenticate let's say via username and password this setting
-enables to to specify where these credentials come from. So e.g. you could reuse the one
+enables to specify where these credentials come from. So e.g. you could reuse the one
 username/password provider class and specify, whether authentication credentials are sent
 in a POST request or set in an HTTP Basic authentication header.
 
@@ -1278,7 +1278,7 @@ from the functional tests, show some more advanced matcher statements:
       matcher: 'isType("Acme\MyPackage\EntityC") && property("simpleStringProperty").in(["Andi", "Robert", "Karsten"])'
 
     'Acme.MyPackage.ComparingWithObjectCollectionFromGlobalObjects':
-      matcher: 'isType("Acme\MyPackage\EntityC") && property("relatedEntityD").in("context.someGloablObject.someEntityDCollection")'
+      matcher: 'isType("Acme\MyPackage\EntityC") && property("relatedEntityD").in("context.someGlobalObject.someEntityDCollection")'
 
 .. warning:: When using class inheritance for your entities, entity privileges will only work with the root entity type.
    For example, if your entity ``Acme\MyPackage\EntityB`` extends ``Acme\MyPackage\EntityA``, the expression
@@ -1361,7 +1361,7 @@ all privilege targets that are not granted to the current user.
   the filter instance from `$entityManager->getFilters()->getEnabledFilters()` and call `setParameter()` then.
 
   Alternatively, you can use the mechanism from above, where you register a global context object in `Neos.Flow.aop.globalObjects`
-  and use it to provide additional identifiers for the caching; effectively seggregating the Doctrine cache some more.
+  and use it to provide additional identifiers for the caching; effectively segregating the Doctrine cache some more.
 
 Creating your custom privilege
 ==============================
@@ -1390,14 +1390,14 @@ framework with the needed information about which methods have to be  intercepte
 
 In case of the EntityPrivilege permissions are not enforced directly with the entities, but by changing SQL queries.
 One could says the database is responsible to enforce the rules by evaluating the SQL. The additional SQL is returned
-by the EnitiyPrivilege’s method ``getSqlConstraint()``, which of course can be overriden to support an alternative
+by the EntityPrivilege’s method ``getSqlConstraint()``, which of course can be overridden to support an alternative
 matcher syntax.
 
 .. tip::
 
   You might still want to use the existing SQL generators, as this is where the hard lowlevel
   magic is happening. You can compose your constraint logic by these generator objects in a
-  nice programmatical way.
+  nice programmatic way.
 
 Coming back to the second use case to create your completely custom privilege type, you also have to implement a
 privilege class with the two functionalities from above:

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/SessionHandling.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/SessionHandling.rst
@@ -127,7 +127,7 @@ Session Storage
 
 	Since Flow 5.2 Sessions are no longer destroyed by default when caches are flushed. This is
 	due to the session caches being marked as "persistent". This previously lead to all sessions
-	being destroyed on each deployment, which was undesireable.
+	being destroyed on each deployment, which was undesirable.
 
 If you deploy changes that change the structure of data that is stored in the session or the class
 of an `@Flow\scope("session")` object, you need to manually destroy sessions to avoid deserialization

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Templating.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Templating.rst
@@ -870,7 +870,7 @@ A XSD schema file for your ViewHelpers can be created by executing
 
 .. code-block:: text
 
-    ./flow documenation:generatexsd <Your>\\<Package>\\ViewHelpers
+    ./flow documentation:generatexsd <Your>\\<Package>\\ViewHelpers
         --target-file /some/directory/your.package.xsd
 
 Then import the XSD file in your favorite IDE and map it to the namespace

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Validation.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/Validation.rst
@@ -312,7 +312,7 @@ certain validation groups are executed:
 Additionally, it is possible to specify a list of validation groups at each controller action
 via the ``@Flow\ValidationGroups`` annotation. This way, you can override the default
 validation groups that are invoked on this action call, for example when you need to
-validate uniqueness of a property like an e-mail adress only in your createAction.
+validate uniqueness of a property like an e-mail address only in your createAction.
 
 A validator is only executed if at least one validation group overlap.
 

--- a/Neos.Flow/Tests/Functional/Aop/PointcutExpressionTest.php
+++ b/Neos.Flow/Tests/Functional/Aop/PointcutExpressionTest.php
@@ -14,7 +14,7 @@ namespace Neos\Flow\Tests\Functional\Aop;
 use Neos\Flow\Tests\FunctionalTestCase;
 
 /**
- * Test suite for poincut expression related features
+ * Test suite for pointcut expression related features
  *
  */
 class PointcutExpressionTest extends FunctionalTestCase

--- a/Neos.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
+++ b/Neos.Flow/Tests/Functional/Configuration/ConfigurationValidationTest.php
@@ -72,7 +72,7 @@ class ConfigurationValidationTest extends FunctionalTestCase
         parent::setUp();
 
         //
-        // create a mock packageManager that only returns the the packages that contain schema files
+        // create a mock packageManager that only returns the packages that contain schema files
         //
 
         $schemaPackages = [];

--- a/Neos.Flow/Tests/Unit/Security/Cryptography/RsaWalletServicePhpTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Cryptography/RsaWalletServicePhpTest.php
@@ -17,7 +17,7 @@ use Neos\Flow\Security\Cryptography\RsaWalletServicePhp;
 use Neos\Flow\Tests\UnitTestCase;
 
 /**
- * Testcase for for the PHP (OpenSSL) based RSAWalletService
+ * Testcase for the PHP (OpenSSL) based RSAWalletService
  *
  * @requires function openssl_pkey_new
  */

--- a/Neos.Flow/Tests/Unit/Security/Policy/PolicyServiceTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Policy/PolicyServiceTest.php
@@ -21,7 +21,7 @@ use Neos\Flow\Security\Policy\Role;
 use Neos\Flow\Tests\UnitTestCase;
 
 /**
- * Testcase for for the PolicyService
+ * Testcase for the PolicyService
  */
 class PolicyServiceTest extends UnitTestCase
 {

--- a/Neos.Flow/Tests/Unit/Security/Policy/RoleTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Policy/RoleTest.php
@@ -15,7 +15,7 @@ use Neos\Flow\Security\Policy\Role;
 use Neos\Flow\Tests\UnitTestCase;
 
 /**
- * Testcase for for Neos\Flow\Security\Policy\Role
+ * Testcase for Neos\Flow\Security\Policy\Role
  */
 class RoleTest extends UnitTestCase
 {

--- a/Neos.Flow/Tests/Unit/Session/SessionTest.php
+++ b/Neos.Flow/Tests/Unit/Session/SessionTest.php
@@ -1004,7 +1004,7 @@ class SessionTest extends UnitTestCase
 
         $session->resume();
         self::assertTrue($session->isStarted());
-        self::assertTrue($metaDataCache->has($sessionIdentifier1), 'session 1 meta entry doesnt exist');
+        self::assertTrue($metaDataCache->has($sessionIdentifier1), 'session 1 meta entry doesn\'t exist');
         $session->close();
 
         $sessionInfo1 = $metaDataCache->get($sessionIdentifier1);

--- a/Neos.FluidAdaptor/Classes/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
+++ b/Neos.FluidAdaptor/Classes/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
@@ -131,7 +131,7 @@ class NamespaceDetectionTemplateProcessor extends FluidNamespaceDetectionTemplat
         foreach ($splitTemplate as $templateElement) {
             if (preg_match(Patterns::$SCAN_PATTERN_TEMPLATE_VIEWHELPERTAG, $templateElement, $matchedVariables) > 0) {
                 if (!$viewHelperResolver->isNamespaceValidOrIgnored($matchedVariables['NamespaceIdentifier'])) {
-                    throw new UnknownNamespaceException('Unkown Namespace: ' . htmlspecialchars($matchedVariables[0]));
+                    throw new UnknownNamespaceException('Unknown Namespace: ' . htmlspecialchars($matchedVariables[0]));
                 }
                 continue;
             }

--- a/Neos.FluidAdaptor/Classes/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
+++ b/Neos.FluidAdaptor/Classes/Core/Parser/TemplateProcessor/NamespaceDetectionTemplateProcessor.php
@@ -22,7 +22,7 @@ use TYPO3Fluid\Fluid\Core\Parser\UnknownNamespaceException;
  *
  * Compared to TYPO3Fluid that just removes all CDATA sections from the template before parsing, this pre processor
  * finds CDATA and base65 encodes those areas of the template and surrounds that with a call to the Base64DecodeViewHelper
- * which results in the the CDATA section to be present in the final output without any changes from fluid.
+ * which results in the CDATA section to be present in the final output without any changes from fluid.
  */
 class NamespaceDetectionTemplateProcessor extends FluidNamespaceDetectionTemplateProcessor
 {

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/Form/SelectViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/Form/SelectViewHelper.php
@@ -107,7 +107,7 @@ use Neos\Utility\ObjectAccess;
  * translations for those ids in the current package's "Main" XLIFF file.)
  * </output>
  *
- * <code title="Label translation usign a prefix">
+ * <code title="Label translation using a prefix">
  * <f:form.select name="paymentOption" options="{payPal: 'PayPal International Services', visa: 'VISA Card'}" translate="{by: 'id', prefix: 'shop.paymentOptions.'}" />
  * </code>
  * <output>

--- a/Neos.FluidAdaptor/Classes/ViewHelpers/FormViewHelper.php
+++ b/Neos.FluidAdaptor/Classes/ViewHelpers/FormViewHelper.php
@@ -40,7 +40,7 @@ use Neos\FluidAdaptor\ViewHelpers\Form\AbstractFormViewHelper;
  * <form method="GET" action="...">...</form>
  * </output>
  *
- * <code title="Form with a sepcified encoding type">
+ * <code title="Form with a specified encoding type">
  * <f:form action=".." controller="..." package="..." enctype="multipart/form-data">...</f:form>
  * </code>
  * <output>

--- a/Neos.FluidAdaptor/Tests/Functional/View/StandaloneViewTest.php
+++ b/Neos.FluidAdaptor/Tests/Functional/View/StandaloneViewTest.php
@@ -281,7 +281,7 @@ class StandaloneViewTest extends FunctionalTestCase
     /**
      * Tests the wrong interceptor behavior described in ticket FLOW-430
      * Basically the rendering should be consistent regardless of cache flushes,
-     * but due to the way the interceptor configuration was build the second second
+     * but due to the way the interceptor configuration was build the second
      * rendering was bound to fail, this should never happen.
      *
      * @test

--- a/Neos.FluidAdaptor/Tests/Functional/View/StandaloneViewTest.php
+++ b/Neos.FluidAdaptor/Tests/Functional/View/StandaloneViewTest.php
@@ -281,7 +281,7 @@ class StandaloneViewTest extends FunctionalTestCase
     /**
      * Tests the wrong interceptor behavior described in ticket FLOW-430
      * Basically the rendering should be consistent regardless of cache flushes,
-     * but due to the way the interceptor configuration was build the second
+     * but due to the way the interceptor configuration was built the second
      * rendering was bound to fail, this should never happen.
      *
      * @test

--- a/Neos.Utility.Files/Classes/Files.php
+++ b/Neos.Utility.Files/Classes/Files.php
@@ -509,7 +509,7 @@ abstract class Files
      * Will create relative symlinks by given absolute paths, falling back to Windows' mklink command because PHP's symlink() does not support relative paths there.
      * If the file exists already, it will be deleted regardless of its attributes.
      *
-     * @param string $target The absolute target where the the symlink should point to relativiely
+     * @param string $target The absolute target where the symlink should point to relatively
      * @param string $link The absolute path to the link where the symlink will be created
      * @return boolean
      * @throws FilesException

--- a/Neos.Utility.ObjectHandling/Readme.rst
+++ b/Neos.Utility.ObjectHandling/Readme.rst
@@ -19,4 +19,4 @@ Dependencies
 ------------
 
 The tests depend on Doctrine/ORM which is therefore
-a dev requirement requirement.
+a dev requirement.

--- a/Neos.Utility.Schema/Classes/SchemaValidator.php
+++ b/Neos.Utility.Schema/Classes/SchemaValidator.php
@@ -28,7 +28,7 @@ use Neos\Error\Messages\Result as ErrorResult;
  *   -> see list of possible constraints below.
  * - The "format" constraint for string type has additional class-name and instance-name options.
  * - The "dependencies" constraint of the spec is not implemented.
- * - Similar to "patternProperties" "formatProperties" can be specified specified for dictionaries
+ * - Similar to "patternProperties" "formatProperties" can be specified for dictionaries
  * - Definition and referencing of local-types with the '@'-sign is added.
  *
  * General constraints for all types (for implementation see validate Method):
@@ -51,10 +51,10 @@ use Neos\Error\Messages\Result as ErrorResult;
  *
  * Local type-definitions:
  * If a schema contains properties that start with an '@'-sign on the root level those schemas are added to the local
- * type definitions and are passed down the validation chain to be refereced with the full identifier and can be used
+ * type definitions and are passed down the validation chain to be referenced with the full identifier and can be used
  * in the same way as simple type definition.
  *
- * Local Types can not be overwitten but they can extend a list of superTypes.
+ * Local Types can not be overwritten but they can extend a list of superTypes.
  *
  */
 class SchemaValidator


### PR DESCRIPTION
Hello!

First of all, thank you for your work!
Just like in https://github.com/neos/neos-development-collection/pull/5846 I fixed typos in this repository too.

**Upgrade instructions**

n/a

**Review instructions**

I split my fixes into separate commits so changes in code (comments) and documentation are easily discernible. Note that c6d0157 changes actual strings in the code.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [~] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [x] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
