### PR TITLE
Adjust note about named arguments support

### DIFF
--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartV/PhpLanguageFeatureReference.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartV/PhpLanguageFeatureReference.rst
@@ -224,10 +224,9 @@ PHP 8.0
      - –
      - 9.2
      - Proxy constructors preserve the original parameter list, so instantiation
-       with named arguments works (`#3076
-       <https://github.com/neos/flow-development-collection/issues/3076>`_; a
-       backport to 9.0 is pending in `#3504
-       <https://github.com/neos/flow-development-collection/pull/3504>`_).
+       with named arguments works since Flow 9.2 (`#3076
+       <https://github.com/neos/flow-development-collection/issues/3076>`_).
+       The fix was not backported to older branches.
    * - Attributes on classes and methods
      - Partial
      - Partial


### PR DESCRIPTION
The backport of the named arguments fix to 9.0 (#3504) was closed in favor of keeping the fix in 9.2, where the constructor code generation evolved further with #3510.