### PR TITLE
BUGFIX: Do not restart cache iteration when entries change

### DIFF
--- a/Neos.Cache/Classes/Backend/ApcuBackend.php
+++ b/Neos.Cache/Classes/Backend/ApcuBackend.php
@@ -133,8 +133,6 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
         } else {
             throw new Exception('Could not set value.', 1232986877);
         }
-
-        $this->cacheEntriesIterator = null;
     }
 
     /**
@@ -177,7 +175,6 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
     public function remove(string $entryIdentifier): bool
     {
         $this->removeIdentifierFromAllTags($entryIdentifier);
-        $this->cacheEntriesIterator = null;
         return apcu_delete($this->getPrefixedIdentifier($entryIdentifier));
     }
 
@@ -241,7 +238,6 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
         foreach ($identifiers as $identifier) {
             $this->remove($identifier);
         }
-        $this->cacheEntriesIterator = null;
         return count($identifiers);
     }
 
@@ -389,16 +385,16 @@ class ApcuBackend extends IndependentAbstractBackend implements TaggableBackendI
     /**
      * Rewinds the cache entry iterator to the first element
      *
+     * APCu is searched anew on every rewind, so this always yields an up-to-date view. That is why writing methods
+     * like set() and remove() must not reset the iterator: doing so would make a running iteration start over from
+     * the first entry whenever an entry is changed.
+     *
      * @return void
      * @api
      */
     #[\ReturnTypeWillChange]
     public function rewind()
     {
-        if ($this->cacheEntriesIterator === null) {
-            $this->cacheEntriesIterator = new \APCUIterator('/^' . $this->identifierPrefix . 'entry_.*/');
-        } else {
-            $this->cacheEntriesIterator->rewind();
-        }
+        $this->cacheEntriesIterator = new \APCUIterator('/^' . $this->identifierPrefix . 'entry_.*/');
     }
 }

--- a/Neos.Cache/Classes/Backend/PdoBackend.php
+++ b/Neos.Cache/Classes/Backend/PdoBackend.php
@@ -217,7 +217,6 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
             }
 
             $this->databaseHandle->commit();
-            $this->cacheEntriesIterator = null;
         } catch (\Exception $exception) {
             $this->databaseHandle->rollBack();
 
@@ -283,7 +282,6 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
         try {
             $rowsWereDeleted = $this->removeWithoutTransaction($entryIdentifier);
             $this->databaseHandle->commit();
-            $this->cacheEntriesIterator = null;
 
             return $rowsWereDeleted;
         } catch (\Exception $exception) {
@@ -340,7 +338,6 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
             $statementHandle->execute([$this->context(), $this->cacheIdentifier]);
 
             $this->databaseHandle->commit();
-            $this->cacheEntriesIterator = null;
         } catch (\Exception $exception) {
             $this->databaseHandle->rollBack();
 
@@ -371,7 +368,6 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
             $statementHandle->execute([$this->context(), $this->cacheIdentifier, $tag]);
 
             $this->databaseHandle->commit();
-            $this->cacheEntriesIterator = null;
 
             return $flushed;
         } catch (\Exception $exception) {
@@ -482,7 +478,6 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
 
             throw $exception;
         }
-        $this->cacheEntriesIterator = null;
     }
 
     /**
@@ -611,6 +606,10 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
      * Rewinds the cache entry iterator to the first element
      * and fetches cacheEntries.
      *
+     * The entries are fetched anew on every rewind, so this always yields an up-to-date view. That is why writing
+     * methods like set() and remove() must not reset the iterator: doing so would make a running iteration start
+     * over from the first entry whenever an entry is changed.
+     *
      * @return void
      * @api
      */
@@ -619,11 +618,6 @@ class PdoBackend extends IndependentAbstractBackend implements TaggableBackendIn
         try {
             $this->connect();
         } catch (Exception $e) {
-            return;
-        }
-
-        if ($this->cacheEntriesIterator !== null) {
-            $this->cacheEntriesIterator->rewind();
             return;
         }
 

--- a/Neos.Cache/Classes/Backend/SimpleFileBackend.php
+++ b/Neos.Cache/Classes/Backend/SimpleFileBackend.php
@@ -161,7 +161,6 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
             if ($this->cacheEntryFileExtension === '.php') {
                 OpcodeCacheHelper::clearAllActive($cacheEntryPathAndFilename);
             }
-            $this->cacheFilesIterator = null;
             return;
         }
 
