### PR TITLE
BUGFIX: Drop `setlocale()` calls from `Functions::pathinfo()`

### DIFF
--- a/Neos.Utility.Unicode/Classes/Functions.php
+++ b/Neos.Utility.Unicode/Classes/Functions.php
@@ -143,15 +143,19 @@ abstract class Functions
 
     /**
      * Unicode variant of pathinfo()
-     * pathinfo() function is not unicode-friendly
-     * if setlocale is not set. It's sufficient to set it
-     * to any UTF-8 locale to correctly handle unicode strings.
-     * This wrapper function temporarily sets locale to 'en_US.UTF-8'
-     * and then restores original locale.
-     * It's not necessary to use this function in cases,
-     * where only file extension is determined, as it's
-     * hard to imagine a unicode file extension.
-     * @see http://www.php.net/manual/en/function.pathinfo.php
+     *
+     * Kept for backwards compatibility only — it delegates to the native function.
+     * pathinfo() is UTF-8 safe on its own: the only characters it splits on, '/' and '.',
+     * cannot occur inside a multi-byte UTF-8 sequence, and PHP no longer classifies path
+     * bytes through LC_CTYPE. Verified identical output under the C, ISO8859-1, SJIS and
+     * UTF-8 locales.
+     *
+     * This used to switch LC_CTYPE to 'en_US.UTF-8' for the duration of the call. That was
+     * both unnecessary and harmful: restoring the locale *string* afterwards does not
+     * restore PCRE's character tables, so from the first call onwards every regex without
+     * the /u modifier changed meaning process-wide — \w started matching bytes >= 0x80.
+     *
+     * @see https://www.php.net/manual/en/function.pathinfo.php
      *
      * @param string $path
      * @param integer $options Optional, one of PATHINFO_DIRNAME, PATHINFO_BASENAME, PATHINFO_EXTENSION or PATHINFO_FILENAME.
@@ -160,13 +164,7 @@ abstract class Functions
      */
     public static function pathinfo(string $path, ?int $options = null)
     {
-        $currentLocale = setlocale(LC_CTYPE, 0);
-        // Before we have a setting for setlocale, his should suffice for pathinfo
-        // to work correctly on Unicode strings
-        setlocale(LC_CTYPE, 'en_US.UTF-8');
-        $pathinfo = $options == null ? pathinfo($path) : pathinfo($path, $options);
-        setlocale(LC_CTYPE, $currentLocale);
-        return $pathinfo;
+        return $options == null ? pathinfo($path) : pathinfo($path, $options);
     }
 
     /**


### PR DESCRIPTION
This avoids a (PHP) bug where following regex calls can change their behaviour.

See neos/flow-development-collection#3606

**Checklist**

- [x] Code follows the PSR-12 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
