### PR TITLE
BUGFIX: Handle false model and pluralRulesSet in generateRulesets

### DIFF
--- a/Neos.Flow/Classes/I18n/Cldr/Reader/PluralsReader.php
+++ b/Neos.Flow/Classes/I18n/Cldr/Reader/PluralsReader.php
@@ -254,7 +254,8 @@ class PluralsReader
     protected function generateRulesets(): void
     {
         $model = $this->cldrRepository->getModel('supplemental/plurals');
-        $pluralRulesSet = $model->getRawArray('plurals');
+        $pluralRulesSet = $model === false ? [] : $model->getRawArray('plurals');
+        $pluralRulesSet = $pluralRulesSet === false ? [] : $pluralRulesSet;
 
         $index = 0;
         foreach ($pluralRulesSet as $pluralRulesNodeString => $pluralRules) {


### PR DESCRIPTION
This avoids `Call to a member function getRawArray() on false`.

**Checklist**

- [x] Code follows the PSR-12 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
