### PR TITLE
TASK: Prepare for PHPUnit 12

### DIFF
--- a/Neos.Flow/Tests/BaseTestCase.php
+++ b/Neos.Flow/Tests/BaseTestCase.php
@@ -47,37 +47,19 @@ abstract class BaseTestCase extends TestCase
      * @param string $mockClassName
      * @param boolean $callOriginalConstructor
      * @param boolean $callOriginalClone
-     * @param boolean $cloneArguments
+     * @param boolean $cloneArguments no longer has an effect
      * @return T&MockObject&AccessibleProxyInterface
      * @deprecated please don't use this {@see AccessibleProxyInterface}
      */
     protected function getAccessibleMock(string $originalClassName, array $methods = [], array $arguments = [], $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $cloneArguments = false)
     {
         $mockBuilder = $this->getMockBuilder($this->buildAccessibleProxy($originalClassName));
-        // PHPUnit 10+ rejects onlyMethods() entries that don't exist on the class. Split
-        // off non-existing methods (e.g. AOP-emitted signal methods, magic methods) so they
-        // can be added via addMethods() instead of failing the mock build.
-        $existingMethods = [];
-        $addedMethods = [];
-        foreach ($methods as $method) {
-            if (method_exists($originalClassName, $method)) {
-                $existingMethods[] = $method;
-            } else {
-                $addedMethods[] = $method;
-            }
-        }
-        $mockBuilder->onlyMethods($existingMethods)->setConstructorArgs($arguments)->setMockClassName($mockClassName);
-        if ($addedMethods !== []) {
-            $mockBuilder->addMethods($addedMethods);
-        }
+        $mockBuilder->onlyMethods($methods)->setConstructorArgs($arguments)->setMockClassName($mockClassName);
         if ($callOriginalConstructor === false) {
             $mockBuilder->disableOriginalConstructor();
         }
         if ($callOriginalClone === false) {
             $mockBuilder->disableOriginalClone();
-        }
-        if ($cloneArguments === true) {
-            $mockBuilder->enableArgumentCloning();
         }
 
         $mockObject = $mockBuilder->getMock();
@@ -97,15 +79,40 @@ abstract class BaseTestCase extends TestCase
      * @param string $mockClassName
      * @param boolean $callOriginalConstructor
      * @param boolean $callOriginalClone
-     * @param boolean $callAutoload
+     * @param boolean $callAutoload no longer has an effect
      * @param array $mockedMethods
-     * @param boolean $cloneArguments
+     * @param boolean $cloneArguments no longer has an effect
      * @return T&MockObject&AccessibleProxyInterface
      * @deprecated please don't use this {@see AccessibleProxyInterface}
      */
     protected function getAccessibleMockForAbstractClass($originalClassName, array $arguments = [], $mockClassName = '', $callOriginalConstructor = true, $callOriginalClone = true, $callAutoload = true, $mockedMethods = [], $cloneArguments = false)
     {
-        return $this->getMockForAbstractClass($this->buildAccessibleProxy($originalClassName), $arguments, $mockClassName, $callOriginalConstructor, $callOriginalClone, $callAutoload, $mockedMethods, $cloneArguments);
+        $proxyClassName = $this->buildAccessibleProxy($originalClassName);
+        // The accessible proxy of an abstract class is abstract itself. PHPUnit only implements
+        // the methods passed to onlyMethods(), so the abstract ones have to be listed explicitly –
+        // otherwise the generated mock class is left with unimplemented abstract methods.
+        $abstractMethods = array_map(
+            static fn (\ReflectionMethod $method) => $method->getName(),
+            (new \ReflectionClass($proxyClassName))->getMethods(\ReflectionMethod::IS_ABSTRACT)
+        );
+
+        $mockBuilder = $this->getMockBuilder($proxyClassName);
+        $mockBuilder
+            ->onlyMethods(array_values(array_unique([...$mockedMethods, ...$abstractMethods])))
+            ->setConstructorArgs($arguments)
+            ->setMockClassName($mockClassName);
+        if ($callOriginalConstructor === false) {
+            $mockBuilder->disableOriginalConstructor();
+        }
+        if ($callOriginalClone === false) {
+            $mockBuilder->disableOriginalClone();
+        }
+
+        $mockObject = $mockBuilder->getMock();
+
+        $this->registerMockObject($mockObject);
+
+        return $mockObject;
     }
 
     /**

--- a/Neos.Flow/Tests/Unit/Error/AbstractExceptionHandlerTest.php
+++ b/Neos.Flow/Tests/Unit/Error/AbstractExceptionHandlerTest.php
@@ -45,7 +45,7 @@ final class AbstractExceptionHandlerTest extends UnitTestCase
 
         $mockLogger = $this->createStub(LoggerInterface::class);
 
-        $exceptionHandler = $this->getMockForAbstractClass(AbstractExceptionHandler::class, [], '', false, true, true, ['echoExceptionCli']);
+        $exceptionHandler = $this->createPartialMock(AbstractExceptionHandler::class, ['echoExceptionWeb', 'echoExceptionCli']);
         /** @var AbstractExceptionHandler $exceptionHandler */
         $exceptionHandler->setOptions($options);
         $exceptionHandler->injectThrowableStorage($mockThrowableStorage);
@@ -85,7 +85,7 @@ final class AbstractExceptionHandlerTest extends UnitTestCase
         $mockThrowableStorage = $this->createMock(ThrowableStorageInterface::class);
         $mockThrowableStorage->expects($this->never())->method('logThrowable');
 
-        $exceptionHandler = $this->getMockForAbstractClass(AbstractExceptionHandler::class, [], '', false, true, true, ['echoExceptionCli']);
+        $exceptionHandler = $this->createPartialMock(AbstractExceptionHandler::class, ['echoExceptionWeb', 'echoExceptioncli']);
         /** @var AbstractExceptionHandler $exceptionHandler */
         $exceptionHandler->setOptions($options);
         $exceptionHandler->injectThrowableStorage($mockThrowableStorage);

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/AbstractControllerTest.php
@@ -150,7 +150,7 @@ final class AbstractControllerTest extends UnitTestCase
     public function forwardSetsControllerAndArgumentsAtTheRequestObjectIfTheyAreSpecified(): void
     {
         $routeValuesNormalizer = $this->createMock(RouteValuesNormalizerInterface::class);
-        $routeValuesNormalizer->expects($this->once())->method('normalizeObjects')->will($this->returnArgument(0));
+        $routeValuesNormalizer->expects($this->once())->method('normalizeObjects')->willReturnArgument(0);
 
         $controller = $this->getAccessibleMock(AbstractController::class, ['processRequest']);
         $this->inject($controller, 'routeValuesNormalizer', $routeValuesNormalizer);
@@ -175,7 +175,7 @@ final class AbstractControllerTest extends UnitTestCase
     public function forwardResetsControllerArguments(): void
     {
         $routeValuesNormalizer = $this->createMock(RouteValuesNormalizerInterface::class);
-        $routeValuesNormalizer->expects($this->once())->method('normalizeObjects')->will($this->returnArgument(0));
+        $routeValuesNormalizer->expects($this->once())->method('normalizeObjects')->willReturnArgument(0);
 
         $controller = $this->getAccessibleMock(AbstractController::class, ['processRequest']);
         $this->inject($controller, 'routeValuesNormalizer', $routeValuesNormalizer);
@@ -199,7 +199,7 @@ final class AbstractControllerTest extends UnitTestCase
     public function forwardSetsSubpackageKeyIfNeeded(): void
     {
         $routeValuesNormalizer = $this->createMock(RouteValuesNormalizerInterface::class);
-        $routeValuesNormalizer->expects($this->once())->method('normalizeObjects')->will($this->returnArgument(0));
+        $routeValuesNormalizer->expects($this->once())->method('normalizeObjects')->willReturnArgument(0);
 
         $controller = $this->getAccessibleMock(AbstractController::class, ['processRequest']);
         $this->inject($controller, 'routeValuesNormalizer', $routeValuesNormalizer);
@@ -220,7 +220,7 @@ final class AbstractControllerTest extends UnitTestCase
     public function forwardResetsSubpackageKeyIfNotSetInPackageKey(): void
     {
         $routeValuesNormalizer = $this->createMock(RouteValuesNormalizerInterface::class);
-        $routeValuesNormalizer->expects($this->once())->method('normalizeObjects')->will($this->returnArgument(0));
+        $routeValuesNormalizer->expects($this->once())->method('normalizeObjects')->willReturnArgument(0);
 
         $controller = $this->getAccessibleMock(AbstractController::class, ['processRequest']);
         $this->inject($controller, 'routeValuesNormalizer', $routeValuesNormalizer);

--- a/Neos.Flow/Tests/Unit/Mvc/Controller/ActionControllerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Controller/ActionControllerTest.php
@@ -227,9 +227,9 @@ final class ActionControllerTest extends UnitTestCase
                 }
                 return $mockView;
             });
-        $this->actionController->expects(self::once())->method('resolveView')->will(self::returnValue($mockView));
+        $this->actionController->expects(self::once())->method('resolveView')->willReturn($mockView);
         $this->actionController->expects(self::once())->method('callActionMethod')->willReturn(new Response());
-        $this->actionController->expects(self::once())->method('resolveActionMethodName')->will(self::returnValue('someAction'));
+        $this->actionController->expects(self::once())->method('resolveActionMethodName')->willReturn('someAction');
 
         $this->actionController->processRequest($this->mockRequest);
     }

--- a/Neos.Flow/Tests/Unit/Mvc/DispatcherTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/DispatcherTest.php
@@ -130,7 +130,7 @@ final class DispatcherTest extends UnitTestCase
     #[Test]
     public function dispatchIgnoresStopExceptionsForFirstLevelActionRequests()
     {
-        $this->mockController->expects($this->atLeastOnce())->method('processRequest')->will(self::throwException(StopActionException::createForResponse(new Response(), '')));
+        $this->mockController->expects($this->atLeastOnce())->method('processRequest')->willThrowException(StopActionException::createForResponse(new Response(), ''));
 
         $this->dispatcher->dispatch($this->mockParentRequest);
     }
@@ -138,7 +138,7 @@ final class DispatcherTest extends UnitTestCase
     #[Test]
     public function dispatchCatchesStopExceptionOfActionRequestsAndRollsBackToTheParentRequest()
     {
-        $this->mockController->expects($this->atLeastOnce())->method('processRequest')->will(self::throwException(StopActionException::createForResponse(new Response(), '')));
+        $this->mockController->expects($this->atLeastOnce())->method('processRequest')->willThrowException(StopActionException::createForResponse(new Response(), ''));
 
         $this->dispatcher->dispatch($this->mockActionRequest);
     }
@@ -172,7 +172,7 @@ final class DispatcherTest extends UnitTestCase
     {
         $forwardException = ForwardException::createForNextRequest($this->mockActionRequest, '');
 
-        $this->mockController->expects(self::any())->method('processRequest')->with($this->mockActionRequest)->will(self::throwException($forwardException));
+        $this->mockController->expects(self::any())->method('processRequest')->with($this->mockActionRequest)->willThrowException($forwardException);
 
         $this->expectException(InfiniteLoopException::class);
 

--- a/Neos.Flow/Tests/Unit/Mvc/Routing/FlowPersistenceRouteValuesNormalizerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/Routing/FlowPersistenceRouteValuesNormalizerTest.php
@@ -34,7 +34,7 @@ class FlowPersistenceRouteValuesNormalizerTest extends UnitTestCase
     public function normalizeObjectsConvertsAnObject()
     {
         $someObject = new \stdClass();
-        $this->persistenceManager->expects(self::once())->method('getIdentifierByObject')->with($someObject)->will(self::returnValue(123));
+        $this->persistenceManager->expects(self::once())->method('getIdentifierByObject')->with($someObject)->willReturn(123);
 
         $expectedResult = [['__identity' => 123]];
         $actualResult = $this->flowPersistenceRouteValuesNormalizer->normalizeObjects([$someObject]);
@@ -47,7 +47,7 @@ class FlowPersistenceRouteValuesNormalizerTest extends UnitTestCase
     {
         $this->expectException(UnknownObjectException::class);
         $someObject = new \stdClass();
-        $this->persistenceManager->expects(self::once())->method('getIdentifierByObject')->with($someObject)->will(self::returnValue(null));
+        $this->persistenceManager->expects(self::once())->method('getIdentifierByObject')->with($someObject)->willReturn(null);
 
         $this->flowPersistenceRouteValuesNormalizer->normalizeObjects([$someObject]);
     }

--- a/Neos.Flow/Tests/Unit/Mvc/ViewConfigurationManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Mvc/ViewConfigurationManagerTest.php
@@ -56,16 +56,16 @@ class ViewConfigurationManagerTest extends \Neos\Flow\Tests\UnitTestCase
 
         // caching is deactivated
         $this->mockCache = $this->getMockBuilder(VariableFrontend::class)->disableOriginalConstructor()->getMock();
-        $this->mockCache->expects(self::any())->method('get')->will(self::returnValue(false));
+        $this->mockCache->expects(self::any())->method('get')->willReturn(false);
 
         // a dummy request is prepared
         $this->mockActionRequest = $this->getMockBuilder(ActionRequest::class)->disableOriginalConstructor()->getMock();
-        $this->mockActionRequest->expects(self::any())->method('getControllerPackageKey')->will(self::returnValue('Neos.Flow'));
-        $this->mockActionRequest->expects(self::any())->method('getControllerSubpackageKey')->will(self::returnValue(''));
-        $this->mockActionRequest->expects(self::any())->method('getControllerName')->will(self::returnValue('Standard'));
-        $this->mockActionRequest->expects(self::any())->method('getControllerActionName')->will(self::returnValue('index'));
-        $this->mockActionRequest->expects(self::any())->method('getFormat')->will(self::returnValue('html'));
-        $this->mockActionRequest->expects(self::any())->method('getParentRequest')->will(self::returnValue(null));
+        $this->mockActionRequest->expects(self::any())->method('getControllerPackageKey')->willReturn('Neos.Flow');
+        $this->mockActionRequest->expects(self::any())->method('getControllerSubpackageKey')->willReturn('');
+        $this->mockActionRequest->expects(self::any())->method('getControllerName')->willReturn('Standard');
+        $this->mockActionRequest->expects(self::any())->method('getControllerActionName')->willReturn('index');
+        $this->mockActionRequest->expects(self::any())->method('getFormat')->willReturn('html');
+        $this->mockActionRequest->expects(self::any())->method('getParentRequest')->willReturn(null);
 
         $this->viewConfigurationManager = new ViewConfigurationManager($this->mockConfigurationManager, $eelEvaluator, $this->mockCache);
     }
@@ -85,7 +85,7 @@ class ViewConfigurationManagerTest extends \Neos\Flow\Tests\UnitTestCase
 
         $viewConfigurations = [$notMatchingConfiguration, $matchingConfiguration];
 
-        $this->mockConfigurationManager->expects(self::any())->method('getConfiguration')->with('Views')->will(self::returnValue($viewConfigurations));
+        $this->mockConfigurationManager->expects(self::any())->method('getConfiguration')->with('Views')->willReturn($viewConfigurations);
         $calculatedConfiguration = $this->viewConfigurationManager->getViewConfiguration($this->mockActionRequest);
 
         self::assertEquals($calculatedConfiguration, $matchingConfiguration);
@@ -111,7 +111,7 @@ class ViewConfigurationManagerTest extends \Neos\Flow\Tests\UnitTestCase
 
         $viewConfigurations = [$notMatchingConfiguration, $matchingConfigurationOne, $matchingConfigurationTwo];
 
-        $this->mockConfigurationManager->expects(self::any())->method('getConfiguration')->with('Views')->will(self::returnValue($viewConfigurations));
+        $this->mockConfigurationManager->expects(self::any())->method('getConfiguration')->with('Views')->willReturn($viewConfigurations);
         $calculatedConfiguration = $this->viewConfigurationManager->getViewConfiguration($this->mockActionRequest);
 
         self::assertEquals($calculatedConfiguration, $matchingConfigurationTwo);

--- a/Neos.Flow/Tests/Unit/ObjectManagement/CompileTimeObjectManagerTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/CompileTimeObjectManagerTest.php
@@ -54,7 +54,7 @@ class CompileTimeObjectManagerTest extends UnitTestCase
                 ]
             ]
         ]);
