### PR TITLE
TASK: Use `Test` attribute in kickstarter test template

### DIFF
--- a/Neos.Kickstarter/Resources/Private/Generator/Tests/Unit/Model/EntityTestTemplate.php.tmpl
+++ b/Neos.Kickstarter/Resources/Private/Generator/Tests/Unit/Model/EntityTestTemplate.php.tmpl
@@ -5,15 +5,15 @@ namespace {namespace};
  * This file is part of the {packageKey} package.
  */
 
+use PHPUnit\Framework\Attributes\Test;
+
 /**
  * Testcase for {modelName -> k:inflect.humanizeCamelCase()}
  */
 class {testName} extends \Neos\Flow\Tests\UnitTestCase
 {
 
-    /**
-     * @test
-     */
+    #[Test]
     public function makeSureThatSomethingHolds()
     {
         $this->markTestIncomplete('Automatically generated test case; you need to adjust this!');


### PR DESCRIPTION
Replaces the `@test` annotation with the PHPUnit `#[Test]` attribute in the generated entity test case, matching the style used since PHPUnit 11.

**Checklist**

- [x] Code follows the PSR-12 coding style
- [ ] ~Tests have been created, run and adjusted as needed~
- [x] The PR is created against the branch adding PHPUnit 11
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