@@ -260,7 +259,6 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
 
                 if ($result === true) {
                     clearstatcache(true, $cacheEntryPathAndFilename);
-                    $this->cacheFilesIterator = null;
                     return true;
                 }
             } catch (\Exception $e) {
@@ -281,7 +279,6 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
     public function flush(): void
     {
         Files::emptyDirectoryRecursively($this->cacheDirectory);
-        $this->cacheFilesIterator = null;
     }
 
     /**
@@ -406,14 +403,16 @@ class SimpleFileBackend extends IndependentAbstractBackend implements PhpCapable
     /**
      * Rewinds the cache entry iterator to the first element
      *
+     * The directory is read anew on every rewind, so this always yields an up-to-date view. That is why writing
+     * methods like set() and remove() must not reset the iterator: doing so would make a running iteration start
+     * over from the first entry whenever an entry is changed.
+     *
      * @return void
      * @api
      */
     public function rewind(): void
     {
-        if ($this->cacheFilesIterator === null) {
-            $this->cacheFilesIterator = new \DirectoryIterator($this->cacheDirectory);
-        }
+        $this->cacheFilesIterator = new \DirectoryIterator($this->cacheDirectory);
         $this->cacheFilesIterator->rewind();
         while (substr($this->cacheFilesIterator->getFilename(), 0, 1) === '.' && $this->cacheFilesIterator->valid()) {
             $this->cacheFilesIterator->next();

--- a/Neos.Cache/Tests/Unit/Backend/ApcuBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/ApcuBackendTest.php
@@ -354,6 +354,56 @@ class ApcuBackendTest extends BaseTestCase
     /**
      * @test
      */
+    public function iterationIsNotRestartedWhenAnEntryIsUpdatedWhileIterating()
+    {
+        $backend = $this->setUpBackend();
+        $cache = new VariableFrontend('UnitTestCache', $backend);
+
+        foreach (['first', 'second', 'third', 'fourth'] as $entryIdentifier) {
+            $cache->set($entryIdentifier, $entryIdentifier . 'Data');
+        }
+
+        $visitedEntryIdentifiers = [];
+        foreach ($cache->getIterator() as $entryIdentifier => $data) {
+            // update while in the middle of the iteration – a restart would visit earlier entries again
+            if (count($visitedEntryIdentifiers) === 2) {
+                $cache->set($entryIdentifier, 'updatedData');
+            }
+            $visitedEntryIdentifiers[] = $entryIdentifier;
+        }
+
+        sort($visitedEntryIdentifiers);
+        self::assertSame(['first', 'fourth', 'second', 'third'], $visitedEntryIdentifiers);
+    }
+
+    /**
+     * @test
+     */
+    public function iterationIsNotRestartedWhenAnEntryIsRemovedWhileIterating()
+    {
+        $backend = $this->setUpBackend();
+        $cache = new VariableFrontend('UnitTestCache', $backend);
+
+        foreach (['first', 'second', 'third', 'fourth'] as $entryIdentifier) {
+            $cache->set($entryIdentifier, $entryIdentifier . 'Data');
+        }
+
+        $visitedEntryIdentifiers = [];
+        foreach ($cache->getIterator() as $entryIdentifier => $data) {
+            // remove an entry that has been visited already, like SessionManager::collectGarbage() does
+            if (count($visitedEntryIdentifiers) === 2) {
+                $cache->remove($visitedEntryIdentifiers[0]);
+            }
+            $visitedEntryIdentifiers[] = $entryIdentifier;
+        }
+
+        sort($visitedEntryIdentifiers);
+        self::assertSame(['first', 'fourth', 'second', 'third'], $visitedEntryIdentifiers);
+    }
+
+    /**
+     * @test
+     */
     public function iterationResetsWhenDataFlushed()
     {
         $backend = $this->setUpBackend();

--- a/Neos.Cache/Tests/Unit/Backend/PdoBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/PdoBackendTest.php
@@ -332,6 +332,54 @@ class PdoBackendTest extends BaseTestCase
     }
 
     /**
+     * @test
+     */
+    public function iterationIsNotRestartedWhenAnEntryIsUpdatedWhileIterating()
+    {
+        $backend = $this->setUpBackend();
+
+        foreach (['first', 'second', 'third', 'fourth'] as $entryIdentifier) {
+            $backend->set($entryIdentifier, $entryIdentifier . 'Data');
+        }
+
+        $visitedEntryIdentifiers = [];
+        foreach ($backend as $entryIdentifier => $data) {
+            // update while in the middle of the iteration – a restart would visit earlier entries again
+            if (count($visitedEntryIdentifiers) === 2) {
+                $backend->set($entryIdentifier, 'updatedData');
+            }
+            $visitedEntryIdentifiers[] = $entryIdentifier;
+        }
+
+        sort($visitedEntryIdentifiers);
+        self::assertSame(['first', 'fourth', 'second', 'third'], $visitedEntryIdentifiers);
+    }
+
+    /**
+     * @test
+     */
+    public function iterationIsNotRestartedWhenAnEntryIsRemovedWhileIterating()
+    {
+        $backend = $this->setUpBackend();
+
+        foreach (['first', 'second', 'third', 'fourth'] as $entryIdentifier) {
+            $backend->set($entryIdentifier, $entryIdentifier . 'Data');
+        }
+
+        $visitedEntryIdentifiers = [];
+        foreach ($backend as $entryIdentifier => $data) {
+            // remove an entry that has been visited already, like SessionManager::collectGarbage() does
+            if (count($visitedEntryIdentifiers) === 2) {
+                $backend->remove($visitedEntryIdentifiers[0]);
+            }
+            $visitedEntryIdentifiers[] = $entryIdentifier;
+        }
+
+        sort($visitedEntryIdentifiers);
+        self::assertSame(['first', 'fourth', 'second', 'third'], $visitedEntryIdentifiers);
+    }
+
+    /**
      * Sets up the APC backend used for testing
      *
      * @return PdoBackend

--- a/Neos.Cache/Tests/Unit/Backend/SimpleFileBackendTest.php
+++ b/Neos.Cache/Tests/Unit/Backend/SimpleFileBackendTest.php
@@ -590,6 +590,54 @@ class SimpleFileBackendTest extends BaseTestCase
     /**
      * @test
      */
+    public function iterationIsNotRestartedWhenAnEntryIsUpdatedWhileIterating(): void
+    {
+        $backend = $this->getSimpleFileBackend();
+
+        foreach (['first', 'second', 'third', 'fourth'] as $entryIdentifier) {
+            $backend->set($entryIdentifier, $entryIdentifier . 'Data');
+        }
+
+        $visitedEntryIdentifiers = [];
+        foreach ($backend as $entryIdentifier => $data) {
+            // update while in the middle of the iteration – a restart would visit earlier entries again
+            if (count($visitedEntryIdentifiers) === 2) {
+                $backend->set($entryIdentifier, 'updatedData');
+            }
+            $visitedEntryIdentifiers[] = $entryIdentifier;
+        }
+
+        sort($visitedEntryIdentifiers);
+        self::assertSame(['first', 'fourth', 'second', 'third'], $visitedEntryIdentifiers);
+    }
+
+    /**
+     * @test
+     */
+    public function iterationIsNotRestartedWhenAnEntryIsRemovedWhileIterating(): void
+    {
+        $backend = $this->getSimpleFileBackend();
+
+        foreach (['first', 'second', 'third', 'fourth'] as $entryIdentifier) {
+            $backend->set($entryIdentifier, $entryIdentifier . 'Data');
+        }
+
+        $visitedEntryIdentifiers = [];
+        foreach ($backend as $entryIdentifier => $data) {
+            // remove an entry that has been visited already, like SessionManager::collectGarbage() does
+            if (count($visitedEntryIdentifiers) === 2) {
+                $backend->remove($visitedEntryIdentifiers[0]);
+            }
+            $visitedEntryIdentifiers[] = $entryIdentifier;
+        }
+
+        sort($visitedEntryIdentifiers);
+        self::assertSame(['first', 'fourth', 'second', 'third'], $visitedEntryIdentifiers);
+    }
+
+    /**
+     * @test
+     */
     public function iterationResetsWhenDataFlushed()
     {
         $backend = $this->getSimpleFileBackend();


### PR DESCRIPTION
The iterable cache backends reset their shared iterator whenever an entry was written or removed. As a result a running iteration started over from the beginning after every change: entries were visited repeatedly and, with the file backends, some were not visited at all.

SessionManager::collectGarbage() removes entries while iterating the session metadata cache (backed by FileBackend by default) and was affected by this.

Instead of resetting the iterator on write, rewind() now always builds a fresh one. That still yields an up-to-date view on every rewind - which is what the reset was meant to achieve - while leaving a running iteration alone.

**Checklist**

- [x] Code follows the PSR-12 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