-        $this->compileTimeObjectManager = $this->getAccessibleMock(CompileTimeObjectManager::class, ['dummy'], [], '', false);
+        $this->compileTimeObjectManager = $this->getAccessibleMock(CompileTimeObjectManager::class, [], [], '', false);
         $this->compileTimeObjectManager->injectLogger($this->createMock(LoggerInterface::class));
         $this->compileTimeObjectManager->injectConfigurationManager($mockConfigurationManager);
     }

--- a/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationBuilderTest.php
+++ b/Neos.Flow/Tests/Unit/ObjectManagement/Configuration/ConfigurationBuilderTest.php
@@ -87,13 +87,13 @@ final class ConfigurationBuilderTest extends UnitTestCase
             ->expects(self::once())
             ->method('getPropertyNamesByAnnotation')
             ->with(__CLASS__, Flow\Inject::class)
-            ->will(self::returnValue(['dummyProperty']));
+            ->willReturn(['dummyProperty']);
 
         $reflectionServiceMock
             ->expects(self::once())
             ->method('isPropertyPrivate')
             ->with(__CLASS__, 'dummyProperty')
-            ->will(self::returnValue(true));
+            ->willReturn(true);
 
         return $reflectionServiceMock;
     }

--- a/Neos.Flow/Tests/Unit/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriverTest.php
+++ b/Neos.Flow/Tests/Unit/Persistence/Doctrine/Mapping/Driver/FlowAnnotationDriverTest.php
@@ -83,7 +83,8 @@ final class FlowAnnotationDriverTest extends UnitTestCase
     #[Test]
     public function getMaxIdentifierLengthAsksDoctrineForValue(): void
     {
-        $mockDatabasePlatform = $this->getMockForAbstractClass(AbstractPlatform::class, [], '', true, true, true, ['getMaxIdentifierLength']);
+        $mockDatabasePlatform = $this->createPartialMock(AbstractPlatform::class, ['getMaxIdentifierLength', '_getCommonIntegerTypeDeclarationSQL', 'getBooleanTypeDeclarationSQL', 'getIntegerTypeDeclarationSQL', 'getBigIntTypeDeclarationSQL', 'getSmallIntTypeDeclarationSQL', 'initializeDoctrineTypeMappings', 'getClobTypeDeclarationSQL', 'getBlobTypeDeclarationSQL', 'getName', 'getCurrentDatabaseExpression']);
+
         $mockDatabasePlatform->expects(self::atLeastOnce())->method('getMaxIdentifierLength')->willReturn(2048);
         $mockConnection = $this->createMock(Connection::class);
         $mockConnection->expects(self::atLeastOnce())->method('getDatabasePlatform')->willReturn($mockDatabasePlatform);

--- a/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderResolverTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/AuthenticationProviderResolverTest.php
@@ -29,7 +29,7 @@ class AuthenticationProviderResolverTest extends UnitTestCase
     {
         $this->expectException(NoAuthenticationProviderFoundException::class);
         $mockObjectManager = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->getMock();
-        $mockObjectManager->expects(self::any())->method('getClassNameByObjectName')->will(self::returnValue(false));
+        $mockObjectManager->expects(self::any())->method('getClassNameByObjectName')->willReturn(false);
 
         $providerResolver = new AuthenticationProviderResolver($mockObjectManager);
 
@@ -52,7 +52,7 @@ class AuthenticationProviderResolverTest extends UnitTestCase
         };
 
         $mockObjectManager = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->getMock();
-        $mockObjectManager->expects(self::any())->method('getClassNameByObjectName')->will(self::returnCallBack($getCaseSensitiveObjectNameCallback));
+        $mockObjectManager->expects(self::any())->method('getClassNameByObjectName')->willReturnCallback($getCaseSensitiveObjectNameCallback);
 
         $providerResolver = new AuthenticationProviderResolver($mockObjectManager);
         $providerClass = $providerResolver->resolveProviderClass('TestingProvider');
@@ -64,7 +64,7 @@ class AuthenticationProviderResolverTest extends UnitTestCase
     public function resolveProviderReturnsTheCorrectProviderForACompleteClassName()
     {
         $mockObjectManager = $this->getMockBuilder(ObjectManager::class)->disableOriginalConstructor()->getMock();
-        $mockObjectManager->expects(self::any())->method('getClassNameByObjectName')->with(TestingProvider::class)->will(self::returnValue(TestingProvider::class));
+        $mockObjectManager->expects(self::any())->method('getClassNameByObjectName')->with(TestingProvider::class)->willReturn(TestingProvider::class);
 
         $providerResolver = new AuthenticationProviderResolver($mockObjectManager);
         $providerClass = $providerResolver->resolveProviderClass(TestingProvider::class);

--- a/Neos.Flow/Tests/Unit/Security/Authentication/Token/AbstractTokenTest.php
+++ b/Neos.Flow/Tests/Unit/Security/Authentication/Token/AbstractTokenTest.php
@@ -35,7 +35,7 @@ final class AbstractTokenTest extends UnitTestCase
 
     protected function setUp(): void
     {
-        $this->token = $this->getMockForAbstractClass(AbstractToken::class);
+        $this->token = $this->createPartialMock(AbstractToken::class, ['updateCredentials']);
     }
 
     #[Test]

--- a/Neos.Flow/Tests/Unit/Security/ContextTest.php
+++ b/Neos.Flow/Tests/Unit/Security/ContextTest.php
@@ -540,7 +540,7 @@ final class ContextTest extends UnitTestCase
         $authenticatedUserRole = new Role('Neos.Flow:AuthenticatedUser');
         $testRole = new Role('Acme.Demo:TestRole');
 
-        $mockPolicyService = $this->getAccessibleMock(PolicyService::class, ['getRole', 'initializeRolesFromPolicy']);
+        $mockPolicyService = $this->getAccessibleMock(PolicyService::class, ['getRole']);
         $mockPolicyService->expects($this->atLeastOnce())->method('getRole')->willReturnCallback(function ($roleIdentifier) use ($everybodyRole, $authenticatedUserRole) {
             switch ($roleIdentifier) {
                 case 'Neos.Flow:Everybody':
@@ -809,7 +809,7 @@ final class ContextTest extends UnitTestCase
         $testRole2 = $this->getAccessibleMock(Role::class, [], ['Acme.Demo:TestRole2']);
         $authenticatedUserRole = new Role('Neos.Flow:AuthenticatedUser');
 
-        $mockPolicyService = $this->getAccessibleMock(PolicyService::class, ['getRole', 'initializeRolesFromPolicy']);
+        $mockPolicyService = $this->getAccessibleMock(PolicyService::class, ['getRole']);
         $mockPolicyService->expects($this->atLeastOnce())->method('getRole')->willReturnCallback(function ($roleIdentifier) use ($everybodyRole, $testRole1, $testRole2, $authenticatedUserRole) {
             switch ($roleIdentifier) {
                 case 'Neos.Flow:Everybody':

--- a/Neos.Flow/Tests/Unit/Session/SessionManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Session/SessionManagerTest.php
@@ -99,7 +99,7 @@ final class SessionManagerTest extends UnitTestCase
     }
 
     /**
-     * @test for #1674
+     * test for #1674
      * @throws
      */
     #[Test]

--- a/Neos.Flow/Tests/Unit/Session/SessionTest.php
+++ b/Neos.Flow/Tests/Unit/Session/SessionTest.php
@@ -104,7 +104,7 @@ final class SessionTest extends UnitTestCase
         $mockRequestHandler->method('getHttpRequest')->willReturn($this->httpRequest);
 
         $this->mockBootstrap = $this->createMock(Bootstrap::class);
-        $this->mockBootstrap->expects(self::any())->method('getActiveRequestHandler')->will(self::returnValue($mockRequestHandler));
+        $this->mockBootstrap->expects(self::any())->method('getActiveRequestHandler')->willReturn($mockRequestHandler);
 
         $this->mockSecurityContext = $this->createMock(Context::class);
 

--- a/Neos.Flow/Tests/Unit/SignalSlot/DispatcherTest.php
+++ b/Neos.Flow/Tests/Unit/SignalSlot/DispatcherTest.php
@@ -29,8 +29,8 @@ final class DispatcherTest extends UnitTestCase
     public function connectAllowsForConnectingASlotWithASignal(): void
     {
 
-        $mockSignal = $this->getMockBuilder('stdClass')->addMethods(['emitSomeSignal'])->getMock();
-        $mockSlot = $this->getMockBuilder('stdClass')->addMethods(['someSlotMethod'])->getMock();
+        $mockSignal = $this->createMock(SignalFixture::class);
+        $mockSlot = $this->createMock(SlotFixture::class);
 
         $dispatcher = new Dispatcher();
         $dispatcher->connect(get_class($mockSignal), 'someSignal', get_class($mockSlot), 'someSlotMethod', false);
@@ -44,8 +44,8 @@ final class DispatcherTest extends UnitTestCase
     #[Test]
     public function connectAlsoAcceptsObjectsInPlaceOfTheClassName(): void
     {
-        $mockSignal = $this->getMockBuilder('stdClass')->addMethods(['emitSomeSignal'])->getMock();
-        $mockSlot = $this->getMockBuilder('stdClass')->addMethods(['someSlotMethod'])->getMock();
+        $mockSignal = $this->createMock(SignalFixture::class);
+        $mockSlot = $this->createMock(SlotFixture::class);
 
         $dispatcher = new Dispatcher();
         $dispatcher->connect(get_class($mockSignal), 'someSignal', $mockSlot, 'someSlotMethod', false);
@@ -59,7 +59,7 @@ final class DispatcherTest extends UnitTestCase
     #[Test]
     public function connectAlsoAcceptsClosuresActingAsASlot(): void
     {
-        $mockSignal = $this->getMockBuilder('stdClass')->addMethods(['emitSomeSignal'])->getMock();
+        $mockSignal = $this->createMock(SignalFixture::class);
         $mockSlot = function () {
         };
 
@@ -75,8 +75,8 @@ final class DispatcherTest extends UnitTestCase
     #[Test]
     public function wireAllowsForConnectingASlotWithASignal(): void
     {
-        $mockSignal = $this->getMockBuilder('stdClass')->addMethods(['emitSomeSignal'])->getMock();
-        $mockSlot = $this->getMockBuilder('stdClass')->addMethods(['someSlotMethod'])->getMock();
+        $mockSignal = $this->createMock(SignalFixture::class);
+        $mockSlot = $this->createMock(SlotFixture::class);
 
         $dispatcher = new Dispatcher();
         $dispatcher->wire(get_class($mockSignal), 'someSignal', get_class($mockSlot), 'someSlotMethod', false);
@@ -90,8 +90,8 @@ final class DispatcherTest extends UnitTestCase
     #[Test]
     public function wireAlsoAcceptsObjectsInPlaceOfTheClassName(): void
     {
-        $mockSignal = $this->getMockBuilder('stdClass')->addMethods(['emitSomeSignal'])->getMock();
-        $mockSlot = $this->getMockBuilder('stdClass')->addMethods(['someSlotMethod'])->getMock();
+        $mockSignal = $this->createMock(SignalFixture::class);
+        $mockSlot = $this->createMock(SlotFixture::class);
 
         $dispatcher = new Dispatcher();
         $dispatcher->wire(get_class($mockSignal), 'someSignal', $mockSlot, 'someSlotMethod', false);
@@ -105,7 +105,7 @@ final class DispatcherTest extends UnitTestCase
     #[Test]
     public function wireAlsoAcceptsClosuresActingAsASlot(): void
     {
-        $mockSignal = $this->getMockBuilder('stdClass')->addMethods(['emitSomeSignal'])->getMock();
+        $mockSignal = $this->createMock(SignalFixture::class);
         $mockSlot = function () {
         };
 
@@ -268,8 +268,8 @@ final class DispatcherTest extends UnitTestCase
     public function connectWithSignalNameStartingWithEmitShouldNotBeAllowed(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $mockSignal = $this->getMockBuilder('stdClass')->addMethods(['emitSomeSignal'])->getMock();
-        $mockSlot = $this->getMockBuilder('stdClass')->addMethods(['someSlotMethod'])->getMock();
+        $mockSignal = $this->createMock(SignalFixture::class);
+        $mockSlot = $this->createMock(SlotFixture::class);
 
         $dispatcher = new Dispatcher();
         $dispatcher->connect(get_class($mockSignal), 'emitSomeSignal', get_class($mockSlot), 'someSlotMethod', false);
@@ -330,5 +330,23 @@ final class DispatcherTest extends UnitTestCase
         $passedArguments = ['bar', 'quux'];
         $dispatcher->dispatch('SignalClassName', 'methodName', $passedArguments);
         self::assertEquals([new SignalInformation('SignalClassName', 'methodName', $passedArguments)], $receivedArguments);
+    }
+}
+
+/**
+ * Fixtures providing a signal emitter and a slot method. The dispatcher only ever needs the
+ * class name of a signal, and a slot has to be an existing method – hence these stand-ins.
+ */
+class SignalFixture
+{
+    public function emitSomeSignal(): void
+    {
+    }
+}
+
+class SlotFixture
+{
+    public function someSlotMethod(): void
+    {
     }
 }

--- a/Neos.Flow/Tests/Unit/Validation/ValidatorResolverTest.php
+++ b/Neos.Flow/Tests/Unit/Validation/ValidatorResolverTest.php
@@ -290,7 +290,7 @@ final class ValidatorResolverTest extends UnitTestCase
     #[Test]
     public function buildMethodArgumentsValidatorConjunctionsReturnsEmptyArrayIfMethodHasNoArguments()
     {
-        $mockController = $this->getAccessibleMock(ActionController::class, ['fooAction'], [], '', false);
+        $mockController = $this->getAccessibleMock(ActionController::class, [], [], '', false);
 
         $mockReflectionService = $this->createMock(ReflectionService::class);
         $mockReflectionService->expects($this->once())->method('getMethodParameters')->with(get_class($mockController), 'fooAction')->willReturn([]);

--- a/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetControllerTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/Core/Widget/AbstractWidgetControllerTest.php
@@ -18,7 +18,6 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\ServerRequest;
 use GuzzleHttp\Psr7\Uri;
 use Neos\Flow\Mvc\ActionRequest;
-use Neos\Flow\Mvc\ActionResponse;
 use Neos\Flow\Mvc\Controller\MvcPropertyMappingConfigurationService;
 use Neos\Flow\Tests\UnitTestCase;
 use Neos\FluidAdaptor\Core\Widget\AbstractWidgetController;
@@ -39,11 +38,9 @@ final class AbstractWidgetControllerTest extends UnitTestCase
         /** @var ActionRequest $mockActionRequest */
         $mockActionRequest = $this->createMock(ActionRequest::class);
         $mockActionRequest->expects($this->atLeastOnce())->method('getInternalArgument')->with('__widgetContext')->willReturn((null));
-        $response = new ActionResponse();
 
-        /** @var AbstractWidgetController $abstractWidgetController */
-        $abstractWidgetController = $this->getMockForAbstractClass(AbstractWidgetController::class);
-        $abstractWidgetController->processRequest($mockActionRequest, $response);
+        $abstractWidgetController = new class () extends AbstractWidgetController {};
+        $abstractWidgetController->processRequest($mockActionRequest);
     }
 
     #[Test]
@@ -63,7 +60,7 @@ final class AbstractWidgetControllerTest extends UnitTestCase
         $mockActionRequest->expects($this->atLeastOnce())->method('getInternalArgument')->with('__widgetContext')->willReturn(($widgetContext));
 
         /** @var AbstractWidgetController|MockObject $abstractWidgetController */
-        $abstractWidgetController = $this->getAccessibleMock(AbstractWidgetController::class, ['resolveActionMethodName', 'initializeActionMethodArguments', 'initializeActionMethodValidators', 'mapRequestArgumentsToControllerArguments', 'detectFormat', 'resolveView', 'callActionMethod']);
+        $abstractWidgetController = $this->getAccessibleMock(AbstractWidgetController::class, ['resolveActionMethodName', 'initializeActionMethodArguments', 'initializeActionMethodValidators', 'mapRequestArgumentsToControllerArguments', 'resolveView', 'callActionMethod']);
         $abstractWidgetController->method('resolveActionMethodName')->willReturn('indexAction');
         $abstractWidgetController->_set('mvcPropertyMappingConfigurationService', $this->createMock(MvcPropertyMappingConfigurationService::class));
         $abstractWidgetController->expects($this->once())->method('callActionMethod')->willReturn(new Response());

--- a/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/AbstractFormFieldViewHelperTest.php
+++ b/Neos.FluidAdaptor/Tests/Unit/ViewHelpers/Form/AbstractFormFieldViewHelperTest.php
@@ -432,7 +432,7 @@ final class AbstractFormFieldViewHelperTest extends ViewHelperBaseTestcase
     #[Test]
     public function setErrorClassAttributeDoesNotSetClassAttributeIfNoErrorOccurred(): void
     {
-        $formViewHelper = $this->getAccessibleMock(AbstractFormFieldViewHelper::class, ['hasArgument', 'getErrorsForProperty'], [], '', false);
+        $formViewHelper = $this->getAccessibleMock(AbstractFormFieldViewHelper::class, ['hasArgument'], [], '', false);
         $this->injectDependenciesIntoViewHelper($formViewHelper);
 
         $this->tagBuilder->expects($this->never())->method('addAttribute');


### PR DESCRIPTION
See previous upgrade to PHPUnit 11 https://github.com/neos/flow-development-collection/pull/3563

Prepare the code for PHPUnit 12 by getting rid of deprecated methods in test code.

**Checklist**

- [x] Code follows the PSR-12 coding style
- [x] Tests have been created, run and adjusted as needed
- [x] The PR is created against the earliest possible branch
- [x] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [x] Reviewer - The first section explains the change briefly for change-logs
- [ ] ~Reviewer - Breaking Changes are marked with `!!!` and have upgrade-instructions~
