### PR TITLE
BUGFIX: Comment out final keyword of static methods

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/Compiler.php
@@ -503,12 +503,12 @@ return ' . var_export($this->storedProxyClasses, true) . ';';
     {
         // comment out "final" keyword, if the method is final and if it is advised (= part of the $proxyClassCode)
         // Note: Method name regex according to http://php.net/manual/en/language.oop5.basic.php
-        $classCode = preg_replace_callback('/^(\s*)((public|protected)\s+)?final(\s+(public|protected))?(\s+function\s+)([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+\s*\()/m', static function ($matches) use ($proxyClassCode) {
+        $classCode = preg_replace_callback('/^(\s*)((?:(?:public|protected|static)\s+)*)final((?:\s+(?:public|protected|static))*)(\s+function\s+&?\s*)([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*\s*\()/m', static function ($matches) use ($proxyClassCode) {
             // the method is not advised => don't remove the final keyword
             if (!str_contains($proxyClassCode, $matches[0])) {
                 return $matches[0];
             }
-            return $matches[1] . $matches[2] . '/*final*/' . $matches[4] . $matches[6] . $matches[7];
+            return $matches[1] . $matches[2] . '/*final*/' . $matches[3] . $matches[4] . $matches[5];
         }, $classCode);
         assert(is_string($classCode), 'preg_replace_callback() failed');
         return $classCode;

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/CompilerTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/CompilerTest.php
@@ -316,4 +316,63 @@ class CompilerTest extends UnitTestCase
         $actualClassCode = $this->compiler->_call('replaceClassName', $originalClassCode, $pathAndFilename);
         self::assertSame($expectedClassCode, $actualClassCode);
     }
+
+    public static function finalMethodDeclarationExamples(): array
+    {
+        return [
+            'final public function' => [
+                '    final public function someMethod(): string',
+                '    /*final*/ public function someMethod(): string'
+            ],
+            'public final function' => [
+                '    public final function someMethod(): string',
+                '    public /*final*/ function someMethod(): string'
+            ],
+            'final public static function' => [
+                '    final public static function someMethod(): string',
+                '    /*final*/ public static function someMethod(): string'
+            ],
+            'public static final function' => [
+                '    public static final function someMethod(): string',
+                '    public static /*final*/ function someMethod(): string'
+            ],
+            'final protected static function' => [
+                '    final protected static function someMethod(): string',
+                '    /*final*/ protected static function someMethod(): string'
+            ],
+            'single character method name' => [
+                '    final public function m(): string',
+                '    /*final*/ public function m(): string'
+            ],
+            'method returning by reference' => [
+                '    final public function &someMethod(): string',
+                '    /*final*/ public function &someMethod(): string'
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider finalMethodDeclarationExamples()
+     */
+    public function commentOutFinalKeywordForMethodsHandlesAllModifierCombinations(string $methodDeclaration, string $expectedMethodDeclaration): void
+    {
+        $classCode = "class SomeClass_Original\n{\n" . $methodDeclaration . "\n    {\n    }\n}\n";
+        $proxyClassCode = "class SomeClass extends SomeClass_Original\n{\n" . $methodDeclaration . "\n    {\n    }\n}\n";
+
+        $actualClassCode = $this->compiler->_call('commentOutFinalKeywordForMethods', $classCode, $proxyClassCode);
+        self::assertStringContainsString($expectedMethodDeclaration, $actualClassCode);
+    }
+
+    /**
+     * @test
+     */
+    public function commentOutFinalKeywordForMethodsLeavesMethodsAloneWhichAreNotPartOfTheProxyClass(): void
+    {
+        $classCode = "class SomeClass_Original\n{\n    final public static function someMethod(): string\n    {\n    }\n}\n";
+        $proxyClassCode = "class SomeClass extends SomeClass_Original\n{\n    public function someOtherMethod(): string\n    {\n    }\n}\n";
+
+        $actualClassCode = $this->compiler->_call('commentOutFinalKeywordForMethods', $classCode, $proxyClassCode);
+        self::assertSame($classCode, $actualClassCode);
+    }
 }


### PR DESCRIPTION
The regular expression which comments out the final keyword of methods that are overridden in a proxy class did not match methods declared as `final public static function` or similar combinations including the static keyword. As a consequence, a final static method annotated with `Flow\CompileStatic` resulted in a "Cannot override final method" fatal error – but only in Production context, where CompileStatic methods are compiled into the proxy class.

The new expression covers all combinations of public, protected, static and final, methods returning by reference and method names consisting of a single character.

Fixes #3592
