### PR TITLE
BUGFIX: Unpack variadic parameters in proxies

### DIFF
--- a/Neos.Flow/Classes/Aop/AdvicesTrait.php
+++ b/Neos.Flow/Classes/Aop/AdvicesTrait.php
@@ -54,8 +54,41 @@ trait AdvicesTrait
         }
         $methodName = $joinPoint->getMethodName();
         if (isset($this->Flow_Aop_Proxy_methodIsInAdviceMode[$methodName])) {
-            $arguments = array_values($joinPoint->getMethodArguments());
+            $arguments = $this->Flow_Aop_Proxy_unpackMethodArguments($methodName, $joinPoint->getMethodArguments());
             return self::$methodName(...$arguments);
         }
+    }
+
+    /**
+     * Converts the method arguments of a join point into a list of arguments which can be
+     * unpacked into a call of the respective method.
+     *
+     * A join point stores the arguments passed to a variadic parameter as one single array,
+     * mapped to the name of that parameter. That array therefore needs to be unpacked again
+     * before the method can be called with the arguments taken from the join point.
+     *
+     * @param string $methodName Name of the method the given arguments belong to
+     * @param array $methodArguments The method arguments of the join point
+     * @return array The arguments, ready to be unpacked into a call of the given method
+     */
+    private function Flow_Aop_Proxy_unpackMethodArguments(string $methodName, array $methodArguments): array
+    {
+        static $variadicParameterNames = [];
+
+        $cacheKey = $this::class . '::' . $methodName;
+        if (!array_key_exists($cacheKey, $variadicParameterNames)) {
+            $parameters = (new \ReflectionMethod($this, $methodName))->getParameters();
+            $lastParameter = end($parameters);
+            $variadicParameterNames[$cacheKey] = ($lastParameter !== false && $lastParameter->isVariadic()) ? $lastParameter->getName() : null;
+        }
+
+        $variadicParameterName = $variadicParameterNames[$cacheKey];
+        if ($variadicParameterName === null || !array_key_exists($variadicParameterName, $methodArguments)) {
+            return array_values($methodArguments);
+        }
+
+        $variadicArguments = $methodArguments[$variadicParameterName];
+        unset($methodArguments[$variadicParameterName]);
+        return array_merge(array_values($methodArguments), is_array($variadicArguments) ? array_values($variadicArguments) : [$variadicArguments]);
     }
 }

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
@@ -223,7 +223,9 @@ class ProxyMethodGenerator extends MethodGenerator
                 if ($addTypeAndDefaultValue) {
                     $parameterOutput[] = $parameter->generate();
                 } else {
-                    $parameterOutput[] = '$' . $parameter->getName();
+                    # A variadic parameter arrives as an array and thus needs to be unpacked again
+                    # when it is passed on to the original method:
+                    $parameterOutput[] = ($parameter->getVariadic() ? '...' : '') . '$' . $parameter->getName();
                 }
             }
             $methodParametersCode .= implode(', ', $parameterOutput);

--- a/Neos.Flow/Tests/Functional/Aop/Fixtures/TargetClassWithVariadicParameters.php
+++ b/Neos.Flow/Tests/Functional/Aop/Fixtures/TargetClassWithVariadicParameters.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Neos\Flow\Tests\Functional\Aop\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A target class for testing advices on methods with variadic parameters
+ */
+class TargetClassWithVariadicParameters
+{
+    /**
+     * The method arguments the before advice was invoked with
+     *
+     * @var array<string, mixed>
+     */
+    public array $beforeAdviceArguments = [];
+
+    /**
+     * The method arguments the around advice was invoked with
+     *
+     * @var array<string, mixed>
+     */
+    public array $aroundAdviceArguments = [];
+
+    /**
+     * A method with a single, typed variadic parameter
+     */
+    public function sum(int ...$numbers): int
+    {
+        return array_sum($numbers);
+    }
+
+    /**
+     * A method with a regular parameter followed by a variadic one
+     */
+    public function concatenate(string $separator, string ...$parts): string
+    {
+        return implode($separator, $parts);
+    }
+
+    /**
+     * A method with an untyped variadic parameter
+     */
+    public function countItems(...$items): int
+    {
+        return count($items);
+    }
+}

