### PR TITLE
TASK: Fix tests after upmerge and PHPUnit migration

### DIFF
--- a/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyMethodGeneratorTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyMethodGeneratorTest.php
@@ -158,22 +158,6 @@ class ProxyMethodGeneratorTest extends UnitTestCase
         self::assertStringNotContainsString('return', $bodyCode);
     }
 
-    /**
-     * Note: This documents the current behavior. For methods returning void or never, the
-     *       call to the parent method is skipped entirely as long as no post parent call
-     *       code was added – which arguably is a bug, because the original method is then
-     *       never executed.
-     */
-    #[DataProvider('voidAndNeverReturnTypesDataProvider')]
-    #[Test]
-    public function noParentCallIsRenderedForVoidAndNeverReturnTypesIfOnlyPreParentCallCodeExists(string $methodName): void
-    {
-        $proxyMethod = $this->createProxyMethodFor($methodName);
-        $proxyMethod->addPreParentCallCode('$foo = 1;');
-
-        self::assertSame("\$foo = 1;\n", $proxyMethod->renderBodyCode());
-    }
-
     #[Test]
     public function noParentCallIsRenderedIfTheOriginalClassIsUnknown(): void
     {

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetControllerTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetControllerTest.php
@@ -18,6 +18,7 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\ServerRequest;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Mvc\ActionResponse;
 use Neos\Flow\Mvc\Controller\MvcPropertyMappingConfigurationService;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\FluidAdaptor\Core\Widget\AbstractWidgetController;


### PR DESCRIPTION
This fixes the two unit test failures which currently break the test run on the 9.2 branch:

The test `noParentCallIsRenderedForVoidAndNeverReturnTypesIfOnlyPreParentCallCodeExists` documented the behavior which was fixed with #3598: for void and never methods which only received pre parent call code, the call to the original method was skipped. After the upmerge of that fix into 9.2, the test failed. Since the merge already brought the corrected test coverage from #3598 into the same test class, the outdated test can simply be removed.

Additionally, the code style clean-up in 2feb05da8 removed the import of `ActionResponse` from `AbstractWidgetControllerTest` although the class is used in one of the tests, which made that test fail with a class not found error. The import is restored.

Related to #3597
