### PR TITLE
BUGFIX: Support circular singleton dependencies

### DIFF
--- a/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
+++ b/Neos.Flow/Classes/ObjectManagement/ObjectManager.php
@@ -222,25 +222,105 @@ class ObjectManager implements ObjectManagerInterface
             return $this->objects[$objectName][self::KEY_INSTANCE];
         }
 
-        // by object name
+        if (!isset($this->objects[$objectName]) || $this->objects[$objectName][self::KEY_SCOPE] === ObjectConfiguration::SCOPE_PROTOTYPE) {
+            return $this->instantiateClass($className, $this->autowireConstructorArguments($objectName, $className, $constructorArguments));
+        }
+
+        return $this->instantiateRegisteredObject($objectName, $className);
+    }
+
+    /**
+     * Creates the instance of a singleton or session scoped object and registers it *before* its
+     * constructor arguments are resolved and its constructor is called.
+     *
+     * Objects of these scopes may depend on each other, directly or through a chain of other
+     * objects. Registering the instance first makes sure that a re-entrant call to get() for the
+     * same object – triggered while resolving its dependencies – returns the instance which is
+     * currently being built, instead of trying to build a second one and running into the
+     * circular dependency guard of instantiateClass().
+     *
+     * @param string $objectName Name of the object to instantiate
+     * @param class-string $className Name of the class implementing the object
+     * @return object The object
+     * @throws Exception\CannotBuildObjectException
+     * @throws \Throwable
+     */
+    protected function instantiateRegisteredObject(string $objectName, string $className): object
+    {
+        $classReflection = new \ReflectionClass($className);
+        if ($classReflection->isInternal()) {
+            $instance = $this->instantiateClass($className, $this->autowireConstructorArguments($objectName, $className, []));
+            $this->registerInstance($objectName, $className, $instance);
+            return $instance;
+        }
+
+        $instance = $classReflection->newInstanceWithoutConstructor();
+        $this->registerInstance($objectName, $className, $instance);
+        try {
+            $constructorArguments = $this->autowireConstructorArguments($objectName, $className, []);
+            if ($classReflection->hasMethod('__construct')) {
+                $instance->__construct(...$constructorArguments);
+            }
+        } catch (\Throwable $throwable) {
+            $this->unregisterInstance($objectName, $className);
+            throw $throwable;
+        }
+        return $instance;
+    }
+
+    /**
+     * Registers the given instance for the object name and – if the implementation class is
+     * registered as a singleton of its own – for the class name as well, so that requesting
+     * the class directly returns the same instance.
+     *
+     * @param class-string $className
+     */
+    protected function registerInstance(string $objectName, string $className, object $instance): void
+    {
+        $this->objects[$objectName][self::KEY_INSTANCE] = $instance;
+        if ($this->classIsRegisteredAsSingleton($objectName, $className)) {
+            $this->objects[$className][self::KEY_INSTANCE] = $instance;
+        }
+    }
+
+    /**
+     * @param class-string $className
+     */
+    protected function unregisterInstance(string $objectName, string $className): void
+    {
+        unset($this->objects[$objectName][self::KEY_INSTANCE]);
+        if ($this->classIsRegisteredAsSingleton($objectName, $className)) {
+            unset($this->objects[$className][self::KEY_INSTANCE]);
+        }
+    }
+
+    /**
+     * @param class-string $className
+     */
+    protected function classIsRegisteredAsSingleton(string $objectName, string $className): bool
+    {
+        return $objectName !== $className
+            && isset($this->objects[$className])
+            && $this->objects[$className][self::KEY_SCOPE] === ObjectConfiguration::SCOPE_SINGLETON;
+    }
+
+    /**
+     * Resolves the constructor arguments configured for the given object – by object name and,
+     * if different, by class name – which were not passed explicitly.
+     *
+     * @param class-string $className
+     * @param array<mixed> $constructorArguments Arguments which were passed explicitly
+     * @return array<mixed> The complete list of constructor arguments
+     */
+    protected function autowireConstructorArguments(string $objectName, string $className, array $constructorArguments): array
+    {
         if (isset($this->objects[$objectName][self::KEY_CONSTRUCTOR_ARGUMENTS])) {
             $constructorArguments = $this->autowireArguments($this->objects[$objectName][self::KEY_CONSTRUCTOR_ARGUMENTS], $constructorArguments);
         }
-
-        // by class name
         if ($objectName !== $className && isset($this->objects[$className][self::KEY_CONSTRUCTOR_ARGUMENTS])) {
             $constructorArguments = $this->autowireArguments($this->objects[$className][self::KEY_CONSTRUCTOR_ARGUMENTS], $constructorArguments);
         }
-
-        if (!isset($this->objects[$objectName]) || $this->objects[$objectName][self::KEY_SCOPE] === ObjectConfiguration::SCOPE_PROTOTYPE) {
-            return $this->instantiateClass($className, $constructorArguments);
-        }
-
-        $this->objects[$objectName][self::KEY_INSTANCE] = $this->instantiateClass($className, $constructorArguments);
-        if ($objectName !== $className && isset($this->objects[$className]) && $this->objects[$className][self::KEY_SCOPE] === ObjectConfiguration::SCOPE_SINGLETON) {
-            $this->objects[$className][self::KEY_INSTANCE] = $this->objects[$objectName][self::KEY_INSTANCE];
-        }
-        return $this->objects[$objectName][self::KEY_INSTANCE];
+        return $constructorArguments;
     }
 
     /**

--- a/Neos.Flow/Tests/Functional/ObjectManagement/CircularDependencyTest.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/CircularDependencyTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Neos\Flow\Tests\Functional\ObjectManagement;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\ObjectManagement\Exception\CannotBuildObjectException;
+use Neos\Flow\Tests\FunctionalTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Functional tests for circular dependencies between singletons
+ */
+class CircularDependencyTest extends FunctionalTestCase
+{
+    #[Test]
+    public function singletonsDependingOnEachOtherThroughPropertyInjectionCanBeInstantiated(): void
+    {
+        $singletonA = $this->objectManager->get(Fixtures\CircularSingletonA::class);
+        $singletonB = $this->objectManager->get(Fixtures\CircularSingletonB::class);
+
+        self::assertSame($singletonB, $singletonA->singletonB);
+        self::assertSame($singletonA, $singletonB->singletonA);
+    }
+
+    #[Test]
+    public function singletonsDependingOnEachOtherThroughPropertyAndConstructorInjectionCanBeInstantiated(): void
+    {
+        $singletonC = $this->objectManager->get(Fixtures\CircularSingletonC::class);
+        $singletonD = $this->objectManager->get(Fixtures\CircularSingletonD::class);
+
+        self::assertSame($singletonD, $singletonC->singletonD);
+        self::assertSame($singletonC, $singletonD->singletonC);
+    }
+
+    /**
+     * The cycle must resolve to the same instances no matter which of the two objects is requested
+     * first. This is what distinguishes a registration before the constructor arguments are resolved
+     * from a registration inside the constructor: the latter comes too late if the object requested
+     * first depends on the other one through its constructor.
+     */
+    #[Test]
+    public function circularDependenciesResolveToTheSameInstancesRegardlessOfWhichObjectIsRequestedFirst(): void
+    {
+        $this->objectManager->forgetInstance(Fixtures\CircularSingletonC::class);
+        $this->objectManager->forgetInstance(Fixtures\CircularSingletonD::class);
+
+        $singletonD = $this->objectManager->get(Fixtures\CircularSingletonD::class);
+        $singletonC = $this->objectManager->get(Fixtures\CircularSingletonC::class);
+
+        self::assertSame($singletonC, $singletonD->singletonC);
+        self::assertSame($singletonD, $singletonC->singletonD);
+    }
+
+    /**
+     * Unlike singletons, prototypes cannot be registered before their dependencies are resolved,
+     * because each request must result in a new instance. Two prototypes depending on each other
+     * would therefore lead to an infinite recursion – which is what the circular dependency guard
+     * of the Object Manager prevents.
+     */
+    #[Test]
+    public function prototypesDependingOnEachOtherAreRejectedWithAnExplanatoryException(): void
+    {
+        $this->expectException(CannotBuildObjectException::class);
+        $this->expectExceptionCode(1168505928);
+
+        $this->objectManager->get(Fixtures\CircularPrototypeE::class);
+    }
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/CircularPrototypeE.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/CircularPrototypeE.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A prototype which gets another prototype injected through its constructor, which in turn
+ * depends on this class through property injection
+ */
+class CircularPrototypeE
+{
+    public function __construct(public CircularPrototypeF $prototypeF)
+    {
+    }
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/CircularPrototypeF.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/CircularPrototypeF.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * The counterpart of CircularPrototypeE, using property injection
+ */
+class CircularPrototypeF
+{
+    #[Flow\Inject]
+    public CircularPrototypeE $prototypeE;
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/CircularSingletonA.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/CircularSingletonA.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A singleton which depends on another singleton depending on this one again (via property injection)
+ */
+#[Flow\Scope('singleton')]
+class CircularSingletonA
+{
+    #[Flow\Inject]
+    public CircularSingletonB $singletonB;
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/CircularSingletonB.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/CircularSingletonB.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * The counterpart of CircularSingletonA
+ */
+#[Flow\Scope('singleton')]
+class CircularSingletonB
+{
+    #[Flow\Inject]
+    public CircularSingletonA $singletonA;
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/CircularSingletonC.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/CircularSingletonC.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A singleton which depends on another singleton via property injection, which in turn
+ * depends on this one via constructor injection
+ */
+#[Flow\Scope('singleton')]
+class CircularSingletonC
+{
+    #[Flow\Inject]
+    public CircularSingletonD $singletonD;
+}

--- a/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/CircularSingletonD.php
+++ b/Neos.Flow/Tests/Functional/ObjectManagement/Fixtures/CircularSingletonD.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Neos\Flow\Tests\Functional\ObjectManagement\Fixtures;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * The counterpart of CircularSingletonC, using constructor injection
+ */
+#[Flow\Scope('singleton')]
+class CircularSingletonD
+{
+    public function __construct(public CircularSingletonC $singletonC)
+    {
+    }
+}


### PR DESCRIPTION
Since #3510, the Object Manager resolves the constructor arguments of an object itself, before the instance exists, and marks the class as being instantiated. At the same time, the generated proxy constructors lost the `setInstance()` call which registered a half-constructed singleton as their very first statement. That early registration was what allowed singletons to depend on each other: a re-entrant `get()` for an object which is currently being built returned that very instance. Without it, such object graphs – which are common in Flow applications and worked up to Flow 9.1 – fail with a "Circular dependency detected" exception while their dependencies are resolved.

The Object Manager now creates the instance of a singleton (or session scoped object) without calling its constructor, registers it, and only then resolves the constructor arguments and calls the constructor. If that fails, the registration is rolled back. This restores the 9.1 behavior at the place where dependencies are resolved today.

Prototypes cannot be registered up front, because each request must result in a new instance. Two prototypes depending on each other lead to an infinite recursion in 9.1 already, so the circular dependency guard keeps rejecting them – now with a meaningful exception instead of a stack overflow.

Fixes #3618