--- a/Neos.Flow/Tests/Functional/Aop/Fixtures/VariadicParametersTestingAspect.php
+++ b/Neos.Flow/Tests/Functional/Aop/Fixtures/VariadicParametersTestingAspect.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Neos\Flow\Tests\Functional\Aop\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Aop\JoinPointInterface;
+
+/**
+ * An aspect for testing advices on methods with variadic parameters
+ */
+#[Flow\Aspect]
+class VariadicParametersTestingAspect
+{
+    /**
+     * A before advice on a method with a variadic parameter: the arguments passed to
+     * the variadic parameter are recorded as one array, the method itself must still
+     * receive them as individual arguments.
+     */
+    #[Flow\Before('method(Neos\Flow\Tests\Functional\Aop\Fixtures\TargetClassWithVariadicParameters->sum())')]
+    public function beforeSumAdvice(JoinPointInterface $joinPoint): void
+    {
+        $proxy = $joinPoint->getProxy();
+        assert($proxy instanceof TargetClassWithVariadicParameters);
+        $proxy->beforeAdviceArguments = $joinPoint->getMethodArguments();
+    }
+
+    /**
+     * An around advice on the very same method, which simply proceeds
+     */
+    #[Flow\Around('method(Neos\Flow\Tests\Functional\Aop\Fixtures\TargetClassWithVariadicParameters->sum())')]
+    public function aroundSumAdvice(JoinPointInterface $joinPoint): int
+    {
+        $proxy = $joinPoint->getProxy();
+        assert($proxy instanceof TargetClassWithVariadicParameters);
+        $proxy->aroundAdviceArguments = $joinPoint->getMethodArguments();
+        return $joinPoint->getAdviceChain()->proceed($joinPoint);
+    }
+
+    /**
+     * An around advice which modifies the arguments of the variadic parameter before
+     * proceeding: the additional argument must arrive at the original method.
+     */
+    #[Flow\Around('method(Neos\Flow\Tests\Functional\Aop\Fixtures\TargetClassWithVariadicParameters->concatenate())')]
+    public function aroundConcatenateAdvice(JoinPointInterface $joinPoint): string
+    {
+        $parts = $joinPoint->getMethodArgument('parts');
+        $parts[] = 'and more';
+        $joinPoint->setMethodArgument('parts', $parts);
+        return $joinPoint->getAdviceChain()->proceed($joinPoint);
+    }
+
+    /**
+     * A before advice on a method with an untyped variadic parameter
+     */
+    #[Flow\Before('method(Neos\Flow\Tests\Functional\Aop\Fixtures\TargetClassWithVariadicParameters->countItems())')]
+    public function beforeCountItemsAdvice(JoinPointInterface $joinPoint): void
+    {
+        $proxy = $joinPoint->getProxy();
+        assert($proxy instanceof TargetClassWithVariadicParameters);
+        $proxy->beforeAdviceArguments = $joinPoint->getMethodArguments();
+    }
+}

