### PR TITLE
BUGFIX: Preserve by-reference returns in proxies

### DIFF
--- a/Neos.Flow/Classes/Aop/Builder/AdvisedMethodInterceptorBuilder.php
+++ b/Neos.Flow/Classes/Aop/Builder/AdvisedMethodInterceptorBuilder.php
@@ -48,6 +48,12 @@ class AdvisedMethodInterceptorBuilder extends AbstractMethodInterceptorBuilder
         if ($declaringClassName !== $targetClassName) {
             $originalMethod = MethodGenerator::copyMethodSignature(new \Laminas\Code\Reflection\MethodReflection($declaringClassName, $methodName));
             $proxyMethod->setParameters($originalMethod->getParameters());
+            $methodReturnsReference = $originalMethod->returnsReference();
+        } else {
+            $methodReturnsReference = $proxyMethod->returnsReference();
+        }
+        if ($methodReturnsReference) {
+            throw new Exception(sprintf('The %s cannot build interceptor code for method %s::%s() because it returns by reference: references cannot be preserved through an advice chain, so the advised method would silently return a copy instead of the original reference. Please remove the advice for this method, or exclude the class from proxying by adding a #[Flow\Proxy(false)] attribute.', __CLASS__, $targetClassName, $methodName), 1785837971);
         }
 
         $groupedAdvices = $methodMetaInformation[$methodName]['groupedAdvices'];

