### PR TITLE
BUGFIX: Call original method in void proxy methods

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
@@ -175,8 +175,12 @@ class ProxyMethodGenerator extends MethodGenerator
             if (!$returnTypeIsVoidOrNever) {
                 $code .= "return \$result;\n";
             }
-        } elseif (!$returnTypeIsVoidOrNever && $callParentMethodCode !== '') {
-            $code .= 'return ' . $callParentMethodCode . ";\n";
+        } elseif ($callParentMethodCode !== '') {
+            if ($returnTypeIsVoidOrNever) {
+                $code .= '    ' . $callParentMethodCode;
+            } else {
+                $code .= 'return ' . $callParentMethodCode . ";\n";
+            }
         }
         return $code;
     }

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Fixture/ClassWithVoidAndNeverMethods.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Fixture/ClassWithVoidAndNeverMethods.php
@@ -1,0 +1,33 @@
+<?php
+namespace Neos\Flow\Tests\Unit\ObjectManagement\Fixture;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A fixture class providing methods with various return types for testing
+ * the proxy method code generation
+ */
+class ClassWithVoidAndNeverMethods
+{
+    public function doSomething(): string
+    {
+        return 'something';
+    }
+
+    public function doSomethingWithoutReturningAnything(): void
+    {
+    }
+
+    public function failForSure(): never
+    {
+        throw new \RuntimeException('as promised', 1754300000);
+    }
+}

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyMethodGeneratorTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyMethodGeneratorTest.php
@@ -1,0 +1,74 @@
+<?php
+namespace Neos\Flow\Tests\Unit\ObjectManagement\Proxy;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\ObjectManagement\Proxy\ProxyMethodGenerator;
+use Neos\Flow\Tests\Unit\ObjectManagement\Fixture\ClassWithVoidAndNeverMethods;
+use Neos\Flow\Tests\UnitTestCase;
+
+class ProxyMethodGeneratorTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function renderBodyCodeRendersParentCallWithReturnStatementIfOnlyPreParentCallCodeWasAdded(): void
+    {
+        $proxyMethod = $this->createProxyMethodGenerator('doSomething', 'string');
+        $proxyMethod->addPreParentCallCode('$foo = 1;');
+
+        $bodyCode = $proxyMethod->renderBodyCode();
+        self::assertStringContainsString("\$foo = 1;\n", $bodyCode);
+        self::assertStringContainsString('return parent::doSomething();', $bodyCode);
+    }
+
+    /**
+     * @test
+     */
+    public function renderBodyCodeRendersParentCallWithoutReturnStatementForVoidMethodsIfOnlyPreParentCallCodeWasAdded(): void
+    {
+        $proxyMethod = $this->createProxyMethodGenerator('doSomethingWithoutReturningAnything', 'void');
+        $proxyMethod->addPreParentCallCode('$foo = 1;');
+
+        self::assertSame("\$foo = 1;\n    parent::doSomethingWithoutReturningAnything();\n", $proxyMethod->renderBodyCode());
+    }
+
+    /**
+     * @test
+     */
+    public function renderBodyCodeRendersParentCallWithoutReturnStatementForNeverMethodsIfOnlyPreParentCallCodeWasAdded(): void
+    {
+        $proxyMethod = $this->createProxyMethodGenerator('failForSure', 'never');
+        $proxyMethod->addPreParentCallCode('$foo = 1;');
+
+        self::assertSame("\$foo = 1;\n    parent::failForSure();\n", $proxyMethod->renderBodyCode());
+    }
+
+    /**
+     * @test
+     */
+    public function renderBodyCodeRendersParentCallWithoutAssignmentForVoidMethodsIfPreAndPostParentCallCodeWasAdded(): void
+    {
+        $proxyMethod = $this->createProxyMethodGenerator('doSomethingWithoutReturningAnything', 'void');
+        $proxyMethod->addPreParentCallCode('$foo = 1;');
+        $proxyMethod->addPostParentCallCode('$bar = 2;');
+
+        self::assertSame("\$foo = 1;\n    parent::doSomethingWithoutReturningAnything();\n\$bar = 2;\n", $proxyMethod->renderBodyCode());
+    }
+
+    private function createProxyMethodGenerator(string $methodName, string $returnType): ProxyMethodGenerator
+    {
+        $proxyMethod = new ProxyMethodGenerator($methodName);
+        $proxyMethod->setReturnType($returnType);
+        $proxyMethod->setFullOriginalClassName(ClassWithVoidAndNeverMethods::class);
+        return $proxyMethod;
+    }
+}


### PR DESCRIPTION
When proxy building adds only pre parent call code to a method – without any post code – and the method declares a `void` or `never` return type, the generated proxy method contains the pre code but no call to the original method: the original implementation is silently skipped.

This change renders the parent call (without a return statement, which is not allowed for these return types) like the branch for pre and post parent call code already does.

Note for the upmerge to 9.2: the unit test `noParentCallIsRenderedForVoidAndNeverReturnTypesIfOnlyPreParentCallCodeExists` introduced with #3596 documents the old behavior and needs to be inverted – the `ProxyMethodGeneratorTest` introduced with this change covers the corrected behavior and will conflict with the file of the same name from #3596.

Fixes #3597