--- a/Neos.Flow/Tests/Functional/Aop/VariadicParametersTest.php
+++ b/Neos.Flow/Tests/Functional/Aop/VariadicParametersTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Neos\Flow\Tests\Functional\Aop;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Tests\Functional\Aop\Fixtures\TargetClassWithVariadicParameters;
+use Neos\Flow\Tests\FunctionalTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Testcase for advices on methods with variadic parameters
+ */
+class VariadicParametersTest extends FunctionalTestCase
+{
+    #[Test]
+    public function argumentsOfAVariadicParameterArePassedOnToTheAdvisedMethod(): void
+    {
+        $targetClass = new TargetClassWithVariadicParameters();
+        self::assertSame(6, $targetClass->sum(1, 2, 3));
+    }
+
+    #[Test]
+    public function anEmptyVariadicParameterIsPassedOnToTheAdvisedMethod(): void
+    {
+        $targetClass = new TargetClassWithVariadicParameters();
+        self::assertSame(0, $targetClass->sum());
+    }
+
+    #[Test]
+    public function joinPointContainsTheArgumentsOfAVariadicParameterAsArray(): void
+    {
+        $targetClass = new TargetClassWithVariadicParameters();
+        $targetClass->sum(1, 2, 3);
+
+        self::assertSame(['numbers' => [1, 2, 3]], $targetClass->beforeAdviceArguments);
+        self::assertSame(['numbers' => [1, 2, 3]], $targetClass->aroundAdviceArguments);
+    }
+
+    #[Test]
+    public function argumentsOfARegularAndAVariadicParameterArePassedOnToTheAdvisedMethod(): void
+    {
+        $targetClass = new TargetClassWithVariadicParameters();
+        self::assertSame('one, two, and more', $targetClass->concatenate(', ', 'one', 'two'));
+    }
+
+    #[Test]
+    public function argumentsOfAnUntypedVariadicParameterArePassedOnToTheAdvisedMethod(): void
+    {
+        $targetClass = new TargetClassWithVariadicParameters();
+
+        self::assertSame(3, $targetClass->countItems('one', 2, null));
+        self::assertSame(['items' => ['one', 2, null]], $targetClass->beforeAdviceArguments);
+        self::assertSame(0, $targetClass->countItems());
+    }
+}

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Fixture/ClassWithVariadicMethods.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Fixture/ClassWithVariadicMethods.php
@@ -1,0 +1,43 @@
+<?php
+namespace Neos\Flow\Tests\Unit\ObjectManagement\Fixture;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * Fixture class with methods using variadic parameters
+ */
+class ClassWithVariadicMethods
+{
+    public function sum(...$numbers)
+    {
+        return array_sum($numbers);
+    }
+
+    public function sumTyped(int ...$numbers): int
+    {
+        return array_sum($numbers);
+    }
+
+    public function concatenate(string $separator, string ...$parts): string
+    {
+        return implode($separator, $parts);
+    }
+
+    public function collect(array &$collection, string ...$items): void
+    {
+        $collection = array_merge($collection, $items);
+    }
+
+    public function noVariadics(string $first, int $second = 42): string
+    {
+        return $first . $second;
+    }
+}

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyMethodVariadicsTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyMethodVariadicsTest.php
@@ -1,0 +1,86 @@
+<?php
+namespace Neos\Flow\Tests\Unit\ObjectManagement\Proxy;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Laminas\Code\Reflection\MethodReflection;
+use Neos\Flow\ObjectManagement\Proxy\ProxyMethodGenerator;
+use Neos\Flow\Tests\Unit\ObjectManagement\Fixture\ClassWithVariadicMethods;
+use Neos\Flow\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Tests for the handling of variadic parameters in generated proxy methods
+ */
+class ProxyMethodVariadicsTest extends UnitTestCase
+{
+    public static function variadicMethodsDataProvider(): array
+    {
+        return [
+            'no variadic parameter' => [
+                'noVariadics',
+                '$first, $second',
+                'string $first, int $second = 42',
+            ],
+            'variadic parameter without type' => [
+                'sum',
+                '...$numbers',
+                '... $numbers',
+            ],
+            'variadic parameter with type' => [
+                'sumTyped',
+                '...$numbers',
+                'int ... $numbers',
+            ],
+            'regular and variadic parameters mixed' => [
+                'concatenate',
+                '$separator, ...$parts',
+                'string $separator, string ... $parts',
+            ],
+            'by-reference and variadic parameters mixed' => [
+                'collect',
+                '$collection, ...$items',
+                'array &$collection, string ... $items',
+            ],
+        ];
+    }
+
+    #[DataProvider('variadicMethodsDataProvider')]
+    #[Test]
+    public function buildMethodParametersCodeUnpacksVariadicParameters(string $methodName, string $expectedArgumentsCode, string $expectedSignatureCode): void
+    {
+        $proxyMethod = ProxyMethodGenerator::fromReflection(new MethodReflection(ClassWithVariadicMethods::class, $methodName));
+
+        self::assertSame($expectedArgumentsCode, $proxyMethod->buildMethodParametersCode(ClassWithVariadicMethods::class, $methodName, false));
+        self::assertSame($expectedSignatureCode, $proxyMethod->buildMethodParametersCode(ClassWithVariadicMethods::class, $methodName, true));
+    }
+
+    #[DataProvider('variadicMethodsDataProvider')]
+    #[Test]
+    public function renderBodyCodeUnpacksVariadicParametersInTheParentCall(string $methodName, string $expectedArgumentsCode): void
+    {
+        $proxyMethod = ProxyMethodGenerator::fromReflection(new MethodReflection(ClassWithVariadicMethods::class, $methodName));
+        $proxyMethod->addPreParentCallCode('$before = true;');
+        $proxyMethod->addPostParentCallCode('$after = true;');
+
+        self::assertStringContainsString('parent::' . $methodName . '(' . $expectedArgumentsCode . ');', $proxyMethod->renderBodyCode());
+    }
+
+    #[Test]
+    public function renderBodyCodeUnpacksVariadicParametersInTheReturningParentCall(): void
+    {
+        $proxyMethod = ProxyMethodGenerator::fromReflection(new MethodReflection(ClassWithVariadicMethods::class, 'sumTyped'));
+        $proxyMethod->addPreParentCallCode('$before = true;');
+
+        self::assertStringContainsString('return parent::sumTyped(...$numbers);', $proxyMethod->renderBodyCode());
+    }
+}


### PR DESCRIPTION
A generated proxy method passes the parameters of the original method on to the parent method one by one. For a variadic parameter this means that the collected arguments are handed over as a single array, which results in a TypeError as soon as a proxied or advised method declares a variadic parameter.

The generated parent call now unpacks variadic parameters again. The same applies to the invocation of a join point at the end of an advice chain: a join point stores the arguments of a variadic parameter as one array, mapped to the name of that parameter, so that array needs to be unpacked before the method is called with the arguments taken from the join point.

Fixes #3589