--- a/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
+++ b/Neos.Flow/Classes/ObjectManagement/Proxy/ProxyMethodGenerator.php
@@ -170,7 +170,10 @@ class ProxyMethodGenerator extends MethodGenerator
                     $code .= '    ' . $callParentMethodCode;
                 }
             } else {
-                $code .= '$result = ' . ($callParentMethodCode === '' ? "null;\n" : $callParentMethodCode);
+                # A method returning by reference must assign the parent call by reference as well,
+                # otherwise the "return $result;" below would return a copy instead of the reference:
+                $referenceOperator = ($this->returnsReference() ? '&' : '');
+                $code .= '$result = ' . ($callParentMethodCode === '' ? "null;\n" : $referenceOperator . $callParentMethodCode);
             }
             $code .= $this->addedPostParentCallCode;
             if (!$returnTypeIsVoidOrNever) {

--- a/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/AspectOrientedProgramming.rst
+++ b/Neos.Flow/Documentation/TheDefinitiveGuide/PartIII/AspectOrientedProgramming.rst
@@ -298,6 +298,13 @@ aspect.
 	This can be explicitly disabled with a ``@Flow\Proxy(false)`` annotation on the
 	class in question.
 
+.. Note::
+	Methods returning by reference (``public function &foo()``) cannot be advised:
+	the return value travels through the advice chain by value, therefore the
+	reference would be lost silently. Instead of changing the semantics of such a
+	method, Flow refuses to build the interceptor code and throws an exception
+	while compiling the proxy classes.
+
 Pointcuts
 =========
 

--- a/Neos.Flow/Tests/Unit/Aop/Builder/AdvisedMethodInterceptorBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/Aop/Builder/AdvisedMethodInterceptorBuilderTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Neos\Flow\Tests\Unit\Aop\Builder;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Aop\Builder\AdvisedMethodInterceptorBuilder;
+use Neos\Flow\Aop\Exception;
+use Neos\Flow\ObjectManagement\Proxy\Compiler;
+use Neos\Flow\ObjectManagement\Proxy\ProxyClass;
+use Neos\Flow\Reflection\ReflectionService;
+use Neos\Flow\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Testcase for the Advised Method Interceptor Builder
+ */
+class AdvisedMethodInterceptorBuilderTest extends UnitTestCase
+{
+    protected ProxyClass $proxyClass;
+
+    protected function buildInterceptorBuilder(string $targetClassName): AdvisedMethodInterceptorBuilder
+    {
+        $this->proxyClass = new ProxyClass($targetClassName);
+
+        $mockCompiler = $this->getMockBuilder(Compiler::class)->disableOriginalConstructor()->getMock();
+        $mockCompiler->method('getProxyClass')->willReturn($this->proxyClass);
+
+        $mockReflectionService = $this->getMockBuilder(ReflectionService::class)->disableOriginalConstructor()->getMock();
+        $mockReflectionService->method('getMethodParameters')->willReturn([]);
+
+        $builder = new AdvisedMethodInterceptorBuilder();
+        $builder->injectCompiler($mockCompiler);
+        $builder->injectReflectionService($mockReflectionService);
+        return $builder;
+    }
+
+    /**
+     * A method returning by reference cannot be advised, because the return value travels
+     * through the advice chain by value.
+     *
+     * @see https://github.com/neos/flow-development-collection/issues/3590
+     */
+    #[Test]
+    public function buildThrowsExceptionIfTheAdvisedMethodReturnsByReference(): void
+    {
+        $targetClassName = 'AdvisedMethodByReferenceFixture' . md5(uniqid((string)mt_rand(), true));
+        eval('
+            class ' . $targetClassName . ' {
+                protected array $items = [];
+                public function &itemsReference(): array { return $this->items; }
+            }
+        ');
+
+        $builder = $this->buildInterceptorBuilder($targetClassName);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(1785837971);
+        $this->expectExceptionMessageMatches('/returns by reference/');
+
+        $builder->build('itemsReference', ['itemsReference' => ['declaringClassName' => $targetClassName, 'groupedAdvices' => []]], $targetClassName);
+    }
+
+    #[Test]
+    public function buildThrowsExceptionIfAMethodIntroducedByAnInterfaceReturnsByReference(): void
+    {
+        $suffix = md5(uniqid((string)mt_rand(), true));
+        $interfaceName = 'AdvisedMethodByReferenceFixtureInterface' . $suffix;
+        $targetClassName = 'AdvisedMethodByReferenceIntroductionFixture' . $suffix;
+        eval('
+            interface ' . $interfaceName . ' {
+                public function &itemsReference(): array;
+            }
+            class ' . $targetClassName . ' {
+            }
+        ');
+
+        $builder = $this->buildInterceptorBuilder($targetClassName);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionCode(1785837971);
+
+        $builder->build('itemsReference', ['itemsReference' => ['declaringClassName' => $interfaceName, 'groupedAdvices' => []]], $targetClassName);
+    }
+
+    #[Test]
+    public function buildAddsInterceptorCodeForMethodsReturningByValue(): void
+    {
+        $targetClassName = 'AdvisedMethodByValueFixture' . md5(uniqid((string)mt_rand(), true));
+        eval('
+            class ' . $targetClassName . ' {
+                protected array $items = [];
+                public function items(): array { return $this->items; }
+            }
+        ');
+
+        $builder = $this->buildInterceptorBuilder($targetClassName);
+        $builder->build('items', ['items' => ['declaringClassName' => $targetClassName, 'groupedAdvices' => []]], $targetClassName);
+
+        $bodyCode = $this->proxyClass->getMethod('items')->renderBodyCode();
+
+        self::assertStringContainsString('$this->Flow_Aop_Proxy_methodIsInAdviceMode[\'items\']', $bodyCode);
+        self::assertStringContainsString('$result = parent::items();', $bodyCode);
+        self::assertStringNotContainsString('&parent::', $bodyCode);
+    }
+}

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyMethodByReferenceTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Proxy/ProxyMethodByReferenceTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Neos\Flow\Tests\Unit\ObjectManagement\Proxy;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Laminas\Code\Reflection\MethodReflection;
+use Neos\Flow\ObjectManagement\Proxy\ProxyMethodGenerator;
+use Neos\Flow\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Testcase for proxy methods which return by reference
+ *
+ * @see https://github.com/neos/flow-development-collection/issues/3590
+ */
+class ProxyMethodByReferenceTest extends UnitTestCase
+{
+    /**
+     * Creates a class with a method returning by reference and one returning by value
+     * and returns the name of that class.
+     */
+    protected function buildOriginalClass(): string
+    {
+        $className = 'ProxyMethodByReferenceFixture' . md5(uniqid((string)mt_rand(), true));
+        eval('
+            class ' . $className . ' {
+                protected array $items = [\'initial\'];
+                public function &itemsReference(): array { return $this->items; }
+                public function items(): array { return $this->items; }
+            }
+        ');
+        return $className;
+    }
+
+    #[Test]
+    public function bodyCodeOfMethodReturningByReferenceAssignsTheParentCallByReference(): void
+    {
+        $className = $this->buildOriginalClass();
+        $proxyMethod = ProxyMethodGenerator::copyMethodSignatureAndDocblock(new MethodReflection($className, 'itemsReference'));
+        $proxyMethod->addPreParentCallCode('// pre parent call');
+        $proxyMethod->addPostParentCallCode('// post parent call');
+
+        $bodyCode = $proxyMethod->renderBodyCode();
+
+        self::assertStringContainsString('$result = &parent::itemsReference();', $bodyCode);
+        self::assertStringContainsString('return $result;', $bodyCode);
+    }
+
+    #[Test]
+    public function bodyCodeOfMethodReturningByValueAssignsTheParentCallByValue(): void
+    {
+        $className = $this->buildOriginalClass();
+        $proxyMethod = ProxyMethodGenerator::copyMethodSignatureAndDocblock(new MethodReflection($className, 'items'));
+        $proxyMethod->addPreParentCallCode('// pre parent call');
+        $proxyMethod->addPostParentCallCode('// post parent call');
+
+        $bodyCode = $proxyMethod->renderBodyCode();
+
+        self::assertStringContainsString('$result = parent::items();', $bodyCode);
+        self::assertStringNotContainsString('&parent::', $bodyCode);
+    }
+
+    /**
+     * If only pre parent call code exists, the parent call is returned directly – which
+     * preserves the reference without any further measures.
+     */
+    #[Test]
+    public function bodyCodeOfMethodReturningByReferenceWithOnlyPreParentCallCodeReturnsTheParentCallDirectly(): void
+    {
+        $className = $this->buildOriginalClass();
+        $proxyMethod = ProxyMethodGenerator::copyMethodSignatureAndDocblock(new MethodReflection($className, 'itemsReference'));
+        $proxyMethod->addPreParentCallCode('// pre parent call');
+
+        $bodyCode = $proxyMethod->renderBodyCode();
+
+        self::assertStringContainsString('return parent::itemsReference();', $bodyCode);
+        self::assertStringNotContainsString('$result', $bodyCode);
+    }
+
+    #[Test]
+    public function generatedProxyMethodPreservesTheReferenceReturnedByTheOriginalMethod(): void
+    {
+        $originalClassName = $this->buildOriginalClass();
+        $proxyMethod = ProxyMethodGenerator::copyMethodSignatureAndDocblock(new MethodReflection($originalClassName, 'itemsReference'));
+        $proxyMethod->addPreParentCallCode('// pre parent call');
+        $proxyMethod->addPostParentCallCode('// post parent call');
+
+        $proxyClassName = $originalClassName . '_Proxy';
+        eval('class ' . $proxyClassName . ' extends ' . $originalClassName . ' {' . $proxyMethod->generate() . '}');
+
+        $proxy = new $proxyClassName();
+        $items = &$proxy->itemsReference();
+        $items[] = 'added via reference';
+
+        self::assertSame(['initial', 'added via reference'], $proxy->items());
+    }
+}


### PR DESCRIPTION
Methods which are declared to return by reference (`function &foo()`) lost their reference semantics when the generated proxy method contained code before and after the parent call: the parent call was assigned to a local variable by value, therefore "return $result" returned a copy.

The proxy method generator now assigns the parent call by reference if the method itself returns by reference.

For advised methods this cannot be repaired: the return value passes through the join point and the advice chain by value, so the reference is lost by design. Instead of silently changing the semantics of such a method, the AdvisedMethodInterceptorBuilder now refuses to build the interceptor code and throws an exception while the proxy classes are compiled. The exception names the affected class and method and explains the possible ways out. Methods returning by reference which are introduced by an interface are covered as well.

Note that this is a change in behavior which should be mentioned in the release notes: a project with a pointcut which happens to match a method returning by reference will not compile anymore until the pointcut is adjusted. None of the Flow and Neos packages declare such methods.

Fixes #3590
