### PR TITLE
BUGFIX: Make --help display command overview

### DIFF
--- a/Neos.Flow/Classes/Cli/RequestBuilder.php
+++ b/Neos.Flow/Classes/Cli/RequestBuilder.php
@@ -93,11 +93,13 @@ class RequestBuilder
             }
         }
         $firstArgument = count($rawCommandLineArguments) ? trim(array_shift($rawCommandLineArguments)) : null;
-        if (
-            $firstArgument === null
-            || $firstArgument === '--help'
-        ) {
+        if ($firstArgument === null) {
             $request->setControllerCommandName('helpStub');
+
+            return $request;
+        }
+        if ($firstArgument === '--help') {
+            $request->setControllerCommandName('help');
 
             return $request;
         }

--- a/Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php
@@ -101,6 +101,17 @@ class RequestBuilderTest extends UnitTestCase
     }
 
     /**
+     * @test
+     */
+    public function helpOptionDisplaysCommandOverview()
+    {
+        $request = $this->requestBuilder->build('--help');
+
+        self::assertSame(HelpCommandController::class, $request->getControllerObjectName());
+        self::assertSame('help', $request->getControllerCommandName());
+    }
+
+    /**
      * Checks if a CLI request specifying some "console style" (--my-argument=value) arguments results in the expected request object
      *
      * @test


### PR DESCRIPTION
`./flow --help` now displays the same command overview as `./flow help` instead of the abbreviated help stub.

The request builder keeps the existing no-argument behavior and routes only the explicit top-level `--help` option to the full help command. A regression test covers the alias.

Fixes #3583

**Upgrade instructions**

None.

**Review instructions**

Run the focused request-builder unit test and verify that `./flow --help` lists the available commands.

**Validation**

- `vendor/bin/phpunit --bootstrap /tmp/neos-unit-bootstrap.php Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php --colors=never` — 30 tests, 107 assertions
- `php -l Neos.Flow/Classes/Cli/RequestBuilder.php`
- `php -l Neos.Flow/Tests/Unit/Cli/RequestBuilderTest.php`

The full development-distribution CI matrix was not reproduced locally.

**Checklist**

- [x] Code follows the PSR-2 coding style
- [x] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the lowest maintained branch
- [x] PR title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] The first section explains the change briefly for change-logs
- [x] No breaking changes
