### PR TITLE
BUGFIX: Prevent reflecting non Flow classes in `couldHaveEntityRelations()`

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
+++ b/Neos.Flow/Classes/ObjectManagement/DependencyInjection/ProxyClassBuilder.php
@@ -633,7 +633,8 @@ class ProxyClassBuilder
                 continue;
             }
 
-            $isEntity = $this->reflectionService->getClassAnnotation($typeInformation['type'], Flow\Entity::class);
+            $isEntity = $this->reflectionService->isClassReflected($typeInformation['type']) &&
+                $this->reflectionService->getClassAnnotation($typeInformation['type'], Flow\Entity::class);
             if (!$isEntity) {
                 continue;
             }


### PR DESCRIPTION
We should check if classes in properties of
proxied classes are reflected, otherwise they
might be non Flow classes or otherwise excluded.
In either case making them definitely not (Flow)
controlled entities.

Fixes: #3585

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions
