### PR TITLE
TASK: Drop support for legacy code caches

### DIFF
--- a/Neos.Utility.OpcodeCache/Classes/OpcodeCacheHelper.php
+++ b/Neos.Utility.OpcodeCache/Classes/OpcodeCacheHelper.php
@@ -51,18 +51,6 @@ abstract class OpcodeCacheHelper
             };
         }
 
-        // WinCache - http://www.php.net/manual/de/book.wincache.php
-        if (extension_loaded('wincache') && ini_get('wincache.ocenabled') === '1') {
-            self::$clearCacheCallbacks[] = function ($absolutePathAndFilename) {
-                if ($absolutePathAndFilename !== null) {
-                    wincache_refresh_if_changed([$absolutePathAndFilename]);
-                } else {
-                    // Refresh everything!
-                    wincache_refresh_if_changed();
-                }
-            };
-        }
-
         // XCache - http://xcache.lighttpd.net/
         // Supported in version >= 3.0.1
         if (extension_loaded('xcache')) {

--- a/Neos.Utility.OpcodeCache/Classes/OpcodeCacheHelper.php
+++ b/Neos.Utility.OpcodeCache/Classes/OpcodeCacheHelper.php
@@ -51,17 +51,6 @@ abstract class OpcodeCacheHelper
             };
         }
 
-        // XCache - http://xcache.lighttpd.net/
-        // Supported in version >= 3.0.1
-        if (extension_loaded('xcache')) {
-            self::$clearCacheCallbacks[] = function ($absolutePathAndFilename) {
-                // XCache can only be fully cleared.
-                if (!ini_get('xcache.admin.enable_auth')) {
-                    /** @phpstan-ignore-next-line */
-                    xcache_clear_cache(XC_TYPE_PHP);
-                }
-            };
-        }
         self::$initialized = true;
     }
 

--- a/Neos.Utility.OpcodeCache/Classes/OpcodeCacheHelper.php
+++ b/Neos.Utility.OpcodeCache/Classes/OpcodeCacheHelper.php
@@ -40,7 +40,7 @@ abstract class OpcodeCacheHelper
     {
         self::$clearCacheCallbacks = [];
 
-        // Zend OpCache (built in by default since PHP 5.5) - http://php.net/manual/de/book.opcache.php
+        // OpCache - http://php.net/manual/en/book.opcache.php
         if (extension_loaded('Zend OPcache') && ini_get('opcache.enable') === '1') {
             self::$clearCacheCallbacks[] = function ($absolutePathAndFilename) {
                 if ($absolutePathAndFilename !== null && function_exists('opcache_invalidate')) {


### PR DESCRIPTION
Drop support for xcache and wincache from our `OpcodeCacheHelper`.

**Checklist**

- [x] Code follows the PSR-12 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
